### PR TITLE
 perf(forma_persister): add caching and O(1) lookup for resource updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,5 +76,8 @@ CLAUDE.md
 .research/
 .plans/
 
+# Design docs (local investigation notes)
+docs/design/
+
 # MCP
 .serena/

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,18 @@ pkg-bin: clean build build-tools
 publish-bin: pkg-bin
 	./ppm repo publish ./dist/packages/*.tgz
 
+postgres-up:
+	docker rm -f formae-test-postgres 2>/dev/null || true
+	docker run -d --name formae-test-postgres \
+		-e POSTGRES_USER=formae \
+		-e POSTGRES_PASSWORD=formae \
+		-e POSTGRES_DB=formae \
+		-p 5433:5432 \
+		postgres:15-alpine
+
+postgres-down:
+	docker rm -f formae-test-postgres
+
 gen-pkl:
 	echo '${VERSION}' > ./version.semver
 	pkl project resolve plugins/pkl/schema
@@ -184,7 +196,7 @@ test-e2e: gen-pkl pkg-pkl build
 		exit $$E2E_EXIT_CODE
 
 test-property:
-	go test -tags=property -failfast ./internal/workflow_tests -run 'TestMetastructure_Property.*'
+	go test -tags=property -failfast ./internal/workflow_tests/local -run 'TestMetastructure_Property.*'
 
 test-schema-pkl:
 	cd plugins/pkl/schema && pkl test tests/formae.pkl

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -563,6 +563,23 @@ const docTemplate = `{
                 }
             }
         },
+        "model.PluginInfo": {
+            "type": "object",
+            "properties": {
+                "MaxRequestsPerSecond": {
+                    "type": "integer"
+                },
+                "Namespace": {
+                    "type": "string"
+                },
+                "NodeName": {
+                    "type": "string"
+                },
+                "ResourceCount": {
+                    "type": "integer"
+                }
+            }
+        },
         "model.Prop": {
             "type": "object",
             "properties": {
@@ -764,6 +781,12 @@ const docTemplate = `{
                     "type": "object",
                     "additionalProperties": {
                         "type": "integer"
+                    }
+                },
+                "Plugins": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.PluginInfo"
                     }
                 },
                 "ResourceErrors": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -557,6 +557,23 @@
                 }
             }
         },
+        "model.PluginInfo": {
+            "type": "object",
+            "properties": {
+                "MaxRequestsPerSecond": {
+                    "type": "integer"
+                },
+                "Namespace": {
+                    "type": "string"
+                },
+                "NodeName": {
+                    "type": "string"
+                },
+                "ResourceCount": {
+                    "type": "integer"
+                }
+            }
+        },
         "model.Prop": {
             "type": "object",
             "properties": {
@@ -758,6 +775,12 @@
                     "type": "object",
                     "additionalProperties": {
                         "type": "integer"
+                    }
+                },
+                "Plugins": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.PluginInfo"
                     }
                 },
                 "ResourceErrors": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -83,6 +83,17 @@ definitions:
           $ref: '#/definitions/github_com_platform-engineering-labs_formae_internal_api_model.Command'
         type: array
     type: object
+  model.PluginInfo:
+    properties:
+      MaxRequestsPerSecond:
+        type: integer
+      Namespace:
+        type: string
+      NodeName:
+        type: string
+      ResourceCount:
+        type: integer
+    type: object
   model.Prop:
     properties:
       Default: {}
@@ -218,6 +229,10 @@ definitions:
         additionalProperties:
           type: integer
         type: object
+      Plugins:
+        items:
+          $ref: '#/definitions/model.PluginInfo'
+        type: array
       ResourceErrors:
         additionalProperties:
           type: integer

--- a/examples/complete/lifeline/vars.pkl
+++ b/examples/complete/lifeline/vars.pkl
@@ -9,7 +9,7 @@ import "@aws/aws.pkl"
 
 projectName = "lifeline"
 stackName = "lifeline"
-region = "us-east-1"
+region = "us-east-2"
 
 regionProp = new formae.Prop {
     flag = "region"

--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,12 @@ require (
 	ergo.services/actor/statemachine v0.0.0-20251202053101-c0aa08b403e5
 	ergo.services/application v0.0.0-20240904055159-7f2e1a954c05
 	ergo.services/ergo v1.999.310
-	github.com/alecthomas/chroma/v2 v2.20.0
 	github.com/blugelabs/bluge v0.1.7
 	github.com/blugelabs/query_string v0.3.0
 	github.com/ddddddO/gtree v1.11.3
 	github.com/demula/mksuid/v2 v2.0.1
 	github.com/fatih/color v1.18.0
+	github.com/goccy/go-json v0.10.5
 	github.com/google/uuid v1.6.0
 	github.com/gookit/color v1.5.4
 	github.com/jackc/pgx/v5 v5.7.6
@@ -86,7 +86,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
-	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,12 +42,6 @@ github.com/RoaringBitmap/roaring v0.9.1/go.mod h1:h1B7iIUOmnAeb5ytYMvnHJwxMc6LUr
 github.com/STARRY-S/zip v0.2.1 h1:pWBd4tuSGm3wtpoqRZZ2EAwOmcHK6XFf7bU9qcJXyFg=
 github.com/STARRY-S/zip v0.2.1/go.mod h1:xNvshLODWtC4EJ702g7cTYn13G53o1+X9BWnPFpcWV4=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
-github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
-github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/chroma/v2 v2.20.0 h1:sfIHpxPyR07/Oylvmcai3X/exDlE8+FA820NTz+9sGw=
-github.com/alecthomas/chroma/v2 v2.20.0/go.mod h1:e7tViK0xh/Nf4BYHl00ycY6rV7b8iXBksI9E359yNmA=
-github.com/alecthomas/repr v0.5.1 h1:E3G4t2QbHTSNpPKBgMTln5KLkZHLOcU7r37J4pXBuIg=
-github.com/alecthomas/repr v0.5.1/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -112,8 +106,6 @@ github.com/demula/mksuid/v2 v2.0.1 h1:XbgVHRregXvQW3jHdXcZkqqQXvnMBQVSb27+GdRSKT
 github.com/demula/mksuid/v2 v2.0.1/go.mod h1:mP1CoqPjVQX4iRoUftWENfi/iApB4iYdbYRn7XbRIq4=
 github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc h1:8WFBn63wegobsYAX0YjD+8suexZDga5CctH4CCTx2+8=
 github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
-github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
-github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 h1:2tV76y6Q9BB+NEBasnqvs7e49aEBFI8ejC89PSnWH+4=
 github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707/go.mod h1:qssHWj60/X5sZFNxpG4HBPDHVqxNm4DfnCKgrbZOT+s=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
@@ -157,6 +149,8 @@ github.com/go-openapi/swag/typeutils v0.25.1 h1:rD/9HsEQieewNt6/k+JBwkxuAHktFtH3
 github.com/go-openapi/swag/typeutils v0.25.1/go.mod h1:9McMC/oCdS4BKwk2shEB7x17P6HmMmA6dQRtAkSnNb8=
 github.com/go-openapi/swag/yamlutils v0.25.1 h1:mry5ez8joJwzvMbaTGLhw8pXUnhDK91oSJLDPF1bmGk=
 github.com/go-openapi/swag/yamlutils v0.25.1/go.mod h1:cm9ywbzncy3y6uPm/97ysW8+wZ09qsks+9RS8fLWKqg=
+github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
+github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -211,8 +205,6 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
-github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/api/otel.go
+++ b/internal/api/otel.go
@@ -132,7 +132,7 @@ func statsToPrometheusMetrics(stats *apimodel.Stats) []promcli.Metric {
 						processNumber(element, elementName, labels)
 
 					default:
-						slog.Warn("skipping unsupported slice/array element type", "elementName", elementName, "elementType", element.Kind())
+						slog.Debug("skipping unsupported slice/array element type", "elementName", elementName, "elementType", element.Kind())
 					}
 				}
 

--- a/internal/metastructure/bridge_actor.go
+++ b/internal/metastructure/bridge_actor.go
@@ -40,7 +40,7 @@ func (b *MetastructureBridge) HandleMessage(from gen.PID, message any) error {
 	switch msg := message.(type) {
 	case CallActorRequest:
 		// Make the synchronous call to the target actor
-		response, err := b.Call(msg.TargetPID, msg.Message)
+		response, err := b.CallWithTimeout(msg.TargetPID, msg.Message, 10)
 
 		// Send the result back through the appropriate channel
 		if err != nil {

--- a/internal/metastructure/datastore/datastore.go
+++ b/internal/metastructure/datastore/datastore.go
@@ -5,8 +5,12 @@
 package datastore
 
 import (
+	"time"
+
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/stats"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/types"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
@@ -70,46 +74,121 @@ type ResourceModification struct {
 	Operation string
 }
 
-type Datastore interface {
-	StoreFormaCommand(fa *forma_command.FormaCommand, commandID string) error
-	LoadFormaCommands() ([]*forma_command.FormaCommand, error)
-	LoadIncompleteFormaCommands() ([]*forma_command.FormaCommand, error)
-	DeleteFormaCommand(fa *forma_command.FormaCommand, commandID string) error
+// ResourceUpdateRef identifies a specific ResourceUpdate by its key components
+// Used for batch operations on ResourceUpdates
+type ResourceUpdateRef struct {
+	KSUID     string
+	Operation types.OperationType
+}
 
+// Datastore defines the persistence interface for formae.
+// It handles storage and retrieval of FormaCommands (requested changes),
+// Resources (actual cloud state), Stacks, and Targets.
+type Datastore interface {
+	// FormaCommand operations - these represent requested changes to infrastructure
+
+	// StoreFormaCommand persists a new FormaCommand with its ResourceUpdates
+	StoreFormaCommand(fa *forma_command.FormaCommand, commandID string) error
+	// LoadFormaCommands returns all stored FormaCommands
+	LoadFormaCommands() ([]*forma_command.FormaCommand, error)
+	// LoadIncompleteFormaCommands returns FormaCommands that haven't reached a terminal state
+	LoadIncompleteFormaCommands() ([]*forma_command.FormaCommand, error)
+	// DeleteFormaCommand removes a FormaCommand and its associated ResourceUpdates
+	DeleteFormaCommand(fa *forma_command.FormaCommand, commandID string) error
+	// GetFormaCommandByCommandID retrieves a single FormaCommand by its ID
 	GetFormaCommandByCommandID(commandID string) (*forma_command.FormaCommand, error)
+	// GetMostRecentFormaCommandByClientID returns the latest command for a given client
 	GetMostRecentFormaCommandByClientID(clientID string) (*forma_command.FormaCommand, error)
+	// GetResourceModificationsSinceLastReconcile returns resources modified since the last reconcile
 	GetResourceModificationsSinceLastReconcile(stack string) ([]ResourceModification, error)
+	// QueryFormaCommands searches commands based on filter criteria
 	QueryFormaCommands(query *StatusQuery) ([]*forma_command.FormaCommand, error)
 
+	// Resource operations - these represent actual cloud state
+
+	// QueryResources searches resources based on filter criteria
 	QueryResources(query *ResourceQuery) ([]*pkgmodel.Resource, error)
+	// StoreResource persists a resource after successful creation/update in the cloud
 	StoreResource(resource *pkgmodel.Resource, commandID string) (string, error)
+	// DeleteResource removes a resource record after successful deletion in the cloud
 	DeleteResource(resource *pkgmodel.Resource, commandID string) (string, error)
+	// LoadResource retrieves a resource by its formae URI
 	LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resource, error)
+	// LoadResourceByNativeID finds a resource by its cloud provider native ID
 	LoadResourceByNativeID(nativeID string, resourceType string) (*pkgmodel.Resource, error)
+	// LoadAllResources returns all stored resources
 	LoadAllResources() ([]*pkgmodel.Resource, error)
+	// LatestLabelForResource returns the most recent label variant for a resource
 	LatestLabelForResource(label string) (string, error)
-
-	StoreStack(stack *pkgmodel.Forma, commandID string) (string, error)
-	LoadStack(stackLabel string) (*pkgmodel.Forma, error)
-	LoadAllStacks() ([]*pkgmodel.Forma, error)
-
-	CreateTarget(target *pkgmodel.Target) (string, error)
-	UpdateTarget(target *pkgmodel.Target) (string, error)
-	LoadTarget(targetLabel string) (*pkgmodel.Target, error)
-	LoadAllTargets() ([]*pkgmodel.Target, error)
-	LoadTargetsByLabels(targetNames []string) ([]*pkgmodel.Target, error)
-	LoadDiscoverableTargets() ([]*pkgmodel.Target, error)
-	QueryTargets(query *TargetQuery) ([]*pkgmodel.Target, error)
-
-	Stats() (*stats.Stats, error)
-
-	GetKSUIDByTriplet(stack, label, resourceType string) (string, error)
-	BatchGetKSUIDsByTriplets(triplets []pkgmodel.TripletKey) (map[pkgmodel.TripletKey]string, error)
-	BatchGetTripletsByKSUIDs(ksuids []string) (map[string]pkgmodel.TripletKey, error)
+	// LoadResourceById retrieves a resource by its KSUID
 	LoadResourceById(ksuid string) (*pkgmodel.Resource, error)
 
-	CleanUp() error
+	// Stack operations - logical groupings of resources
+
+	// StoreStack persists a stack definition
+	StoreStack(stack *pkgmodel.Forma, commandID string) (string, error)
+	// LoadStack retrieves a stack by its label
+	LoadStack(stackLabel string) (*pkgmodel.Forma, error)
+	// LoadAllStacks returns all stored stacks
+	LoadAllStacks() ([]*pkgmodel.Forma, error)
+
+	// Target operations - cloud provider configurations
+
+	// CreateTarget persists a new target configuration
+	CreateTarget(target *pkgmodel.Target) (string, error)
+	// UpdateTarget modifies an existing target configuration
+	UpdateTarget(target *pkgmodel.Target) (string, error)
+	// LoadTarget retrieves a target by its label
+	LoadTarget(targetLabel string) (*pkgmodel.Target, error)
+	// LoadAllTargets returns all stored targets
+	LoadAllTargets() ([]*pkgmodel.Target, error)
+	// LoadTargetsByLabels retrieves multiple targets by their labels
+	LoadTargetsByLabels(targetNames []string) ([]*pkgmodel.Target, error)
+	// LoadDiscoverableTargets returns targets that have discovery enabled
+	LoadDiscoverableTargets() ([]*pkgmodel.Target, error)
+	// QueryTargets searches targets based on filter criteria
+	QueryTargets(query *TargetQuery) ([]*pkgmodel.Target, error)
+
+	// Stats returns aggregated statistics about the datastore contents
+	Stats() (*stats.Stats, error)
+
+	// KSUID/Triplet mapping - conversion between internal IDs and user-facing identifiers
+
+	// GetKSUIDByTriplet converts a (stack, label, type) triplet to a KSUID
+	GetKSUIDByTriplet(stack, label, resourceType string) (string, error)
+	// BatchGetKSUIDsByTriplets converts multiple triplets to KSUIDs in one query
+	BatchGetKSUIDsByTriplets(triplets []pkgmodel.TripletKey) (map[pkgmodel.TripletKey]string, error)
+	// BatchGetTripletsByKSUIDs converts multiple KSUIDs to triplets in one query
+	BatchGetTripletsByKSUIDs(ksuids []string) (map[string]pkgmodel.TripletKey, error)
+
+	// Close releases database connections
 	Close()
+
+	// ResourceUpdate methods for normalized schema
+	// These methods work with the resource_updates table for improved write performance
+
+	// BulkStoreResourceUpdates stores multiple ResourceUpdates in a single transaction
+	// Used when creating a new FormaCommand
+	BulkStoreResourceUpdates(commandID string, updates []resource_update.ResourceUpdate) error
+
+	// LoadResourceUpdates loads all ResourceUpdates for a given command
+	LoadResourceUpdates(commandID string) ([]resource_update.ResourceUpdate, error)
+
+	// UpdateResourceUpdateState updates the state of a single ResourceUpdate
+	// This is the key performance improvement: updating one row instead of re-serializing entire command
+	UpdateResourceUpdateState(commandID string, ksuid string, operation types.OperationType, state resource_update.ResourceUpdateState, modifiedTs time.Time) error
+
+	// UpdateResourceUpdateProgress updates a ResourceUpdate with progress information
+	UpdateResourceUpdateProgress(commandID string, ksuid string, operation types.OperationType, state resource_update.ResourceUpdateState, modifiedTs time.Time, progress resource.ProgressResult) error
+
+	// BatchUpdateResourceUpdateState updates multiple ResourceUpdates to the same state
+	// Used for bulk operations like marking dependent resources as failed
+	BatchUpdateResourceUpdateState(commandID string, refs []ResourceUpdateRef, state resource_update.ResourceUpdateState, modifiedTs time.Time) error
+
+	// UpdateFormaCommandProgress updates only the command-level metadata (state, modified_ts)
+	// without re-writing all ResourceUpdates. This is a performance optimization for
+	// progress updates where the ResourceUpdate is already updated via UpdateResourceUpdateProgress.
+	UpdateFormaCommandProgress(commandID string, state forma_command.CommandState, modifiedTs time.Time) error
 }
 
 // resourcesAreEqual compares two resources and returns two booleans: the first one indicating whether the

--- a/internal/metastructure/datastore/datastore_stack_transition_test.go
+++ b/internal/metastructure/datastore/datastore_stack_transition_test.go
@@ -21,7 +21,7 @@ func TestDatastore_StackTransition(t *testing.T) {
 	t.Run("preserves KSUID when transitioning from unmanaged to managed", func(t *testing.T) {
 		ds, err := prepareDatastore()
 		require.NoError(t, err)
-		defer ds.CleanUp()
+		defer cleanupDatastore(ds)
 
 		unmanagedResource := &pkgmodel.Resource{
 			NativeID: "vpc-12345",
@@ -80,7 +80,7 @@ func TestDatastore_StackTransition(t *testing.T) {
 	t.Run("preserves native ID during stack transition", func(t *testing.T) {
 		ds, err := prepareDatastore()
 		require.NoError(t, err)
-		defer ds.CleanUp()
+		defer cleanupDatastore(ds)
 
 		nativeID := "subnet-abc123"
 		unmanagedResource := &pkgmodel.Resource{
@@ -136,7 +136,7 @@ func TestDatastore_StackTransition(t *testing.T) {
 	t.Run("preserves read only properties during stack transition", func(t *testing.T) {
 		ds, err := prepareDatastore()
 		require.NoError(t, err)
-		defer ds.CleanUp()
+		defer cleanupDatastore(ds)
 
 		readOnlyProps := json.RawMessage(`{
 			"VpcId": "vpc-readonly-test",
@@ -188,7 +188,7 @@ func TestDatastore_StackTransition(t *testing.T) {
 	t.Run("multiple unmanaged resources transition independently", func(t *testing.T) {
 		ds, err := prepareDatastore()
 		require.NoError(t, err)
-		defer ds.CleanUp()
+		defer cleanupDatastore(ds)
 
 		vpc1 := &pkgmodel.Resource{
 			NativeID:           "vpc-independent-1",
@@ -252,7 +252,7 @@ func TestDatastore_StackTransition(t *testing.T) {
 	t.Run("handles property changes during stack transition", func(t *testing.T) {
 		ds, err := prepareDatastore()
 		require.NoError(t, err)
-		defer ds.CleanUp()
+		defer cleanupDatastore(ds)
 
 		unmanagedResource := &pkgmodel.Resource{
 			NativeID: "vpc-prop-change",
@@ -308,7 +308,7 @@ func TestDatastore_StackTransition(t *testing.T) {
 	t.Run("batch get KSUIDs works for resources in different stacks", func(t *testing.T) {
 		ds, err := prepareDatastore()
 		require.NoError(t, err)
-		defer ds.CleanUp()
+		defer cleanupDatastore(ds)
 
 		vpc1 := &pkgmodel.Resource{
 			NativeID:   "vpc-batch-1",

--- a/internal/metastructure/datastore/migrations_postgres/00003_resource_updates.sql
+++ b/internal/metastructure/datastore/migrations_postgres/00003_resource_updates.sql
@@ -1,0 +1,42 @@
+-- +goose Up
+-- Create the resource_updates table to store ResourceUpdates separately from forma_commands
+-- This enables O(1) lookups and updates instead of deserializing the entire JSON blob
+CREATE TABLE IF NOT EXISTS resource_updates (
+    command_id TEXT NOT NULL,
+    ksuid TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    state TEXT NOT NULL,
+    start_ts TIMESTAMP,
+    modified_ts TIMESTAMP,
+    retries INTEGER DEFAULT 0,
+    remaining INTEGER DEFAULT 0,
+    version TEXT,
+    stack_label TEXT,
+    group_id TEXT,
+    source TEXT,
+    resource TEXT,
+    resource_target TEXT,
+    existing_resource TEXT,
+    existing_target TEXT,
+    metadata TEXT,
+    progress_result TEXT,
+    most_recent_progress TEXT,
+    remaining_resolvables TEXT,
+    reference_labels TEXT,
+    previous_properties TEXT,
+    PRIMARY KEY (command_id, ksuid, operation)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ru_command_id ON resource_updates (command_id);
+CREATE INDEX IF NOT EXISTS idx_ru_ksuid ON resource_updates (ksuid);
+CREATE INDEX IF NOT EXISTS idx_ru_state ON resource_updates (state);
+CREATE INDEX IF NOT EXISTS idx_ru_stack_label ON resource_updates (stack_label);
+CREATE INDEX IF NOT EXISTS idx_ru_operation ON resource_updates (operation);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_ru_operation;
+DROP INDEX IF EXISTS idx_ru_stack_label;
+DROP INDEX IF EXISTS idx_ru_state;
+DROP INDEX IF EXISTS idx_ru_ksuid;
+DROP INDEX IF EXISTS idx_ru_command_id;
+DROP TABLE IF EXISTS resource_updates;

--- a/internal/metastructure/datastore/migrations_postgres/00004_normalize_forma_commands.sql
+++ b/internal/metastructure/datastore/migrations_postgres/00004_normalize_forma_commands.sql
@@ -1,0 +1,90 @@
+-- +goose Up
+-- Add new columns to forma_commands for normalized storage
+-- These columns replace the JSON blob in the 'data' column
+
+-- Normalize description: was JSON {Text, Confirm}, now separate columns
+ALTER TABLE forma_commands ADD COLUMN IF NOT EXISTS description_text TEXT;
+ALTER TABLE forma_commands ADD COLUMN IF NOT EXISTS description_confirm BOOLEAN DEFAULT FALSE;
+
+-- Normalize config: was JSON {Mode, Force, Simulate}, now separate columns
+ALTER TABLE forma_commands ADD COLUMN IF NOT EXISTS config_mode TEXT DEFAULT 'reconcile';
+ALTER TABLE forma_commands ADD COLUMN IF NOT EXISTS config_force BOOLEAN DEFAULT FALSE;
+ALTER TABLE forma_commands ADD COLUMN IF NOT EXISTS config_simulate BOOLEAN DEFAULT FALSE;
+
+-- Keep target_updates as JSON (array type, genuinely dynamic)
+ALTER TABLE forma_commands ADD COLUMN IF NOT EXISTS target_updates TEXT;
+ALTER TABLE forma_commands ADD COLUMN IF NOT EXISTS modified_ts TIMESTAMP;
+
+-- Migrate existing data from the JSON blob to the new columns
+UPDATE forma_commands
+SET
+    description_text = (data::jsonb->'Description')->>'Text',
+    description_confirm = (data::jsonb->'Description')->>'Confirm' = 'true',
+    config_mode = COALESCE((data::jsonb->'Config')->>'Mode', 'reconcile'),
+    config_force = (data::jsonb->'Config')->>'Force' = 'true',
+    config_simulate = (data::jsonb->'Config')->>'Simulate' = 'true',
+    target_updates = (data::jsonb->'TargetUpdates')::text,
+    modified_ts = CASE
+        WHEN data::jsonb->>'ModifiedTs' IS NOT NULL AND data::jsonb->>'ModifiedTs' != ''
+        THEN (data::jsonb->>'ModifiedTs')::timestamp
+        ELSE NULL
+    END
+WHERE data IS NOT NULL;
+
+-- Migrate ResourceUpdates from the JSON blob to the resource_updates table
+-- Uses jsonb_array_elements to iterate through the JSON array
+INSERT INTO resource_updates (
+    command_id, ksuid, operation, state, start_ts, modified_ts,
+    retries, remaining, version, stack_label, group_id, source,
+    resource, resource_target, existing_resource, existing_target,
+    metadata, progress_result, most_recent_progress,
+    remaining_resolvables, reference_labels, previous_properties
+)
+SELECT
+    fc.command_id,
+    (ru->'Resource')->>'Ksuid',
+    ru->>'Operation',
+    ru->>'State',
+    CASE WHEN ru->>'StartTs' IS NOT NULL AND ru->>'StartTs' != '' THEN (ru->>'StartTs')::timestamp ELSE NULL END,
+    CASE WHEN ru->>'ModifiedTs' IS NOT NULL AND ru->>'ModifiedTs' != '' THEN (ru->>'ModifiedTs')::timestamp ELSE NULL END,
+    COALESCE((ru->>'Retries')::integer, 0),
+    COALESCE((ru->>'Remaining')::integer, 0),
+    ru->>'Version',
+    COALESCE(ru->>'StackLabel', (ru->'Resource')->>'Stack'),
+    ru->>'GroupID',
+    ru->>'Source',
+    (ru->'Resource')::text,
+    (ru->'ResourceTarget')::text,
+    (ru->'ExistingResource')::text,
+    (ru->'ExistingTarget')::text,
+    (ru->'MetaData')::text,
+    (ru->'ProgressResult')::text,
+    (ru->'MostRecentProgressResult')::text,
+    (ru->'RemainingResolvables')::text,
+    (ru->'ReferenceLabels')::text,
+    (ru->'PreviousProperties')::text
+FROM forma_commands fc,
+     jsonb_array_elements(fc.data::jsonb->'ResourceUpdates') ru
+WHERE fc.data IS NOT NULL
+  AND fc.data::jsonb->'ResourceUpdates' IS NOT NULL
+  AND jsonb_array_length(fc.data::jsonb->'ResourceUpdates') > 0
+  -- Only migrate ResourceUpdates with a version set (matching production behavior)
+  -- Sync commands without detected changes have empty versions and don't need persistence
+  AND ru->>'Version' IS NOT NULL
+  AND ru->>'Version' != ''
+ON CONFLICT (command_id, ksuid, operation) DO NOTHING;
+
+-- +goose Down
+-- Remove the migrated resource_updates (only those that came from migration)
+-- Note: This is a best-effort rollback - new data added after migration won't be affected
+DELETE FROM resource_updates WHERE command_id IN (
+    SELECT command_id FROM forma_commands WHERE data IS NOT NULL
+);
+
+ALTER TABLE forma_commands DROP COLUMN IF EXISTS modified_ts;
+ALTER TABLE forma_commands DROP COLUMN IF EXISTS target_updates;
+ALTER TABLE forma_commands DROP COLUMN IF EXISTS config_simulate;
+ALTER TABLE forma_commands DROP COLUMN IF EXISTS config_force;
+ALTER TABLE forma_commands DROP COLUMN IF EXISTS config_mode;
+ALTER TABLE forma_commands DROP COLUMN IF EXISTS description_confirm;
+ALTER TABLE forma_commands DROP COLUMN IF EXISTS description_text;

--- a/internal/metastructure/datastore/migrations_postgres/00005_replace_forma_with_description.sql
+++ b/internal/metastructure/datastore/migrations_postgres/00005_replace_forma_with_description.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- Drop the data column now that all data has been migrated to normalized columns
+-- PostgreSQL supports DROP COLUMN directly
+ALTER TABLE forma_commands DROP COLUMN IF EXISTS data;
+
+-- Add index for the normalized config_mode column (used in queries)
+CREATE INDEX IF NOT EXISTS idx_config_mode ON forma_commands (config_mode);
+
+-- +goose Down
+-- Add back the data column
+-- Note: This is a destructive operation - we cannot fully restore the original JSON data
+-- The down migration creates the column but leaves it NULL
+ALTER TABLE forma_commands ADD COLUMN IF NOT EXISTS data TEXT;

--- a/internal/metastructure/datastore/migrations_sqlite/00003_resource_updates.sql
+++ b/internal/metastructure/datastore/migrations_sqlite/00003_resource_updates.sql
@@ -1,0 +1,42 @@
+-- +goose Up
+-- Create the resource_updates table to store ResourceUpdates separately from forma_commands
+-- This enables O(1) lookups and updates instead of deserializing the entire JSON blob
+CREATE TABLE IF NOT EXISTS resource_updates (
+    command_id TEXT NOT NULL,
+    ksuid TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    state TEXT NOT NULL,
+    start_ts TEXT,
+    modified_ts TEXT,
+    retries INTEGER DEFAULT 0,
+    remaining INTEGER DEFAULT 0,
+    version TEXT,
+    stack_label TEXT,
+    group_id TEXT,
+    source TEXT,
+    resource TEXT,
+    resource_target TEXT,
+    existing_resource TEXT,
+    existing_target TEXT,
+    metadata TEXT,
+    progress_result TEXT,
+    most_recent_progress TEXT,
+    remaining_resolvables TEXT,
+    reference_labels TEXT,
+    previous_properties TEXT,
+    PRIMARY KEY (command_id, ksuid, operation)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ru_command_id ON resource_updates (command_id);
+CREATE INDEX IF NOT EXISTS idx_ru_ksuid ON resource_updates (ksuid);
+CREATE INDEX IF NOT EXISTS idx_ru_state ON resource_updates (state);
+CREATE INDEX IF NOT EXISTS idx_ru_stack_label ON resource_updates (stack_label);
+CREATE INDEX IF NOT EXISTS idx_ru_operation ON resource_updates (operation);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_ru_operation;
+DROP INDEX IF EXISTS idx_ru_stack_label;
+DROP INDEX IF EXISTS idx_ru_state;
+DROP INDEX IF EXISTS idx_ru_ksuid;
+DROP INDEX IF EXISTS idx_ru_command_id;
+DROP TABLE IF EXISTS resource_updates;

--- a/internal/metastructure/datastore/migrations_sqlite/00004_normalize_forma_commands.sql
+++ b/internal/metastructure/datastore/migrations_sqlite/00004_normalize_forma_commands.sql
@@ -1,0 +1,84 @@
+-- +goose Up
+-- Add new columns to forma_commands for normalized storage
+-- These columns replace the JSON blob in the 'data' column
+
+-- Normalize description: was JSON {Text, Confirm}, now separate columns
+ALTER TABLE forma_commands ADD COLUMN description_text TEXT;
+ALTER TABLE forma_commands ADD COLUMN description_confirm INTEGER DEFAULT 0;
+
+-- Normalize config: was JSON {Mode, Force, Simulate}, now separate columns
+ALTER TABLE forma_commands ADD COLUMN config_mode TEXT DEFAULT 'reconcile';
+ALTER TABLE forma_commands ADD COLUMN config_force INTEGER DEFAULT 0;
+ALTER TABLE forma_commands ADD COLUMN config_simulate INTEGER DEFAULT 0;
+
+-- Keep target_updates as JSON (array type, genuinely dynamic)
+ALTER TABLE forma_commands ADD COLUMN target_updates TEXT;
+ALTER TABLE forma_commands ADD COLUMN modified_ts TEXT;
+
+-- Migrate existing data from the JSON blob to the new columns
+UPDATE forma_commands
+SET
+    description_text = json_extract(data, '$.Description.Text'),
+    description_confirm = CASE WHEN json_extract(data, '$.Description.Confirm') = true THEN 1 ELSE 0 END,
+    config_mode = COALESCE(json_extract(data, '$.Config.Mode'), 'reconcile'),
+    config_force = CASE WHEN json_extract(data, '$.Config.Force') = true THEN 1 ELSE 0 END,
+    config_simulate = CASE WHEN json_extract(data, '$.Config.Simulate') = true THEN 1 ELSE 0 END,
+    target_updates = json_extract(data, '$.TargetUpdates'),
+    modified_ts = json_extract(data, '$.ModifiedTs')
+WHERE data IS NOT NULL;
+
+-- Migrate ResourceUpdates from the JSON blob to the resource_updates table
+-- This uses a recursive CTE to iterate through the JSON array
+INSERT OR IGNORE INTO resource_updates (
+    command_id, ksuid, operation, state, start_ts, modified_ts,
+    retries, remaining, version, stack_label, group_id, source,
+    resource, resource_target, existing_resource, existing_target,
+    metadata, progress_result, most_recent_progress,
+    remaining_resolvables, reference_labels, previous_properties
+)
+SELECT
+    fc.command_id,
+    json_extract(ru.value, '$.Resource.Ksuid'),
+    json_extract(ru.value, '$.Operation'),
+    json_extract(ru.value, '$.State'),
+    json_extract(ru.value, '$.StartTs'),
+    json_extract(ru.value, '$.ModifiedTs'),
+    COALESCE(json_extract(ru.value, '$.Retries'), 0),
+    COALESCE(json_extract(ru.value, '$.Remaining'), 0),
+    json_extract(ru.value, '$.Version'),
+    COALESCE(json_extract(ru.value, '$.StackLabel'), json_extract(ru.value, '$.Resource.Stack')),
+    json_extract(ru.value, '$.GroupID'),
+    json_extract(ru.value, '$.Source'),
+    json_extract(ru.value, '$.Resource'),
+    json_extract(ru.value, '$.ResourceTarget'),
+    json_extract(ru.value, '$.ExistingResource'),
+    json_extract(ru.value, '$.ExistingTarget'),
+    json_extract(ru.value, '$.MetaData'),
+    json_extract(ru.value, '$.ProgressResult'),
+    json_extract(ru.value, '$.MostRecentProgressResult'),
+    json_extract(ru.value, '$.RemainingResolvables'),
+    json_extract(ru.value, '$.ReferenceLabels'),
+    json_extract(ru.value, '$.PreviousProperties')
+FROM forma_commands fc, json_each(json_extract(fc.data, '$.ResourceUpdates')) ru
+WHERE fc.data IS NOT NULL
+  AND json_extract(fc.data, '$.ResourceUpdates') IS NOT NULL
+  AND json_array_length(json_extract(fc.data, '$.ResourceUpdates')) > 0
+  -- Only migrate ResourceUpdates with a version set (matching production behavior)
+  -- Sync commands without detected changes have empty versions and don't need persistence
+  AND json_extract(ru.value, '$.Version') IS NOT NULL
+  AND json_extract(ru.value, '$.Version') != '';
+
+-- +goose Down
+-- Remove the migrated resource_updates (only those that came from migration)
+-- Note: This is a best-effort rollback - new data added after migration won't be affected
+DELETE FROM resource_updates WHERE command_id IN (
+    SELECT command_id FROM forma_commands WHERE data IS NOT NULL
+);
+
+ALTER TABLE forma_commands DROP COLUMN modified_ts;
+ALTER TABLE forma_commands DROP COLUMN target_updates;
+ALTER TABLE forma_commands DROP COLUMN config_simulate;
+ALTER TABLE forma_commands DROP COLUMN config_force;
+ALTER TABLE forma_commands DROP COLUMN config_mode;
+ALTER TABLE forma_commands DROP COLUMN description_confirm;
+ALTER TABLE forma_commands DROP COLUMN description_text;

--- a/internal/metastructure/datastore/migrations_sqlite/00005_replace_forma_with_description.sql
+++ b/internal/metastructure/datastore/migrations_sqlite/00005_replace_forma_with_description.sql
@@ -1,0 +1,95 @@
+-- +goose Up
+-- Drop the data column now that all data has been migrated to normalized columns
+-- SQLite doesn't support DROP COLUMN directly in older versions, so we need to recreate the table
+
+-- Create a new table without the data column
+CREATE TABLE forma_commands_new (
+    command_id TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    command TEXT NOT NULL,
+    state TEXT NOT NULL,
+    agent_version TEXT,
+    client_id TEXT,
+    agent_id TEXT,
+    description_text TEXT,
+    description_confirm INTEGER DEFAULT 0,
+    config_mode TEXT DEFAULT 'reconcile',
+    config_force INTEGER DEFAULT 0,
+    config_simulate INTEGER DEFAULT 0,
+    target_updates TEXT,
+    modified_ts TEXT,
+    PRIMARY KEY (command_id)
+);
+
+-- Copy data from old table to new table
+INSERT INTO forma_commands_new (
+    command_id, timestamp, command, state, agent_version, client_id, agent_id,
+    description_text, description_confirm, config_mode, config_force, config_simulate,
+    target_updates, modified_ts
+)
+SELECT
+    command_id, timestamp, command, state, agent_version, client_id, agent_id,
+    description_text, description_confirm, config_mode, config_force, config_simulate,
+    target_updates, modified_ts
+FROM forma_commands;
+
+-- Drop old table
+DROP TABLE forma_commands;
+
+-- Rename new table to original name
+ALTER TABLE forma_commands_new RENAME TO forma_commands;
+
+-- Recreate indexes
+CREATE INDEX IF NOT EXISTS idx_timestamp ON forma_commands (timestamp);
+CREATE INDEX IF NOT EXISTS idx_command ON forma_commands (command);
+CREATE INDEX IF NOT EXISTS idx_state ON forma_commands (state);
+CREATE INDEX IF NOT EXISTS idx_agent_version ON forma_commands (agent_version);
+CREATE INDEX IF NOT EXISTS idx_agent_id ON forma_commands (agent_id);
+CREATE INDEX IF NOT EXISTS idx_client_id ON forma_commands (client_id);
+CREATE INDEX IF NOT EXISTS idx_config_mode ON forma_commands (config_mode);
+
+-- +goose Down
+-- Add back the data column
+-- Note: This is a destructive operation - we cannot fully restore the original JSON data
+-- The down migration creates the column but leaves it NULL
+
+CREATE TABLE forma_commands_old (
+    command_id TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    command TEXT NOT NULL,
+    state TEXT NOT NULL,
+    agent_version TEXT,
+    client_id TEXT,
+    agent_id TEXT,
+    data TEXT,
+    description_text TEXT,
+    description_confirm INTEGER DEFAULT 0,
+    config_mode TEXT DEFAULT 'reconcile',
+    config_force INTEGER DEFAULT 0,
+    config_simulate INTEGER DEFAULT 0,
+    target_updates TEXT,
+    modified_ts TEXT,
+    PRIMARY KEY (command_id)
+);
+
+INSERT INTO forma_commands_old (
+    command_id, timestamp, command, state, agent_version, client_id, agent_id,
+    description_text, description_confirm, config_mode, config_force, config_simulate,
+    target_updates, modified_ts
+)
+SELECT
+    command_id, timestamp, command, state, agent_version, client_id, agent_id,
+    description_text, description_confirm, config_mode, config_force, config_simulate,
+    target_updates, modified_ts
+FROM forma_commands;
+
+DROP TABLE forma_commands;
+
+ALTER TABLE forma_commands_old RENAME TO forma_commands;
+
+CREATE INDEX IF NOT EXISTS idx_timestamp ON forma_commands (timestamp);
+CREATE INDEX IF NOT EXISTS idx_command ON forma_commands (command);
+CREATE INDEX IF NOT EXISTS idx_state ON forma_commands (state);
+CREATE INDEX IF NOT EXISTS idx_agent_version ON forma_commands (agent_version);
+CREATE INDEX IF NOT EXISTS idx_agent_id ON forma_commands (agent_id);
+CREATE INDEX IF NOT EXISTS idx_client_id ON forma_commands (client_id);

--- a/internal/metastructure/datastore/postgres.go
+++ b/internal/metastructure/datastore/postgres.go
@@ -7,13 +7,14 @@ package datastore
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/demula/mksuid/v2"
+	json "github.com/goccy/go-json"
 	pgx "github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -23,8 +24,10 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/stats"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/types"
 	metautil "github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
 type DatastorePostgres struct {
@@ -124,20 +127,23 @@ func NewDatastorePostgres(ctx context.Context, cfg *pkgmodel.DatastoreConfig, ag
 }
 
 func (d DatastorePostgres) StoreFormaCommand(fa *forma_command.FormaCommand, commandID string) error {
-	jsonData, err := json.Marshal(fa)
-	if err != nil {
-		return err
-	}
-
 	for _, r := range fa.ResourceUpdates {
 		if r.Resource.Properties == nil {
 			slog.Debug("Resource properties are empty for resource", "resourceLabel", r.Resource.Label, "commandID", commandID)
 		}
 	}
 
+	targetUpdatesJSON, err := json.Marshal(fa.TargetUpdates)
+	if err != nil {
+		return fmt.Errorf("failed to marshal target updates: %w", err)
+	}
+
+	// We no longer store the forma JSON - Description and Config are stored as normalized columns
 	query := fmt.Sprintf(`
-	INSERT INTO %s (command_id, timestamp, command, state, agent_version, client_id, agent_id, data)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	INSERT INTO %s (command_id, timestamp, command, state, agent_version, client_id, agent_id,
+		description_text, description_confirm, config_mode, config_force, config_simulate,
+		target_updates, modified_ts)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 	ON CONFLICT (command_id) DO UPDATE
 	SET timestamp = EXCLUDED.timestamp,
 	command = EXCLUDED.command,
@@ -145,93 +151,309 @@ func (d DatastorePostgres) StoreFormaCommand(fa *forma_command.FormaCommand, com
 	agent_version = EXCLUDED.agent_version,
 	client_id = EXCLUDED.client_id,
 	agent_id = EXCLUDED.agent_id,
-	data = EXCLUDED.data
+	description_text = EXCLUDED.description_text,
+	description_confirm = EXCLUDED.description_confirm,
+	config_mode = EXCLUDED.config_mode,
+	config_force = EXCLUDED.config_force,
+	config_simulate = EXCLUDED.config_simulate,
+	target_updates = EXCLUDED.target_updates,
+	modified_ts = EXCLUDED.modified_ts
 	`, CommandsTable)
 
-	_, err = d.pool.Exec(context.Background(), query, commandID, fa.StartTs, fa.Command, fa.State, formae.Version, fa.ClientID, d.agentID, jsonData)
+	_, err = d.pool.Exec(context.Background(), query, commandID, fa.StartTs.UTC(), fa.Command, fa.State, formae.Version, fa.ClientID, d.agentID,
+		fa.Description.Text, fa.Description.Confirm, fa.Config.Mode, fa.Config.Force, fa.Config.Simulate,
+		targetUpdatesJSON, fa.ModifiedTs.UTC())
 	if err != nil {
 		slog.Error("failed to store FormaCommand", "query", query, "error", err)
 		return err
 	}
 
+	// Store ResourceUpdates in the normalized table
+	// Skip for sync commands - they don't need upfront storage since:
+	// 1. Sync commands are never resumed after restart (excluded from LoadIncompleteFormaCommands)
+	// 2. Progress is tracked in-memory via the FormaCommandPersister cache
+	// 3. Only resource updates with actual changes (Version set) are inserted on completion
+	if len(fa.ResourceUpdates) > 0 && fa.Command != pkgmodel.CommandSync {
+		if err := d.BulkStoreResourceUpdates(commandID, fa.ResourceUpdates); err != nil {
+			return fmt.Errorf("failed to store resource updates: %w", err)
+		}
+	}
+
 	return nil
 }
 
+const formaCommandWithResourceUpdatesQueryBasePostgres = `
+SELECT
+	fc.command_id, fc.timestamp, fc.command, fc.state, fc.client_id,
+	fc.description_text, fc.description_confirm, fc.config_mode, fc.config_force, fc.config_simulate,
+	fc.target_updates, fc.modified_ts,
+	ru.ksuid, ru.operation, ru.state, ru.start_ts, ru.modified_ts,
+	ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
+	ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
+	ru.metadata, ru.progress_result, ru.most_recent_progress,
+	ru.remaining_resolvables, ru.reference_labels, ru.previous_properties
+FROM forma_commands fc
+LEFT JOIN resource_updates ru ON fc.command_id = ru.command_id`
+
+const resourceUpdateOrderByPostgres = " ORDER BY fc.timestamp DESC, ru.ksuid ASC"
+
+// scanJoinedRowPostgres scans a row from the joined FormaCommand + ResourceUpdate query
+// Returns the FormaCommand and optionally a ResourceUpdate (nil if LEFT JOIN has no match)
+func scanJoinedRowPostgres(rows pgx.Rows) (*forma_command.FormaCommand, *resource_update.ResourceUpdate, error) {
+	var cmd forma_command.FormaCommand
+	var commandID, fcCommand, fcState string
+	var fcTimestamp time.Time
+	var fcClientID *string
+	var descriptionText *string
+	var descriptionConfirm *bool
+	var configMode *string
+	var configForce, configSimulate *bool
+	var targetUpdatesJSON []byte
+	var fcModifiedTs *time.Time
+
+	// ResourceUpdate fields (all nullable due to LEFT JOIN)
+	var ruKsuid, ruOperation, ruState *string
+	var ruStartTs, ruModifiedTs *time.Time
+	var ruRetries, ruRemaining *uint16
+	var ruVersion, ruStackLabel, ruGroupID, ruSource *string
+	var resourceJSON, resourceTargetJSON, existingResourceJSON, existingTargetJSON []byte
+	var metadataJSON, progressResultJSON, mostRecentProgressJSON []byte
+	var remainingResolvablesJSON, referenceLabelsJSON, previousPropertiesJSON []byte
+
+	err := rows.Scan(
+		// FormaCommand columns
+		&commandID, &fcTimestamp, &fcCommand, &fcState, &fcClientID,
+		&descriptionText, &descriptionConfirm, &configMode, &configForce, &configSimulate,
+		&targetUpdatesJSON, &fcModifiedTs,
+		// ResourceUpdate columns
+		&ruKsuid, &ruOperation, &ruState, &ruStartTs, &ruModifiedTs,
+		&ruRetries, &ruRemaining, &ruVersion, &ruStackLabel, &ruGroupID, &ruSource,
+		&resourceJSON, &resourceTargetJSON, &existingResourceJSON, &existingTargetJSON,
+		&metadataJSON, &progressResultJSON, &mostRecentProgressJSON,
+		&remainingResolvablesJSON, &referenceLabelsJSON, &previousPropertiesJSON,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Populate FormaCommand
+	cmd.ID = commandID
+	cmd.StartTs = fcTimestamp
+	cmd.Command = pkgmodel.Command(fcCommand)
+	cmd.State = forma_command.CommandState(fcState)
+	if fcClientID != nil {
+		cmd.ClientID = *fcClientID
+	}
+
+	// Read description from normalized columns
+	if descriptionText != nil {
+		cmd.Description.Text = *descriptionText
+	}
+	cmd.Description.Confirm = descriptionConfirm != nil && *descriptionConfirm
+
+	// Read config from normalized columns
+	if configMode != nil {
+		cmd.Config.Mode = pkgmodel.FormaApplyMode(*configMode)
+	}
+	cmd.Config.Force = configForce != nil && *configForce
+	cmd.Config.Simulate = configSimulate != nil && *configSimulate
+
+	if fcModifiedTs != nil {
+		cmd.ModifiedTs = *fcModifiedTs
+	}
+
+	if len(targetUpdatesJSON) > 0 {
+		if err := json.Unmarshal(targetUpdatesJSON, &cmd.TargetUpdates); err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal target updates: %w", err)
+		}
+	}
+
+	// Check if there's a ResourceUpdate (LEFT JOIN may return NULL)
+	if ruKsuid == nil {
+		return &cmd, nil, nil
+	}
+
+	// Populate ResourceUpdate
+	var ru resource_update.ResourceUpdate
+	ru.Operation = types.OperationType(*ruOperation)
+	ru.State = resource_update.ResourceUpdateState(*ruState)
+
+	if ruStartTs != nil {
+		ru.StartTs = *ruStartTs
+	}
+	if ruModifiedTs != nil {
+		ru.ModifiedTs = *ruModifiedTs
+	}
+
+	if ruRetries != nil {
+		ru.Retries = *ruRetries
+	}
+	if ruRemaining != nil {
+		ru.Remaining = int16(*ruRemaining)
+	}
+	if ruVersion != nil {
+		ru.Version = *ruVersion
+	}
+	if ruStackLabel != nil {
+		ru.StackLabel = *ruStackLabel
+	}
+	if ruGroupID != nil {
+		ru.GroupID = *ruGroupID
+	}
+	if ruSource != nil {
+		ru.Source = resource_update.FormaCommandSource(*ruSource)
+	}
+
+	if len(resourceJSON) > 0 {
+		if err := json.Unmarshal(resourceJSON, &ru.Resource); err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal resource: %w", err)
+		}
+		ru.Resource.Ksuid = *ruKsuid
+	}
+	if len(resourceTargetJSON) > 0 {
+		if err := json.Unmarshal(resourceTargetJSON, &ru.ResourceTarget); err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal resource target: %w", err)
+		}
+	}
+	if len(existingResourceJSON) > 0 {
+		if err := json.Unmarshal(existingResourceJSON, &ru.ExistingResource); err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal existing resource: %w", err)
+		}
+	}
+	if len(existingTargetJSON) > 0 {
+		if err := json.Unmarshal(existingTargetJSON, &ru.ExistingTarget); err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal existing target: %w", err)
+		}
+	}
+
+	ru.MetaData = metadataJSON
+
+	if len(progressResultJSON) > 0 {
+		if err := json.Unmarshal(progressResultJSON, &ru.ProgressResult); err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal progress result: %w", err)
+		}
+	}
+	if len(mostRecentProgressJSON) > 0 {
+		if err := json.Unmarshal(mostRecentProgressJSON, &ru.MostRecentProgressResult); err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal most recent progress: %w", err)
+		}
+	}
+	if len(remainingResolvablesJSON) > 0 {
+		if err := json.Unmarshal(remainingResolvablesJSON, &ru.RemainingResolvables); err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal remaining resolvables: %w", err)
+		}
+	}
+	if len(referenceLabelsJSON) > 0 {
+		if err := json.Unmarshal(referenceLabelsJSON, &ru.ReferenceLabels); err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal reference labels: %w", err)
+		}
+	}
+
+	ru.PreviousProperties = previousPropertiesJSON
+
+	return &cmd, &ru, nil
+}
+
+// loadFormaCommandsFromJoinedRowsPostgres processes rows from a joined query
+// and groups ResourceUpdates by FormaCommand ID
+func loadFormaCommandsFromJoinedRowsPostgres(rows pgx.Rows) ([]*forma_command.FormaCommand, error) {
+	defer rows.Close()
+
+	// Use a map to collect ResourceUpdates for each command
+	commandMap := make(map[string]*forma_command.FormaCommand)
+	var commandOrder []string // Preserve order
+
+	for rows.Next() {
+		cmd, ru, err := scanJoinedRowPostgres(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		existing, found := commandMap[cmd.ID]
+		if !found {
+			commandMap[cmd.ID] = cmd
+			commandOrder = append(commandOrder, cmd.ID)
+			existing = cmd
+		}
+
+		if ru != nil {
+			existing.ResourceUpdates = append(existing.ResourceUpdates, *ru)
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Return commands in original order
+	result := make([]*forma_command.FormaCommand, 0, len(commandOrder))
+	for _, id := range commandOrder {
+		result = append(result, commandMap[id])
+	}
+
+	return result, nil
+}
+
 func (d DatastorePostgres) LoadFormaCommands() ([]*forma_command.FormaCommand, error) {
-	query := fmt.Sprintf("SELECT data FROM %s", CommandsTable)
-	rows, err := d.pool.Query(context.Background(), query)
+	rows, err := d.pool.Query(context.Background(), formaCommandWithResourceUpdatesQueryBasePostgres+resourceUpdateOrderByPostgres)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-
-	var commands []*forma_command.FormaCommand
-	for rows.Next() {
-		var jsonData string
-		if err := rows.Scan(&jsonData); err != nil {
-			return nil, err
-		}
-
-		var app forma_command.FormaCommand
-		if err := json.Unmarshal([]byte(jsonData), &app); err != nil {
-			return nil, err
-		}
-
-		commands = append(commands, &app)
-	}
-
-	return commands, rows.Err()
+	return loadFormaCommandsFromJoinedRowsPostgres(rows)
 }
 
 func (d DatastorePostgres) DeleteFormaCommand(fa *forma_command.FormaCommand, commandID string) error {
+	// Delete resource_updates first (no FK constraint, so we must do this manually)
+	_, err := d.pool.Exec(context.Background(), "DELETE FROM resource_updates WHERE command_id = $1", commandID)
+	if err != nil {
+		return fmt.Errorf("failed to delete resource_updates: %w", err)
+	}
+
 	query := fmt.Sprintf("DELETE FROM %s WHERE command_id = $1", CommandsTable)
-	_, err := d.pool.Exec(context.Background(), query, commandID)
+	_, err = d.pool.Exec(context.Background(), query, commandID)
 	return err
 }
 
 func (d DatastorePostgres) GetFormaCommandByCommandID(commandID string) (*forma_command.FormaCommand, error) {
-	query := fmt.Sprintf("SELECT data FROM %s WHERE command_id = $1", CommandsTable)
-	row := d.pool.QueryRow(context.Background(), query, commandID)
-
-	var jsonData string
-	if err := row.Scan(&jsonData); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, fmt.Errorf("forma command not found: %v", commandID)
-		}
+	query := formaCommandWithResourceUpdatesQueryBasePostgres + " WHERE fc.command_id = $1" + resourceUpdateOrderByPostgres
+	rows, err := d.pool.Query(context.Background(), query, commandID)
+	if err != nil {
 		return nil, err
 	}
 
-	var app forma_command.FormaCommand
-	if err := json.Unmarshal([]byte(jsonData), &app); err != nil {
+	commands, err := loadFormaCommandsFromJoinedRowsPostgres(rows)
+	if err != nil {
 		return nil, err
 	}
 
-	return &app, nil
+	if len(commands) == 0 {
+		return nil, fmt.Errorf("forma command not found: %v", commandID)
+	}
+
+	return commands[0], nil
 }
 
 func (d DatastorePostgres) GetMostRecentFormaCommandByClientID(clientID string) (*forma_command.FormaCommand, error) {
-	query := fmt.Sprintf(`
-	SELECT data FROM %s
-	WHERE client_id = $1
-	ORDER BY timestamp DESC
-	LIMIT 1
-	`, CommandsTable)
-	row := d.pool.QueryRow(context.Background(), query, clientID)
-
-	var jsonData string
-	if err := row.Scan(&jsonData); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, fmt.Errorf("no forma commands found for client: %v", clientID)
-		}
+	// Use subquery to find the most recent command_id first, then fetch all its resource_updates
+	// LIMIT 1 on the joined query would only return 1 row, not 1 command
+	query := formaCommandWithResourceUpdatesQueryBasePostgres +
+		" WHERE fc.command_id = (SELECT command_id FROM forma_commands WHERE client_id = $1 ORDER BY timestamp DESC LIMIT 1)" +
+		resourceUpdateOrderByPostgres
+	rows, err := d.pool.Query(context.Background(), query, clientID)
+	if err != nil {
 		return nil, err
 	}
 
-	var command forma_command.FormaCommand
-	if err := json.Unmarshal([]byte(jsonData), &command); err != nil {
+	commands, err := loadFormaCommandsFromJoinedRowsPostgres(rows)
+	if err != nil {
 		return nil, err
 	}
 
-	return &command, nil
+	if len(commands) == 0 {
+		return nil, fmt.Errorf("no forma commands found for client: %v", clientID)
+	}
+
+	return commands[0], nil
 }
 
 func extendPostgresQueryString[T any](queryStr string, queryItem *QueryItem[T], sqlPart string, args *[]any) string {
@@ -266,47 +488,51 @@ func extendPostgresQueryString[T any](queryStr string, queryItem *QueryItem[T], 
 }
 
 func (d DatastorePostgres) QueryFormaCommands(query *StatusQuery) ([]*forma_command.FormaCommand, error) {
-	queryStr := fmt.Sprintf("SELECT data FROM %s WHERE 1=1", CommandsTable)
+	// Build subquery to find matching command IDs with filtering and LIMIT
+	subqueryStr := "SELECT command_id FROM forma_commands WHERE 1=1"
 	args := []any{}
 
-	queryStr = extendPostgresQueryString(queryStr, query.CommandID, " AND command_id %s $%d", &args)
-	queryStr = extendPostgresQueryString(queryStr, query.ClientID, " AND client_id %s $%d", &args)
-	queryStr = extendPostgresQueryString(queryStr, query.Command, " AND LOWER(command) %s LOWER($%d)", &args)
+	subqueryStr = extendPostgresQueryString(subqueryStr, query.CommandID, " AND command_id %s $%d", &args)
+	subqueryStr = extendPostgresQueryString(subqueryStr, query.ClientID, " AND client_id %s $%d", &args)
+	subqueryStr = extendPostgresQueryString(subqueryStr, query.Command, " AND LOWER(command) %s LOWER($%d)", &args)
 	if query.Command == nil {
-		queryStr += fmt.Sprintf(" AND command != '%s'", pkgmodel.CommandSync)
+		subqueryStr += fmt.Sprintf(" AND command != '%s'", pkgmodel.CommandSync)
 	}
 
-	queryStr = extendPostgresQueryString(queryStr, query.Stack, " AND EXISTS (SELECT 1 FROM jsonb_array_elements(data->'ResourceUpdates') AS elem WHERE elem->'Resource'->>'Stack' %s $%d)", &args)
-	queryStr = extendPostgresQueryString(queryStr, query.Status, " AND LOWER(state) %s LOWER($%d)", &args)
+	// Stack filter uses the normalized resource_updates table
+	subqueryStr = extendPostgresQueryString(subqueryStr, query.Stack, " AND EXISTS (SELECT 1 FROM resource_updates ru WHERE ru.command_id = forma_commands.command_id AND ru.stack_label %s $%d)", &args)
+	subqueryStr = extendPostgresQueryString(subqueryStr, query.Status, " AND LOWER(state) %s LOWER($%d)", &args)
 
-	queryStr += " ORDER BY timestamp DESC"
+	subqueryStr += " ORDER BY timestamp DESC"
 	if query.N > 0 {
-		queryStr += fmt.Sprintf(" LIMIT $%d", len(args)+1)
-		args = append(args, query.N)
+		subqueryStr += fmt.Sprintf(" LIMIT $%d", len(args)+1)
+		args = append(args, min(DefaultFormaCommandsQueryLimit, query.N))
+	} else {
+		subqueryStr += fmt.Sprintf(" LIMIT %d", DefaultFormaCommandsQueryLimit)
 	}
+
+	// Main query joins with resource_updates for commands matching the subquery
+	queryStr := fmt.Sprintf(`
+		SELECT
+			fc.command_id, fc.timestamp, fc.command, fc.state, fc.client_id,
+			fc.description_text, fc.description_confirm, fc.config_mode, fc.config_force, fc.config_simulate,
+			fc.target_updates, fc.modified_ts,
+			ru.ksuid, ru.operation, ru.state, ru.start_ts, ru.modified_ts,
+			ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
+			ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
+			ru.metadata, ru.progress_result, ru.most_recent_progress,
+			ru.remaining_resolvables, ru.reference_labels, ru.previous_properties
+		FROM forma_commands fc
+		LEFT JOIN resource_updates ru ON fc.command_id = ru.command_id
+		WHERE fc.command_id IN (%s)
+		ORDER BY fc.timestamp DESC, ru.ksuid ASC
+	`, subqueryStr)
 
 	rows, err := d.pool.Query(context.Background(), queryStr, args...)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-
-	var commands []*forma_command.FormaCommand
-	for rows.Next() {
-		var jsonData string
-		if err := rows.Scan(&jsonData); err != nil {
-			return nil, err
-		}
-
-		var app forma_command.FormaCommand
-		if err := json.Unmarshal([]byte(jsonData), &app); err != nil {
-			return nil, err
-		}
-
-		commands = append(commands, &app)
-	}
-
-	return commands, rows.Err()
+	return loadFormaCommandsFromJoinedRowsPostgres(rows)
 }
 
 func (d DatastorePostgres) GetKSUIDByTriplet(stack, label, resourceType string) (string, error) {
@@ -350,13 +576,15 @@ func (d DatastorePostgres) BatchGetKSUIDsByTriplets(triplets []pkgmodel.TripletK
 	SELECT stack, label, type, ksuid
 	FROM resources r1
 	WHERE (stack, label, type) IN (%s)
+	AND r1.operation != $%d
 	AND NOT EXISTS (
 		SELECT 1 FROM resources r2
 		WHERE r1.stack = r2.stack AND r1.label = r2.label AND r1.type = r2.type
 		AND r2.version > r1.version
 	)
-	`, strings.Join(placeholders, ","))
+	`, strings.Join(placeholders, ","), len(triplets)*3+1)
 
+	args = append(args, resource_update.OperationDelete)
 	rows, err := d.pool.Query(context.Background(), query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
@@ -407,7 +635,7 @@ func (d DatastorePostgres) GetResourceModificationsSinceLastReconcile(stack stri
 	AND T1.timestamp > (
 		SELECT fc.timestamp
 		FROM forma_commands fc
-		WHERE fc.data->'Config'->>'Mode' = 'reconcile'
+		WHERE fc.config_mode = 'reconcile'
 		AND EXISTS (
 			SELECT 1
 			FROM resources r
@@ -649,34 +877,16 @@ func (d DatastorePostgres) LoadAllTargets() ([]*pkgmodel.Target, error) {
 }
 
 func (d DatastorePostgres) LoadIncompleteFormaCommands() ([]*forma_command.FormaCommand, error) {
-	query := fmt.Sprintf(`
-	SELECT data
-	FROM %s
-	WHERE command != 'sync' AND state = $1
-	`, CommandsTable)
+	query := formaCommandWithResourceUpdatesQueryBasePostgres +
+		" WHERE fc.command != 'sync' AND fc.state = $1" +
+		resourceUpdateOrderByPostgres
 
 	rows, err := d.pool.Query(context.Background(), query, forma_command.CommandStateInProgress)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
-	var commands []*forma_command.FormaCommand
-	for rows.Next() {
-		var jsonData string
-		if err := rows.Scan(&jsonData); err != nil {
-			return nil, err
-		}
-
-		var command forma_command.FormaCommand
-		if err := json.Unmarshal([]byte(jsonData), &command); err != nil {
-			return nil, err
-		}
-
-		commands = append(commands, &command)
-	}
-
-	return commands, rows.Err()
+	return loadFormaCommandsFromJoinedRowsPostgres(rows)
 }
 
 func (d DatastorePostgres) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resource, error) {
@@ -1207,32 +1417,32 @@ func (d DatastorePostgres) Stats() (*stats.Stats, error) {
 		res.ResourceTypes[resourceType] = count
 	}
 
-	// Count resource errors
+	// Count resource errors from resource_updates table
 	res.ResourceErrors = make(map[string]int)
-	errorQuery := fmt.Sprintf(`
-	SELECT data
-	FROM %s
-	WHERE state = $1
-	`, CommandsTable)
-	rows, err = d.pool.Query(context.Background(), errorQuery, forma_command.CommandStateFailed)
+	errorQuery := `
+	SELECT ru.progress_result
+	FROM resource_updates ru
+	JOIN forma_commands fc ON ru.command_id = fc.command_id
+	WHERE fc.state = $1 AND ru.state = $2
+	`
+	rows, err = d.pool.Query(context.Background(), errorQuery, forma_command.CommandStateFailed, types.ResourceUpdateStateFailed)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
 	for rows.Next() {
-		var jsonData string
-		if err := rows.Scan(&jsonData); err != nil {
+		var progressResultJSON sql.NullString
+		if err := rows.Scan(&progressResultJSON); err != nil {
 			return nil, err
 		}
 
-		var command forma_command.FormaCommand
-		if err := json.Unmarshal([]byte(jsonData), &command); err != nil {
-			return nil, err
-		}
-
-		for _, ru := range command.ResourceUpdates {
-			if failureMessage := findFailureMessage(ru.ProgressResult); failureMessage != "" {
+		if progressResultJSON.Valid && progressResultJSON.String != "" {
+			var progressResults []resource.ProgressResult
+			if err := json.Unmarshal([]byte(progressResultJSON.String), &progressResults); err != nil {
+				continue // Skip invalid JSON
+			}
+			if failureMessage := findFailureMessage(progressResults); failureMessage != "" {
 				res.ResourceErrors[failureMessage]++
 			}
 		}
@@ -1450,6 +1660,374 @@ func (d DatastorePostgres) UpdateTarget(target *pkgmodel.Target) (string, error)
 	}
 
 	return fmt.Sprintf("%s_%d", target.Label, newVersion), nil
+}
+
+// BulkStoreResourceUpdates stores multiple ResourceUpdates in a single transaction
+// This is the key performance optimization: insert all updates in one transaction
+func (d DatastorePostgres) BulkStoreResourceUpdates(commandID string, updates []resource_update.ResourceUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+
+	ctx := context.Background()
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+
+	for _, ru := range updates {
+		resourceJSON, err := json.Marshal(ru.Resource)
+		if err != nil {
+			return fmt.Errorf("failed to marshal resource: %w", err)
+		}
+
+		resourceTargetJSON, err := json.Marshal(ru.ResourceTarget)
+		if err != nil {
+			return fmt.Errorf("failed to marshal resource target: %w", err)
+		}
+
+		existingResourceJSON, err := json.Marshal(ru.ExistingResource)
+		if err != nil {
+			return fmt.Errorf("failed to marshal existing resource: %w", err)
+		}
+
+		existingTargetJSON, err := json.Marshal(ru.ExistingTarget)
+		if err != nil {
+			return fmt.Errorf("failed to marshal existing target: %w", err)
+		}
+
+		progressResultJSON, err := json.Marshal(ru.ProgressResult)
+		if err != nil {
+			return fmt.Errorf("failed to marshal progress result: %w", err)
+		}
+
+		mostRecentProgressJSON, err := json.Marshal(ru.MostRecentProgressResult)
+		if err != nil {
+			return fmt.Errorf("failed to marshal most recent progress: %w", err)
+		}
+
+		remainingResolvablesJSON, err := json.Marshal(ru.RemainingResolvables)
+		if err != nil {
+			return fmt.Errorf("failed to marshal remaining resolvables: %w", err)
+		}
+
+		referenceLabelsJSON, err := json.Marshal(ru.ReferenceLabels)
+		if err != nil {
+			return fmt.Errorf("failed to marshal reference labels: %w", err)
+		}
+
+		_, err = tx.Exec(ctx, `
+			INSERT INTO resource_updates (
+				command_id, ksuid, operation, state, start_ts, modified_ts,
+				retries, remaining, version, stack_label, group_id, source,
+				resource, resource_target, existing_resource, existing_target,
+				metadata, progress_result, most_recent_progress,
+				remaining_resolvables, reference_labels, previous_properties
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
+			ON CONFLICT (command_id, ksuid, operation) DO UPDATE SET
+				state = EXCLUDED.state,
+				start_ts = EXCLUDED.start_ts,
+				modified_ts = EXCLUDED.modified_ts,
+				retries = EXCLUDED.retries,
+				remaining = EXCLUDED.remaining,
+				version = EXCLUDED.version,
+				stack_label = EXCLUDED.stack_label,
+				group_id = EXCLUDED.group_id,
+				source = EXCLUDED.source,
+				resource = EXCLUDED.resource,
+				resource_target = EXCLUDED.resource_target,
+				existing_resource = EXCLUDED.existing_resource,
+				existing_target = EXCLUDED.existing_target,
+				metadata = EXCLUDED.metadata,
+				progress_result = EXCLUDED.progress_result,
+				most_recent_progress = EXCLUDED.most_recent_progress,
+				remaining_resolvables = EXCLUDED.remaining_resolvables,
+				reference_labels = EXCLUDED.reference_labels,
+				previous_properties = EXCLUDED.previous_properties
+		`,
+			commandID,
+			ru.Resource.Ksuid,
+			string(ru.Operation),
+			string(ru.State),
+			ru.StartTs.UTC(),
+			ru.ModifiedTs.UTC(),
+			ru.Retries,
+			ru.Remaining,
+			ru.Version,
+			ru.StackLabel,
+			ru.GroupID,
+			string(ru.Source),
+			resourceJSON,
+			resourceTargetJSON,
+			existingResourceJSON,
+			existingTargetJSON,
+			ru.MetaData,
+			progressResultJSON,
+			mostRecentProgressJSON,
+			remainingResolvablesJSON,
+			referenceLabelsJSON,
+			ru.PreviousProperties,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to insert resource update: %w", err)
+		}
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// LoadResourceUpdates loads all ResourceUpdates for a given command
+// ORDER BY ksuid ensures deterministic ordering (KSUIDs are time-sortable)
+func (d DatastorePostgres) LoadResourceUpdates(commandID string) ([]resource_update.ResourceUpdate, error) {
+	query := `
+		SELECT ksuid, operation, state, start_ts, modified_ts,
+			retries, remaining, version, stack_label, group_id, source,
+			resource, resource_target, existing_resource, existing_target,
+			metadata, progress_result, most_recent_progress,
+			remaining_resolvables, reference_labels, previous_properties
+		FROM resource_updates
+		WHERE command_id = $1
+		ORDER BY ksuid ASC
+	`
+
+	rows, err := d.pool.Query(context.Background(), query, commandID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query resource updates: %w", err)
+	}
+	defer rows.Close()
+
+	var updates []resource_update.ResourceUpdate
+	for rows.Next() {
+		var ru resource_update.ResourceUpdate
+		var ksuid, operation, state string
+		var startTs, modifiedTs *time.Time
+		var stackLabel, groupID, source, version *string
+		var resourceJSON, resourceTargetJSON, existingResourceJSON, existingTargetJSON []byte
+		var metadataJSON, progressResultJSON, mostRecentProgressJSON []byte
+		var remainingResolvablesJSON, referenceLabelsJSON, previousPropertiesJSON []byte
+
+		err := rows.Scan(
+			&ksuid,
+			&operation,
+			&state,
+			&startTs,
+			&modifiedTs,
+			&ru.Retries,
+			&ru.Remaining,
+			&version,
+			&stackLabel,
+			&groupID,
+			&source,
+			&resourceJSON,
+			&resourceTargetJSON,
+			&existingResourceJSON,
+			&existingTargetJSON,
+			&metadataJSON,
+			&progressResultJSON,
+			&mostRecentProgressJSON,
+			&remainingResolvablesJSON,
+			&referenceLabelsJSON,
+			&previousPropertiesJSON,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan resource update: %w", err)
+		}
+
+		ru.Operation = types.OperationType(operation)
+		ru.State = resource_update.ResourceUpdateState(state)
+		if startTs != nil {
+			ru.StartTs = *startTs
+		}
+		if modifiedTs != nil {
+			ru.ModifiedTs = *modifiedTs
+		}
+		if version != nil {
+			ru.Version = *version
+		}
+		if stackLabel != nil {
+			ru.StackLabel = *stackLabel
+		}
+		if groupID != nil {
+			ru.GroupID = *groupID
+		}
+		if source != nil {
+			ru.Source = resource_update.FormaCommandSource(*source)
+		}
+
+		if err := json.Unmarshal(resourceJSON, &ru.Resource); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal resource: %w", err)
+		}
+		ru.Resource.Ksuid = ksuid
+
+		if err := json.Unmarshal(resourceTargetJSON, &ru.ResourceTarget); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal resource target: %w", err)
+		}
+
+		if err := json.Unmarshal(existingResourceJSON, &ru.ExistingResource); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal existing resource: %w", err)
+		}
+
+		if err := json.Unmarshal(existingTargetJSON, &ru.ExistingTarget); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal existing target: %w", err)
+		}
+
+		ru.MetaData = metadataJSON
+
+		if err := json.Unmarshal(progressResultJSON, &ru.ProgressResult); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal progress result: %w", err)
+		}
+
+		if err := json.Unmarshal(mostRecentProgressJSON, &ru.MostRecentProgressResult); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal most recent progress: %w", err)
+		}
+
+		if err := json.Unmarshal(remainingResolvablesJSON, &ru.RemainingResolvables); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal remaining resolvables: %w", err)
+		}
+
+		if err := json.Unmarshal(referenceLabelsJSON, &ru.ReferenceLabels); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal reference labels: %w", err)
+		}
+
+		ru.PreviousProperties = previousPropertiesJSON
+
+		updates = append(updates, ru)
+	}
+
+	return updates, rows.Err()
+}
+
+// UpdateResourceUpdateState updates the state of a single ResourceUpdate
+// This is the key performance improvement: updating one row instead of re-serializing entire command
+func (d DatastorePostgres) UpdateResourceUpdateState(commandID string, ksuid string, operation types.OperationType, state resource_update.ResourceUpdateState, modifiedTs time.Time) error {
+	query := `
+		UPDATE resource_updates
+		SET state = $1, modified_ts = $2
+		WHERE command_id = $3 AND ksuid = $4 AND operation = $5
+	`
+
+	result, err := d.pool.Exec(context.Background(), query, string(state), modifiedTs.UTC(), commandID, ksuid, string(operation))
+	if err != nil {
+		return fmt.Errorf("failed to update resource update state: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("resource update not found: command_id=%s, ksuid=%s, operation=%s", commandID, ksuid, operation)
+	}
+
+	return nil
+}
+
+// UpdateResourceUpdateProgress updates a ResourceUpdate with progress information
+func (d DatastorePostgres) UpdateResourceUpdateProgress(commandID string, ksuid string, operation types.OperationType, state resource_update.ResourceUpdateState, modifiedTs time.Time, progress resource.ProgressResult) error {
+	ctx := context.Background()
+
+	// First, load existing progress results to append to
+	var existingProgressJSON []byte
+	query := `SELECT progress_result FROM resource_updates WHERE command_id = $1 AND ksuid = $2 AND operation = $3`
+	err := d.pool.QueryRow(ctx, query, commandID, ksuid, string(operation)).Scan(&existingProgressJSON)
+	if err != nil {
+		return fmt.Errorf("failed to load existing progress: %w", err)
+	}
+
+	var existingProgress []resource.ProgressResult
+	if len(existingProgressJSON) > 0 {
+		if err := json.Unmarshal(existingProgressJSON, &existingProgress); err != nil {
+			return fmt.Errorf("failed to unmarshal existing progress: %w", err)
+		}
+	}
+
+	// Append new progress
+	existingProgress = append(existingProgress, progress)
+
+	progressJSON, err := json.Marshal(existingProgress)
+	if err != nil {
+		return fmt.Errorf("failed to marshal progress: %w", err)
+	}
+
+	mostRecentJSON, err := json.Marshal(progress)
+	if err != nil {
+		return fmt.Errorf("failed to marshal most recent progress: %w", err)
+	}
+
+	updateQuery := `
+		UPDATE resource_updates
+		SET state = $1, modified_ts = $2, progress_result = $3, most_recent_progress = $4
+		WHERE command_id = $5 AND ksuid = $6 AND operation = $7
+	`
+
+	result, err := d.pool.Exec(ctx, updateQuery, string(state), modifiedTs.UTC(), progressJSON, mostRecentJSON, commandID, ksuid, string(operation))
+	if err != nil {
+		return fmt.Errorf("failed to update resource update progress: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("resource update not found: command_id=%s, ksuid=%s, operation=%s", commandID, ksuid, operation)
+	}
+
+	return nil
+}
+
+// BatchUpdateResourceUpdateState updates multiple ResourceUpdates to the same state
+// Used for bulk operations like marking dependent resources as failed
+func (d DatastorePostgres) BatchUpdateResourceUpdateState(commandID string, refs []ResourceUpdateRef, state resource_update.ResourceUpdateState, modifiedTs time.Time) error {
+	if len(refs) == 0 {
+		return nil
+	}
+
+	ctx := context.Background()
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+
+	for _, ref := range refs {
+		_, err = tx.Exec(ctx, `
+			UPDATE resource_updates
+			SET state = $1, modified_ts = $2
+			WHERE command_id = $3 AND ksuid = $4 AND operation = $5
+		`, string(state), modifiedTs.UTC(), commandID, ref.KSUID, string(ref.Operation))
+		if err != nil {
+			return fmt.Errorf("failed to update resource update: %w", err)
+		}
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateFormaCommandProgress updates only the command-level metadata (state, modified_ts)
+// without re-writing all ResourceUpdates. This is a performance optimization for
+// progress updates where the ResourceUpdate is already updated via UpdateResourceUpdateProgress.
+func (d DatastorePostgres) UpdateFormaCommandProgress(commandID string, state forma_command.CommandState, modifiedTs time.Time) error {
+	query := `UPDATE forma_commands SET state = $1, modified_ts = $2 WHERE command_id = $3`
+	result, err := d.pool.Exec(context.Background(), query, string(state), modifiedTs.UTC(), commandID)
+	if err != nil {
+		return fmt.Errorf("failed to update forma command meta: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("forma command not found: %s", commandID)
+	}
+
+	return nil
 }
 
 func (d DatastorePostgres) Close() {

--- a/internal/metastructure/forma_command/forma_command.go
+++ b/internal/metastructure/forma_command/forma_command.go
@@ -29,7 +29,7 @@ const (
 
 type FormaCommand struct {
 	ID              string                           `json:"ID"`
-	Forma           pkgmodel.Forma                   `json:"Forma"`
+	Description     pkgmodel.Description             `json:"Description"`
 	State           CommandState                     `json:"State"`
 	StartTs         time.Time                        `json:"StartTs"`
 	ModifiedTs      time.Time                        `json:"ModifiedTs"`
@@ -65,7 +65,7 @@ func NewFormaCommand(
 		TargetUpdates:   targetUpdates,
 		Config:          *formaCommandConfig,
 		Command:         command,
-		Forma:           *forma,
+		Description:     forma.Description,
 		State:           CommandStateNotStarted,
 		ClientID:        clientID,
 	}
@@ -91,4 +91,18 @@ func (fc *FormaCommand) HasResourceVersions() bool {
 		}
 	}
 	return false
+}
+
+// GetStackLabels returns unique stack labels from all ResourceUpdates.
+// This derives stack information from ResourceUpdates rather than storing it separately.
+func (fc *FormaCommand) GetStackLabels() []string {
+	seen := make(map[string]bool)
+	var labels []string
+	for _, ru := range fc.ResourceUpdates {
+		if !seen[ru.StackLabel] {
+			seen[ru.StackLabel] = true
+			labels = append(labels, ru.StackLabel)
+		}
+	}
+	return labels
 }

--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -6,7 +6,6 @@ package forma_persister
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -29,6 +28,66 @@ type FormaCommandPersister struct {
 	act.Actor
 
 	datastore datastore.Datastore
+
+	// activeCommands caches in-flight FormaCommands to avoid repeated JSON unmarshaling.
+	// Commands are evicted when they reach a final state (Success, Failed, Canceled).
+	activeCommands map[string]*cachedCommand
+}
+
+// cachedCommand holds an in-memory FormaCommand with optimized lookup structures.
+type cachedCommand struct {
+	command            *forma_command.FormaCommand
+	ksuidOpToIndex     map[string]int // O(1) lookup: "ksuid:operation" -> ResourceUpdates index
+	pendingCompletions int            // Number of MarkResourceUpdateAsComplete messages expected
+}
+
+// resourceUpdateKey creates a composite key for looking up a ResourceUpdate by ksuid and operation.
+// Replace operations are stored as two separate entries (delete + create) with the same ksuid,
+// so we need both ksuid and operation to uniquely identify an entry.
+func resourceUpdateKey(ksuid string, operation types.OperationType) string {
+	return ksuid + ":" + string(operation)
+}
+
+// buildResourceUpdateIndex creates a lookup map for O(1) access to ResourceUpdates.
+// Uses composite key "ksuid:operation" since Replace operations store two entries
+// (delete + create) with the same ksuid.
+func buildResourceUpdateIndex(cmd *forma_command.FormaCommand) map[string]int {
+	ksuidOpToIndex := make(map[string]int, len(cmd.ResourceUpdates))
+	for i, ru := range cmd.ResourceUpdates {
+		key := resourceUpdateKey(ru.Resource.Ksuid, types.OperationType(ru.Operation))
+		ksuidOpToIndex[key] = i
+	}
+	return ksuidOpToIndex
+}
+
+// countNonFinalResources returns the number of resource updates not yet in final state.
+// Used when loading a command from DB to initialize the pending completions counter.
+func countNonFinalResources(cmd *forma_command.FormaCommand) int {
+	count := 0
+	for _, ru := range cmd.ResourceUpdates {
+		if !isResourceInFinalState(ru.State) {
+			count++
+		}
+	}
+	return count
+}
+
+// isResourceInFinalState checks if a resource update is in a final state.
+func isResourceInFinalState(state types.ResourceUpdateState) bool {
+	return state == types.ResourceUpdateStateSuccess ||
+		state == types.ResourceUpdateStateFailed ||
+		state == types.ResourceUpdateStateRejected ||
+		state == types.ResourceUpdateStateCanceled
+}
+
+// findResourceUpdateIndex returns the index of the ResourceUpdate with the given ksuid and operation.
+// Returns -1 if not found.
+func (c *cachedCommand) findResourceUpdateIndex(ksuid string, operation types.OperationType) int {
+	key := resourceUpdateKey(ksuid, operation)
+	if idx, ok := c.ksuidOpToIndex[key]; ok {
+		return idx
+	}
+	return -1
 }
 
 func NewFormaCommandPersister() gen.ProcessBehavior {
@@ -36,41 +95,94 @@ func NewFormaCommandPersister() gen.ProcessBehavior {
 }
 
 func (f *FormaCommandPersister) Init(args ...any) error {
-	cfg, ok := f.Env("DatastoreConfig")
+	ds, ok := f.Env("Datastore")
 	if !ok {
-		f.Log().Error("FormaCommandPersister: missing 'Config' environment variable")
-		return fmt.Errorf("formaCommandPersister: missing 'Config' environment variable")
+		f.Log().Error("FormaCommandPersister: missing 'Datastore' environment variable")
+		return fmt.Errorf("formaCommandPersister: missing 'Datastore' environment variable")
 	}
-	config := cfg.(pkgmodel.DatastoreConfig)
+	f.datastore = ds.(datastore.Datastore)
+	f.activeCommands = make(map[string]*cachedCommand)
 
-	_agentID, ok := f.Env("AgentID")
-	if !ok {
-		f.Log().Error("FormaCommandPersister: missing 'AgentID' environment variable")
-		return fmt.Errorf("formaCommandPersister: missing 'AgentID' environment variable")
-	}
-	agentID := _agentID.(string)
+	f.Log().Info("FormaCommandPersister initialized", "datastoreType", fmt.Sprintf("%T", f.datastore))
 
-	_ctx, ok := f.Env("Context")
-	if !ok {
-		f.Log().Error("FormaCommandPersister: missing 'Context' environment variable")
-		return fmt.Errorf("formaCommandPersister: missing 'Context' environment variable")
-	}
-	ctx := _ctx.(context.Context)
+	return nil
+}
 
-	// Initialize the datastore
-	var ds datastore.Datastore
-	var err error
-	if config.DatastoreType == pkgmodel.PostgresDatastore {
-		ds, err = datastore.NewDatastorePostgres(ctx, &config, agentID)
-	} else {
-		ds, err = datastore.NewDatastoreSQLite(ctx, &config, agentID)
+// getOrLoadCommand retrieves a command from cache or loads it from the database.
+// The command is cached for subsequent accesses until it reaches a final state.
+func (f *FormaCommandPersister) getOrLoadCommand(commandID string) (*cachedCommand, error) {
+	// Check cache first
+	if cached, ok := f.activeCommands[commandID]; ok {
+		return cached, nil
 	}
 
+	// Load from DB
+	cmd, err := f.datastore.GetFormaCommandByCommandID(commandID)
 	if err != nil {
-		f.Log().Error("FormaCommandPersister: failed to initialize datastore", "error", err)
-		return fmt.Errorf("formaCommandPersister: failed to initialize datastore: %w", err)
+		return nil, err
 	}
-	f.datastore = ds
+
+	// Build cache entry
+	cached := &cachedCommand{
+		command:            cmd,
+		ksuidOpToIndex:     buildResourceUpdateIndex(cmd),
+		pendingCompletions: countNonFinalResources(cmd),
+	}
+	f.activeCommands[commandID] = cached
+
+	return cached, nil
+}
+
+// persistCommand writes the command to the database.
+// For simple progress updates, use this directly.
+func (f *FormaCommandPersister) persistCommand(cached *cachedCommand) error {
+	cmd := cached.command
+
+	if err := f.datastore.StoreFormaCommand(cmd, cmd.ID); err != nil {
+		f.Log().Error("Failed to store command", "commandID", cmd.ID, "error", err)
+		return fmt.Errorf("failed to store command: %w", err)
+	}
+
+	return nil
+}
+
+// finalizeAndPersist handles finalization logic after a command completes:
+// hashes sensitive data, deletes empty sync commands, and evicts from cache.
+// Use this for markResourceUpdateAsComplete and bulkUpdateResourceState.
+func (f *FormaCommandPersister) finalizeAndPersist(cached *cachedCommand) error {
+	cmd := cached.command
+
+	if _, err := f.hashSensitiveDataIfComplete(cmd); err != nil {
+		f.Log().Error("Failed to hash sensitive data", "commandID", cmd.ID, "error", err)
+		return fmt.Errorf("failed to hash sensitive data: %w", err)
+	}
+
+	shouldDelete := shouldDeleteSyncCommand(cmd, cached)
+	if shouldDelete {
+		if err := f.datastore.DeleteFormaCommand(cmd, cmd.ID); err != nil {
+			f.Log().Error("Failed to delete sync command", "commandID", cmd.ID, "error", err)
+			return fmt.Errorf("failed to delete sync command: %w", err)
+		}
+		delete(f.activeCommands, cmd.ID)
+		return nil
+	}
+
+	if err := f.datastore.StoreFormaCommand(cmd, cmd.ID); err != nil {
+		f.Log().Error("Failed to store command", "commandID", cmd.ID, "error", err)
+		return fmt.Errorf("failed to store command: %w", err)
+	}
+
+	// Evict from cache if command is complete.
+	// For sync commands, we must wait for all completions before evicting because
+	// sync commands don't store ResourceUpdates in DB (they rely on in-memory cache).
+	// If we evict early, late completions will load from DB and find 0 resources.
+	if cmd.IsInFinalState() {
+		if cmd.Command == pkgmodel.CommandSync && cached.pendingCompletions > 0 {
+			// Don't evict yet - sync command still waiting for completions
+			return nil
+		}
+		delete(f.activeCommands, cmd.ID)
+	}
 
 	return nil
 }
@@ -83,41 +195,35 @@ type LoadFormaCommand struct {
 	CommandID string
 }
 
+// ResourceUpdateRef identifies a specific ResourceUpdate by URI and operation.
+// This is needed because Replace operations create two entries (delete + create)
+// with the same KSUID, so URI alone is not sufficient.
+type ResourceUpdateRef struct {
+	URI       pkgmodel.FormaeURI
+	Operation types.OperationType
+}
+
 type MarkResourcesAsRejected struct {
 	CommandID          string
-	ResourceUris       []pkgmodel.FormaeURI
+	Resources          []ResourceUpdateRef
 	ResourceModifiedTs time.Time
 }
 
 type MarkResourcesAsFailed struct {
 	CommandID          string
-	ResourceUris       []pkgmodel.FormaeURI
-	ResourceModifiedTs time.Time
-}
-
-// BulkUpdateResourceState is a common structure for rejecting and failing resources.
-type BulkUpdateResourceState struct {
-	CommandID          string
-	ResourceState      types.ResourceUpdateState
-	ResourceModifiedTs time.Time
-}
-
-type BulkUpdateResourceStateByKsuid struct {
-	CommandID          string
-	ResourceUris       []pkgmodel.FormaeURI
-	ResourceState      types.ResourceUpdateState
+	Resources          []ResourceUpdateRef
 	ResourceModifiedTs time.Time
 }
 
 type MarkResourcesAsCanceled struct {
-	CommandID    string
-	ResourceUris []pkgmodel.FormaeURI
+	CommandID string
+	Resources []ResourceUpdateRef
 }
 
 func (f *FormaCommandPersister) HandleCall(from gen.PID, ref gen.Ref, message any) (any, error) {
 	switch msg := message.(type) {
 	case StoreNewFormaCommand:
-		return f.storeNewFormaCommand(msg.Command)
+		return f.storeNewFormaCommand(&msg.Command)
 	case LoadFormaCommand:
 		return f.loadFormaCommand(msg.CommandID)
 	case messages.UpdateResourceProgress:
@@ -137,31 +243,45 @@ func (f *FormaCommandPersister) HandleCall(from gen.PID, ref gen.Ref, message an
 	}
 }
 
-func (f *FormaCommandPersister) storeNewFormaCommand(command forma_command.FormaCommand) (bool, error) {
-	err := f.datastore.StoreFormaCommand(&command, command.ID)
+func (f *FormaCommandPersister) storeNewFormaCommand(command *forma_command.FormaCommand) (bool, error) {
+	f.Log().Debug("Storing new Forma command", "commandID", command.ID, "commandType", command.Command)
+
+	// Store the command metadata and ResourceUpdates (StoreFormaCommand handles both)
+	err := f.datastore.StoreFormaCommand(command, command.ID)
 	if err != nil {
 		f.Log().Error("Failed to store new Forma command", "error", err)
 		return false, fmt.Errorf("failed to store new Forma command: %w", err)
 	}
+
+	// Cache the command to avoid immediate database reload on next message
+	f.activeCommands[command.ID] = &cachedCommand{
+		command:            command,
+		ksuidOpToIndex:     buildResourceUpdateIndex(command),
+		pendingCompletions: len(command.ResourceUpdates),
+	}
+
+	f.Log().Debug("Stored and cached new Forma command", "commandID", command.ID)
+
 	return true, nil
 }
 
 func (f *FormaCommandPersister) loadFormaCommand(commandID string) (*forma_command.FormaCommand, error) {
-	command, err := f.datastore.GetFormaCommandByCommandID(commandID)
+	cached, err := f.getOrLoadCommand(commandID)
 	if err != nil {
 		f.Log().Error("Failed to load Forma command", "commandID", commandID, "error", err)
 		return nil, fmt.Errorf("failed to load Forma command: %w", err)
 	}
-	return command, nil
+	return cached.command, nil
 }
 
 func (f *FormaCommandPersister) updateCommandFromProgress(progress *messages.UpdateResourceProgress) (bool, error) {
-	f.Log().Debug("Updating Forma command from resource progress", "commandID", progress.CommandID, "resourceURI", progress.ResourceURI)
-	command, err := f.datastore.GetFormaCommandByCommandID(progress.CommandID)
+	cached, err := f.getOrLoadCommand(progress.CommandID)
 	if err != nil {
-		f.Log().Error("Failed to load Forma command for update", "commandID", progress.CommandID, "error", err)
-		return false, fmt.Errorf("failed to load Forma command for update: %w", err)
+		f.Log().Error("Failed to load Forma command for progress update", "commandID", progress.CommandID, "error", err)
+		return false, fmt.Errorf("failed to load Forma command for progress update: %w", err)
 	}
+
+	command := cached.command
 
 	// Don't update if command is already canceled
 	if command.State == forma_command.CommandStateCanceled {
@@ -169,40 +289,54 @@ func (f *FormaCommandPersister) updateCommandFromProgress(progress *messages.Upd
 		return true, nil
 	}
 
-	for i, res := range command.ResourceUpdates {
-		// Don't update if resource is already canceled
-		if res.State == types.ResourceUpdateStateCanceled {
-			continue
+	// Find matching ResourceUpdate by KSUID and operation
+	idx := cached.findResourceUpdateIndex(progress.ResourceURI.KSUID(), progress.Operation)
+	if idx != -1 {
+		res := &command.ResourceUpdates[idx]
+		res.State = progress.ResourceState
+		res.StartTs = progress.ResourceStartTs
+		res.ModifiedTs = progress.ResourceModifiedTs
+
+		// NOTE: Do NOT decrement pendingCompletions here!
+		// pendingCompletions tracks expected MarkResourceUpdateAsComplete messages, not state transitions.
+		// Progress updates can set state to Success, but completion messages arrive separately.
+
+		index := slices.IndexFunc(res.ProgressResult, func(p resource.ProgressResult) bool {
+			return p.Operation == progress.Progress.Operation
+		})
+		if index == -1 {
+			res.ProgressResult = append(res.ProgressResult, progress.Progress)
+		} else {
+			res.ProgressResult = slices.Replace(res.ProgressResult, index, index+1, progress.Progress)
 		}
-		if res.Resource.Ksuid == progress.ResourceURI.KSUID() && shouldUpdateResourceUpdate(res, progress.Progress) {
-			res.State = progress.ResourceState
-			res.StartTs = progress.ResourceStartTs
-			res.ModifiedTs = progress.ResourceModifiedTs
+		res.MostRecentProgressResult = progress.Progress
 
-			index := slices.IndexFunc(res.ProgressResult, func(p resource.ProgressResult) bool {
-				return p.Operation == progress.Progress.Operation
-			})
-			if index == -1 {
-				res.ProgressResult = append(res.ProgressResult, progress.Progress)
-			} else {
-				res.ProgressResult = slices.Replace(res.ProgressResult, index, index+1, progress.Progress)
+		if progress.ResourceProperties != nil {
+			res.Resource.Properties = progress.ResourceProperties
+		}
+
+		if progress.ResourceReadOnlyProperties != nil {
+			res.Resource.ReadOnlyProperties = progress.ResourceReadOnlyProperties
+		}
+
+		if progress.Version != "" {
+			res.Version = progress.Version
+		}
+
+		// Update the normalized resource_updates table
+		// Skip for sync commands: resource updates are not stored upfront, progress tracked in-memory only
+		if command.Command != pkgmodel.CommandSync {
+			if err := f.datastore.UpdateResourceUpdateProgress(
+				progress.CommandID,
+				progress.ResourceURI.KSUID(),
+				progress.Operation,
+				progress.ResourceState,
+				progress.ResourceModifiedTs,
+				progress.Progress,
+			); err != nil {
+				f.Log().Error("Failed to update resource update progress in normalized table", "commandID", progress.CommandID, "error", err)
+				// Continue with command meta update even if normalized update fails
 			}
-			res.MostRecentProgressResult = progress.Progress
-
-			if progress.ResourceProperties != nil {
-				res.Resource.Properties = progress.ResourceProperties
-			}
-
-			if progress.ResourceReadOnlyProperties != nil {
-				res.Resource.ReadOnlyProperties = progress.ResourceReadOnlyProperties
-			}
-
-			if progress.Version != "" {
-				res.Version = progress.Version
-			}
-
-			command.ResourceUpdates[i] = res
-			break
 		}
 	}
 
@@ -211,12 +345,14 @@ func (f *FormaCommandPersister) updateCommandFromProgress(progress *messages.Upd
 		command.StartTs = progress.ResourceStartTs
 	}
 	command.ModifiedTs = progress.ResourceModifiedTs
+
 	command.State = overallCommandState(command)
 
-	err = f.datastore.StoreFormaCommand(command, command.ID)
-	if err != nil {
-		f.Log().Error("Failed to update Forma command from resource progress", "commandID", progress.CommandID, "error", err)
-		return false, fmt.Errorf("failed to update Forma command from resource progress: %w", err)
+	// Only update command-level metadata (state, modified_ts)
+	// ResourceUpdates are already persisted via UpdateResourceUpdateProgress above
+	if err := f.datastore.UpdateFormaCommandProgress(command.ID, command.State, command.ModifiedTs); err != nil {
+		f.Log().Error("Failed to update Forma command meta from resource progress", "commandID", progress.CommandID, "error", err)
+		return false, fmt.Errorf("failed to update Forma command meta from resource progress: %w", err)
 	}
 
 	return true, nil
@@ -225,17 +361,17 @@ func (f *FormaCommandPersister) updateCommandFromProgress(progress *messages.Upd
 func (f *FormaCommandPersister) updateTargetStates(msg *messages.UpdateTargetStates) (bool, error) {
 	f.Log().Debug("Updating Forma command with target states", "commandID", msg.CommandID, "targetCount", len(msg.TargetUpdates))
 
-	command, err := f.datastore.GetFormaCommandByCommandID(msg.CommandID)
+	cached, err := f.getOrLoadCommand(msg.CommandID)
 	if err != nil {
 		f.Log().Error("Failed to load Forma command for target state update", "commandID", msg.CommandID, "error", err)
 		return false, fmt.Errorf("failed to load Forma command for target state update: %w", err)
 	}
 
+	command := cached.command
 	command.TargetUpdates = msg.TargetUpdates
 	command.State = overallCommandState(command)
 
-	err = f.datastore.StoreFormaCommand(command, command.ID)
-	if err != nil {
+	if err := f.persistCommand(cached); err != nil {
 		f.Log().Error("Failed to update Forma command with target states", "commandID", msg.CommandID, "error", err)
 		return false, fmt.Errorf("failed to update Forma command with target states: %w", err)
 	}
@@ -245,45 +381,30 @@ func (f *FormaCommandPersister) updateTargetStates(msg *messages.UpdateTargetSta
 }
 
 func (f *FormaCommandPersister) markResourcesAsRejected(msg *MarkResourcesAsRejected) (bool, error) {
-	return f.bulkUpdateResourceState(&BulkUpdateResourceStateByKsuid{
-		CommandID:          msg.CommandID,
-		ResourceUris:       msg.ResourceUris,
-		ResourceState:      types.ResourceUpdateStateRejected,
-		ResourceModifiedTs: msg.ResourceModifiedTs,
-	})
+	return f.bulkUpdateResourceState(msg.CommandID, msg.Resources, types.ResourceUpdateStateRejected, msg.ResourceModifiedTs)
 }
 
 func (f *FormaCommandPersister) markResourcesAsFailed(msg *MarkResourcesAsFailed) (bool, error) {
-	return f.bulkUpdateResourceState(&BulkUpdateResourceStateByKsuid{
-		CommandID:          msg.CommandID,
-		ResourceUris:       msg.ResourceUris,
-		ResourceState:      types.ResourceUpdateStateFailed,
-		ResourceModifiedTs: msg.ResourceModifiedTs,
-	})
+	return f.bulkUpdateResourceState(msg.CommandID, msg.Resources, types.ResourceUpdateStateFailed, msg.ResourceModifiedTs)
 }
 
 func (f *FormaCommandPersister) markResourcesAsCanceled(msg *MarkResourcesAsCanceled) (bool, error) {
-	return f.bulkUpdateResourceState(&BulkUpdateResourceStateByKsuid{
-		CommandID:          msg.CommandID,
-		ResourceUris:       msg.ResourceUris,
-		ResourceState:      types.ResourceUpdateStateCanceled,
-		ResourceModifiedTs: util.TimeNow(),
-	})
+	return f.bulkUpdateResourceState(msg.CommandID, msg.Resources, types.ResourceUpdateStateCanceled, util.TimeNow())
 }
 
 func (f *FormaCommandPersister) markResourceUpdateAsComplete(msg *messages.MarkResourceUpdateAsComplete) (bool, error) {
-	f.Log().Debug("Marking command resource as complete", "commandID", msg.CommandID, "resourceURI", msg.ResourceURI)
-	cmd, err := f.datastore.GetFormaCommandByCommandID(msg.CommandID)
+	cached, err := f.getOrLoadCommand(msg.CommandID)
 	if err != nil {
 		f.Log().Error("Failed to load Forma command for complete update", "commandID", msg.CommandID, "error", err)
 		return false, fmt.Errorf("failed to load Forma command for complete update: %w", err)
 	}
 
-	for i, res := range cmd.ResourceUpdates {
-		if res.Resource.Ksuid != msg.ResourceURI.KSUID() {
-			continue
-		}
+	cmd := cached.command
 
+	// O(1) lookup by KSUID and operation
+	idx := cached.findResourceUpdateIndex(msg.ResourceURI.KSUID(), msg.Operation)
+	if idx != -1 {
+		res := &cmd.ResourceUpdates[idx]
 		res.State = msg.FinalState
 		res.StartTs = msg.ResourceStartTs
 		res.ModifiedTs = msg.ResourceModifiedTs
@@ -298,54 +419,135 @@ func (f *FormaCommandPersister) markResourceUpdateAsComplete(msg *messages.MarkR
 			res.Version = msg.Version
 		}
 
-		cmd.ResourceUpdates[i] = res
-		break
+		// Persist the resource update to the normalized table
+		// For sync commands: resource updates were not stored upfront, so INSERT only if change detected (Version set)
+		// For non-sync commands: resource updates exist in DB, so UPDATE the state
+		if cmd.Command == pkgmodel.CommandSync {
+			// Sync commands only persist resource updates that detected changes
+			if msg.Version != "" {
+				if err := f.datastore.BulkStoreResourceUpdates(msg.CommandID, []resource_update.ResourceUpdate{*res}); err != nil {
+					f.Log().Error("Failed to insert sync resource update with change", "commandID", msg.CommandID, "error", err)
+					// Continue with command meta update even if insert fails
+				}
+			}
+			// If no version (no change), nothing to persist - that's the optimization
+		} else {
+			// Non-sync commands: update the existing resource update state
+			if err := f.datastore.UpdateResourceUpdateState(
+				msg.CommandID,
+				msg.ResourceURI.KSUID(),
+				msg.Operation,
+				msg.FinalState,
+				msg.ResourceModifiedTs,
+			); err != nil {
+				f.Log().Error("Failed to update resource update state in normalized table", "commandID", msg.CommandID, "error", err)
+				// Continue with command meta update even if normalized update fails
+			}
+		}
+
+		// Always decrement pending completions counter when we receive a completion message.
+		// This counter tracks the number of expected MarkResourceUpdateAsComplete messages,
+		// NOT the number of resources in non-final state (which can be set by UpdateResourceProgress).
+		if cached.pendingCompletions > 0 {
+			cached.pendingCompletions--
+		}
+
+		cmd.ModifiedTs = msg.ResourceModifiedTs
+
+		// Calculate new command state
+		cmd.State = overallCommandState(cmd)
+
+		// If command is in final state, do full finalization (hash sensitive data, potentially delete, etc.)
+		// Otherwise just update command meta for performance
+		if cmd.IsInFinalState() {
+			if err := f.finalizeAndPersist(cached); err != nil {
+				return false, err
+			}
+		} else {
+			// Only update command-level metadata (state, modified_ts)
+			// ResourceUpdate is already persisted via UpdateResourceUpdateState above
+			if err := f.datastore.UpdateFormaCommandProgress(cmd.ID, cmd.State, cmd.ModifiedTs); err != nil {
+				f.Log().Error("Failed to update Forma command meta", "commandID", msg.CommandID, "error", err)
+				return false, fmt.Errorf("failed to update Forma command meta: %w", err)
+			}
+		}
+	} else {
+		// Resource not found in this command - this indicates a bug or unexpected race condition.
+		// Log as error but return success to avoid actor crash.
+		f.Log().Error("Received completion for resource not in command",
+			"commandID", msg.CommandID,
+			"resource", msg.ResourceURI.KSUID(),
+			"operation", msg.Operation)
 	}
 
-	cmd.ModifiedTs = msg.ResourceModifiedTs
-	cmd.State = overallCommandState(cmd)
-
-	if err := f.finalizeAndPersist(cmd); err != nil {
-		return false, err
-	}
-
-	f.Log().Debug("Successfully marked command resource as complete", "commandID", msg.CommandID)
 	return true, nil
 }
 
-func (f *FormaCommandPersister) bulkUpdateResourceState(bulkUpdate *BulkUpdateResourceStateByKsuid) (bool, error) {
-	f.Log().Debug("Bulk updating resource states by KSUID", "commandID", bulkUpdate.CommandID, "resourceCount", len(bulkUpdate.ResourceUris), "state", bulkUpdate.ResourceState)
-
-	command, err := f.datastore.GetFormaCommandByCommandID(bulkUpdate.CommandID)
+func (f *FormaCommandPersister) bulkUpdateResourceState(
+	commandID string,
+	resources []ResourceUpdateRef,
+	state types.ResourceUpdateState,
+	modifiedTs time.Time,
+) (bool, error) {
+	cached, err := f.getOrLoadCommand(commandID)
 	if err != nil {
-		f.Log().Error("Failed to load Forma command for bulk update", "commandID", bulkUpdate.CommandID, "error", err)
+		f.Log().Error("Failed to load Forma command for bulk update", "commandID", commandID, "error", err)
 		return false, fmt.Errorf("failed to load Forma command for bulk update: %w", err)
 	}
 
-	// Create a set of KSUIDs for fast lookup
-	ksuidSet := make(map[string]struct{})
-	for _, uri := range bulkUpdate.ResourceUris {
-		ksuidSet[uri.KSUID()] = struct{}{}
-	}
+	command := cached.command
 
-	// Match resources by their KSUID instead of URI
-	for i, res := range command.ResourceUpdates {
-		if _, exists := ksuidSet[res.Resource.Ksuid]; exists {
-			res.State = bulkUpdate.ResourceState
-			res.ModifiedTs = bulkUpdate.ResourceModifiedTs
-			command.ResourceUpdates[i] = res
-			f.Log().Debug("Marked resource as failed due to cascading failure", "resourceKsuid", res.Resource.Ksuid, "state", bulkUpdate.ResourceState)
+	// O(1) lookup by KSUID and operation for each resource
+	for _, ref := range resources {
+		idx := cached.findResourceUpdateIndex(ref.URI.KSUID(), ref.Operation)
+		if idx != -1 {
+			res := &command.ResourceUpdates[idx]
+
+			// If transitioning to final state, decrement counter
+			if !isResourceInFinalState(res.State) && isResourceInFinalState(state) {
+				if cached.pendingCompletions > 0 {
+					cached.pendingCompletions--
+				}
+			}
+
+			res.State = state
+			res.ModifiedTs = modifiedTs
 		}
 	}
 
-	command.ModifiedTs = bulkUpdate.ResourceModifiedTs
-	command.State = overallCommandState(command)
-
-	if err := f.finalizeAndPersist(command); err != nil {
-		return false, err
+	// Update the normalized resource_updates table in batch
+	if len(resources) > 0 {
+		datastoreRefs := make([]datastore.ResourceUpdateRef, len(resources))
+		for i, ref := range resources {
+			datastoreRefs[i] = datastore.ResourceUpdateRef{
+				KSUID:     ref.URI.KSUID(),
+				Operation: ref.Operation,
+			}
+		}
+		if err := f.datastore.BatchUpdateResourceUpdateState(commandID, datastoreRefs, state, modifiedTs); err != nil {
+			f.Log().Error("Failed to batch update resource states in normalized table", "commandID", commandID, "error", err)
+			// Continue with command meta update even if normalized update fails
+		}
 	}
 
-	f.Log().Debug("Successfully bulk updated resource states by KSUID", "commandID", bulkUpdate.CommandID, "resourceCount", len(bulkUpdate.ResourceUris))
+	command.ModifiedTs = modifiedTs
+	command.State = overallCommandState(command)
+
+	// If command is in final state, do full finalization (hash sensitive data, potentially delete, etc.)
+	// Otherwise just update command meta for performance
+	if command.IsInFinalState() {
+		if err := f.finalizeAndPersist(cached); err != nil {
+			return false, err
+		}
+	} else {
+		// Only update command-level metadata (state, modified_ts)
+		// ResourceUpdates are already persisted via BatchUpdateResourceUpdateState above
+		if err := f.datastore.UpdateFormaCommandProgress(command.ID, command.State, command.ModifiedTs); err != nil {
+			f.Log().Error("Failed to update Forma command meta", "commandID", commandID, "error", err)
+			return false, fmt.Errorf("failed to update Forma command meta: %w", err)
+		}
+	}
+
 	return true, nil
 }
 
@@ -356,62 +558,48 @@ func overallCommandState(command *forma_command.FormaCommand) forma_command.Comm
 	}
 
 	// Check if any resources are not in a final state
-	if slices.ContainsFunc(states, func(s types.ResourceUpdateState) bool {
+	hasNonFinalState := slices.ContainsFunc(states, func(s types.ResourceUpdateState) bool {
 		return s != types.ResourceUpdateStateSuccess &&
 			s != types.ResourceUpdateStateFailed &&
 			s != types.ResourceUpdateStateRejected &&
 			s != types.ResourceUpdateStateCanceled
-	}) {
+	})
+
+	if hasNonFinalState {
 		return forma_command.CommandStateInProgress
 	}
 
-	// Check if any resources were canceled
-	if slices.ContainsFunc(states, func(s types.ResourceUpdateState) bool {
+	// All resources are in final state, determine which final state
+	hasCanceled := slices.ContainsFunc(states, func(s types.ResourceUpdateState) bool {
 		return s == types.ResourceUpdateStateCanceled
-	}) {
+	})
+
+	// Check if any resources were canceled
+	if hasCanceled {
 		return forma_command.CommandStateCanceled
 	}
 
-	// Check if any resources failed or were rejected
-	if slices.ContainsFunc(states, func(s types.ResourceUpdateState) bool {
+	hasFailedOrRejected := slices.ContainsFunc(states, func(s types.ResourceUpdateState) bool {
 		return s == types.ResourceUpdateStateFailed || s == types.ResourceUpdateStateRejected
-	}) {
+	})
+
+	// Check if any resources failed or were rejected
+	if hasFailedOrRejected {
 		return forma_command.CommandStateFailed
 	}
 
 	return forma_command.CommandStateSuccess
 }
 
-// finalizeAndPersist handles the common finalization logic after updating a command:
-// hashes sensitive data if complete, and either deletes empty sync commands or stores the command.
-func (f *FormaCommandPersister) finalizeAndPersist(command *forma_command.FormaCommand) error {
-	if _, err := f.hashSensitiveDataIfComplete(command); err != nil {
-		f.Log().Error("Failed to hash sensitive data", "commandID", command.ID, "error", err)
-		return fmt.Errorf("failed to hash sensitive data: %w", err)
-	}
-
-	if shouldDeleteSyncCommand(command) {
-		f.Log().Debug("Deleting sync command with no resource versions", "commandID", command.ID)
-		if err := f.datastore.DeleteFormaCommand(command, command.ID); err != nil {
-			f.Log().Error("Failed to delete sync command", "commandID", command.ID, "error", err)
-			return fmt.Errorf("failed to delete sync command: %w", err)
-		}
-		return nil
-	}
-
-	if err := f.datastore.StoreFormaCommand(command, command.ID); err != nil {
-		f.Log().Error("Failed to store command", "commandID", command.ID, "error", err)
-		return fmt.Errorf("failed to store command: %w", err)
-	}
-	return nil
-}
-
 // shouldDeleteSyncCommand determines if a sync command should be deleted because it has no resource versions.
 // This helps keep the database clean by not retaining sync commands that resulted in no changes.
-func shouldDeleteSyncCommand(command *forma_command.FormaCommand) bool {
-	return command.Command == pkgmodel.CommandSync &&
-		command.IsInFinalState() &&
-		!command.HasResourceVersions()
+// The cached parameter is used to ensure all completion messages have been processed before deletion.
+func shouldDeleteSyncCommand(command *forma_command.FormaCommand, cached *cachedCommand) bool {
+	isSync := command.Command == pkgmodel.CommandSync
+	isFinal := command.IsInFinalState()
+	hasVersions := command.HasResourceVersions()
+	allCompleted := cached.pendingCompletions == 0
+	return isSync && isFinal && !hasVersions && allCompleted
 }
 
 func hasOpaqueValues(props json.RawMessage) bool {
@@ -430,23 +618,7 @@ func (f *FormaCommandPersister) hashSensitiveDataIfComplete(command *forma_comma
 	t := transformations.NewPersistValueTransformer()
 	hashedCount := 0
 
-	// Hash opaque vals in Forma.Resources array
-	for i, resource := range command.Forma.Resources {
-		if hasOpaqueValues(resource.Properties) {
-			transformed, err := t.ApplyToResource(&resource)
-			if err != nil {
-				f.Log().Error("Failed to hash forma resource during final cleanup",
-					"commandID", command.ID,
-					"resourceLabel", resource.Label,
-					"error", err)
-				return false, fmt.Errorf("failed to hash forma resource %s during final cleanup: %w", resource.Label, err)
-			}
-			command.Forma.Resources[i] = *transformed
-			hashedCount++
-		}
-	}
-
-	// Hash opaque vals in ResourceUpdates array
+	// Hash opaque vals in ResourceUpdates array (Resources are stored in resource_updates table, not forma.Resources)
 	for i, resourceUpdate := range command.ResourceUpdates {
 		if hasOpaqueValues(resourceUpdate.Resource.Properties) {
 			transformed, err := t.ApplyToResource(&resourceUpdate.Resource)
@@ -470,25 +642,4 @@ func (f *FormaCommandPersister) hashSensitiveDataIfComplete(command *forma_comma
 	}
 
 	return hashedCount > 0, nil
-}
-
-// shouldUpdateResourceUpdate determines if a ResourceUpdate should be updated based on the progress
-func shouldUpdateResourceUpdate(resourceUpdate resource_update.ResourceUpdate, progress resource.ProgressResult) bool {
-	switch progress.Operation {
-	case resource.OperationCreate:
-		return resourceUpdate.Operation == resource_update.OperationCreate || resourceUpdate.Operation == resource_update.OperationReplace
-	case resource.OperationDelete:
-		return resourceUpdate.Operation == resource_update.OperationDelete || resourceUpdate.Operation == resource_update.OperationReplace
-	case resource.OperationUpdate:
-		return resourceUpdate.Operation == resource_update.OperationUpdate || resourceUpdate.Operation == resource_update.OperationReplace
-	case resource.OperationRead:
-		// Read operations can apply to Delete, Update, Replace, or Read ResourceUpdates
-		return resourceUpdate.Operation == resource_update.OperationDelete ||
-			resourceUpdate.Operation == resource_update.OperationUpdate ||
-			resourceUpdate.Operation == resource_update.OperationRead ||
-			resourceUpdate.Operation == resource_update.OperationReplace
-	default:
-		// Default to allowing the update if we can't determine
-		return true
-	}
 }

--- a/internal/metastructure/forma_persister/forma_command_persister_test.go
+++ b/internal/metastructure/forma_persister/forma_command_persister_test.go
@@ -15,6 +15,7 @@ import (
 	"ergo.services/ergo/gen"
 	"ergo.services/ergo/testing/unit"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/datastore"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
@@ -57,6 +58,7 @@ func TestFormaCommandPersister_RecordsResourceProgress(t *testing.T) {
 	updateResourceProgress := messages.UpdateResourceProgress{
 		CommandID:          formaCommand.ID,
 		ResourceURI:        resourceURI,
+		Operation:          resource_update.OperationCreate,
 		ResourceStartTs:    util.TimeNow(),
 		ResourceModifiedTs: util.TimeNow().Add(20 * time.Second),
 		ResourceState:      resource_update.ResourceUpdateStateInProgress,
@@ -89,6 +91,7 @@ func TestFormaCommandPersister_RecordsResourceProgress(t *testing.T) {
 	secondProgressUpdate := messages.UpdateResourceProgress{
 		CommandID:          formaCommand.ID,
 		ResourceURI:        resourceURI,
+		Operation:          resource_update.OperationCreate,
 		ResourceStartTs:    util.TimeNow(),
 		ResourceModifiedTs: util.TimeNow().Add(20 * time.Second),
 		ResourceState:      resource_update.ResourceUpdateStateSuccess,
@@ -125,6 +128,7 @@ func TestFormaCommandPersister_BulkUpdateResourceState(t *testing.T) {
 		ID: "test-bulk-update",
 		ResourceUpdates: []resource_update.ResourceUpdate{
 			{
+				Operation: resource_update.OperationCreate,
 				Resource: pkgmodel.Resource{
 					Label:      "resource0",
 					Type:       "AWS::EC2::VPC",
@@ -135,6 +139,7 @@ func TestFormaCommandPersister_BulkUpdateResourceState(t *testing.T) {
 				State: resource_update.ResourceUpdateStateNotStarted,
 			},
 			{
+				Operation: resource_update.OperationCreate,
 				Resource: pkgmodel.Resource{
 					Label:      "resource1",
 					Type:       "AWS::EC2::Subnet",
@@ -145,6 +150,7 @@ func TestFormaCommandPersister_BulkUpdateResourceState(t *testing.T) {
 				State: resource_update.ResourceUpdateStateNotStarted,
 			},
 			{
+				Operation: resource_update.OperationCreate,
 				Resource: pkgmodel.Resource{
 					Label:      "resource2",
 					Type:       "AWS::EC2::Instance",
@@ -166,9 +172,9 @@ func TestFormaCommandPersister_BulkUpdateResourceState(t *testing.T) {
 	now := util.TimeNow()
 	failResources := MarkResourcesAsFailed{
 		CommandID: formaCommand.ID,
-		ResourceUris: []pkgmodel.FormaeURI{
-			resource1Ksuid,
-			resource2Ksuid,
+		Resources: []ResourceUpdateRef{
+			{URI: resource1Ksuid, Operation: resource_update.OperationCreate},
+			{URI: resource2Ksuid, Operation: resource_update.OperationCreate},
 		},
 		ResourceModifiedTs: now,
 	}
@@ -181,14 +187,21 @@ func TestFormaCommandPersister_BulkUpdateResourceState(t *testing.T) {
 	assert.NoError(t, loadResult.Error)
 	loadedCommand := loadResult.Response.(*forma_command.FormaCommand)
 
-	// Verify first command unchanged, second and third commands failed
-	assert.Equal(t, resource_update.ResourceUpdateStateNotStarted, loadedCommand.ResourceUpdates[0].State)
-	assert.Equal(t, resource_update.ResourceUpdateStateFailed, loadedCommand.ResourceUpdates[1].State)
-	assert.Equal(t, resource_update.ResourceUpdateStateFailed, loadedCommand.ResourceUpdates[2].State)
+	// Build a map of KSUID -> ResourceUpdate for order-agnostic assertions
+	ruByKsuid := make(map[string]*resource_update.ResourceUpdate)
+	for i := range loadedCommand.ResourceUpdates {
+		ru := &loadedCommand.ResourceUpdates[i]
+		ruByKsuid[ru.Resource.Ksuid] = ru
+	}
 
-	// Ensure ts modified
-	assert.WithinDuration(t, now, loadedCommand.ResourceUpdates[1].ModifiedTs, 1*time.Second)
-	assert.WithinDuration(t, now, loadedCommand.ResourceUpdates[2].ModifiedTs, 1*time.Second)
+	// Verify resource0 unchanged, resource1 and resource2 failed
+	assert.Equal(t, resource_update.ResourceUpdateStateNotStarted, ruByKsuid[resource0Ksuid.KSUID()].State)
+	assert.Equal(t, resource_update.ResourceUpdateStateFailed, ruByKsuid[resource1Ksuid.KSUID()].State)
+	assert.Equal(t, resource_update.ResourceUpdateStateFailed, ruByKsuid[resource2Ksuid.KSUID()].State)
+
+	// Ensure ts modified for failed resources
+	assert.WithinDuration(t, now, ruByKsuid[resource1Ksuid.KSUID()].ModifiedTs, 1*time.Second)
+	assert.WithinDuration(t, now, ruByKsuid[resource2Ksuid.KSUID()].ModifiedTs, 1*time.Second)
 }
 
 func TestFormaCommandPersister_DeletesSyncCommandWithNoVersions(t *testing.T) {
@@ -206,6 +219,7 @@ func TestFormaCommandPersister_DeletesSyncCommandWithNoVersions(t *testing.T) {
 	markComplete := messages.MarkResourceUpdateAsComplete{
 		CommandID:                  formaCommand.ID,
 		ResourceURI:                resourceURI,
+		Operation:                  formaCommand.ResourceUpdates[0].Operation,
 		FinalState:                 resource_update.ResourceUpdateStateSuccess,
 		ResourceStartTs:            util.TimeNow(),
 		ResourceModifiedTs:         util.TimeNow().Add(20 * time.Second),
@@ -238,6 +252,7 @@ func TestFormaCommandPersister_KeepsSyncCommandWithVersions(t *testing.T) {
 	markComplete := messages.MarkResourceUpdateAsComplete{
 		CommandID:                  formaCommand.ID,
 		ResourceURI:                resourceURI,
+		Operation:                  formaCommand.ResourceUpdates[0].Operation,
 		FinalState:                 resource_update.ResourceUpdateStateSuccess,
 		ResourceStartTs:            util.TimeNow(),
 		ResourceModifiedTs:         util.TimeNow().Add(20 * time.Second),
@@ -276,6 +291,7 @@ func TestFormaCommandPersister_KeepsApplyCommandWithNoVersions(t *testing.T) {
 	markComplete := messages.MarkResourceUpdateAsComplete{
 		CommandID:                  formaCommand.ID,
 		ResourceURI:                resourceURI,
+		Operation:                  formaCommand.ResourceUpdates[0].Operation,
 		FinalState:                 resource_update.ResourceUpdateStateSuccess,
 		ResourceStartTs:            util.TimeNow(),
 		ResourceModifiedTs:         util.TimeNow().Add(20 * time.Second),
@@ -300,31 +316,9 @@ func newSyncFormaCommand() *forma_command.FormaCommand {
 	resourceKsuid := util.NewID()
 
 	return &forma_command.FormaCommand{
-		ID:      "test-sync-command-id",
-		Command: pkgmodel.CommandSync,
-		Forma: pkgmodel.Forma{
-			Stacks: []pkgmodel.Stack{
-				{
-					Label:       "test-stack",
-					Description: "A test stack",
-				},
-			},
-			Targets: []pkgmodel.Target{
-				{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-			},
-			Resources: []pkgmodel.Resource{
-				{
-					Label:      "test-resource",
-					Type:       "test-type",
-					Stack:      "test-stack",
-					Properties: json.RawMessage("{}"),
-					Ksuid:      resourceKsuid,
-				},
-			},
-		},
+		ID:          "test-sync-command-id",
+		Command:     pkgmodel.CommandSync,
+		Description: pkgmodel.Description{},
 		Config: config.FormaCommandConfig{
 			Mode:     pkgmodel.FormaApplyModeReconcile,
 			Simulate: false,
@@ -346,6 +340,7 @@ func newSyncFormaCommand() *forma_command.FormaCommand {
 				Operation:      resource_update.OperationRead,
 				State:          resource_update.ResourceUpdateStateNotStarted,
 				ProgressResult: []resource.ProgressResult{},
+				StackLabel:     "test-stack",
 			},
 		},
 	}
@@ -355,30 +350,8 @@ func newFormaCommandWithCreateResourceUpdate() *forma_command.FormaCommand {
 	resourceKsuid := util.NewID()
 
 	return &forma_command.FormaCommand{
-		ID: "test-forma-id",
-		Forma: pkgmodel.Forma{
-			Stacks: []pkgmodel.Stack{
-				{
-					Label:       "test-stack",
-					Description: "A test stack",
-				},
-			},
-			Targets: []pkgmodel.Target{
-				{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-			},
-			Resources: []pkgmodel.Resource{
-				{
-					Label:      "test-resource",
-					Type:       "test-type",
-					Stack:      "test-stack",
-					Properties: json.RawMessage("{}"),
-					Ksuid:      resourceKsuid,
-				},
-			},
-		},
+		ID:          "test-forma-id",
+		Description: pkgmodel.Description{},
 		Config: config.FormaCommandConfig{
 			Mode:     pkgmodel.FormaApplyModeReconcile,
 			Simulate: false,
@@ -397,24 +370,216 @@ func newFormaCommandWithCreateResourceUpdate() *forma_command.FormaCommand {
 					Label:     "test-target",
 					Namespace: "test-namespace",
 				},
-				Operation:      resource_update.OperationReplace,
+				Operation:      resource_update.OperationCreate,
 				State:          resource_update.ResourceUpdateStateNotStarted,
 				ProgressResult: []resource.ProgressResult{},
+				StackLabel:     "test-stack",
 			},
 		},
 	}
 }
 
-func newFormaCommandPersisterForTest(t *testing.T) (*unit.TestActor, gen.PID, error) {
-	env := map[gen.Env]any{
-		"DatastoreConfig": pkgmodel.DatastoreConfig{
-			DatastoreType: pkgmodel.SqliteDatastore,
-			Sqlite: pkgmodel.SqliteConfig{
-				FilePath: ":memory:",
+// Test cache helper functions
+func TestBuildResourceUpdateIndex(t *testing.T) {
+	ksuid1 := util.NewID()
+	ksuid2 := util.NewID()
+	ksuid3 := util.NewID()
+
+	cmd := &forma_command.FormaCommand{
+		ID: "test-command",
+		ResourceUpdates: []resource_update.ResourceUpdate{
+			{Resource: pkgmodel.Resource{Ksuid: ksuid1, Label: "resource1"}, Operation: resource_update.OperationCreate},
+			{Resource: pkgmodel.Resource{Ksuid: ksuid2, Label: "resource2"}, Operation: resource_update.OperationUpdate},
+			{Resource: pkgmodel.Resource{Ksuid: ksuid3, Label: "resource3"}, Operation: resource_update.OperationDelete},
+		},
+	}
+
+	ksuidOpToIndex := buildResourceUpdateIndex(cmd)
+
+	// Composite key index should have 3 entries
+	assert.Len(t, ksuidOpToIndex, 3)
+	assert.Equal(t, 0, ksuidOpToIndex[resourceUpdateKey(ksuid1, resource_update.OperationCreate)])
+	assert.Equal(t, 1, ksuidOpToIndex[resourceUpdateKey(ksuid2, resource_update.OperationUpdate)])
+	assert.Equal(t, 2, ksuidOpToIndex[resourceUpdateKey(ksuid3, resource_update.OperationDelete)])
+}
+
+func TestBuildResourceUpdateIndex_DuplicateKsuids(t *testing.T) {
+	// Test case: Replace operation stores two ResourceUpdates with same ksuid (delete + create)
+	ksuid1 := util.NewID()
+
+	cmd := &forma_command.FormaCommand{
+		ID: "test-command",
+		ResourceUpdates: []resource_update.ResourceUpdate{
+			{Resource: pkgmodel.Resource{Ksuid: ksuid1, Label: "resource1"}, Operation: resource_update.OperationDelete},
+			{Resource: pkgmodel.Resource{Ksuid: ksuid1, Label: "resource1"}, Operation: resource_update.OperationCreate},
+		},
+	}
+
+	ksuidOpToIndex := buildResourceUpdateIndex(cmd)
+
+	// Composite key index should have 2 entries (delete + create for same ksuid)
+	assert.Len(t, ksuidOpToIndex, 2)
+	assert.Equal(t, 0, ksuidOpToIndex[resourceUpdateKey(ksuid1, resource_update.OperationDelete)])
+	assert.Equal(t, 1, ksuidOpToIndex[resourceUpdateKey(ksuid1, resource_update.OperationCreate)])
+}
+
+func TestCachedCommand_FindResourceUpdateIndex(t *testing.T) {
+	ksuid1 := util.NewID()
+	ksuid2 := util.NewID()
+
+	cached := &cachedCommand{
+		command: &forma_command.FormaCommand{
+			ResourceUpdates: []resource_update.ResourceUpdate{
+				{Resource: pkgmodel.Resource{Ksuid: ksuid1}, Operation: resource_update.OperationCreate},
+				{Resource: pkgmodel.Resource{Ksuid: ksuid2}, Operation: resource_update.OperationUpdate},
 			},
 		},
-		"AgentID": "test-agent-id",
-		"Context": context.Background(),
+		ksuidOpToIndex: map[string]int{
+			resourceUpdateKey(ksuid1, resource_update.OperationCreate): 0,
+			resourceUpdateKey(ksuid2, resource_update.OperationUpdate): 1,
+		},
+	}
+
+	// Test composite key lookup
+	assert.Equal(t, 0, cached.findResourceUpdateIndex(ksuid1, resource_update.OperationCreate))
+	assert.Equal(t, 1, cached.findResourceUpdateIndex(ksuid2, resource_update.OperationUpdate))
+	assert.Equal(t, -1, cached.findResourceUpdateIndex(ksuid1, resource_update.OperationDelete)) // wrong operation
+	assert.Equal(t, -1, cached.findResourceUpdateIndex("nonexistent", resource_update.OperationCreate))
+}
+
+func TestCachedCommand_FindResourceUpdateIndex_DuplicateKsuid(t *testing.T) {
+	// Test case: same ksuid with different operations (replace = delete + create)
+	ksuid1 := util.NewID()
+
+	cached := &cachedCommand{
+		command: &forma_command.FormaCommand{
+			ResourceUpdates: []resource_update.ResourceUpdate{
+				{Resource: pkgmodel.Resource{Ksuid: ksuid1}, Operation: resource_update.OperationDelete},
+				{Resource: pkgmodel.Resource{Ksuid: ksuid1}, Operation: resource_update.OperationCreate},
+			},
+		},
+		ksuidOpToIndex: map[string]int{
+			resourceUpdateKey(ksuid1, resource_update.OperationDelete): 0,
+			resourceUpdateKey(ksuid1, resource_update.OperationCreate): 1,
+		},
+	}
+
+	// Composite key lookup should find the correct entry
+	assert.Equal(t, 0, cached.findResourceUpdateIndex(ksuid1, resource_update.OperationDelete))
+	assert.Equal(t, 1, cached.findResourceUpdateIndex(ksuid1, resource_update.OperationCreate))
+}
+
+func TestFormaCommandPersister_CacheEvictionOnFinalState(t *testing.T) {
+	formaCommand := newFormaCommandWithCreateResourceUpdate()
+	formaPersister, sender, err := newFormaCommandPersisterForTest(t)
+	assert.NoError(t, err)
+
+	// Store the command - this should add it to the cache
+	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
+	assert.NoError(t, storeResult.Error)
+
+	// Mark the resource as complete - this should trigger cache eviction
+	resourceURI := formaCommand.ResourceUpdates[0].Resource.URI()
+	markComplete := messages.MarkResourceUpdateAsComplete{
+		CommandID:          formaCommand.ID,
+		ResourceURI:        resourceURI,
+		Operation:          formaCommand.ResourceUpdates[0].Operation,
+		FinalState:         resource_update.ResourceUpdateStateSuccess,
+		ResourceStartTs:    util.TimeNow(),
+		ResourceModifiedTs: util.TimeNow().Add(20 * time.Second),
+		Version:            "test-version",
+	}
+	res := formaPersister.Call(sender, markComplete)
+	assert.NoError(t, res.Error)
+
+	// Load the command again - this should work (from DB since cache was evicted)
+	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
+	assert.NoError(t, loadResult.Error)
+	loadedCommand := loadResult.Response.(*forma_command.FormaCommand)
+	assert.Equal(t, forma_command.CommandStateSuccess, loadedCommand.State)
+}
+
+func TestFormaCommandPersister_MultipleProgressUpdatesUseCacheHit(t *testing.T) {
+	// Create a command with multiple resources
+	ksuid1 := util.NewID()
+	ksuid2 := util.NewID()
+
+	formaCommand := &forma_command.FormaCommand{
+		ID: "test-multi-resource-cache",
+		ResourceUpdates: []resource_update.ResourceUpdate{
+			{
+				Resource: pkgmodel.Resource{
+					Label:      "resource1",
+					Type:       "AWS::EC2::VPC",
+					Stack:      "test-stack",
+					Properties: json.RawMessage(`{}`),
+					Ksuid:      ksuid1,
+				},
+				Operation: resource_update.OperationCreate,
+				State:     resource_update.ResourceUpdateStateNotStarted,
+			},
+			{
+				Resource: pkgmodel.Resource{
+					Label:      "resource2",
+					Type:       "AWS::EC2::Subnet",
+					Stack:      "test-stack",
+					Properties: json.RawMessage(`{}`),
+					Ksuid:      ksuid2,
+				},
+				Operation: resource_update.OperationCreate,
+				State:     resource_update.ResourceUpdateStateNotStarted,
+			},
+		},
+	}
+
+	formaPersister, sender, err := newFormaCommandPersisterForTest(t)
+	assert.NoError(t, err)
+
+	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
+	assert.NoError(t, storeResult.Error)
+
+	// Send multiple progress updates for both resources
+	for i := 0; i < 3; i++ {
+		for _, ksuid := range []string{ksuid1, ksuid2} {
+			progress := messages.UpdateResourceProgress{
+				CommandID:          formaCommand.ID,
+				ResourceURI:        pkgmodel.NewFormaeURI(ksuid, ""),
+				Operation:          resource_update.OperationCreate,
+				ResourceStartTs:    util.TimeNow(),
+				ResourceModifiedTs: util.TimeNow(),
+				ResourceState:      resource_update.ResourceUpdateStateInProgress,
+				Progress: resource.ProgressResult{
+					Operation:       resource.OperationCreate,
+					OperationStatus: resource.OperationStatusInProgress,
+				},
+			}
+			res := formaPersister.Call(sender, progress)
+			assert.NoError(t, res.Error)
+		}
+	}
+
+	// Verify both resources are updated
+	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
+	assert.NoError(t, loadResult.Error)
+	loadedCommand := loadResult.Response.(*forma_command.FormaCommand)
+
+	assert.Equal(t, resource_update.ResourceUpdateStateInProgress, loadedCommand.ResourceUpdates[0].State)
+	assert.Equal(t, resource_update.ResourceUpdateStateInProgress, loadedCommand.ResourceUpdates[1].State)
+}
+
+func newFormaCommandPersisterForTest(t *testing.T) (*unit.TestActor, gen.PID, error) {
+	ds, err := datastore.NewDatastoreSQLite(context.Background(), &pkgmodel.DatastoreConfig{
+		DatastoreType: pkgmodel.SqliteDatastore,
+		Sqlite: pkgmodel.SqliteConfig{
+			FilePath: ":memory:",
+		},
+	}, "test-agent-id")
+	if err != nil {
+		return nil, gen.PID{}, err
+	}
+
+	env := map[gen.Env]any{
+		"Datastore": ds,
 	}
 
 	sender := gen.PID{Node: "test", ID: 100}

--- a/internal/metastructure/messages/forma_persister.go
+++ b/internal/metastructure/messages/forma_persister.go
@@ -17,6 +17,7 @@ import (
 type MarkResourceUpdateAsComplete struct {
 	CommandID                  string
 	ResourceURI                pkgmodel.FormaeURI
+	Operation                  types.OperationType // The ResourceUpdate operation (create, delete, update, etc.)
 	FinalState                 types.ResourceUpdateState
 	ResourceStartTs            time.Time
 	ResourceModifiedTs         time.Time
@@ -28,6 +29,7 @@ type MarkResourceUpdateAsComplete struct {
 type UpdateResourceProgress struct {
 	CommandID                  string
 	ResourceURI                pkgmodel.FormaeURI
+	Operation                  types.OperationType // The ResourceUpdate operation (create, delete, update, etc.)
 	ResourceStartTs            time.Time
 	ResourceModifiedTs         time.Time
 	ResourceState              types.ResourceUpdateState

--- a/internal/metastructure/resource_persister/resource_persister.go
+++ b/internal/metastructure/resource_persister/resource_persister.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"time"
 
 	"ergo.services/ergo/act"
 	"ergo.services/ergo/gen"
@@ -103,7 +102,6 @@ func (rp *ResourcePersister) storeResourceUpdate(commandID string, resourceOpera
 
 	forma := &forma_command.FormaCommand{
 		ID:      commandID,
-		Forma:   rp.formaFromResourceUpate(pluginOperation, resourceUpdate),
 		Command: formaCommandFromOperation(pluginOperation),
 		ResourceUpdates: []resource_update.ResourceUpdate{
 			{
@@ -115,6 +113,7 @@ func (rp *ResourcePersister) storeResourceUpdate(commandID string, resourceOpera
 				ModifiedTs:               relevantProgress.ModifiedTs,
 				MostRecentProgressResult: *relevantProgress,
 				GroupID:                  resourceUpdate.GroupID,
+				StackLabel:               resourceUpdate.StackLabel,
 			},
 		},
 	}
@@ -171,42 +170,47 @@ func validateRequiredFields(resource pkgmodel.Resource) error {
 }
 
 func (rp *ResourcePersister) storeStacks(formaCommand *forma_command.FormaCommand) error {
-	for _, stack := range formaCommand.Forma.SplitByStack() {
-		for i := range formaCommand.ResourceUpdates {
-			rc := &formaCommand.ResourceUpdates[i]
-			if rc.Resource.Stack == stack.SingleStackLabel() && rc.State == resource_update.ResourceUpdateStateSuccess && rc.Version == "" {
-				slog.Debug("Resource command successful, persisting...",
-					"stackLabel", rc.Resource.Stack,
+	// Iterate ResourceUpdates directly - no need to use Forma.Resources/SplitByStack()
+	// since all information needed is in the ResourceUpdate itself
+	for i := range formaCommand.ResourceUpdates {
+		rc := &formaCommand.ResourceUpdates[i]
+		// Only process if the resource's stack matches the expected stack label.
+		// This is important for Update operations where the ExistingResource (with old stack)
+		// may be substituted - we should skip persisting if the stacks don't match,
+		// as this indicates a stack change is in progress and we shouldn't persist the
+		// old stack's resource state.
+		if rc.Resource.Stack != rc.StackLabel {
+			slog.Debug("Skipping resource persist - stack mismatch (stack change in progress)",
+				"resourceStack", rc.Resource.Stack,
+				"stackLabel", rc.StackLabel,
+				"resourceLabel", rc.Resource.Label)
+			continue
+		}
+		if rc.State == resource_update.ResourceUpdateStateSuccess && rc.Version == "" {
+			slog.Debug("Resource command successful, persisting...",
+				"stackLabel", rc.Resource.Stack,
+				"resourceLabel", rc.Resource.Label,
+				"command", rc.Operation)
+
+			hash, err := rp.processResourceUpdate(formaCommand.ID, *rc)
+			if err != nil {
+				slog.Error("Failed to persist resource command",
+					"error", err,
 					"resourceLabel", rc.Resource.Label,
+					"stackLabel", rc.Resource.Stack)
+				return fmt.Errorf("failed to persist resource %s in stack %s: %w", rc.Resource.Label, rc.Resource.Stack, err)
+			}
+			if hash != "" {
+				rc.Version = hash
+				slog.Debug("Resource command persisted",
+					"resourceLabel", rc.Resource.Label,
+					"stackLabel", rc.Resource.Stack,
+					"hash", hash)
+			} else {
+				slog.Debug("No persist needed for resource command",
+					"resourceLabel", rc.Resource.Label,
+					"stackLabel", rc.Resource.Stack,
 					"command", rc.Operation)
-
-				if len(stack.Stacks) == 0 {
-					slog.Error("Stack has no Stacks slice elements",
-						"stackLabel", stack.SingleStackLabel(),
-						"resourceLabel", rc.Resource.Label)
-					return fmt.Errorf("stack %s has no Stacks elements", stack.SingleStackLabel())
-				}
-
-				hash, err := rp.processResourceUpdate(formaCommand.ID, stack.Stacks[0], *rc)
-				if err != nil {
-					slog.Error("Failed to persist resource command",
-						"error", err,
-						"resourceLabel", rc.Resource.Label,
-						"stackLabel", rc.Resource.Stack)
-					return fmt.Errorf("failed to persist resource %s in stack %s: %w", rc.Resource.Label, rc.Resource.Stack, err)
-				}
-				if hash != "" {
-					rc.Version = hash
-					slog.Debug("Resource command persisted",
-						"resourceLabel", rc.Resource.Label,
-						"stackLabel", rc.Resource.Stack,
-						"hash", hash)
-				} else {
-					slog.Debug("No persist needed for resource command",
-						"resourceLabel", rc.Resource.Label,
-						"stackLabel", rc.Resource.Stack,
-						"command", rc.Operation)
-				}
 			}
 		}
 	}
@@ -235,18 +239,6 @@ func (rp *ResourcePersister) loadResource(resourceURI pkgmodel.FormaeURI) (messa
 		Resource: *res,
 		Target:   *currentTarget,
 	}, nil
-}
-
-func (rp *ResourcePersister) formaFromResourceUpate(operation pkgresource.Operation, resourceUpdate *resource_update.ResourceUpdate) pkgmodel.Forma {
-	return pkgmodel.Forma{
-		Stacks: []pkgmodel.Stack{
-			{
-				Label: resourceUpdate.StackLabel,
-			},
-		},
-		Resources: []pkgmodel.Resource{resourceUpdate.Resource},
-		Targets:   []pkgmodel.Target{resourceUpdate.ResourceTarget},
-	}
 }
 
 // Moving forward, every read operation that has a diff will be persisted to the datastore. To not change the existing code,
@@ -278,7 +270,7 @@ func resourceOperationFromPluginOperation(resourceOperation resource_update.Oper
 	}
 }
 
-func (rp *ResourcePersister) processResourceUpdate(commandID string, stack pkgmodel.Stack, rc resource_update.ResourceUpdate) (string, error) {
+func (rp *ResourcePersister) processResourceUpdate(commandID string, rc resource_update.ResourceUpdate) (string, error) {
 	stackLabel := rc.Resource.Stack
 
 	var resourceVersion string
@@ -429,7 +421,7 @@ func (rp *ResourcePersister) persistTargetUpdate(update *target_update.TargetUpd
 	if err != nil {
 		update.State = target_update.TargetUpdateStateFailed
 		update.ErrorMessage = err.Error()
-		update.ModifiedTs = time.Now()
+		update.ModifiedTs = util.TimeNow()
 		slog.Error("Failed to persist target",
 			"label", update.Target.Label,
 			"operation", update.Operation,
@@ -439,7 +431,7 @@ func (rp *ResourcePersister) persistTargetUpdate(update *target_update.TargetUpd
 
 	update.Version = version
 	update.State = target_update.TargetUpdateStateSuccess
-	update.ModifiedTs = time.Now()
+	update.ModifiedTs = util.TimeNow()
 	slog.Debug("Successfully persisted target",
 		"label", update.Target.Label,
 		"operation", update.Operation,

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -156,7 +156,7 @@ func (ru *ResourceUpdate) RecordProgress(progress *resource.ProgressResult) erro
 }
 
 func (ru *ResourceUpdate) updateResourceUpdateFromProgress(progress *resource.ProgressResult) error {
-	ru.updateState()
+	ru.UpdateState()
 	slog.Debug("Updating resource state for " + string(ru.URI()) + " to " + string(ru.State))
 
 	slog.Debug("Setting NativeID from progress", "nativeID", progress.NativeID, "uri", ru.URI())
@@ -232,7 +232,10 @@ func (ru *ResourceUpdate) FilterProgressMessage(filter func(resource.ProgressRes
 	return ""
 }
 
-func (ru *ResourceUpdate) updateState() {
+// UpdateState derives the ResourceUpdate state from its ProgressResult.
+// This is used during restart recovery to restore the correct state based on
+// the progress that was persisted before the restart.
+func (ru *ResourceUpdate) UpdateState() {
 	if len(ru.ProgressResult) == 0 {
 		ru.State = ResourceUpdateStateNotStarted
 		return

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -238,6 +238,7 @@ func onStateChange(oldState gen.Atom, newState gen.Atom, data ResourceUpdateData
 			messages.MarkResourceUpdateAsComplete{
 				CommandID:                  data.commandID,
 				ResourceURI:                data.originalResourceKsuidURI,
+				Operation:                  data.resourceUpdate.Operation,
 				FinalState:                 data.resourceUpdate.State,
 				ResourceStartTs:            data.resourceUpdate.StartTs,
 				ResourceModifiedTs:         data.resourceUpdate.ModifiedTs,
@@ -589,6 +590,7 @@ func handleProgressUpdate(from gen.PID, state gen.Atom, data ResourceUpdateData,
 		messages.UpdateResourceProgress{
 			CommandID:          data.commandID,
 			ResourceURI:        data.resourceUpdate.Resource.URI(),
+			Operation:          data.resourceUpdate.Operation,
 			ResourceStartTs:    data.resourceUpdate.StartTs,
 			ResourceModifiedTs: message.ModifiedTs,
 			ResourceState:      data.resourceUpdate.State,

--- a/internal/metastructure/synchronizer.go
+++ b/internal/metastructure/synchronizer.go
@@ -255,6 +255,7 @@ func synchronizeAllResources(state gen.Atom, data SynchronizerData, proc gen.Pro
 		"",
 	)
 	data.commandID = syncCommand.ID
+	proc.Log().Info("Synchronizer: created sync command", "commandID", syncCommand.ID, "resourceUpdateCount", len(allResourceUpdates))
 
 	_, err = proc.Call(
 		gen.ProcessID{Name: actornames.FormaCommandPersister, Node: proc.Node().Name()},

--- a/internal/metastructure/target_update/target_update_generator.go
+++ b/internal/metastructure/target_update/target_update_generator.go
@@ -7,8 +7,8 @@ package target_update
 import (
 	"fmt"
 	"log/slog"
-	"time"
 
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
@@ -56,7 +56,7 @@ func (tp *TargetUpdateGenerator) GenerateTargetUpdates(targets []pkgmodel.Target
 }
 
 func (tp *TargetUpdateGenerator) determineTargetUpdate(target pkgmodel.Target) (TargetUpdate, bool, error) {
-	now := time.Now()
+	now := util.TimeNow()
 
 	existing, err := tp.datastore.LoadTarget(target.Label)
 	if err != nil {

--- a/internal/metastructure/util/time.go
+++ b/internal/metastructure/util/time.go
@@ -6,6 +6,9 @@ package util
 
 import "time"
 
+// TimeNow returns the current time in UTC.
+// All timestamps in the system should be stored in UTC for consistent ordering
+// and comparison, especially important for TEXT-based timestamp storage in SQLite.
 func TimeNow() time.Time {
-	return time.Now()
+	return time.Now().UTC()
 }

--- a/internal/workflow_tests/local/apply_forma/conflicting_updates_test.go
+++ b/internal/workflow_tests/local/apply_forma/conflicting_updates_test.go
@@ -22,6 +22,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// newTestResourceUpdate creates a ResourceUpdate with a generated KSUID for testing.
+// In production, KSUIDs are assigned by the resource_update_generator, but tests that
+// bypass that flow need to set KSUIDs explicitly to avoid PRIMARY KEY collisions
+// in the normalized resource_updates table.
+func newTestResourceUpdate(label, resourceType, stack, target string, state resource_update.ResourceUpdateState, operation resource_update.OperationType) resource_update.ResourceUpdate {
+	return resource_update.ResourceUpdate{
+		Resource: pkgmodel.Resource{
+			Label:  label,
+			Type:   resourceType,
+			Stack:  stack,
+			Target: target,
+			Ksuid:  util.NewID(),
+		},
+		ResourceTarget: pkgmodel.Target{
+			Label:     target,
+			Namespace: "test-namespace",
+		},
+		StartTs:   util.TimeNow(),
+		State:     state,
+		Operation: operation,
+	}
+}
+
 func TestMetastructure_ApplyWhileAnotherFormaIsModifyingTheStack_ReturnsConflictingResourcesError(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		m, stop, err := test_helpers.NewTestMetastructure(t, nil)
@@ -32,111 +55,13 @@ func TestMetastructure_ApplyWhileAnotherFormaIsModifyingTheStack_ReturnsConflict
 		}
 
 		executingFormaResourceUpdates := []resource_update.ResourceUpdate{
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource1",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack1",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateNotStarted, // conflicting
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource2",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack1",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStatePending, // conflicting
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource3",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack1",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateCanceled, // conflicting
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource4",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack1",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateInProgress, // conflicting
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource5",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack1",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateSuccess, // not conflicting
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource6",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack1",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateFailed, // not conflicting
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource7",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack1",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateInProgress,
-				Operation: resource_update.OperationRead, // not conflicting
-			},
+			newTestResourceUpdate("test-resource1", "FakeAWS::S3::Bucket", "test-stack1", "test-target", resource_update.ResourceUpdateStateNotStarted, resource_update.OperationCreate),  // conflicting
+			newTestResourceUpdate("test-resource2", "FakeAWS::S3::Bucket", "test-stack1", "test-target", resource_update.ResourceUpdateStatePending, resource_update.OperationCreate),     // conflicting
+			newTestResourceUpdate("test-resource3", "FakeAWS::S3::Bucket", "test-stack1", "test-target", resource_update.ResourceUpdateStateCanceled, resource_update.OperationCreate),   // conflicting
+			newTestResourceUpdate("test-resource4", "FakeAWS::S3::Bucket", "test-stack1", "test-target", resource_update.ResourceUpdateStateInProgress, resource_update.OperationCreate), // conflicting
+			newTestResourceUpdate("test-resource5", "FakeAWS::S3::Bucket", "test-stack1", "test-target", resource_update.ResourceUpdateStateSuccess, resource_update.OperationCreate),    // not conflicting
+			newTestResourceUpdate("test-resource6", "FakeAWS::S3::Bucket", "test-stack1", "test-target", resource_update.ResourceUpdateStateFailed, resource_update.OperationCreate),     // not conflicting
+			newTestResourceUpdate("test-resource7", "FakeAWS::S3::Bucket", "test-stack1", "test-target", resource_update.ResourceUpdateStateInProgress, resource_update.OperationRead),   // not conflicting
 		}
 
 		executingForma := forma_command.NewFormaCommand(
@@ -161,21 +86,7 @@ func TestMetastructure_ApplyWhileAnotherFormaIsModifyingTheStack_ReturnsConflict
 		executingForma.State = forma_command.CommandStateInProgress
 
 		newFormaResourceUpdates := []resource_update.ResourceUpdate{
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource8",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack1",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateNotStarted,
-				Operation: resource_update.OperationCreate,
-			},
+			newTestResourceUpdate("test-resource8", "FakeAWS::S3::Bucket", "test-stack1", "test-target", resource_update.ResourceUpdateStateNotStarted, resource_update.OperationCreate),
 		}
 
 		newForma := &pkgmodel.Forma{
@@ -195,7 +106,7 @@ func TestMetastructure_ApplyWhileAnotherFormaIsModifyingTheStack_ReturnsConflict
 				},
 			},
 		}
-		newFormaCommand := forma_command.NewFormaCommand(newForma, &config.FormaCommandConfig{}, pkgmodel.CommandApply, newFormaResourceUpdates, nil, "")
+		_ = forma_command.NewFormaCommand(newForma, &config.FormaCommandConfig{}, pkgmodel.CommandApply, newFormaResourceUpdates, nil, "")
 		err = m.Datastore.StoreFormaCommand(executingForma, "1")
 		if err != nil {
 			t.Fatalf("Failed to store forma command: %v", err)
@@ -207,7 +118,7 @@ func TestMetastructure_ApplyWhileAnotherFormaIsModifyingTheStack_ReturnsConflict
 			Simulate: false,
 		}
 
-		_, err = m.ApplyForma(&newFormaCommand.Forma, &cfg, "test")
+		_, err = m.ApplyForma(newForma, &cfg, "test")
 		assert.Error(t, err)
 
 		var conflictErr apimodel.FormaConflictingCommandsError
@@ -230,51 +141,9 @@ func TestMetastructure_ApplyFormaRejectIfResourceIsUpdating(t *testing.T) {
 		}
 
 		executingFormaResourceUpdates := []resource_update.ResourceUpdate{
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource1",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack1",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateNotStarted, // conflicting
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource2",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack1",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStatePending, // conflicting
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource3",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack1",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateInProgress, // conflicting
-				Operation: resource_update.OperationCreate,
-			},
+			newTestResourceUpdate("test-resource1", "FakeAWS::S3::Bucket", "test-stack1", "test-target", resource_update.ResourceUpdateStateNotStarted, resource_update.OperationCreate),  // conflicting
+			newTestResourceUpdate("test-resource2", "FakeAWS::S3::Bucket", "test-stack1", "test-target", resource_update.ResourceUpdateStatePending, resource_update.OperationCreate),     // conflicting
+			newTestResourceUpdate("test-resource3", "FakeAWS::S3::Bucket", "test-stack1", "test-target", resource_update.ResourceUpdateStateInProgress, resource_update.OperationCreate), // conflicting
 		}
 
 		executingForma := forma_command.NewFormaCommand(
@@ -304,66 +173,10 @@ func TestMetastructure_ApplyFormaRejectIfResourceIsUpdating(t *testing.T) {
 		}
 
 		anotherExecutingFormaResourceUpdates := []resource_update.ResourceUpdate{
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource4",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack2",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateInProgress, // conflicting
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource5",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack2",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateSuccess, // not conflicting
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource6",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack2",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateFailed, // not conflicting
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource7",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack2",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateInProgress,
-				Operation: resource_update.OperationRead, // not conflicting
-			},
+			newTestResourceUpdate("test-resource4", "FakeAWS::S3::Bucket", "test-stack2", "test-target", resource_update.ResourceUpdateStateInProgress, resource_update.OperationCreate), // conflicting
+			newTestResourceUpdate("test-resource5", "FakeAWS::S3::Bucket", "test-stack2", "test-target", resource_update.ResourceUpdateStateSuccess, resource_update.OperationCreate),    // not conflicting
+			newTestResourceUpdate("test-resource6", "FakeAWS::S3::Bucket", "test-stack2", "test-target", resource_update.ResourceUpdateStateFailed, resource_update.OperationCreate),     // not conflicting
+			newTestResourceUpdate("test-resource7", "FakeAWS::S3::Bucket", "test-stack2", "test-target", resource_update.ResourceUpdateStateInProgress, resource_update.OperationRead),   // not conflicting
 		}
 
 		anotherExecutingForma := forma_command.NewFormaCommand(
@@ -446,128 +259,35 @@ func TestMetastructure_ApplyFormaRejectIfResourceIsUpdating(t *testing.T) {
 			},
 		}
 		newFormaResourceUpdates := []resource_update.ResourceUpdate{
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource1",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack1",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateNotStarted,
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource2",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack1",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateNotStarted,
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource3",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack1",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateNotStarted,
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource4",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack2",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateNotStarted,
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource5",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack2",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateNotStarted,
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource6",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack2",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateNotStarted,
-				Operation: resource_update.OperationCreate,
-			},
-			{
-				Resource: pkgmodel.Resource{
-					Label:  "test-resource7",
-					Type:   "FakeAWS::S3::Bucket",
-					Stack:  "test-stack2",
-					Target: "test-target",
-				},
-				ResourceTarget: pkgmodel.Target{
-					Label:     "test-target",
-					Namespace: "test-namespace",
-				},
-				StartTs:   util.TimeNow(),
-				State:     resource_update.ResourceUpdateStateNotStarted,
-				Operation: resource_update.OperationCreate,
-			},
+			newTestResourceUpdate("test-resource1", "FakeAWS::S3::Bucket", "test-stack1", "test-target", resource_update.ResourceUpdateStateNotStarted, resource_update.OperationCreate),
+			newTestResourceUpdate("test-resource2", "FakeAWS::S3::Bucket", "test-stack1", "test-target", resource_update.ResourceUpdateStateNotStarted, resource_update.OperationCreate),
+			newTestResourceUpdate("test-resource3", "FakeAWS::S3::Bucket", "test-stack1", "test-target", resource_update.ResourceUpdateStateNotStarted, resource_update.OperationCreate),
+			newTestResourceUpdate("test-resource4", "FakeAWS::S3::Bucket", "test-stack2", "test-target", resource_update.ResourceUpdateStateNotStarted, resource_update.OperationCreate),
+			newTestResourceUpdate("test-resource5", "FakeAWS::S3::Bucket", "test-stack2", "test-target", resource_update.ResourceUpdateStateNotStarted, resource_update.OperationCreate),
+			newTestResourceUpdate("test-resource6", "FakeAWS::S3::Bucket", "test-stack2", "test-target", resource_update.ResourceUpdateStateNotStarted, resource_update.OperationCreate),
+			newTestResourceUpdate("test-resource7", "FakeAWS::S3::Bucket", "test-stack2", "test-target", resource_update.ResourceUpdateStateNotStarted, resource_update.OperationCreate),
 		}
 
-		newFormaCommand := forma_command.NewFormaCommand(newForma, &config.FormaCommandConfig{}, pkgmodel.CommandApply, newFormaResourceUpdates, nil, "")
+		_ = forma_command.NewFormaCommand(newForma, &config.FormaCommandConfig{}, pkgmodel.CommandApply, newFormaResourceUpdates, nil, "")
 
 		cfg := config.FormaCommandConfig{
 			Mode:     pkgmodel.FormaApplyModeReconcile,
 			Simulate: false,
 		}
 
-		_, err = m.ApplyForma(&newFormaCommand.Forma, &cfg, "test")
+		_, err = m.ApplyForma(newForma, &cfg, "test")
 		assert.Error(t, err)
 
 		var conflictErr apimodel.FormaConflictingCommandsError
 		if errors.As(err, &conflictErr) {
 			assert.Equal(t, 2, len(conflictErr.ConflictingCommands))
-			assert.Equal(t, 3, len(conflictErr.ConflictingCommands[0].ResourceUpdates))
-			assert.Equal(t, 1, len(conflictErr.ConflictingCommands[1].ResourceUpdates))
+			// Check that we have one command with 3 updates and one with 1, regardless of order
+			counts := []int{
+				len(conflictErr.ConflictingCommands[0].ResourceUpdates),
+				len(conflictErr.ConflictingCommands[1].ResourceUpdates),
+			}
+			assert.Contains(t, counts, 3, "Expected one command with 3 conflicting resource updates")
+			assert.Contains(t, counts, 1, "Expected one command with 1 conflicting resource update")
 		} else {
 			t.Errorf("Expected a ConflctingResourcesError, got: %T", err)
 		}

--- a/internal/workflow_tests/local/apply_forma/soft_reconcile_test.go
+++ b/internal/workflow_tests/local/apply_forma/soft_reconcile_test.go
@@ -23,6 +23,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// allCommandsSuccessful returns true if all commands in the slice have succeeded
+func allCommandsSuccessful(commands []*forma_command.FormaCommand) bool {
+	for _, cmd := range commands {
+		if cmd.State != forma_command.CommandStateSuccess {
+			return false
+		}
+	}
+	return true
+}
+
 // Soft reconcile means applying a forma without the `--force` flag. If the resources in the stack have been altered
 // since the last reconcile, the apply will be rejected and the last update to the resource will be returned.
 func TestApplyForma_SoftReconcile_ReturnsMostRecentChangesPerStack(t *testing.T) {
@@ -184,7 +194,8 @@ func TestApplyForma_SoftReconcile_ReturnsMostRecentChangesPerStack(t *testing.T)
 			commands, err = m.Datastore.LoadFormaCommands()
 			assert.NoError(t, err)
 
-			return len(commands) == 2 && commands[1].State == forma_command.CommandStateSuccess
+			// Check all commands are successful (don't rely on order)
+			return len(commands) == 2 && allCommandsSuccessful(commands)
 		}, 5*time.Second, 100*time.Millisecond)
 
 		// patch both resources
@@ -239,7 +250,8 @@ func TestApplyForma_SoftReconcile_ReturnsMostRecentChangesPerStack(t *testing.T)
 			commands, err = m.Datastore.LoadFormaCommands()
 			assert.NoError(t, err)
 
-			return len(commands) == 3 && commands[2].State == forma_command.CommandStateSuccess
+			// Check all commands are successful (don't rely on order)
+			return len(commands) == 3 && allCommandsSuccessful(commands)
 		}, 5*time.Second, 100*time.Millisecond)
 
 		// reconcile the stack to a new state, forcing a hard reconcile
@@ -473,7 +485,8 @@ func TestApplyForma_SoftReconcile_ReturnsEmtpyFormaCommandNoChangesAreDetected(t
 			commands, err = m.Datastore.LoadFormaCommands()
 			assert.NoError(t, err)
 
-			return len(commands) == 2 && commands[1].State == forma_command.CommandStateSuccess
+			// Check all commands are successful (don't rely on order)
+			return len(commands) == 2 && allCommandsSuccessful(commands)
 		}, 5*time.Second, 100*time.Millisecond)
 
 		// reconcile the stack with a forma that incorporates the patch (should result in no changes)

--- a/internal/workflow_tests/local/apply_forma/unmanaged_tagless_resource_test.go
+++ b/internal/workflow_tests/local/apply_forma/unmanaged_tagless_resource_test.go
@@ -294,22 +294,23 @@ func TestApplyForma_ReconcileFormaWithExistingStackAndUnmanagedTaglessResource(t
 		require.NoError(t, err, "ApplyForma should not return an error")
 
 		// Step 4: Wait for the command to complete successfully
+		// Commands are ordered by timestamp DESC, so the newest command is at index 0
 		eventually(func() bool {
 			commands, err := m.Datastore.LoadFormaCommands()
 			if err != nil || len(commands) != 2 {
 				return false
 			}
-			return commands[1].State == forma_command.CommandStateSuccess
+			return commands[0].State == forma_command.CommandStateSuccess
 		}, "Second command should complete successfully")
 
 		// Step 5: Verify the resource was brought under management correctly
 		commands, err := m.Datastore.LoadFormaCommands()
 		require.NoError(t, err)
 		require.Equal(t, 2, len(commands), "Should have exactly two commands")
-		require.Equal(t, forma_command.CommandStateSuccess, commands[1].State, "Second command should be successful")
+		require.Equal(t, forma_command.CommandStateSuccess, commands[0].State, "Second command should be successful")
 
-		// The second command should have one resource update for the VPC Gateway Attachment
-		secondCommand := commands[1]
+		// The second (newest) command should have one resource update for the VPC Gateway Attachment
+		secondCommand := commands[0]
 		t.Logf("Second command has %d resource updates", len(secondCommand.ResourceUpdates))
 
 		// Find the VPC Gateway Attachment resource update

--- a/internal/workflow_tests/local/property_test.go
+++ b/internal/workflow_tests/local/property_test.go
@@ -262,6 +262,10 @@ func (pt *PropertyTest) WaitForCommandSuccess(commandID string, clientId string)
 				pt.Log("GetFormaCommandsStatus error: %v", err)
 				return false
 			}
+			if len(result.Commands) == 0 {
+				pt.Log("GetFormaCommandsStatus returned no commands for id:%s", commandID)
+				return false
+			}
 			return result.Commands[0].State == "Success"
 		},
 		10*time.Second,

--- a/internal/workflow_tests/local/resource_updater_test.go
+++ b/internal/workflow_tests/local/resource_updater_test.go
@@ -166,7 +166,7 @@ func TestResourceUpdater_SuccessfullySynchronizesAResource(t *testing.T) {
 				StartTs: util.TimeNow(),
 				ResourceUpdates: []resource_update.ResourceUpdate{
 					{
-						Operation: resource_update.OperationUpdate,
+						Operation: resource_update.OperationRead, // Must match the operation used by resourceUpdateReadingS3Bucket
 						Resource: pkgmodel.Resource{
 							Label:      "test-resource",
 							Type:       "FakeAWS::S3::Bucket",
@@ -285,7 +285,7 @@ func TestResourceUpdater_SuccessfullyDeletesAResource(t *testing.T) {
 				StartTs: util.TimeNow(),
 				ResourceUpdates: []resource_update.ResourceUpdate{
 					{
-						Operation: resource_update.OperationUpdate,
+						Operation: resource_update.OperationDelete, // Must match the operation used by resourceUpdateDeletingS3Bucket
 						Resource: pkgmodel.Resource{
 							Label: "test-resource",
 							Type:  "FakeAWS::S3::Bucket",
@@ -710,7 +710,7 @@ func TestResourceUpdater_SuccessfullyRecoversFromADeleteOperationLeftInInProgres
 				StartTs: util.TimeNow(),
 				ResourceUpdates: []resource_update.ResourceUpdate{
 					{
-						Operation: resource_update.OperationUpdate,
+						Operation: resource_update.OperationDelete, // Must match partiallyCompletedResourceUpdateDeletingS3Bucket
 						Resource: pkgmodel.Resource{
 							Label: "test-resource",
 							Type:  "FakeAWS::S3::Bucket",
@@ -836,7 +836,7 @@ func TestResourceUpdater_SuccessfullyRecoversFromACreateOperationLeftInInProgres
 				StartTs: util.TimeNow(),
 				ResourceUpdates: []resource_update.ResourceUpdate{
 					{
-						Operation: resource_update.OperationUpdate,
+						Operation: resource_update.OperationCreate, // Must match partiallyCompletedResourceUpdateCreatingS3Bucket
 						Resource: pkgmodel.Resource{
 							Label: "test-resource",
 							Type:  "FakeAWS::S3::Bucket",

--- a/plugins/pkl/assets/formae/Config.pkl
+++ b/plugins/pkl/assets/formae/Config.pkl
@@ -56,7 +56,7 @@ class PostgresConfig {
 }
 
 class RetryConfig {
-    statusCheckInterval: Duration = 10.s
+    statusCheckInterval: Duration = 20.s
 
     maxRetries: Int = 9
 

--- a/plugins/yaml/go.mod
+++ b/plugins/yaml/go.mod
@@ -1,0 +1,26 @@
+module github.com/platform-engineering-labs/formae/plugins/yaml
+
+go 1.25.1
+
+replace github.com/platform-engineering-labs/formae/pkg/plugin => ../../pkg/plugin
+
+replace github.com/platform-engineering-labs/formae/pkg/model => ../../pkg/model
+
+require (
+	github.com/alecthomas/chroma/v2 v2.20.0
+	github.com/masterminds/semver v1.5.0
+	github.com/platform-engineering-labs/formae/pkg/model v0.0.0-00010101000000-000000000000
+	github.com/platform-engineering-labs/formae/pkg/plugin v0.0.0-00010101000000-000000000000
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	ergo.services/actor/statemachine v0.0.0-20251202053101-c0aa08b403e5 // indirect
+	ergo.services/ergo v1.999.310 // indirect
+	github.com/PaesslerAG/gval v1.0.0 // indirect
+	github.com/PaesslerAG/jsonpath v0.1.1 // indirect
+	github.com/dlclark/regexp2 v1.11.5 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+)

--- a/plugins/yaml/go.sum
+++ b/plugins/yaml/go.sum
@@ -1,3 +1,7 @@
+ergo.services/actor/statemachine v0.0.0-20251202053101-c0aa08b403e5 h1:8b8Y8gLBvQrDIuKFSCwT089l1iltqsTEWXzhm/pSguE=
+ergo.services/actor/statemachine v0.0.0-20251202053101-c0aa08b403e5/go.mod h1:epgQDQTm93L3/plOnIejSYbl/SNhulI78aa1LC0tLn0=
+ergo.services/ergo v1.999.310 h1:qHx35J5UxCheNJaFrOK/1K6/p7jir680+NTPZo6bhbI=
+ergo.services/ergo v1.999.310/go.mod h1:bLQ6PoO6Mz/8gVuzvPv3xfMfo1P9w6rZV1WnMXMeMdg=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=

--- a/scripts/generate-perf-test-env.py
+++ b/scripts/generate-perf-test-env.py
@@ -1,0 +1,1832 @@
+#!/usr/bin/env python3
+# © 2025 Platform Engineering Labs Inc.
+#
+# SPDX-License-Identifier: FSL-1.1-ALv2
+
+"""
+Generate a large-scale AWS infrastructure environment for performance testing formae.
+
+This script generates PKL files that create a realistic production-like AWS environment
+with a configurable number of resources. The distribution of resource types mimics
+typical enterprise production environments.
+
+Usage:
+    python3 scripts/generate-perf-test-env.py --count 1000 --region us-east-1
+    python3 scripts/generate-perf-test-env.py --count 3000 --region eu-west-1 --output ./perf-test
+
+To apply the generated environment:
+    cd <output-dir>
+    pkl project resolve
+    formae apply --mode reconcile main.pkl
+
+To destroy:
+    formae destroy main.pkl
+"""
+
+import argparse
+import math
+import os
+import sys
+import uuid
+from dataclasses import dataclass
+from typing import List, Dict, Tuple
+
+
+# Resource distribution percentages for a realistic production environment
+# Based on typical enterprise AWS usage patterns
+# NOTE: VPC-related resources are capped to stay within AWS quotas (max 5 VPCs, IGWs, NAT GWs)
+DISTRIBUTION = {
+    # Networking - Capped (8% total, down from 38%)
+    # These scale logarithmically to stay within AWS quotas
+    "vpc": 0.001,           # Cap at ~5 VPCs even for large environments
+    "subnet": 0.01,         # Multiple subnets per VPC
+    "route_table": 0.008,   # Route tables
+    "route": 0.01,          # Routes
+    "igw": 0.001,           # Internet gateways (1 per VPC, capped)
+    "nat_gw": 0.003,        # NAT gateways (expensive, capped at ~5)
+    "eip": 0.01,            # Elastic IPs (mostly for instances now)
+    "security_group": 0.05, # Security groups
+    "sg_ingress": 0.08,     # Security group rules
+    "sg_egress": 0.03,      # Egress rules
+    "vpc_endpoint": 0.01,   # VPC endpoints
+
+    # Compute (15% - NEW)
+    "ec2_instance": 0.08,   # EC2 instances
+    "ebs_volume": 0.05,     # EBS volumes (some instances have extra volumes)
+    "launch_template": 0.02, # Launch templates
+
+    # IAM & Security (20%, down from 28%)
+    "iam_role": 0.08,       # IAM roles
+    "iam_policy": 0.05,     # IAM policies (managed + inline)
+    "instance_profile": 0.03, # Instance profiles
+    "kms_key": 0.01,        # KMS keys
+    "secret": 0.02,         # Secrets
+    "kms_alias": 0.01,      # KMS aliases
+
+    # Storage (18%, up from 15%)
+    "s3_bucket": 0.10,      # S3 buckets (very common)
+    "dynamodb_table": 0.04, # DynamoDB tables
+    "efs": 0.02,            # EFS file systems
+    "efs_mount_target": 0.02, # EFS mount targets
+
+    # Observability (12%, up from 10%)
+    "log_group": 0.08,      # CloudWatch log groups
+    "sqs_queue": 0.04,      # SQS queues
+
+    # Application (12%, up from 9%)
+    "lambda": 0.06,         # Lambda functions (very common)
+    "ecr_repo": 0.03,       # ECR repositories
+
+    # DNS & API Gateway (10% - NEW)
+    "route53_zone": 0.02,   # Route53 hosted zones
+    "route53_record": 0.05, # Route53 records
+    "api_gateway": 0.02,    # API Gateway REST APIs
+    "api_stage": 0.01,      # API Gateway stages
+
+    # RDS (5% - NEW)
+    "rds_instance": 0.02,   # RDS instances
+    "db_subnet_group": 0.01, # DB subnet groups
+    "db_parameter_group": 0.02, # DB parameter groups
+}
+
+
+@dataclass
+class ResourceCounts:
+    """Calculated resource counts based on total target."""
+    vpcs: int
+    subnets_per_vpc: int
+    route_tables: int
+    routes: int
+    igws: int
+    nat_gws: int
+    eips: int
+    security_groups: int
+    sg_ingress_rules: int
+    sg_egress_rules: int
+    vpc_endpoints: int
+    # Compute
+    ec2_instances: int
+    ebs_volumes: int
+    launch_templates: int
+    # IAM & Security
+    iam_roles: int
+    iam_policies: int
+    instance_profiles: int
+    kms_keys: int
+    secrets: int
+    kms_aliases: int
+    # Storage
+    s3_buckets: int
+    dynamodb_tables: int
+    efs_filesystems: int
+    efs_mount_targets: int
+    # Observability
+    log_groups: int
+    sqs_queues: int
+    # Application
+    lambdas: int
+    ecr_repos: int
+    # DNS & API Gateway
+    route53_zones: int
+    route53_records: int
+    api_gateways: int
+    api_stages: int
+    # RDS
+    rds_instances: int
+    db_subnet_groups: int
+    db_parameter_groups: int
+
+    @property
+    def total(self) -> int:
+        return (
+            self.vpcs +
+            (self.vpcs * self.subnets_per_vpc) +
+            self.route_tables +
+            self.routes +
+            self.igws +
+            self.nat_gws +
+            self.eips +
+            self.security_groups +
+            self.sg_ingress_rules +
+            self.sg_egress_rules +
+            self.vpc_endpoints +
+            self.ec2_instances +
+            self.ebs_volumes +
+            self.launch_templates +
+            self.iam_roles +
+            self.iam_policies +
+            self.instance_profiles +
+            self.kms_keys +
+            self.secrets +
+            self.kms_aliases +
+            self.s3_buckets +
+            self.dynamodb_tables +
+            self.efs_filesystems +
+            self.efs_mount_targets +
+            self.log_groups +
+            self.sqs_queues +
+            self.lambdas +
+            self.ecr_repos +
+            self.route53_zones +
+            self.route53_records +
+            self.api_gateways +
+            self.api_stages +
+            self.rds_instances +
+            self.db_subnet_groups +
+            self.db_parameter_groups +
+            # Additional resources created implicitly
+            self.vpcs +  # VPC gateway attachments
+            (self.vpcs * self.subnets_per_vpc) +  # Subnet route table associations
+            (self.ec2_instances * 2)  # Volume attachments (2 per instance on average)
+        )
+
+
+def calculate_counts(total: int) -> ResourceCounts:
+    """Calculate resource counts based on target total and distribution.
+
+    VPC-related resources are capped to stay within AWS quotas:
+    - Max 5 VPCs (default quota)
+    - Max 5 Internet Gateways (1 per VPC)
+    - Max 5 NAT Gateways per AZ (we cap at 5 total)
+    """
+    # Cap VPCs using logarithmic scaling: 1 VPC for <500, 2 for <1000, 3 for <2000, max 5
+    if total < 500:
+        vpcs = 1
+    elif total < 1000:
+        vpcs = 2
+    elif total < 2000:
+        vpcs = 3
+    elif total < 3500:
+        vpcs = 4
+    else:
+        vpcs = 5  # Hard cap at 5 VPCs
+
+    # Subnets per VPC: scale based on total but keep reasonable
+    subnets_per_vpc = max(2, min(8, int(total * DISTRIBUTION["subnet"] / vpcs)))
+
+    # Cap NAT gateways at 5 (expensive and quota-limited)
+    nat_gws = min(5, max(1, int(total * DISTRIBUTION["nat_gw"])))
+
+    return ResourceCounts(
+        vpcs=vpcs,
+        subnets_per_vpc=subnets_per_vpc,
+        route_tables=max(vpcs * 2, int(total * DISTRIBUTION["route_table"])),
+        routes=max(vpcs * 2, int(total * DISTRIBUTION["route"])),
+        igws=vpcs,  # One per VPC, capped by VPC count
+        nat_gws=nat_gws,
+        eips=max(1, int(total * DISTRIBUTION["eip"])),
+        security_groups=max(vpcs * 2, int(total * DISTRIBUTION["security_group"])),
+        sg_ingress_rules=max(5, int(total * DISTRIBUTION["sg_ingress"])),
+        sg_egress_rules=max(5, int(total * DISTRIBUTION["sg_egress"])),
+        vpc_endpoints=max(1, int(total * DISTRIBUTION["vpc_endpoint"])),
+        # Compute
+        ec2_instances=max(2, int(total * DISTRIBUTION["ec2_instance"])),
+        ebs_volumes=max(2, int(total * DISTRIBUTION["ebs_volume"])),
+        launch_templates=max(1, int(total * DISTRIBUTION["launch_template"])),
+        # IAM & Security
+        iam_roles=max(5, int(total * DISTRIBUTION["iam_role"])),
+        iam_policies=max(5, int(total * DISTRIBUTION["iam_policy"])),
+        instance_profiles=max(2, int(total * DISTRIBUTION["instance_profile"])),
+        kms_keys=max(1, int(total * DISTRIBUTION["kms_key"])),
+        secrets=max(2, int(total * DISTRIBUTION["secret"])),
+        kms_aliases=max(1, int(total * DISTRIBUTION["kms_alias"])),
+        # Storage
+        s3_buckets=max(5, int(total * DISTRIBUTION["s3_bucket"])),
+        dynamodb_tables=max(2, int(total * DISTRIBUTION["dynamodb_table"])),
+        efs_filesystems=max(1, int(total * DISTRIBUTION["efs"])),
+        efs_mount_targets=max(2, int(total * DISTRIBUTION["efs_mount_target"])),
+        # Observability
+        log_groups=max(5, int(total * DISTRIBUTION["log_group"])),
+        sqs_queues=max(2, int(total * DISTRIBUTION["sqs_queue"])),
+        # Application
+        lambdas=max(2, int(total * DISTRIBUTION["lambda"])),
+        ecr_repos=max(2, int(total * DISTRIBUTION["ecr_repo"])),
+        # DNS & API Gateway
+        route53_zones=max(1, int(total * DISTRIBUTION["route53_zone"])),
+        route53_records=max(5, int(total * DISTRIBUTION["route53_record"])),
+        api_gateways=max(1, int(total * DISTRIBUTION["api_gateway"])),
+        api_stages=max(1, int(total * DISTRIBUTION["api_stage"])),
+        # RDS (note: db_subnet_groups require multiple AZs - disabled when vpcs < 2)
+        rds_instances=0,  # Disabled: requires db_subnet_groups to work properly
+        db_subnet_groups=0,  # Disabled: requires subnets in multiple AZs (need vpcs >= 2)
+        db_parameter_groups=max(1, int(total * DISTRIBUTION["db_parameter_group"])),
+    )
+
+
+COPYRIGHT = '''/*
+ * Performance Test Environment - Auto-generated
+ * Generated by generate-perf-test-env.py
+ *
+ * WARNING: This environment is for testing only. Resources will incur AWS costs.
+ */
+'''
+
+
+def generate_vars_pkl(env_id: str, region: str, stack_name: str) -> str:
+    """Generate vars.pkl with environment configuration."""
+    return f'''{COPYRIGHT}
+import "@formae/formae.pkl"
+import "@aws/aws.pkl"
+
+envId = "{env_id}"
+_region = "{region}"
+stackName = "{stack_name}"
+
+stack: formae.Stack = new {{
+    label = stackName
+    description = "Performance test environment {env_id}"
+}}
+
+target: formae.Target = new {{
+    label = "perf-test-target"
+    config = new aws.Config {{
+        region = _region
+    }}
+}}
+
+// Helper for unique naming
+local function uniqueName(base: String): String = "\\(envId)-\\(base)"
+'''
+
+
+def generate_networking_pkl(counts: ResourceCounts, region: str) -> str:
+    """Generate networking.pkl with VPCs, subnets, and routing."""
+
+    # Generate subnet blocks dynamically for multiple AZs
+    azs = ["a", "b", "c"]
+
+    vpc_blocks = []
+    for i in range(counts.vpcs):
+        # Calculate CIDR blocks - use 10.{vpc_index}.0.0/16 pattern
+        vpc_cidr = f"10.{i}.0.0/16"
+
+        vpc_blocks.append(f'''
+  hidden vpc{i}: vpc.VPC = new {{
+    label = "\\(name)-vpc-{i}"
+    cidrBlock = "{vpc_cidr}"
+    enableDnsHostnames = true
+    enableDnsSupport = true
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "Environment"; value = "perf-test" }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}
+
+  hidden igw{i}: internetgateway.InternetGateway = new {{
+    label = "\\(name)-igw-{i}"
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}
+
+  hidden igwAttach{i}: vpcgatewayattachment.VPCGatewayAttachment = new {{
+    label = "\\(name)-igw-attach-{i}"
+    vpcId = vpc{i}.res.id
+    internetGatewayId = igw{i}.res.id
+  }}
+
+  hidden publicRt{i}: routetable.RouteTable = new {{
+    label = "\\(name)-public-rt-{i}"
+    vpcId = vpc{i}.res.id
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}
+
+  hidden privateRt{i}: routetable.RouteTable = new {{
+    label = "\\(name)-private-rt-{i}"
+    vpcId = vpc{i}.res.id
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}
+
+  // Note: gatewayId references the attachment's InternetGatewayId to ensure
+  // the route is created only after the IGW is attached to the VPC
+  hidden publicRoute{i}: route.Route = new {{
+    label = "\\(name)-public-route-{i}"
+    routeTableId = publicRt{i}.res.id
+    destinationCidrBlock = "0.0.0.0/0"
+    gatewayId = igwAttach{i}.internetGatewayId
+  }}''')
+
+        # Generate subnets for this VPC
+        for j in range(counts.subnets_per_vpc):
+            az = azs[j % len(azs)]
+            is_public = j < counts.subnets_per_vpc // 2
+            subnet_type = "public" if is_public else "private"
+            subnet_cidr = f"10.{i}.{j}.0/24"
+            rt_ref = f"publicRt{i}" if is_public else f"privateRt{i}"
+
+            vpc_blocks.append(f'''
+  hidden subnet{i}_{j}: subnet.Subnet = new {{
+    label = "\\(name)-{subnet_type}-subnet-{i}-{j}"
+    vpcId = vpc{i}.res.id
+    cidrBlock = "{subnet_cidr}"
+    availabilityZone = "\\(region){az}"
+    mapPublicIpOnLaunch = {str(is_public).lower()}
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "Type"; value = "{subnet_type}" }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}
+
+  hidden subnetRtAssoc{i}_{j}: subnetroutetableassociation.SubnetRouteTableAssociation = new {{
+    label = "\\(name)-subnet-rt-assoc-{i}-{j}"
+    subnetId = subnet{i}_{j}.res.id
+    routeTableId = {rt_ref}.res.id
+  }}''')
+
+    # Generate resource listing
+    resource_list = []
+    for i in range(counts.vpcs):
+        resource_list.append(f"    vpc{i}")
+        resource_list.append(f"    igw{i}")
+        resource_list.append(f"    igwAttach{i}")
+        resource_list.append(f"    publicRt{i}")
+        resource_list.append(f"    privateRt{i}")
+        resource_list.append(f"    publicRoute{i}")
+        for j in range(counts.subnets_per_vpc):
+            resource_list.append(f"    subnet{i}_{j}")
+            resource_list.append(f"    subnetRtAssoc{i}_{j}")
+
+    return f'''{COPYRIGHT}
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/internetgateway.pkl"
+import "@aws/ec2/routetable.pkl"
+import "@aws/ec2/route.pkl"
+import "@aws/ec2/subnetroutetableassociation.pkl"
+import "@aws/ec2/vpcgatewayattachment.pkl"
+
+class Networking {{
+  name: String
+  region: String
+{"".join(vpc_blocks)}
+
+  // Expose VPCs and subnets for other modules
+  vpcs: Listing = new {{
+{chr(10).join(f"    vpc{i}" for i in range(counts.vpcs))}
+  }}
+
+  // First private subnet per VPC for EFS mount targets
+  privateSubnets: Listing = new {{
+{chr(10).join(f"    subnet{i}_{counts.subnets_per_vpc // 2}" for i in range(counts.vpcs))}
+  }}
+
+  resources: Listing = new {{
+{chr(10).join(resource_list)}
+  }}
+}}
+'''
+
+
+def generate_security_groups_pkl(counts: ResourceCounts) -> str:
+    """Generate security_groups.pkl with security groups and rules."""
+
+    sg_blocks = []
+    ingress_blocks = []
+    egress_blocks = []
+
+    # Distribute SGs across VPCs
+    for i in range(counts.security_groups):
+        vpc_idx = i % max(1, int(counts.security_groups * 0.005))  # Distribute across VPCs
+        sg_blocks.append(f'''
+  hidden sg{i}: securitygroup.SecurityGroup = new {{
+    label = "\\(name)-sg-{i}"
+    groupDescription = "Security group {i} for perf test"
+    vpcId = networking.vpcs.toList()[{vpc_idx}].res.id
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    # Generate ingress rules distributed across security groups
+    for i in range(counts.sg_ingress_rules):
+        sg_idx = i % counts.security_groups
+        port = 80 + (i % 20) * 100  # Vary ports
+        ingress_blocks.append(f'''
+  hidden sgIngress{i}: securitygroupingress.SecurityGroupIngress = new {{
+    label = "\\(name)-sg-ingress-{i}"
+    groupId = sg{sg_idx}.res.groupId
+    ipProtocol = "tcp"
+    fromPort = {port}
+    toPort = {port}
+    cidrIp = "10.0.0.0/8"
+    description = "Ingress rule {i}"
+  }}''')
+
+    # Generate egress rules
+    for i in range(counts.sg_egress_rules):
+        sg_idx = i % counts.security_groups
+        egress_blocks.append(f'''
+  hidden sgEgress{i}: securitygroupegress.SecurityGroupEgress = new {{
+    label = "\\(name)-sg-egress-{i}"
+    groupId = sg{sg_idx}.res.groupId
+    ipProtocol = "-1"
+    fromPort = -1
+    toPort = -1
+    cidrIp = "0.0.0.0/0"
+  }}''')
+
+    # Generate resource listing
+    resource_list = []
+    for i in range(counts.security_groups):
+        resource_list.append(f"    sg{i}")
+    for i in range(counts.sg_ingress_rules):
+        resource_list.append(f"    sgIngress{i}")
+    for i in range(counts.sg_egress_rules):
+        resource_list.append(f"    sgEgress{i}")
+
+    return f'''{COPYRIGHT}
+import "@aws/ec2/securitygroup.pkl"
+import "@aws/ec2/securitygroupingress.pkl"
+import "@aws/ec2/securitygroupegress.pkl"
+
+import "./networking.pkl" as networkingModule
+
+class SecurityGroups {{
+  name: String
+  networking: networkingModule.Networking
+{"".join(sg_blocks)}
+{"".join(ingress_blocks)}
+{"".join(egress_blocks)}
+
+  // Expose security groups for other modules
+  securityGroups: Listing = new {{
+{chr(10).join(f"    sg{i}" for i in range(counts.security_groups))}
+  }}
+
+  resources: Listing = new {{
+{chr(10).join(resource_list)}
+  }}
+}}
+'''
+
+
+def generate_compute_pkl(counts: ResourceCounts, region: str) -> str:
+    """Generate compute.pkl with EC2 instances, volumes, and launch templates."""
+
+    # Amazon Linux 2 AMIs by region (verified Dec 2024)
+    ami_map = {
+        "us-east-1": "ami-0c02fb55b2c6c5bdc",
+        "us-east-2": "ami-06ba60a55dcbf8bf2",  # Verified working in us-east-2
+        "us-west-1": "ami-0ecb7bb3a2c9a8b9d",
+        "us-west-2": "ami-0c2ab3b8efb09f272",
+        "eu-west-1": "ami-0c1c30571d2dae5c9",
+        "eu-central-1": "ami-0a49b025fffbbdac6",
+        "ap-southeast-1": "ami-0c802847a7dd848c0",
+    }
+
+    # Get AMI for the specified region, fallback to us-east-1
+    ami_id = ami_map.get(region, ami_map["us-east-1"])
+
+    lt_blocks = []
+    instance_blocks = []
+    volume_blocks = []
+    volume_attachment_blocks = []
+
+    # Generate launch templates
+    for i in range(counts.launch_templates):
+        lt_blocks.append(f'''
+  hidden launchTemplate{i}: launchtemplate.LaunchTemplate = new {{
+    label = "\\(name)-lt-{i}"
+    launchTemplateName = "\\(name)-lt-{i}"
+    launchTemplateData = new launchtemplate.LaunchTemplateData {{
+      imageId = "{ami_id}"  // Amazon Linux 2023 - {region}
+      instanceType = "t3.micro"
+      monitoring = new launchtemplate.Monitoring {{
+        enabled = true
+      }}
+      blockDeviceMappings {{
+        new launchtemplate.BlockDeviceMapping {{
+          deviceName = "/dev/xvda"
+          ebs = new launchtemplate.EBS {{
+            volumeSize = 8
+            volumeType = "gp3"
+            deleteOnTermination = true
+          }}
+        }}
+      }}
+    }}
+    // Note: tagSpecifications removed - CloudControl API doesn't support "instance" resourceType for LaunchTemplate
+  }}''')
+
+    # Generate EC2 instances
+    instance_types = ["t3.micro", "t3.small", "t3.medium"]
+    for i in range(counts.ec2_instances):
+        vpc_idx = i % counts.vpcs
+        sg_idx = i % counts.security_groups
+        instance_type = instance_types[i % len(instance_types)]
+
+        instance_blocks.append(f'''
+  hidden instance{i}: instance.Instance = new {{
+    label = "\\(name)-instance-{i}"
+    imageId = "{ami_id}"  // Amazon Linux 2023 - {region}
+    instanceType = "{instance_type}"
+    subnetId = networking.privateSubnets.toList()[{vpc_idx}].res.subnetId
+    securityGroupIds {{
+      sgs.securityGroups.toList()[{sg_idx}].res.groupId
+    }}
+    monitoring = true
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "Environment"; value = "perf-test" }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    # Generate EBS volumes (some standalone, some for attachment)
+    # First 50% are standalone, rest are for attachment to instances
+    standalone_volumes = counts.ebs_volumes // 2
+    attachable_volumes = counts.ebs_volumes - standalone_volumes
+
+    # Pre-calculate which instance each attachable volume will be attached to
+    # This ensures we create volumes in the same AZ as their target instance
+    num_attachments = min(attachable_volumes, counts.ec2_instances * 2)
+
+    # Calculate the AZ of the private subnet that all instances use
+    # privateSubnets contains subnet{vpc_idx}_{subnets_per_vpc // 2}
+    # Subnet AZ is determined by the subnet index (j) within the VPC
+    private_subnet_idx = counts.subnets_per_vpc // 2  # j value for private subnet
+    private_subnet_az = ["a", "b", "c"][private_subnet_idx % 3]
+
+    for i in range(counts.ebs_volumes):
+        # For standalone volumes, distribute across AZs
+        # For attachable volumes, use the same AZ as the private subnet (where instances run)
+        if i < standalone_volumes:
+            az_suffix = ["a", "b", "c"][i % 3]
+        else:
+            # This volume will be attached - use same AZ as the private subnet
+            attachment_idx = i - standalone_volumes
+            if attachment_idx < num_attachments:
+                # All instances use the same private subnet, so all attachable volumes
+                # need to be in that subnet's AZ
+                az_suffix = private_subnet_az
+            else:
+                az_suffix = ["a", "b", "c"][i % 3]
+
+        volume_blocks.append(f'''
+  hidden volume{i}: volume.Volume = new {{
+    label = "\\(name)-volume-{i}"
+    availabilityZone = "\\(region){az_suffix}"
+    size = {20 + (i % 5) * 10}  // 20-60 GB
+    volumeType = "{["gp3", "gp2"][i % 2]}"  // Only use gp3/gp2 (io1 requires iops parameter)
+    encrypted = {str(i % 2 == 0).lower()}
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    # Generate volume attachments for the attachable volumes
+    # Attach to instances (multiple volumes per instance)
+    for i in range(num_attachments):
+        instance_idx = i % counts.ec2_instances
+        volume_idx = standalone_volumes + i
+        device_names = ["/dev/sdf", "/dev/sdg", "/dev/sdh", "/dev/sdi"]
+        device_name = device_names[i % len(device_names)]
+
+        volume_attachment_blocks.append(f'''
+  hidden volumeAttachment{i}: volumeattachment.VolumeAttachment = new {{
+    label = "\\(name)-vol-attach-{i}"
+    instanceId = instance{instance_idx}.res.instanceId
+    volumeId = volume{volume_idx}.res.volumeId
+    device = "{device_name}"
+  }}''')
+
+    # Generate resource listing
+    resource_list = []
+    for i in range(counts.launch_templates):
+        resource_list.append(f"    launchTemplate{i}")
+    for i in range(counts.ec2_instances):
+        resource_list.append(f"    instance{i}")
+    for i in range(counts.ebs_volumes):
+        resource_list.append(f"    volume{i}")
+    for i in range(len(volume_attachment_blocks)):
+        resource_list.append(f"    volumeAttachment{i}")
+
+    return f'''{COPYRIGHT}
+import "@aws/ec2/launchtemplate.pkl"
+import "@aws/ec2/instance.pkl"
+import "@aws/ec2/volume.pkl"
+import "@aws/ec2/volumeattachment.pkl"
+
+import "./networking.pkl" as networkingModule
+import "./security_groups.pkl" as securityGroupsModule
+
+class Compute {{
+  name: String
+  region: String
+  networking: networkingModule.Networking
+  sgs: securityGroupsModule.SecurityGroups
+{"".join(lt_blocks)}
+{"".join(instance_blocks)}
+{"".join(volume_blocks)}
+{"".join(volume_attachment_blocks)}
+
+  resources: Listing = new {{
+{chr(10).join(resource_list)}
+  }}
+}}
+'''
+
+
+def generate_iam_pkl(counts: ResourceCounts) -> str:
+    """Generate iam.pkl with IAM roles, policies, and instance profiles."""
+
+    role_blocks = []
+    lambda_role_blocks = []
+    policy_blocks = []
+    profile_blocks = []
+
+    # Calculate how many Lambda execution roles we need
+    # Ensure we have enough Lambda roles for all Lambda functions (50% should be plenty)
+    # But also ensure we have at least 1 non-Lambda role if we have policies or instance profiles
+    min_other_roles = 1 if (counts.iam_policies > 0 or counts.instance_profiles > 0) else 0
+    lambda_roles_count = min(
+        max(5, int(counts.iam_roles * 0.2)),  # At least 5, or 20% of total roles
+        counts.iam_roles - min_other_roles     # But leave room for non-Lambda roles if needed
+    )
+    other_roles_count = counts.iam_roles - lambda_roles_count
+
+    # Generate Lambda execution roles with lambda.amazonaws.com trust policy
+    for i in range(lambda_roles_count):
+        lambda_role_blocks.append(f'''
+  hidden lambdaRole{i}: role.Role = new {{
+    label = "\\(name)-lambda-role-{i}"
+    roleName = "\\(name)-lambda-role-{i}"
+    assumeRolePolicyDocument {{
+      ["Version"] = "2012-10-17"
+      ["Statement"] {{
+        new {{
+          ["Effect"] = "Allow"
+          ["Principal"] {{
+            ["Service"] = "lambda.amazonaws.com"
+          }}
+          ["Action"] = "sts:AssumeRole"
+        }}
+      }}
+    }}
+    managedPolicyArns {{
+      "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+    }}
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "Type"; value = "lambda-execution" }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    # Generate other IAM roles with various service principals
+    services = ["ec2.amazonaws.com", "ecs-tasks.amazonaws.com",
+                "sagemaker.amazonaws.com", "states.amazonaws.com"]
+
+    for i in range(other_roles_count):
+        service = services[i % len(services)]
+        role_blocks.append(f'''
+  hidden role{i}: role.Role = new {{
+    label = "\\(name)-role-{i}"
+    roleName = "\\(name)-role-{i}"
+    assumeRolePolicyDocument {{
+      ["Version"] = "2012-10-17"
+      ["Statement"] {{
+        new {{
+          ["Effect"] = "Allow"
+          ["Principal"] {{
+            ["Service"] = "{service}"
+          }}
+          ["Action"] = "sts:AssumeRole"
+        }}
+      }}
+    }}
+    managedPolicyArns {{
+      "arn:aws:iam::aws:policy/ReadOnlyAccess"
+    }}
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    # Generate IAM policies (standalone - not attached to roles to avoid deletion order issues)
+    # AWS requires policies to be detached before deletion, and roles to be removed from
+    # instance profiles before deletion. By not using the `roles` property, we avoid
+    # creating implicit attachments that cause deletion failures.
+    for i in range(counts.iam_policies):
+        policy_blocks.append(f'''
+  hidden policy{i}: policy.ManagedPolicy = new {{
+    label = "\\(name)-policy-{i}"
+    managedPolicyName = "\\(name)-policy-{i}"
+    policyDocument {{
+      ["Version"] = "2012-10-17"
+      ["Statement"] {{
+        new {{
+          ["Effect"] = "Allow"
+          ["Action"] {{
+            "logs:CreateLogGroup"
+            "logs:CreateLogStream"
+            "logs:PutLogEvents"
+          }}
+          ["Resource"] = "*"
+        }}
+      }}
+    }}
+  }}''')
+
+    # Generate instance profiles (standalone - not attached to roles to avoid deletion order issues)
+    # AWS requires roles to be removed from instance profiles before the role can be deleted.
+    # By not using the `roles` property, we avoid creating implicit attachments.
+    for i in range(counts.instance_profiles):
+        profile_blocks.append(f'''
+  hidden instanceProfile{i}: instanceprofile.InstanceProfile = new {{
+    label = "\\(name)-instance-profile-{i}"
+    instanceProfileName = "\\(name)-instance-profile-{i}"
+  }}''')
+
+    # Generate resource listing
+    resource_list = []
+    for i in range(lambda_roles_count):
+        resource_list.append(f"    lambdaRole{i}")
+    for i in range(other_roles_count):
+        resource_list.append(f"    role{i}")
+    for i in range(counts.iam_policies):
+        resource_list.append(f"    policy{i}")
+    for i in range(counts.instance_profiles):
+        resource_list.append(f"    instanceProfile{i}")
+
+    return f'''{COPYRIGHT}
+import "@aws/iam/role.pkl"
+import "@aws/iam/managedpolicy.pkl" as policy
+import "@aws/iam/instanceprofile.pkl"
+
+class IAM {{
+  name: String
+{"".join(lambda_role_blocks)}
+{"".join(role_blocks)}
+{"".join(policy_blocks)}
+{"".join(profile_blocks)}
+
+  // Expose Lambda execution roles separately for Lambda functions
+  lambdaRoles: Listing = new {{
+{chr(10).join(f"    lambdaRole{i}" for i in range(lambda_roles_count))}
+  }}
+
+  // Expose other roles for general use
+  roles: Listing = new {{
+{chr(10).join(f"    role{i}" for i in range(other_roles_count))}
+  }}
+
+  resources: Listing = new {{
+{chr(10).join(resource_list)}
+  }}
+}}
+'''
+
+
+def generate_kms_pkl(counts: ResourceCounts) -> str:
+    """Generate kms.pkl with KMS keys and aliases."""
+
+    key_blocks = []
+    alias_blocks = []
+
+    for i in range(counts.kms_keys):
+        key_blocks.append(f'''
+  hidden kmsKey{i}: key.Key = new {{
+    label = "\\(name)-kms-key-{i}"
+    description = "KMS key {i} for perf test"
+    enableKeyRotation = true
+    keyPolicy {{
+      ["Version"] = "2012-10-17"
+      ["Statement"] {{
+        new {{
+          ["Sid"] = "Enable IAM User Permissions"
+          ["Effect"] = "Allow"
+          ["Principal"] {{
+            ["AWS"] = "*"
+          }}
+          ["Action"] = "kms:*"
+          ["Resource"] = "*"
+        }}
+      }}
+    }}
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    for i in range(min(counts.kms_aliases, counts.kms_keys)):
+        alias_blocks.append(f'''
+  hidden kmsAlias{i}: alias.Alias = new {{
+    label = "\\(name)-kms-alias-{i}"
+    aliasName = "alias/\\(name)-key-{i}"
+    targetKeyId = kmsKey{i}.res.arn
+  }}''')
+
+    resource_list = []
+    for i in range(counts.kms_keys):
+        resource_list.append(f"    kmsKey{i}")
+    for i in range(min(counts.kms_aliases, counts.kms_keys)):
+        resource_list.append(f"    kmsAlias{i}")
+
+    return f'''{COPYRIGHT}
+import "@aws/kms/key.pkl"
+import "@aws/kms/kmsalias.pkl" as alias
+
+class KMS {{
+  name: String
+{"".join(key_blocks)}
+{"".join(alias_blocks)}
+
+  // Expose keys for other modules
+  keys: Listing = new {{
+{chr(10).join(f"    kmsKey{i}" for i in range(counts.kms_keys))}
+  }}
+
+  resources: Listing = new {{
+{chr(10).join(resource_list)}
+  }}
+}}
+'''
+
+
+def generate_storage_pkl(counts: ResourceCounts) -> str:
+    """Generate storage.pkl with S3 buckets, DynamoDB tables, and EFS."""
+
+    bucket_blocks = []
+    dynamo_blocks = []
+    efs_blocks = []
+    mount_target_blocks = []
+
+    # S3 Buckets
+    for i in range(counts.s3_buckets):
+        bucket_blocks.append(f'''
+  hidden bucket{i}: bucket.Bucket = new {{
+    label = "\\(name)-bucket-{i}"
+    // S3 bucket names must be globally unique - include full env name
+    bucketName = "\\(name)-bucket-{i}"
+    versioningConfiguration = new bucket.VersioningConfiguration {{
+      status = "Enabled"
+    }}
+    publicAccessBlockConfiguration = new bucket.PublicAccessBlockConfiguration {{
+      blockPublicAcls = true
+      blockPublicPolicy = true
+      ignorePublicAcls = true
+      restrictPublicBuckets = true
+    }}
+    bucketEncryption = new bucket.BucketEncryption {{
+      serverSideEncryptionConfiguration {{
+        new bucket.ServerSideEncryptionRule {{
+          serverSideEncryptionByDefault = new bucket.ServerSideEncryptionByDefault {{
+            sseAlgorithm = "AES256"
+          }}
+        }}
+      }}
+    }}
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    # DynamoDB Tables
+    for i in range(counts.dynamodb_tables):
+        dynamo_blocks.append(f'''
+  hidden dynamoTable{i}: table.Table = new {{
+    label = "\\(name)-table-{i}"
+    tableName = "\\(name)-table-{i}"
+    billingMode = "PAY_PER_REQUEST"
+    attributeDefinitions {{
+      new table.AttributeDefinition {{
+        attributeName = "pk"
+        attributeType = "S"
+      }}
+      new table.AttributeDefinition {{
+        attributeName = "sk"
+        attributeType = "S"
+      }}
+    }}
+    keySchema {{
+      new table.KeySchema {{
+        attributeName = "pk"
+        keyType = "HASH"
+      }}
+      new table.KeySchema {{
+        attributeName = "sk"
+        keyType = "RANGE"
+      }}
+    }}
+    deletionProtectionEnabled = false
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    # EFS File Systems
+    for i in range(counts.efs_filesystems):
+        efs_blocks.append(f'''
+  hidden efs{i}: filesystem.FileSystem = new {{
+    label = "\\(name)-efs-{i}"
+    performanceMode = "generalPurpose"
+    encrypted = true
+    fileSystemTags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    # EFS Mount Targets (distributed across subnets)
+    for i in range(min(counts.efs_mount_targets, counts.efs_filesystems)):
+        mount_target_blocks.append(f'''
+  hidden efsMountTarget{i}: mounttarget.MountTarget = new {{
+    label = "\\(name)-efs-mount-{i}"
+    fileSystemId = efs{i}.res.fileSystemId
+    subnetId = networking.privateSubnets.toList()[{i % max(1, int(counts.efs_filesystems * 0.005))}].res.id
+    securityGroups {{
+      sgs.securityGroups.toList()[0].res.groupId
+    }}
+  }}''')
+
+    resource_list = []
+    for i in range(counts.s3_buckets):
+        resource_list.append(f"    bucket{i}")
+    for i in range(counts.dynamodb_tables):
+        resource_list.append(f"    dynamoTable{i}")
+    for i in range(counts.efs_filesystems):
+        resource_list.append(f"    efs{i}")
+    for i in range(min(counts.efs_mount_targets, counts.efs_filesystems)):
+        resource_list.append(f"    efsMountTarget{i}")
+
+    return f'''{COPYRIGHT}
+import "@aws/s3/bucket.pkl"
+import "@aws/dynamodb/table.pkl"
+import "@aws/efs/filesystem.pkl"
+import "@aws/efs/mounttarget.pkl"
+
+import "./networking.pkl" as networkingModule
+import "./security_groups.pkl" as securityGroupsModule
+
+class Storage {{
+  name: String
+  networking: networkingModule.Networking
+  sgs: securityGroupsModule.SecurityGroups
+{"".join(bucket_blocks)}
+{"".join(dynamo_blocks)}
+{"".join(efs_blocks)}
+{"".join(mount_target_blocks)}
+
+  resources: Listing = new {{
+{chr(10).join(resource_list)}
+  }}
+}}
+'''
+
+
+def generate_observability_pkl(counts: ResourceCounts) -> str:
+    """Generate observability.pkl with CloudWatch Log Groups and SQS Queues."""
+
+    log_group_blocks = []
+    sqs_blocks = []
+
+    # CloudWatch Log Groups
+    for i in range(counts.log_groups):
+        log_group_blocks.append(f'''
+  hidden logGroup{i}: loggroup.LogGroup = new {{
+    label = "\\(name)-log-group-{i}"
+    logGroupName = "/perf-test/\\(name)/app-{i}"
+    retentionInDays = 7
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    # SQS Queues (SNS not available in the AWS plugin)
+    for i in range(counts.sqs_queues):
+        sqs_blocks.append(f'''
+  hidden sqsQueue{i}: queue.Queue = new {{
+    label = "\\(name)-sqs-queue-{i}"
+    queueName = "\\(name)-queue-{i}"
+    visibilityTimeout = 30.s
+    messageRetentionPeriod = 345600.s
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    resource_list = []
+    for i in range(counts.log_groups):
+        resource_list.append(f"    logGroup{i}")
+    for i in range(counts.sqs_queues):
+        resource_list.append(f"    sqsQueue{i}")
+
+    return f'''{COPYRIGHT}
+import "@aws/logs/loggroup.pkl"
+import "@aws/sqs/queue.pkl"
+
+class Observability {{
+  name: String
+{"".join(log_group_blocks)}
+{"".join(sqs_blocks)}
+
+  resources: Listing = new {{
+{chr(10).join(resource_list)}
+  }}
+}}
+'''
+
+
+def generate_secrets_pkl(counts: ResourceCounts) -> str:
+    """Generate secrets.pkl with Secrets Manager secrets."""
+
+    secret_blocks = []
+
+    # Secrets Manager secrets (SSM not available in the AWS plugin)
+    for i in range(counts.secrets):
+        secret_blocks.append(f'''
+  hidden secret{i}: secret.Secret = new {{
+    label = "\\(envName)-secret-{i}"
+    name = "\\(envName)/secret-{i}"
+    description = "Secret {i} for perf test"
+    generateSecretString = new secret.GenerateSecretString {{
+      secretStringTemplate = #"{{"username": "admin-{i}"}}"#
+      generateStringKey = "password"
+      passwordLength = 32
+      excludePunctuation = true
+    }}
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    resource_list = []
+    for i in range(counts.secrets):
+        resource_list.append(f"    secret{i}")
+
+    return f'''{COPYRIGHT}
+import "@aws/secretsmanager/secret.pkl"
+
+class Secrets {{
+  envName: String
+{"".join(secret_blocks)}
+
+  resources: Listing = new {{
+{chr(10).join(resource_list)}
+  }}
+}}
+'''
+
+
+def generate_application_pkl(counts: ResourceCounts) -> str:
+    """Generate application.pkl with Lambda functions and ECR repos."""
+
+    lambda_blocks = []
+    ecr_blocks = []
+
+    # Calculate lambda_roles_count the same way as in generate_iam_pkl
+    min_other_roles = 1 if (counts.iam_policies > 0 or counts.instance_profiles > 0) else 0
+    lambda_roles_count = min(
+        max(5, int(counts.iam_roles * 0.2)),
+        counts.iam_roles - min_other_roles
+    )
+
+    # Lambda functions (without actual code - just the function resource)
+    # Use the dedicated Lambda execution roles pool
+    for i in range(counts.lambdas):
+        role_idx = i % lambda_roles_count
+        lambda_blocks.append(f'''
+  hidden lambda{i}: lambdaFunc.Function = new {{
+    label = "\\(name)-lambda-{i}"
+    functionName = "\\(name)-lambda-{i}"
+    runtime = "python3.11"
+    handler = "index.handler"
+    role = iam.lambdaRoles.toList()[{role_idx}].res.arn
+    // Minimal inline code - just a placeholder
+    code = new lambdaFunc.Code {{
+      zipFile = #"def handler(event, context): return {{'statusCode': 200}}"#
+    }}
+    memorySize = 128
+    timeout = 30
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    # ECR Repositories
+    for i in range(counts.ecr_repos):
+        ecr_blocks.append(f'''
+  hidden ecrRepo{i}: repository.Repository = new {{
+    label = "\\(name)-ecr-repo-{i}"
+    repositoryName = "\\(name)-repo-{i}"
+    imageScanningConfiguration = new repository.ImageScanningConfiguration {{
+      scanOnPush = true
+    }}
+    imageTagMutability = "MUTABLE"
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    resource_list = []
+    for i in range(counts.lambdas):
+        resource_list.append(f"    lambda{i}")
+    for i in range(counts.ecr_repos):
+        resource_list.append(f"    ecrRepo{i}")
+
+    return f'''{COPYRIGHT}
+import "@aws/lambda/func.pkl" as lambdaFunc
+import "@aws/ecr/repository.pkl"
+
+import "./iam.pkl" as iamModule
+
+class Application {{
+  name: String
+  iam: iamModule.IAM
+{"".join(lambda_blocks)}
+{"".join(ecr_blocks)}
+
+  resources: Listing = new {{
+{chr(10).join(resource_list)}
+  }}
+}}
+'''
+
+
+def generate_route53_pkl(counts: ResourceCounts) -> str:
+    """Generate route53.pkl with hosted zones and DNS records."""
+
+    zone_blocks = []
+    record_blocks = []
+
+    # Generate hosted zones
+    for i in range(counts.route53_zones):
+        zone_blocks.append(f'''
+  hidden hostedZone{i}: hostedzone.HostedZone = new {{
+    label = "\\(envName)-zone-{i}"
+    name = "\\(envName)-zone-{i}.perftest.internal"  // Use .internal to avoid AWS reserved domains
+    hostedZoneConfig = new hostedzone.HostedZoneConfig {{
+      comment = "Hosted zone {i} for perf test"
+    }}
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    # Generate DNS records distributed across zones
+    record_types = ["A", "CNAME", "TXT"]
+    for i in range(counts.route53_records):
+        zone_idx = i % counts.route53_zones
+        record_type = record_types[i % len(record_types)]
+
+        if record_type == "A":
+            resource_records = '"1.2.3.4"\n      "5.6.7.8"'
+        elif record_type == "CNAME":
+            resource_records = '"target.perftest.internal"'
+        else:  # TXT
+            resource_records = '"\\"v=spf1 -all\\""'
+
+        record_blocks.append(f'''
+  hidden record{i}: recordset.RecordSet = new {{
+    label = "\\(envName)-record-{i}"
+    hostedZoneId = hostedZone{zone_idx}.res.id
+    name = "record-{i}.\\(envName)-zone-{zone_idx}.perftest.internal"
+    type = "{record_type}"
+    ttl = 300
+    resourceRecords {{
+      {resource_records}
+    }}
+  }}''')
+
+    resource_list = []
+    for i in range(counts.route53_zones):
+        resource_list.append(f"    hostedZone{i}")
+    for i in range(counts.route53_records):
+        resource_list.append(f"    record{i}")
+
+    return f'''{COPYRIGHT}
+import "@aws/route53/hostedzone.pkl"
+import "@aws/route53/recordset.pkl"
+
+class Route53 {{
+  envName: String
+{"".join(zone_blocks)}
+{"".join(record_blocks)}
+
+  resources: Listing = new {{
+{chr(10).join(resource_list)}
+  }}
+}}
+'''
+
+
+def generate_api_gateway_pkl(counts: ResourceCounts) -> str:
+    """Generate api_gateway.pkl with REST APIs.
+
+    Note: Deployments and Stages are not included because AWS requires at least one
+    Method to exist on the REST API before creating a Deployment. Adding Methods
+    would require additional Resource configuration.
+    """
+
+    api_blocks = []
+
+    # Generate REST APIs only (no Deployments/Stages - requires Methods first)
+    for i in range(counts.api_gateways):
+        api_blocks.append(f'''
+  hidden restApi{i}: restapi.RestApi = new {{
+    label = "\\(envName)-api-{i}"
+    name = "\\(envName)-api-{i}"
+    description = "API Gateway {i} for perf test"
+    endpointConfiguration = new restapi.EndpointConfiguration {{
+      types {{
+        "REGIONAL"
+      }}
+    }}
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    resource_list = []
+    for i in range(counts.api_gateways):
+        resource_list.append(f"    restApi{i}")
+
+    return f'''{COPYRIGHT}
+import "@aws/apigateway/restapi.pkl"
+
+class ApiGateway {{
+  envName: String
+{"".join(api_blocks)}
+
+  resources: Listing = new {{
+{chr(10).join(resource_list)}
+  }}
+}}
+'''
+
+
+def generate_rds_pkl(counts: ResourceCounts) -> str:
+    """Generate rds.pkl with RDS instances, subnet groups, and parameter groups."""
+
+    subnet_group_blocks = []
+    param_group_blocks = []
+    instance_blocks = []
+
+    # Generate DB subnet groups
+    for i in range(counts.db_subnet_groups):
+        # Use private subnets from different VPCs
+        vpc_idx = i % counts.vpcs
+        subnet_group_blocks.append(f'''
+  hidden dbSubnetGroup{i}: dbsubnetgroup.DBSubnetGroup = new {{
+    label = "\\(name)-db-subnet-group-{i}"
+    dbSubnetGroupName = "\\(name)-db-subnet-group-{i}"
+    dbSubnetGroupDescription = "DB subnet group {i} for perf test"
+    subnetIds {{
+      networking.privateSubnets.toList()[{vpc_idx}].res.id
+      networking.privateSubnets.toList()[{(vpc_idx + 1) % max(1, counts.vpcs)}].res.id
+    }}
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    # Generate DB parameter groups
+    engines = ["mysql8.0", "postgres14", "mariadb10.6"]
+    for i in range(counts.db_parameter_groups):
+        engine_family = engines[i % len(engines)]
+        param_group_blocks.append(f'''
+  hidden dbParamGroup{i}: dbparametergroup.DBParameterGroup = new {{
+    label = "\\(name)-db-param-group-{i}"
+    dbParameterGroupName = "\\(name)-db-param-group-{i}"
+    description = "DB parameter group {i} for perf test"
+    family = "{engine_family}"
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    # Generate RDS instances
+    for i in range(counts.rds_instances):
+        subnet_group_idx = i % counts.db_subnet_groups
+        param_group_idx = i % counts.db_parameter_groups
+        sg_idx = i % counts.security_groups
+        engine = ["mysql", "postgres", "mariadb"][i % 3]
+        engine_version = ["8.0.35", "14.9", "10.6.14"][i % 3]
+        instance_class = ["db.t3.micro", "db.t3.small"][i % 2]
+
+        instance_blocks.append(f'''
+  hidden rdsInstance{i}: dbinstance.DBInstance = new {{
+    label = "\\(name)-rds-{i}"
+    dbInstanceIdentifier = "\\(name)-rds-{i}"
+    dbInstanceClass = "{instance_class}"
+    engine = "{engine}"
+    engineVersion = "{engine_version}"
+    masterUsername = "admin"
+    masterUserPassword = "TempPassword123!"  // In real env, use Secrets Manager
+    allocatedStorage = 20
+    dbSubnetGroupName = dbSubnetGroup{subnet_group_idx}.res.dbSubnetGroupName
+    // Use string literal since dbParameterGroupName doesn't accept Resolvable
+    dbParameterGroupName = "\\(name)-db-param-group-{param_group_idx}"
+    vpcSecurityGroups {{
+      sgs.securityGroups.toList()[{sg_idx}].res.groupId
+    }}
+    publiclyAccessible = false
+    storageEncrypted = true
+    backupRetentionPeriod = 7
+    deletionProtection = false
+    tags {{
+      new {{ key = "Name"; value = label }}
+      new {{ key = "ManagedBy"; value = "formae" }}
+    }}
+  }}''')
+
+    resource_list = []
+    for i in range(counts.db_subnet_groups):
+        resource_list.append(f"    dbSubnetGroup{i}")
+    for i in range(counts.db_parameter_groups):
+        resource_list.append(f"    dbParamGroup{i}")
+    for i in range(counts.rds_instances):
+        resource_list.append(f"    rdsInstance{i}")
+
+    return f'''{COPYRIGHT}
+import "@aws/rds/dbsubnetgroup.pkl"
+import "@aws/rds/dbparametergroup.pkl"
+import "@aws/rds/dbinstance.pkl"
+
+import "./networking.pkl" as networkingModule
+import "./security_groups.pkl" as securityGroupsModule
+
+class RDS {{
+  name: String
+  networking: networkingModule.Networking
+  sgs: securityGroupsModule.SecurityGroups
+{"".join(subnet_group_blocks)}
+{"".join(param_group_blocks)}
+{"".join(instance_blocks)}
+
+  resources: Listing = new {{
+{chr(10).join(resource_list)}
+  }}
+}}
+'''
+
+
+def generate_main_pkl(env_id: str, stack_name: str, counts: ResourceCounts) -> str:
+    """Generate main.pkl that ties everything together."""
+
+    return f'''{COPYRIGHT}
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "./vars.pkl"
+import "./networking.pkl" as networkingModule
+import "./security_groups.pkl" as securityGroupsModule
+import "./compute.pkl" as computeModule
+import "./iam.pkl" as iamModule
+import "./kms.pkl" as kmsModule
+import "./storage.pkl" as storageModule
+import "./observability.pkl" as observabilityModule
+import "./secrets.pkl" as secretsModule
+import "./application.pkl" as applicationModule
+import "./route53.pkl" as route53Module
+import "./api_gateway.pkl" as apiGatewayModule
+import "./rds.pkl" as rdsModule
+
+description {{
+    text = """
+    Performance Test Environment: {env_id}
+
+    This environment contains approximately {counts.total} AWS resources
+    distributed across various resource types to simulate a realistic
+    production environment.
+
+    Resource Distribution:
+    - Networking: VPCs (capped at 5), Subnets, Route Tables, Security Groups
+    - Compute: EC2 Instances, EBS Volumes, Launch Templates
+    - IAM: Roles, Policies, Instance Profiles
+    - Storage: S3 Buckets, DynamoDB Tables, EFS
+    - Observability: CloudWatch Log Groups, SQS Queues
+    - Application: Lambda Functions, ECR Repositories
+    - DNS & API: Route53 Hosted Zones/Records, API Gateway
+    - Database: RDS Instances, DB Subnet Groups, DB Parameter Groups
+    - Secrets: Secrets Manager
+    - Security: KMS Keys
+
+    WARNING: This will create real AWS resources that incur costs.
+    Use 'formae destroy --stack {stack_name}' to clean up.
+    """
+    confirm = true
+}}
+
+local _name = vars.envId
+local _region = vars._region
+
+local _networking = new networkingModule.Networking {{
+    name = _name
+    region = _region
+}}
+
+local _securityGroups = new securityGroupsModule.SecurityGroups {{
+    name = _name
+    networking = _networking
+}}
+
+local _compute = new computeModule.Compute {{
+    name = _name
+    region = _region
+    networking = _networking
+    sgs = _securityGroups
+}}
+
+local _iam = new iamModule.IAM {{
+    name = _name
+}}
+
+local _kms = new kmsModule.KMS {{
+    name = _name
+}}
+
+local _storage = new storageModule.Storage {{
+    name = _name
+    networking = _networking
+    sgs = _securityGroups
+}}
+
+local _observability = new observabilityModule.Observability {{
+    name = _name
+}}
+
+local _secrets = new secretsModule.Secrets {{
+    envName = _name
+}}
+
+local _application = new applicationModule.Application {{
+    name = _name
+    iam = _iam
+}}
+
+local _route53 = new route53Module.Route53 {{
+    envName = _name
+}}
+
+local _apiGateway = new apiGatewayModule.ApiGateway {{
+    envName = _name
+}}
+
+local _rds = new rdsModule.RDS {{
+    name = _name
+    networking = _networking
+    sgs = _securityGroups
+}}
+
+forma {{
+    vars.stack
+    vars.target
+
+    ..._networking.resources
+    ..._securityGroups.resources
+    ..._compute.resources
+    ..._iam.resources
+    ..._kms.resources
+    ..._storage.resources
+    ..._observability.resources
+    ..._secrets.resources
+    ..._application.resources
+    ..._route53.resources
+    ..._apiGateway.resources
+    ..._rds.resources
+}}
+'''
+
+
+def generate_pkl_project(formae_path: str) -> str:
+    """Generate PklProject file."""
+    return f'''amends "pkl:Project"
+
+dependencies {{
+  ["formae"] = import("{formae_path}/plugins/pkl/schema/PklProject")
+  ["aws"] = import("{formae_path}/plugins/aws/schema/pkl/PklProject")
+}}
+'''
+
+
+def generate_readme(env_id: str, stack_name: str, region: str, counts: ResourceCounts) -> str:
+    """Generate README.md with usage instructions."""
+    return f'''# Performance Test Environment: {env_id}
+
+## Overview
+
+This directory contains PKL files that define a large-scale AWS infrastructure
+environment for performance testing formae. The environment creates approximately
+**{counts.total} resources** distributed across various AWS services.
+
+## Resource Distribution
+
+| Category | Resources | Count |
+|----------|-----------|-------|
+| Networking | VPCs (capped at 5), Subnets, Route Tables, IGWs, NAT GWs | {counts.vpcs + counts.vpcs * counts.subnets_per_vpc + counts.route_tables + counts.igws + counts.nat_gws} |
+| Security Groups | SGs + Rules | {counts.security_groups + counts.sg_ingress_rules + counts.sg_egress_rules} |
+| Compute | EC2 Instances, EBS Volumes, Launch Templates | {counts.ec2_instances + counts.ebs_volumes + counts.launch_templates} |
+| IAM | Roles, Policies, Profiles | {counts.iam_roles + counts.iam_policies + counts.instance_profiles} |
+| Storage | S3, DynamoDB, EFS | {counts.s3_buckets + counts.dynamodb_tables + counts.efs_filesystems + counts.efs_mount_targets} |
+| Observability | Logs, SQS | {counts.log_groups + counts.sqs_queues} |
+| Application | Lambda, ECR | {counts.lambdas + counts.ecr_repos} |
+| DNS & API | Route53, API Gateway | {counts.route53_zones + counts.route53_records + counts.api_gateways + counts.api_stages} |
+| RDS | Instances, Subnet Groups, Parameter Groups | {counts.rds_instances + counts.db_subnet_groups + counts.db_parameter_groups} |
+| Secrets | Secrets Manager | {counts.secrets} |
+| KMS | Keys, Aliases | {counts.kms_keys + counts.kms_aliases} |
+
+## Configuration
+
+- **Environment ID**: `{env_id}`
+- **Stack Name**: `{stack_name}`
+- **Region**: `{region}`
+
+## Usage
+
+### Prerequisites
+
+1. AWS credentials configured
+2. formae agent running: `formae agent start`
+3. PKL CLI installed
+
+### Deploy
+
+```bash
+# Resolve PKL dependencies
+pkl project resolve
+
+# Preview the deployment (dry-run)
+formae apply --simulate main.pkl
+
+# Deploy the environment
+formae apply main.pkl
+```
+
+### Monitor Progress
+
+```bash
+# Check deployment status
+formae status
+
+# View resources
+formae inventory
+```
+
+### Cleanup
+
+```bash
+# Destroy all resources
+formae destroy --stack {stack_name}
+```
+
+## Cost Warning
+
+This environment creates real AWS resources that will incur costs:
+- NAT Gateways (~$0.045/hour each)
+- KMS Keys (~$1/month each)
+- Secrets Manager (~$0.40/secret/month)
+- CloudWatch Logs (varies by ingestion)
+
+**Always destroy the environment when testing is complete!**
+
+## Files
+
+- `main.pkl` - Main entry point
+- `vars.pkl` - Environment configuration
+- `networking.pkl` - VPCs, Subnets, Routing
+- `security_groups.pkl` - Security Groups and Rules
+- `iam.pkl` - IAM Roles, Policies, Instance Profiles
+- `kms.pkl` - KMS Keys and Aliases
+- `storage.pkl` - S3, DynamoDB, EFS
+- `observability.pkl` - CloudWatch, SNS, SQS
+- `secrets.pkl` - Secrets Manager, SSM Parameters
+- `application.pkl` - Lambda, ECR
+'''
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate a large-scale AWS infrastructure environment for performance testing formae.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --count 100 --region us-east-1
+  %(prog)s --count 1000 --region eu-west-1 --output ./perf-test
+  %(prog)s --count 3000 --region us-west-2 --output /tmp/large-env
+        """
+    )
+
+    parser.add_argument(
+        "--count", "-c",
+        type=int,
+        default=100,
+        help="Target number of resources to generate (default: 100)"
+    )
+
+    parser.add_argument(
+        "--region", "-r",
+        type=str,
+        default="us-east-1",
+        help="AWS region for the environment (default: us-east-1)"
+    )
+
+    parser.add_argument(
+        "--output", "-o",
+        type=str,
+        default=None,
+        help="Output directory (default: ./perf-test-<uuid>)"
+    )
+
+    parser.add_argument(
+        "--formae-path",
+        type=str,
+        default=None,
+        help="Path to formae repository (default: auto-detect from script location)"
+    )
+
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print resource counts without generating files"
+    )
+
+    args = parser.parse_args()
+
+    # Generate unique environment ID
+    env_id = f"perf-{uuid.uuid4().hex[:8]}"
+    stack_name = f"perf-test-{env_id}"
+
+    # Calculate resource counts
+    counts = calculate_counts(args.count)
+
+    if args.dry_run:
+        print(f"Target count: {args.count}")
+        print(f"Calculated total: {counts.total}")
+        print(f"\nResource breakdown:")
+        print(f"\n  Networking (capped to stay within quotas):")
+        print(f"    VPCs: {counts.vpcs} (hard cap at 5)")
+        print(f"    Subnets: {counts.vpcs * counts.subnets_per_vpc} ({counts.subnets_per_vpc} per VPC)")
+        print(f"    Route Tables: {counts.route_tables}")
+        print(f"    Routes: {counts.routes}")
+        print(f"    Internet Gateways: {counts.igws} (1 per VPC)")
+        print(f"    NAT Gateways: {counts.nat_gws} (capped at 5)")
+        print(f"    Elastic IPs: {counts.eips}")
+        print(f"    Security Groups: {counts.security_groups}")
+        print(f"    SG Ingress Rules: {counts.sg_ingress_rules}")
+        print(f"    SG Egress Rules: {counts.sg_egress_rules}")
+        print(f"    VPC Endpoints: {counts.vpc_endpoints}")
+        print(f"\n  Compute:")
+        print(f"    EC2 Instances: {counts.ec2_instances}")
+        print(f"    EBS Volumes: {counts.ebs_volumes}")
+        print(f"    Launch Templates: {counts.launch_templates}")
+        print(f"\n  IAM & Security:")
+        print(f"    IAM Roles: {counts.iam_roles}")
+        print(f"    IAM Policies: {counts.iam_policies}")
+        print(f"    Instance Profiles: {counts.instance_profiles}")
+        print(f"    KMS Keys: {counts.kms_keys}")
+        print(f"    KMS Aliases: {counts.kms_aliases}")
+        print(f"    Secrets: {counts.secrets}")
+        print(f"\n  Storage:")
+        print(f"    S3 Buckets: {counts.s3_buckets}")
+        print(f"    DynamoDB Tables: {counts.dynamodb_tables}")
+        print(f"    EFS File Systems: {counts.efs_filesystems}")
+        print(f"    EFS Mount Targets: {counts.efs_mount_targets}")
+        print(f"\n  Observability:")
+        print(f"    CloudWatch Log Groups: {counts.log_groups}")
+        print(f"    SQS Queues: {counts.sqs_queues}")
+        print(f"\n  Application:")
+        print(f"    Lambda Functions: {counts.lambdas}")
+        print(f"    ECR Repositories: {counts.ecr_repos}")
+        print(f"\n  DNS & API Gateway:")
+        print(f"    Route53 Hosted Zones: {counts.route53_zones}")
+        print(f"    Route53 Records: {counts.route53_records}")
+        print(f"    API Gateways: {counts.api_gateways}")
+        print(f"    API Stages: {counts.api_stages}")
+        print(f"\n  RDS:")
+        print(f"    RDS Instances: {counts.rds_instances}")
+        print(f"    DB Subnet Groups: {counts.db_subnet_groups}")
+        print(f"    DB Parameter Groups: {counts.db_parameter_groups}")
+        print(f"\n  Implicit Resources:")
+        print(f"    VPC Gateway Attachments: {counts.vpcs}")
+        print(f"    Subnet Route Table Associations: {counts.vpcs * counts.subnets_per_vpc}")
+        print(f"    EBS Volume Attachments: ~{counts.ec2_instances * 2}")
+        return
+
+    # Determine output directory
+    if args.output:
+        output_dir = args.output
+    else:
+        output_dir = f"./perf-test-{env_id}"
+
+    # Determine formae path
+    if args.formae_path:
+        formae_path = args.formae_path
+    else:
+        # Auto-detect from script location
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        formae_path = os.path.dirname(script_dir)
+
+    # Create output directory
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Generate all files
+    files = {
+        "PklProject": generate_pkl_project(formae_path),
+        "vars.pkl": generate_vars_pkl(env_id, args.region, stack_name),
+        "networking.pkl": generate_networking_pkl(counts, args.region),
+        "security_groups.pkl": generate_security_groups_pkl(counts),
+        "compute.pkl": generate_compute_pkl(counts, args.region),
+        "iam.pkl": generate_iam_pkl(counts),
+        "kms.pkl": generate_kms_pkl(counts),
+        "storage.pkl": generate_storage_pkl(counts),
+        "observability.pkl": generate_observability_pkl(counts),
+        "secrets.pkl": generate_secrets_pkl(counts),
+        "application.pkl": generate_application_pkl(counts),
+        "route53.pkl": generate_route53_pkl(counts),
+        "api_gateway.pkl": generate_api_gateway_pkl(counts),
+        "rds.pkl": generate_rds_pkl(counts),
+        "main.pkl": generate_main_pkl(env_id, stack_name, counts),
+        "README.md": generate_readme(env_id, stack_name, args.region, counts),
+    }
+
+    for filename, content in files.items():
+        filepath = os.path.join(output_dir, filename)
+        with open(filepath, "w") as f:
+            f.write(content)
+        print(f"Generated: {filepath}")
+
+    print(f"\n{'=' * 60}")
+    print(f"Performance test environment generated successfully!")
+    print(f"{'=' * 60}")
+    print(f"\nEnvironment ID: {env_id}")
+    print(f"Stack Name: {stack_name}")
+    print(f"Region: {args.region}")
+    print(f"Target Resources: {args.count}")
+    print(f"Calculated Resources: {counts.total}")
+    print(f"Output Directory: {output_dir}")
+    print(f"\nNext steps:")
+    print(f"  1. cd {output_dir}")
+    print(f"  2. pkl project resolve")
+    print(f"  3. formae apply --simulate main.pkl  # dry-run")
+    print(f"  4. formae apply main.pkl             # deploy")
+    print(f"  5. formae destroy --stack {stack_name}  # cleanup")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
  ## Summary

  Optimizes FormaCommandPersister to address timeout issues when processing large FormaCommands with many ResourceUpdates.

  ### Changes

  - **Faster JSON library**: Swap `encoding/json` for `github.com/goccy/go-json` in the datastore layer for faster marshaling/unmarshaling
  - **In-memory caching**: Cache active FormaCommands to avoid repeated database reads and JSON unmarshaling on every progress update
  - **O(1) resource lookup**: Use composite key (`ksuid:operation`) index for direct ResourceUpdate access instead of O(n) linear scans
  - **Fix bulk update handling**: Add `Operation` field to progress/completion messages and introduce `ResourceUpdateRef` struct for bulk failure messages, enabling correct handling of Replace operations (which store two entries with the same KSUID)

  ### Background

  The FormaCommandPersister was timing out (5s) when processing commands with many resources because every progress update triggered. After profiling we noticed that most of the time was spent in JSON (un)marshalling.

#### CPU profile before

<img width="2956" height="1927" alt="before" src="https://github.com/user-attachments/assets/94867b05-cb95-45fc-8ae2-b90f0b091c6c" />

#### CPU profile after

<img width="2740" height="1930" alt="after" src="https://github.com/user-attachments/assets/5cf0c9de-f383-4b12-ae9f-efffc8a4862a" />
