### PR TITLE
fix: discoverable property in extractor

### DIFF
--- a/pkg/plugin/descriptors/Extractor.pkl
+++ b/pkg/plugin/descriptors/Extractor.pkl
@@ -29,6 +29,7 @@ function extractDescriptors(): Listing<resourceDescriptor.ResourceDescriptor> = 
                                 Nonprovisionable = clazz.annotations[0].getProperty("nonprovisionable")
                                 Identifier = clazz.annotations[0].getProperty("identifier")
                                 Tags = clazz.annotations[0].getProperty("tags")
+                                Discoverable = clazz.annotations[0].getProperty("discoverable")
                                 Hints = new Mapping<String, formae.FieldHint> {
                                     for (fieldName, fieldHint in formae.fq.hints(clazz)) {
                                         [fieldName] = fieldHint


### PR DESCRIPTION
In recent changes regarding the dynamic schema extraction the property `discoverable` wasn't passed correctly which results into non discoverable resources (based on schema) have been tried to discover by the agent which lead to expected error behaviour. 