### PR TITLE
fix(plugin): route plugin logs through stdout instead of stderr

### DIFF
--- a/pkg/plugin/sdk/run.go
+++ b/pkg/plugin/sdk/run.go
@@ -114,8 +114,11 @@ func (h *ergoHandler) WithGroup(name string) slog.Handler {
 }
 
 // setupPluginLogger creates a logger for the plugin that outputs in Ergo format.
+// Logs are written to stdout so that Ergo routes them through MessagePortText,
+// which allows PluginProcessSupervisor to parse and route by log level.
+// Stderr is reserved for actual errors (MessagePortError).
 func setupPluginLogger(namespace string) plugin.Logger {
-	handler := &ergoHandler{w: os.Stderr, level: getPluginLogLevel()}
+	handler := &ergoHandler{w: os.Stdout, level: getPluginLogLevel()}
 	slogger := slog.New(handler).With("plugin.namespace", namespace)
 	return plugin.NewPluginLogger(slogger)
 }


### PR DESCRIPTION
## Summary

Plugin logs were being written to stderr, which Ergo routes through MessagePortError. This caused all plugin log messages (including info level) to appear as errors in the agent logs.

Changed to stdout so logs route through MessagePortText, allowing PluginProcessSupervisor to correctly parse and route by log level.