### PR TITLE
feat(plugin): add observability SDK with Logger and MetricRegistry

### DIFF
--- a/pkg/plugin/logger.go
+++ b/pkg/plugin/logger.go
@@ -1,0 +1,76 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package plugin
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Logger provides structured logging for plugin authors.
+// Automatically includes plugin metadata (namespace, resource type, operation).
+type Logger interface {
+	Debug(msg string, attrs ...any)
+	Info(msg string, attrs ...any)
+	Warn(msg string, attrs ...any)
+	Error(msg string, attrs ...any)
+	With(attrs ...any) Logger
+}
+
+type loggerKey struct{}
+
+// LoggerFromContext extracts the logger from context.
+// Returns a no-op logger if none is present.
+func LoggerFromContext(ctx context.Context) Logger {
+	if l, ok := ctx.Value(loggerKey{}).(Logger); ok {
+		return l
+	}
+	return noopLogger{}
+}
+
+// WithLogger returns a new context with the given logger.
+func WithLogger(ctx context.Context, l Logger) context.Context {
+	return context.WithValue(ctx, loggerKey{}, l)
+}
+
+// pluginLogger wraps slog.Logger with persistent attributes.
+type pluginLogger struct {
+	slog  *slog.Logger
+	attrs []any
+}
+
+// NewPluginLogger creates a new Logger wrapping the given slog.Logger.
+func NewPluginLogger(logger *slog.Logger) Logger {
+	return &pluginLogger{slog: logger, attrs: nil}
+}
+
+func (l *pluginLogger) Debug(msg string, attrs ...any) {
+	l.slog.Debug(msg, append(l.attrs, attrs...)...)
+}
+
+func (l *pluginLogger) Info(msg string, attrs ...any) {
+	l.slog.Info(msg, append(l.attrs, attrs...)...)
+}
+
+func (l *pluginLogger) Warn(msg string, attrs ...any) {
+	l.slog.Warn(msg, append(l.attrs, attrs...)...)
+}
+
+func (l *pluginLogger) Error(msg string, attrs ...any) {
+	l.slog.Error(msg, append(l.attrs, attrs...)...)
+}
+
+func (l *pluginLogger) With(attrs ...any) Logger {
+	return &pluginLogger{slog: l.slog, attrs: append(l.attrs, attrs...)}
+}
+
+// noopLogger does nothing - used when no logger in context.
+type noopLogger struct{}
+
+func (noopLogger) Debug(msg string, attrs ...any) {}
+func (noopLogger) Info(msg string, attrs ...any)  {}
+func (noopLogger) Warn(msg string, attrs ...any)  {}
+func (noopLogger) Error(msg string, attrs ...any) {}
+func (noopLogger) With(attrs ...any) Logger       { return noopLogger{} }

--- a/pkg/plugin/logger_test.go
+++ b/pkg/plugin/logger_test.go
@@ -1,0 +1,51 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package plugin
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+)
+
+func TestLoggerFromContext_WithLogger(t *testing.T) {
+	logger := NewPluginLogger(slog.Default())
+	ctx := WithLogger(context.Background(), logger)
+
+	got := LoggerFromContext(ctx)
+	if _, ok := got.(*pluginLogger); !ok {
+		t.Errorf("expected *pluginLogger, got %T", got)
+	}
+}
+
+func TestLoggerFromContext_WithoutLogger(t *testing.T) {
+	ctx := context.Background()
+	got := LoggerFromContext(ctx)
+	if _, ok := got.(noopLogger); !ok {
+		t.Errorf("expected noopLogger, got %T", got)
+	}
+}
+
+func TestPluginLogger_With(t *testing.T) {
+	logger := NewPluginLogger(slog.Default())
+	enriched := logger.With("key1", "value1")
+
+	pl, ok := enriched.(*pluginLogger)
+	if !ok {
+		t.Fatalf("expected *pluginLogger, got %T", enriched)
+	}
+	if len(pl.attrs) != 2 {
+		t.Errorf("expected 2 attrs, got %d", len(pl.attrs))
+	}
+}
+
+func TestNoopLogger_DoesNotPanic(t *testing.T) {
+	logger := noopLogger{}
+	logger.Debug("test")
+	logger.Info("test", "key", "value")
+	logger.Warn("test")
+	logger.Error("test", "error", "some error")
+	_ = logger.With("key", "value")
+}

