### PR TITLE
chore: point plugin refs to feat/msgpack-serialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,14 @@ PKL_BIN_URL := https://github.com/apple/pkl/releases/download/${PKL_BUNDLE_VERSI
 # Without @ref, the default branch (main) is used.
 EXTERNAL_PLUGIN_REPOS ?= \
     https://github.com/platform-engineering-labs/formae-plugin-auth-basic.git \
-    https://github.com/platform-engineering-labs/formae-plugin-aws.git@feat/resource-plugin-config \
-    https://github.com/platform-engineering-labs/formae-plugin-azure.git@feat/resource-plugin-config \
-    https://github.com/platform-engineering-labs/formae-plugin-compose.git@feat/resource-plugin-config \
-    https://github.com/platform-engineering-labs/formae-plugin-gcp.git@feat/resource-plugin-config \
-    https://github.com/platform-engineering-labs/formae-plugin-grafana.git@feat/resource-plugin-config \
-    https://github.com/platform-engineering-labs/formae-plugin-oci.git@feat/resource-plugin-config \
-    https://github.com/platform-engineering-labs/formae-plugin-ovh.git@feat/resource-plugin-config \
-    https://github.com/platform-engineering-labs/formae-plugin-sftp.git@feat/resource-plugin-config
+    https://github.com/platform-engineering-labs/formae-plugin-aws.git@feat/msgpack-serialization \
+    https://github.com/platform-engineering-labs/formae-plugin-azure.git@feat/msgpack-serialization \
+    https://github.com/platform-engineering-labs/formae-plugin-compose.git@feat/msgpack-serialization \
+    https://github.com/platform-engineering-labs/formae-plugin-gcp.git@feat/msgpack-serialization \
+    https://github.com/platform-engineering-labs/formae-plugin-grafana.git@feat/msgpack-serialization \
+    https://github.com/platform-engineering-labs/formae-plugin-oci.git@feat/msgpack-serialization \
+    https://github.com/platform-engineering-labs/formae-plugin-ovh.git@feat/msgpack-serialization \
+    https://github.com/platform-engineering-labs/formae-plugin-sftp.git@feat/msgpack-serialization
 
 # Directory for cloned plugins
 PLUGINS_CACHE := .plugins


### PR DESCRIPTION
## Summary

- Switch all external plugin refs from `@feat/resource-plugin-config` to `@feat/msgpack-serialization`
- The resource-plugin-config changes have been merged into the msgpack branches, consolidating to a single feature branch per plugin
- Unblocks e2e tests on branches that depend on the msgpack wire protocol + config type moves