### PR TITLE
refactor(plugin-config): unify config handling and surface silent drops

### DIFF
--- a/internal/metastructure/plugin_coordinator/plugin_coordinator.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator.go
@@ -27,11 +27,59 @@ import (
 type PluginCoordinator struct {
 	act.Actor
 
-	plugins                   map[string]*RegisteredPlugin // namespace → plugin info (remote)
-	registeredLocalNamespaces map[string]bool              // namespaces registered with RateLimiter (local)
-	testPlugin                plugin.FullResourcePlugin    // test-only: directly injected plugin (e.g. FakeAWS) for workflow tests
+	plugins                   *namespaceRegistry        // namespace → plugin info (remote), case-insensitive
+	registeredLocalNamespaces *namespaceSet             // namespaces registered with RateLimiter (local), case-insensitive
+	testPlugin                plugin.FullResourcePlugin // test-only: directly injected plugin (e.g. FakeAWS) for workflow tests
 	retryConfig               model.RetryConfig
 	resourcePluginConfigs     map[string]model.ResourcePluginUserConfig // keyed by plugin name (lowercase)
+}
+
+// namespaceRegistry is a case-insensitive map keyed by plugin namespace.
+// Keys are normalized to lowercase on Set; Get/Delete lowercase their input.
+// The stored RegisteredPlugin.Namespace field keeps the announcement's original
+// casing for display; only the map key is canonical.
+type namespaceRegistry struct {
+	m map[string]*RegisteredPlugin
+}
+
+func newNamespaceRegistry() *namespaceRegistry {
+	return &namespaceRegistry{m: make(map[string]*RegisteredPlugin)}
+}
+
+func (r *namespaceRegistry) Set(ns string, p *RegisteredPlugin) {
+	r.m[strings.ToLower(ns)] = p
+}
+
+func (r *namespaceRegistry) Get(ns string) (*RegisteredPlugin, bool) {
+	p, ok := r.m[strings.ToLower(ns)]
+	return p, ok
+}
+
+func (r *namespaceRegistry) Delete(ns string) {
+	delete(r.m, strings.ToLower(ns))
+}
+
+// All returns the underlying map for iteration. Callers must not mutate it.
+func (r *namespaceRegistry) All() map[string]*RegisteredPlugin {
+	return r.m
+}
+
+// namespaceSet is a case-insensitive set of namespaces.
+type namespaceSet struct {
+	m map[string]struct{}
+}
+
+func newNamespaceSet() *namespaceSet {
+	return &namespaceSet{m: make(map[string]struct{})}
+}
+
+func (s *namespaceSet) Has(ns string) bool {
+	_, ok := s.m[strings.ToLower(ns)]
+	return ok
+}
+
+func (s *namespaceSet) Add(ns string) {
+	s.m[strings.ToLower(ns)] = struct{}{}
 }
 
 // RegisteredPlugin contains information about a registered plugin
@@ -51,22 +99,6 @@ type RegisteredPlugin struct {
 	// Per-plugin config (merged from user config)
 	ResourceTypesToDiscover []string
 	RetryConfig             *model.RetryConfig
-}
-
-// findPluginByNamespace performs a case-insensitive lookup for a plugin by namespace.
-// We use case-insensitive matching because different parts of the system may use different
-// casing conventions for namespaces. For example, the PKL Target schema normalizes namespace
-// to uppercase (via toUpperCase()), while plugins may register with mixed case (e.g., "Azure"
-// vs "AZURE"). This ensures seamless plugin discovery regardless of casing.
-// Note: If we ever need to support plugins with the same name but different casing (unlikely),
-// we would need to revisit this approach.
-func (c *PluginCoordinator) findPluginByNamespace(namespace string) (*RegisteredPlugin, bool) {
-	for ns, plugin := range c.plugins {
-		if strings.EqualFold(ns, namespace) {
-			return plugin, true
-		}
-	}
-	return nil, false
 }
 
 // findTestPlugin returns the test plugin if it matches the given namespace (case-insensitive).
@@ -98,9 +130,14 @@ func (c *PluginCoordinator) mergePluginConfig(name, namespace string, announced 
 		if userCfg.LabelConfig != nil {
 			merged.LabelConfig = *userCfg.LabelConfig
 		}
+		// DiscoveryFilters: `!= nil` - explicit empty (user wrote `discoveryFilters { }`)
+		// means "no filters, don't exclude anything," distinct from the plugin default.
 		if userCfg.DiscoveryFilters != nil {
 			merged.MatchFilters = userCfg.DiscoveryFilters
 		}
+		// ResourceTypesToDiscover: `len > 0` - empty and absent both mean "discover all"
+		// at the discovery layer (see discovery.go handling of a zero-length list), so
+		// explicit empty has no distinct meaning to preserve here.
 		if len(userCfg.ResourceTypesToDiscover) > 0 {
 			merged.ResourceTypesToDiscover = userCfg.ResourceTypesToDiscover
 		}
@@ -114,7 +151,7 @@ func (c *PluginCoordinator) mergePluginConfig(name, namespace string, announced 
 
 // resolveRetryConfig returns per-plugin RetryConfig if set, otherwise the global fallback.
 func (c *PluginCoordinator) resolveRetryConfig(namespace string) model.RetryConfig {
-	if p, ok := c.findPluginByNamespace(namespace); ok && p.RetryConfig != nil {
+	if p, ok := c.plugins.Get(namespace); ok && p.RetryConfig != nil {
 		return *p.RetryConfig
 	}
 	return c.retryConfig
@@ -126,29 +163,12 @@ func NewPluginCoordinator() gen.ProcessBehavior {
 }
 
 func (c *PluginCoordinator) Init(args ...any) error {
-	c.plugins = make(map[string]*RegisteredPlugin)
-	c.registeredLocalNamespaces = make(map[string]bool)
+	c.plugins = newNamespaceRegistry()
+	c.registeredLocalNamespaces = newNamespaceSet()
 
 	// Test-only: check for directly injected test plugin (e.g. FakeAWS for workflow tests)
 	if tp, ok := c.Env("TestResourcePlugin"); ok {
 		c.testPlugin = tp.(plugin.FullResourcePlugin)
-	}
-
-	// Register test plugin namespace with RateLimiter at startup
-	// This is needed because ChangesetExecutor requests tokens before SpawnPluginOperator
-	if c.testPlugin != nil {
-		namespace := c.testPlugin.Namespace()
-		maxRPS := c.testPlugin.RateLimit().MaxRequestsPerSecondForNamespace
-		err := c.Send(actornames.RateLimiter, changeset.RegisterNamespace{
-			Namespace:            namespace,
-			MaxRequestsPerSecond: maxRPS,
-		})
-		if err != nil {
-			c.Log().Error("Failed to register test plugin namespace %s with RateLimiter: %v", namespace, err)
-		} else {
-			c.registeredLocalNamespaces[namespace] = true
-			c.Log().Debug("Registered test plugin namespace %s with RateLimiter (maxRPS=%d)", namespace, maxRPS)
-		}
 	}
 
 	retryCfg, ok := c.Env("RetryConfig")
@@ -168,14 +188,100 @@ func (c *PluginCoordinator) Init(args ...any) error {
 		c.resourcePluginConfigs = make(map[string]model.ResourcePluginUserConfig)
 	}
 
+	// Register the test plugin through the same merge path that external plugins
+	// use at announcement time, so read paths (getPluginInfo, resolveRetryConfig)
+	// see identical merged config regardless of whether the plugin is local or remote.
+	// The NodeName is left empty to signal "local" to spawnPluginOperator.
+	if c.testPlugin != nil {
+		c.registerTestPlugin()
+	}
+
+	c.warnUnclaimedPluginConfigs()
+
 	c.Log().Debug("PluginCoordinator started")
 	return nil
+}
+
+// registerTestPlugin builds a synthetic RegisteredPlugin from the injected test
+// plugin, runs it through mergePluginConfig to apply any user overrides, stores
+// it in c.plugins, and registers the namespace with the RateLimiter using the
+// merged RPS. This unifies config handling: all read paths go through c.plugins
+// whether the plugin is remote (announced) or local (test-injected).
+func (c *PluginCoordinator) registerTestPlugin() {
+	namespace := c.testPlugin.Namespace()
+
+	schemas := make(map[string]model.Schema)
+	for _, rd := range c.testPlugin.SupportedResources() {
+		if schema, err := c.testPlugin.SchemaForResourceType(rd.Type); err == nil {
+			schemas[rd.Type] = schema
+		}
+	}
+
+	announced := RegisteredPlugin{
+		Namespace:            namespace,
+		MaxRequestsPerSecond: c.testPlugin.RateLimit().MaxRequestsPerSecondForNamespace,
+		RegisteredAt:         time.Now(),
+		SupportedResources:   c.testPlugin.SupportedResources(),
+		ResourceSchemas:      schemas,
+		MatchFilters:         c.testPlugin.DiscoveryFilters(),
+		LabelConfig:          c.testPlugin.LabelConfig(),
+		// NodeName intentionally empty - signals "local" to spawnPluginOperator.
+	}
+
+	merged, enabled := c.mergePluginConfig(c.testPlugin.Name(), namespace, announced)
+	if !enabled {
+		c.Log().Info("Test plugin disabled by config, skipping registration: namespace=%s", namespace)
+		return
+	}
+	c.plugins.Set(namespace, &merged)
+
+	// Register namespace with RateLimiter using the merged RPS so per-plugin
+	// rate-limit overrides apply to test plugins too. Required because
+	// ChangesetExecutor requests tokens before SpawnPluginOperator.
+	if err := c.Send(actornames.RateLimiter, changeset.RegisterNamespace{
+		Namespace:            namespace,
+		MaxRequestsPerSecond: merged.MaxRequestsPerSecond,
+	}); err != nil {
+		c.Log().Error("Failed to register test plugin namespace %s with RateLimiter: %v", namespace, err)
+		return
+	}
+	c.registeredLocalNamespaces.Add(namespace)
+	c.Log().Debug("Registered test plugin namespace %s with RateLimiter (maxRPS=%d)", namespace, merged.MaxRequestsPerSecond)
+}
+
+// warnUnclaimedPluginConfigs emits a warning for each user-configured plugin
+// whose `type` does not match any installed plugin's name (case-insensitive).
+// The install list comes from the shared ExternalResourcePlugins env var; a
+// configured type with no matching installed plugin is silently inert
+// otherwise, which is a common misconfiguration trap.
+func (c *PluginCoordinator) warnUnclaimedPluginConfigs() {
+	if len(c.resourcePluginConfigs) == 0 {
+		return
+	}
+
+	installed := make(map[string]struct{})
+	if val, ok := c.Env("ExternalResourcePlugins"); ok {
+		if plugins, ok := val.([]plugin.ResourcePluginInfo); ok {
+			for _, p := range plugins {
+				installed[strings.ToLower(p.Name)] = struct{}{}
+			}
+		}
+	}
+	if c.testPlugin != nil {
+		installed[strings.ToLower(c.testPlugin.Name())] = struct{}{}
+	}
+
+	for key, cfg := range c.resourcePluginConfigs {
+		if _, ok := installed[key]; !ok {
+			c.Log().Warning("Resource plugin config references unknown plugin - config will be ignored: type=%s", cfg.Type)
+		}
+	}
 }
 
 func (c *PluginCoordinator) HandleCall(from gen.PID, ref gen.Ref, request any) (any, error) {
 	switch req := request.(type) {
 	case messages.GetPluginNode:
-		plugin, ok := c.findPluginByNamespace(req.Namespace)
+		plugin, ok := c.plugins.Get(req.Namespace)
 		if !ok {
 			return nil, fmt.Errorf("plugin not found: %s", req.Namespace)
 		}
@@ -220,7 +326,7 @@ func (c *PluginCoordinator) HandleMessage(from gen.PID, message any) error {
 			return nil
 		}
 
-		c.plugins[msg.Namespace] = &merged
+		c.plugins.Set(msg.Namespace, &merged)
 		c.Log().Info("Plugin registered: namespace=%s node=%s rateLimit=%d resources=%d",
 			msg.Namespace, msg.NodeName, merged.MaxRequestsPerSecond, len(caps.SupportedResources))
 
@@ -233,8 +339,8 @@ func (c *PluginCoordinator) HandleMessage(from gen.PID, message any) error {
 		}
 
 	case messages.UnregisterPlugin:
-		if _, ok := c.plugins[msg.Namespace]; ok {
-			delete(c.plugins, msg.Namespace)
+		if _, ok := c.plugins.Get(msg.Namespace); ok {
+			c.plugins.Delete(msg.Namespace)
 			c.Log().Debug("Plugin unregistered: namespace=%s reason=%s", msg.Namespace, msg.Reason)
 		}
 
@@ -255,8 +361,10 @@ func (c *PluginCoordinator) spawnPluginOperator(req messages.SpawnPluginOperator
 		req.OperationID,
 	)
 
-	// 1. Check if plugin is registered (distributed mode)
-	if registeredPlugin, ok := c.findPluginByNamespace(req.Namespace); ok {
+	// 1. Check if plugin is registered. NodeName distinguishes remote (announced
+	//    from a plugin process) from local (test-injected). Registration itself
+	//    is unified - see registerTestPlugin.
+	if registeredPlugin, ok := c.plugins.Get(req.Namespace); ok && registeredPlugin.NodeName != "" {
 		pid, err := c.remoteSpawn(req.Namespace, registeredPlugin.NodeName, registerName)
 		if err != nil {
 			c.Log().Error("Failed to remote spawn PluginOperator for namespace %s on node %s: %v", req.Namespace, registeredPlugin.NodeName, err)
@@ -266,24 +374,8 @@ func (c *PluginCoordinator) spawnPluginOperator(req messages.SpawnPluginOperator
 		return messages.SpawnPluginOperatorResult{PID: pid}
 	}
 
-	// 2. Fallback: Check test plugin / legacy PluginManager
+	// 2. Fall back to the locally-injected test plugin.
 	if localPlugin := c.findTestPlugin(req.Namespace); localPlugin != nil {
-		// Register namespace with RateLimiter if not already registered
-		if !c.registeredLocalNamespaces[req.Namespace] {
-			maxRPS := localPlugin.RateLimit().MaxRequestsPerSecondForNamespace
-			err := c.Send(actornames.RateLimiter, changeset.RegisterNamespace{
-				Namespace:            req.Namespace,
-				MaxRequestsPerSecond: maxRPS,
-			})
-			if err != nil {
-				c.Log().Error("Failed to register namespace %s with RateLimiter: %v", req.Namespace, err)
-				// Don't fail the spawn - rate limiting is not critical
-			} else {
-				c.registeredLocalNamespaces[req.Namespace] = true
-				c.Log().Debug("Registered local plugin namespace %s with RateLimiter (maxRPS=%d)", req.Namespace, maxRPS)
-			}
-		}
-
 		pid, err := c.localSpawn(req.Namespace, localPlugin, registerName)
 		if err != nil {
 			c.Log().Error("Failed to local spawn PluginOperator for namespace %s: %v", req.Namespace, err)
@@ -354,70 +446,34 @@ func (c *PluginCoordinator) localSpawn(namespace string, localPlugin plugin.Full
 }
 
 // getPluginInfo retrieves plugin information for the given namespace.
-// It first checks registered external plugins, then falls back to local plugins.
-// Filters are cached from the initial plugin announcement (no refresh needed since filters are static).
+// Both remote plugins (announced) and local test plugins (registered at Init)
+// live in c.plugins with their user-config overrides already merged in, so the
+// lookup is a single path.
 func (c *PluginCoordinator) getPluginInfo(req messages.GetPluginInfo) messages.PluginInfoResponse {
-	// 1. Check external plugins first
-	if registered, ok := c.findPluginByNamespace(req.Namespace); ok {
-		return messages.PluginInfoResponse{
-			Found:                   true,
-			Namespace:               req.Namespace,
-			SupportedResources:      registered.SupportedResources,
-			ResourceSchemas:         registered.ResourceSchemas,
-			MatchFilters:            registered.MatchFilters,
-			LabelConfig:             registered.LabelConfig,
-			ResourceTypesToDiscover: registered.ResourceTypesToDiscover,
-		}
-	}
-
-	// 2. Fall back to test plugin / legacy PluginManager
-	localPlugin := c.findTestPlugin(req.Namespace)
-	if localPlugin == nil {
+	registered, ok := c.plugins.Get(req.Namespace)
+	if !ok {
 		return messages.PluginInfoResponse{
 			Found: false,
 			Error: fmt.Sprintf("plugin not found: %s", req.Namespace),
 		}
 	}
-
-	// Build schema map from local plugin
-	schemas := make(map[string]model.Schema)
-	for _, rd := range localPlugin.SupportedResources() {
-		schema, err := localPlugin.SchemaForResourceType(rd.Type)
-		if err == nil {
-			schemas[rd.Type] = schema
-		}
+	return messages.PluginInfoResponse{
+		Found:                   true,
+		Namespace:               req.Namespace,
+		SupportedResources:      registered.SupportedResources,
+		ResourceSchemas:         registered.ResourceSchemas,
+		MatchFilters:            registered.MatchFilters,
+		LabelConfig:             registered.LabelConfig,
+		ResourceTypesToDiscover: registered.ResourceTypesToDiscover,
 	}
-
-	resp := messages.PluginInfoResponse{
-		Found:              true,
-		Namespace:          req.Namespace,
-		SupportedResources: localPlugin.SupportedResources(),
-		ResourceSchemas:    schemas,
-		MatchFilters:       localPlugin.DiscoveryFilters(),
-		LabelConfig:        localPlugin.LabelConfig(),
-	}
-
-	// Overlay user config for local/test plugins (lookup by name, not namespace)
-	if userCfg, ok := c.resourcePluginConfigs[strings.ToLower(localPlugin.Name())]; ok {
-		if userCfg.LabelConfig != nil {
-			resp.LabelConfig = *userCfg.LabelConfig
-		}
-		if userCfg.DiscoveryFilters != nil {
-			resp.MatchFilters = userCfg.DiscoveryFilters
-		}
-		if len(userCfg.ResourceTypesToDiscover) > 0 {
-			resp.ResourceTypesToDiscover = userCfg.ResourceTypesToDiscover
-		}
-	}
-
-	return resp
 }
 
 // getRegisteredPlugins returns a list of all registered plugins
 func (c *PluginCoordinator) getRegisteredPlugins() messages.GetRegisteredPluginsResult {
-	plugins := make([]messages.RegisteredPluginInfo, 0, len(c.plugins))
+	all := c.plugins.All()
+	plugins := make([]messages.RegisteredPluginInfo, 0, len(all))
 
-	for _, registered := range c.plugins {
+	for _, registered := range all {
 		plugins = append(plugins, messages.RegisteredPluginInfo{
 			Namespace:               registered.Namespace,
 			Version:                 registered.Version,

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator_test.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator_test.go
@@ -15,50 +15,48 @@ import (
 
 func TestPluginCoordinator_CaseInsensitiveNamespaceLookup(t *testing.T) {
 	c := &PluginCoordinator{
-		plugins: map[string]*RegisteredPlugin{
-			"Azure": {
-				Namespace:            "Azure",
-				MaxRequestsPerSecond: 10,
-			},
-			"aws": {
-				Namespace:            "aws",
-				MaxRequestsPerSecond: 20,
-			},
-		},
+		plugins: newNamespaceRegistry(),
 	}
+	c.plugins.Set("Azure", &RegisteredPlugin{
+		Namespace:            "Azure",
+		MaxRequestsPerSecond: 10,
+	})
+	c.plugins.Set("aws", &RegisteredPlugin{
+		Namespace:            "aws",
+		MaxRequestsPerSecond: 20,
+	})
 
-	plugin, ok := c.findPluginByNamespace("azure")
+	plugin, ok := c.plugins.Get("azure")
 	require.True(t, ok)
 	assert.Equal(t, "Azure", plugin.Namespace)
 
-	plugin, ok = c.findPluginByNamespace("AZURE")
+	plugin, ok = c.plugins.Get("AZURE")
 	require.True(t, ok)
 	assert.Equal(t, "Azure", plugin.Namespace)
 
-	plugin, ok = c.findPluginByNamespace("AWS")
+	plugin, ok = c.plugins.Get("AWS")
 	require.True(t, ok)
 	assert.Equal(t, "aws", plugin.Namespace)
 
-	plugin, ok = c.findPluginByNamespace("aws")
+	plugin, ok = c.plugins.Get("aws")
 	require.True(t, ok)
 	assert.Equal(t, "aws", plugin.Namespace)
 
-	_, ok = c.findPluginByNamespace("NonExistent")
+	_, ok = c.plugins.Get("NonExistent")
 	assert.False(t, ok)
 }
 
 func TestPluginCoordinator_GetPluginInfo_CaseInsensitive(t *testing.T) {
 	c := &PluginCoordinator{
-		plugins: map[string]*RegisteredPlugin{
-			"Azure": {
-				Namespace:            "Azure",
-				MaxRequestsPerSecond: 10,
-				SupportedResources: []plugin.ResourceDescriptor{
-					{Type: "Azure::Compute::VM", Discoverable: true},
-				},
-			},
-		},
+		plugins: newNamespaceRegistry(),
 	}
+	c.plugins.Set("Azure", &RegisteredPlugin{
+		Namespace:            "Azure",
+		MaxRequestsPerSecond: 10,
+		SupportedResources: []plugin.ResourceDescriptor{
+			{Type: "Azure::Compute::VM", Discoverable: true},
+		},
+	})
 
 	resp := c.getPluginInfo(messages.GetPluginInfo{Namespace: "azure"})
 	assert.True(t, resp.Found)

--- a/internal/metastructure/plugin_process_supervisor/plugin_process_supervisor.go
+++ b/internal/metastructure/plugin_process_supervisor/plugin_process_supervisor.go
@@ -214,7 +214,7 @@ func (p *PluginProcessSupervisor) HandleMessage(from gen.PID, message any) error
 				go p.completeAuthPluginInit()
 				return nil
 			}
-			// Subsequent binary data is RPC traffic — feed to MetaPortConn.
+			// Subsequent binary data is RPC traffic - feed to MetaPortConn.
 			// Use entry.conn directly because handle.conn is nil until
 			// Connect() is called after the RPC handshake completes.
 			if p.authPlugin.conn != nil {
@@ -336,7 +336,7 @@ func (p *PluginProcessSupervisor) handleAuthPluginTerminate(tag string) {
 		p.Log().Error("Failed to restart auth plugin name=%s restartCount=%d: %v",
 			name, entry.restartCount, err)
 	} else {
-		// RPC Init deferred — the new process will send a ready signal.
+		// RPC Init deferred - the new process will send a ready signal.
 		p.Log().Info("Auth plugin restarted successfully name=%s restartCount=%d",
 			name, entry.restartCount)
 	}
@@ -384,7 +384,9 @@ func (p *PluginProcessSupervisor) spawnResourcePlugin(namespace string, pluginIn
 		}
 	}
 
-	// Add plugin-specific config if available
+	// NOTE: FORMAE_PLUGIN_CONFIG is cleartext-equivalent (base64 is encoding,
+	// not encryption). Plugin authors should never put secrets in Configurable
+	// fields - see the pkg/plugin.Configurable doc comment for the trust boundary.
 	if pluginCfg, ok := p.pluginConfigs[strings.ToLower(namespace)]; ok {
 		env[gen.Env("FORMAE_PLUGIN_CONFIG")] = base64.StdEncoding.EncodeToString(pluginCfg)
 	}
@@ -420,7 +422,7 @@ func (p *PluginProcessSupervisor) spawnResourcePlugin(namespace string, pluginIn
 }
 
 // spawnAuthPluginProcess spawns an auth plugin binary via meta.Port with binary mode
-// and sets up the MetaPortConn. Does NOT call RPC Init — that must be deferred to
+// and sets up the MetaPortConn. Does NOT call RPC Init - that must be deferred to
 // completeAuthPluginInit() after the actor's Init() returns, because the RPC call
 // needs HandleMessage to route meta.Port data.
 func (p *PluginProcessSupervisor) spawnAuthPluginProcess(tag string, entry *authPluginEntry) error {
@@ -501,7 +503,7 @@ func (p *PluginProcessSupervisor) completeAuthPluginInit() {
 	if initErr != nil {
 		_ = rpcClient.Close()
 		_ = conn.Close()
-		p.Log().Error("Auth plugin init call failed — agent cannot serve authenticated requests name=%s: %v",
+		p.Log().Error("Auth plugin init call failed - agent cannot serve authenticated requests name=%s: %v",
 			handle.Name(), initErr)
 		handle.SetInitError(fmt.Errorf("auth plugin %q init failed: %w", handle.Name(), initErr))
 		return
@@ -509,7 +511,7 @@ func (p *PluginProcessSupervisor) completeAuthPluginInit() {
 	if resp.Error != "" {
 		_ = rpcClient.Close()
 		_ = conn.Close()
-		p.Log().Error("Auth plugin rejected config — agent cannot serve authenticated requests name=%s: %s",
+		p.Log().Error("Auth plugin rejected config - agent cannot serve authenticated requests name=%s: %s",
 			handle.Name(), resp.Error)
 		handle.SetInitError(fmt.Errorf("auth plugin %q: %s", handle.Name(), resp.Error))
 		return

--- a/internal/schema/pkl/pkl.go
+++ b/internal/schema/pkl/pkl.go
@@ -255,13 +255,13 @@ func checkResourcePluginDeprecations(translated *pkgmodel.Config) {
 	}
 
 	if hasPerPluginRetry && translated.Agent.Retry != defaultRetry {
-		w := "Your configuration file uses per-plugin 'retry' — the global 'agent.retry' is deprecated in favor of per-plugin retry config"
+		w := "Your configuration file uses per-plugin 'retry' - the global 'agent.retry' is deprecated in favor of per-plugin retry config"
 		slog.Warn(w)
 		translated.Warnings = append(translated.Warnings, w)
 	}
 
 	if hasPerPluginRTD && len(translated.Agent.Discovery.ResourceTypesToDiscover) > 0 {
-		w := "Your configuration file uses per-plugin 'resourceTypesToDiscover' — the global 'agent.discovery.resourceTypesToDiscover' is deprecated in favor of per-plugin config"
+		w := "Your configuration file uses per-plugin 'resourceTypesToDiscover' - the global 'agent.discovery.resourceTypesToDiscover' is deprecated in favor of per-plugin config"
 		slog.Warn(w)
 		translated.Warnings = append(translated.Warnings, w)
 	}
@@ -276,14 +276,14 @@ func applyDeprecatedPluginsConfig(plugins *pklmodel.PluginConfig, translated *pk
 	}
 
 	if plugins.PluginDir != "" && plugins.PluginDir != "~/.pel/formae/plugins" && translated.PluginDir == "~/.pel/formae/plugins" {
-		w := "Your configuration file uses deprecated 'plugins.pluginDir' — migrate to top-level 'pluginDir'"
+		w := "Your configuration file uses deprecated 'plugins.pluginDir' - migrate to top-level 'pluginDir'"
 		slog.Warn(w)
 		translated.Warnings = append(translated.Warnings, w)
 		translated.PluginDir = plugins.PluginDir
 	}
 
 	if plugins.Authentication != nil && translated.Agent.Auth == nil {
-		w := "Your configuration file uses deprecated 'plugins.authentication' — migrate to 'agent.auth' and 'cli.auth'"
+		w := "Your configuration file uses deprecated 'plugins.authentication' - migrate to 'agent.auth' and 'cli.auth'"
 		slog.Warn(w)
 		translated.Warnings = append(translated.Warnings, w)
 		authJSON := translateDynamic(plugins.Authentication)
@@ -292,7 +292,7 @@ func applyDeprecatedPluginsConfig(plugins *pklmodel.PluginConfig, translated *pk
 	}
 
 	if plugins.Network != nil && translated.Network == nil {
-		w := "Your configuration file uses deprecated 'plugins.network' — migrate to top-level 'network'"
+		w := "Your configuration file uses deprecated 'plugins.network' - migrate to top-level 'network'"
 		slog.Warn(w)
 		translated.Warnings = append(translated.Warnings, w)
 		// The old format was a Dynamic blob. Convert to typed NetworkConfig
@@ -668,44 +668,33 @@ func translateResourcePluginConfig(obj *pklgo.Object) pkgmodel.ResourcePluginUse
 		Enabled: pklBool(props, "enabled", true),
 	}
 
-	// rateLimit
-	if rl, ok := props["rateLimit"]; ok && rl != nil {
-		if rlObj, ok := rl.(*pklmodel.RateLimitConfig); ok {
-			cfg.RateLimit = &pkgmodel.RateLimitConfig{
-				Scope:                            pkgmodel.RateLimitScope(rlObj.Scope),
-				MaxRequestsPerSecondForNamespace: int(rlObj.MaxRequestsPerSecondForNamespace),
-			}
+	if rl, ok := pklTypedField[*pklmodel.RateLimitConfig](props, "rateLimit", cfg.Type); ok {
+		cfg.RateLimit = &pkgmodel.RateLimitConfig{
+			Scope:                            pkgmodel.RateLimitScope(rl.Scope),
+			MaxRequestsPerSecondForNamespace: int(rl.MaxRequestsPerSecondForNamespace),
 		}
 	}
 
-	// labelConfig
-	if lc, ok := props["labelConfig"]; ok && lc != nil {
-		if lcObj, ok := lc.(*pklmodel.LabelConfig); ok {
-			cfg.LabelConfig = &pkgmodel.LabelConfig{
-				DefaultQuery:      lcObj.DefaultQuery,
-				ResourceOverrides: pklMappingToStringMap(lcObj.ResourceOverrides),
-			}
+	if lc, ok := pklTypedField[*pklmodel.LabelConfig](props, "labelConfig", cfg.Type); ok {
+		cfg.LabelConfig = &pkgmodel.LabelConfig{
+			DefaultQuery:      lc.DefaultQuery,
+			ResourceOverrides: pklMappingToStringMap(lc.ResourceOverrides),
 		}
 	}
 
-	// discoveryFilters
 	if df, ok := props["discoveryFilters"]; ok && df != nil {
 		cfg.DiscoveryFilters = translateDiscoveryFilters(df)
 	}
 
-	// resourceTypesToDiscover
 	if rtd, ok := props["resourceTypesToDiscover"]; ok && rtd != nil {
 		cfg.ResourceTypesToDiscover = pklListingToStringSlice(rtd)
 	}
 
-	// retry
-	if r, ok := props["retry"]; ok && r != nil {
-		if rObj, ok := r.(*pklmodel.RetryConfig); ok {
-			cfg.Retry = &pkgmodel.RetryConfig{
-				StatusCheckInterval: rObj.StatusCheckInterval.GoDuration(),
-				MaxRetries:          int(rObj.MaxRetries),
-				RetryDelay:          rObj.RetryDelay.GoDuration(),
-			}
+	if r, ok := pklTypedField[*pklmodel.RetryConfig](props, "retry", cfg.Type); ok {
+		cfg.Retry = &pkgmodel.RetryConfig{
+			StatusCheckInterval: r.StatusCheckInterval.GoDuration(),
+			MaxRetries:          int(r.MaxRetries),
+			RetryDelay:          r.RetryDelay.GoDuration(),
 		}
 	}
 
@@ -721,7 +710,12 @@ func translateResourcePluginConfig(obj *pklgo.Object) pkgmodel.ResourcePluginUse
 		}
 	}
 	if len(extra) > 0 {
-		cfg.PluginConfig, _ = json.Marshal(sanitizeConfig(extra))
+		raw, err := json.Marshal(sanitizeConfig(extra))
+		if err != nil {
+			slog.Error("failed to marshal plugin-specific config - plugin will start with defaults", "type", cfg.Type, "error", err)
+		} else {
+			cfg.PluginConfig = raw
+		}
 	}
 
 	return cfg
@@ -753,6 +747,25 @@ func translateMatchFilter(mf *pklmodel.MatchFilter) pkgmodel.MatchFilter {
 		})
 	}
 	return result
+}
+
+// pklTypedField extracts a typed value from a pkl.Object properties map.
+// Returns (zero, false) when the key is absent or nil. When the key is present
+// but the stored value does not match T, logs a Warn and returns (zero, false)
+// - callers treat that the same as "absent," but the log line surfaces the
+// mismatch so it isn't silently dropped. pluginType is included for context.
+func pklTypedField[T any](props map[string]any, key string, pluginType string) (T, bool) {
+	var zero T
+	v, ok := props[key]
+	if !ok || v == nil {
+		return zero, false
+	}
+	typed, ok := v.(T)
+	if !ok {
+		slog.Warn("plugin config field has unexpected type - ignoring", "type", pluginType, "field", key, "got", fmt.Sprintf("%T", v))
+		return zero, false
+	}
+	return typed, true
 }
 
 // pklString extracts a string from a pkl.Object properties map.

--- a/internal/workflow_tests/local/resource_plugin_config_test.go
+++ b/internal/workflow_tests/local/resource_plugin_config_test.go
@@ -24,10 +24,12 @@ func TestResourcePluginConfig_DisabledPlugin(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		cfg := test_helpers.NewTestMetastructureConfig()
 		cfg.Agent.ResourcePlugins = []pkgmodel.ResourcePluginUserConfig{
-			{
-				Type:    "fakeaws",
-				Enabled: false,
-			},
+			// Covers both the announced "fakeaws" (below) and the injected test
+			// plugin whose Name() is "fake-aws" - both share the FakeAWS namespace.
+			// The coordinator looks up user config by plugin name, not namespace,
+			// so both entries are needed to suppress registration end-to-end.
+			{Type: "fakeaws", Enabled: false},
+			{Type: "fake-aws", Enabled: false},
 		}
 
 		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, nil, cfg)
@@ -59,7 +61,7 @@ func TestResourcePluginConfig_DisabledPlugin(t *testing.T) {
 		// Give the coordinator time to process the announcement
 		time.Sleep(500 * time.Millisecond)
 
-		// Query the coordinator for registered plugins — the disabled plugin
+		// Query the coordinator for registered plugins - the disabled plugin
 		// should NOT appear in the list.
 		result, err := testutil.Call(m.Node, "PluginCoordinator", messages.GetRegisteredPlugins{})
 		require.NoError(t, err)
@@ -109,7 +111,7 @@ func TestResourcePluginConfig_RateLimitOverride(t *testing.T) {
 		// Give the coordinator time to process the announcement
 		time.Sleep(500 * time.Millisecond)
 
-		// Query the coordinator for registered plugins — the plugin should be
+		// Query the coordinator for registered plugins - the plugin should be
 		// registered with the overridden rate limit of 3, not the announced 10.
 		result, err := testutil.Call(m.Node, "PluginCoordinator", messages.GetRegisteredPlugins{})
 		require.NoError(t, err)

--- a/pkg/plugin/resource.go
+++ b/pkg/plugin/resource.go
@@ -70,6 +70,17 @@ type ObservablePlugin interface {
 // If implemented, the SDK calls Configure with the plugin-specific config JSON from
 // the user's formae.conf.pkl (the fields beyond BaseResourcePluginConfig).
 // Configure is called once during plugin setup, before the plugin announces to the agent.
+//
+// SECURITY: the config payload is transported to the plugin process via the
+// FORMAE_PLUGIN_CONFIG environment variable (base64-encoded JSON). Environment
+// is cleartext-equivalent - readable via /proc/<pid>/environ, surfaced in core
+// dumps, and may appear in journal output under some configurations. Plugin
+// authors MUST NOT place secrets (API keys, passwords, private keys) in
+// Configurable fields. Route secrets through the $ref/$value resolver path
+// instead, which is designed for that purpose.
+//
+// Configure is called once per plugin-process lifetime. Config changes in
+// formae.conf.pkl require an agent restart to take effect.
 type Configurable interface {
 	Configure(config json.RawMessage) error
 }


### PR DESCRIPTION
- Wrap namespace maps in case insensitive types (Replaces findPluginByNamespace)                                                                                                                                                                                                                                                                                                              
- Route the test plugin through mergePluginConfig. spawnPluginOperator splits local/remote by NodeName
- Extract a pklTypedField generic for repeated type assertions. Warns on mismatch.                     
- Warn on config for uninstalled plugins                                                                                                                                                                                                                                                                                                            