--- a/pkg/plugin/metrics.go
+++ b/pkg/plugin/metrics.go
@@ -1,0 +1,48 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package plugin
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// MetricRegistry allows plugins to record custom metrics.
+// All metrics are automatically tagged with plugin.namespace.
+type MetricRegistry interface {
+	// Counter records a monotonically increasing value (e.g., total requests, errors).
+	Counter(name string, value int64, attrs ...attribute.KeyValue)
+	// UpDownCounter records a value that can increase or decrease (e.g., in-flight operations).
+	UpDownCounter(name string, value int64, attrs ...attribute.KeyValue)
+	// Gauge records a point-in-time value (e.g., current connections, queue size).
+	Gauge(name string, value float64, attrs ...attribute.KeyValue)
+	// Histogram records a distribution of values (e.g., latency, file sizes).
+	Histogram(name string, value float64, attrs ...attribute.KeyValue)
+}
+
+type metricsKey struct{}
+
+// MetricsFromContext extracts the MetricRegistry from context.
+// Returns a no-op registry if none is present.
+func MetricsFromContext(ctx context.Context) MetricRegistry {
+	if m, ok := ctx.Value(metricsKey{}).(MetricRegistry); ok {
+		return m
+	}
+	return noopMetrics{}
+}
+
+// WithMetrics returns a new context with the given MetricRegistry.
+func WithMetrics(ctx context.Context, m MetricRegistry) context.Context {
+	return context.WithValue(ctx, metricsKey{}, m)
+}
+
+// noopMetrics does nothing - used when no registry in context.
+type noopMetrics struct{}
+
+func (noopMetrics) Counter(name string, value int64, attrs ...attribute.KeyValue)       {}
+func (noopMetrics) UpDownCounter(name string, value int64, attrs ...attribute.KeyValue) {}
+func (noopMetrics) Gauge(name string, value float64, attrs ...attribute.KeyValue)       {}
+func (noopMetrics) Histogram(name string, value float64, attrs ...attribute.KeyValue)   {}

--- a/pkg/plugin/metrics_test.go
+++ b/pkg/plugin/metrics_test.go
@@ -1,0 +1,65 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type mockMetrics struct {
+	counterCalls       int
+	upDownCounterCalls int
+	gaugeCalls         int
+	histogramCalls     int
+}
+
+func (m *mockMetrics) Counter(name string, value int64, attrs ...attribute.KeyValue) {
+	m.counterCalls++
+}
+
+func (m *mockMetrics) UpDownCounter(name string, value int64, attrs ...attribute.KeyValue) {
+	m.upDownCounterCalls++
+}
+
+func (m *mockMetrics) Gauge(name string, value float64, attrs ...attribute.KeyValue) {
+	m.gaugeCalls++
+}
+
+func (m *mockMetrics) Histogram(name string, value float64, attrs ...attribute.KeyValue) {
+	m.histogramCalls++
+}
+
+func TestMetricsFromContext_WithMetrics(t *testing.T) {
+	metrics := &mockMetrics{}
+	ctx := WithMetrics(context.Background(), metrics)
+
+	got := MetricsFromContext(ctx)
+	if got != metrics {
+		t.Error("expected same metrics instance")
+	}
+}
+
+func TestMetricsFromContext_WithoutMetrics(t *testing.T) {
+	ctx := context.Background()
+	got := MetricsFromContext(ctx)
+	if _, ok := got.(noopMetrics); !ok {
+		t.Errorf("expected noopMetrics, got %T", got)
+	}
+}
+
+func TestNoopMetrics_DoesNotPanic(t *testing.T) {
+	metrics := noopMetrics{}
+	metrics.Counter("test.counter", 1)
+	metrics.Counter("test.counter", 5, attribute.String("key", "value"))
+	metrics.UpDownCounter("test.updown", 1)
+	metrics.UpDownCounter("test.updown", -1, attribute.String("key", "value"))
+	metrics.Gauge("test.gauge", 42.0)
+	metrics.Gauge("test.gauge", 100.0, attribute.String("key", "value"))
+	metrics.Histogram("test.histogram", 1.5)
+	metrics.Histogram("test.histogram", 2.5, attribute.String("key", "value"))
+}

--- a/pkg/plugin/resource.go
+++ b/pkg/plugin/resource.go
@@ -97,6 +97,13 @@ func (c LabelConfig) QueryForResourceType(resourceType string) string {
 	return c.DefaultQuery
 }
 
+// ObservablePlugin is an optional interface for plugins that support observability.
+// The SDK will check if a wrapped plugin implements this interface and configure
+// logging and metrics if so.
+type ObservablePlugin interface {
+	SetObservability(logger Logger, metrics MetricRegistry)
+}
+
 // PluginInfo provides read-only plugin metadata for discovery operations.
 // This interface is implemented by both local ResourcePlugin and remote plugin info proxies.
 type PluginInfo interface {


### PR DESCRIPTION
## Summary

- Add `Logger` interface with `Debug/Info/Warn/Error` and `With()` for structured logging
- Add `MetricRegistry` interface with `Counter`, `UpDownCounter`, `Gauge`, `Histogram`
- SDK auto-injects observability into context for all CRUD operations
- Custom slog handler outputs in Ergo format for agent log parsing
- No-op implementations when observability not configured