### PR TITLE
chore(cli): different colors for rendering canceled commands

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -419,6 +419,12 @@ const docTemplate = `{
                 },
                 "State": {
                     "type": "string"
+                },
+                "TargetUpdates": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.TargetUpdate"
+                    }
                 }
             }
         },
@@ -776,10 +782,46 @@ const docTemplate = `{
                         "type": "integer"
                     }
                 },
+                "Discoverable": {
+                    "type": "boolean"
+                },
                 "Label": {
                     "type": "string"
                 },
                 "Namespace": {
+                    "type": "string"
+                },
+                "Version": {
+                    "type": "integer"
+                }
+            }
+        },
+        "model.TargetUpdate": {
+            "type": "object",
+            "properties": {
+                "Discoverable": {
+                    "type": "boolean"
+                },
+                "Duration": {
+                    "description": "milliseconds",
+                    "type": "integer"
+                },
+                "ErrorMessage": {
+                    "type": "string"
+                },
+                "ModifiedTs": {
+                    "type": "string"
+                },
+                "Operation": {
+                    "type": "string"
+                },
+                "StartTs": {
+                    "type": "string"
+                },
+                "State": {
+                    "type": "string"
+                },
+                "TargetLabel": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -409,6 +409,12 @@
                 },
                 "State": {
                     "type": "string"
+                },
+                "TargetUpdates": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.TargetUpdate"
+                    }
                 }
             }
         },
@@ -766,10 +772,46 @@
                         "type": "integer"
                     }
                 },
+                "Discoverable": {
+                    "type": "boolean"
+                },
                 "Label": {
                     "type": "string"
                 },
                 "Namespace": {
+                    "type": "string"
+                },
+                "Version": {
+                    "type": "integer"
+                }
+            }
+        },
+        "model.TargetUpdate": {
+            "type": "object",
+            "properties": {
+                "Discoverable": {
+                    "type": "boolean"
+                },
+                "Duration": {
+                    "description": "milliseconds",
+                    "type": "integer"
+                },
+                "ErrorMessage": {
+                    "type": "string"
+                },
+                "ModifiedTs": {
+                    "type": "string"
+                },
+                "Operation": {
+                    "type": "string"
+                },
+                "StartTs": {
+                    "type": "string"
+                },
+                "State": {
+                    "type": "string"
+                },
+                "TargetLabel": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -16,6 +16,10 @@ definitions:
         type: string
       State:
         type: string
+      TargetUpdates:
+        items:
+          $ref: '#/definitions/model.TargetUpdate'
+        type: array
     type: object
   github_com_platform-engineering-labs_formae_internal_api_model.Description:
     properties:
@@ -250,9 +254,33 @@ definitions:
         items:
           type: integer
         type: array
+      Discoverable:
+        type: boolean
       Label:
         type: string
       Namespace:
+        type: string
+      Version:
+        type: integer
+    type: object
+  model.TargetUpdate:
+    properties:
+      Discoverable:
+        type: boolean
+      Duration:
+        description: milliseconds
+        type: integer
+      ErrorMessage:
+        type: string
+      ModifiedTs:
+        type: string
+      Operation:
+        type: string
+      StartTs:
+        type: string
+      State:
+        type: string
+      TargetLabel:
         type: string
     type: object
 host: localhost:8080

--- a/internal/cli/renderer/renderer.go
+++ b/internal/cli/renderer/renderer.go
@@ -380,23 +380,6 @@ func formatResourceUpdate(root *gtree.Node, rc apimodel.ResourceUpdate) {
 	addStatusDetails(node, rc)
 }
 
-// coloredResourceUpdateStateForCanceledCommand returns the state formatted with appropriate color
-// for resource updates belonging to a canceled command. The semantics are flipped:
-// - "Canceled" is considered success (the user wanted to cancel) -> shown in green
-// - "Success" means the operation completed before cancellation -> shown in grey with different text
-func coloredResourceUpdateStateForCanceledCommand(state string) string {
-	switch state {
-	case "Canceled":
-		return display.Green(state)
-	case "Success":
-		return display.Grey("Completed (unable to cancel)")
-	case "Failed", "Rejected":
-		return display.Red(state)
-	default:
-		return display.Grey(state)
-	}
-}
-
 // formatResourceUpdateForCanceledCommand formats resource updates for commands that were canceled.
 // In the context of a canceled command, the semantics flip:
 // - "Canceled" resource updates represent successful cancellations (shown in green)
@@ -446,6 +429,24 @@ func coloredUpdateState(state string) string {
 		return display.Red(state)
 	default:
 		return display.Grey(state)
+	}
+}
+
+// coloredResourceUpdateStateForCanceledCommand returns the state formatted with appropriate color
+// for resource updates belonging to a canceled command. The semantics are flipped:
+// - "Canceled" is considered success (the user wanted to cancel) -> shown in green
+// - "Failed" and "Rejected" are similar as "Canceled" as they did not execute, which is what the user wanted -> shown in green
+// - "Success" means the operation completed before cancellation -> shown in red with different text
+func coloredResourceUpdateStateForCanceledCommand(state string) string {
+	switch state {
+	case "Canceled":
+		return display.Green(string(state))
+	case "Success":
+		return display.Red("Completed (unable to cancel)")
+	case "Failed", "Rejected":
+		return display.Green(string(state))
+	default:
+		return display.Grey(string(state))
 	}
 }
 


### PR DESCRIPTION
This PR changes the coloring of resource update statuses in the detailed status output:
* A resource update that got `canceled`, `rejected` or `failed` is shown as green.  The desired end state for resource updates in case of cancellation is that updates did not execute, in all these states this was the case.
* A resource update that finished is shown as red.
* An in-progress resource update is grey.