### PR TITLE
debug: add comprehensive logging to patch document generation

### DIFF
--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -7,6 +7,7 @@ package patch
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 
@@ -23,7 +24,24 @@ var defaultIgnoredFields = []jsonpatch.Path{
 }
 
 func GeneratePatch(document []byte, patch []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode) (json.RawMessage, bool, error) {
-	return generatePatch(document, patch, properties, schema, mode)
+	// Log full schema as JSON for debugging
+	schemaJSON, _ := json.Marshal(schema)
+	slog.Info("DEBUG GeneratePatch - inputs",
+		"document", string(document),
+		"patch", string(patch),
+		"mode", mode,
+		"schema", string(schemaJSON),
+	)
+	result, needsReplacement, err := generatePatch(document, patch, properties, schema, mode)
+	if err != nil {
+		slog.Error("DEBUG GeneratePatch - failed", "error", err)
+	} else {
+		slog.Info("DEBUG GeneratePatch - result",
+			"patchDocument", string(result),
+			"needsReplacement", needsReplacement,
+		)
+	}
+	return result, needsReplacement, err
 }
 
 func collectionSemanticsFromFieldHints(hints map[string]pkgmodel.FieldHint) jsonpatch.Collections {

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -54,6 +54,17 @@ func NewResourceUpdateForExisting(
 	var needsReplacement bool
 
 	if hasChanges {
+		// Log full resource objects as JSON for debugging
+		existingResourceJSON, _ := json.Marshal(existingResource)
+		newResourceJSON, _ := json.Marshal(newResource)
+		slog.Info("DEBUG NewResourceUpdateForExisting - raw inputs",
+			"existingResource", string(existingResourceJSON),
+			"newResource", string(newResourceJSON),
+			"filteredProps", string(filteredProps),
+			"stackChanged", stackChanged,
+			"mode", mode,
+		)
+
 		existingPluginProps, err := resolver.ConvertToPluginFormat(existingResource.Properties)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert existing properties to plugin format: %w", err)
@@ -63,6 +74,11 @@ func NewResourceUpdateForExisting(
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert new properties to plugin format: %w", err)
 		}
+
+		slog.Info("DEBUG NewResourceUpdateForExisting - after ConvertToPluginFormat",
+			"existingPluginProps", string(existingPluginProps),
+			"newPluginProps", string(newPluginProps),
+		)
 
 		patchDocument, needsReplacement, err = patch.GeneratePatch(
 			existingPluginProps,


### PR DESCRIPTION
Add debug logging to diagnose incorrect array indices in patch documents when bringing resources under management. Logs capture:

- Full existing and new resource objects (including Schema)
- Properties before and after ConvertToPluginFormat
- Full schema with Hints (UpdateMethod/IndexField)
- Generated patch document result