### PR TITLE
feat(schema): add MappingResolvable and ListingResolvable for collection access

### DIFF
--- a/internal/metastructure/resolver/resolver_test.go
+++ b/internal/metastructure/resolver/resolver_test.go
@@ -1386,3 +1386,28 @@ func newTestRef(property string) string {
 	ksuid := util.NewID()
 	return fmt.Sprintf("formae://%s#/%s", ksuid, property)
 }
+
+func TestExtractPropertyValue_MapKey(t *testing.T) {
+	properties := []byte(`{"endpoints":{"lgtm:3000":"http://localhost:3000","lgtm:4318":"http://localhost:4318"}}`)
+	result := gjson.GetBytes(properties, `endpoints.lgtm\:3000`)
+	require.True(t, result.Exists())
+	assert.Equal(t, "http://localhost:3000", result.String())
+}
+
+func TestExtractPropertyValue_ListIndexField(t *testing.T) {
+	properties := []byte(`{"endpoints":[{"uri":"https://db-1.ovh.net:5432","component":"postgresql"},{"uri":"https://db-2.ovh.net:5432","component":"replica"}]}`)
+	result := gjson.GetBytes(properties, "endpoints.0.uri")
+	require.True(t, result.Exists())
+	assert.Equal(t, "https://db-1.ovh.net:5432", result.String())
+
+	result2 := gjson.GetBytes(properties, "endpoints.1.component")
+	require.True(t, result2.Exists())
+	assert.Equal(t, "replica", result2.String())
+}
+
+func TestExtractPropertyValue_EscapedDotInKey(t *testing.T) {
+	properties := []byte(`{"config":{"host.name":"example.com"}}`)
+	result := gjson.GetBytes(properties, `config.host\.name`)
+	require.True(t, result.Exists())
+	assert.Equal(t, "example.com", result.String())
+}

