### PR TITLE
test(aws): add plugin SDK tests for 8 additional AWS resources

### DIFF
--- a/plugins/aws/testdata/dynamodb-table.pkl
+++ b/plugins/aws/testdata/dynamodb-table.pkl
@@ -1,0 +1,46 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/dynamodb/table.pkl"
+
+local stackName = "plugin-sdk-test-stack"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for DynamoDB Table"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  new table.Table {
+    label = "plugin-sdk-test-table"
+    tableName = "formae-plugin-sdk-test-dynamodb-20250107"
+    billingMode = "PAY_PER_REQUEST"
+    keySchema {
+      new {
+        attributeName = "id"
+        keyType = "HASH"
+      }
+    }
+    attributeDefinitions {
+      new {
+        attributeName = "id"
+        attributeType = "S"
+      }
+    }
+  }
+}

--- a/plugins/aws/testdata/ecr-repository.pkl
+++ b/plugins/aws/testdata/ecr-repository.pkl
@@ -1,0 +1,33 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ecr/repository.pkl"
+
+local stackName = "plugin-sdk-test-stack"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for ECR Repository"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  new repository.Repository {
+    label = "plugin-sdk-test-repo"
+    repositoryName = "formae-plugin-sdk-test-repo-20250107"
+  }
+}

--- a/plugins/aws/testdata/iam-role.pkl
+++ b/plugins/aws/testdata/iam-role.pkl
@@ -1,0 +1,45 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/iam/role.pkl"
+
+local stackName = "plugin-sdk-test-stack"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for IAM Role"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  new role.Role {
+    label = "plugin-sdk-test-role"
+    roleName = "formae-plugin-sdk-test-role-20250107"
+    assumeRolePolicyDocument {
+      ["Version"] = "2012-10-17"
+      ["Statement"] {
+        new {
+          ["Effect"] = "Allow"
+          ["Principal"] {
+            ["Service"] = "lambda.amazonaws.com"
+          }
+          ["Action"] = "sts:AssumeRole"
+        }
+      }
+    }
+  }
+}

--- a/plugins/aws/testdata/iam-user.pkl
+++ b/plugins/aws/testdata/iam-user.pkl
@@ -1,0 +1,33 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/iam/user.pkl"
+
+local stackName = "plugin-sdk-test-stack"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for IAM User"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  new user.User {
+    label = "plugin-sdk-test-user"
+    userName = "formae-plugin-sdk-test-user-20250107"
+  }
+}

--- a/plugins/aws/testdata/kms-key.pkl
+++ b/plugins/aws/testdata/kms-key.pkl
@@ -1,0 +1,33 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/kms/key.pkl"
+
+local stackName = "plugin-sdk-test-stack"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for KMS Key"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  new key.Key {
+    label = "plugin-sdk-test-key"
+    description = "Formae plugin SDK test key"
+  }
+}

--- a/plugins/aws/testdata/logs-loggroup.pkl
+++ b/plugins/aws/testdata/logs-loggroup.pkl
@@ -1,0 +1,33 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/logs/loggroup.pkl"
+
+local stackName = "plugin-sdk-test-stack"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for CloudWatch Logs LogGroup"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  new loggroup.LogGroup {
+    label = "plugin-sdk-test-loggroup"
+    logGroupName = "/formae/plugin-sdk-test/20250107"
+  }
+}

--- a/plugins/aws/testdata/secretsmanager-secret.pkl
+++ b/plugins/aws/testdata/secretsmanager-secret.pkl
@@ -1,0 +1,34 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/secretsmanager/secret.pkl"
+
+local stackName = "plugin-sdk-test-stack"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for Secrets Manager Secret"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  new secret.Secret {
+    label = "plugin-sdk-test-secret"
+    name = "formae-plugin-sdk-test-secret-20250107"
+    description = "Formae plugin SDK test secret"
+  }
+}

--- a/plugins/aws/testdata/sqs-queue.pkl
+++ b/plugins/aws/testdata/sqs-queue.pkl
@@ -1,0 +1,33 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/sqs/queue.pkl"
+
+local stackName = "plugin-sdk-test-stack"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for SQS Queue"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  new queue.Queue {
+    label = "plugin-sdk-test-queue"
+    queueName = "formae-plugin-sdk-test-queue-20250107"
+  }
+}


### PR DESCRIPTION
Add plugin SDK tests for:
- DynamoDB Table (PAY_PER_REQUEST billing)
- ECR Repository (container registry)
- IAM Role (with Lambda trust policy)
- IAM User (basic user)
- KMS Key (encryption key)
- CloudWatch Logs LogGroup
- Secrets Manager Secret
- SQS Queue (standard queue)
