### PR TITLE
feat(plugin): add Extractable to schema extraction + tidy aws migration

### DIFF
--- a/pkg/plugin/descriptors/Extractor.pkl
+++ b/pkg/plugin/descriptors/Extractor.pkl
@@ -35,6 +35,7 @@ function extractDescriptors(): Listing<resourceDescriptor.ResourceDescriptor> = 
                                     }
                                 }
                                 Fields = formae.fq.fields(clazz)
+                                Extractable = clazz.annotations[0].getProperty("extractable")
                             }
                             ParentResourceTypesWithMappingProperties = extractParentMappings(clazz.annotations[0])
                         }

--- a/plugins/pkl/docs/PklProject
+++ b/plugins/pkl/docs/PklProject
@@ -2,5 +2,4 @@ amends "pkl:Project"
 
 dependencies {
   ["formae"] = import("../schema/PklProject")
-  ["aws"] = import("../../aws/schema/pkl/PklProject")
 }


### PR DESCRIPTION
- Extracts Extractable from annotations (field existed but wasn't being populated)                                                                                                                                                                                                                                                                                                  
- Removes stale aws dep from docs `PklProject`