### PR TITLE
fix(upgrade): wipe plugin namespace directory instead of entire plugins folder

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -287,18 +287,19 @@ func migrateResourcePlugins(userPluginDir string) error {
 
 	userPluginDir = util.ExpandHomePath(userPluginDir)
 
-	// Wipe existing user plugin directory - old plugins are incompatible
-	if err := os.RemoveAll(userPluginDir); err != nil {
-		return fmt.Errorf("failed to remove old plugins directory: %w", err)
-	}
-	slog.Info("Removed old plugins directory for migration", "path", userPluginDir)
-
 	for _, nsEntry := range namespaces {
 		if !nsEntry.IsDir() {
 			continue
 		}
 		namespace := strings.ToLower(nsEntry.Name())
 		nsPath := filepath.Join(systemResourcePluginsDir, nsEntry.Name())
+
+		// Remove existing namespace directory before installing new versions
+		existingNamespaceDir := filepath.Join(userPluginDir, namespace)
+		if err := os.RemoveAll(existingNamespaceDir); err != nil {
+			return fmt.Errorf("failed to remove existing plugin directory %s: %w", existingNamespaceDir, err)
+		}
+		slog.Info("Removed existing plugin directory for migration", "path", existingNamespaceDir)
 
 		versions, err := os.ReadDir(nsPath)
 		if err != nil {

--- a/internal/cli/upgrade/upgrade.go
+++ b/internal/cli/upgrade/upgrade.go
@@ -362,6 +362,12 @@ func installResourcePlugins(installPrefix string) error {
 		namespace := strings.ToLower(nsEntry.Name())
 		nsPath := filepath.Join(resourcePluginsDir, nsEntry.Name())
 
+		// Remove existing namespace directory before installing new versions
+		existingNamespaceDir := filepath.Join(homeDir, ".pel", "formae", "plugins", namespace)
+		if err := os.RemoveAll(existingNamespaceDir); err != nil {
+			return fmt.Errorf("failed to remove existing plugin directory %s: %w", existingNamespaceDir, err)
+		}
+
 		versions, err := os.ReadDir(nsPath)
 		if err != nil {
 			continue

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -175,6 +175,8 @@ if [ -d "$RESOURCE_PLUGINS_SRC" ]; then
   for namespace_dir in "$RESOURCE_PLUGINS_SRC"/*; do
     if [ -d "$namespace_dir" ]; then
       namespace=$(basename "$namespace_dir")
+      # Remove existing namespace directory before installing new versions
+      rm -rf "${PLUGINDIR}/${namespace}"
       for version_dir in "$namespace_dir"/*; do
         if [ -d "$version_dir" ]; then
           ver=$(basename "$version_dir")


### PR DESCRIPTION
## Summary

- When upgrading or migrating resource plugins, only remove the specific namespace directory being installed (e.g., `~/.pel/formae/plugins/aws`) rather than wiping the entire plugins directory
- This preserves other installed plugins during upgrades
- Applied consistently across all three upgrade paths: `setup.sh`, `formae upgrade` command, and agent migration logic