### PR TITLE
chore: examine discovery loading

### DIFF
--- a/internal/metastructure/datastore/datastore.go
+++ b/internal/metastructure/datastore/datastore.go
@@ -85,7 +85,7 @@ type Datastore interface {
 	StoreResource(resource *pkgmodel.Resource, commandID string) (string, error)
 	DeleteResource(resource *pkgmodel.Resource, commandID string) (string, error)
 	LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resource, error)
-	LoadResourceByNativeID(nativeID string) (*pkgmodel.Resource, error)
+	LoadResourceByNativeID(nativeID string, resourceType string) (*pkgmodel.Resource, error)
 	LoadAllResources() ([]*pkgmodel.Resource, error)
 	LatestLabelForResource(label string) (string, error)
 

--- a/internal/metastructure/datastore/postgres.go
+++ b/internal/metastructure/datastore/postgres.go
@@ -735,21 +735,21 @@ func (d DatastorePostgres) LoadResourceById(ksuid string) (*pkgmodel.Resource, e
 	return &resource, nil
 }
 
-func (d DatastorePostgres) LoadResourceByNativeID(nativeID string) (*pkgmodel.Resource, error) {
+func (d DatastorePostgres) LoadResourceByNativeID(nativeID string, resourceType string) (*pkgmodel.Resource, error) {
 	query := `
 	SELECT data, ksuid
 	FROM resources r1
-	WHERE native_id = $1
+	WHERE native_id = $1 AND type = $2
 	AND NOT EXISTS (
 		SELECT 1
 		FROM resources r2
 		WHERE r1.uri = r2.uri
 		AND r2.version > r1.version
 	)
-	AND r1.operation != $2
+	AND r1.operation != $3
 	LIMIT 1
 	`
-	row := d.pool.QueryRow(context.Background(), query, nativeID, resource_update.OperationDelete)
+	row := d.pool.QueryRow(context.Background(), query, nativeID, resourceType, resource_update.OperationDelete)
 
 	var jsonData string
 	var ksuid string

--- a/internal/metastructure/datastore/sqlite.go
+++ b/internal/metastructure/datastore/sqlite.go
@@ -577,11 +577,11 @@ func (d DatastoreSQLite) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resourc
 	return &loadedResource, nil
 }
 
-func (d DatastoreSQLite) LoadResourceByNativeID(nativeID string) (*pkgmodel.Resource, error) {
+func (d DatastoreSQLite) LoadResourceByNativeID(nativeID string, resourceType string) (*pkgmodel.Resource, error) {
 	query := `
 	SELECT data, ksuid
 	FROM resources r1
-	WHERE native_id = ?
+	WHERE native_id = ? AND type = ?
 	AND NOT EXISTS (
 		SELECT 1
 		FROM resources r2
@@ -591,7 +591,7 @@ func (d DatastoreSQLite) LoadResourceByNativeID(nativeID string) (*pkgmodel.Reso
 	AND r1.operation != ?
 	LIMIT 1
 	`
-	row := d.conn.QueryRow(query, nativeID, resource_update.OperationDelete)
+	row := d.conn.QueryRow(query, nativeID, resourceType, resource_update.OperationDelete)
 
 	var jsonData string
 	var ksuid string


### PR DESCRIPTION
Fix discovery bug where resources with same native ID but different types were incorrectly deduplicated