### PR TITLE
refactor(cli): remove --schema-location flag, default to local

### DIFF
--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -489,15 +489,14 @@ func (a *App) SerializeForma(forma *pkgmodel.Forma, options *plugin.SerializeOpt
 	return (*schemaPlugin).SerializeForma(forma, options)
 }
 
-func (a *App) GenerateSourceCode(forma *pkgmodel.Forma, targetPath string, outputSchema string, schemaLocation string) (plugin.GenerateSourcesResult, error) {
+func (a *App) GenerateSourceCode(forma *pkgmodel.Forma, targetPath string, outputSchema string) (plugin.GenerateSourcesResult, error) {
 	schemaPlugin, err := a.PluginManager.SchemaPlugin(outputSchema)
 	if err != nil {
 		return plugin.GenerateSourcesResult{}, err
 	}
-	location := plugin.SchemaLocation(schemaLocation)
-	includes := a.Projects.formatIncludes(outputSchema, []string{"aws"}, location)
+	includes := a.Projects.formatIncludes(outputSchema, []string{"aws"}, plugin.SchemaLocationLocal)
 
-	return (*schemaPlugin).GenerateSourceCode(forma, targetPath, includes, location)
+	return (*schemaPlugin).GenerateSourceCode(forma, targetPath, includes, plugin.SchemaLocationLocal)
 }
 
 func (a *App) ExtractTargets(query string) ([]*pkgmodel.Target, []string, error) {
@@ -536,22 +535,21 @@ func (p *Plugins) SupportedSchemas() []string {
 
 // Projects
 
-func (p *Projects) Init(path string, format string, include []string, schemaLocation string) error {
+func (p *Projects) Init(path string, format string, include []string) error {
 	// TODO(discount-elf) think about this namespace issue, since different packages can be included in plugins we currently
 	// need plugin.package for download delivery
 	var includes []string
-	location := plugin.SchemaLocation(schemaLocation)
 
 	switch format {
 	case "pkl":
-		includes = p.formatIncludes(format, include, location)
+		includes = p.formatIncludes(format, include, plugin.SchemaLocationLocal)
 
 		schemaPlugin, err := p.pluginManager.SchemaPluginByFileExtension(".pkl")
 		if err != nil {
 			return err
 		}
 
-		err = (*schemaPlugin).ProjectInit(path, includes, location)
+		err = (*schemaPlugin).ProjectInit(path, includes, plugin.SchemaLocationLocal)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/extract/extract.go
+++ b/internal/cli/extract/extract.go
@@ -23,11 +23,10 @@ import (
 )
 
 type ExtractOptions struct {
-	TargetPath     string
-	Query          string
-	Yes            bool
-	OutputSchema   string
-	SchemaLocation string
+	TargetPath   string
+	Query        string
+	Yes          bool
+	OutputSchema string
 }
 
 func ExtractCmd() *cobra.Command {
@@ -43,7 +42,6 @@ func ExtractCmd() *cobra.Command {
 			opts.Query, _ = command.Flags().GetString("query")
 			opts.Yes, _ = command.Flags().GetBool("yes")
 			opts.OutputSchema, _ = command.Flags().GetString("output-schema")
-			opts.SchemaLocation, _ = command.Flags().GetString("schema-location")
 
 			configFile, _ := command.Flags().GetString("config")
 			app, err := cmd.AppFromContext(command.Context(), configFile, "", command)
@@ -66,7 +64,6 @@ func ExtractCmd() *cobra.Command {
 	command.Flags().String("query", " ", "Query that allows to find resources by their attributes")
 	command.Flags().Bool("yes", false, "Overwrite existing files without prompting")
 	command.Flags().String("output-schema", "pkl", "Output schema (only 'pkl' is currently supported)")
-	command.Flags().String("schema-location", "remote", "Schema location: 'remote' (PKL registry) or 'local' (installed plugins)")
 	command.Flags().String("config", "", "Path to config file")
 
 	return command
@@ -111,7 +108,7 @@ func runExtract(app *app.App, opts *ExtractOptions) error {
 		}
 	}
 
-	res, err := app.GenerateSourceCode(forma, opts.TargetPath, opts.OutputSchema, opts.SchemaLocation)
+	res, err := app.GenerateSourceCode(forma, opts.TargetPath, opts.OutputSchema)
 	if errors.Is(err, plugin.ErrFailedToGenerateSources) {
 		logFilePath := fmt.Sprintf("%s/log/client.log", config.Config.DataDirectory())
 		return fmt.Errorf("something went wrong during the extraction. This is our fault. Please contact us and send over the error logs from '%s'", logFilePath)

--- a/internal/cli/project/project.go
+++ b/internal/cli/project/project.go
@@ -35,21 +35,19 @@ func ProjectInitCmd() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			schema, _ := command.Flags().GetString("schema")
 			include, _ := command.Flags().GetStringArray("include")
-			schemaLocation, _ := command.Flags().GetString("schema-location")
 
 			app, err := cmd.AppFromContext(command.Context(), "", "", command)
 			if err != nil {
 				return err
 			}
 
-			return app.Projects.Init(command.Flags().Arg(0), schema, include, schemaLocation)
+			return app.Projects.Init(command.Flags().Arg(0), schema, include)
 		},
 		SilenceErrors: true,
 	}
 
 	command.Flags().String("schema", "pkl", "Schema to use for the project (pkl)")
 	command.Flags().StringArray("include", []string{"aws"}, "Packages to include (aws)")
-	command.Flags().String("schema-location", "local", "Schema location: 'remote' (PKL registry) or 'local' (installed plugins)")
 
 	return command
 }


### PR DESCRIPTION
## Summary

- Remove the `--schema-location` flag from the `extract` command (was defaulting to "remote")
- Remove the `--schema-location` flag from the `project init` command (was defaulting to "local")
- Always use local schema resolution from installed plugins at `~/.pel/formae/plugins/`

The flag allowed switching between "remote" (PKL registry) and "local" (installed plugins) schema resolution, but defaulting to local is the sensible choice for most users.