### PR TITLE
feat(config): add configurable Ergo port for parallel test execution

### DIFF
--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -15,6 +15,7 @@ import (
 	"ergo.services/application/observer"
 	"ergo.services/ergo"
 	"ergo.services/ergo/gen"
+	"ergo.services/ergo/net/registrar"
 	"github.com/tidwall/gjson"
 
 	"github.com/platform-engineering-labs/formae"
@@ -140,6 +141,17 @@ func NewMetastructureWithDataStoreAndContext(ctx context.Context, cfg *pkgmodel.
 
 	// Use the secret from config which now defaults to a random value via PKL
 	metastructure.options.Network.Cookie = cfg.Agent.Server.Secret
+
+	// Configure Ergo listen address with custom port (enables parallel test execution)
+	if cfg.Agent.Server.ErgoPort != 0 {
+		metastructure.options.Network.Acceptors = []gen.AcceptorOptions{
+			{
+				Host:      cfg.Agent.Server.Hostname,
+				Port:      uint16(cfg.Agent.Server.ErgoPort),
+				Registrar: registrar.Create(registrar.Options{Port: uint16(cfg.Agent.Server.ErgoPort)}),
+			},
+		}
+	}
 
 	metastructure.options.Log.DefaultLogger.Disable = true
 	metastructure.options.Log.Level = gen.LogLevelDebug

--- a/internal/metastructure/plugin_process_supervisor/plugin_process_supervisor.go
+++ b/internal/metastructure/plugin_process_supervisor/plugin_process_supervisor.go
@@ -7,6 +7,7 @@ package plugin_process_supervisor
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -217,6 +218,7 @@ func (p *PluginProcessSupervisor) spawnPlugin(namespace string, pluginInfo *Plug
 		gen.Env("FORMAE_PLUGIN_NODE"):    nodeName,
 		gen.Env("FORMAE_NETWORK_COOKIE"): serverConfig.Secret,
 		gen.Env("FORMAE_VERSION"):        formae.Version,
+		gen.Env("FORMAE_ERGO_PORT"):      strconv.Itoa(serverConfig.ErgoPort),
 	}
 
 	// Add OTel configuration if available

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -19,6 +19,7 @@ type ServerConfig struct {
 	Nodename     string
 	Hostname     string
 	Port         int
+	ErgoPort     int `pkl:"ergoPort"`
 	Secret       string
 	ObserverPort int
 	TLSCert      string

--- a/plugins/pkl/assets/formae/Config.pkl
+++ b/plugins/pkl/assets/formae/Config.pkl
@@ -17,6 +17,8 @@ class ServerConfig {
 
     port: Port = 49684
 
+    ergoPort: Port = 0
+
     secret: String = "secret"
 
     observerPort: Port = 0

--- a/plugins/pkl/model/config.go
+++ b/plugins/pkl/model/config.go
@@ -14,6 +14,7 @@ type ServerConfig struct {
 	Nodename     string `pkl:"nodename"`
 	Hostname     string `pkl:"hostname"`
 	Port         int32  `pkl:"port"`
+	ErgoPort     int32  `pkl:"ergoPort"`
 	Secret       string `pkl:"secret"`
 	ObserverPort int32  `pkl:"observerPort"`
 	TLSCert      string `pkl:"tlsCert"`

--- a/plugins/pkl/pkl.go
+++ b/plugins/pkl/pkl.go
@@ -132,6 +132,7 @@ func translateConfig(config *pklmodel.Config) *pkgmodel.Config {
 				Nodename:     config.Agent.Server.Nodename,
 				Hostname:     config.Agent.Server.Hostname,
 				Port:         int(config.Agent.Server.Port),
+				ErgoPort:     int(config.Agent.Server.ErgoPort),
 				Secret:       config.Agent.Server.Secret,
 				ObserverPort: int(config.Agent.Server.ObserverPort),
 				TLSCert:      config.Agent.Server.TLSCert,

--- a/plugins/pkl/pkl_test.go
+++ b/plugins/pkl/pkl_test.go
@@ -99,6 +99,7 @@ func TestPkl_FormaeConfig(t *testing.T) {
 	assert.Equal(t, "formae", config.Agent.Server.Nodename)
 	assert.Equal(t, "formae.example.com", config.Agent.Server.Hostname)
 	assert.Equal(t, 1234, config.Agent.Server.Port)
+	assert.Equal(t, 15100, config.Agent.Server.ErgoPort)
 	assert.Equal(t, "secret", config.Agent.Server.Secret)
 	assert.Equal(t, 0, config.Agent.Server.ObserverPort)
 

--- a/plugins/pkl/testdata/config/test_config.pkl
+++ b/plugins/pkl/testdata/config/test_config.pkl
@@ -11,6 +11,7 @@ agent {
         nodename = "formae"
         hostname = "formae.example.com"
         port = 1234
+        ergoPort = 15100
         secret = "secret"
     }
     datastore {


### PR DESCRIPTION
## Summary
- Add `ergoPort` field to ServerConfig (PKL schema and Go model) to configure Ergo registrar and acceptors
- Pass `FORMAE_ERGO_PORT` environment variable to plugin processes
- Configure test harness to allocate unique Ergo ports per test run

## Problem
When running parallel conformance tests (PARALLEL=10 in nightly), multiple formae agent instances try to bind to Ergo's default port. Only one succeeds, causing other tests to fail with "timeout waiting for agent to become ready".

In Ergo, the first node launched on a host becomes the registrar for other nodes. When multiple test agents start in parallel, they all compete for the default registrar port, causing bind conflicts.

## Solution
Make the Ergo port configurable so each test cluster uses a unique port. When `ergoPort` is set to a non-zero value, both the agent and plugins use that port for node discovery and communication within their cluster.

Default is 0 (auto-select), which provides better out-of-box parallel support.