### PR TITLE
feat(config): per-plugin resource configuration with typed PKL schema

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -101,6 +101,7 @@ jobs:
           - TestSimulateApply
           - TestExtractAndReapply
           - TestAuthBasic
+          - TestPluginConfig
 
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,14 @@ build-external-plugins: fetch-external-plugins
 		cd "$(PLUGINS_CACHE)/$$name" && \
 			if grep -q 'formae/pkg/auth' go.mod 2>/dev/null; then \
 				go mod edit -replace github.com/platform-engineering-labs/formae/pkg/auth=$(CURDIR)/pkg/auth; \
-				go mod tidy; \
 			fi && \
+			if grep -q 'formae/pkg/model' go.mod 2>/dev/null; then \
+				go mod edit -replace github.com/platform-engineering-labs/formae/pkg/model=$(CURDIR)/pkg/model; \
+			fi && \
+			if grep -q 'formae/pkg/plugin' go.mod 2>/dev/null; then \
+				go mod edit -replace github.com/platform-engineering-labs/formae/pkg/plugin=$(CURDIR)/pkg/plugin; \
+			fi && \
+			go mod tidy && \
 			cd $(CURDIR); \
 		$(MAKE) -C "$(PLUGINS_CACHE)/$$name" build; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ EXTERNAL_PLUGIN_REPOS ?= \
     https://github.com/platform-engineering-labs/formae-plugin-grafana.git@feat/msgpack-serialization \
     https://github.com/platform-engineering-labs/formae-plugin-oci.git@feat/msgpack-serialization \
     https://github.com/platform-engineering-labs/formae-plugin-ovh.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-sftp.git
+    https://github.com/platform-engineering-labs/formae-plugin-sftp.git@feat/resource-plugin-config
 
 # Directory for cloned plugins
 PLUGINS_CACHE := .plugins

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,13 @@ PKL_BIN_URL := https://github.com/apple/pkl/releases/download/${PKL_BUNDLE_VERSI
 # Without @ref, the default branch (main) is used.
 EXTERNAL_PLUGIN_REPOS ?= \
     https://github.com/platform-engineering-labs/formae-plugin-auth-basic.git \
-    https://github.com/platform-engineering-labs/formae-plugin-aws.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-azure.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-compose.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-gcp.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-grafana.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-oci.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-ovh.git@feat/msgpack-serialization \
+    https://github.com/platform-engineering-labs/formae-plugin-aws.git@feat/resource-plugin-config \
+    https://github.com/platform-engineering-labs/formae-plugin-azure.git@feat/resource-plugin-config \
+    https://github.com/platform-engineering-labs/formae-plugin-compose.git@feat/resource-plugin-config \
+    https://github.com/platform-engineering-labs/formae-plugin-gcp.git@feat/resource-plugin-config \
+    https://github.com/platform-engineering-labs/formae-plugin-grafana.git@feat/resource-plugin-config \
+    https://github.com/platform-engineering-labs/formae-plugin-oci.git@feat/resource-plugin-config \
+    https://github.com/platform-engineering-labs/formae-plugin-ovh.git@feat/resource-plugin-config \
     https://github.com/platform-engineering-labs/formae-plugin-sftp.git@feat/resource-plugin-config
 
 # Directory for cloned plugins

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,10 @@ install-external-plugins: build-external-plugins
 				mkdir -p "$$dest/schema"; \
 				cp -r "$$plugin_dir/schema/pkl" "$$dest/schema/"; \
 			fi; \
+			if [ -f "$$plugin_dir/schema/Config.pkl" ]; then \
+				mkdir -p "$$dest/schema"; \
+				cp "$$plugin_dir/schema/Config.pkl" "$$dest/schema/"; \
+			fi; \
 		else \
 			namespace=$$(pkl eval -x 'namespace' "$$plugin_dir/formae-plugin.pkl" | tr '[:upper:]' '[:lower:]'); \
 			dest="$$HOME/.pel/formae/plugins/$$namespace/v$$version"; \
@@ -128,6 +132,9 @@ install-external-plugins: build-external-plugins
 			cp "$$plugin_dir/bin/$$plugin_name" "$$dest/$$namespace"; \
 			cp "$$plugin_dir/formae-plugin.pkl" "$$dest/"; \
 			cp -r "$$plugin_dir/schema/pkl" "$$dest/schema/"; \
+			if [ -f "$$plugin_dir/schema/Config.pkl" ]; then \
+				cp "$$plugin_dir/schema/Config.pkl" "$$dest/schema/"; \
+			fi; \
 		fi; \
 	done
 	@echo "External plugins installed successfully."
@@ -158,6 +165,10 @@ pkg-bin: clean build build-tools build-external-plugins
 				mkdir -p "$$dest/schema"; \
 				cp -r "$$plugin_dir/schema/pkl" "$$dest/schema/"; \
 			fi; \
+			if [ -f "$$plugin_dir/schema/Config.pkl" ]; then \
+				mkdir -p "$$dest/schema"; \
+				cp "$$plugin_dir/schema/Config.pkl" "$$dest/schema/"; \
+			fi; \
 		else \
 			namespace=$$(pkl eval -x 'namespace' "$$plugin_dir/formae-plugin.pkl" | tr '[:upper:]' '[:lower:]'); \
 			dest="./dist/pel/formae/resource-plugins/$$namespace/v$$version"; \
@@ -166,6 +177,9 @@ pkg-bin: clean build build-tools build-external-plugins
 			cp "$$plugin_dir/bin/$$plugin_name" "$$dest/$$namespace"; \
 			cp "$$plugin_dir/formae-plugin.pkl" "$$dest/"; \
 			cp -r "$$plugin_dir/schema/pkl" "$$dest/schema/"; \
+			if [ -f "$$plugin_dir/schema/Config.pkl" ]; then \
+				cp "$$plugin_dir/schema/Config.pkl" "$$dest/schema/"; \
+			fi; \
 			mkdir -p "./dist/pel/formae/examples/$$plugin_name"; \
 			cp -r "$$plugin_dir/examples/"* "./dist/pel/formae/examples/$$plugin_name/" 2>/dev/null || true; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ EXTERNAL_PLUGIN_REPOS ?= \
     https://github.com/platform-engineering-labs/formae-plugin-gcp.git@feat/msgpack-serialization \
     https://github.com/platform-engineering-labs/formae-plugin-grafana.git@feat/msgpack-serialization \
     https://github.com/platform-engineering-labs/formae-plugin-oci.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-ovh.git@feat/msgpack-serialization
+    https://github.com/platform-engineering-labs/formae-plugin-ovh.git@feat/msgpack-serialization \
+    https://github.com/platform-engineering-labs/formae-plugin-sftp.git
 
 # Directory for cloned plugins
 PLUGINS_CACHE := .plugins

--- a/go.mod
+++ b/go.mod
@@ -259,3 +259,5 @@ require (
 )
 
 replace ergo.services/ergo => github.com/JeroenSoeters/ergo v1.999.320-pel.1
+
+replace github.com/apple/pkl-go => github.com/JeroenSoeters/pkl-go v0.12.1-pel.1

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/JeroenSoeters/actor/statemachine v0.0.0-20260319024748-85c28f9f660b h
 github.com/JeroenSoeters/actor/statemachine v0.0.0-20260319024748-85c28f9f660b/go.mod h1:pZkasfR9a9QIG3HbjvI5dDZpv07YQFgYXiXqCctIrmg=
 github.com/JeroenSoeters/ergo v1.999.320-pel.1 h1:f+FhIqLSeK81oArXJ9QkaOhHjahyW9Ec0T50xlGVxI4=
 github.com/JeroenSoeters/ergo v1.999.320-pel.1/go.mod h1:bLQ6PoO6Mz/8gVuzvPv3xfMfo1P9w6rZV1WnMXMeMdg=
+github.com/JeroenSoeters/pkl-go v0.12.1-pel.1 h1:g0UYRvQlzoK3v/frW8jvHD+i/A21jEPkXRV7AWhf7ws=
+github.com/JeroenSoeters/pkl-go v0.12.1-pel.1/go.mod h1:Ko3AgXOKd/vVYtsRZgoCZhymymz9RxqCIcfdZhOX85I=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
@@ -61,8 +63,6 @@ github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwTo
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
-github.com/apple/pkl-go v0.12.0 h1:0gnhEIXo6coSHPpxdOESfGn2GrSkBSaeitkZLwZAcWE=
-github.com/apple/pkl-go v0.12.0/go.mod h1:EDQmYVtFBok/eLI+9rT0EoBBXNtMM1THwR+rwBcAH3I=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
 github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=

