### PR TITLE
fix: Ensure PATH is preserved on Linux when upgrading

### DIFF
--- a/pkg/ppm/sys.go
+++ b/pkg/ppm/sys.go
@@ -29,9 +29,10 @@ func (sys) InvokeSelfWithSudo(args ...string) error {
 		return err
 	}
 
-	args = append([]string{" ", self}, args...)
-
 	env := os.Environ()
+	path := os.Getenv("PATH")
+
+	args = append([]string{" ", "env", "PATH=" + path, self}, args...)
 
 	err = syscall.Exec(sudo, args, env)
 	if err != nil {


### PR DESCRIPTION
This PR will be followed up with another that hardens the pkl binary invocation to ensure the plugin will be more resilient in the face of system variability.