### PR TITLE
test(e2e): use collection resolvable at() in target resolvable test

### DIFF
--- a/tests/e2e/go/fixtures/target_resolvable.pkl
+++ b/tests/e2e/go/fixtures/target_resolvable.pkl
@@ -46,10 +46,8 @@ forma {
   local grafanaTarget = new formae.Target {
     label = "e2e-grafana"
     namespace = "GRAFANA"
-    config = new Mapping {
-      ["Type"] = "Grafana"
-      ["Endpoints"] = lgtmStack.res.endpoints
-      ["EndpointKey"] = "lgtm:3000"
+    config = new grafana.Config {
+      url = lgtmStack.res.endpoints.at("lgtm:3000")
     }
   }
   grafanaTarget


### PR DESCRIPTION
## Summary

Updates the target resolvable e2e test fixture to use the new `MappingResolvable.at()` syntax instead of the deprecated `Endpoints`/`EndpointKey` pattern.

```pkl
// Before
config = new Mapping {
    ["Type"] = "Grafana"
    ["Endpoints"] = lgtmStack.res.endpoints
    ["EndpointKey"] = "lgtm:3000"
}

// After
config = new grafana.Config {
    url = lgtmStack.res.endpoints.at("lgtm:3000")
}
```

**Depends on:** Compose plugin PR (platform-engineering-labs/formae-plugin-compose#12) and Grafana plugin PR (platform-engineering-labs/formae-plugin-grafana#14) being released.