### PR TITLE
fix(pkl): add namespace-based imports for non-AWS resources

### DIFF
--- a/plugins/pkl/generator/pklGenerator.pkl
+++ b/plugins/pkl/generator/pklGenerator.pkl
@@ -142,7 +142,7 @@ function generateFormaFile(parsed: json.Value): String =
         let (properties = appendProperties(resource))
         // Extract namespace from resource type (e.g. "Azure::Resources::ResourceGroup" -> "azure")
         let (namespace = resourceType.split("::").first.toLowerCase())
-        let (pklMap = gen.genPklToMap(gen.applyResource(typeMap[resourceType].clazz, properties).toDynamic()).put("target", target).put("stack", stack).put("__namespace__", namespace))
+        let (pklMap = gen.genPklToMap(gen.applyResource(typeMap[resourceType].clazz, properties).toDynamic()).put("target", target).put("stack", stack))
         let (dependencyImports = gen.generateImportStatements(pklMap))
         let (resourceImport = typeMap[resourceType].moduleName)
 


### PR DESCRIPTION
Adds namespace base imports during PKL code generation so Tag types from non-AWS plugins resolve correctly                                                                                                                                                 
                                              