### PR TITLE
feat(pkg): publish PKL schemas for external plugins

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -52,6 +52,9 @@ jobs:
           role-to-assume: arn:aws:iam::897722706215:role/github-pel
           role-session-name: PublishSession
 
+      - name: Fetch external plugins
+        run: make fetch-external-plugins
+
       - name: Resolve Pkl
         run: make gen-pkl
 


### PR DESCRIPTION
Add support for packaging and publishing PKL schemas from external plugin repositories (aws, azure, gcp, oci, ovh).

- Add gen-external-pkl target to resolve external plugin schemas
- Extend pkg-pkl to package external plugin schemas
- Extend publish-pkl to sync external schemas to S3
- Add fetch-external-plugins step to pkg_pkl workflow job