### PR TITLE
fix(ci): upgrade e2e test runner to 4-core

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -81,7 +81,7 @@ jobs:
           done
 
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     timeout-minutes: 30
     needs: [pre-cleanup]
     strategy:


### PR DESCRIPTION
## Summary

- Upgrade the e2e test job runner from `ubuntu-latest` (2-core) to `ubuntu-latest-4-cores`
- Matches the property-tests runner upgrade from #384
- Pre-cleanup and cleanup jobs stay on `ubuntu-latest` (no CPU pressure)

Intermittent e2e failures were caused by Ergo actor timeouts (plugin operator spawn, CheckStatus) on the resource-constrained 2-core runner.