### PR TITLE
fix: apply terminal width constraint to inventory resources table

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.16.0
 	go.opentelemetry.io/otel/sdk/metric v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
+	golang.org/x/term v0.39.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 	pgregory.net/rapid v1.2.0
@@ -236,7 +237,6 @@ require (
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
-	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	golang.org/x/tools v0.40.0 // indirect

--- a/internal/cli/display/display.go
+++ b/internal/cli/display/display.go
@@ -41,8 +41,20 @@ func ClearScreen() {
 	fmt.Print("\033[2;1H") // Clear screen
 }
 
+// bannerMinWidth is the minimum terminal width needed to render the
+// combined banner without wrapping. Lines are at most 88 visible
+// characters wide (with tab expansion).
+const bannerMinWidth = 90
+
 func PrintBanner() {
-	fmt.Println(strings.Replace(banner, "version", formae.Version, 1))
+	b := strings.Replace(banner, "version", formae.Version, 1)
+	if TerminalWidth() < bannerMinWidth {
+		// Terminal too narrow for the ASCII art banner; print a
+		// compact fallback so the brand is still visible.
+		fmt.Printf("%s %s\n\n", Gold("formae"), LightBlue("v"+formae.Version))
+		return
+	}
+	fmt.Println(b)
 }
 
 func Success(msg string) {

--- a/internal/cli/display/termwidth.go
+++ b/internal/cli/display/termwidth.go
@@ -1,4 +1,8 @@
-package renderer
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package display
 
 import (
 	"os"
@@ -8,9 +12,9 @@ import (
 
 const defaultTerminalWidth = 100
 
-// terminalWidth returns the current terminal width, falling back to
+// TerminalWidth returns the current terminal width, falling back to
 // defaultTerminalWidth when the width cannot be determined (e.g., piped output).
-func terminalWidth() int {
+func TerminalWidth() int {
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil || width <= 0 {
 		return defaultTerminalWidth

--- a/internal/cli/renderer/renderer.go
+++ b/internal/cli/renderer/renderer.go
@@ -909,6 +909,7 @@ func operationSummary(targetCreates, targetUpdates, stackCreates, stackUpdates, 
 func RenderInventoryResources(resources []pkgmodel.Resource, maxRows int) (string, error) {
 	var buf strings.Builder
 	table := tablewriter.NewTable(&buf,
+		tablewriter.WithMaxWidth(display.TerminalWidth()),
 		tablewriter.WithRowAutoWrap(tw.WrapBreak),
 		tablewriter.WithHeaderAutoFormat(tw.Off),
 		tablewriter.WithRenderer(renderer.NewBlueprint(tw.Rendition{

--- a/internal/cli/renderer/renderer.go
+++ b/internal/cli/renderer/renderer.go
@@ -42,6 +42,7 @@ func RenderSimulation(s *apimodel.Simulation) (string, error) {
 func RenderStatusSummary(status *apimodel.ListCommandStatusResponse) (string, error) {
 	var buf strings.Builder
 	table := tablewriter.NewTable(&buf,
+		tablewriter.WithMaxWidth(display.TerminalWidth()),
 		tablewriter.WithHeaderAutoFormat(tw.Off),
 		tablewriter.WithRenderer(renderer.NewBlueprint(tw.Rendition{
 			Settings: tw.Settings{Separators: tw.Separators{BetweenRows: tw.On}},

--- a/internal/cli/renderer/stats.go
+++ b/internal/cli/renderer/stats.go
@@ -174,7 +174,7 @@ func renderTablesSideBySide(tables []struct {
 
 		// Create tablewriter table
 		tw := tablewriter.NewTable(&buf,
-			tablewriter.WithMaxWidth(terminalWidth()),
+			tablewriter.WithMaxWidth(display.TerminalWidth()),
 			tablewriter.WithRowAutoWrap(tw.WrapBreak),
 			tablewriter.WithRenderer(renderer.NewBlueprint(tw.Rendition{
 				Settings: tw.Settings{Separators: tw.Separators{BetweenRows: tw.On, ShowHeader: tw.On}},

--- a/internal/cli/renderer/stats.go
+++ b/internal/cli/renderer/stats.go
@@ -174,7 +174,7 @@ func renderTablesSideBySide(tables []struct {
 
 		// Create tablewriter table
 		tw := tablewriter.NewTable(&buf,
-			tablewriter.WithMaxWidth(100),
+			tablewriter.WithMaxWidth(terminalWidth()),
 			tablewriter.WithRowAutoWrap(tw.WrapBreak),
 			tablewriter.WithRenderer(renderer.NewBlueprint(tw.Rendition{
 				Settings: tw.Settings{Separators: tw.Separators{BetweenRows: tw.On, ShowHeader: tw.On}},

--- a/internal/cli/renderer/termwidth.go
+++ b/internal/cli/renderer/termwidth.go
@@ -1,0 +1,19 @@
+package renderer
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+const defaultTerminalWidth = 100
+
+// terminalWidth returns the current terminal width, falling back to
+// defaultTerminalWidth when the width cannot be determined (e.g., piped output).
+func terminalWidth() int {
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || width <= 0 {
+		return defaultTerminalWidth
+	}
+	return width
+}


### PR DESCRIPTION
`RenderInventoryResources` was the only table constructor missing `tablewriter.WithMaxWidth(display.TerminalWidth())`. The summary table (renderer.go:44) and stats tables (stats.go:177) already had it. Without the constraint, the inventory table wraps incorrectly in narrow terminals.

One-line addition to match the pattern used by the other tables in the same package.

Fixes #39

This contribution was developed with AI assistance (Claude Code).