### PR TITLE
fix(resolver):  preserve $ref structures in arrays during property merge

### DIFF
--- a/internal/metastructure/resource_update/resource_update_test.go
+++ b/internal/metastructure/resource_update/resource_update_test.go
@@ -284,7 +284,7 @@ func Test_mergeRefsPreservingUserRefs_preservesResolvableValues(t *testing.T) {
         "Type": "A"
     }`, distributionKsuid, hostedZoneKsuid)
 
-	merged, err := mergeRefsPreservingUserRefs(userProps, pluginProps)
+	merged, err := mergeRefsPreservingUserRefs(userProps, pluginProps, pkgmodel.Schema{})
 	require.NoError(t, err)
 
 	var mergedMap map[string]any
@@ -432,7 +432,7 @@ func Test_mergeRefsPreservingUserRefs_preservesResolvableValuesWithVisibilityWit
         "Type": "A"
     }`)
 
-	merged, err := mergeRefsPreservingUserRefs(userProps, pluginProps)
+	merged, err := mergeRefsPreservingUserRefs(userProps, pluginProps, pkgmodel.Schema{})
 	require.NoError(t, err)
 
 	var mergedMap map[string]any
@@ -483,7 +483,7 @@ func Test_mergeRefsPreservingUserRefs_preservesResolvableValuesWithVisibilityAnd
         "Type": "A"
     }`)
 
-	merged, err := mergeRefsPreservingUserRefs(userProps, pluginProps)
+	merged, err := mergeRefsPreservingUserRefs(userProps, pluginProps, pkgmodel.Schema{})
 	require.NoError(t, err)
 
 	var mergedMap map[string]any
@@ -530,7 +530,7 @@ func Test_mergeRefsPreservingUserRefs_RemovesArrayElements(t *testing.T) {
         "Type": "A"
     }`)
 
-	merged, err := mergeRefsPreservingUserRefs(userProps, pluginProps)
+	merged, err := mergeRefsPreservingUserRefs(userProps, pluginProps, pkgmodel.Schema{})
 	require.NoError(t, err)
 
 	var mergedMap map[string]any
