### PR TITLE
fix(e2e): remove formae-managed tags from expected test payloads

### DIFF
--- a/tests/e2e/expected/alias-record/alias-lb-hosted-zone.json
+++ b/tests/e2e/expected/alias-record/alias-lb-hosted-zone.json
@@ -56,16 +56,7 @@
   },
   "Properties": {
     "HostedZoneConfig": {},
-    "HostedZoneTags": [
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "alias-record-stack"
-      },
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "alias-lb-hosted-zone"
-      }
-    ],
+    "HostedZoneTags": [],
     "Name": "lb.snarf.platform.engineering.",
     "VPCs": []
   },

--- a/tests/e2e/expected/alias-record/alias-lb-igw.json
+++ b/tests/e2e/expected/alias-record/alias-lb-igw.json
@@ -23,16 +23,7 @@
     "Extractable": true
   },
   "Properties": {
-    "Tags": [
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "alias-lb-igw"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "alias-record-stack"
-      }
-    ]
+    "Tags": []
   },
   "ReadOnlyProperties": {
     "InternetGatewayId": "igw-0594118d4cbb1727e"

--- a/tests/e2e/expected/alias-record/alias-lb-load-balancer.json
+++ b/tests/e2e/expected/alias-record/alias-lb-load-balancer.json
@@ -223,14 +223,6 @@
     ],
     "Tags": [
       {
-        "Key": "FormaeResourceLabel",
-        "Value": "alias-lb-load-balancer"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "alias-record-stack"
-      },
-      {
         "Key": "Name",
         "Value": "alias-lb-alb"
       }

--- a/tests/e2e/expected/alias-record/alias-lb-route-table.json
+++ b/tests/e2e/expected/alias-record/alias-lb-route-table.json
@@ -35,14 +35,6 @@
       {
         "Key": "Name",
         "Value": "alias-lb-route-table"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "alias-record-stack"
-      },
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "alias-lb-route-table"
       }
     ],
     "VpcId": {

--- a/tests/e2e/expected/alias-record/alias-lb-security-group.json
+++ b/tests/e2e/expected/alias-record/alias-lb-security-group.json
@@ -49,16 +49,7 @@
   "Properties": {
     "GroupDescription": "Security group for alias load balancer",
     "GroupName": "jVnDzHqajb0GKSJ0jjfKgaI8Q-CdgF2cUozHOw",
-    "Tags": [
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "alias-record-stack"
-      },
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "alias-lb-security-group"
-      }
-    ],
+    "Tags": [],
     "VpcId": {
       "$label": "alias-lb-vpc",
       "$property": "VpcId",

--- a/tests/e2e/expected/alias-record/alias-lb-subnet-1.json
+++ b/tests/e2e/expected/alias-record/alias-lb-subnet-1.json
@@ -167,14 +167,6 @@
       {
         "Key": "Name",
         "Value": "alias-lb-subnet-1"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "alias-record-stack"
-      },
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "alias-lb-subnet-1"
       }
     ],
     "VpcId": {

--- a/tests/e2e/expected/alias-record/alias-lb-subnet-2.json
+++ b/tests/e2e/expected/alias-record/alias-lb-subnet-2.json
@@ -167,14 +167,6 @@
       {
         "Key": "Name",
         "Value": "alias-lb-subnet-2"
-      },
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "alias-lb-subnet-2"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "alias-record-stack"
       }
     ],
     "VpcId": {

--- a/tests/e2e/expected/alias-record/alias-lb-vpc.json
+++ b/tests/e2e/expected/alias-record/alias-lb-vpc.json
@@ -77,14 +77,6 @@
     "InstanceTenancy": "default",
     "Tags": [
       {
-        "Key": "FormaeStackLabel",
-        "Value": "alias-record-stack"
-      },
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "alias-lb-vpc"
-      },
-      {
         "Key": "Name",
         "Value": "alias-lb-vpc"
       }

--- a/tests/e2e/expected/e2e-s3-bucket/Bucket.S3.AWS_s3-bucket-stack_e2e-s3-bucket.json
+++ b/tests/e2e/expected/e2e-s3-bucket/Bucket.S3.AWS_s3-bucket-stack_e2e-s3-bucket.json
@@ -199,16 +199,7 @@
       "IgnorePublicAcls": true,
       "RestrictPublicBuckets": true
     },
