### PR TITLE
fix(conformance): scope discovery to tested resource type

### DIFF
--- a/pkg/plugin-conformance-tests/runner.go
+++ b/pkg/plugin-conformance-tests/runner.go
@@ -860,6 +860,13 @@ func runDiscoveryTest(t *testing.T, tc TestCase) {
 		}
 	})
 
+	// Configure discovery to only scan the specific resource type being tested.
+	// This prevents discovery from scanning all resource types, which causes
+	// excessive rate limiting and timeouts.
+	if err := harness.ConfigureDiscovery([]string{resourceType}); err != nil {
+		t.Fatalf("failed to configure discovery: %v", err)
+	}
+
 	// Start the agent with discovery enabled
 	if err := harness.StartAgent(); err != nil {
 		t.Fatalf("failed to start agent: %v", err)


### PR DESCRIPTION
## Summary
- Fixed discovery conformance tests timing out due to scanning ALL resource types instead of just the tested type
- Added `ConfigureDiscovery` call in `runDiscoveryTest` before `StartAgent` to scope discovery to the specific resource type being tested
- This prevents excessive rate limiting and 70+ second delays during discovery tests

## Context
Discovery tests (`iam-role`, `secretsmanager-secret`) in formae-plugin-aws were failing after ~50 minutes due to rate limiting. The root cause was that `runDiscoveryTest` never called `ConfigureDiscovery`, causing discovery to scan all 169+ resource types instead of just the one being tested.