### PR TITLE
fix(target): strip $value from resolvables in config change classification

### DIFF
--- a/internal/metastructure/target_update/classify_config_change.go
+++ b/internal/metastructure/target_update/classify_config_change.go
@@ -84,7 +84,30 @@ func jsonBytesEqual(a, b json.RawMessage) bool {
 	if err := json.Unmarshal(b, &bVal); err != nil {
 		return false
 	}
+	// Strip $value from resolvables so that resolved vs unresolved
+	// configs compare equal when the $ref is the same.
+	stripResolvableValues(aVal)
+	stripResolvableValues(bVal)
 	aBytes, _ := json.Marshal(aVal)
 	bBytes, _ := json.Marshal(bVal)
 	return string(aBytes) == string(bBytes)
+}
+
+// stripResolvableValues recursively removes $value from any object that
+// contains a $ref key. This ensures that a resolved config (with cached
+// $value) compares equal to an unresolved config (only $ref).
+func stripResolvableValues(v any) {
+	switch val := v.(type) {
+	case map[string]any:
+		if _, hasRef := val["$ref"]; hasRef {
+			delete(val, "$value")
+		}
+		for _, child := range val {
+			stripResolvableValues(child)
+		}
+	case []any:
+		for _, item := range val {
+			stripResolvableValues(item)
+		}
+	}
 }

--- a/internal/metastructure/target_update/classify_config_change_test.go
+++ b/internal/metastructure/target_update/classify_config_change_test.go
@@ -126,6 +126,42 @@ func TestClassifyConfigChange_FieldAdded(t *testing.T) {
 	assert.Equal(t, ConfigMutableChange, result)
 }
 
+func TestClassifyConfigChange_ResolvableValueIgnored(t *testing.T) {
+	// Stored config has resolved $value, new config only has $ref — should be equal
+	existing := json.RawMessage(`{
+		"Auth": {"Type":"EKS","Endpoint":{"$ref":"formae://abc#/Endpoint","$value":"https://cluster.eks.amazonaws.com"},"ClusterName":{"$ref":"formae://abc#/Name","$value":"my-cluster"}},
+		"HasLoadBalancer": false
+	}`)
+	new := json.RawMessage(`{
+		"Auth": {"Type":"EKS","Endpoint":{"$ref":"formae://abc#/Endpoint"},"ClusterName":{"$ref":"formae://abc#/Name"}},
+		"HasLoadBalancer": true
+	}`)
+	schema := pkgmodel.ConfigSchema{
+		Hints: map[string]pkgmodel.ConfigFieldHint{
+			"Auth":            {CreateOnly: true},
+			"HasLoadBalancer": {CreateOnly: false},
+		},
+	}
+
+	result := ClassifyConfigChange(existing, new, schema)
+	// Auth is unchanged (same $ref), HasLoadBalancer is mutable — so MutableChange, not ImmutableChange
+	assert.Equal(t, ConfigMutableChange, result)
+}
+
+func TestClassifyConfigChange_ResolvableDifferentRef_IsImmutable(t *testing.T) {
+	// Different $ref means genuinely different config
+	existing := json.RawMessage(`{"Auth": {"Endpoint":{"$ref":"formae://abc#/Endpoint","$value":"https://old.com"}}}`)
+	new := json.RawMessage(`{"Auth": {"Endpoint":{"$ref":"formae://xyz#/Endpoint"}}}`)
+	schema := pkgmodel.ConfigSchema{
+		Hints: map[string]pkgmodel.ConfigFieldHint{
+			"Auth": {CreateOnly: true},
+		},
+	}
+
+	result := ClassifyConfigChange(existing, new, schema)
+	assert.Equal(t, ConfigImmutableChange, result)
+}
+
 func TestClassifyConfigChange_FieldRemoved(t *testing.T) {
 	existing := json.RawMessage(`{"Region":"us-east-1","Profile":"prod"}`)
 	new := json.RawMessage(`{"Region":"us-east-1"}`)


### PR DESCRIPTION
## Summary

- When a target config contains `$ref` resolvables, the stored config has resolved `$value` entries while the new config from a forma only has `$ref`. `ClassifyConfigChange` compared the raw JSON, treating resolved and unresolved configs as different — incorrectly classifying mutable updates (e.g., changing `HasLoadBalancer`) as immutable changes, triggering a full target replace.
- Add `stripResolvableValues` to recursively remove `$value` from any object that has a `$ref` key before comparing, so that configs with the same `$ref` are treated as equal regardless of resolution state.
- Add two test cases: one verifying that matching `$ref` with different `$value` state is treated as no change, and one verifying that genuinely different `$ref` values are correctly detected as immutable changes.