-    "Tags": [
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "e2e-s3-bucket"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "s3-bucket-stack"
-      }
-    ]
+    "Tags": []
   },
   "ReadOnlyProperties": {
     "Arn": "arn:aws:s3:::e2e-test-bucket-1234567890-911",

--- a/tests/e2e/expected/ec2-route/ec2-route-igw.json
+++ b/tests/e2e/expected/ec2-route/ec2-route-igw.json
@@ -25,14 +25,6 @@
   "Properties": {
     "Tags": [
       {
-        "Key": "FormaeResourceLabel",
-        "Value": "ec2-route-igw"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "ec2-route"
-      },
-      {
         "Key": "Name",
         "Value": "ec2-route-igw"
       }

--- a/tests/e2e/expected/ec2-route/ec2-route-public-rt.json
+++ b/tests/e2e/expected/ec2-route/ec2-route-public-rt.json
@@ -33,15 +33,7 @@
   "Properties": {
     "Tags": [
       {
-        "Key": "FormaeStackLabel",
-        "Value": "ec2-route"
-      },
-      {
         "Key": "Name",
-        "Value": "ec2-route-public-rt"
-      },
-      {
-        "Key": "FormaeResourceLabel",
         "Value": "ec2-route-public-rt"
       }
     ],

--- a/tests/e2e/expected/ec2-route/ec2-route-public-subnet-1.json
+++ b/tests/e2e/expected/ec2-route/ec2-route-public-subnet-1.json
@@ -165,15 +165,7 @@
     },
     "Tags": [
       {
-        "Key": "FormaeStackLabel",
-        "Value": "ec2-route"
-      },
-      {
         "Key": "Name",
-        "Value": "ec2-route-public-subnet-1"
-      },
-      {
-        "Key": "FormaeResourceLabel",
         "Value": "ec2-route-public-subnet-1"
       }
     ],

--- a/tests/e2e/expected/ec2-route/ec2-route-vpc.json
+++ b/tests/e2e/expected/ec2-route/ec2-route-vpc.json
@@ -79,14 +79,6 @@
       {
         "Key": "Name",
         "Value": "ec2-route-vpc"
-      },
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "ec2-route-vpc"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "ec2-route"
       }
     ]
   },

--- a/tests/e2e/expected/legacy-record/HostedZone.Route53.AWS_legacy-record-stack_route53-hostedzone.json
+++ b/tests/e2e/expected/legacy-record/HostedZone.Route53.AWS_legacy-record-stack_route53-hostedzone.json
@@ -56,16 +56,7 @@
   },
   "Properties": {
     "HostedZoneConfig": {},
-    "HostedZoneTags": [
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "route53-hostedzone"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "legacy-record-stack"
-      }
-    ],
+    "HostedZoneTags": [],
     "Name": "snarf.platform.engineering.",
     "VPCs": []
   },

--- a/tests/e2e/expected/lifeline/lifeline-alb-sg.json
+++ b/tests/e2e/expected/lifeline/lifeline-alb-sg.json
@@ -51,14 +51,6 @@
     "GroupName": "sIItUIl0RC5IyVqKUXJyPkhpN-qIHAT1pR1dAV",
     "Tags": [
       {
-        "Key": "FormaeStackLabel",
-        "Value": "lifeline"
-      },
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "lifeline-alb-sg"
-      },
-      {
         "Key": "Name",
         "Value": "test-alb-sg"
       }

