### PR TITLE
docs: regenerate API docs with Version field

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -595,6 +595,9 @@ const docTemplate = `{
                 },
                 "ResourceCount": {
                     "type": "integer"
+                },
+                "Version": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -589,6 +589,9 @@
                 },
                 "ResourceCount": {
                     "type": "integer"
+                },
+                "Version": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -107,6 +107,8 @@ definitions:
         type: string
       ResourceCount:
         type: integer
+      Version:
+        type: string
     type: object
   model.Prop:
     properties:


### PR DESCRIPTION
Regenerated API docs to include the Version field in the model.