--- a/internal/schema/pkl/generator/gen.pkl
+++ b/internal/schema/pkl/generator/gen.pkl
@@ -272,6 +272,38 @@ function applyPropertyWithMapping(valueAsMap: Map, prop: reflect.Property, rever
         else
             null
 
+/// Renders a resolvable property path as valid PKL.
+/// Simple paths like "arn" render as "arn".
+/// Collection paths like "endpoints.lgtm\:3000" render as "endpoints.at("lgtm:3000")".
+/// Nested paths like "endpoints.0.uri" render as "endpoints.at(0).at("uri")".
+function renderResolvableProperty(property: String): String =
+    if (!property.contains("."))
+        // Simple scalar property — render as-is
+        property
+    else
+        // Collection path — split on unescaped dots and render at() chain
+        let (segments = splitGjsonPath(property))
+        let (base = segments[0])
+        let (rest = segments.drop(1))
+        base + rest.fold("", (acc, seg) ->
+            let (unescaped = seg.replaceAll("\\:", ":").replaceAll("\\.", "."))
+            // Numeric segments are list indices, otherwise map keys
+            if (unescaped.matches(Regex("[0-9]+")))
+                acc + ".at(" + unescaped + ")"
+            else
+                acc + ".at(\"" + unescaped + "\")"
+        )
+
+/// Splits a gjson path on unescaped dots.
+/// "endpoints.lgtm\:3000" -> ["endpoints", "lgtm\:3000"]
+/// "endpoints.0.uri" -> ["endpoints", "0", "uri"]
+function splitGjsonPath(path: String): List<String> =
+    // Replace escaped dots with a placeholder, split on dots, restore
+    let (placeholder = "<<ESCAPED_DOT>>")
+    let (escaped = path.replaceAll("\\.", placeholder))
+    let (parts = escaped.split("."))
+    parts.map((p) -> p.replaceAll(placeholder, "\\."))
+
 function getResolvablePropertyMapping(typeName: String): Map<String, String> =
     if (resolvables.MapResolvableResourceUri().containsKey(typeName))
         let (resolvableInfo = resolvables.MapResolvableResourceUri()[typeName])
@@ -306,13 +338,20 @@ local function applyDynamicOrMapping(type: reflect.Class, value: Dynamic|Mapping
         let (property = valueAsMap.getOrNull("$property"))
         let (resolvableMapping = getResolvablePropertyMapping(typeName))
         let (mappedProperty =
-            if (property != null && resolvableMapping.containsKey(property))
-                resolvableMapping[property]
-            else if (property != null)
-               // This should not happen
-               property
-            else
+            if (property == null)
                 null
+            else if (resolvableMapping.containsKey(property))
+                // Direct match — simple scalar property
+                resolvableMapping[property]
+            else if (property.contains("."))
+                // Collection path — map the base segment, keep the rest
+                let (segments = splitGjsonPath(property))
+                let (base = segments[0])
+                let (rest = segments.drop(1))
+                let (mappedBase = if (resolvableMapping.containsKey(base)) resolvableMapping[base] else base)
+                mappedBase + rest.fold("", (acc, seg) -> acc + "." + seg)
+            else
+                property
         )
         let (r = new FakeResolvable {
             stack = s
@@ -599,7 +638,7 @@ local function formatValueWithTypes(value: Any, indent: String): String =
               comment + "\n" +
               (if (stack != null) indent + "  stack = \"\(stack)\" //resolvable\n" else "") +
               (if (label != null) indent + "  label = \"\(label)\"\n" else "") +
-              indent + "}.\(property)"
+              indent + "}." + renderResolvableProperty(property)
         else if (typeName == "FakeValue")
           // Special handling for FakeValue - render using fluent API
           let (fakeValue = value.getOrNull("FakeValue"))

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -274,6 +274,41 @@ open class Resolvable {
     $visibility: String = visibility
 }
 
+/// Resolvable that resolves to a Mapping. Supports key-based access via at().
+/// Usage: stack.res.endpoints.at("service:3000")
+open class MappingResolvable extends Resolvable {
+    local _self = this
+    /// Access a value by its key in the resolved Mapping.
+    /// Special characters (colons, dots) are escaped automatically for gjson.
+    function at(key: String): Resolvable = new Resolvable {
+        label = _self.label
+        type = _self.type
+        stack = _self.stack
+        property = if (_self.property != null)
+            _self.property + "." + key.replaceAll(":", "\\:").replaceAll(".", "\\.")
+            else key.replaceAll(":", "\\:").replaceAll(".", "\\.")
+        visibility = _self.visibility
+    }
+}
+
+/// Resolvable that resolves to a Listing. Supports index-based access via at().
+/// Returns MappingResolvable by default. Plugin authors can subclass and
+/// override at() to return a typed element resolvable for ergonomic field
+/// access (e.g., svc.res.endpoints.at(0).uri).
+open class ListingResolvable extends Resolvable {
+    local _self = this
+    /// Access an element by its index in the resolved Listing.
+    function at(index: Int): MappingResolvable = new MappingResolvable {
+        label = _self.label
+        type = _self.type
+        stack = _self.stack
+        property = if (_self.property != null)
+            _self.property + "." + index.toString()
+            else index.toString()
+        visibility = _self.visibility
+    }
+}
+
 open class Value {
     hidden value: String
     hidden visibility: "Clear"|"Opaque" = "Clear"

--- a/internal/schema/pkl/schema/tests/collection_resolvable_test.pkl
+++ b/internal/schema/pkl/schema/tests/collection_resolvable_test.pkl
@@ -1,0 +1,86 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+/// Tests for MappingResolvable and ListingResolvable.
+/// Run with: pkl test internal/schema/pkl/schema/tests/collection_resolvable_test.pkl
+amends "pkl:test"
+
+import "../formae.pkl"
+
+// Simulate a compose stack resolvable with a Mapping property
+local open class TestStackResolvable extends formae.Resolvable {
+    local _self = this
+    hidden endpoints: formae.MappingResolvable = new formae.MappingResolvable {
+        label = _self.label
+        type = _self.type
+        stack = _self.stack
+        property = "endpoints"
+    }
+    hidden projectName: formae.Resolvable = new formae.Resolvable {
+        label = _self.label
+        type = _self.type
+        stack = _self.stack
+        property = "projectName"
+    }
+}
+
+// Simulate an OVH service resolvable with a Listing property
+local open class TestServiceResolvable extends formae.Resolvable {
+    local _self = this
+    hidden endpoints: formae.ListingResolvable = new formae.ListingResolvable {
+        label = _self.label
+        type = _self.type
+        stack = _self.stack
+        property = "endpoints"
+    }
+}
+
+local stack = new TestStackResolvable {
+    label = "lgtm"
+    type = "Docker::Compose::Stack"
+}
+
+local svc = new TestServiceResolvable {
+    label = "db"
+    type = "OVH::Database::Service"
+}
+
+facts {
+    ["MappingResolvable.at() builds correct property path"] {
+        stack.endpoints.at("lgtm:3000").$property == "endpoints.lgtm\\:3000"
+    }
+
+    ["MappingResolvable.at() preserves label and type"] {
+        stack.endpoints.at("key").$label == "lgtm"
+        stack.endpoints.at("key").$type == "Docker::Compose::Stack"
+    }
+
+    ["MappingResolvable.at() escapes dots in keys"] {
+        stack.endpoints.at("host.name").$property == "endpoints.host\\.name"
+    }
+
+    ["MappingResolvable.at() returns a resolvable"] {
+        stack.endpoints.at("key").$res == true
+    }
+
+    ["ListingResolvable.at() builds correct property path"] {
+        svc.endpoints.at(0).$property == "endpoints.0"
+    }
+
+    ["ListingResolvable.at() chains with MappingResolvable.at() for nested access"] {
+        svc.endpoints.at(0).at("uri").$property == "endpoints.0.uri"
+    }
+
+    ["ListingResolvable.at() preserves label and type"] {
+        svc.endpoints.at(0).$label == "db"
+        svc.endpoints.at(0).$type == "OVH::Database::Service"
+    }
+
+    ["Scalar resolvable has correct property path"] {
+        stack.projectName.$property == "projectName"
+        stack.projectName.$label == "lgtm"
+    }
+}


### PR DESCRIPTION
## Summary

Adds two new resolvable types to the core PKL schema for indexing into collection-typed properties:

- `MappingResolvable` — `at(key: String)` for map key access (e.g., compose endpoints)
- `ListingResolvable` — `at(index: Int)` for list index access (e.g., OVH endpoints)

Both build gjson-compatible property paths. No engine changes — the resolver already supports these paths.

## Motivation

Collection resolvable properties (Compose `endpoints: Mapping`, OVH `endpoints: Listing`) couldn't be indexed — users got the entire collection instead of a single value. This blocked wiring compose stack endpoints into Grafana target configs without workarounds.

## Schema Pre-release

The 0.84.0 schema has been published with these types via the `schema/config-field-hint` branch.