### PR TITLE
feat: base patch resource support

### DIFF
--- a/plugins/aws/schema/pkl/s3/bucket.pkl
+++ b/plugins/aws/schema/pkl/s3/bucket.pkl
@@ -666,3 +666,8 @@ open class Bucket extends formae.Resource {
         stack = parent.stack?.label
     }
 }
+
+@formae.PatchHint{ forClass = Bucket }
+open class BucketPatch extends formae.ResourcePatch {
+  modify: formae.Patch<Bucket>
+}

--- a/plugins/pkl/schema/forma.pkl
+++ b/plugins/pkl/schema/forma.pkl
@@ -10,7 +10,7 @@ import "formae.pkl"
 
 description: formae.Description?
 properties: Dynamic?
-hidden forma: Listing<formae.Resource|formae.Resolvable|formae.Stack|formae.Target>
+hidden forma: Listing<formae.Resource|formae.ResourcePatch|formae.Resolvable|formae.Stack|formae.Target>
 
 /// defaultStack: returns the first defined Stack
 hidden defaultStack: formae.StackResolvable =
@@ -31,40 +31,47 @@ output {
             }
         else
             new formae.FormaRender {
-                Description = module.description
-                Properties = module.properties
-                Stacks = forma.toList().filterIsInstance(formae.Stack).toListing()
-                Targets = forma.toList().filterIsInstance(formae.Target).toListing()
-                Resolvables = forma.toList().filterIsInstance(formae.Resolvable).toListing()
-                Resources = new Listing {
-                    for (res in forma.toList().filterIsInstance(formae.Resource).toListing()) {
-                        (res) {
-                            when (res.stack == null) {
-                                stack = defaultStack
-                            }
-                            when (res.target == null) {
-                                target = defaultTarget
-                            }
-                            tags = (res.tags) {
-                                new {
-                                    key = formae.Tags.FormaeResourceLabel
-                                    value = res.label
-                                }
-                                when (res.group != null) {
-                                    new {
-                                        key = formae.Tags.FormaeResourceGroup
-                                        value = res.group
-                                    }
-                                }
-                                new {
-                                    key = formae.Tags.FormaeStackLabel
-                                    value = res.stack?.label ?? defaultStack.label
-                                }
-                            }
-                        }
+              Description = module.description
+              Properties = module.properties
+              Stacks = forma.toList().filterIsInstance(formae.Stack).toListing()
+              Targets = forma.toList().filterIsInstance(formae.Target).toListing()
+              Resolvables = forma.toList().filterIsInstance(formae.Resolvable).toListing()
+              Resources =
+                let (resources = new Listing {
+                  ...forma.toList().filterIsInstance(formae.Resource).toListing()
+                  ...forma.toList().filterIsInstance(formae.ResourcePatch).map((patch) -> patch.toSparse())
+                })
+                new Listing {
+                for (res in resources) {
+                  (res) {
+                    when (res.stack == null) {
+                      stack = defaultStack
                     }
+                    when (res.target == null) {
+                      target = defaultTarget
+                    }
+                    tags = (res.tags) {
+                      new {
+                        key = formae.Tags.FormaeResourceLabel
+                        value = res.label
+                      }
+                      when (res.group != null) {
+                        new {
+                          key = formae.Tags.FormaeResourceGroup
+                          value = res.group
+                        }
+                      }
+                      new {
+                        key = formae.Tags.FormaeStackLabel
+                        value = res.stack?.label ?? defaultStack.label
+                      }
+                    }
+                  }
                 }
+              }
             }
+
+
     // NOTE: this is needed currently due to the immutability of pkl values on assignment, and the lack of a Reference type
     // when this is addressed we can use a PKL native reference type: https://github.com/apple/pkl/issues/912
     // this is a workaround required to enable the addition of default stack and target support
@@ -75,6 +82,7 @@ output {
             [formae.TargetResolvable] = (it) -> it.label
             [formae.Resolvable] = (it) -> if (it.stack == null && it.type != "Formae::Stack" && it.type != "Formae::Target") (it) { stack = output.value.getResource(it.label, it.type).stack.label } else it
             [formae.Resource] = (it) -> it.render()
+            [formae.ResourcePatch] = (it) -> it.render()
             [formae.SubResource] = (it) -> it.render()
         }
     }

--- a/plugins/pkl/schema/formae.pkl
+++ b/plugins/pkl/schema/formae.pkl
@@ -19,6 +19,8 @@ open class Description {
     fixed Confirm: Boolean = confirm
 }
 
+typealias Patch<T> = Mixin<T | Dynamic>
+
 open class Resource {
     label: String
     group: String?
@@ -45,6 +47,47 @@ open class Resource {
         Schema = self.schema()
         Properties = self.props()
     }
+}
+
+open class ResourceSparse extends Resource {
+  forClass: Class
+  patch: Dynamic(hasProperty("label"))
+
+  label: String = patch.getPropertyOrNull("label")
+  group: String? = patch.getPropertyOrNull("group")
+  target: TargetResolvable? = patch.getPropertyOrNull("target")
+  stack: StackResolvable? = patch.getPropertyOrNull("stack")
+  hidden tags: (Listing<Tag>)? = patch.getPropertyOrNull("tags")
+  fixed managed: Boolean = patch.getPropertyOrNull("managed") ?? true
+
+  local self = this
+  function fields(): Listing<String> = module.fq.fields(reflect.Class(forClass))
+  function hints(): Mapping<String, FieldHint> = module.fq.hints(reflect.Class(forClass))
+  function schema(): Schema = module.fq.schema(reflect.Class(forClass))
+  function type(): String = module.fq.type(reflect.Class(forClass))
+  function props(): Dynamic = module.fq.sparseProps(reflect.Class(forClass), patch)
+
+  function render(): Dynamic = new {
+    Label = self.label
+    Group = self.group
+    Target = self.target
+    Stack = self.stack
+    Managed = self.managed
+
+    Type = self.type()
+    Schema = self.schema()
+    Properties = self.props()
+  }
+}
+
+open class ResourcePatch {
+  hidden modify: Patch
+
+  local self = this
+  function toSparse(): ResourceSparse = new ResourceSparse {
+    forClass = reflect.Class(self.getClass()).annotations.filterIsInstance(PatchHint).first.forClass
+    patch = new Dynamic{} |> self.modify
+  }
 }
 
 open class SubResource {
@@ -120,6 +163,10 @@ open class ListProperty {
 
     fixed ParentProperty: String = parentProperty
     fixed ListParameter: String = listParameter
+}
+
+open class PatchHint extends Annotation {
+  forClass: Class
 }
 
 open class FieldHint extends Annotation {
@@ -466,6 +513,17 @@ class Fq {
             else
                 Pair(key, resource.getPropertyOrNull(k))
         ).toDynamic()
+
+  function sparseProps(resourceClass: reflect.Class, resource: Dynamic): Dynamic =
+    let(resourceHint = findResourceHint(resourceClass))
+      resourceClass.properties.filter((_, v) -> v.allAnnotations.filterIsInstance(FieldHint).length > 0).filter((k, _) -> resource.hasProperty(k)).map((k, v) ->
+        let(fieldHint = v.allAnnotations.filterIsInstance(FieldHint).firstOrNull)
+          let(key = if(fieldHint.outputField != null) fieldHint.outputField else resourceHint.outputKeyTransformation.apply(k))
+            if (fieldHint.outputTransformation != null && resource.getPropertyOrNull(k) != null && fieldHint.outputCondition.apply(resource.getPropertyOrNull(k)))
+              Pair(key, fieldHint.outputTransformation.apply(resource.getPropertyOrNull(k)))
+            else
+              Pair(key, resource.getPropertyOrNull(k))
+      ).toDynamic()
 
     function schema(resourceClass: reflect.Class): Schema =
         let (hint = findResourceHint(resourceClass))

--- a/plugins/pkl/testdata/forma/resource_patch_test.pkl
+++ b/plugins/pkl/testdata/forma/resource_patch_test.pkl
@@ -1,0 +1,40 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+import "@aws/aws.pkl"
+import "@aws/s3/bucket.pkl"
+
+properties {
+  name = new formae.Prop {
+    flag = "name"
+    default = "pel-patch-test"
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = "pel-s3-simple-bucket"
+    description = "Stack for a simple S3 Bucket"
+  }
+
+  new formae.Target {
+    label = "default-aws-target"
+    config = new aws.Config {
+      region = "us-west-2"
+    }
+  }
+
+  new bucket.BucketPatch {
+    modify {
+      label = "bucket-to-patch"
+      versioningConfiguration = new bucket.VersioningConfiguration {
+        status = "Enabled"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is draft of what a patch with only provided fields could look like. Unsure if we will carry this forward or not.

```pkl
new bucket.BucketPatch {
  modify { // name of this node could be better, only needed due to type system limitations
    // must provide the label of the resource to patch
    label = "bucket-to-patch"
    // any properties that are to change validated against the schema inline as expected
    versioningConfiguration = new bucket.VersioningConfiguration {
      status = "Enabled"
    }
  }
}
```

Sadly if Pkl supported extending `Mixin` or annotating functions the result could have been:
```pkl
new Patch<bucket.Bucket> {
  label = "bucket-to-patch"
  versioningConfiguration = new bucket.VersioningConfiguration {
    status = "Enabled"
  }
}
```