### PR TITLE
refactor(cli): replace --schema-location with per-include @local suffix

### DIFF
--- a/internal/cli/app/app_test.go
+++ b/internal/cli/app/app_test.go
@@ -22,3 +22,63 @@ func TestAppPluginLoading(t *testing.T) {
 	assert.NoError(t, config.Config.EnsureDataDirectory())
 	assert.NotNil(t, NewApp())
 }
+
+func TestParseIncludeSpec(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantNamespace string
+		wantIsLocal   bool
+	}{
+		{
+			name:          "simple namespace defaults to remote",
+			input:         "aws",
+			wantNamespace: "aws",
+			wantIsLocal:   false,
+		},
+		{
+			name:          "namespace with @local suffix",
+			input:         "ovh@local",
+			wantNamespace: "ovh",
+			wantIsLocal:   true,
+		},
+		{
+			name:          "@local suffix is case-insensitive (uppercase)",
+			input:         "myplugin@LOCAL",
+			wantNamespace: "myplugin",
+			wantIsLocal:   true,
+		},
+		{
+			name:          "@local suffix is case-insensitive (mixed case)",
+			input:         "myplugin@Local",
+			wantNamespace: "myplugin",
+			wantIsLocal:   true,
+		},
+		{
+			name:          "namespace is lowercased",
+			input:         "AWS",
+			wantNamespace: "aws",
+			wantIsLocal:   false,
+		},
+		{
+			name:          "both namespace and @local are lowercased",
+			input:         "MyPlugin@LOCAL",
+			wantNamespace: "myplugin",
+			wantIsLocal:   true,
+		},
+		{
+			name:          "namespace with @ but not @local is treated as remote",
+			input:         "plugin@0.1.0",
+			wantNamespace: "plugin@0.1.0",
+			wantIsLocal:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace, isLocal := parseIncludeSpec(tt.input)
+			assert.Equal(t, tt.wantNamespace, namespace)
+			assert.Equal(t, tt.wantIsLocal, isLocal)
+		})
+	}
+}

--- a/internal/cli/extract/extract.go
+++ b/internal/cli/extract/extract.go
@@ -23,11 +23,10 @@ import (
 )
 
 type ExtractOptions struct {
-	TargetPath     string
-	Query          string
-	Yes            bool
-	OutputSchema   string
-	SchemaLocation string
+	TargetPath   string
+	Query        string
+	Yes          bool
+	OutputSchema string
 }
 
 func ExtractCmd() *cobra.Command {
@@ -43,7 +42,6 @@ func ExtractCmd() *cobra.Command {
 			opts.Query, _ = command.Flags().GetString("query")
 			opts.Yes, _ = command.Flags().GetBool("yes")
 			opts.OutputSchema, _ = command.Flags().GetString("output-schema")
-			opts.SchemaLocation, _ = command.Flags().GetString("schema-location")
 
 			configFile, _ := command.Flags().GetString("config")
 			app, err := cmd.AppFromContext(command.Context(), configFile, "", command)
@@ -66,7 +64,6 @@ func ExtractCmd() *cobra.Command {
 	command.Flags().String("query", " ", "Query that allows to find resources by their attributes")
 	command.Flags().Bool("yes", false, "Overwrite existing files without prompting")
 	command.Flags().String("output-schema", "pkl", "Output schema (only 'pkl' is currently supported)")
-	command.Flags().String("schema-location", "local", "Schema location: 'remote' (PKL registry) or 'local' (installed plugins)")
 	command.Flags().String("config", "", "Path to config file")
 
 	return command
@@ -111,7 +108,7 @@ func runExtract(app *app.App, opts *ExtractOptions) error {
 		}
 	}
 
-	res, err := app.GenerateSourceCode(forma, opts.TargetPath, opts.OutputSchema, opts.SchemaLocation)
+	res, err := app.GenerateSourceCode(forma, opts.TargetPath, opts.OutputSchema)
 	if errors.Is(err, plugin.ErrFailedToGenerateSources) {
 		logFilePath := fmt.Sprintf("%s/log/client.log", config.Config.DataDirectory())
 		return fmt.Errorf("something went wrong during the extraction. This is our fault. Please contact us and send over the error logs from '%s'", logFilePath)

--- a/internal/cli/project/project.go
+++ b/internal/cli/project/project.go
@@ -5,9 +5,13 @@
 package project
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/platform-engineering-labs/formae/internal/cli/cmd"
+	"github.com/platform-engineering-labs/formae/internal/cli/display"
+	"github.com/platform-engineering-labs/formae/internal/cli/prompter"
 )
 
 func ProjectCmd() *cobra.Command {
@@ -35,21 +39,35 @@ func ProjectInitCmd() *cobra.Command {
 		RunE: func(command *cobra.Command, args []string) error {
 			schema, _ := command.Flags().GetString("schema")
 			include, _ := command.Flags().GetStringArray("include")
-			schemaLocation, _ := command.Flags().GetString("schema-location")
+			yes, _ := command.Flags().GetBool("yes")
+
+			// Confirm with user if no plugins specified
+			if len(include) == 0 && !yes {
+				fmt.Println(display.Gold("No plugins specified.") + " The project will not include any cloud provider schemas.")
+				fmt.Println(display.Grey("  To add plugins, use: --include aws --include gcp"))
+				fmt.Println()
+
+				p := prompter.NewBasicPrompter()
+				if !p.Confirm("Continue without plugins?", false) {
+					fmt.Print(display.Red("\nProject initialization aborted\n"))
+					return nil
+				}
+				fmt.Println()
+			}
 
 			app, err := cmd.AppFromContext(command.Context(), "", "", command)
 			if err != nil {
 				return err
 			}
 
-			return app.Projects.Init(command.Flags().Arg(0), schema, include, schemaLocation)
+			return app.Projects.Init(command.Flags().Arg(0), schema, include)
 		},
 		SilenceErrors: true,
 	}
 
 	command.Flags().String("schema", "pkl", "Schema to use for the project (pkl)")
-	command.Flags().StringArray("include", []string{"aws"}, "Packages to include (aws)")
-	command.Flags().String("schema-location", "local", "Schema location: 'remote' (PKL registry) or 'local' (installed plugins)")
+	command.Flags().StringArray("include", []string{}, "Packages to include (use @local suffix for local plugins, e.g. myplugin@local)")
+	command.Flags().BoolP("yes", "y", false, "Skip confirmation prompts")
 
 	return command
 }


### PR DESCRIPTION
## Summary

Replace the global `--schema-location` flag with per-include `@local` suffix syntax for more granular control over schema resolution.

**Changes:**
- Remove `--schema-location` flag from `extract` and `project init` commands
- Add `@local` suffix parsing to `--include` flag (e.g. `--include ovh@local`)
- Default schema resolution to remote (hub.platform.engineering)
- `extract` command always uses local resolution (hardcoded)
- Add confirmation prompt when `project init` has no plugins specified
- Add `--yes` flag to `project init` to skip confirmation
- Remove `aws` as default for `--include` (now empty by default)

**New syntax:**
```bash
# All remote (default)
formae project init --include aws --include gcp

# Mixed: aws from hub, ovh from local plugins
formae project init --include aws --include ovh@local

# Skip confirmation for empty project
formae project init --yes
```

**Error handling:**
```
$ formae project init --include nonexistent@local
Error: plugin "nonexistent" not installed locally. Install with: formae plugin install nonexistent
```

Supersedes #171