### PR TITLE
feat(pkl): toString transform for turning int to string for cloud providers

### DIFF
--- a/plugins/pkl/schema/formae.pkl
+++ b/plugins/pkl/schema/formae.pkl
@@ -544,6 +544,7 @@ const fq: Fq = new Fq{}
 class Transform {
     capitalizeMemberKeys: (Any) -> Dynamic = (it) -> it.toList().map((tag) -> tag.toMap().mapKeys((k, _) -> k.capitalize()).toDynamic())
     capitalizeKeys: (Any) -> Dynamic = (it) -> it.toMap().mapKeys((k, _) -> k.capitalize()).toDynamic()
+    toString: (Any) -> String = (it) -> it.toString()
 }
 
 const transform: Transform = new Transform{}


### PR DESCRIPTION
Adds the feature to convert schema ints to strings because some cloud provider handle needs string value for integers in their api. 🤡