### PR TITLE
fix(cli): show usage only for validation errors, not runtime errors

### DIFF
--- a/internal/cli/apply/apply.go
+++ b/internal/cli/apply/apply.go
@@ -103,20 +103,20 @@ func runApply(app *app.App, opts *ApplyOptions) error {
 
 func validateApplyOptions(opts *ApplyOptions) error {
 	if opts.FormaFile == "" {
-		return fmt.Errorf("forma file is required")
+		return cmd.FlagErrorf("forma file is required")
 	}
 	if opts.Mode == "" {
-		return fmt.Errorf("the --mode flag is required")
+		return cmd.FlagErrorf("the --mode flag is required")
 	}
 	if opts.Mode != pkgmodel.FormaApplyModeReconcile && opts.Mode != pkgmodel.FormaApplyModePatch {
-		return fmt.Errorf("invalid mode: %s. Should be either reconcile or patch", opts.Mode)
+		return cmd.FlagErrorf("invalid mode: %s. Should be either reconcile or patch", opts.Mode)
 	}
 	if opts.OutputConsumer != printer.ConsumerHuman && opts.OutputConsumer != printer.ConsumerMachine {
-		return fmt.Errorf("output consumer must be either 'human' or 'machine'")
+		return cmd.FlagErrorf("output consumer must be either 'human' or 'machine'")
 	}
 	if opts.OutputConsumer == printer.ConsumerMachine {
 		if opts.OutputSchema != "json" && opts.OutputSchema != "yaml" {
-			return fmt.Errorf("output schema must be either 'json' or 'yaml' for machine consumer")
+			return cmd.FlagErrorf("output schema must be either 'json' or 'yaml' for machine consumer")
 		}
 	}
 

--- a/internal/cli/cancel/cancel.go
+++ b/internal/cli/cancel/cancel.go
@@ -82,11 +82,11 @@ before transitioning to 'Canceled' state to avoid orphaned resources.`,
 
 func Validate(opts *CancelOptions) error {
 	if opts.OutputConsumer != printer.ConsumerHuman && opts.OutputConsumer != printer.ConsumerMachine {
-		return fmt.Errorf("output consumer must be either 'human' or 'machine'")
+		return cmd.FlagErrorf("output consumer must be either 'human' or 'machine'")
 	}
 	if opts.OutputConsumer == printer.ConsumerMachine {
 		if opts.OutputSchema != "json" && opts.OutputSchema != "yaml" {
-			return fmt.Errorf("output schema must be either 'json' or 'yaml' for machine consumer")
+			return cmd.FlagErrorf("output schema must be either 'json' or 'yaml' for machine consumer")
 		}
 	}
 

--- a/internal/cli/cmd/errors.go
+++ b/internal/cli/cmd/errors.go
@@ -1,0 +1,39 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package cmd
+
+import "fmt"
+
+// FlagError indicates an error processing command-line flags or other arguments.
+// When a FlagError is returned, the CLI will display the command's usage information
+// in addition to the error message, helping users understand correct command syntax.
+//
+// Use FlagError for validation errors in validate*Options functions.
+// Do not use FlagError for runtime errors (API errors, network errors, etc.)
+// as those should not trigger usage display.
+type FlagError struct {
+	Err error
+}
+
+func (e *FlagError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *FlagError) Unwrap() error {
+	return e.Err
+}
+
+// FlagErrorf creates a new FlagError with a formatted message.
+func FlagErrorf(format string, args ...interface{}) error {
+	return &FlagError{Err: fmt.Errorf(format, args...)}
+}
+
+// FlagErrorWrap wraps an existing error as a FlagError.
+func FlagErrorWrap(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &FlagError{Err: err}
+}

--- a/internal/cli/destroy/destroy.go
+++ b/internal/cli/destroy/destroy.go
@@ -90,17 +90,17 @@ func DestroyCmd() *cobra.Command {
 
 func validateDestroyOptions(opts *DestroyOptions) error {
 	if opts.FormaFile == "" && opts.Query == "" {
-		return fmt.Errorf("either a forma file needs to be provided, or --query must be specified")
+		return cmd.FlagErrorf("either a forma file needs to be provided, or --query must be specified")
 	}
 	if opts.FormaFile != "" && opts.Query != "" {
-		return fmt.Errorf("either a forma file needs to be provided, or --query must be specified, but not both")
+		return cmd.FlagErrorf("either a forma file needs to be provided, or --query must be specified, but not both")
 	}
 	if opts.OutputConsumer != printer.ConsumerHuman && opts.OutputConsumer != printer.ConsumerMachine {
-		return fmt.Errorf("output consumer must be either 'human' or 'machine'")
+		return cmd.FlagErrorf("output consumer must be either 'human' or 'machine'")
 	}
 	if opts.OutputConsumer == printer.ConsumerMachine {
 		if opts.OutputSchema != "json" && opts.OutputSchema != "yaml" {
-			return fmt.Errorf("output schema must be either 'json' or 'yaml' for machine consumer")
+			return cmd.FlagErrorf("output schema must be either 'json' or 'yaml' for machine consumer")
 		}
 	}
 

--- a/internal/cli/eval/eval.go
+++ b/internal/cli/eval/eval.go
@@ -31,17 +31,17 @@ type EvalOptions struct {
 
 func validateEvalOptions(opts *EvalOptions) error {
 	if opts.FormaFile == "" {
-		return fmt.Errorf("forma file is required")
+		return cmd.FlagErrorf("forma file is required")
 	}
 	if opts.Mode != pkgmodel.FormaApplyModePatch && opts.Mode != pkgmodel.FormaApplyModeReconcile {
-		return fmt.Errorf("mode must be 'patch' or 'reconcile'")
+		return cmd.FlagErrorf("mode must be 'patch' or 'reconcile'")
 	}
 	if opts.OutputConsumer != printer.ConsumerHuman && opts.OutputConsumer != printer.ConsumerMachine {
-		return fmt.Errorf("output-consumer must be 'human' or 'machine'")
+		return cmd.FlagErrorf("output-consumer must be 'human' or 'machine'")
 	}
 	if opts.OutputConsumer == printer.ConsumerMachine {
 		if opts.OutputSchema != "json" && opts.OutputSchema != "yaml" {
-			return fmt.Errorf("output-schema must be 'json' or 'yaml' for machine consumer")
+			return cmd.FlagErrorf("output-schema must be 'json' or 'yaml' for machine consumer")
 		}
 	}
 	return nil

--- a/internal/cli/extract/extract.go
+++ b/internal/cli/extract/extract.go
@@ -132,11 +132,11 @@ func runExtract(app *app.App, opts *ExtractOptions) error {
 
 func validateExtractOptions(opts *ExtractOptions) error {
 	if opts.TargetPath == "" {
-		return fmt.Errorf("target file is required")
+		return cmd.FlagErrorf("target file is required")
 	}
 
 	if strings.TrimSpace(opts.Query) == "" {
-		return fmt.Errorf("query is required")
+		return cmd.FlagErrorf("query is required")
 	}
 
 	return nil

--- a/internal/cli/inventory/inventory.go
+++ b/internal/cli/inventory/inventory.go
@@ -28,14 +28,14 @@ type InventoryOptions struct {
 
 func validateInventoryOptions(opts *InventoryOptions) error {
 	if opts.MaxResults < 0 {
-		return fmt.Errorf("max-results must be 0 (unlimited) or a positive number")
+		return cmd.FlagErrorf("max-results must be 0 (unlimited) or a positive number")
 	}
 	if opts.OutputConsumer != printer.ConsumerHuman && opts.OutputConsumer != printer.ConsumerMachine {
-		return fmt.Errorf("output-consumer must be 'human' or 'machine'")
+		return cmd.FlagErrorf("output-consumer must be 'human' or 'machine'")
 	}
 	if opts.OutputConsumer == printer.ConsumerMachine {
 		if opts.OutputSchema != "json" && opts.OutputSchema != "yaml" {
-			return fmt.Errorf("output-schema must be 'json' or 'yaml' for machine consumer")
+			return cmd.FlagErrorf("output-schema must be 'json' or 'yaml' for machine consumer")
 		}
 	}
 

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -105,15 +105,15 @@ func runStatus(app *app.App, opts *StatusOptions) error {
 
 func validateStatusOptions(options *StatusOptions) error {
 	if options.OutputConsumer != printer.ConsumerHuman && options.OutputConsumer != printer.ConsumerMachine {
-		return fmt.Errorf("output consumer must be either 'human' or 'machine'")
+		return cmd.FlagErrorf("output consumer must be either 'human' or 'machine'")
 	}
 	if options.OutputConsumer == printer.ConsumerMachine {
 		if options.OutputSchema != "json" && options.OutputSchema != "yaml" {
-			return fmt.Errorf("output schema must be either 'json' or 'yaml' for machine consumer")
+			return cmd.FlagErrorf("output schema must be either 'json' or 'yaml' for machine consumer")
 		}
 	}
 	if options.OutputLayout != StatusOutputDetailed && options.OutputLayout != StatusOutputSummary {
-		return fmt.Errorf("output layout must be either 'detailed' or 'summary'")
+		return cmd.FlagErrorf("output layout must be either 'detailed' or 'summary'")
 	}
 
 	return nil


### PR DESCRIPTION
### Summary

 Fixes CLI error handling to only show usage information for validation errors (flag/argument issues), not for runtime errors (API errors, network errors, etc.).

###  Changes:
  - Introduce FlagError type following the GitHub CLI pattern to distinguish validation vs runtime errors
  - Update all validate*Options functions to return FlagError for validation failures
  - Add centralized error handling in root.go that shows usage only for FlagError and unknown commands
  - Set SilenceUsage/SilenceErrors on all commands to prevent Cobra from printing usage on runtime errors

**Before:** Runtime errors like `FormaConflictingCommandsError` would show the full usage text above the error message.
**After:** Only validation errors (missing required flags, invalid flag values) and unknown commands show usage.
