### PR TITLE
fix(datastore): handle consistent azure native-ids

### DIFF
--- a/internal/metastructure/datastore/sqlite.go
+++ b/internal/metastructure/datastore/sqlite.go
@@ -789,8 +789,13 @@ func (d DatastoreSQLite) storeResource(resource *pkgmodel.Resource, data []byte,
 	} else {
 		// For non-delete operations, compare resources
 		if readWriteEqual && readOnlyEqual {
-			// Resource data is identical, return existing version ID
-			return fmt.Sprintf("%s_%s", resource.Ksuid, version), nil
+			// Resource data is identical. Only return early if KSUIDs match.
+			// If a new KSUID was assigned (e.g., after destroy with deterministic native_id like Azure),
+			// we need to insert a row with the new KSUID for references to resolve.
+			if resource.Ksuid == ksuid {
+				return fmt.Sprintf("%s_%s", resource.Ksuid, version), nil
+			}
+			// KSUIDs differ - fall through to insert with the new KSUID
 		}
 	}
 


### PR DESCRIPTION
### Problem: 
After a destroy/re-apply cycle, some dependent resources fail to resolve references to their parent resources. 

This affects cloud providers like Azure where native_id is deterministic (based on subscription/resource-group/name)
                                                                                                                     
### Fix:                                                                                                                       
                                                                                                                    
1. Track whether KSUID was provided vs generated in storeResource                                                         
2. Only adopt discovered KSUID if incoming resource didn't already have one assigned                                                                                                           
3. Check if incoming KSUID matches existing KSUID before returning early; only skip insert when BOTH data AND KSUID are identical                                                                