### PR TITLE
feat(plugins): bundle external resource plugins with distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,5 +91,8 @@ docs/design/
 .serena/
 .handoffs/
 
+# External plugin cache (cloned plugin repos during build)
+.plugins/
+
 # fake-aws plugin binary
 plugins/fake-aws/fake-aws


### PR DESCRIPTION
## Summary

- Add support for bundling external plugins (AWS, GCP, OVH) from separate Git repositories into the formae distribution package
- New Makefile targets: `fetch-external-plugins`, `build-external-plugins`, `install-external-plugins`
- Resource plugins packaged with namespace/version structure (e.g., `aws/v0.1.0/`)
- setup.sh: Add resource-plugins installation and `-f` flag for local file testing
- upgrade.go: Add `installResourcePlugins()` to handle upgrade path
- Agent migration wipes existing user plugins (interface changed, old incompatible)