### PR TITLE
fix(patch): remove writeOnly+createOnly fields from desired state before comparison

### DIFF
--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -68,6 +68,20 @@ func generatePatch(document []byte, patch []byte, properties resolver.Resolvable
 		return nil, false, fmt.Errorf("unable to generate patch document for apply mode: %s", mode)
 	}
 
+	// Strip fields that are both writeOnly AND createOnly from the desired
+	// state (patch) before comparison. writeOnly fields are never returned by
+	// the provider's Read, so they're always absent from the document. If the
+	// field is also createOnly, the "add" op that jsonpatch generates triggers
+	// a resource replacement even though nothing actually changed. Stripping
+	// them from the patch prevents phantom replacements on re-apply.
+	writeOnlyCreateOnly := intersectFields(schema.WriteOnly(), schema.CreateOnly())
+	if len(writeOnlyCreateOnly) > 0 {
+		flattenedPatch, err = removeWriteOnlyFields(flattenedPatch, writeOnlyCreateOnly)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to strip writeOnly+createOnly fields from desired state: %w", err)
+		}
+	}
+
 	patchOps, err := createPatchDocument(flattenedDocument, flattenedPatch, schema.Fields, schema.WriteOnly(), schema.HasProviderDefault(), entitySetProviderDefaultsFromHints(schema.Hints), collectionSemanticsFromFieldHints(schema.Hints), defaultIgnoredFields, strategy)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to create patch document: %w", err)
@@ -168,6 +182,21 @@ func createPatchDocument(document []byte, patch []byte, schemaFields []string, w
 	}
 
 	return patchDoc, nil
+}
+
+// intersectFields returns fields present in both slices.
+func intersectFields(a, b []string) []string {
+	set := make(map[string]struct{}, len(b))
+	for _, f := range b {
+		set[f] = struct{}{}
+	}
+	var result []string
+	for _, f := range a {
+		if _, ok := set[f]; ok {
+			result = append(result, f)
+		}
+	}
+	return result
 }
 
 // removeWriteOnlyFields removes writeOnly fields from the document.

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -634,6 +634,47 @@ func TestGeneratePatch_WriteOnlyFieldsGenerateAddOperation(t *testing.T) {
 	assert.Equal(t, "secret123", passwordOp.Value, "Password value should be preserved")
 }
 
+func TestGeneratePatch_WriteOnlyCreateOnlyFieldsNoPhantomReplacement(t *testing.T) {
+	// Reproduces GitHub Issue #21: fields marked both writeOnly AND createOnly
+	// trigger phantom resource replacement on re-apply.
+	//
+	// writeOnly fields are stripped from the document (Read never returns them).
+	// If the field is also createOnly, jsonpatch generates an "add" op,
+	// which triggers needsReplacement. The fix strips these fields from the
+	// desired state (patch) before comparison.
+
+	// Existing state (from Read — writeOnly field is absent)
+	document := []byte(`{
+		"ClusterName": "my-cluster",
+		"Endpoint": "https://eks.example.com"
+	}`)
+
+	// Desired state (from PKL — includes the writeOnly+createOnly field)
+	patch := []byte(`{
+		"ClusterName": "my-cluster",
+		"Endpoint": "https://eks.example.com",
+		"AccessConfig": {
+			"AuthenticationMode": "API_AND_CONFIG_MAP"
+		}
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"ClusterName", "Endpoint", "AccessConfig"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"AccessConfig": {
+				WriteOnly:  true,
+				CreateOnly: true,
+			},
+		},
+	}
+	props := resolver.NewResolvableProperties()
+
+	patchDoc, needsReplacement, err := generatePatch(document, patch, props, schema, pkgmodel.FormaApplyModePatch)
+	require.NoError(t, err)
+	assert.False(t, needsReplacement, "writeOnly+createOnly field should NOT trigger replacement")
+	assert.Nil(t, patchDoc, "No patch should be generated when only writeOnly+createOnly fields differ")
+}
+
 func TestGeneratePatch_AddTagsWhileRetainingExisting(t *testing.T) {
 	// This is the existing resource state (from the database) - VPC with 1 tag
 	document := []byte(`{


### PR DESCRIPTION
### Problem:

Fields marked writeOnly AND createOnly (e.g. EKS AccessConfig) trigger phantom resource replacement on re-apply. removeWriteOnlyFields strips these from the actual state (Read never returns them), but they remain in the desired state. jsonpatch sees a diff, generates an add op, and the createOnly check interprets it as a field change requiring delete + recreate

### Fix:

Before patch comparison, strip fields that are both writeOnly AND createOnly from the desired state. This prevents the phantom diff while preserving the existing behavior for writeOnly-only fields (passwords etc. still generate add ops as expected)

https://github.com/platform-engineering-labs/formae-plugin-k8s/issues/21