--- a/internal/cli/plugin/init.go
+++ b/internal/cli/plugin/init.go
@@ -574,8 +574,9 @@ func transformContent(content string, config *PluginConfig) string {
 	// Module path
 	content = strings.ReplaceAll(content, "github.com/your-org/formae-plugin-example", config.ModulePath)
 
-	// Plugin name (lowercase)
+	// Plugin name and type (lowercase)
 	content = strings.ReplaceAll(content, `name = "example"`, fmt.Sprintf(`name = "%s"`, config.Name))
+	content = strings.ReplaceAll(content, `type = "example"`, fmt.Sprintf(`type = "%s"`, config.Name))
 
 	// Namespace (uppercase in resource types)
 	upperNamespace := strings.ToUpper(config.Namespace)

--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -328,9 +328,15 @@ func discover(from gen.PID, state gen.Atom, data DiscoveryData, message Discover
 
 		discoverableResources := pluginInfo.SupportedResources
 		supportedResources := make([]plugin.ResourceDescriptor, 0)
+
+		// Per-plugin resourceTypesToDiscover takes precedence over global
+		typesToDiscover := pluginInfo.ResourceTypesToDiscover
+		if len(typesToDiscover) == 0 {
+			typesToDiscover = data.discoveryCfg.ResourceTypesToDiscover
+		}
+
 		for _, desc := range discoverableResources {
-			if len(data.discoveryCfg.ResourceTypesToDiscover) == 0 ||
-				slices.Contains(data.discoveryCfg.ResourceTypesToDiscover, desc.Type) {
+			if len(typesToDiscover) == 0 || slices.Contains(typesToDiscover, desc.Type) {
 				supportedResources = append(supportedResources, desc)
 				data.resourceDescriptors[desc.Type] = desc
 			}
@@ -596,7 +602,7 @@ func getSchemaFromCache(data *DiscoveryData, namespace, resourceType string) (pk
 }
 
 // getMatchFiltersFromCache retrieves MatchFilters from the cached plugin info
-func getMatchFiltersFromCache(data *DiscoveryData, namespace string) []plugin.MatchFilter {
+func getMatchFiltersFromCache(data *DiscoveryData, namespace string) []pkgmodel.MatchFilter {
 	pluginInfo, ok := data.pluginInfoCache[namespace]
 	if !ok {
 		return nil
@@ -605,8 +611,8 @@ func getMatchFiltersFromCache(data *DiscoveryData, namespace string) []plugin.Ma
 }
 
 // findMatchFiltersForType finds all MatchFilters that apply to the given resource type
-func findMatchFiltersForType(filters []plugin.MatchFilter, resourceType string) []plugin.MatchFilter {
-	var result []plugin.MatchFilter
+func findMatchFiltersForType(filters []pkgmodel.MatchFilter, resourceType string) []pkgmodel.MatchFilter {
+	var result []pkgmodel.MatchFilter
 	for i := range filters {
 		if slices.Contains(filters[i].ResourceTypes, resourceType) {
 			result = append(result, filters[i])

--- a/internal/metastructure/messages/plugin.go
+++ b/internal/metastructure/messages/plugin.go
@@ -61,7 +61,6 @@ type PluginInfoResponse struct {
 	MatchFilters            []model.MatchFilter
 	LabelConfig             model.LabelConfig
 	ResourceTypesToDiscover []string
-	LabelTagKeys            []string
 	Error                   string // Set if Found is false
 }
 
@@ -77,7 +76,6 @@ type RegisteredPluginInfo struct {
 	MaxRequestsPerSecond    int
 	ResourceCount           int
 	ResourceTypesToDiscover []string
-	LabelTagKeys            []string
 	RetryConfig             *model.RetryConfig
 	LabelConfig             model.LabelConfig
 	DiscoveryFilters        []model.MatchFilter

--- a/internal/metastructure/messages/plugin.go
+++ b/internal/metastructure/messages/plugin.go
@@ -69,12 +69,17 @@ type PluginInfoResponse struct {
 type GetRegisteredPlugins struct{}
 
 // RegisteredPluginInfo contains basic information about a registered plugin
+// including the merged config (plugin defaults + user overrides).
 type RegisteredPluginInfo struct {
-	Namespace            string
-	Version              string
-	NodeName             string
-	MaxRequestsPerSecond int
-	ResourceCount        int
+	Namespace               string
+	Version                 string
+	NodeName                string
+	MaxRequestsPerSecond    int
+	ResourceCount           int
+	ResourceTypesToDiscover []string
+	LabelTagKeys            []string
+	RetryConfig             *model.RetryConfig
+	LabelConfig             model.LabelConfig
 }
 
 // GetRegisteredPluginsResult is the response to GetRegisteredPlugins

--- a/internal/metastructure/messages/plugin.go
+++ b/internal/metastructure/messages/plugin.go
@@ -54,13 +54,15 @@ type GetPluginInfo struct {
 
 // PluginInfoResponse contains plugin capabilities
 type PluginInfoResponse struct {
-	Found              bool
-	Namespace          string
-	SupportedResources []plugin.ResourceDescriptor
-	ResourceSchemas    map[string]model.Schema
-	MatchFilters       []plugin.MatchFilter
-	LabelConfig        plugin.LabelConfig
-	Error              string // Set if Found is false
+	Found                   bool
+	Namespace               string
+	SupportedResources      []plugin.ResourceDescriptor
+	ResourceSchemas         map[string]model.Schema
+	MatchFilters            []model.MatchFilter
+	LabelConfig             model.LabelConfig
+	ResourceTypesToDiscover []string
+	LabelTagKeys            []string
+	Error                   string // Set if Found is false
 }
 
 // GetRegisteredPlugins requests a list of all registered plugins from PluginCoordinator

--- a/internal/metastructure/messages/plugin.go
+++ b/internal/metastructure/messages/plugin.go
@@ -80,6 +80,7 @@ type RegisteredPluginInfo struct {
 	LabelTagKeys            []string
 	RetryConfig             *model.RetryConfig
 	LabelConfig             model.LabelConfig
+	DiscoveryFilters        []model.MatchFilter
 }
 
 // GetRegisteredPluginsResult is the response to GetRegisteredPlugins

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1939,6 +1939,7 @@ func (m *Metastructure) Stats() (*apimodel.Stats, error) {
 					LabelTagKeys:            p.LabelTagKeys,
 					RetryConfig:             p.RetryConfig,
 					LabelConfig:             &p.LabelConfig,
+					DiscoveryFilters:        p.DiscoveryFilters,
 				})
 			}
 		}

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1930,11 +1930,15 @@ func (m *Metastructure) Stats() (*apimodel.Stats, error) {
 		if pluginsResult, ok := result.(messages.GetRegisteredPluginsResult); ok {
 			for _, p := range pluginsResult.Plugins {
 				plugins = append(plugins, apimodel.PluginInfo{
-					Namespace:            p.Namespace,
-					Version:              p.Version,
-					NodeName:             p.NodeName,
-					MaxRequestsPerSecond: p.MaxRequestsPerSecond,
-					ResourceCount:        p.ResourceCount,
+					Namespace:               p.Namespace,
+					Version:                 p.Version,
+					NodeName:                p.NodeName,
+					MaxRequestsPerSecond:    p.MaxRequestsPerSecond,
+					ResourceCount:           p.ResourceCount,
+					ResourceTypesToDiscover: p.ResourceTypesToDiscover,
+					LabelTagKeys:            p.LabelTagKeys,
+					RetryConfig:             p.RetryConfig,
+					LabelConfig:             &p.LabelConfig,
 				})
 			}
 		}

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1936,7 +1936,6 @@ func (m *Metastructure) Stats() (*apimodel.Stats, error) {
 					MaxRequestsPerSecond:    p.MaxRequestsPerSecond,
 					ResourceCount:           p.ResourceCount,
 					ResourceTypesToDiscover: p.ResourceTypesToDiscover,
-					LabelTagKeys:            p.LabelTagKeys,
 					RetryConfig:             p.RetryConfig,
 					LabelConfig:             &p.LabelConfig,
 					DiscoveryFilters:        p.DiscoveryFilters,

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -142,6 +142,7 @@ func NewMetastructureWithDataStoreAndContext(ctx context.Context, cfg *pkgmodel.
 		gen.Env("OTelConfig"):              cfg.Agent.OTel,
 		gen.Env("StackExpirerConfig"):      cfg.Agent.StackExpirer,
 		gen.Env("AgentID"):                 agentID,
+		gen.Env("ResourcePluginConfigs"):   cfg.Agent.ResourcePlugins,
 	}
 
 	// Enable Ergo networking for distributed plugin architecture

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator.go
@@ -435,6 +435,7 @@ func (c *PluginCoordinator) getRegisteredPlugins() messages.GetRegisteredPlugins
 			LabelTagKeys:            registered.LabelTagKeys,
 			RetryConfig:             registered.RetryConfig,
 			LabelConfig:             registered.LabelConfig,
+			DiscoveryFilters:        registered.MatchFilters,
 		})
 	}
 

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator.go
@@ -426,11 +426,15 @@ func (c *PluginCoordinator) getRegisteredPlugins() messages.GetRegisteredPlugins
 
 	for _, registered := range c.plugins {
 		plugins = append(plugins, messages.RegisteredPluginInfo{
-			Namespace:            registered.Namespace,
-			Version:              registered.Version,
-			NodeName:             string(registered.NodeName),
-			MaxRequestsPerSecond: registered.MaxRequestsPerSecond,
-			ResourceCount:        len(registered.SupportedResources),
+			Namespace:               registered.Namespace,
+			Version:                 registered.Version,
+			NodeName:                string(registered.NodeName),
+			MaxRequestsPerSecond:    registered.MaxRequestsPerSecond,
+			ResourceCount:           len(registered.SupportedResources),
+			ResourceTypesToDiscover: registered.ResourceTypesToDiscover,
+			LabelTagKeys:            registered.LabelTagKeys,
+			RetryConfig:             registered.RetryConfig,
+			LabelConfig:             registered.LabelConfig,
 		})
 	}
 

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator.go
@@ -31,6 +31,7 @@ type PluginCoordinator struct {
 	registeredLocalNamespaces map[string]bool              // namespaces registered with RateLimiter (local)
 	testPlugin                plugin.FullResourcePlugin    // test-only: directly injected plugin (e.g. FakeAWS) for workflow tests
 	retryConfig               model.RetryConfig
+	resourcePluginConfigs     map[string]model.ResourcePluginUserConfig // keyed by type (lowercase)
 }
 
 // RegisteredPlugin contains information about a registered plugin
@@ -44,8 +45,13 @@ type RegisteredPlugin struct {
 	// Cached capabilities from announcement
 	SupportedResources []plugin.ResourceDescriptor
 	ResourceSchemas    map[string]model.Schema
-	MatchFilters       []plugin.MatchFilter
-	LabelConfig        plugin.LabelConfig
+	MatchFilters       []model.MatchFilter
+	LabelConfig        model.LabelConfig
+
+	// Per-plugin config (merged from user config)
+	ResourceTypesToDiscover []string
+	LabelTagKeys            []string
+	RetryConfig             *model.RetryConfig
 }
 
 // findPluginByNamespace performs a case-insensitive lookup for a plugin by namespace.
@@ -73,6 +79,50 @@ func (c *PluginCoordinator) findTestPlugin(namespace string) plugin.FullResource
 	return nil
 }
 
+// mergePluginConfig overlays user config on top of plugin-announced defaults.
+// Returns a zero-value RegisteredPlugin and false if the plugin is disabled.
+func (c *PluginCoordinator) mergePluginConfig(namespace string, announced RegisteredPlugin) (RegisteredPlugin, bool) {
+	userCfg, hasUserConfig := c.resourcePluginConfigs[strings.ToLower(namespace)]
+
+	if hasUserConfig && !userCfg.Enabled {
+		c.Log().Info("Plugin disabled by config, skipping registration: namespace=%s", namespace)
+		return RegisteredPlugin{}, false
+	}
+
+	merged := announced
+
+	if hasUserConfig {
+		if userCfg.RateLimit != nil {
+			merged.MaxRequestsPerSecond = userCfg.RateLimit.MaxRequestsPerSecond
+		}
+		if userCfg.LabelConfig != nil {
+			merged.LabelConfig = *userCfg.LabelConfig
+		}
+		if userCfg.DiscoveryFilters != nil {
+			merged.MatchFilters = userCfg.DiscoveryFilters
+		}
+		if len(userCfg.ResourceTypesToDiscover) > 0 {
+			merged.ResourceTypesToDiscover = userCfg.ResourceTypesToDiscover
+		}
+		if len(userCfg.LabelTagKeys) > 0 {
+			merged.LabelTagKeys = userCfg.LabelTagKeys
+		}
+		if userCfg.Retry != nil {
+			merged.RetryConfig = userCfg.Retry
+		}
+	}
+
+	return merged, true
+}
+
+// resolveRetryConfig returns per-plugin RetryConfig if set, otherwise the global fallback.
+func (c *PluginCoordinator) resolveRetryConfig(namespace string) model.RetryConfig {
+	if p, ok := c.plugins[namespace]; ok && p.RetryConfig != nil {
+		return *p.RetryConfig
+	}
+	return c.retryConfig
+}
+
 // NewPluginCoordinator creates a new PluginCoordinator actor
 func NewPluginCoordinator() gen.ProcessBehavior {
 	return &PluginCoordinator{}
@@ -91,7 +141,7 @@ func (c *PluginCoordinator) Init(args ...any) error {
 	// This is needed because ChangesetExecutor requests tokens before SpawnPluginOperator
 	if c.testPlugin != nil {
 		namespace := c.testPlugin.Namespace()
-		maxRPS := c.testPlugin.RateLimit().MaxRequestsPerSecondForNamespace
+		maxRPS := c.testPlugin.RateLimit().MaxRequestsPerSecond
 		err := c.Send(actornames.RateLimiter, changeset.RegisterNamespace{
 			Namespace:            namespace,
 			MaxRequestsPerSecond: maxRPS,
@@ -110,6 +160,16 @@ func (c *PluginCoordinator) Init(args ...any) error {
 		return fmt.Errorf("resourceUpdater: missing 'RetryConfig' environment variable")
 	}
 	c.retryConfig = retryCfg.(model.RetryConfig)
+
+	if rpcs, ok := c.Env("ResourcePluginConfigs"); ok {
+		configs := rpcs.([]model.ResourcePluginUserConfig)
+		c.resourcePluginConfigs = make(map[string]model.ResourcePluginUserConfig, len(configs))
+		for _, cfg := range configs {
+			c.resourcePluginConfigs[strings.ToLower(cfg.Type)] = cfg
+		}
+	} else {
+		c.resourcePluginConfigs = make(map[string]model.ResourcePluginUserConfig)
+	}
 
 	c.Log().Debug("PluginCoordinator started")
 	return nil
@@ -146,7 +206,7 @@ func (c *PluginCoordinator) HandleMessage(from gen.PID, message any) error {
 
 		c.Log().Debug("Received capabilities for namespace %s: %d resources, %d schemas", msg.Namespace, len(caps.SupportedResources), len(caps.ResourceSchemas))
 
-		c.plugins[msg.Namespace] = &RegisteredPlugin{
+		announced := RegisteredPlugin{
 			Namespace:            msg.Namespace,
 			Version:              msg.Version,
 			NodeName:             from.Node,
@@ -157,13 +217,20 @@ func (c *PluginCoordinator) HandleMessage(from gen.PID, message any) error {
 			MatchFilters:         caps.MatchFilters,
 			LabelConfig:          caps.LabelConfig,
 		}
+
+		merged, enabled := c.mergePluginConfig(msg.Namespace, announced)
+		if !enabled {
+			return nil
+		}
+
+		c.plugins[msg.Namespace] = &merged
 		c.Log().Info("Plugin registered: namespace=%s node=%s rateLimit=%d resources=%d",
-			msg.Namespace, msg.NodeName, msg.MaxRequestsPerSecond, len(caps.SupportedResources))
+			msg.Namespace, msg.NodeName, merged.MaxRequestsPerSecond, len(caps.SupportedResources))
 
 		// Register the namespace with RateLimiter
 		if err := c.Send(actornames.RateLimiter, changeset.RegisterNamespace{
 			Namespace:            msg.Namespace,
-			MaxRequestsPerSecond: msg.MaxRequestsPerSecond,
+			MaxRequestsPerSecond: merged.MaxRequestsPerSecond,
 		}); err != nil {
 			c.Log().Error("Failed to register namespace %s with RateLimiter: %v", msg.Namespace, err)
 		}
@@ -193,7 +260,7 @@ func (c *PluginCoordinator) spawnPluginOperator(req messages.SpawnPluginOperator
 
 	// 1. Check if plugin is registered (distributed mode)
 	if registeredPlugin, ok := c.findPluginByNamespace(req.Namespace); ok {
-		pid, err := c.remoteSpawn(registeredPlugin.NodeName, registerName)
+		pid, err := c.remoteSpawn(req.Namespace, registeredPlugin.NodeName, registerName)
 		if err != nil {
 			c.Log().Error("Failed to remote spawn PluginOperator for namespace %s on node %s: %v", req.Namespace, registeredPlugin.NodeName, err)
 			return messages.SpawnPluginOperatorResult{Error: err.Error()}
@@ -206,7 +273,7 @@ func (c *PluginCoordinator) spawnPluginOperator(req messages.SpawnPluginOperator
 	if localPlugin := c.findTestPlugin(req.Namespace); localPlugin != nil {
 		// Register namespace with RateLimiter if not already registered
 		if !c.registeredLocalNamespaces[req.Namespace] {
-			maxRPS := localPlugin.RateLimit().MaxRequestsPerSecondForNamespace
+			maxRPS := localPlugin.RateLimit().MaxRequestsPerSecond
 			err := c.Send(actornames.RateLimiter, changeset.RegisterNamespace{
 				Namespace:            req.Namespace,
 				MaxRequestsPerSecond: maxRPS,
@@ -220,7 +287,7 @@ func (c *PluginCoordinator) spawnPluginOperator(req messages.SpawnPluginOperator
 			}
 		}
 
-		pid, err := c.localSpawn(localPlugin, registerName)
+		pid, err := c.localSpawn(req.Namespace, localPlugin, registerName)
 		if err != nil {
 			c.Log().Error("Failed to local spawn PluginOperator for namespace %s: %v", req.Namespace, err)
 			return messages.SpawnPluginOperatorResult{Error: err.Error()}
@@ -236,7 +303,7 @@ func (c *PluginCoordinator) spawnPluginOperator(req messages.SpawnPluginOperator
 }
 
 // remoteSpawn spawns a PluginOperator on a remote plugin node
-func (c *PluginCoordinator) remoteSpawn(nodeName gen.Atom, registerName gen.Atom) (gen.PID, error) {
+func (c *PluginCoordinator) remoteSpawn(namespace string, nodeName gen.Atom, registerName gen.Atom) (gen.PID, error) {
 	// Get connection to remote node
 	remoteNode, err := c.Node().Network().GetNode(nodeName)
 	if err != nil {
@@ -248,7 +315,7 @@ func (c *PluginCoordinator) remoteSpawn(nodeName gen.Atom, registerName gen.Atom
 	// (configured in pkg/plugin/run.go)
 	opts := gen.ProcessOptions{
 		Env: map[gen.Env]any{
-			gen.Env("RetryConfig"): c.retryConfig,
+			gen.Env("RetryConfig"): c.resolveRetryConfig(namespace),
 		},
 	}
 	start := time.Now()
@@ -265,7 +332,7 @@ func (c *PluginCoordinator) remoteSpawn(nodeName gen.Atom, registerName gen.Atom
 }
 
 // localSpawn spawns a PluginOperator locally with the given plugin
-func (c *PluginCoordinator) localSpawn(localPlugin plugin.FullResourcePlugin, registerName gen.Atom) (gen.PID, error) {
+func (c *PluginCoordinator) localSpawn(namespace string, localPlugin plugin.FullResourcePlugin, registerName gen.Atom) (gen.PID, error) {
 	// Get context and retry config from environment
 	ctx := context.Background()
 	if envCtx, ok := c.Env("Context"); ok {
@@ -277,7 +344,7 @@ func (c *PluginCoordinator) localSpawn(localPlugin plugin.FullResourcePlugin, re
 		Env: map[gen.Env]any{
 			gen.Env("Plugin"):      localPlugin,
 			gen.Env("Context"):     ctx,
-			gen.Env("RetryConfig"): c.retryConfig,
+			gen.Env("RetryConfig"): c.resolveRetryConfig(namespace),
 		},
 	}
 
@@ -296,12 +363,14 @@ func (c *PluginCoordinator) getPluginInfo(req messages.GetPluginInfo) messages.P
 	// 1. Check external plugins first
 	if registered, ok := c.findPluginByNamespace(req.Namespace); ok {
 		return messages.PluginInfoResponse{
-			Found:              true,
-			Namespace:          req.Namespace,
-			SupportedResources: registered.SupportedResources,
-			ResourceSchemas:    registered.ResourceSchemas,
-			MatchFilters:       registered.MatchFilters,
-			LabelConfig:        registered.LabelConfig,
+			Found:                   true,
+			Namespace:               req.Namespace,
+			SupportedResources:      registered.SupportedResources,
+			ResourceSchemas:         registered.ResourceSchemas,
+			MatchFilters:            registered.MatchFilters,
+			LabelConfig:             registered.LabelConfig,
+			ResourceTypesToDiscover: registered.ResourceTypesToDiscover,
+			LabelTagKeys:            registered.LabelTagKeys,
 		}
 	}
 
@@ -323,7 +392,7 @@ func (c *PluginCoordinator) getPluginInfo(req messages.GetPluginInfo) messages.P
 		}
 	}
 
-	return messages.PluginInfoResponse{
+	resp := messages.PluginInfoResponse{
 		Found:              true,
 		Namespace:          req.Namespace,
 		SupportedResources: localPlugin.SupportedResources(),
@@ -331,6 +400,24 @@ func (c *PluginCoordinator) getPluginInfo(req messages.GetPluginInfo) messages.P
 		MatchFilters:       localPlugin.DiscoveryFilters(),
 		LabelConfig:        localPlugin.LabelConfig(),
 	}
+
+	// Overlay user config for local/test plugins
+	if userCfg, ok := c.resourcePluginConfigs[strings.ToLower(req.Namespace)]; ok {
+		if userCfg.LabelConfig != nil {
+			resp.LabelConfig = *userCfg.LabelConfig
+		}
+		if userCfg.DiscoveryFilters != nil {
+			resp.MatchFilters = userCfg.DiscoveryFilters
+		}
+		if len(userCfg.ResourceTypesToDiscover) > 0 {
+			resp.ResourceTypesToDiscover = userCfg.ResourceTypesToDiscover
+		}
+		if len(userCfg.LabelTagKeys) > 0 {
+			resp.LabelTagKeys = userCfg.LabelTagKeys
+		}
+	}
+
+	return resp
 }
 
 // getRegisteredPlugins returns a list of all registered plugins

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator.go
@@ -50,7 +50,6 @@ type RegisteredPlugin struct {
 
 	// Per-plugin config (merged from user config)
 	ResourceTypesToDiscover []string
-	LabelTagKeys            []string
 	RetryConfig             *model.RetryConfig
 }
 
@@ -93,7 +92,7 @@ func (c *PluginCoordinator) mergePluginConfig(namespace string, announced Regist
 
 	if hasUserConfig {
 		if userCfg.RateLimit != nil {
-			merged.MaxRequestsPerSecond = userCfg.RateLimit.MaxRequestsPerSecond
+			merged.MaxRequestsPerSecond = userCfg.RateLimit.MaxRequestsPerSecondForNamespace
 		}
 		if userCfg.LabelConfig != nil {
 			merged.LabelConfig = *userCfg.LabelConfig
@@ -103,9 +102,6 @@ func (c *PluginCoordinator) mergePluginConfig(namespace string, announced Regist
 		}
 		if len(userCfg.ResourceTypesToDiscover) > 0 {
 			merged.ResourceTypesToDiscover = userCfg.ResourceTypesToDiscover
-		}
-		if len(userCfg.LabelTagKeys) > 0 {
-			merged.LabelTagKeys = userCfg.LabelTagKeys
 		}
 		if userCfg.Retry != nil {
 			merged.RetryConfig = userCfg.Retry
@@ -141,7 +137,7 @@ func (c *PluginCoordinator) Init(args ...any) error {
 	// This is needed because ChangesetExecutor requests tokens before SpawnPluginOperator
 	if c.testPlugin != nil {
 		namespace := c.testPlugin.Namespace()
-		maxRPS := c.testPlugin.RateLimit().MaxRequestsPerSecond
+		maxRPS := c.testPlugin.RateLimit().MaxRequestsPerSecondForNamespace
 		err := c.Send(actornames.RateLimiter, changeset.RegisterNamespace{
 			Namespace:            namespace,
 			MaxRequestsPerSecond: maxRPS,
@@ -273,7 +269,7 @@ func (c *PluginCoordinator) spawnPluginOperator(req messages.SpawnPluginOperator
 	if localPlugin := c.findTestPlugin(req.Namespace); localPlugin != nil {
 		// Register namespace with RateLimiter if not already registered
 		if !c.registeredLocalNamespaces[req.Namespace] {
-			maxRPS := localPlugin.RateLimit().MaxRequestsPerSecond
+			maxRPS := localPlugin.RateLimit().MaxRequestsPerSecondForNamespace
 			err := c.Send(actornames.RateLimiter, changeset.RegisterNamespace{
 				Namespace:            req.Namespace,
 				MaxRequestsPerSecond: maxRPS,
@@ -370,7 +366,6 @@ func (c *PluginCoordinator) getPluginInfo(req messages.GetPluginInfo) messages.P
 			MatchFilters:            registered.MatchFilters,
 			LabelConfig:             registered.LabelConfig,
 			ResourceTypesToDiscover: registered.ResourceTypesToDiscover,
-			LabelTagKeys:            registered.LabelTagKeys,
 		}
 	}
 
@@ -412,9 +407,6 @@ func (c *PluginCoordinator) getPluginInfo(req messages.GetPluginInfo) messages.P
 		if len(userCfg.ResourceTypesToDiscover) > 0 {
 			resp.ResourceTypesToDiscover = userCfg.ResourceTypesToDiscover
 		}
-		if len(userCfg.LabelTagKeys) > 0 {
-			resp.LabelTagKeys = userCfg.LabelTagKeys
-		}
 	}
 
 	return resp
@@ -432,7 +424,6 @@ func (c *PluginCoordinator) getRegisteredPlugins() messages.GetRegisteredPlugins
 			MaxRequestsPerSecond:    registered.MaxRequestsPerSecond,
 			ResourceCount:           len(registered.SupportedResources),
 			ResourceTypesToDiscover: registered.ResourceTypesToDiscover,
-			LabelTagKeys:            registered.LabelTagKeys,
 			RetryConfig:             registered.RetryConfig,
 			LabelConfig:             registered.LabelConfig,
 			DiscoveryFilters:        registered.MatchFilters,

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator.go
@@ -31,7 +31,7 @@ type PluginCoordinator struct {
 	registeredLocalNamespaces map[string]bool              // namespaces registered with RateLimiter (local)
 	testPlugin                plugin.FullResourcePlugin    // test-only: directly injected plugin (e.g. FakeAWS) for workflow tests
 	retryConfig               model.RetryConfig
-	resourcePluginConfigs     map[string]model.ResourcePluginUserConfig // keyed by type (lowercase)
+	resourcePluginConfigs     map[string]model.ResourcePluginUserConfig // keyed by plugin name (lowercase)
 }
 
 // RegisteredPlugin contains information about a registered plugin
@@ -80,11 +80,12 @@ func (c *PluginCoordinator) findTestPlugin(namespace string) plugin.FullResource
 
 // mergePluginConfig overlays user config on top of plugin-announced defaults.
 // Returns a zero-value RegisteredPlugin and false if the plugin is disabled.
-func (c *PluginCoordinator) mergePluginConfig(namespace string, announced RegisteredPlugin) (RegisteredPlugin, bool) {
-	userCfg, hasUserConfig := c.resourcePluginConfigs[strings.ToLower(namespace)]
+// Config is looked up by plugin name (from manifest), not namespace.
+func (c *PluginCoordinator) mergePluginConfig(name, namespace string, announced RegisteredPlugin) (RegisteredPlugin, bool) {
+	userCfg, hasUserConfig := c.resourcePluginConfigs[strings.ToLower(name)]
 
 	if hasUserConfig && !userCfg.Enabled {
-		c.Log().Info("Plugin disabled by config, skipping registration: namespace=%s", namespace)
+		c.Log().Info("Plugin disabled by config, skipping registration: name=%s namespace=%s", name, namespace)
 		return RegisteredPlugin{}, false
 	}
 
@@ -113,7 +114,7 @@ func (c *PluginCoordinator) mergePluginConfig(namespace string, announced Regist
 
 // resolveRetryConfig returns per-plugin RetryConfig if set, otherwise the global fallback.
 func (c *PluginCoordinator) resolveRetryConfig(namespace string) model.RetryConfig {
-	if p, ok := c.plugins[namespace]; ok && p.RetryConfig != nil {
+	if p, ok := c.findPluginByNamespace(namespace); ok && p.RetryConfig != nil {
 		return *p.RetryConfig
 	}
 	return c.retryConfig
@@ -214,7 +215,7 @@ func (c *PluginCoordinator) HandleMessage(from gen.PID, message any) error {
 			LabelConfig:          caps.LabelConfig,
 		}
 
-		merged, enabled := c.mergePluginConfig(msg.Namespace, announced)
+		merged, enabled := c.mergePluginConfig(msg.Name, msg.Namespace, announced)
 		if !enabled {
 			return nil
 		}
@@ -396,8 +397,8 @@ func (c *PluginCoordinator) getPluginInfo(req messages.GetPluginInfo) messages.P
 		LabelConfig:        localPlugin.LabelConfig(),
 	}
 
-	// Overlay user config for local/test plugins
-	if userCfg, ok := c.resourcePluginConfigs[strings.ToLower(req.Namespace)]; ok {
+	// Overlay user config for local/test plugins (lookup by name, not namespace)
+	if userCfg, ok := c.resourcePluginConfigs[strings.ToLower(localPlugin.Name())]; ok {
 		if userCfg.LabelConfig != nil {
 			resp.LabelConfig = *userCfg.LabelConfig
 		}

--- a/internal/metastructure/plugin_coordinator/remote_plugin_info.go
+++ b/internal/metastructure/plugin_coordinator/remote_plugin_info.go
@@ -17,8 +17,8 @@ type RemotePluginInfo struct {
 	namespace          string
 	supportedResources []plugin.ResourceDescriptor
 	resourceSchemas    map[string]model.Schema
-	matchFilters       []plugin.MatchFilter
-	labelConfig        plugin.LabelConfig
+	matchFilters       []model.MatchFilter
+	labelConfig        model.LabelConfig
 }
 
 // NewRemotePluginInfo creates a new RemotePluginInfo instance
@@ -26,8 +26,8 @@ func NewRemotePluginInfo(
 	namespace string,
 	supportedResources []plugin.ResourceDescriptor,
 	schemas map[string]model.Schema,
-	filters []plugin.MatchFilter,
-	labelConfig plugin.LabelConfig,
+	filters []model.MatchFilter,
+	labelConfig model.LabelConfig,
 ) *RemotePluginInfo {
 	return &RemotePluginInfo{
 		namespace:          namespace,
@@ -54,11 +54,11 @@ func (r *RemotePluginInfo) SchemaForResourceType(resourceType string) (model.Sch
 	return schema, nil
 }
 
-func (r *RemotePluginInfo) DiscoveryFilters() []plugin.MatchFilter {
+func (r *RemotePluginInfo) DiscoveryFilters() []model.MatchFilter {
 	return r.matchFilters
 }
 
-func (r *RemotePluginInfo) LabelConfig() plugin.LabelConfig {
+func (r *RemotePluginInfo) LabelConfig() model.LabelConfig {
 	return r.labelConfig
 }
 

--- a/internal/metastructure/plugin_process_supervisor/plugin_process_supervisor.go
+++ b/internal/metastructure/plugin_process_supervisor/plugin_process_supervisor.go
@@ -5,6 +5,8 @@
 package plugin_process_supervisor
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/rpc"
 	"regexp"
@@ -34,9 +36,10 @@ type authPluginInitComplete struct{}
 type PluginProcessSupervisor struct {
 	act.Actor
 
-	plugins      map[string]*PluginInfo
-	authPlugin   *authPluginEntry
-	shuttingDown bool
+	plugins       map[string]*PluginInfo
+	authPlugin    *authPluginEntry
+	shuttingDown  bool
+	pluginConfigs map[string]json.RawMessage // plugin-specific config keyed by type (lowercase)
 }
 
 // authPluginEntry wraps an AuthPluginHandle with supervisor-specific tracking state.
@@ -102,6 +105,21 @@ func (p *PluginProcessSupervisor) Init(args ...any) error {
 			// Continue with other plugins even if one fails
 			continue
 		}
+	}
+
+	// Read per-plugin custom configs for passing to plugin binaries
+	if val, ok := p.Env("ResourcePluginConfigs"); ok {
+		if configs, ok := val.([]pkgmodel.ResourcePluginUserConfig); ok {
+			p.pluginConfigs = make(map[string]json.RawMessage)
+			for _, cfg := range configs {
+				if len(cfg.PluginConfig) > 0 {
+					p.pluginConfigs[cfg.Type] = cfg.PluginConfig
+				}
+			}
+		}
+	}
+	if p.pluginConfigs == nil {
+		p.pluginConfigs = make(map[string]json.RawMessage)
 	}
 
 	// Spawn auth plugin if configured
@@ -364,6 +382,11 @@ func (p *PluginProcessSupervisor) spawnResourcePlugin(namespace string, pluginIn
 			}
 			p.Log().Debug("OTel config passed to plugin namespace=%s endpoint=%s", namespace, otelConfig.OTLP.Endpoint)
 		}
+	}
+
+	// Add plugin-specific config if available
+	if pluginCfg, ok := p.pluginConfigs[strings.ToLower(namespace)]; ok {
+		env[gen.Env("FORMAE_PLUGIN_CONFIG")] = base64.StdEncoding.EncodeToString(pluginCfg)
 	}
 
 	// Configure meta.Port options

--- a/internal/metastructure/plugin_process_supervisor/plugin_process_supervisor.go
+++ b/internal/metastructure/plugin_process_supervisor/plugin_process_supervisor.go
@@ -73,6 +73,21 @@ func (p *PluginProcessSupervisor) Init(args ...any) error {
 	p.plugins = make(map[string]*PluginInfo)
 	p.Log().Debug("PluginProcessSupervisor started")
 
+	// Read per-plugin custom configs before spawning plugins so the env vars are available
+	if val, ok := p.Env("ResourcePluginConfigs"); ok {
+		if configs, ok := val.([]pkgmodel.ResourcePluginUserConfig); ok {
+			p.pluginConfigs = make(map[string]json.RawMessage)
+			for _, cfg := range configs {
+				if len(cfg.PluginConfig) > 0 {
+					p.pluginConfigs[cfg.Type] = cfg.PluginConfig
+				}
+			}
+		}
+	}
+	if p.pluginConfigs == nil {
+		p.pluginConfigs = make(map[string]json.RawMessage)
+	}
+
 	// Get external resource plugins from environment
 	var externalPlugins []plugin.ResourcePluginInfo
 	if val, ok := p.Env("ExternalResourcePlugins"); ok {
@@ -105,21 +120,6 @@ func (p *PluginProcessSupervisor) Init(args ...any) error {
 			// Continue with other plugins even if one fails
 			continue
 		}
-	}
-
-	// Read per-plugin custom configs for passing to plugin binaries
-	if val, ok := p.Env("ResourcePluginConfigs"); ok {
-		if configs, ok := val.([]pkgmodel.ResourcePluginUserConfig); ok {
-			p.pluginConfigs = make(map[string]json.RawMessage)
-			for _, cfg := range configs {
-				if len(cfg.PluginConfig) > 0 {
-					p.pluginConfigs[cfg.Type] = cfg.PluginConfig
-				}
-			}
-		}
-	}
-	if p.pluginConfigs == nil {
-		p.pluginConfigs = make(map[string]json.RawMessage)
 	}
 
 	// Spawn auth plugin if configured

--- a/internal/metastructure/resource_update/resource_labeler.go
+++ b/internal/metastructure/resource_update/resource_labeler.go
@@ -14,7 +14,6 @@ import (
 	"github.com/theory/jsonpath/registry"
 
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
-	"github.com/platform-engineering-labs/formae/pkg/plugin"
 )
 
 const labelSeparator = "-"
@@ -45,7 +44,7 @@ func (l *ResourceLabeler) LabelForUnmanagedResource(
 	nativeID string,
 	resourceType string,
 	properties json.RawMessage,
-	labelConfig plugin.LabelConfig,
+	labelConfig pkgmodel.LabelConfig,
 	legacyTagKeys []string,
 ) string {
 	// Try JSONPath query first (from LabelConfig)

--- a/internal/metastructure/resource_update/resource_labeler_test.go
+++ b/internal/metastructure/resource_update/resource_labeler_test.go
@@ -13,7 +13,6 @@ import (
 	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
-	"github.com/platform-engineering-labs/formae/pkg/plugin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +29,7 @@ func tagsToProperties(tags []pkgmodel.Tag) json.RawMessage {
 func TestLabelForUnmanagedResource_UsesJSONPathQuery(t *testing.T) {
 	nativeId := "i-1234567890abcdef0"
 	properties := json.RawMessage(`{"Tags":[{"Key":"Name","Value":"MyInstance"}]}`)
-	labelConfig := plugin.LabelConfig{
+	labelConfig := pkgmodel.LabelConfig{
 		DefaultQuery: `$.Tags[?(@.Key=='Name')].Value`,
 	}
 
@@ -42,7 +41,7 @@ func TestLabelForUnmanagedResource_UsesJSONPathQuery(t *testing.T) {
 func TestLabelForUnmanagedResource_UsesResourceOverride(t *testing.T) {
 	nativeId := "arn:aws:iam::123456789012:policy/MyPolicy"
 	properties := json.RawMessage(`{"PolicyName":"MyPolicy","Tags":[{"Key":"Name","Value":"ShouldNotUseThis"}]}`)
-	labelConfig := plugin.LabelConfig{
+	labelConfig := pkgmodel.LabelConfig{
 		DefaultQuery: `$.Tags[?(@.Key=='Name')].Value`,
 		ResourceOverrides: map[string]string{
 			"AWS::IAM::Policy": "$.PolicyName",
@@ -57,7 +56,7 @@ func TestLabelForUnmanagedResource_UsesResourceOverride(t *testing.T) {
 func TestLabelForUnmanagedResource_FallsBackToNativeID_WhenQueryReturnsNoResult(t *testing.T) {
 	nativeId := "i-1234567890abcdef0"
 	properties := json.RawMessage(`{"Tags":[{"Key":"Environment","Value":"Production"}]}`)
-	labelConfig := plugin.LabelConfig{
+	labelConfig := pkgmodel.LabelConfig{
 		DefaultQuery: `$.Tags[?(@.Key=='Name')].Value`,
 	}
 
@@ -69,7 +68,7 @@ func TestLabelForUnmanagedResource_FallsBackToNativeID_WhenQueryReturnsNoResult(
 func TestLabelForUnmanagedResource_FallsBackToNativeID_WhenNoLabelConfig(t *testing.T) {
 	nativeId := "i-1234567890abcdef0"
 	properties := json.RawMessage(`{"Tags":[{"Key":"Name","Value":"MyInstance"}]}`)
-	labelConfig := plugin.LabelConfig{} // Empty config
+	labelConfig := pkgmodel.LabelConfig{} // Empty config
 
 	l := newResourceLabelerForTest(t)
 	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig, nil)
@@ -79,7 +78,7 @@ func TestLabelForUnmanagedResource_FallsBackToNativeID_WhenNoLabelConfig(t *test
 func TestLabelForUnmanagedResource_HandlesEmptyProperties(t *testing.T) {
 	nativeId := "i-1234567890abcdef0"
 	properties := json.RawMessage(`{}`)
-	labelConfig := plugin.LabelConfig{
+	labelConfig := pkgmodel.LabelConfig{
 		DefaultQuery: `$.Tags[?(@.Key=='Name')].Value`,
 	}
 
@@ -90,7 +89,7 @@ func TestLabelForUnmanagedResource_HandlesEmptyProperties(t *testing.T) {
 
 func TestLabelForUnmanagedResource_HandlesNilProperties(t *testing.T) {
 	nativeId := "i-1234567890abcdef0"
-	labelConfig := plugin.LabelConfig{
+	labelConfig := pkgmodel.LabelConfig{
 		DefaultQuery: `$.Tags[?(@.Key=='Name')].Value`,
 	}
 
@@ -103,7 +102,7 @@ func TestLabelForUnmanagedResource_ConcatenatesMultipleQueryResults(t *testing.T
 	nativeId := "i-1234567890abcdef0"
 	properties := json.RawMessage(`{"Tags":[{"Key":"Name","Value":"MyInstance"},{"Key":"Environment","Value":"Production"},{"Key":"Owner","Value":"Alice"}]}`)
 	// Query that matches multiple tags using OR condition
-	labelConfig := plugin.LabelConfig{
+	labelConfig := pkgmodel.LabelConfig{
 		DefaultQuery: `$.Tags[?(@.Key=='Name' || @.Key=='Environment')].Value`,
 	}
 
@@ -121,7 +120,7 @@ func TestLabelForUnmanagedResource_FallsBackToLegacyTagKeys(t *testing.T) {
 		{Key: "Name", Value: "MyInstance"},
 		{Key: "Project", Value: "Alpha"},
 	})
-	labelConfig := plugin.LabelConfig{} // Empty config, should fall back to legacy
+	labelConfig := pkgmodel.LabelConfig{} // Empty config, should fall back to legacy
 	legacyTagKeys := []string{"Name", "Project"}
 
 	l := newResourceLabelerForTest(t)
@@ -135,7 +134,7 @@ func TestLabelForUnmanagedResource_ReturnsNativeIdWhenNoTagKeysAreFound(t *testi
 		{Key: "Environment", Value: "Production"},
 		{Key: "Owner", Value: "Alice"},
 	})
-	labelConfig := plugin.LabelConfig{}
+	labelConfig := pkgmodel.LabelConfig{}
 	legacyTagKeys := []string{"Name", "Project"}
 
 	l := newResourceLabelerForTest(t)
@@ -149,7 +148,7 @@ func TestLabelForUnmanagedResource_HandlesMissingTagValuesGracefully(t *testing.
 		{Key: "Name", Value: "MyInstance"},
 		{Key: "Environment", Value: "Production"},
 	})
-	labelConfig := plugin.LabelConfig{}
+	labelConfig := pkgmodel.LabelConfig{}
 	legacyTagKeys := []string{"Name", "Project"}
 
 	l := newResourceLabelerForTest(t)
@@ -162,7 +161,7 @@ func TestLabelForUnmanagedResource_HandlesMissingTagValuesGracefully(t *testing.
 func TestLabelForUnmanagedResource_AppendsIncrementingNumberForDuplicates(t *testing.T) {
 	nativeId := "i-1234567890abcdef0"
 	properties := json.RawMessage(`{"Tags":[{"Key":"Name","Value":"MyInstance"}]}`)
-	labelConfig := plugin.LabelConfig{
+	labelConfig := pkgmodel.LabelConfig{
 		DefaultQuery: `$.Tags[?(@.Key=='Name')].Value`,
 	}
 
@@ -178,7 +177,7 @@ func TestLabelForUnmanagedResource_AppendsIncrementingNumberForDuplicates(t *tes
 func TestLabelForUnmanagedResource_IncrementsExistingVersion(t *testing.T) {
 	nativeId := "i-1234567890abcdef0"
 	properties := json.RawMessage(`{"Tags":[{"Key":"Name","Value":"MyInstance"}]}`)
-	labelConfig := plugin.LabelConfig{
+	labelConfig := pkgmodel.LabelConfig{
 		DefaultQuery: `$.Tags[?(@.Key=='Name')].Value`,
 	}
 
@@ -196,7 +195,7 @@ func TestLabelForUnmanagedResource_IncrementsExistingVersion(t *testing.T) {
 func TestLabelForUnmanagedResource_JSONPathQueryTakesPrecedenceOverLegacyTagKeys(t *testing.T) {
 	nativeId := "i-1234567890abcdef0"
 	properties := json.RawMessage(`{"Tags":[{"Key":"Name","Value":"FromJSONPath"},{"Key":"LegacyTag","Value":"FromLegacy"}]}`)
-	labelConfig := plugin.LabelConfig{
+	labelConfig := pkgmodel.LabelConfig{
 		DefaultQuery: `$.Tags[?(@.Key=='Name')].Value`,
 	}
 	legacyTagKeys := []string{"LegacyTag"}

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -74,7 +74,7 @@ type ResourceUpdate struct {
 	GroupID                  string                   `json:"GroupId,omitempty"`
 	ReferenceLabels          map[string]string        `json:"ReferenceLabels,omitempty"`
 	PreviousProperties       json.RawMessage          `json:"PreviousProperties,omitempty"`
-	MatchFilters             []plugin.MatchFilter     `json:"matchFilters,omitempty"`  // Declarative filters (any match = exclude)
+	MatchFilters             []pkgmodel.MatchFilter   `json:"matchFilters,omitempty"`  // Declarative filters (any match = exclude)
 	IsCascade                bool                     `json:"IsCascade,omitempty"`     // True if this delete is triggered by cascade
 	CascadeSource            string                   `json:"CascadeSource,omitempty"` // Label of resource that triggered the cascade
 }

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -158,8 +158,8 @@ var PluginOperationCallTimeout = 60
 type ResourceUpdateData struct {
 	resourceUpdate  *ResourceUpdate
 	commandID       string
-	labelConfig     plugin.LabelConfig // JSONPath-based label extraction config from plugin
-	labelTagKeys    []string           // Legacy tag-based label keys for backwards compatibility
+	labelConfig     pkgmodel.LabelConfig // JSONPath-based label extraction config from plugin
+	labelTagKeys    []string             // Legacy tag-based label keys for backwards compatibility
 	resourceLabeler *ResourceLabeler
 	retryConfig     pkgmodel.RetryConfig
 	requestedBy     gen.PID
@@ -874,7 +874,7 @@ func resourceFailedToResolve(from gen.PID, state gen.Atom, data ResourceUpdateDa
 
 // shouldFilterByMatchFilter checks if a resource should be filtered using declarative MatchFilter.
 // Returns true if all conditions match (AND logic), indicating the resource should be excluded.
-func shouldFilterByMatchFilter(filter *plugin.MatchFilter, properties json.RawMessage) bool {
+func shouldFilterByMatchFilter(filter *pkgmodel.MatchFilter, properties json.RawMessage) bool {
 	if filter == nil {
 		return false
 	}
@@ -892,7 +892,7 @@ func shouldFilterByMatchFilter(filter *plugin.MatchFilter, properties json.RawMe
 // evaluateCondition evaluates a single filter condition using JSONPath.
 // PropertyPath is a JSONPath expression to query properties.
 // PropertyValue: empty = existence check, non-empty = exact string match.
-func evaluateCondition(cond plugin.FilterCondition, properties json.RawMessage) bool {
+func evaluateCondition(cond pkgmodel.FilterCondition, properties json.RawMessage) bool {
 	var data any
 	if err := json.Unmarshal(properties, &data); err != nil {
 		return false

--- a/internal/schema/pkl/assets/formae/Config.pkl
+++ b/internal/schema/pkl/assets/formae/Config.pkl
@@ -168,6 +168,36 @@ class NetworkConfig {
     tailscale: TailscaleConfig?
 }
 
+class RateLimitConfig {
+    maxRequestsPerSecond: Int = 10
+}
+
+class LabelConfig {
+    defaultQuery: String?
+    resourceOverrides: Mapping<String, String>?
+}
+
+class FilterCondition {
+    propertyPath: String
+    propertyValue: String?
+}
+
+class MatchFilter {
+    resourceTypes: Listing<String>
+    conditions: Listing<FilterCondition>
+}
+
+abstract class BaseResourcePluginConfig {
+    type: String
+    enabled: Boolean = true
+    rateLimit: RateLimitConfig?
+    labelConfig: LabelConfig?
+    discoveryFilters: Listing<MatchFilter>?
+    resourceTypesToDiscover: Listing<String>?
+    labelTagKeys: Listing<String>?
+    retry: RetryConfig?
+}
+
 abstract class BaseAgentAuthConfig {
     type: String
 }
@@ -193,7 +223,11 @@ class AgentConfig {
 
     stackExpirer: StackExpirerConfig = new StackExpirerConfig{}
 
-    auth: (BaseAgentAuthConfig|Dynamic)?
+    auth: BaseAgentAuthConfig?
+
+    resourcePlugins: Listing<BaseResourcePluginConfig>(
+        this.toList().map((it) -> it.type).isDistinct
+    )?
 }
 
 class ApiConfig {
@@ -215,7 +249,7 @@ class CliConfig {
 
     disableUsageReporting: Boolean = false
 
-    auth: (BaseCliAuthConfig|Dynamic)?
+    auth: BaseCliAuthConfig?
 }
 
 /// Deprecated: use top-level pluginDir, network, and agent.auth / cli.auth instead.

--- a/internal/schema/pkl/assets/formae/Config.pkl
+++ b/internal/schema/pkl/assets/formae/Config.pkl
@@ -223,7 +223,7 @@ class AgentConfig {
 
     stackExpirer: StackExpirerConfig = new StackExpirerConfig{}
 
-    auth: BaseAgentAuthConfig?
+    auth: (BaseAgentAuthConfig|Dynamic)?
 
     resourcePlugins: Listing<BaseResourcePluginConfig>(
         this.toList().map((it) -> it.type).isDistinct
@@ -249,7 +249,7 @@ class CliConfig {
 
     disableUsageReporting: Boolean = false
 
-    auth: BaseCliAuthConfig?
+    auth: (BaseCliAuthConfig|Dynamic)?
 }
 
 /// Deprecated: use top-level pluginDir, network, and agent.auth / cli.auth instead.

--- a/internal/schema/pkl/assets/formae/Config.pkl
+++ b/internal/schema/pkl/assets/formae/Config.pkl
@@ -169,7 +169,8 @@ class NetworkConfig {
 }
 
 class RateLimitConfig {
-    maxRequestsPerSecond: Int = 10
+    scope: String = "Namespace"
+    maxRequestsPerSecondForNamespace: Int = 10
 }
 
 class LabelConfig {
@@ -194,7 +195,6 @@ open class BaseResourcePluginConfig {
     labelConfig: LabelConfig?
     discoveryFilters: Listing<MatchFilter>?
     resourceTypesToDiscover: Listing<String>?
-    labelTagKeys: Listing<String>?
     retry: RetryConfig?
 }
 

--- a/internal/schema/pkl/assets/formae/Config.pkl
+++ b/internal/schema/pkl/assets/formae/Config.pkl
@@ -226,7 +226,7 @@ class AgentConfig {
     auth: BaseAgentAuthConfig?
 
     resourcePlugins: Listing(
-        this.toList().every((it) -> it.hasProperty("type"))
+        this.toList().every((it) -> it.hasProperty("type")) &&
         this.toList().map((it) -> it.type).isDistinct
     )?
 }

--- a/internal/schema/pkl/assets/formae/Config.pkl
+++ b/internal/schema/pkl/assets/formae/Config.pkl
@@ -225,7 +225,8 @@ class AgentConfig {
 
     auth: BaseAgentAuthConfig?
 
-    resourcePlugins: Listing<BaseResourcePluginConfig>(
+    resourcePlugins: Listing(
+        this.toList().every((it) -> it.hasProperty("type"))
         this.toList().map((it) -> it.type).isDistinct
     )?
 }

--- a/internal/schema/pkl/assets/formae/Config.pkl
+++ b/internal/schema/pkl/assets/formae/Config.pkl
@@ -187,7 +187,7 @@ class MatchFilter {
     conditions: Listing<FilterCondition>
 }
 
-abstract class BaseResourcePluginConfig {
+open class BaseResourcePluginConfig {
     type: String
     enabled: Boolean = true
     rateLimit: RateLimitConfig?
@@ -225,8 +225,7 @@ class AgentConfig {
 
     auth: BaseAgentAuthConfig?
 
-    resourcePlugins: Listing(
-        this.toList().every((it) -> it.hasProperty("type")) &&
+    resourcePlugins: Listing<BaseResourcePluginConfig>(
         this.toList().map((it) -> it.type).isDistinct
     )?
 }

--- a/internal/schema/pkl/assets/formae/Config.pkl
+++ b/internal/schema/pkl/assets/formae/Config.pkl
@@ -198,11 +198,11 @@ open class BaseResourcePluginConfig {
     retry: RetryConfig?
 }
 
-abstract class BaseAgentAuthConfig {
+open class BaseAgentAuthConfig {
     type: String
 }
 
-abstract class BaseCliAuthConfig {
+open class BaseCliAuthConfig {
     type: String
 }
 

--- a/internal/schema/pkl/model/config.go
+++ b/internal/schema/pkl/model/config.go
@@ -19,7 +19,8 @@ func init() {
 // subclasses from pkl.Object properties.
 
 type RateLimitConfig struct {
-	MaxRequestsPerSecond int32 `pkl:"maxRequestsPerSecond"`
+	Scope                            string `pkl:"scope"`
+	MaxRequestsPerSecondForNamespace int32  `pkl:"maxRequestsPerSecondForNamespace"`
 }
 
 type LabelConfig struct {

--- a/internal/schema/pkl/model/config.go
+++ b/internal/schema/pkl/model/config.go
@@ -8,6 +8,33 @@ import "github.com/apple/pkl-go/pkl"
 
 func init() {
 	pkl.RegisterMapping("formae.Config#User", User{})
+	pkl.RegisterMapping("formae.Config#RateLimitConfig", RateLimitConfig{})
+	pkl.RegisterMapping("formae.Config#RetryConfig", RetryConfig{})
+	pkl.RegisterMapping("formae.Config#LabelConfig", LabelConfig{})
+	pkl.RegisterMapping("formae.Config#MatchFilter", MatchFilter{})
+	pkl.RegisterMapping("formae.Config#FilterCondition", FilterCondition{})
+}
+
+// ResourcePlugin nested types used when decoding BaseResourcePluginConfig
+// subclasses from pkl.Object properties.
+
+type RateLimitConfig struct {
+	MaxRequestsPerSecond int32 `pkl:"maxRequestsPerSecond"`
+}
+
+type LabelConfig struct {
+	DefaultQuery      string      `pkl:"defaultQuery"`
+	ResourceOverrides *pkl.Object `pkl:"resourceOverrides"`
+}
+
+type MatchFilter struct {
+	ResourceTypes []string          `pkl:"resourceTypes"`
+	Conditions    []FilterCondition `pkl:"conditions"`
+}
+
+type FilterCondition struct {
+	PropertyPath  string `pkl:"propertyPath"`
+	PropertyValue string `pkl:"propertyValue"`
 }
 
 type ServerConfig struct {
@@ -127,13 +154,14 @@ type NetworkConfig struct {
 type AgentConfig struct {
 	Server          ServerConfig          `pkl:"server"`
 	Datastore       DatastoreConfig       `pkl:"datastore"`
-	Retry           RetryConfig           `pkl:"retry"`
+	Retry           *RetryConfig          `pkl:"retry"`
 	Synchronization SynchronizationConfig `pkl:"synchronization"`
 	Discovery       DiscoveryConfig       `pkl:"discovery"`
 	Logging         LoggingConfig         `pkl:"logging"`
 	OTel            OTelConfig            `pkl:"oTel"`
 	StackExpirer    StackExpirerConfig    `pkl:"stackExpirer"`
 	Auth            pkl.Object            `pkl:"auth"`
+	ResourcePlugins []pkl.Object          `pkl:"resourcePlugins"`
 }
 
 type APIConfig struct {

--- a/internal/schema/pkl/model/config.go
+++ b/internal/schema/pkl/model/config.go
@@ -29,8 +29,8 @@ type LabelConfig struct {
 }
 
 type MatchFilter struct {
-	ResourceTypes []string          `pkl:"resourceTypes"`
-	Conditions    []FilterCondition `pkl:"conditions"`
+	ResourceTypes []string           `pkl:"resourceTypes"`
+	Conditions    []*FilterCondition `pkl:"conditions"`
 }
 
 type FilterCondition struct {

--- a/internal/schema/pkl/pkl.go
+++ b/internal/schema/pkl/pkl.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"time"
 
 	pklgo "github.com/apple/pkl-go/pkl"
 	"github.com/platform-engineering-labs/formae"
@@ -164,11 +165,7 @@ func translateConfig(config *pklmodel.Config) *pkgmodel.Config {
 					Region:     config.Agent.Datastore.AuroraDataAPI.Region,
 				},
 			},
-			Retry: pkgmodel.RetryConfig{
-				StatusCheckInterval: config.Agent.Retry.StatusCheckInterval.GoDuration(),
-				MaxRetries:          int(config.Agent.Retry.MaxRetries),
-				RetryDelay:          config.Agent.Retry.RetryDelay.GoDuration(),
-			},
+			Retry: translateRetryConfig(config.Agent.Retry),
 			Synchronization: pkgmodel.SynchronizationConfig{
 				Enabled:  config.Agent.Synchronization.Enabled,
 				Interval: config.Agent.Synchronization.Interval.GoDuration(),
@@ -202,7 +199,8 @@ func translateConfig(config *pklmodel.Config) *pkgmodel.Config {
 					Enabled: config.Agent.OTel.Prometheus.Enabled,
 				},
 			},
-			Auth: translateAuthConfig(&config.Agent.Auth),
+			Auth:            translateAuthConfig(&config.Agent.Auth),
+			ResourcePlugins: translateResourcePluginConfigs(config.Agent.ResourcePlugins),
 		},
 		Artifacts: pkgmodel.ArtifactConfig{
 			URL:      config.Artifacts.URL,
@@ -225,7 +223,63 @@ func translateConfig(config *pklmodel.Config) *pkgmodel.Config {
 	// Backwards compatibility: fall back to deprecated plugins block
 	applyDeprecatedPluginsConfig(config.Plugins, &translated)
 
+	// Warn when global settings conflict with per-plugin overrides
+	checkResourcePluginDeprecations(&translated)
+
 	return &translated
+}
+
+// checkResourcePluginDeprecations warns when global settings conflict with per-plugin overrides.
+func checkResourcePluginDeprecations(translated *pkgmodel.Config) {
+	if len(translated.Agent.ResourcePlugins) == 0 {
+		return
+	}
+
+	hasPerPluginRetry := false
+	hasPerPluginRTD := false
+	hasPerPluginLTK := false
+
+	for _, rpc := range translated.Agent.ResourcePlugins {
+		if rpc.Retry != nil {
+			hasPerPluginRetry = true
+		}
+		if len(rpc.ResourceTypesToDiscover) > 0 {
+			hasPerPluginRTD = true
+		}
+		if len(rpc.LabelTagKeys) > 0 {
+			hasPerPluginLTK = true
+		}
+	}
+
+	// Default RetryConfig values as defined in Config.pkl
+	defaultRetry := pkgmodel.RetryConfig{
+		StatusCheckInterval: 20 * time.Second,
+		MaxRetries:          9,
+		RetryDelay:          10 * time.Second,
+	}
+
+	if hasPerPluginRetry && translated.Agent.Retry != defaultRetry {
+		w := "Your configuration file uses per-plugin 'retry' — the global 'agent.retry' is deprecated in favor of per-plugin retry config"
+		slog.Warn(w)
+		translated.Warnings = append(translated.Warnings, w)
+	}
+
+	if hasPerPluginRTD && len(translated.Agent.Discovery.ResourceTypesToDiscover) > 0 {
+		w := "Your configuration file uses per-plugin 'resourceTypesToDiscover' — the global 'agent.discovery.resourceTypesToDiscover' is deprecated in favor of per-plugin config"
+		slog.Warn(w)
+		translated.Warnings = append(translated.Warnings, w)
+	}
+
+	// The PKL default for labelTagKeys is ["Name"]; treat it as "not explicitly set"
+	defaultLTK := []string{"Name"}
+	globalLTKIsNonDefault := len(translated.Agent.Discovery.LabelTagKeys) > 0 &&
+		(len(translated.Agent.Discovery.LabelTagKeys) != 1 || translated.Agent.Discovery.LabelTagKeys[0] != defaultLTK[0])
+
+	if hasPerPluginLTK && globalLTKIsNonDefault {
+		w := "Your configuration file uses per-plugin 'labelTagKeys' — the global 'agent.discovery.labelTagKeys' is deprecated in favor of per-plugin config"
+		slog.Warn(w)
+		translated.Warnings = append(translated.Warnings, w)
+	}
 }
 
 // applyDeprecatedPluginsConfig copies values from the deprecated plugins block
@@ -597,6 +651,166 @@ func translateDynamic(dyn *pklgo.Object) json.RawMessage {
 	}
 
 	return configJson
+}
+
+func translateRetryConfig(rc *pklmodel.RetryConfig) pkgmodel.RetryConfig {
+	if rc == nil {
+		return pkgmodel.RetryConfig{}
+	}
+	return pkgmodel.RetryConfig{
+		StatusCheckInterval: rc.StatusCheckInterval.GoDuration(),
+		MaxRetries:          int(rc.MaxRetries),
+		RetryDelay:          rc.RetryDelay.GoDuration(),
+	}
+}
+
+func translateResourcePluginConfigs(objects []pklgo.Object) []pkgmodel.ResourcePluginUserConfig {
+	if len(objects) == 0 {
+		return nil
+	}
+	var configs []pkgmodel.ResourcePluginUserConfig
+	for i := range objects {
+		configs = append(configs, translateResourcePluginConfig(&objects[i]))
+	}
+	return configs
+}
+
+func translateResourcePluginConfig(obj *pklgo.Object) pkgmodel.ResourcePluginUserConfig {
+	props := obj.Properties
+
+	cfg := pkgmodel.ResourcePluginUserConfig{
+		Type:    pklString(props, "type"),
+		Enabled: pklBool(props, "enabled", true),
+	}
+
+	// rateLimit
+	if rl, ok := props["rateLimit"]; ok && rl != nil {
+		if rlObj, ok := rl.(*pklmodel.RateLimitConfig); ok {
+			cfg.RateLimit = &pkgmodel.RateLimitConfig{
+				MaxRequestsPerSecond: int(rlObj.MaxRequestsPerSecond),
+			}
+		}
+	}
+
+	// labelConfig
+	if lc, ok := props["labelConfig"]; ok && lc != nil {
+		if lcObj, ok := lc.(*pklmodel.LabelConfig); ok {
+			cfg.LabelConfig = &pkgmodel.LabelConfig{
+				DefaultQuery:      lcObj.DefaultQuery,
+				ResourceOverrides: pklMappingToStringMap(lcObj.ResourceOverrides),
+			}
+		}
+	}
+
+	// discoveryFilters
+	if df, ok := props["discoveryFilters"]; ok && df != nil {
+		cfg.DiscoveryFilters = translateDiscoveryFilters(df)
+	}
+
+	// resourceTypesToDiscover
+	if rtd, ok := props["resourceTypesToDiscover"]; ok && rtd != nil {
+		cfg.ResourceTypesToDiscover = pklListingToStringSlice(rtd)
+	}
+
+	// labelTagKeys
+	if ltk, ok := props["labelTagKeys"]; ok && ltk != nil {
+		cfg.LabelTagKeys = pklListingToStringSlice(ltk)
+	}
+
+	// retry
+	if r, ok := props["retry"]; ok && r != nil {
+		if rObj, ok := r.(*pklmodel.RetryConfig); ok {
+			cfg.Retry = &pkgmodel.RetryConfig{
+				StatusCheckInterval: rObj.StatusCheckInterval.GoDuration(),
+				MaxRetries:          int(rObj.MaxRetries),
+				RetryDelay:          rObj.RetryDelay.GoDuration(),
+			}
+		}
+	}
+
+	return cfg
+}
+
+func translateDiscoveryFilters(v any) []pkgmodel.MatchFilter {
+	switch filters := v.(type) {
+	case []any:
+		var result []pkgmodel.MatchFilter
+		for _, f := range filters {
+			if mf, ok := f.(*pklmodel.MatchFilter); ok {
+				result = append(result, translateMatchFilter(mf))
+			}
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func translateMatchFilter(mf *pklmodel.MatchFilter) pkgmodel.MatchFilter {
+	result := pkgmodel.MatchFilter{
+		ResourceTypes: mf.ResourceTypes,
+	}
+	for _, c := range mf.Conditions {
+		result.Conditions = append(result.Conditions, pkgmodel.FilterCondition{
+			PropertyPath:  c.PropertyPath,
+			PropertyValue: c.PropertyValue,
+		})
+	}
+	return result
+}
+
+// pklString extracts a string from a pkl.Object properties map.
+func pklString(props map[string]any, key string) string {
+	if v, ok := props[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// pklBool extracts a bool from a pkl.Object properties map with a default.
+func pklBool(props map[string]any, key string, defaultVal bool) bool {
+	if v, ok := props[key]; ok {
+		if b, ok := v.(bool); ok {
+			return b
+		}
+	}
+	return defaultVal
+}
+
+// pklListingToStringSlice converts a PKL Listing value (typically []any) to []string.
+func pklListingToStringSlice(v any) []string {
+	switch val := v.(type) {
+	case []any:
+		var result []string
+		for _, item := range val {
+			if s, ok := item.(string); ok {
+				result = append(result, s)
+			}
+		}
+		return result
+	case []string:
+		return val
+	default:
+		return nil
+	}
+}
+
+// pklMappingToStringMap converts a PKL Mapping (pkl.Object with Entries) to map[string]string.
+func pklMappingToStringMap(obj *pklgo.Object) map[string]string {
+	if obj == nil || len(obj.Entries) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(obj.Entries))
+	for k, v := range obj.Entries {
+		if ks, ok := k.(string); ok {
+			if vs, ok := v.(string); ok {
+				result[ks] = vs
+			}
+		}
+	}
+	return result
 }
 
 func parseLogLevel(level string) slog.Level {

--- a/internal/schema/pkl/pkl.go
+++ b/internal/schema/pkl/pkl.go
@@ -237,7 +237,6 @@ func checkResourcePluginDeprecations(translated *pkgmodel.Config) {
 
 	hasPerPluginRetry := false
 	hasPerPluginRTD := false
-	hasPerPluginLTK := false
 
 	for _, rpc := range translated.Agent.ResourcePlugins {
 		if rpc.Retry != nil {
@@ -245,9 +244,6 @@ func checkResourcePluginDeprecations(translated *pkgmodel.Config) {
 		}
 		if len(rpc.ResourceTypesToDiscover) > 0 {
 			hasPerPluginRTD = true
-		}
-		if len(rpc.LabelTagKeys) > 0 {
-			hasPerPluginLTK = true
 		}
 	}
 
@@ -266,17 +262,6 @@ func checkResourcePluginDeprecations(translated *pkgmodel.Config) {
 
 	if hasPerPluginRTD && len(translated.Agent.Discovery.ResourceTypesToDiscover) > 0 {
 		w := "Your configuration file uses per-plugin 'resourceTypesToDiscover' — the global 'agent.discovery.resourceTypesToDiscover' is deprecated in favor of per-plugin config"
-		slog.Warn(w)
-		translated.Warnings = append(translated.Warnings, w)
-	}
-
-	// The PKL default for labelTagKeys is ["Name"]; treat it as "not explicitly set"
-	defaultLTK := []string{"Name"}
-	globalLTKIsNonDefault := len(translated.Agent.Discovery.LabelTagKeys) > 0 &&
-		(len(translated.Agent.Discovery.LabelTagKeys) != 1 || translated.Agent.Discovery.LabelTagKeys[0] != defaultLTK[0])
-
-	if hasPerPluginLTK && globalLTKIsNonDefault {
-		w := "Your configuration file uses per-plugin 'labelTagKeys' — the global 'agent.discovery.labelTagKeys' is deprecated in favor of per-plugin config"
 		slog.Warn(w)
 		translated.Warnings = append(translated.Warnings, w)
 	}
@@ -687,7 +672,8 @@ func translateResourcePluginConfig(obj *pklgo.Object) pkgmodel.ResourcePluginUse
 	if rl, ok := props["rateLimit"]; ok && rl != nil {
 		if rlObj, ok := rl.(*pklmodel.RateLimitConfig); ok {
 			cfg.RateLimit = &pkgmodel.RateLimitConfig{
-				MaxRequestsPerSecond: int(rlObj.MaxRequestsPerSecond),
+				Scope:                            pkgmodel.RateLimitScope(rlObj.Scope),
+				MaxRequestsPerSecondForNamespace: int(rlObj.MaxRequestsPerSecondForNamespace),
 			}
 		}
 	}
@@ -712,11 +698,6 @@ func translateResourcePluginConfig(obj *pklgo.Object) pkgmodel.ResourcePluginUse
 		cfg.ResourceTypesToDiscover = pklListingToStringSlice(rtd)
 	}
 
-	// labelTagKeys
-	if ltk, ok := props["labelTagKeys"]; ok && ltk != nil {
-		cfg.LabelTagKeys = pklListingToStringSlice(ltk)
-	}
-
 	// retry
 	if r, ok := props["retry"]; ok && r != nil {
 		if rObj, ok := r.(*pklmodel.RetryConfig); ok {
@@ -731,7 +712,7 @@ func translateResourcePluginConfig(obj *pklgo.Object) pkgmodel.ResourcePluginUse
 	// Marshal remaining unknown properties into PluginConfig for plugin-specific fields
 	baseKeys := map[string]bool{
 		"type": true, "enabled": true, "rateLimit": true, "labelConfig": true,
-		"discoveryFilters": true, "resourceTypesToDiscover": true, "labelTagKeys": true, "retry": true,
+		"discoveryFilters": true, "resourceTypesToDiscover": true, "retry": true,
 	}
 	extra := make(map[string]any)
 	for k, v := range props {

--- a/internal/schema/pkl/pkl.go
+++ b/internal/schema/pkl/pkl.go
@@ -728,6 +728,21 @@ func translateResourcePluginConfig(obj *pklgo.Object) pkgmodel.ResourcePluginUse
 		}
 	}
 
+	// Marshal remaining unknown properties into PluginConfig for plugin-specific fields
+	baseKeys := map[string]bool{
+		"type": true, "enabled": true, "rateLimit": true, "labelConfig": true,
+		"discoveryFilters": true, "resourceTypesToDiscover": true, "labelTagKeys": true, "retry": true,
+	}
+	extra := make(map[string]any)
+	for k, v := range props {
+		if !baseKeys[k] {
+			extra[k] = v
+		}
+	}
+	if len(extra) > 0 {
+		cfg.PluginConfig, _ = json.Marshal(sanitizeConfig(extra))
+	}
+
 	return cfg
 }
 

--- a/internal/schema/pkl/pkl_test.go
+++ b/internal/schema/pkl/pkl_test.go
@@ -157,9 +157,9 @@ func TestTranslateResourcePluginConfig(t *testing.T) {
 	assert.Equal(t, "fake-aws", rpc.Type)
 	assert.True(t, rpc.Enabled)
 	assert.NotNil(t, rpc.RateLimit)
-	assert.Equal(t, 5, rpc.RateLimit.MaxRequestsPerSecond)
+	assert.Equal(t, model.RateLimitScopeNamespace, rpc.RateLimit.Scope)
+	assert.Equal(t, 5, rpc.RateLimit.MaxRequestsPerSecondForNamespace)
 	assert.Equal(t, []string{"FakeAWS::S3::Bucket"}, rpc.ResourceTypesToDiscover)
-	assert.Equal(t, []string{"Name", "Env"}, rpc.LabelTagKeys)
 	assert.NotNil(t, rpc.Retry)
 	assert.Equal(t, 3, rpc.Retry.MaxRetries)
 	assert.Equal(t, 5*time.Second, rpc.Retry.RetryDelay)
@@ -187,7 +187,7 @@ func TestTranslateResourcePluginConfig_Dynamic(t *testing.T) {
 	assert.Equal(t, "sftp", rpc.Type)
 	assert.True(t, rpc.Enabled)
 	require.NotNil(t, rpc.RateLimit)
-	assert.Equal(t, 3, rpc.RateLimit.MaxRequestsPerSecond)
+	assert.Equal(t, 3, rpc.RateLimit.MaxRequestsPerSecondForNamespace)
 }
 
 func TestTranslateResourcePluginConfig_CustomFields(t *testing.T) {

--- a/internal/schema/pkl/pkl_test.go
+++ b/internal/schema/pkl/pkl_test.go
@@ -190,6 +190,22 @@ func TestTranslateResourcePluginConfig_Dynamic(t *testing.T) {
 	assert.Equal(t, 3, rpc.RateLimit.MaxRequestsPerSecond)
 }
 
+func TestTranslateResourcePluginConfig_CustomFields(t *testing.T) {
+	p := PKL{}
+	config, err := p.FormaeConfig("./testdata/config/test_resource_plugin_custom.pkl")
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	require.Len(t, config.Agent.ResourcePlugins, 1)
+	rpc := config.Agent.ResourcePlugins[0]
+	assert.Equal(t, "sftp", rpc.Type)
+	require.NotNil(t, rpc.PluginConfig)
+	assert.Contains(t, string(rpc.PluginConfig), "defaultTimeoutSeconds")
+	assert.Contains(t, string(rpc.PluginConfig), "60")
+	assert.Contains(t, string(rpc.PluginConfig), "defaultFilePermissions")
+	assert.Contains(t, string(rpc.PluginConfig), "0755")
+}
+
 func TestDeprecationWarning_GlobalRetryWithPerPlugin(t *testing.T) {
 	p := PKL{}
 	config, err := p.FormaeConfig("./testdata/config/test_deprecation_retry.pkl")

--- a/internal/schema/pkl/pkl_test.go
+++ b/internal/schema/pkl/pkl_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
 
@@ -144,4 +145,43 @@ func TestPkl_FormaeConfig(t *testing.T) {
 	assert.NotNil(t, config.Network.Tailscale)
 	assert.False(t, config.Network.Tailscale.TLS)
 	assert.Equal(t, "someAuthKey", config.Network.Tailscale.AuthKey)
+}
+
+func TestTranslateResourcePluginConfig(t *testing.T) {
+	p := PKL{}
+	config, err := p.FormaeConfig("./testdata/config/test_resource_plugin_config.pkl")
+	require.NoError(t, err)
+
+	require.Len(t, config.Agent.ResourcePlugins, 1)
+	rpc := config.Agent.ResourcePlugins[0]
+	assert.Equal(t, "fake-aws", rpc.Type)
+	assert.True(t, rpc.Enabled)
+	assert.NotNil(t, rpc.RateLimit)
+	assert.Equal(t, 5, rpc.RateLimit.MaxRequestsPerSecond)
+	assert.Equal(t, []string{"FakeAWS::S3::Bucket"}, rpc.ResourceTypesToDiscover)
+	assert.Equal(t, []string{"Name", "Env"}, rpc.LabelTagKeys)
+	assert.NotNil(t, rpc.Retry)
+	assert.Equal(t, 3, rpc.Retry.MaxRetries)
+	assert.Equal(t, 5*time.Second, rpc.Retry.RetryDelay)
+	assert.Equal(t, 2*time.Second, rpc.Retry.StatusCheckInterval)
+}
+
+func TestTranslateResourcePluginConfig_Disabled(t *testing.T) {
+	p := PKL{}
+	config, err := p.FormaeConfig("./testdata/config/test_resource_plugin_disabled.pkl")
+	require.NoError(t, err)
+
+	require.Len(t, config.Agent.ResourcePlugins, 1)
+	assert.Equal(t, "fake-aws", config.Agent.ResourcePlugins[0].Type)
+	assert.False(t, config.Agent.ResourcePlugins[0].Enabled)
+}
+
+func TestDeprecationWarning_GlobalRetryWithPerPlugin(t *testing.T) {
+	p := PKL{}
+	config, err := p.FormaeConfig("./testdata/config/test_deprecation_retry.pkl")
+	require.NoError(t, err)
+
+	require.Len(t, config.Warnings, 1)
+	assert.Contains(t, config.Warnings[0], "agent.retry")
+	assert.Contains(t, config.Warnings[0], "deprecated")
 }

--- a/internal/schema/pkl/pkl_test.go
+++ b/internal/schema/pkl/pkl_test.go
@@ -176,6 +176,20 @@ func TestTranslateResourcePluginConfig_Disabled(t *testing.T) {
 	assert.False(t, config.Agent.ResourcePlugins[0].Enabled)
 }
 
+func TestTranslateResourcePluginConfig_Dynamic(t *testing.T) {
+	p := PKL{}
+	config, err := p.FormaeConfig("./testdata/config/test_resource_plugin_dynamic.pkl")
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	require.Len(t, config.Agent.ResourcePlugins, 1)
+	rpc := config.Agent.ResourcePlugins[0]
+	assert.Equal(t, "sftp", rpc.Type)
+	assert.True(t, rpc.Enabled)
+	require.NotNil(t, rpc.RateLimit)
+	assert.Equal(t, 3, rpc.RateLimit.MaxRequestsPerSecond)
+}
+
 func TestDeprecationWarning_GlobalRetryWithPerPlugin(t *testing.T) {
 	p := PKL{}
 	config, err := p.FormaeConfig("./testdata/config/test_deprecation_retry.pkl")

--- a/internal/schema/pkl/plugins.go
+++ b/internal/schema/pkl/plugins.go
@@ -42,7 +42,7 @@ func GeneratePluginWrappers(pluginDir string) error {
 			continue
 		}
 
-		configPath := filepath.Join(pluginPath, versionDir, "schema", "pkl", "Config.pkl")
+		configPath := filepath.Join(pluginPath, versionDir, "schema", "Config.pkl")
 		if _, err := os.Stat(configPath); err != nil {
 			continue
 		}
@@ -50,7 +50,7 @@ func GeneratePluginWrappers(pluginDir string) error {
 		wrapperName := toPascalCase(pluginName) + ".pkl"
 		wrapperPath := filepath.Join(pluginDir, wrapperName)
 
-		relativePath := fmt.Sprintf("./%s/%s/schema/pkl/Config.pkl", pluginName, versionDir)
+		relativePath := fmt.Sprintf("./%s/%s/schema/Config.pkl", pluginName, versionDir)
 		content := fmt.Sprintf(
 			"/// Auto-generated wrapper for %s plugin.\n"+
 				"/// Do not edit — regenerated on each config evaluation.\n"+

--- a/internal/schema/pkl/plugins_test.go
+++ b/internal/schema/pkl/plugins_test.go
@@ -18,8 +18,8 @@ import (
 func TestGeneratePluginWrappers_CreatesWrapperForPluginWithSchema(t *testing.T) {
 	pluginDir := t.TempDir()
 
-	// Create a fake plugin with schema/pkl/Config.pkl
-	configDir := filepath.Join(pluginDir, "auth-basic", "v0.1.0", "schema", "pkl")
+	// Create a fake plugin with schema/Config.pkl
+	configDir := filepath.Join(pluginDir, "auth-basic", "v0.1.0", "schema")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(configDir, "Config.pkl"), []byte("open module authBasic.Config\n"), 0644))
 
@@ -30,15 +30,15 @@ func TestGeneratePluginWrappers_CreatesWrapperForPluginWithSchema(t *testing.T) 
 	content, err := os.ReadFile(wrapperPath)
 	require.NoError(t, err)
 
-	assert.Contains(t, string(content), `extends "./auth-basic/v0.1.0/schema/pkl/Config.pkl"`)
+	assert.Contains(t, string(content), `extends "./auth-basic/v0.1.0/schema/Config.pkl"`)
 	assert.Contains(t, string(content), "Auto-generated wrapper for auth-basic plugin")
 }
 
 func TestGeneratePluginWrappers_SkipsPluginsWithoutSchema(t *testing.T) {
 	pluginDir := t.TempDir()
 
-	// Create a plugin directory without schema/pkl/Config.pkl
-	require.NoError(t, os.MkdirAll(filepath.Join(pluginDir, "aws", "v0.1.3", "schema", "pkl"), 0755))
+	// Create a plugin directory without schema/Config.pkl
+	require.NoError(t, os.MkdirAll(filepath.Join(pluginDir, "aws", "v0.1.3", "schema"), 0755))
 	// No Config.pkl written
 
 	err := GeneratePluginWrappers(pluginDir)
@@ -65,7 +65,7 @@ func TestGeneratePluginWrappers_PicksHighestVersion(t *testing.T) {
 
 	// Create two versions — only v0.2.0 has Config.pkl but both are version dirs
 	for _, ver := range []string{"v0.1.0", "v0.2.0"} {
-		configDir := filepath.Join(pluginDir, "my-plugin", ver, "schema", "pkl")
+		configDir := filepath.Join(pluginDir, "my-plugin", ver, "schema")
 		require.NoError(t, os.MkdirAll(configDir, 0755))
 		require.NoError(t, os.WriteFile(filepath.Join(configDir, "Config.pkl"), []byte("open module myPlugin.Config\n"), 0644))
 	}
@@ -76,7 +76,7 @@ func TestGeneratePluginWrappers_PicksHighestVersion(t *testing.T) {
 	content, err := os.ReadFile(filepath.Join(pluginDir, "MyPlugin.pkl"))
 	require.NoError(t, err)
 
-	assert.Contains(t, string(content), `extends "./my-plugin/v0.2.0/schema/pkl/Config.pkl"`)
+	assert.Contains(t, string(content), `extends "./my-plugin/v0.2.0/schema/Config.pkl"`)
 }
 
 func TestGeneratePluginWrappers_SkipsNonDirectoryEntries(t *testing.T) {

--- a/internal/schema/pkl/testdata/config/test_deprecation_retry.pkl
+++ b/internal/schema/pkl/testdata/config/test_deprecation_retry.pkl
@@ -1,0 +1,20 @@
+amends "formae:/Config.pkl"
+
+import "formae:/Config.pkl"
+
+local class FakeAwsConfig extends Config.BaseResourcePluginConfig {
+    type = "fake-aws"
+}
+
+agent {
+    retry {
+        maxRetries = 5
+    }
+    resourcePlugins {
+        new FakeAwsConfig {
+            retry {
+                maxRetries = 3
+            }
+        }
+    }
+}

--- a/internal/schema/pkl/testdata/config/test_deprecation_retry.pkl
+++ b/internal/schema/pkl/testdata/config/test_deprecation_retry.pkl
@@ -1,3 +1,9 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
 amends "formae:/Config.pkl"
 
 import "formae:/Config.pkl"

--- a/internal/schema/pkl/testdata/config/test_resource_plugin_config.pkl
+++ b/internal/schema/pkl/testdata/config/test_resource_plugin_config.pkl
@@ -1,3 +1,9 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
 amends "formae:/Config.pkl"
 
 import "formae:/Config.pkl"

--- a/internal/schema/pkl/testdata/config/test_resource_plugin_config.pkl
+++ b/internal/schema/pkl/testdata/config/test_resource_plugin_config.pkl
@@ -14,9 +14,8 @@ agent {
     resourcePlugins {
         new FakeAwsConfig {
             type = "fake-aws"
-            rateLimit { maxRequestsPerSecond = 5 }
+            rateLimit { maxRequestsPerSecondForNamespace = 5 }
             resourceTypesToDiscover { "FakeAWS::S3::Bucket" }
-            labelTagKeys { "Name"; "Env" }
             retry {
                 maxRetries = 3
                 retryDelay = 5.s

--- a/internal/schema/pkl/testdata/config/test_resource_plugin_config.pkl
+++ b/internal/schema/pkl/testdata/config/test_resource_plugin_config.pkl
@@ -1,0 +1,21 @@
+amends "formae:/Config.pkl"
+
+import "formae:/Config.pkl"
+
+local class FakeAwsConfig extends Config.BaseResourcePluginConfig {}
+
+agent {
+    resourcePlugins {
+        new FakeAwsConfig {
+            type = "fake-aws"
+            rateLimit { maxRequestsPerSecond = 5 }
+            resourceTypesToDiscover { "FakeAWS::S3::Bucket" }
+            labelTagKeys { "Name"; "Env" }
+            retry {
+                maxRetries = 3
+                retryDelay = 5.s
+                statusCheckInterval = 2.s
+            }
+        }
+    }
+}

--- a/internal/schema/pkl/testdata/config/test_resource_plugin_custom.pkl
+++ b/internal/schema/pkl/testdata/config/test_resource_plugin_custom.pkl
@@ -1,0 +1,23 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+amends "formae:/Config.pkl"
+
+import "formae:/Config.pkl"
+
+local class SftpConfig extends Config.BaseResourcePluginConfig {
+    defaultTimeoutSeconds: Int = 30
+    defaultFilePermissions: String = "0644"
+}
+
+agent {
+    resourcePlugins {
+        new SftpConfig {
+            type = "sftp"
+            defaultTimeoutSeconds = 60
+            defaultFilePermissions = "0755"
+        }
+    }
+}

--- a/internal/schema/pkl/testdata/config/test_resource_plugin_disabled.pkl
+++ b/internal/schema/pkl/testdata/config/test_resource_plugin_disabled.pkl
@@ -1,3 +1,9 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
 amends "formae:/Config.pkl"
 
 import "formae:/Config.pkl"

--- a/internal/schema/pkl/testdata/config/test_resource_plugin_disabled.pkl
+++ b/internal/schema/pkl/testdata/config/test_resource_plugin_disabled.pkl
@@ -1,0 +1,14 @@
+amends "formae:/Config.pkl"
+
+import "formae:/Config.pkl"
+
+local class FakeAwsConfig extends Config.BaseResourcePluginConfig {}
+
+agent {
+    resourcePlugins {
+        new FakeAwsConfig {
+            type = "fake-aws"
+            enabled = false
+        }
+    }
+}

--- a/internal/schema/pkl/testdata/config/test_resource_plugin_dynamic.pkl
+++ b/internal/schema/pkl/testdata/config/test_resource_plugin_dynamic.pkl
@@ -9,7 +9,7 @@ agent {
     resourcePlugins {
         new BaseResourcePluginConfig {
             type = "sftp"
-            rateLimit { maxRequestsPerSecond = 3 }
+            rateLimit { maxRequestsPerSecondForNamespace = 3 }
         }
     }
 }

--- a/internal/schema/pkl/testdata/config/test_resource_plugin_dynamic.pkl
+++ b/internal/schema/pkl/testdata/config/test_resource_plugin_dynamic.pkl
@@ -1,0 +1,15 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+amends "formae:/Config.pkl"
+
+agent {
+    resourcePlugins {
+        new BaseResourcePluginConfig {
+            type = "sftp"
+            rateLimit { maxRequestsPerSecond = 3 }
+        }
+    }
+}

--- a/internal/testplugin/fakeaws/fake_aws.go
+++ b/internal/testplugin/fakeaws/fake_aws.go
@@ -6,6 +6,7 @@ package fakeaws
 
 import (
 	"context"
+	"sync"
 
 	"github.com/masterminds/semver"
 	"github.com/platform-engineering-labs/formae/pkg/model"
@@ -16,6 +17,7 @@ import (
 type FakeAWS struct {
 	// pendingCreates tracks in-progress creates by RequestID so Status can
 	// return the original properties when the resource "completes".
+	mu             sync.Mutex
 	pendingCreates map[string][]byte
 }
 
@@ -155,7 +157,9 @@ func (s *FakeAWS) Create(context context.Context, request *resource.CreateReques
 	}
 
 	requestID := "1234"
+	s.mu.Lock()
 	s.pendingCreates[requestID] = request.Properties
+	s.mu.Unlock()
 	return &resource.CreateResult{
 		ProgressResult: &resource.ProgressResult{
 			Operation:       resource.OperationCreate,
@@ -221,8 +225,10 @@ func (s *FakeAWS) Status(ctx context.Context, request *resource.StatusRequest) (
 			return ret, nil
 		}
 	}
+	s.mu.Lock()
 	props := s.pendingCreates[request.RequestID]
 	delete(s.pendingCreates, request.RequestID)
+	s.mu.Unlock()
 	return &resource.StatusResult{
 		ProgressResult: &resource.ProgressResult{
 			Operation:          resource.OperationCreate,

--- a/internal/testplugin/fakeaws/fake_aws.go
+++ b/internal/testplugin/fakeaws/fake_aws.go
@@ -81,10 +81,9 @@ func (s *FakeAWS) SupportedResources() []plugin.ResourceDescriptor {
 	}
 }
 
-func (s *FakeAWS) RateLimit() plugin.RateLimitConfig {
-	return plugin.RateLimitConfig{
-		Scope:                            plugin.RateLimitScopeNamespace,
-		MaxRequestsPerSecondForNamespace: RateLimitMaxRPS,
+func (s *FakeAWS) RateLimit() model.RateLimitConfig {
+	return model.RateLimitConfig{
+		MaxRequestsPerSecond: RateLimitMaxRPS,
 	}
 }
 
@@ -277,12 +276,12 @@ func (s *FakeAWS) List(context context.Context, request *resource.ListRequest) (
 }
 
 // DiscoveryFilters returns declarative filters for testing discovery exclusion
-func (s *FakeAWS) DiscoveryFilters() []plugin.MatchFilter {
-	return []plugin.MatchFilter{
+func (s *FakeAWS) DiscoveryFilters() []model.MatchFilter {
+	return []model.MatchFilter{
 		{
 			// Filter 1: Exclude by top-level property
 			ResourceTypes: []string{"FakeAWS::S3::Bucket"},
-			Conditions: []plugin.FilterCondition{
+			Conditions: []model.FilterCondition{
 				{
 					PropertyPath:  "$.SkipDiscovery",
 					PropertyValue: "true",
@@ -292,7 +291,7 @@ func (s *FakeAWS) DiscoveryFilters() []plugin.MatchFilter {
 		{
 			// Filter 2: Exclude by tag in array format [{"Key": "...", "Value": "..."}]
 			ResourceTypes: []string{"FakeAWS::S3::Bucket"},
-			Conditions: []plugin.FilterCondition{
+			Conditions: []model.FilterCondition{
 				{
 					PropertyPath:  `$.Tags[?(@.Key=="SkipDiscovery")].Value`,
 					PropertyValue: "true",
@@ -302,7 +301,7 @@ func (s *FakeAWS) DiscoveryFilters() []plugin.MatchFilter {
 		{
 			// Filter 3: Exclude by tag in map format {"key": "value"}
 			ResourceTypes: []string{"FakeAWS::S3::Bucket"},
-			Conditions: []plugin.FilterCondition{
+			Conditions: []model.FilterCondition{
 				{
 					PropertyPath:  "$.Tags.SkipDiscovery",
 					PropertyValue: "true",
@@ -314,8 +313,8 @@ func (s *FakeAWS) DiscoveryFilters() []plugin.MatchFilter {
 
 // LabelConfig returns the label extraction configuration for discovered FakeAWS resources.
 // Uses the same pattern as the real AWS plugin for testing.
-func (s *FakeAWS) LabelConfig() plugin.LabelConfig {
-	return plugin.LabelConfig{
+func (s *FakeAWS) LabelConfig() model.LabelConfig {
+	return model.LabelConfig{
 		DefaultQuery:      `$.Tags[?(@.Key=='Name')].Value`,
 		ResourceOverrides: map[string]string{},
 	}

--- a/internal/testplugin/fakeaws/fake_aws.go
+++ b/internal/testplugin/fakeaws/fake_aws.go
@@ -85,7 +85,8 @@ func (s *FakeAWS) SupportedResources() []plugin.ResourceDescriptor {
 
 func (s *FakeAWS) RateLimit() model.RateLimitConfig {
 	return model.RateLimitConfig{
-		MaxRequestsPerSecond: RateLimitMaxRPS,
+		Scope:                            model.RateLimitScopeNamespace,
+		MaxRequestsPerSecondForNamespace: RateLimitMaxRPS,
 	}
 }
 

--- a/internal/workflow_tests/local/resource_plugin_config_test.go
+++ b/internal/workflow_tests/local/resource_plugin_config_test.go
@@ -43,6 +43,7 @@ func TestResourcePluginConfig_DisabledPlugin(t *testing.T) {
 		// Because the config has Enabled=false for "fakeaws", the coordinator
 		// should reject the announcement and not register the plugin.
 		err = testutil.Send(m.Node, "PluginCoordinator", messages.PluginAnnouncement{
+			Name:                 "fakeaws",
 			Namespace:            "FakeAWS",
 			Version:              "0.0.1",
 			NodeName:             "fake-plugin-node",
@@ -92,6 +93,7 @@ func TestResourcePluginConfig_RateLimitOverride(t *testing.T) {
 		// Simulate a plugin announcing itself with a default rate limit of 10.
 		// The user config overrides this to 3.
 		err = testutil.Send(m.Node, "PluginCoordinator", messages.PluginAnnouncement{
+			Name:                 "fakeaws",
 			Namespace:            "FakeAWS",
 			Version:              "0.0.1",
 			NodeName:             "fake-plugin-node",

--- a/internal/workflow_tests/local/resource_plugin_config_test.go
+++ b/internal/workflow_tests/local/resource_plugin_config_test.go
@@ -76,7 +76,7 @@ func TestResourcePluginConfig_RateLimitOverride(t *testing.T) {
 			{
 				Type:      "fakeaws",
 				Enabled:   true,
-				RateLimit: &pkgmodel.RateLimitConfig{MaxRequestsPerSecond: 3},
+				RateLimit: &pkgmodel.RateLimitConfig{Scope: pkgmodel.RateLimitScopeNamespace, MaxRequestsPerSecondForNamespace: 3},
 			},
 		}
 

--- a/internal/workflow_tests/local/resource_plugin_config_test.go
+++ b/internal/workflow_tests/local/resource_plugin_config_test.go
@@ -1,0 +1,122 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+)
+
+func TestResourcePluginConfig_DisabledPlugin(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.ResourcePlugins = []pkgmodel.ResourcePluginUserConfig{
+			{
+				Type:    "fakeaws",
+				Enabled: false,
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, nil, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		// Start a test helper actor so we can interact with the actor system
+		incoming := make(chan any, 1)
+		_, err = testutil.StartTestHelperActor(m.Node, incoming)
+		require.NoError(t, err)
+
+		// Simulate a plugin announcing itself to the PluginCoordinator.
+		// Because the config has Enabled=false for "fakeaws", the coordinator
+		// should reject the announcement and not register the plugin.
+		err = testutil.Send(m.Node, "PluginCoordinator", messages.PluginAnnouncement{
+			Namespace:            "FakeAWS",
+			Version:              "0.0.1",
+			NodeName:             "fake-plugin-node",
+			MaxRequestsPerSecond: 10,
+			Capabilities: plugin.PluginCapabilities{
+				SupportedResources: []plugin.ResourceDescriptor{
+					{Type: "FakeAWS::S3::Bucket"},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Give the coordinator time to process the announcement
+		time.Sleep(500 * time.Millisecond)
+
+		// Query the coordinator for registered plugins — the disabled plugin
+		// should NOT appear in the list.
+		result, err := testutil.Call(m.Node, "PluginCoordinator", messages.GetRegisteredPlugins{})
+		require.NoError(t, err)
+
+		pluginsResult, ok := result.(messages.GetRegisteredPluginsResult)
+		require.True(t, ok, "expected GetRegisteredPluginsResult, got %T", result)
+		assert.Empty(t, pluginsResult.Plugins, "disabled plugin should not be registered")
+	})
+}
+
+func TestResourcePluginConfig_RateLimitOverride(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.ResourcePlugins = []pkgmodel.ResourcePluginUserConfig{
+			{
+				Type:      "fakeaws",
+				Enabled:   true,
+				RateLimit: &pkgmodel.RateLimitConfig{MaxRequestsPerSecond: 3},
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, nil, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		// Start a test helper actor so we can interact with the actor system
+		incoming := make(chan any, 1)
+		_, err = testutil.StartTestHelperActor(m.Node, incoming)
+		require.NoError(t, err)
+
+		// Simulate a plugin announcing itself with a default rate limit of 10.
+		// The user config overrides this to 3.
+		err = testutil.Send(m.Node, "PluginCoordinator", messages.PluginAnnouncement{
+			Namespace:            "FakeAWS",
+			Version:              "0.0.1",
+			NodeName:             "fake-plugin-node",
+			MaxRequestsPerSecond: 10,
+			Capabilities: plugin.PluginCapabilities{
+				SupportedResources: []plugin.ResourceDescriptor{
+					{Type: "FakeAWS::S3::Bucket"},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Give the coordinator time to process the announcement
+		time.Sleep(500 * time.Millisecond)
+
+		// Query the coordinator for registered plugins — the plugin should be
+		// registered with the overridden rate limit of 3, not the announced 10.
+		result, err := testutil.Call(m.Node, "PluginCoordinator", messages.GetRegisteredPlugins{})
+		require.NoError(t, err)
+
+		pluginsResult, ok := result.(messages.GetRegisteredPluginsResult)
+		require.True(t, ok, "expected GetRegisteredPluginsResult, got %T", result)
+		require.Len(t, pluginsResult.Plugins, 1, "enabled plugin should be registered")
+		assert.Equal(t, "FakeAWS", pluginsResult.Plugins[0].Namespace)
+		assert.Equal(t, 3, pluginsResult.Plugins[0].MaxRequestsPerSecond, "rate limit should be overridden from 10 to 3")
+		assert.Equal(t, 1, pluginsResult.Plugins[0].ResourceCount)
+	})
+}

--- a/pkg/api/model/types.go
+++ b/pkg/api/model/types.go
@@ -7,6 +7,8 @@ package model
 import (
 	"encoding/json"
 	"time"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
 type SubmitCommandResponse struct {
@@ -164,12 +166,17 @@ type Stats struct {
 }
 
 // PluginInfo represents information about a registered plugin
+// including the merged config (plugin defaults + user overrides).
 type PluginInfo struct {
-	Namespace            string `json:"Namespace"`
-	Version              string `json:"Version"`
-	NodeName             string `json:"NodeName"`
-	MaxRequestsPerSecond int    `json:"MaxRequestsPerSecond"`
-	ResourceCount        int    `json:"ResourceCount"`
+	Namespace               string           `json:"Namespace"`
+	Version                 string           `json:"Version"`
+	NodeName                string           `json:"NodeName"`
+	MaxRequestsPerSecond    int              `json:"MaxRequestsPerSecond"`
+	ResourceCount           int              `json:"ResourceCount"`
+	ResourceTypesToDiscover []string         `json:"ResourceTypesToDiscover,omitempty"`
+	LabelTagKeys            []string         `json:"LabelTagKeys,omitempty"`
+	RetryConfig             *pkgmodel.RetryConfig `json:"RetryConfig,omitempty"`
+	LabelConfig             *pkgmodel.LabelConfig `json:"LabelConfig,omitempty"`
 }
 
 type ForceReconcileResponse struct {

--- a/pkg/api/model/types.go
+++ b/pkg/api/model/types.go
@@ -175,8 +175,9 @@ type PluginInfo struct {
 	ResourceCount           int              `json:"ResourceCount"`
 	ResourceTypesToDiscover []string         `json:"ResourceTypesToDiscover,omitempty"`
 	LabelTagKeys            []string         `json:"LabelTagKeys,omitempty"`
-	RetryConfig             *pkgmodel.RetryConfig `json:"RetryConfig,omitempty"`
-	LabelConfig             *pkgmodel.LabelConfig `json:"LabelConfig,omitempty"`
+	RetryConfig             *pkgmodel.RetryConfig    `json:"RetryConfig,omitempty"`
+	LabelConfig             *pkgmodel.LabelConfig    `json:"LabelConfig,omitempty"`
+	DiscoveryFilters        []pkgmodel.MatchFilter   `json:"DiscoveryFilters,omitempty"`
 }
 
 type ForceReconcileResponse struct {

--- a/pkg/api/model/types.go
+++ b/pkg/api/model/types.go
@@ -174,7 +174,6 @@ type PluginInfo struct {
 	MaxRequestsPerSecond    int              `json:"MaxRequestsPerSecond"`
 	ResourceCount           int              `json:"ResourceCount"`
 	ResourceTypesToDiscover []string         `json:"ResourceTypesToDiscover,omitempty"`
-	LabelTagKeys            []string         `json:"LabelTagKeys,omitempty"`
 	RetryConfig             *pkgmodel.RetryConfig    `json:"RetryConfig,omitempty"`
 	LabelConfig             *pkgmodel.LabelConfig    `json:"LabelConfig,omitempty"`
 	DiscoveryFilters        []pkgmodel.MatchFilter   `json:"DiscoveryFilters,omitempty"`

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -10,6 +10,59 @@ import (
 	"time"
 )
 
+// RateLimitConfig specifies rate limiting behavior for a plugin.
+type RateLimitConfig struct {
+	MaxRequestsPerSecond int
+}
+
+// LabelConfig defines how to extract labels from discovered resources.
+// Labels are constructed by evaluating JSONPath queries against resource properties.
+type LabelConfig struct {
+	// DefaultQuery is a JSONPath expression applied to all resources in this namespace.
+	// Example for AWS: `$.Tags[?(@.Key=='Name')].Value`
+	// If empty, falls back to NativeID.
+	DefaultQuery string
+
+	// ResourceOverrides provides JSONPath expressions for specific resource types,
+	// overriding the DefaultQuery. Use for resources without tags or with
+	// non-standard label sources.
+	// Key: resource type (e.g., "AWS::IAM::Policy")
+	// Value: JSONPath expression (e.g., "$.PolicyName")
+	ResourceOverrides map[string]string
+}
+
+// QueryForResourceType returns the JSONPath query for a given resource type.
+// Returns the resource-specific override if exists, otherwise the default query.
+func (c LabelConfig) QueryForResourceType(resourceType string) string {
+	if override, ok := c.ResourceOverrides[resourceType]; ok {
+		return override
+	}
+	return c.DefaultQuery
+}
+
+// MatchFilter is a declarative, serializable filter definition for discovery.
+// Resources matching ALL conditions in a filter are excluded from discovery.
+type MatchFilter struct {
+	ResourceTypes []string          // Resource types this filter applies to
+	Conditions    []FilterCondition // All conditions must match (AND logic) to exclude
+}
+
+// FilterCondition defines a single condition for filtering resources.
+// Uses JSONPath expressions to query resource properties.
+type FilterCondition struct {
+	// PropertyPath is a JSONPath expression to query resource properties.
+	// Examples:
+	//   - "$.Tags[?(@.Key=='Name')].Value" - get value of tag with key "Name"
+	//   - "$.Tags[?(@.Key=~'eks:automode:.*')]" - check if any tag key matches regex
+	//   - "$.SkipDiscovery" - get top-level property value
+	PropertyPath string
+
+	// PropertyValue is the expected value to match.
+	// Empty string means existence check (path returns any value = match).
+	// Non-empty means exact string match against the query result.
+	PropertyValue string
+}
+
 const (
 	SqliteDatastore        = "sqlite"
 	PostgresDatastore      = "postgres"
@@ -122,6 +175,20 @@ type NetworkConfig struct {
 	LegacyRawJSON json.RawMessage `json:"-"`
 }
 
+// ResourcePluginUserConfig holds per-plugin configuration from the user's
+// formae.conf.pkl. Fields are optional — nil means "use plugin default."
+type ResourcePluginUserConfig struct {
+	Type                    string
+	Enabled                 bool
+	RateLimit               *RateLimitConfig
+	LabelConfig             *LabelConfig
+	DiscoveryFilters        []MatchFilter
+	ResourceTypesToDiscover []string
+	LabelTagKeys            []string
+	Retry                   *RetryConfig
+	PluginConfig            json.RawMessage
+}
+
 type AgentConfig struct {
 	Server          ServerConfig
 	Datastore       DatastoreConfig
@@ -132,6 +199,7 @@ type AgentConfig struct {
 	OTel            OTelConfig
 	StackExpirer    StackExpirerConfig
 	Auth            json.RawMessage
+	ResourcePlugins []ResourcePluginUserConfig
 }
 
 type APIConfig struct {

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -10,9 +10,18 @@ import (
 	"time"
 )
 
-// RateLimitConfig specifies rate limiting behavior for a plugin.
+// RateLimitScope defines the granularity of rate limiting
+type RateLimitScope string
+
+const (
+	// RateLimitScopeNamespace applies rate limiting at the plugin namespace level (e.g., AWS, Azure)
+	RateLimitScopeNamespace RateLimitScope = "Namespace"
+)
+
+// RateLimitConfig specifies rate limiting behavior for a plugin
 type RateLimitConfig struct {
-	MaxRequestsPerSecond int
+	Scope                            RateLimitScope
+	MaxRequestsPerSecondForNamespace int
 }
 
 // LabelConfig defines how to extract labels from discovered resources.
@@ -184,7 +193,6 @@ type ResourcePluginUserConfig struct {
 	LabelConfig             *LabelConfig
 	DiscoveryFilters        []MatchFilter
 	ResourceTypesToDiscover []string
-	LabelTagKeys            []string
 	Retry                   *RetryConfig
 	PluginConfig            json.RawMessage
 }

--- a/pkg/plugin-conformance-tests/plugin_coordinator.go
+++ b/pkg/plugin-conformance-tests/plugin_coordinator.go
@@ -46,7 +46,7 @@ type RegisteredPluginInfo struct {
 	NodeName           gen.Atom
 	SupportedResources []plugin.ResourceDescriptor
 	ResourceSchemas    map[string]model.Schema
-	MatchFilters       []plugin.MatchFilter
+	MatchFilters       []model.MatchFilter
 	RegisteredAt       time.Time
 }
 

--- a/pkg/plugin/actor.go
+++ b/pkg/plugin/actor.go
@@ -73,7 +73,7 @@ func (p *PluginActor) Init(args ...any) error {
 		Namespace:            p.namespace,
 		Version:              p.plugin.Version().String(),
 		NodeName:             string(p.Node().Name()),
-		MaxRequestsPerSecond: p.plugin.RateLimit().MaxRequestsPerSecondForNamespace,
+		MaxRequestsPerSecond: p.plugin.RateLimit().MaxRequestsPerSecond,
 		Capabilities:         caps,
 	}
 

--- a/pkg/plugin/actor.go
+++ b/pkg/plugin/actor.go
@@ -73,7 +73,7 @@ func (p *PluginActor) Init(args ...any) error {
 		Namespace:            p.namespace,
 		Version:              p.plugin.Version().String(),
 		NodeName:             string(p.Node().Name()),
-		MaxRequestsPerSecond: p.plugin.RateLimit().MaxRequestsPerSecond,
+		MaxRequestsPerSecond: p.plugin.RateLimit().MaxRequestsPerSecondForNamespace,
 		Capabilities:         caps,
 	}
 

--- a/pkg/plugin/actor.go
+++ b/pkg/plugin/actor.go
@@ -70,6 +70,7 @@ func (p *PluginActor) Init(args ...any) error {
 		Node: p.agentNode,
 	}
 	announcement := PluginAnnouncement{
+		Name:                 p.plugin.Name(),
 		Namespace:            p.namespace,
 		Version:              p.plugin.Version().String(),
 		NodeName:             string(p.Node().Name()),

--- a/pkg/plugin/resource.go
+++ b/pkg/plugin/resource.go
@@ -6,9 +6,10 @@ package plugin
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/masterminds/semver"
-	"github.com/platform-engineering-labs/formae/pkg/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
@@ -24,9 +25,9 @@ const Resource Type = "resource"
 // used internally by the formae agent.
 type ResourcePlugin interface {
 	// Configuration methods
-	RateLimit() RateLimitConfig
-	DiscoveryFilters() []MatchFilter
-	LabelConfig() LabelConfig
+	RateLimit() pkgmodel.RateLimitConfig
+	DiscoveryFilters() []pkgmodel.MatchFilter
+	LabelConfig() pkgmodel.LabelConfig
 
 	// CRUD operations
 	Create(context context.Context, request *resource.CreateRequest) (*resource.CreateResult, error)
@@ -39,20 +40,6 @@ type ResourcePlugin interface {
 
 	// Discovery support
 	List(context context.Context, request *resource.ListRequest) (*resource.ListResult, error)
-}
-
-// RateLimitScope defines the granularity of rate limiting
-type RateLimitScope string
-
-const (
-	// RateLimitScopeNamespace applies rate limiting at the plugin namespace level (e.g., AWS, Azure)
-	RateLimitScopeNamespace RateLimitScope = "Namespace"
-)
-
-// RateLimitConfig specifies rate limiting behavior for a plugin
-type RateLimitConfig struct {
-	Scope                            RateLimitScope
-	MaxRequestsPerSecondForNamespace int
 }
 
 // FullResourcePlugin is the internal interface used by the formae agent.
@@ -69,32 +56,7 @@ type FullResourcePlugin interface {
 
 	// Schema methods - auto-extracted from schema/pkl/ directory
 	SupportedResources() []ResourceDescriptor
-	SchemaForResourceType(resourceType string) (model.Schema, error)
-}
-
-// LabelConfig defines how to extract labels from discovered resources.
-// Labels are constructed by evaluating JSONPath queries against resource properties.
-type LabelConfig struct {
-	// DefaultQuery is a JSONPath expression applied to all resources in this namespace.
-	// Example for AWS: `$.Tags[?(@.Key=='Name')].Value`
-	// If empty, falls back to NativeID.
-	DefaultQuery string
-
-	// ResourceOverrides provides JSONPath expressions for specific resource types,
-	// overriding the DefaultQuery. Use for resources without tags or with
-	// non-standard label sources.
-	// Key: resource type (e.g., "AWS::IAM::Policy")
-	// Value: JSONPath expression (e.g., "$.PolicyName")
-	ResourceOverrides map[string]string
-}
-
-// QueryForResourceType returns the JSONPath query for a given resource type.
-// Returns the resource-specific override if exists, otherwise the default query.
-func (c LabelConfig) QueryForResourceType(resourceType string) string {
-	if override, ok := c.ResourceOverrides[resourceType]; ok {
-		return override
-	}
-	return c.DefaultQuery
+	SchemaForResourceType(resourceType string) (pkgmodel.Schema, error)
 }
 
 // ObservablePlugin is an optional interface for plugins that support observability.
@@ -104,37 +66,22 @@ type ObservablePlugin interface {
 	SetObservability(logger Logger, metrics MetricRegistry)
 }
 
+// Configurable is an optional interface for plugins that accept custom configuration.
+// If implemented, the SDK calls Configure with the plugin-specific config JSON from
+// the user's formae.conf.pkl (the fields beyond BaseResourcePluginConfig).
+// Configure is called once during plugin setup, before the plugin announces to the agent.
+type Configurable interface {
+	Configure(config json.RawMessage) error
+}
+
 // PluginInfo provides read-only plugin metadata for discovery operations.
 // This interface is implemented by both local ResourcePlugin and remote plugin info proxies.
 type PluginInfo interface {
 	GetNamespace() string
 	SupportedResources() []ResourceDescriptor
-	SchemaForResourceType(resourceType string) (model.Schema, error)
-	DiscoveryFilters() []MatchFilter
-	LabelConfig() LabelConfig
-}
-
-// MatchFilter is a declarative, serializable filter definition for discovery.
-// Resources matching ALL conditions in a filter are excluded from discovery.
-type MatchFilter struct {
-	ResourceTypes []string          // Resource types this filter applies to
-	Conditions    []FilterCondition // All conditions must match (AND logic) to exclude
-}
-
-// FilterCondition defines a single condition for filtering resources.
-// Uses JSONPath expressions to query resource properties.
-type FilterCondition struct {
-	// PropertyPath is a JSONPath expression to query resource properties.
-	// Examples:
-	//   - "$.Tags[?(@.Key=='Name')].Value" - get value of tag with key "Name"
-	//   - "$.Tags[?(@.Key=~'eks:automode:.*')]" - check if any tag key matches regex
-	//   - "$.SkipDiscovery" - get top-level property value
-	PropertyPath string
-
-	// PropertyValue is the expected value to match.
-	// Empty string means existence check (path returns any value = match).
-	// Non-empty means exact string match against the query result.
-	PropertyValue string
+	SchemaForResourceType(resourceType string) (pkgmodel.Schema, error)
+	DiscoveryFilters() []pkgmodel.MatchFilter
+	LabelConfig() pkgmodel.LabelConfig
 }
 
 // used in tests to simulate testable behaviour

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -36,8 +36,8 @@ import (
 type PluginCapabilities struct {
 	SupportedResources []ResourceDescriptor
 	ResourceSchemas    map[string]model.Schema // key = resource type
-	MatchFilters       []MatchFilter
-	LabelConfig        LabelConfig
+	MatchFilters       []model.MatchFilter
+	LabelConfig        model.LabelConfig
 }
 
 // PluginAnnouncement is sent by plugins to PluginCoordinator on startup.

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -43,6 +43,7 @@ type PluginCapabilities struct {
 // PluginAnnouncement is sent by plugins to PluginCoordinator on startup.
 // It contains all information needed for the agent to interact with the plugin.
 type PluginAnnouncement struct {
+	Name                 string // Plugin name from manifest (e.g., "compose", "aws")
 	Namespace            string
 	Version              string
 	NodeName             string

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -89,6 +89,7 @@ func Run(fp FullResourcePlugin) {
 	options.Network.Cookie = cookie
 	options.Security.ExposeEnvRemoteSpawn = true
 	options.Log.Level = gen.LogLevelDebug
+	options.Log.DefaultLogger.Disable = true
 
 	// Configure plugin's own Ergo acceptor on a random free port.
 	// The plugin needs its own acceptor for the agent to spawn remote PluginOperator processes.

--- a/pkg/plugin/sdk/run.go
+++ b/pkg/plugin/sdk/run.go
@@ -8,6 +8,7 @@ package sdk
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"log"
@@ -210,6 +211,19 @@ func SetupPlugin(ctx context.Context, p plugin.ResourcePlugin, config RunConfig)
 		obs.SetObservability(logger, nil) // Metrics can be added later
 	}
 
+	// 9. Configure plugin-specific settings if the plugin supports it
+	if cfg, ok := wrapped.(plugin.Configurable); ok {
+		if pluginConfigB64 := os.Getenv("FORMAE_PLUGIN_CONFIG"); pluginConfigB64 != "" {
+			pluginConfigJSON, err := base64.StdEncoding.DecodeString(pluginConfigB64)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode FORMAE_PLUGIN_CONFIG: %w", err)
+			}
+			if err := cfg.Configure(pluginConfigJSON); err != nil {
+				return nil, fmt.Errorf("plugin configuration failed: %w", err)
+			}
+		}
+	}
+
 	return wrapped, nil
 }
 
@@ -282,6 +296,19 @@ func SetupPluginFromDir(ctx context.Context, p plugin.ResourcePlugin, pluginDir 
 	if obs, ok := wrapped.(plugin.ObservablePlugin); ok {
 		logger := setupPluginLogger(manifest.Namespace)
 		obs.SetObservability(logger, nil) // Metrics can be added later
+	}
+
+	// 8. Configure plugin-specific settings if the plugin supports it
+	if cfg, ok := wrapped.(plugin.Configurable); ok {
+		if pluginConfigB64 := os.Getenv("FORMAE_PLUGIN_CONFIG"); pluginConfigB64 != "" {
+			pluginConfigJSON, err := base64.StdEncoding.DecodeString(pluginConfigB64)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode FORMAE_PLUGIN_CONFIG: %w", err)
+			}
+			if err := cfg.Configure(pluginConfigJSON); err != nil {
+				return nil, fmt.Errorf("plugin configuration failed: %w", err)
+			}
+		}
 	}
 
 	return wrapped, nil

--- a/pkg/plugin/sdk/run_test.go
+++ b/pkg/plugin/sdk/run_test.go
@@ -15,26 +15,25 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
 // mockPlugin is a minimal ResourcePlugin implementation for testing
 type mockPlugin struct{}
 
-func (m *mockPlugin) RateLimit() plugin.RateLimitConfig {
-	return plugin.RateLimitConfig{
-		Scope:                            plugin.RateLimitScopeNamespace,
-		MaxRequestsPerSecondForNamespace: 10,
+func (m *mockPlugin) RateLimit() pkgmodel.RateLimitConfig {
+	return pkgmodel.RateLimitConfig{
+		MaxRequestsPerSecond: 10,
 	}
 }
 
-func (m *mockPlugin) DiscoveryFilters() []plugin.MatchFilter {
+func (m *mockPlugin) DiscoveryFilters() []pkgmodel.MatchFilter {
 	return nil
 }
 
-func (m *mockPlugin) LabelConfig() plugin.LabelConfig {
-	return plugin.LabelConfig{DefaultQuery: "$.Name"}
+func (m *mockPlugin) LabelConfig() pkgmodel.LabelConfig {
+	return pkgmodel.LabelConfig{DefaultQuery: "$.Name"}
 }
 
 func (m *mockPlugin) Create(ctx context.Context, req *resource.CreateRequest) (*resource.CreateResult, error) {
@@ -101,8 +100,7 @@ func TestSetupPluginFromDir_CreatesFullResourcePlugin(t *testing.T) {
 	assert.NotEmpty(t, schema.Fields, "Schema should have fields")
 
 	// Verify config methods are delegated to the plugin
-	assert.Equal(t, plugin.RateLimitScopeNamespace, wrapped.RateLimit().Scope)
-	assert.Equal(t, 10, wrapped.RateLimit().MaxRequestsPerSecondForNamespace)
+	assert.Equal(t, 10, wrapped.RateLimit().MaxRequestsPerSecond)
 	assert.Equal(t, "$.Name", wrapped.LabelConfig().DefaultQuery)
 }
 

--- a/pkg/plugin/sdk/run_test.go
+++ b/pkg/plugin/sdk/run_test.go
@@ -24,7 +24,8 @@ type mockPlugin struct{}
 
 func (m *mockPlugin) RateLimit() pkgmodel.RateLimitConfig {
 	return pkgmodel.RateLimitConfig{
-		MaxRequestsPerSecond: 10,
+		Scope:                            pkgmodel.RateLimitScopeNamespace,
+		MaxRequestsPerSecondForNamespace: 10,
 	}
 }
 
@@ -100,7 +101,7 @@ func TestSetupPluginFromDir_CreatesFullResourcePlugin(t *testing.T) {
 	assert.NotEmpty(t, schema.Fields, "Schema should have fields")
 
 	// Verify config methods are delegated to the plugin
-	assert.Equal(t, 10, wrapped.RateLimit().MaxRequestsPerSecond)
+	assert.Equal(t, 10, wrapped.RateLimit().MaxRequestsPerSecondForNamespace)
 	assert.Equal(t, "$.Name", wrapped.LabelConfig().DefaultQuery)
 }
 

--- a/pkg/plugin/wrapper.go
+++ b/pkg/plugin/wrapper.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/masterminds/semver"
-	"github.com/platform-engineering-labs/formae/pkg/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
@@ -26,7 +26,7 @@ type pluginWrapper struct {
 
 	// Auto-extracted from schema directory
 	descriptors         []ResourceDescriptor
-	resourceTypeSchemas map[string]model.Schema
+	resourceTypeSchemas map[string]pkgmodel.Schema
 
 	// Observability - optional, may be nil
 	logger  Logger
@@ -39,7 +39,7 @@ func WrapPlugin(
 	p ResourcePlugin,
 	manifest *Manifest,
 	descriptors []ResourceDescriptor,
-	schemas map[string]model.Schema,
+	schemas map[string]pkgmodel.Schema,
 ) (FullResourcePlugin, error) {
 	v, err := semver.NewVersion(manifest.Version)
 	if err != nil {
@@ -82,24 +82,24 @@ func (w *pluginWrapper) SupportedResources() []ResourceDescriptor {
 	return w.descriptors
 }
 
-func (w *pluginWrapper) SchemaForResourceType(resourceType string) (model.Schema, error) {
+func (w *pluginWrapper) SchemaForResourceType(resourceType string) (pkgmodel.Schema, error) {
 	if schema, ok := w.resourceTypeSchemas[resourceType]; ok {
 		return schema, nil
 	}
-	return model.Schema{}, nil
+	return pkgmodel.Schema{}, nil
 }
 
 // Configuration methods - delegated to user's plugin
 
-func (w *pluginWrapper) RateLimit() RateLimitConfig {
+func (w *pluginWrapper) RateLimit() pkgmodel.RateLimitConfig {
 	return w.plugin.RateLimit()
 }
 
-func (w *pluginWrapper) DiscoveryFilters() []MatchFilter {
+func (w *pluginWrapper) DiscoveryFilters() []pkgmodel.MatchFilter {
 	return w.plugin.DiscoveryFilters()
 }
 
-func (w *pluginWrapper) LabelConfig() LabelConfig {
+func (w *pluginWrapper) LabelConfig() pkgmodel.LabelConfig {
 	return w.plugin.LabelConfig()
 }
 

--- a/pkg/plugin/wrapper.go
+++ b/pkg/plugin/wrapper.go
@@ -6,6 +6,7 @@ package plugin
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/masterminds/semver"
@@ -60,6 +61,14 @@ func WrapPlugin(
 func (w *pluginWrapper) SetObservability(logger Logger, metrics MetricRegistry) {
 	w.logger = logger
 	w.metrics = metrics
+}
+
+// Configure passes plugin-specific config to the inner plugin if it implements Configurable.
+func (w *pluginWrapper) Configure(config json.RawMessage) error {
+	if cfg, ok := w.plugin.(Configurable); ok {
+		return cfg.Configure(config)
+	}
+	return nil
 }
 
 // Identity methods - from manifest

--- a/pkg/plugin/wrapper_test.go
+++ b/pkg/plugin/wrapper_test.go
@@ -13,26 +13,25 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/platform-engineering-labs/formae/pkg/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
 // mockPlugin is a minimal ResourcePlugin implementation for testing
 type mockPlugin struct{}
 
-func (m *mockPlugin) RateLimit() RateLimitConfig {
-	return RateLimitConfig{
-		Scope:                            RateLimitScopeNamespace,
-		MaxRequestsPerSecondForNamespace: 10,
+func (m *mockPlugin) RateLimit() pkgmodel.RateLimitConfig {
+	return pkgmodel.RateLimitConfig{
+		MaxRequestsPerSecond: 10,
 	}
 }
 
-func (m *mockPlugin) DiscoveryFilters() []MatchFilter {
+func (m *mockPlugin) DiscoveryFilters() []pkgmodel.MatchFilter {
 	return nil
 }
 
-func (m *mockPlugin) LabelConfig() LabelConfig {
-	return LabelConfig{DefaultQuery: "$.Name"}
+func (m *mockPlugin) LabelConfig() pkgmodel.LabelConfig {
+	return pkgmodel.LabelConfig{DefaultQuery: "$.Name"}
 }
 
 func (m *mockPlugin) Create(ctx context.Context, req *resource.CreateRequest) (*resource.CreateResult, error) {
@@ -73,7 +72,7 @@ func TestWrapPlugin_CreatesFullResourcePlugin(t *testing.T) {
 		{Type: "Test::Resource::Two"},
 	}
 
-	schemas := map[string]model.Schema{
+	schemas := map[string]pkgmodel.Schema{
 		"Test::Resource::One": {Identifier: "Name", Fields: []string{"Name", "Tags"}},
 		"Test::Resource::Two": {Identifier: "Value", Fields: []string{"Value"}},
 	}
@@ -98,8 +97,7 @@ func TestWrapPlugin_CreatesFullResourcePlugin(t *testing.T) {
 	assert.Equal(t, schemas["Test::Resource::Two"], schema2)
 
 	// Verify config methods are delegated
-	assert.Equal(t, RateLimitScopeNamespace, wrapped.RateLimit().Scope)
-	assert.Equal(t, 10, wrapped.RateLimit().MaxRequestsPerSecondForNamespace)
+	assert.Equal(t, 10, wrapped.RateLimit().MaxRequestsPerSecond)
 	assert.Equal(t, "$.Name", wrapped.LabelConfig().DefaultQuery)
 }
 
@@ -131,5 +129,5 @@ func TestWrapPlugin_SchemaForResourceType_ReturnsEmptyForUnknownType(t *testing.
 
 	schema, err := wrapped.SchemaForResourceType("Unknown::Type")
 	require.NoError(t, err)
-	assert.Equal(t, model.Schema{}, schema)
+	assert.Equal(t, pkgmodel.Schema{}, schema)
 }

--- a/pkg/plugin/wrapper_test.go
+++ b/pkg/plugin/wrapper_test.go
@@ -22,7 +22,8 @@ type mockPlugin struct{}
 
 func (m *mockPlugin) RateLimit() pkgmodel.RateLimitConfig {
 	return pkgmodel.RateLimitConfig{
-		MaxRequestsPerSecond: 10,
+		Scope:                            pkgmodel.RateLimitScopeNamespace,
+		MaxRequestsPerSecondForNamespace: 10,
 	}
 }
 
@@ -97,7 +98,7 @@ func TestWrapPlugin_CreatesFullResourcePlugin(t *testing.T) {
 	assert.Equal(t, schemas["Test::Resource::Two"], schema2)
 
 	// Verify config methods are delegated
-	assert.Equal(t, 10, wrapped.RateLimit().MaxRequestsPerSecond)
+	assert.Equal(t, 10, wrapped.RateLimit().MaxRequestsPerSecondForNamespace)
 	assert.Equal(t, "$.Name", wrapped.LabelConfig().DefaultQuery)
 }
 

--- a/tests/blackbox/executor.go
+++ b/tests/blackbox/executor.go
@@ -923,7 +923,13 @@ func correctModelFromCommandOutcome(t *testing.T, cmd *apimodel.Command, model *
 		if ru.State == "Success" {
 			switch ru.Operation {
 			case "create":
-				model.ClearAuthoritativeSlot(stackIdx, slotIdx)
+				// Don't let stale command completions override authoritative
+				// slots (e.g. TTL destroy that happened after this command was
+				// accepted). Authoritative is only cleared during optimistic
+				// prediction when a NEW command is accepted.
+				if model.IsAuthoritativeSlot(stackIdx, slotIdx) {
+					goto markDone
+				}
 				props := ""
 				if ru.Properties != nil {
 					props = model.NormalizePropertiesForResource(stackIdx, slotIdx, string(ru.Properties))

--- a/tests/blackbox/executor.go
+++ b/tests/blackbox/executor.go
@@ -345,7 +345,18 @@ func (h *TestHarness) reconcileCompletedAcceptedCommands(t *testing.T, model *St
 	// Process completed commands in REVERSE order (most recent first) so
 	// later command outcomes take precedence over earlier ones. This matches
 	// DrainPendingCommands' reverse-order processing.
+	//
+	// Seed the corrected map from authoritative slots so that stale commands
+	// (accepted before a TTL destroy or similar authoritative event) cannot
+	// override ground truth established by ForceCheckTTLAndWait.
 	corrected := make(map[struct{ stackIdx, slotIdx int }]bool)
+	for s, stack := range model.Stacks {
+		for idx := range stack.Resources {
+			if model.IsAuthoritativeSlot(s, idx) {
+				corrected[struct{ stackIdx, slotIdx int }{s, idx}] = true
+			}
+		}
+	}
 	for i := len(completed) - 1; i >= 0; i-- {
 		cc := completed[i]
 		t.Logf("reconcileCompletedAcceptedCommands: command %s completed early (state=%s)", cc.ac.CommandID, cc.cmd.State)
@@ -923,13 +934,7 @@ func correctModelFromCommandOutcome(t *testing.T, cmd *apimodel.Command, model *
 		if ru.State == "Success" {
 			switch ru.Operation {
 			case "create":
-				// Don't let stale command completions override authoritative
-				// slots (e.g. TTL destroy that happened after this command was
-				// accepted). Authoritative is only cleared during optimistic
-				// prediction when a NEW command is accepted.
-				if model.IsAuthoritativeSlot(stackIdx, slotIdx) {
-					goto markDone
-				}
+				model.ClearAuthoritativeSlot(stackIdx, slotIdx)
 				props := ""
 				if ru.Properties != nil {
 					props = model.NormalizePropertiesForResource(stackIdx, slotIdx, string(ru.Properties))

--- a/tests/e2e/go/agent.go
+++ b/tests/e2e/go/agent.go
@@ -49,6 +49,7 @@ type agentOptions struct {
 	authUsername            string
 	authPassword            string
 	authBcryptHash         string
+	resourcePluginsBlock    string   // raw PKL block for agent.resourcePlugins
 }
 
 // WithDiscovery enables discovery with the given interval (PKL duration format, e.g. "30.s").
@@ -64,6 +65,13 @@ func WithDiscovery(interval string, resourceTypes ...string) AgentOption {
 func WithEnv(envVars ...string) AgentOption {
 	return func(o *agentOptions) {
 		o.extraEnv = append(o.extraEnv, envVars...)
+	}
+}
+
+// WithResourcePlugins adds a raw PKL block for agent.resourcePlugins.
+func WithResourcePlugins(pklBlock string) AgentOption {
+	return func(o *agentOptions) {
+		o.resourcePluginsBlock = pklBlock
 	}
 }
 
@@ -166,7 +174,7 @@ agent {
         consoleLogLevel = "debug"
         filePath = %q
         fileLogLevel = "debug"
-    }%s
+    }%s%s
 }
 
 cli {
@@ -175,7 +183,7 @@ cli {
     }
     disableUsageReporting = true%s
 }
-`, port, dbPath, discoveryEnabled, options.discoveryInterval, resourceTypesBlock, logPath, agentAuthBlock, port, cliAuthBlock)
+`, port, dbPath, discoveryEnabled, options.discoveryInterval, resourceTypesBlock, logPath, agentAuthBlock, options.resourcePluginsBlock, port, cliAuthBlock)
 
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write agent config: %v", err)
@@ -304,6 +312,16 @@ func (a *Agent) Port() int {
 // ConfigPath returns the path to the agent's configuration file.
 func (a *Agent) ConfigPath() string {
 	return a.config.ConfigPath
+}
+
+// LogFile returns the path to the agent's log file.
+func (a *Agent) LogFile() string {
+	return a.config.LogFile
+}
+
+// StdoutLogFile returns the path to the agent's stdout/stderr capture.
+func (a *Agent) StdoutLogFile() string {
+	return filepath.Join(a.config.DataDir, "agent-stdout.log")
 }
 
 // pickFreePort asks the OS for a free TCP port by listening on :0 and

--- a/tests/e2e/go/agent.go
+++ b/tests/e2e/go/agent.go
@@ -124,20 +124,20 @@ func StartAgent(t *testing.T, binaryPath string, opts ...AgentOption) *Agent {
 
 	agentAuthBlock := ""
 	cliAuthBlock := ""
+	authImport := ""
 	if options.authEnabled {
+		authImport = `import "plugins:/AuthBasic.pkl" as AuthBasic`
 		agentAuthBlock = fmt.Sprintf(`
-    auth {
-        type = "auth-basic"
+    auth = new AuthBasic.AgentConfig {
         authorizedUsers = new Listing {
-            new Mapping {
-                ["Username"] = %q
-                ["Password"] = %q
+            new AuthBasic.AuthorizedUser {
+                username = %q
+                password = %q
             }
         }
     }`, options.authUsername, options.authBcryptHash)
 		cliAuthBlock = fmt.Sprintf(`
-    auth {
-        type = "auth-basic"
+    auth = new AuthBasic.CliConfig {
         username = %q
         password = %q
     }`, options.authUsername, options.authPassword)
@@ -148,6 +148,7 @@ func StartAgent(t *testing.T, binaryPath string, opts ...AgentOption) *Agent {
  */
 
 amends "formae:/Config.pkl"
+%s
 
 agent {
     server {
@@ -179,7 +180,7 @@ cli {
     }
     disableUsageReporting = true%s
 }
-`, port, dbPath, discoveryEnabled, options.discoveryInterval, resourceTypesBlock, logPath, agentAuthBlock, options.resourcePluginsBlock, port, cliAuthBlock)
+`, authImport, port, dbPath, discoveryEnabled, options.discoveryInterval, resourceTypesBlock, logPath, agentAuthBlock, options.resourcePluginsBlock, port, cliAuthBlock)
 
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write agent config: %v", err)

--- a/tests/e2e/go/agent.go
+++ b/tests/e2e/go/agent.go
@@ -124,20 +124,20 @@ func StartAgent(t *testing.T, binaryPath string, opts ...AgentOption) *Agent {
 
 	agentAuthBlock := ""
 	cliAuthBlock := ""
-	authImport := ""
 	if options.authEnabled {
-		authImport = `import "plugins:/AuthBasic.pkl" as AuthBasic`
 		agentAuthBlock = fmt.Sprintf(`
-    auth = new AuthBasic.AgentConfig {
+    auth {
+        type = "auth-basic"
         authorizedUsers = new Listing {
-            new AuthBasic.AuthorizedUser {
-                username = %q
-                password = %q
+            new Mapping {
+                ["Username"] = %q
+                ["Password"] = %q
             }
         }
     }`, options.authUsername, options.authBcryptHash)
 		cliAuthBlock = fmt.Sprintf(`
-    auth = new AuthBasic.CliConfig {
+    auth {
+        type = "auth-basic"
         username = %q
         password = %q
     }`, options.authUsername, options.authPassword)
@@ -148,7 +148,6 @@ func StartAgent(t *testing.T, binaryPath string, opts ...AgentOption) *Agent {
  */
 
 amends "formae:/Config.pkl"
-%s
 
 agent {
     server {
@@ -180,7 +179,7 @@ cli {
     }
     disableUsageReporting = true%s
 }
-`, authImport, port, dbPath, discoveryEnabled, options.discoveryInterval, resourceTypesBlock, logPath, agentAuthBlock, options.resourcePluginsBlock, port, cliAuthBlock)
+`, port, dbPath, discoveryEnabled, options.discoveryInterval, resourceTypesBlock, logPath, agentAuthBlock, options.resourcePluginsBlock, port, cliAuthBlock)
 
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write agent config: %v", err)

--- a/tests/e2e/go/agent.go
+++ b/tests/e2e/go/agent.go
@@ -125,22 +125,18 @@ func StartAgent(t *testing.T, binaryPath string, opts ...AgentOption) *Agent {
 	agentAuthBlock := ""
 	cliAuthBlock := ""
 	if options.authEnabled {
-		// Use Dynamic rather than typed plugin classes because pkl-go v0.12
-		// cannot decode typed PKL classes nested inside pkl.Object fields
-		// (e.g. AuthorizedUser inside a Listing inside an auth pkl.Object).
-		// Dynamic objects are decoded via the generic pkl.Object path.
 		agentAuthBlock = fmt.Sprintf(`
-    auth = new Dynamic {
+    auth {
         type = "auth-basic"
         authorizedUsers = new Listing {
-            new Dynamic {
-                username = %q
-                password = %q
+            new Mapping {
+                ["Username"] = %q
+                ["Password"] = %q
             }
         }
     }`, options.authUsername, options.authBcryptHash)
 		cliAuthBlock = fmt.Sprintf(`
-    auth = new Dynamic {
+    auth {
         type = "auth-basic"
         username = %q
         password = %q

--- a/tests/e2e/go/agent.go
+++ b/tests/e2e/go/agent.go
@@ -50,6 +50,7 @@ type agentOptions struct {
 	authPassword            string
 	authBcryptHash         string
 	resourcePluginsBlock    string   // raw PKL block for agent.resourcePlugins
+	pklImports              string   // raw PKL import statements (top-level)
 }
 
 // WithDiscovery enables discovery with the given interval (PKL duration format, e.g. "30.s").
@@ -69,8 +70,10 @@ func WithEnv(envVars ...string) AgentOption {
 }
 
 // WithResourcePlugins adds a raw PKL block for agent.resourcePlugins.
-func WithResourcePlugins(pklBlock string) AgentOption {
+// imports is optional top-level PKL import statements (e.g., `import "plugins:/Sftp.pkl" as Sftp`).
+func WithResourcePlugins(imports, pklBlock string) AgentOption {
 	return func(o *agentOptions) {
+		o.pklImports = imports
 		o.resourcePluginsBlock = pklBlock
 	}
 }
@@ -148,7 +151,7 @@ func StartAgent(t *testing.T, binaryPath string, opts ...AgentOption) *Agent {
  */
 
 amends "formae:/Config.pkl"
-
+%s
 agent {
     server {
         port = %d
@@ -179,7 +182,7 @@ cli {
     }
     disableUsageReporting = true%s
 }
-`, port, dbPath, discoveryEnabled, options.discoveryInterval, resourceTypesBlock, logPath, agentAuthBlock, options.resourcePluginsBlock, port, cliAuthBlock)
+`, options.pklImports, port, dbPath, discoveryEnabled, options.discoveryInterval, resourceTypesBlock, logPath, agentAuthBlock, options.resourcePluginsBlock, port, cliAuthBlock)
 
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write agent config: %v", err)

--- a/tests/e2e/go/plugin_config_test.go
+++ b/tests/e2e/go/plugin_config_test.go
@@ -64,9 +64,12 @@ func TestPluginConfig(t *testing.T) {
 			MaxRequestsPerSecond    int      `json:"MaxRequestsPerSecond"`
 			ResourceTypesToDiscover []string `json:"ResourceTypesToDiscover"`
 			LabelTagKeys            []string `json:"LabelTagKeys"`
-			LabelConfig             *struct {
+			LabelConfig *struct {
 				DefaultQuery string `json:"DefaultQuery"`
 			} `json:"LabelConfig"`
+			DiscoveryFilters []struct {
+				ResourceTypes []string `json:"ResourceTypes"`
+			} `json:"DiscoveryFilters"`
 		} `json:"Plugins"`
 	}
 	if err := json.Unmarshal(body, &stats); err != nil {
@@ -93,6 +96,13 @@ func TestPluginConfig(t *testing.T) {
 			t.Run("labelTagKeys override", func(t *testing.T) {
 				if len(p.LabelTagKeys) != 1 || p.LabelTagKeys[0] != "custom-label" {
 					t.Errorf("expected labelTagKeys [custom-label], got %v", p.LabelTagKeys)
+				}
+			})
+
+			t.Run("discovery filters from plugin defaults", func(t *testing.T) {
+				// SFTP plugin returns nil discovery filters — field should be empty
+				if len(p.DiscoveryFilters) != 0 {
+					t.Errorf("expected empty DiscoveryFilters, got %v", p.DiscoveryFilters)
 				}
 			})
 

--- a/tests/e2e/go/plugin_config_test.go
+++ b/tests/e2e/go/plugin_config_test.go
@@ -37,7 +37,7 @@ func TestPluginConfig(t *testing.T) {
             type = "sftp"
             rateLimit { maxRequestsPerSecond = 3 }
             defaultTimeoutSeconds = 60
-            maxConcurrentConnections = 10
+            defaultFilePermissions = "0755"
         }
     }`
 
@@ -102,8 +102,8 @@ func TestPluginConfig(t *testing.T) {
 		if !strings.Contains(allLogs, "defaultTimeoutSeconds=60") {
 			t.Errorf("logs do not contain Configure() output with defaultTimeoutSeconds=60.\nLogs:\n%s", allLogs)
 		}
-		if !strings.Contains(allLogs, "maxConcurrentConnections=10") {
-			t.Errorf("logs do not contain Configure() output with maxConcurrentConnections=10.\nLogs:\n%s", allLogs)
+		if !strings.Contains(allLogs, "defaultFilePermissions=0755") {
+			t.Errorf("logs do not contain Configure() output with defaultFilePermissions=0755.\nLogs:\n%s", allLogs)
 		}
 	})
 }

--- a/tests/e2e/go/plugin_config_test.go
+++ b/tests/e2e/go/plugin_config_test.go
@@ -33,6 +33,17 @@ func TestPluginConfig(t *testing.T) {
             rateLimit { maxRequestsPerSecond = 3 }
             resourceTypesToDiscover { "SFTP::File" }
             labelTagKeys { "custom-label" }
+            discoveryFilters {
+                new MatchFilter {
+                    resourceTypes { "SFTP::File" }
+                    conditions {
+                        new FilterCondition {
+                            propertyPath = "$.hidden"
+                            propertyValue = "true"
+                        }
+                    }
+                }
+            }
             defaultTimeoutSeconds = 60
             defaultFilePermissions = "0755"
         }
@@ -99,10 +110,12 @@ func TestPluginConfig(t *testing.T) {
 				}
 			})
 
-			t.Run("discovery filters from plugin defaults", func(t *testing.T) {
-				// SFTP plugin returns nil discovery filters — field should be empty
-				if len(p.DiscoveryFilters) != 0 {
-					t.Errorf("expected empty DiscoveryFilters, got %v", p.DiscoveryFilters)
+			t.Run("discovery filters override", func(t *testing.T) {
+				if len(p.DiscoveryFilters) != 1 {
+					t.Fatalf("expected 1 discovery filter, got %d", len(p.DiscoveryFilters))
+				}
+				if len(p.DiscoveryFilters[0].ResourceTypes) != 1 || p.DiscoveryFilters[0].ResourceTypes[0] != "SFTP::File" {
+					t.Errorf("expected filter for SFTP::File, got %v", p.DiscoveryFilters[0].ResourceTypes)
 				}
 			})
 

--- a/tests/e2e/go/plugin_config_test.go
+++ b/tests/e2e/go/plugin_config_test.go
@@ -11,30 +11,34 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"strings"
 	"testing"
 	"time"
 )
 
-// TestPluginConfig verifies that per-plugin configuration flows through the
-// full path: PKL config → agent translation → coordinator merge → stats API.
+// TestPluginConfig verifies the full per-plugin configuration flow:
 //
-// It configures the SFTP plugin with overrides for rate limit, label config,
-// and resourceTypesToDiscover, then verifies these merged values are visible
-// in the /api/v1/stats response.
+// 1. Typed PKL config with plugin import → agent translation → coordinator merge
+// 2. Base-class overrides (rate limit, resourceTypesToDiscover) visible in stats API
+// 3. Plugin-specific custom fields (defaultTimeoutSeconds, defaultFilePermissions)
+//    reach the plugin binary via the Configurable interface
 func TestPluginConfig(t *testing.T) {
 	bin := FormaeBinary(t)
 
+	sftpImport := `import "plugins:/Sftp.pkl" as Sftp`
 	resourcePluginsBlock := `
     resourcePlugins {
-        new BaseResourcePluginConfig {
-            type = "sftp"
+        new Sftp.PluginConfig {
             rateLimit { maxRequestsPerSecond = 3 }
             resourceTypesToDiscover { "SFTP::File" }
             labelTagKeys { "custom-label" }
+            defaultTimeoutSeconds = 60
+            defaultFilePermissions = "0755"
         }
     }`
 
-	agent := StartAgent(t, bin, WithResourcePlugins(resourcePluginsBlock))
+	agent := StartAgent(t, bin, WithResourcePlugins(sftpImport, resourcePluginsBlock))
 	baseURL := fmt.Sprintf("http://localhost:%d", agent.Port())
 
 	waitForAgent(t, baseURL, 30*time.Second)
@@ -108,6 +112,25 @@ func TestPluginConfig(t *testing.T) {
 	if !found {
 		t.Errorf("SFTP plugin not found in stats. Plugins: %s", string(body))
 	}
+
+	t.Run("plugin-specific config received via Configure()", func(t *testing.T) {
+		// The SFTP plugin logs its config when Configure() is called.
+		// Check the agent stdout log for the expected output.
+		var allLogs string
+		if content, err := os.ReadFile(agent.LogFile()); err == nil {
+			allLogs += string(content)
+		}
+		if content, err := os.ReadFile(agent.StdoutLogFile()); err == nil {
+			allLogs += string(content)
+		}
+
+		if !strings.Contains(allLogs, "defaultTimeoutSeconds=60") {
+			t.Errorf("expected Configure() log with defaultTimeoutSeconds=60\nLogs:\n%s", allLogs)
+		}
+		if !strings.Contains(allLogs, "defaultFilePermissions=0755") {
+			t.Errorf("expected Configure() log with defaultFilePermissions=0755\nLogs:\n%s", allLogs)
+		}
+	})
 }
 
 // waitForAgent polls the health endpoint until the agent is ready.

--- a/tests/e2e/go/plugin_config_test.go
+++ b/tests/e2e/go/plugin_config_test.go
@@ -1,0 +1,126 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build e2e
+
+package e2e_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPluginConfig verifies that per-plugin configuration flows through the
+// full path: PKL config → agent translation → supervisor env var → SDK
+// Configure() call on the plugin binary.
+//
+// It bundles the SFTP plugin (installed by make install-external-plugins)
+// and configures it with a custom rate limit override and plugin-specific
+// fields (defaultTimeoutSeconds, maxConcurrentConnections). The test verifies:
+//
+// 1. The SFTP plugin appears in /api/v1/stats with the overridden rate limit
+// 2. The agent log contains the SFTP plugin's Configure() output showing
+//    the custom config values were received
+func TestPluginConfig(t *testing.T) {
+	bin := FormaeBinary(t)
+
+	resourcePluginsBlock := `
+    resourcePlugins {
+        new {
+            type = "sftp"
+            rateLimit { maxRequestsPerSecond = 3 }
+            defaultTimeoutSeconds = 60
+            maxConcurrentConnections = 10
+        }
+    }`
+
+	agent := StartAgent(t, bin, WithResourcePlugins(resourcePluginsBlock))
+	baseURL := fmt.Sprintf("http://localhost:%d", agent.Port())
+
+	// Wait for the agent to be ready
+	waitForAgent(t, baseURL, 30*time.Second)
+
+	// Give the SFTP plugin time to start and announce
+	time.Sleep(3 * time.Second)
+
+	t.Run("SFTP plugin registered with overridden rate limit", func(t *testing.T) {
+		resp, err := http.Get(baseURL + "/api/v1/stats")
+		if err != nil {
+			t.Fatalf("stats request failed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		var stats struct {
+			Plugins []struct {
+				Namespace            string `json:"Namespace"`
+				MaxRequestsPerSecond int    `json:"MaxRequestsPerSecond"`
+			} `json:"Plugins"`
+		}
+		if err := json.Unmarshal(body, &stats); err != nil {
+			t.Fatalf("failed to parse stats: %v", err)
+		}
+
+		var found bool
+		for _, p := range stats.Plugins {
+			if p.Namespace == "SFTP" {
+				found = true
+				if p.MaxRequestsPerSecond != 3 {
+					t.Errorf("expected SFTP rate limit 3, got %d", p.MaxRequestsPerSecond)
+				}
+				break
+			}
+		}
+		if !found {
+			t.Errorf("SFTP plugin not found in stats. Plugins: %+v", stats.Plugins)
+		}
+	})
+
+	t.Run("SFTP plugin received custom config via Configure()", func(t *testing.T) {
+		// The SFTP plugin prints "SFTP plugin configured: defaultTimeoutSeconds=60 maxConcurrentConnections=10"
+		// to stdout when Configure() is called. The supervisor captures plugin stdout and
+		// logs it to the agent's log file. Check both the agent log and stdout capture.
+		var allLogs string
+		if content, err := os.ReadFile(agent.LogFile()); err == nil {
+			allLogs += string(content)
+		}
+		if content, err := os.ReadFile(agent.StdoutLogFile()); err == nil {
+			allLogs += string(content)
+		}
+
+		if !strings.Contains(allLogs, "defaultTimeoutSeconds=60") {
+			t.Errorf("logs do not contain Configure() output with defaultTimeoutSeconds=60.\nLogs:\n%s", allLogs)
+		}
+		if !strings.Contains(allLogs, "maxConcurrentConnections=10") {
+			t.Errorf("logs do not contain Configure() output with maxConcurrentConnections=10.\nLogs:\n%s", allLogs)
+		}
+	})
+}
+
+// waitForAgent polls the health endpoint until the agent is ready.
+func waitForAgent(t *testing.T, baseURL string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/api/v1/health")
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("agent not ready after %v", timeout)
+}

--- a/tests/e2e/go/plugin_config_test.go
+++ b/tests/e2e/go/plugin_config_test.go
@@ -30,9 +30,8 @@ func TestPluginConfig(t *testing.T) {
 	resourcePluginsBlock := `
     resourcePlugins {
         new Sftp.PluginConfig {
-            rateLimit { maxRequestsPerSecond = 3 }
+            rateLimit { maxRequestsPerSecondForNamespace = 3 }
             resourceTypesToDiscover { "SFTP::File" }
-            labelTagKeys { "custom-label" }
             discoveryFilters {
                 new MatchFilter {
                     resourceTypes { "SFTP::File" }
@@ -74,7 +73,6 @@ func TestPluginConfig(t *testing.T) {
 			Namespace               string   `json:"Namespace"`
 			MaxRequestsPerSecond    int      `json:"MaxRequestsPerSecond"`
 			ResourceTypesToDiscover []string `json:"ResourceTypesToDiscover"`
-			LabelTagKeys            []string `json:"LabelTagKeys"`
 			LabelConfig *struct {
 				DefaultQuery string `json:"DefaultQuery"`
 			} `json:"LabelConfig"`
@@ -101,12 +99,6 @@ func TestPluginConfig(t *testing.T) {
 			t.Run("resourceTypesToDiscover override", func(t *testing.T) {
 				if len(p.ResourceTypesToDiscover) != 1 || p.ResourceTypesToDiscover[0] != "SFTP::File" {
 					t.Errorf("expected resourceTypesToDiscover [SFTP::File], got %v", p.ResourceTypesToDiscover)
-				}
-			})
-
-			t.Run("labelTagKeys override", func(t *testing.T) {
-				if len(p.LabelTagKeys) != 1 || p.LabelTagKeys[0] != "custom-label" {
-					t.Errorf("expected labelTagKeys [custom-label], got %v", p.LabelTagKeys)
 				}
 			})
 

--- a/tests/e2e/go/plugin_config_test.go
+++ b/tests/e2e/go/plugin_config_test.go
@@ -11,8 +11,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
-	"strings"
 	"testing"
 	"time"
 )
@@ -33,11 +31,9 @@ func TestPluginConfig(t *testing.T) {
 
 	resourcePluginsBlock := `
     resourcePlugins {
-        new {
+        new BaseResourcePluginConfig {
             type = "sftp"
             rateLimit { maxRequestsPerSecond = 3 }
-            defaultTimeoutSeconds = 60
-            defaultFilePermissions = "0755"
         }
     }`
 
@@ -87,25 +83,10 @@ func TestPluginConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("SFTP plugin received custom config via Configure()", func(t *testing.T) {
-		// The SFTP plugin prints "SFTP plugin configured: defaultTimeoutSeconds=60 maxConcurrentConnections=10"
-		// to stdout when Configure() is called. The supervisor captures plugin stdout and
-		// logs it to the agent's log file. Check both the agent log and stdout capture.
-		var allLogs string
-		if content, err := os.ReadFile(agent.LogFile()); err == nil {
-			allLogs += string(content)
-		}
-		if content, err := os.ReadFile(agent.StdoutLogFile()); err == nil {
-			allLogs += string(content)
-		}
-
-		if !strings.Contains(allLogs, "defaultTimeoutSeconds=60") {
-			t.Errorf("logs do not contain Configure() output with defaultTimeoutSeconds=60.\nLogs:\n%s", allLogs)
-		}
-		if !strings.Contains(allLogs, "defaultFilePermissions=0755") {
-			t.Errorf("logs do not contain Configure() output with defaultFilePermissions=0755.\nLogs:\n%s", allLogs)
-		}
-	})
+	// Note: Testing custom plugin-specific config fields (defaultTimeoutSeconds,
+	// defaultFilePermissions) requires a typed PKL import via plugins:/ scheme.
+	// That's tested via the SFTP plugin's unit tests and conformance tests.
+	// The e2e test here validates the base-class override path (rate limit).
 }
 
 // waitForAgent polls the health endpoint until the agent is ready.

--- a/tests/e2e/go/plugin_config_test.go
+++ b/tests/e2e/go/plugin_config_test.go
@@ -16,16 +16,11 @@ import (
 )
 
 // TestPluginConfig verifies that per-plugin configuration flows through the
-// full path: PKL config → agent translation → supervisor env var → SDK
-// Configure() call on the plugin binary.
+// full path: PKL config → agent translation → coordinator merge → stats API.
 //
-// It bundles the SFTP plugin (installed by make install-external-plugins)
-// and configures it with a custom rate limit override and plugin-specific
-// fields (defaultTimeoutSeconds, maxConcurrentConnections). The test verifies:
-//
-// 1. The SFTP plugin appears in /api/v1/stats with the overridden rate limit
-// 2. The agent log contains the SFTP plugin's Configure() output showing
-//    the custom config values were received
+// It configures the SFTP plugin with overrides for rate limit, label config,
+// and resourceTypesToDiscover, then verifies these merged values are visible
+// in the /api/v1/stats response.
 func TestPluginConfig(t *testing.T) {
 	bin := FormaeBinary(t)
 
@@ -34,59 +29,85 @@ func TestPluginConfig(t *testing.T) {
         new BaseResourcePluginConfig {
             type = "sftp"
             rateLimit { maxRequestsPerSecond = 3 }
+            resourceTypesToDiscover { "SFTP::File" }
+            labelTagKeys { "custom-label" }
         }
     }`
 
 	agent := StartAgent(t, bin, WithResourcePlugins(resourcePluginsBlock))
 	baseURL := fmt.Sprintf("http://localhost:%d", agent.Port())
 
-	// Wait for the agent to be ready
 	waitForAgent(t, baseURL, 30*time.Second)
 
-	// Give the SFTP plugin time to start and announce
+	// Give plugins time to start and announce
 	time.Sleep(3 * time.Second)
 
-	t.Run("SFTP plugin registered with overridden rate limit", func(t *testing.T) {
-		resp, err := http.Get(baseURL + "/api/v1/stats")
-		if err != nil {
-			t.Fatalf("stats request failed: %v", err)
-		}
-		defer func() { _ = resp.Body.Close() }()
+	resp, err := http.Get(baseURL + "/api/v1/stats")
+	if err != nil {
+		t.Fatalf("stats request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
 
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected 200, got %d", resp.StatusCode)
-		}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
 
-		body, _ := io.ReadAll(resp.Body)
-		var stats struct {
-			Plugins []struct {
-				Namespace            string `json:"Namespace"`
-				MaxRequestsPerSecond int    `json:"MaxRequestsPerSecond"`
-			} `json:"Plugins"`
-		}
-		if err := json.Unmarshal(body, &stats); err != nil {
-			t.Fatalf("failed to parse stats: %v", err)
-		}
+	body, _ := io.ReadAll(resp.Body)
 
-		var found bool
-		for _, p := range stats.Plugins {
-			if p.Namespace == "SFTP" {
-				found = true
+	var stats struct {
+		Plugins []struct {
+			Namespace               string   `json:"Namespace"`
+			MaxRequestsPerSecond    int      `json:"MaxRequestsPerSecond"`
+			ResourceTypesToDiscover []string `json:"ResourceTypesToDiscover"`
+			LabelTagKeys            []string `json:"LabelTagKeys"`
+			LabelConfig             *struct {
+				DefaultQuery string `json:"DefaultQuery"`
+			} `json:"LabelConfig"`
+		} `json:"Plugins"`
+	}
+	if err := json.Unmarshal(body, &stats); err != nil {
+		t.Fatalf("failed to parse stats: %v\nbody: %s", err, string(body))
+	}
+
+	var found bool
+	for _, p := range stats.Plugins {
+		if p.Namespace == "SFTP" {
+			found = true
+
+			t.Run("rate limit override", func(t *testing.T) {
 				if p.MaxRequestsPerSecond != 3 {
-					t.Errorf("expected SFTP rate limit 3, got %d", p.MaxRequestsPerSecond)
+					t.Errorf("expected rate limit 3, got %d", p.MaxRequestsPerSecond)
 				}
-				break
-			}
-		}
-		if !found {
-			t.Errorf("SFTP plugin not found in stats. Plugins: %+v", stats.Plugins)
-		}
-	})
+			})
 
-	// Note: Testing custom plugin-specific config fields (defaultTimeoutSeconds,
-	// defaultFilePermissions) requires a typed PKL import via plugins:/ scheme.
-	// That's tested via the SFTP plugin's unit tests and conformance tests.
-	// The e2e test here validates the base-class override path (rate limit).
+			t.Run("resourceTypesToDiscover override", func(t *testing.T) {
+				if len(p.ResourceTypesToDiscover) != 1 || p.ResourceTypesToDiscover[0] != "SFTP::File" {
+					t.Errorf("expected resourceTypesToDiscover [SFTP::File], got %v", p.ResourceTypesToDiscover)
+				}
+			})
+
+			t.Run("labelTagKeys override", func(t *testing.T) {
+				if len(p.LabelTagKeys) != 1 || p.LabelTagKeys[0] != "custom-label" {
+					t.Errorf("expected labelTagKeys [custom-label], got %v", p.LabelTagKeys)
+				}
+			})
+
+			t.Run("label config from plugin defaults", func(t *testing.T) {
+				if p.LabelConfig == nil {
+					t.Fatal("expected LabelConfig to be present")
+				}
+				// SFTP plugin default: $.path
+				if p.LabelConfig.DefaultQuery != "$.path" {
+					t.Errorf("expected LabelConfig.DefaultQuery '$.path', got %q", p.LabelConfig.DefaultQuery)
+				}
+			})
+
+			break
+		}
+	}
+	if !found {
+		t.Errorf("SFTP plugin not found in stats. Plugins: %s", string(body))
+	}
 }
 
 // waitForAgent polls the health endpoint until the agent is ready.

--- a/tests/testplugin/plugin.go
+++ b/tests/testplugin/plugin.go
@@ -80,7 +80,8 @@ func (p *TestPlugin) RateLimit() model.RateLimitConfig {
 		// 60+ concurrent PluginOperator CRUD calls on the plugin Ergo node,
 		// which delays cross-node message delivery to the TestController and
 		// causes test harness call timeouts.
-		MaxRequestsPerSecond: 20,
+		Scope:                            model.RateLimitScopeNamespace,
+		MaxRequestsPerSecondForNamespace: 20,
 	}
 }
 

--- a/tests/testplugin/plugin.go
+++ b/tests/testplugin/plugin.go
@@ -74,14 +74,13 @@ func (p *TestPlugin) SupportedResources() []plugin.ResourceDescriptor {
 	}
 }
 
-func (p *TestPlugin) RateLimit() plugin.RateLimitConfig {
-	return plugin.RateLimitConfig{
-		Scope:                            plugin.RateLimitScopeNamespace,
+func (p *TestPlugin) RateLimit() model.RateLimitConfig {
+	return model.RateLimitConfig{
 		// Keep rate limit realistic. Higher values (e.g. 100) cause bursts of
 		// 60+ concurrent PluginOperator CRUD calls on the plugin Ergo node,
 		// which delays cross-node message delivery to the TestController and
 		// causes test harness call timeouts.
-		MaxRequestsPerSecondForNamespace: 20,
+		MaxRequestsPerSecond: 20,
 	}
 }
 
@@ -316,12 +315,12 @@ func (p *TestPlugin) List(_ context.Context, request *resource.ListRequest) (*re
 	}, nil
 }
 
-func (p *TestPlugin) DiscoveryFilters() []plugin.MatchFilter {
+func (p *TestPlugin) DiscoveryFilters() []model.MatchFilter {
 	return nil
 }
 
-func (p *TestPlugin) LabelConfig() plugin.LabelConfig {
-	return plugin.LabelConfig{
+func (p *TestPlugin) LabelConfig() model.LabelConfig {
+	return model.LabelConfig{
 		DefaultQuery:      "$.Name",
 		ResourceOverrides: map[string]string{},
 	}


### PR DESCRIPTION
## Summary

Adds per-plugin resource configuration via `agent.resourcePlugins` in the user's `formae.conf.pkl`. Each plugin can now have its own rate limit, retry behavior, discovery filters, label config, and resource types to discover — previously these were global settings that applied to all plugins equally.

Additionally, plugins that implement the new `Configurable` interface can receive custom, plugin-specific configuration fields (e.g., connection timeouts, file permissions) that are passed through from the PKL config to the plugin binary at startup.

### What moved from global to per-plugin config

**Previously hardcoded in plugins, now user-configurable:**

| Setting | Per-plugin location |
|---------|---------------------|
| Rate limit | \`resourcePlugins[*].rateLimit\` |
| Discovery filters | \`resourcePlugins[*].discoveryFilters\` |
| Label config | \`resourcePlugins[*].labelConfig\` |

Plugin defaults still apply when no user override is set.

**Previously global, now per-plugin:**

| Setting | Old global location | Per-plugin location |
|---------|---------------------|---------------------|
| Retry config | \`agent.retry\` | \`resourcePlugins[*].retry\` |
| Resource types to discover | \`agent.discovery.resourceTypesToDiscover\` | \`resourcePlugins[*].resourceTypesToDiscover\` |

Global settings continue to work as fallback defaults. When a per-plugin override is set, it takes precedence with a deprecation warning for the global equivalent.

### PKL config examples

**Single plugin with overrides:**

```pkl
amends "formae:/Config.pkl"
import "plugins:/Aws.pkl" as Aws

agent {
    resourcePlugins {
        new Aws.PluginConfig {
            rateLimit { maxRequestsPerSecondForNamespace = 5 }
            resourceTypesToDiscover { "AWS::S3::Bucket"; "AWS::EC2::Instance" }
            retry {
                maxRetries = 5
                retryDelay = 15.s
                statusCheckInterval = 10.s
            }
        }
    }
}
```

**Multiple plugins, custom fields, and disabling a plugin:**

```pkl
amends "formae:/Config.pkl"
import "plugins:/Aws.pkl" as Aws
import "plugins:/Sftp.pkl" as Sftp
import "plugins:/Oci.pkl" as Oci

agent {
    resourcePlugins {
        new Aws.PluginConfig {
            rateLimit { maxRequestsPerSecondForNamespace = 3 }
            discoveryFilters {
                new MatchFilter {
                    resourceTypes { "AWS::EC2::Instance" }
                    conditions {
                        new FilterCondition {
                            propertyPath = "$.Tags[?(@.Key=='Environment')].Value"
                            propertyValue = "staging"
                        }
                    }
                }
            }
        }
        new Sftp.PluginConfig {
            rateLimit { maxRequestsPerSecondForNamespace = 2 }
            resourceTypesToDiscover { "SFTP::File" }
            retry {
                maxRetries = 3
                retryDelay = 5.s
            }
            // Plugin-specific fields (require Configurable interface)
            defaultTimeoutSeconds = 60
            defaultFilePermissions = "0755"
        }
        new Oci.PluginConfig {
            enabled = false
        }
    }
}
```

### Plugin SDK: `Configurable` interface

Plugins that want to receive custom configuration implement the optional `Configurable` interface:

```go
type Configurable interface {
    Configure(config json.RawMessage) error
}
```

The SDK reads the plugin-specific fields (everything beyond `BaseResourcePluginConfig`) from the `FORMAE_PLUGIN_CONFIG` env var and calls `Configure()` once during startup. Plugin authors define their config shape in a `schema/Config.pkl` that extends `BaseResourcePluginConfig`.

### Key changes

- **PKL schema**: `BaseResourcePluginConfig` open class with rate limit, retry, discovery filters, label config, resource types to discover
- **Config translation**: `translateResourcePluginConfigs` in `pkl.go` extracts known fields, marshals remainder into `PluginConfig` for plugin-specific fields
- **PluginCoordinator**: merges user config with plugin-announced defaults; disabled plugins (`enabled=false`) skipped; per-plugin retry resolution; config lookup by plugin name (not namespace)
- **PluginProcessSupervisor**: passes `FORMAE_PLUGIN_CONFIG` env var per-plugin
- **Discovery**: uses per-plugin `resourceTypesToDiscover` from coordinator
- **Stats API**: `PluginInfo` includes merged config fields (rate limit, retry, label config, discovery filters, resource types)
- **Plugin template**: `formae plugin init` generates `schema/Config.pkl` with `type` field auto-populated
- **E2e test**: `TestPluginConfig` validates full flow with typed SFTP import, base-class overrides, and `Configure()` callback

### External plugin updates

All resource plugins updated on `feat/resource-plugin-config` branches:
- Import path changes: `plugin.RateLimitConfig` → `model.RateLimitConfig` (types moved to `pkg/model`)
- `RateLimitConfig` fields: `Scope` + `MaxRequestsPerSecondForNamespace` (restored to match published interface)
- Nightly workflows updated with "Inject formae replace directives" step

### pkl-go fix

Fork at `github.com/JeroenSoeters/pkl-go` branch `fix/decode-typed-class-to-interface` (tagged `v0.12.1-pel.1`): fixes typed class instances into `interface{}` decoding as `*pkl.Object` instead of erroring. Required for typed plugin config imports.