@@ -541,4 +541,279 @@ func Test_mergeRefsPreservingUserRefs_RemovesArrayElements(t *testing.T) {
 	require.Len(t, resourceRecords, 2)
 	require.Equal(t, "192.168.55.1", resourceRecords[0])
 	require.Equal(t, "192.168.55.3", resourceRecords[1])
+}
+
+func Test_mergeRefsPreservingUserRefs_PreservesRefsInArrays(t *testing.T) {
+	// This test verifies that $ref structures inside arrays are preserved during merge.
+	// This is critical for dependency tracking during DELETE operations.
+	//
+	// Scenario: Provider provides Instance with networks array containing $ref to subnet's network_id
+	// User provides: networks: [{uuid: {$ref: "formae://subnet#network_id", $value: "net-123"}}]
+	// Plugin returns: networks: [{uuid: "net-123"}]
+	// Expected: networks: [{uuid: {$ref: "formae://subnet#network_id", $value: "net-123"}}]
+	//
+	// If $ref is lost, ExtractResolvableURIs won't find the dependency,
+	// and DELETE will run Instance and Subnet in parallel, causing SubnetInUse errors.
+
+	subnetKsuid := util.NewID()
+
+	userProps := fmt.Appendf(nil, `{
+		"name": "my-instance",
+		"networks": [
+			{
+				"uuid": {
+					"$ref": "formae://%s#/network_id",
+					"$value": "net-123"
+				}
+			}
+		]
+	}`, subnetKsuid)
+
+	pluginProps := []byte(`{
+		"name": "my-instance",
+		"networks": [
+			{
+				"uuid": "net-123"
+			}
+		]
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"name", "networks"},
+		Hints:  map[string]pkgmodel.FieldHint{},
+	}
+
+	merged, err := mergeRefsPreservingUserRefs(userProps, pluginProps, schema)
+	require.NoError(t, err)
+
+	var mergedMap map[string]any
+	err = json.Unmarshal(merged, &mergedMap)
+	require.NoError(t, err)
+
+	// Verify name is preserved
+	require.Equal(t, "my-instance", mergedMap["name"])
+
+	// Verify networks array preserves the $ref structure
+	networks := mergedMap["networks"].([]any)
+	require.Len(t, networks, 1)
+
+	network := networks[0].(map[string]any)
+	uuid := network["uuid"].(map[string]any)
+
+	// The $ref should be preserved from userProps
+	require.Equal(t, fmt.Sprintf("formae://%s#/network_id", subnetKsuid), uuid["$ref"])
+	// The $value should be updated from pluginProps (or preserved if same)
+	require.Equal(t, "net-123", uuid["$value"])
+}
+
+func Test_mergeRefsPreservingUserRefs_PreservesRefsInArrays_MixedWithHardcoded(t *testing.T) {
+	// More realistic test matching Provider Instance scenario:
+	// - First network: hardcoded public network ID (no $ref)
+	// - Second network: $ref to subnet's network_id
+	// Plugin may return them in different order
+
+	subnetKsuid := util.NewID()
+	extNetID := "b347ed75-8603-4ce0-a40c-c6c98a8820fc"
+	privateNetID := "a9a04d82-051a-42d4-87a6-83052fccb081"
+
+	userProps := fmt.Appendf(nil, `{
+		"name": "my-instance",
+		"networks": [
+			{
+				"uuid": "%s"
+			},
+			{
+				"uuid": {
+					"$ref": "formae://%s#/network_id",
+					"$value": "%s"
+				}
+			}
+		]
+	}`, extNetID, subnetKsuid, privateNetID)
+
+	// Plugin returns in DIFFERENT order (private first, then public)
+	pluginProps := fmt.Appendf(nil, `{
+		"name": "my-instance",
+		"networks": [
+			{
+				"uuid": "%s"
+			},
+			{
+				"uuid": "%s"
+			}
+		]
+	}`, privateNetID, extNetID)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"name", "networks"},
+		Hints:  map[string]pkgmodel.FieldHint{},
+	}
+
+	merged, err := mergeRefsPreservingUserRefs(userProps, pluginProps, schema)
+	require.NoError(t, err)
+
+	var mergedMap map[string]any
+	err = json.Unmarshal(merged, &mergedMap)
+	require.NoError(t, err)
+
+	networks := mergedMap["networks"].([]any)
+	require.Len(t, networks, 2)
+
+	// Plugin element 0 (privateNetID) should match user element 1 (the one with $ref)
+	network0 := networks[0].(map[string]any)
+	uuid0, isMap := network0["uuid"].(map[string]any)
+	require.True(t, isMap, "networks[0].uuid should be a map with $ref preserved")
+	require.Equal(t, fmt.Sprintf("formae://%s#/network_id", subnetKsuid), uuid0["$ref"])
+	require.Equal(t, privateNetID, uuid0["$value"])
+
+	// Plugin element 1 (extNetID) should match user element 0 (hardcoded, no $ref)
+	network1 := networks[1].(map[string]any)
+	uuid1, isString := network1["uuid"].(string)
+	require.True(t, isString, "networks[1].uuid should be a plain string")
+	require.Equal(t, extNetID, uuid1)
+}
+
+func Test_mergeRefsPreservingUserRefs_WithoutInitialValue(t *testing.T) {
+	// Test that merge works when user properties have $ref WITHOUT $value
+	// This is the format produced by translateFormaeReferencesToKsuid
+
+	subnetKsuid := util.NewID()
+	extNetID := "b347ed75-8603-4ce0-a40c-c6c98a8820fc"
+	privateNetID := "a9a04d82-051a-42d4-87a6-83052fccb081"
+
+	// User properties with $ref ONLY (no $value) - this is what translation produces
+	userProps := fmt.Appendf(nil, `{
+		"name": "my-instance",
+		"networks": [
+			{
+				"uuid": "%s"
+			},
+			{
+				"uuid": {
+					"$ref": "formae://%s#/network_id"
+				}
+			}
+		]
+	}`, extNetID, subnetKsuid)
+
+	// Plugin returns resolved values
+	pluginProps := fmt.Appendf(nil, `{
+		"name": "my-instance",
+		"networks": [
+			{
+				"uuid": "%s"
+			},
+			{
+				"uuid": "%s"
+			}
+		]
+	}`, privateNetID, extNetID)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"name", "networks"},
+		Hints:  map[string]pkgmodel.FieldHint{},
+	}
+
+	merged, err := mergeRefsPreservingUserRefs(userProps, pluginProps, schema)
+	require.NoError(t, err)
+
+	var mergedMap map[string]any
+	err = json.Unmarshal(merged, &mergedMap)
+	require.NoError(t, err)
+
+	networks := mergedMap["networks"].([]any)
+	require.Len(t, networks, 2)
+
+	// Find which network has the $ref
+	var refFound bool
+	var refValue string
+	for _, net := range networks {
+		netMap := net.(map[string]any)
+		if uuid, ok := netMap["uuid"].(map[string]any); ok {
+			if ref, hasRef := uuid["$ref"].(string); hasRef {
+				refFound = true
+				refValue = ref
+				// Should also have $value from plugin
+				require.Contains(t, uuid, "$value", "merged $ref object should have $value")
+			}
+		}
+	}
+
+	require.True(t, refFound, "$ref should be preserved in merged properties")
+	require.Equal(t, fmt.Sprintf("formae://%s#/network_id", subnetKsuid), refValue)
+}
+
+// Test_EndToEnd_MergeToDestroyDependency verifies that the entire flow works:
+// 1. User properties with $ref (no $value) are merged with plugin properties
+// 2. The merged result preserves $ref with $value
+// 3. A resource with the merged properties can be used to create a destroy update
+// 4. The destroy update's RemainingResolvables contains the expected URIs
+func Test_EndToEnd_MergeToDestroyDependency(t *testing.T) {
+	// Setup: Create a scenario like the Provider Instance with networks referencing Subnet
+	subnetKsuid := util.NewID()
+	instanceKsuid := util.NewID()
+	extNetID := "b347ed75-8603-4ce0-a40c-c6c98a8820fc"
+	privateNetID := "4cba1d81-051a-42d4-87a6-83052fccb081"
+
+	// Step 1: User properties with $ref ONLY (no $value) - what PKL translation produces
+	userProps := fmt.Appendf(nil, `{
+		"name": "my-instance",
+		"networks": [
+			{"uuid": "%s"},
+			{"uuid": {"$ref": "formae://%s#/network_id"}}
+		]
+	}`, extNetID, subnetKsuid)
+
+	// Step 2: Plugin returns properties (plain values, potentially in different order)
+	pluginProps := fmt.Appendf(nil, `{
+		"name": "my-instance",
+		"networks": [
+			{"uuid": "%s"},
+			{"uuid": "%s"}
+		]
+	}`, privateNetID, extNetID)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"name", "networks"},
+		Hints:  map[string]pkgmodel.FieldHint{},
+	}
+
+	// Step 3: Merge the properties (simulates what happens after Create)
+	merged, err := mergeRefsPreservingUserRefs(userProps, pluginProps, schema)
+	require.NoError(t, err)
+
+	// Step 4: Create a resource with the merged properties (simulates what's stored in datastore)
+	instanceResource := pkgmodel.Resource{
+		Label:      "my-instance",
+		Type:       "Provider::Compute::Instance",
+		Stack:      "default",
+		Ksuid:      instanceKsuid,
+		Properties: merged,
+		Schema:     schema,
+	}
+
+	// Step 5: Create a destroy update from the resource
+	target := pkgmodel.Target{
+		Label: "test-target",
+	}
+	destroyUpdate, err := NewResourceUpdateForDestroy(instanceResource, target, FormaCommandSourceUser)
+	require.NoError(t, err)
+
+	// Step 6: Verify RemainingResolvables contains the Subnet's URI
+	require.NotEmpty(t, destroyUpdate.RemainingResolvables,
+		"Destroy update should have RemainingResolvables extracted from properties")
+
+	// Find the subnet's URI in the resolvables
+	expectedSubnetURI := pkgmodel.FormaeURI(fmt.Sprintf("formae://%s#/network_id", subnetKsuid))
+	found := false
+	for _, uri := range destroyUpdate.RemainingResolvables {
+		if uri.Stripped() == expectedSubnetURI.Stripped() {
+			found = true
+			break
+		}
+	}
+	require.True(t, found,
+		"RemainingResolvables should contain the subnet's URI. Got: %v", destroyUpdate.RemainingResolvables)
+
+	t.Logf("Success! Destroy update has RemainingResolvables: %v", destroyUpdate.RemainingResolvables)
 }


### PR DESCRIPTION
## Problem

`$ref` structures inside arrays were lost during property merge after plugin Read operations, breaking destroy dependency tracking and causing resources to be deleted in parallel instead of respecting dependencies.

## Solution

- Schema-aware array element matching using `FieldHint.UpdateMethod (Default/Set, Array, EntitySet)` 
- Two-phase matching algorithm to handle elements with unresolved `$ref` (no `$value` yet)

## Example Test Case

**Scenario:** Instance with two networks - one hardcoded, one referencing a subnet. Plugin returns them in different order.

```go
// User properties (from PKL translation)
userProps := `{
    "name": "my-instance",
    "networks": [
        {"uuid": "b347ed75-8603-4ce0-a40c-c6c98a8820fc"},
        {"uuid": {"$ref": "formae://subnet-ksuid#/network_id", "$value": "a9a04d82-051a-42d4-87a6-83052fccb081"}}
    ]
}`

// Plugin returns (different order!)
pluginProps := `{
    "name": "my-instance",
    "networks": [
        {"uuid": "a9a04d82-051a-42d4-87a6-83052fccb081"},
        {"uuid": "b347ed75-8603-4ce0-a40c-c6c98a8820fc"}
    ]
}`
```

**BEFORE (bug):**
```json
{
    "name": "my-instance",
    "networks": [
        {"uuid": "a9a04d82-051a-42d4-87a6-83052fccb081"},
        {"uuid": "b347ed75-8603-4ce0-a40c-c6c98a8820fc"}
    ]
}
// $ref lost
```

**AFTER (fix):**
```json
{
    "name": "my-instance",
    "networks": [
        {"uuid": {"$ref": "formae://subnet-ksuid#/network_id", "$value": "a9a04d82-051a-42d4-87a6-83052fccb081"}},
        {"uuid": "b347ed75-8603-4ce0-a40c-c6c98a8820fc"}
    ]
}
// $ref preserved
```