### PR TITLE
feat(plugin): show resource plugins in plugin list command

### DIFF
--- a/internal/cli/plugin/plugin.go
+++ b/internal/cli/plugin/plugin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/platform-engineering-labs/formae/internal/cli/cmd"
+	"github.com/platform-engineering-labs/formae/internal/cli/display"
 )
 
 func PluginCmd() *cobra.Command {
@@ -34,15 +35,28 @@ func PluginCmd() *cobra.Command {
 func PluginListCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "list",
-		Short: "List all active plugins",
+		Short: "List resource plugins registered with the agent",
 		RunE: func(command *cobra.Command, args []string) error {
 			app, err := cmd.AppFromContext(command.Context(), "", "", command)
 			if err != nil {
 				return err
 			}
 
-			for _, plugin := range app.Plugins.List() {
-				fmt.Printf("%s %s %s\n", (*plugin).Name(), (*plugin).Version(), (*plugin).Type())
+			stats, _, err := app.Stats()
+			if err != nil {
+				return err
+			}
+
+			if len(stats.Plugins) == 0 {
+				fmt.Println("No resource plugins registered with the agent.")
+				return nil
+			}
+
+			fmt.Println(display.LightBlue("Resource Plugins"))
+			for _, p := range stats.Plugins {
+				fmt.Printf("  %s %s\n",
+					display.Green(p.Namespace),
+					display.Grey(p.Version))
 			}
 
 			return nil

--- a/internal/metastructure/messages/plugin.go
+++ b/internal/metastructure/messages/plugin.go
@@ -69,6 +69,7 @@ type GetRegisteredPlugins struct{}
 // RegisteredPluginInfo contains basic information about a registered plugin
 type RegisteredPluginInfo struct {
 	Namespace            string
+	Version              string
 	NodeName             string
 	MaxRequestsPerSecond int
 	ResourceCount        int

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -973,6 +973,7 @@ func (m *Metastructure) Stats() (*apimodel.Stats, error) {
 			for _, p := range pluginsResult.Plugins {
 				plugins = append(plugins, apimodel.PluginInfo{
 					Namespace:            p.Namespace,
+					Version:              p.Version,
 					NodeName:             p.NodeName,
 					MaxRequestsPerSecond: p.MaxRequestsPerSecond,
 					ResourceCount:        p.ResourceCount,

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator.go
@@ -36,6 +36,7 @@ type PluginCoordinator struct {
 // RegisteredPlugin contains information about a registered plugin
 type RegisteredPlugin struct {
 	Namespace            string
+	Version              string
 	NodeName             gen.Atom // Ergo node where plugin runs (for remote spawn)
 	MaxRequestsPerSecond int
 	RegisteredAt         time.Time
@@ -143,6 +144,7 @@ func (c *PluginCoordinator) HandleMessage(from gen.PID, message any) error {
 
 		c.plugins[msg.Namespace] = &RegisteredPlugin{
 			Namespace:            msg.Namespace,
+			Version:              msg.Version,
 			NodeName:             from.Node,
 			MaxRequestsPerSecond: msg.MaxRequestsPerSecond,
 			RegisteredAt:         time.Now(),
@@ -353,6 +355,7 @@ func (c *PluginCoordinator) getRegisteredPlugins() messages.GetRegisteredPlugins
 	for _, registered := range c.plugins {
 		plugins = append(plugins, messages.RegisteredPluginInfo{
 			Namespace:            registered.Namespace,
+			Version:              registered.Version,
 			NodeName:             string(registered.NodeName),
 			MaxRequestsPerSecond: registered.MaxRequestsPerSecond,
 			ResourceCount:        len(registered.SupportedResources),

--- a/pkg/api/model/types.go
+++ b/pkg/api/model/types.go
@@ -116,6 +116,7 @@ type Stats struct {
 // PluginInfo represents information about a registered plugin
 type PluginInfo struct {
 	Namespace            string `json:"Namespace"`
+	Version              string `json:"Version"`
 	NodeName             string `json:"NodeName"`
 	MaxRequestsPerSecond int    `json:"MaxRequestsPerSecond"`
 	ResourceCount        int    `json:"ResourceCount"`

--- a/pkg/plugin/actor.go
+++ b/pkg/plugin/actor.go
@@ -77,6 +77,7 @@ func (p *PluginActor) Init(args ...any) error {
 	}
 	announcement := PluginAnnouncement{
 		Namespace:            p.namespace,
+		Version:              p.plugin.Version().String(),
 		NodeName:             string(p.Node().Name()),
 		MaxRequestsPerSecond: p.plugin.RateLimit().MaxRequestsPerSecondForNamespace,
 		Capabilities:         compressedCaps,

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -43,6 +43,7 @@ type PluginCapabilities struct {
 // It contains all information needed for the agent to interact with the plugin.
 type PluginAnnouncement struct {
 	Namespace            string
+	Version              string
 	NodeName             string
 	MaxRequestsPerSecond int
 


### PR DESCRIPTION
## Summary

- Change `formae plugin list` to query registered resource plugins from the agent instead of listing local .so files
- Add Version field to PluginAnnouncement, RegisteredPlugin, RegisteredPluginInfo, and PluginInfo structs
- Display plugin namespace and version with consistent CLI styling

## Before
```
$ formae plugin list
pkl v0.77.0 schema
json v0.77.0 schema
yaml v0.77.0 schema
```

## After
```
$ formae plugin list
Resource Plugins
  aws 0.1.0
  ovh 0.1.0
  gcp 0.1.0
```

The version shown comes from each plugin's `formae-plugin.pkl` manifest.

## Breaking Change

External plugins need to be recompiled with the updated `pkg/plugin` package that includes `Version` in `PluginAnnouncement`. After this merges, we should tag a new version of `pkg/plugin` so external plugin repos can update their dependency.