### PR TITLE
chore: Enable builds for linux_arm64 and macos_x8664

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,50 @@
+name: formae-container
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  container_linux:
+    runs-on: ubuntu-latest
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push container image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./packaging/container
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,6 +1,19 @@
 name: formae-package
 
 on:
+  workflow_dispatch:
+    inputs:
+      pkg_job:
+        description: "platform to build and publish"
+        type: choice
+        default: "all"
+        options:
+          - "all"
+          - "pkg_pkl"
+          - "pkg_linux_arm64"
+          - "pkg_linux_x8664"
+          - "pkg_macos_arm64"
+          - "pkg_macos_x8664"
   push:
     tags:
       - '*'
@@ -13,8 +26,10 @@ jobs:
   pkg_pkl:
     runs-on: ubuntu-latest
 
+    if: ${{ contains(fromJSON('["", "all", "pkg_pkl"]'), inputs.pkg_job) }}
+
     concurrency:
-      group: package-pkl
+      group: package_pkl
       cancel-in-progress: false
 
     steps:
@@ -47,11 +62,13 @@ jobs:
       - name: Publish Setup Script to S3
         run: make publish-setup
 
-  pkg_linux_x8664:
-    runs-on: ubuntu-latest
+  pkg_linux_arm64:
+    runs-on: ubuntu-24.04-arm
+
+    if: ${{ contains(fromJSON('["", "all", "pkg_linux_arm64"]'), inputs.pkg_job) }}
 
     concurrency:
-      group: package-bin
+      group: pkg_linux_arm64
       cancel-in-progress: false
 
     steps:
@@ -80,41 +97,48 @@ jobs:
       - name: Build and Publish
         run: make publish-bin
 
-# Save for when Linux Arm is available for private repositories
-#
-#  pkg_linux_arm64:
-#    runs-on: ubuntu-24.04-arm
-#
-#    concurrency:
-#      group: package-bin
-#      cancel-in-progress: false
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#        with:
-#          fetch-depth: 0
-#          fetch-tags: true
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          aws-region: us-west-2
-#          role-to-assume: arn:aws:iam::897722706215:role/github-pel
-#          role-session-name: PublishSession
-#
-#      - name: Set up Go
-#        uses: actions/setup-go@v4
-#        with:
-#          go-version: '1.25.1'
-#
-#      - name: Build and Publish
-#        run: make publish-bin
+  pkg_linux_x8664:
+    runs-on: ubuntu-latest
+
+    if: ${{ contains(fromJSON('["", "all", "pkg_linux_x8664"]'), inputs.pkg_job) }}
+
+    concurrency:
+      group: pkg_linux_x8664
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install pkl
+        uses: pkl-community/setup-pkl@v0
+        with:
+          pkl-version: 0.29.0
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::897722706215:role/github-pel
+          role-session-name: PublishSession
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.25.1'
+
+      - name: Build and Publish
+        run: make publish-bin
   
   pkg_macos_arm64:
     runs-on: macos-latest
 
+    if: ${{ contains(fromJSON('["", "all", "pkg_macos_arm64"]'), inputs.pkg_job) }}
+
     concurrency:
-      group: package-bin
+      group: pkg_macos_arm64
       cancel-in-progress: false
 
     steps:
@@ -143,49 +167,37 @@ jobs:
       - name: Build and Publish
         run: make publish-bin
 
-  container_linux_x8664:
-    runs-on: ubuntu-latest
+  pkg_macos_x8664:
+    runs-on: macos-15-intel
 
-    needs:
-      - pkg_pkl
-      - pkg_linux_x8664
+    if: ${{ contains(fromJSON('["", "all", "pkg_macos_x8664"]'), inputs.pkg_job) }}
 
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
-
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
+    concurrency:
+      group: pkg_macos_x8664
+      cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Log in to the container registry
-        uses: docker/login-action@v3
+      - name: Install pkl
+        uses: pkl-community/setup-pkl@v0
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          pkl-version: 0.29.0
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::897722706215:role/github-pel
+          role-session-name: PublishSession
 
-      - name: Build and push container image
-        id: push
-        uses: docker/build-push-action@v6
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          context: ./packaging/container
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ github.ref_name }}
+          go-version: '1.25.1'
+
+      - name: Build and Publish
+        run: make publish-bin


### PR DESCRIPTION
This PR:

- Also splits out the container build for manual triggers for now
- Allows conditional manual build of each package