--- a/tests/e2e/expected/lifeline/lifeline-igw.json
+++ b/tests/e2e/expected/lifeline/lifeline-igw.json
@@ -25,14 +25,6 @@
   "Properties": {
     "Tags": [
       {
-        "Key": "FormaeResourceLabel",
-        "Value": "lifeline-igw"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "lifeline"
-      },
-      {
         "Key": "Name",
         "Value": "test-igw"
       }

--- a/tests/e2e/expected/lifeline/lifeline-public-rt.json
+++ b/tests/e2e/expected/lifeline/lifeline-public-rt.json
@@ -33,14 +33,6 @@
   "Properties": {
     "Tags": [
       {
-        "Key": "FormaeResourceLabel",
-        "Value": "lifeline-public-rt"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "lifeline"
-      },
-      {
         "Key": "Name",
         "Value": "test-public-rt"
       }

--- a/tests/e2e/expected/lifeline/lifeline-public-subnet-1.json
+++ b/tests/e2e/expected/lifeline/lifeline-public-subnet-1.json
@@ -165,16 +165,8 @@
     },
     "Tags": [
       {
-        "Key": "FormaeResourceLabel",
-        "Value": "lifeline-public-subnet-1"
-      },
-      {
         "Key": "Name",
         "Value": "test-public-subnet-1"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "lifeline"
       }
     ],
     "VpcId": {

--- a/tests/e2e/expected/lifeline/lifeline-public-subnet-2.json
+++ b/tests/e2e/expected/lifeline/lifeline-public-subnet-2.json
@@ -167,14 +167,6 @@
       {
         "Key": "Name",
         "Value": "test-public-subnet-2"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "lifeline"
-      },
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "lifeline-public-subnet-2"
       }
     ],
     "VpcId": {

--- a/tests/e2e/expected/lifeline/lifeline-task-sg.json
+++ b/tests/e2e/expected/lifeline/lifeline-task-sg.json
@@ -51,16 +51,8 @@
     "GroupName": "9ClkHb0LDGP5O3uHmHWKjbCV5-BhTfDTW0xCSU",
     "Tags": [
       {
-        "Key": "FormaeStackLabel",
-        "Value": "lifeline"
-      },
-      {
         "Key": "Name",
         "Value": "test-task-sg"
-      },
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "lifeline-task-sg"
       }
     ],
     "VpcId": {

--- a/tests/e2e/expected/lifeline/lifeline-vpc.json
+++ b/tests/e2e/expected/lifeline/lifeline-vpc.json
@@ -79,14 +79,6 @@
       {
         "Key": "Name",
         "Value": "test-vpc"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "lifeline"
-      },
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "lifeline-vpc"
       }
     ]
   },

--- a/tests/e2e/expected/route53-hostedzone/HostedZone.Route53.AWS_route53-hostedzone-stack_route53-hostedzone.json
+++ b/tests/e2e/expected/route53-hostedzone/HostedZone.Route53.AWS_route53-hostedzone-stack_route53-hostedzone.json
@@ -56,16 +56,7 @@
   },
   "Properties": {
     "HostedZoneConfig": {},
-    "HostedZoneTags": [
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "route53-hostedzone"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "route53-hostedzone-stack"
-      }
-    ],
+    "HostedZoneTags": [],
     "Name": "snarf.platform.engineering.",
     "VPCs": []
   },

--- a/tests/e2e/expected/static-website/Bucket.S3.AWS_static-website-stack_WebsiteBucket.json
+++ b/tests/e2e/expected/static-website/Bucket.S3.AWS_static-website-stack_WebsiteBucket.json
@@ -207,14 +207,6 @@
       {
         "Key": "Environment",
         "Value": "dev"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "static-website-stack"
-      },
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "WebsiteBucket"
       }
     ],
     "WebsiteConfiguration": {

--- a/tests/e2e/expected/static-website/HostedZone.Route53.AWS_static-website-stack_StaticWebsiteHostedZone.json
+++ b/tests/e2e/expected/static-website/HostedZone.Route53.AWS_static-website-stack_StaticWebsiteHostedZone.json
@@ -56,16 +56,7 @@
   },
   "Properties": {
     "HostedZoneConfig": {},
-    "HostedZoneTags": [
-      {
-        "Key": "FormaeResourceLabel",
-        "Value": "StaticWebsiteHostedZone"
-      },
-      {
-        "Key": "FormaeStackLabel",
-        "Value": "static-website-stack"
-      }
-    ],
+    "HostedZoneTags": [],
     "Name": "test.platform.engineering.",
     "VPCs": []
   },


### PR DESCRIPTION
## Summary

Remove FormaeResourceLabel, FormaeStackLabel, and FormaeResourceGroup tags from expected test files. These tags are no longer injected by formae after commit 08d2dda removed automatic tag injection.

This is the proper fix - removing the tags from expected payloads rather than filtering them during comparison.

## Changes

- Remove Formae-managed tags from 24 expected test JSON files