### PR TITLE
fix(build): support Linux in gen-aws-pkl-types Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,11 @@ gen-aws-pkl-types:
 	cd plugins/aws && go generate .
 	rm plugins/aws/pkg/descriptors/gen/Types.pkl.go
 	cd plugins/aws &&  pkl eval pkg/descriptors/pkl/resources.pkl > pkg/descriptors/pkl/generated_resources.pkl
-	sed -i '' '/pkl.RegisterStrictMapping("types", Types{})/d' plugins/aws/pkg/descriptors/gen/init.pkl.go
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		sed -i '' '/pkl.RegisterStrictMapping("types", Types{})/d' plugins/aws/pkg/descriptors/gen/init.pkl.go; \
+	else \
+		sed -i '/pkl.RegisterStrictMapping("types", Types{})/d' plugins/aws/pkg/descriptors/gen/init.pkl.go; \
+	fi
 
 pkg-pkl:
 	pkl project package ./plugins/aws/schema/pkl ./plugins/pkl/schema --skip-publish-check


### PR DESCRIPTION
  # Fix sed command compatibility in Makefile for Linux

  ## Problem

  The `gen-aws-pkl-types` target in the Makefile uses `sed -i ''` syntax, which is BSD-specific (macOS) and fails on Linux with GNU sed.

  ## Changes
  - Updated `Makefile` with conditional logic based on OS detection:
    - **macOS (Darwin)**: `sed -i ''` (requires empty string for backup extension)
    - **Linux**: `sed -i` (no empty string needed)

## Related Issues

Closes #23 