### PR TITLE
fix(pkl): convert generatorDir to URL for pkl-go 0.12.0 compatibility

### DIFF
--- a/plugins/pkl/pkl_serialize_local.go
+++ b/plugins/pkl/pkl_serialize_local.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -47,10 +48,15 @@ func (p PKL) serializeWithPKL(data any, options *plugin.SerializeOptions) (strin
 		"Json": string(input),
 	}
 
+	generatorURL, err := url.Parse("file://" + generatorDir)
+	if err != nil {
+		return "", fmt.Errorf("error parsing generator directory path: %w", err)
+	}
+
 	// Use the local generator directory directly with ProjectEvaluator
 	evaluator, err := pkl.NewProjectEvaluator(
 		context.Background(),
-		generatorDir,
+		generatorURL,
 		pkl.PreconfiguredOptions,
 		pkl.WithResourceReader(libExtension{}),
 		func(opts *pkl.EvaluatorOptions) {


### PR DESCRIPTION
## Description
Fixes build failure caused by breaking changes in pkl-go 0.12.0 upgrade.

The `pkl.NewProjectEvaluator` function signature changed to require a `*url.URL` parameter instead of a string for the project directory path. This PR updates the code to properly parse the generator directory path into a URL before passing it to the evaluator.

## Changes
- Added `net/url` import
- Parse `generatorDir` string to `*url.URL` using `url.Parse()` with `file://` scheme
- Pass `generatorURL` instead of `generatorDir` to `pkl.NewProjectEvaluator()`
- Added error handling for URL parsing

## Error Fixed
```
make build-pkl-local
# github.com/platform-engineering-labs/formae/plugins/pkl
./pkl_serialize_local.go:53:3: cannot use generatorDir (variable of type string) as *url.URL value in argument to pkl.NewProjectEvaluator
make: *** [build-pkl-local] Error 1
```

## Testing
Build completes successfully
```
make build-pkl-local
go build -C plugins/pkl -tags local -ldflags="-X 'main.Version=0.75.1'" -buildmode=plugin -o pkl.so
pkl project resolve plugins/pkl/generator/
```

## Related Issues
Closes #80 
