### PR TITLE
fix(sync): clean up orphaned resources when target is deleted

### DIFF
--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -578,18 +578,11 @@ func startUpdates(updates []Update, commandID string, proc gen.Process) error {
 func startResourceUpdate(ru *resource_update.ResourceUpdate, commandID string, proc gen.Process) error {
 	proc.Log().Debug("Starting resource updater uri=%v operation=%s", ru.URI(), ru.Operation)
 
-	// Register non-sync resources as in-progress with the Synchronizer
-	// to prevent race conditions where sync might include resources being updated by user operations
-	if ru.Source != resource_update.FormaCommandSourceSynchronize {
-		synchronizerPID := gen.ProcessID{Name: actornames.Synchronizer, Node: proc.Node().Name()}
-		err := proc.Send(synchronizerPID, messages.RegisterInProgressResource{
-			ResourceURI: string(ru.URI()),
-		})
-		if err != nil {
-			proc.Log().Error("Failed to register in-progress resource with synchronizer resourceURI=%v: %v", ru.URI(), err)
-			// Don't return error - this is not critical enough to fail the operation
-		}
-	}
+	// Sync exclusion is handled in bulk by registerAllResourcesWithSynchronizer
+	// at changeset start and unregisterAllResourcesFromSynchronizer at changeset
+	// end. This guarantees atomic protection for the entire stack — all resources
+	// in the changeset are excluded from sync for the full duration, with a clean
+	// unregister when the changeset reaches a terminal state.
 
 	_, err := proc.Call(gen.ProcessID{Name: actornames.ResourceUpdaterSupervisor, Node: proc.Node().Name()},
 		resource_update.EnsureResourceUpdater{

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -441,7 +441,16 @@ func generateResourceUpdatesForSync(
 		if source == FormaCommandSourceDiscovery {
 			for _, r := range forma.Resources {
 				if r.Stack == stack.SingleStackLabel() {
-					ru, err := NewResourceUpdateForSyncWithFilter(r, *existingTargetMap[r.Target], source)
+					// When a target has been deleted but resources referencing it
+					// remain in the DB (e.g., unmanaged resources from discovery),
+					// pass an empty sentinel Target. The ResourceUpdater will
+					// detect the nil Config and short-circuit to NotFound, causing
+					// the resource to be cleaned up via the "deleted OOB" path.
+					target := existingTargetMap[r.Target]
+					if target == nil {
+						target = &pkgmodel.Target{Label: r.Target}
+					}
+					ru, err := NewResourceUpdateForSyncWithFilter(r, *target, source)
 					if err != nil {
 						return nil, fmt.Errorf("failed to create resource update sync for %s: %w", r.Label, err)
 					}
@@ -464,9 +473,14 @@ func generateResourceUpdatesForSync(
 					// from the plugin) rather than the stale schema stored in the DB
 					existingResource.Schema = resource.Schema
 
+					// See comment above: pass empty sentinel when target is gone.
+					target := existingTargetMap[existingResource.Target]
+					if target == nil {
+						target = &pkgmodel.Target{Label: existingResource.Target}
+					}
 					resourceUpdate, err := NewResourceUpdateForSync(
 						*existingResource,
-						*existingTargetMap[existingResource.Target],
+						*target,
 						source,
 					)
 					if err != nil {

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -334,6 +334,28 @@ func start(from gen.PID, state gen.Atom, data ResourceUpdateData, message StartR
 }
 
 func synchronize(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom, ResourceUpdateData, []statemachine.Action, error) {
+	// When a resource's target has been deleted (e.g., unmanaged resources
+	// orphaned after a destroy), the target config will be nil. We can't
+	// call the plugin without a target config, so short-circuit to NotFound.
+	// The "deleted OOB" path in the ResourcePersister will then remove the
+	// resource from the DB.
+	if data.resourceUpdate.ResourceTarget.Config == nil {
+		proc.Log().Debug("ResourceUpdater: target config is nil for resource %v (target %s was likely deleted), treating as NotFound",
+			data.resourceUpdate.DesiredState.URI(), data.resourceUpdate.ResourceTarget.Label)
+		now := util.TimeNow()
+		notFound := plugin.TrackedProgress{
+			ProgressResult: resource.ProgressResult{
+				Operation:       resource.OperationRead,
+				OperationStatus: resource.OperationStatusSuccess,
+				ErrorCode:       resource.OperationErrorCodeNotFound,
+			},
+			ResourceType: data.resourceUpdate.DesiredState.Type,
+			StartTs:      now,
+			ModifiedTs:   now,
+		}
+		return handleProgressUpdate(gen.PID{}, state, data, notFound, proc)
+	}
+
 	// Convert properties to plugin format (extracts $value from opaque structures)
 	convertedResource, err := convertResourceForPlugin(data.resourceUpdate.DesiredState)
 	if err != nil {

--- a/internal/workflow_tests/local/resource_updater_test.go
+++ b/internal/workflow_tests/local/resource_updater_test.go
@@ -1340,6 +1340,7 @@ func successfullyFinishedResourceUpdateCreatingS3Bucket() *resource_update.Resou
 		ResourceTarget: pkgmodel.Target{
 			Label:     "test-target",
 			Namespace: "test-namespace",
+			Config:    json.RawMessage(`{"region":"us-east-1"}`),
 		},
 		Operation: resource_update.OperationCreate,
 		State:     resource_update.ResourceUpdateStateSuccess,
@@ -1393,6 +1394,7 @@ func resourceUpdateModifyingS3Bucket(ksuid string) *resource_update.ResourceUpda
 		ResourceTarget: pkgmodel.Target{
 			Label:     "test-target",
 			Namespace: "test-namespace",
+			Config:    json.RawMessage(`{"region":"us-east-1"}`),
 		},
 		Operation:            resource_update.OperationUpdate,
 		State:                resource_update.ResourceUpdateStateNotStarted,
@@ -1427,6 +1429,7 @@ func resourceUpdateDeletingS3Bucket(ksuid string) *resource_update.ResourceUpdat
 		ResourceTarget: pkgmodel.Target{
 			Label:     "test-target",
 			Namespace: "test-namespace",
+			Config:    json.RawMessage(`{"region":"us-east-1"}`),
 		},
 		Operation:            resource_update.OperationDelete,
 		State:                resource_update.ResourceUpdateStateNotStarted,
@@ -1461,6 +1464,7 @@ func resourceUpdateReadingS3Bucket(ksuid string) *resource_update.ResourceUpdate
 		ResourceTarget: pkgmodel.Target{
 			Label:     "test-target",
 			Namespace: "test-namespace",
+			Config:    json.RawMessage(`{"region":"us-east-1"}`),
 		},
 		Operation:            resource_update.OperationRead,
 		State:                resource_update.ResourceUpdateStateNotStarted,
@@ -1488,6 +1492,7 @@ func resourceUpdateCreatingS3Bucket(bucketKsuid, vpcKsuid string) *resource_upda
 		ResourceTarget: pkgmodel.Target{
 			Label:     "test-target",
 			Namespace: "test-namespace",
+			Config:    json.RawMessage(`{"region":"us-east-1"}`),
 		},
 		Operation:      resource_update.OperationCreate,
 		State:          resource_update.ResourceUpdateStateNotStarted,
@@ -1512,6 +1517,7 @@ func partiallyCompletedResourceUpdateDeletingS3Bucket(ksuid string) *resource_up
 		ResourceTarget: pkgmodel.Target{
 			Label:     "test-target",
 			Namespace: "test-namespace",
+			Config:    json.RawMessage(`{"region":"us-east-1"}`),
 		},
 		Operation: resource_update.OperationDelete,
 		State:     resource_update.ResourceUpdateStateInProgress,
@@ -1552,6 +1558,7 @@ func partiallyCompletedResourceUpdateCreatingS3Bucket() *resource_update.Resourc
 		ResourceTarget: pkgmodel.Target{
 			Label:     "test-target",
 			Namespace: "test-namespace",
+			Config:    json.RawMessage(`{"region":"us-east-1"}`),
 		},
 		Operation: resource_update.OperationCreate,
 		State:     resource_update.ResourceUpdateStateInProgress,
@@ -1593,6 +1600,7 @@ func partiallyCompletedResourceUpdateModifyingS3Bucket() *resource_update.Resour
 		ResourceTarget: pkgmodel.Target{
 			Label:     "test-target",
 			Namespace: "test-namespace",
+			Config:    json.RawMessage(`{"region":"us-east-1"}`),
 		},
 		Operation: resource_update.OperationUpdate,
 		State:     resource_update.ResourceUpdateStateInProgress,

--- a/internal/workflow_tests/local/synchronizer_test.go
+++ b/internal/workflow_tests/local/synchronizer_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
 	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/discovery"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
@@ -1192,5 +1193,213 @@ func TestSynchronizer_SyncPicksUpNewSchemaFields(t *testing.T) {
 			assert.NotContains(t, roProps, "VersioningConfiguration",
 				"VersioningConfiguration should NOT be in ReadOnlyProperties")
 		}
+	})
+}
+
+// TestSynchronizer_SyncCleansUpOrphanedResources_TargetDeleted reproduces a
+// real cross-cloud scenario:
+//
+//  1. Deploy: static target → EKS cluster → nested K8S target ($ref to
+//     cluster endpoint) → K8S resource on the nested target
+//  2. Discovery finds an additional unmanaged resource on the nested target
+//  3. Destroy the stack — managed resources + nested target are deleted
+//  4. Sync cycle runs — the orphaned unmanaged resource (whose target no
+//     longer exists) should be cleaned up via the "deleted OOB" path
+//
+// Without the fix, the sync generator panics on nil target dereference or the
+// ResourceUpdater sends an empty target config to the plugin, producing
+// repeated UnforeseenError logs on every sync tick.
+func TestSynchronizer_SyncCleansUpOrphanedResources_TargetDeleted(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		clusterProps := `{"BucketName":"eks-cluster","Endpoint":"https://eks.example.com"}`
+		clusterKsuid := "2MiD2rA1SJbLMGZgTL0hCxjkjjr"
+
+		// isConsumerTarget distinguishes the nested target (consumer) from the
+		// static target (provider) by checking whether the plugin-format config
+		// contains "endpoint" (resolved from $ref) vs "region" (plain value).
+		isConsumerTarget := func(targetConfig json.RawMessage) bool {
+			var cfg map[string]any
+			if err := json.Unmarshal(targetConfig, &cfg); err != nil {
+				return false
+			}
+			_, hasEndpoint := cfg["endpoint"]
+			return hasEndpoint
+		}
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          request.Label,
+					NativeID:           "native-" + request.Label,
+					ResourceProperties: request.Properties,
+				}}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				switch request.NativeID {
+				case "native-cluster":
+					return &resource.ReadResult{
+						ResourceType: "FakeAWS::S3::Bucket",
+						Properties:   clusterProps,
+					}, nil
+				case "native-app":
+					return &resource.ReadResult{
+						ResourceType: "FakeAWS::S3::Bucket",
+						Properties:   `{"BucketName":"my-app"}`,
+					}, nil
+				case "discovered-ns":
+					return &resource.ReadResult{
+						ResourceType: "FakeAWS::S3::Bucket",
+						Properties:   `{"BucketName":"discovered-ns"}`,
+					}, nil
+				default:
+					return &resource.ReadResult{
+						ResourceType: request.ResourceType,
+						Properties:   fmt.Sprintf(`{"BucketName":"%s"}`, request.NativeID),
+					}, nil
+				}
+			},
+			List: func(request *resource.ListRequest) (*resource.ListResult, error) {
+				if request.ResourceType != "FakeAWS::S3::Bucket" {
+					return &resource.ListResult{}, nil
+				}
+				// Only the consumer target should yield a discovered resource.
+				if isConsumerTarget(request.TargetConfig) {
+					return &resource.ListResult{
+						NativeIDs:     []string{"discovered-ns"},
+						NextPageToken: nil,
+					}, nil
+				}
+				return &resource.ListResult{}, nil
+			},
+			Delete: func(request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+				return &resource.DeleteResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationDelete,
+					OperationStatus: resource.OperationStatusSuccess,
+					NativeID:        request.NativeID,
+				}}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		cfg.Agent.Retry.MaxRetries = 0
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		// ── Step 1: Apply ───────────────────────────────────────────────
+		// provider (static target) → cluster resource → consumer (nested
+		// target with $ref to cluster's Endpoint) → app resource
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "infra"}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label: "cluster", Type: "FakeAWS::S3::Bucket", Stack: "infra", Target: "provider",
+					Managed: true, Ksuid: clusterKsuid,
+					Schema:     pkgmodel.Schema{Identifier: "BucketName", Fields: []string{"BucketName", "Endpoint"}, Portable: true},
+					Properties: json.RawMessage(clusterProps),
+				},
+				{
+					Label: "app", Type: "FakeAWS::S3::Bucket", Stack: "infra", Target: "consumer",
+					Managed: true,
+					Schema:     pkgmodel.Schema{Identifier: "BucketName", Fields: []string{"BucketName"}, Portable: true},
+					Properties: json.RawMessage(`{"BucketName":"my-app"}`),
+				},
+			},
+			Targets: []pkgmodel.Target{
+				{Label: "provider", Namespace: "FakeAWS", Config: json.RawMessage(`{"region":"us-east-1"}`)},
+				{
+					Label:        "consumer",
+					Namespace:    "FakeAWS",
+					Discoverable: true,
+					Config: json.RawMessage(fmt.Sprintf(`{
+						"endpoint": {"$ref": "formae://%s#/Endpoint"}
+					}`, clusterKsuid)),
+				},
+			},
+		}
+
+		_, err = m.ApplyForma(forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+		require.NoError(t, err)
+
+		assert.Eventually(t, func() bool {
+			incomplete, _ := m.Datastore.LoadIncompleteFormaCommands()
+			return len(incomplete) == 0
+		}, 10*time.Second, 100*time.Millisecond, "apply should complete")
+
+		// Verify managed resources exist
+		infraResources, err := m.Datastore.LoadResourcesByStack("infra")
+		require.NoError(t, err)
+		require.Len(t, infraResources, 2, "cluster + app should exist after apply")
+
+		// ── Step 2: Discovery ───────────────────────────────────────────
+		// Discover an unmanaged resource on the consumer target.
+		incoming := make(chan any, 1)
+		_, err = testutil.StartTestHelperActor(m.Node, incoming)
+		require.NoError(t, err)
+
+		err = testutil.Send(m.Node, "Discovery", discovery.Discover{})
+		require.NoError(t, err)
+
+		assert.Eventually(t, func() bool {
+			unmanaged, err := m.Datastore.LoadResourcesByStack("$unmanaged")
+			if err != nil {
+				return false
+			}
+			return len(unmanaged) >= 1
+		}, 10*time.Second, 100*time.Millisecond, "discovery should find unmanaged resource")
+
+		// ── Step 3: Destroy ─────────────────────────────────────────────
+		// Destroy the forma. This deletes:
+		// - managed resources (cluster, app)
+		// - consumer target (has $ref dependency → eligible for deletion)
+		// But leaves:
+		// - provider target (no $ref → survives)
+		// - unmanaged discovered resource (not in forma → not destroyed)
+		_, err = m.DestroyForma(forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+		require.NoError(t, err)
+
+		assert.Eventually(t, func() bool {
+			cmds, _ := m.Datastore.LoadFormaCommands()
+			incomplete, _ := m.Datastore.LoadIncompleteFormaCommands()
+			// apply + destroy = 2 commands (discovery doesn't create forma commands)
+			return len(cmds) >= 2 && len(incomplete) == 0
+		}, 10*time.Second, 100*time.Millisecond, "destroy should complete")
+
+		// ── Step 4: Verify post-destroy state ───────────────────────────
+		// Managed resources and consumer target are gone.
+		infraResources, err = m.Datastore.LoadResourcesByStack("infra")
+		require.NoError(t, err)
+		assert.Empty(t, infraResources, "managed resources should be destroyed")
+
+		consumerTarget, err := m.Datastore.LoadTarget("consumer")
+		require.NoError(t, err)
+		assert.Nil(t, consumerTarget, "consumer target should be deleted (has $ref)")
+
+		// The discovered resource is still in the DB — orphaned.
+		unmanaged, err := m.Datastore.LoadResourcesByStack("$unmanaged")
+		require.NoError(t, err)
+		require.NotEmpty(t, unmanaged, "discovered resource should still exist (orphaned)")
+
+		// ── Step 5: Sync ────────────────────────────────────────────────
+		// The sync cycle encounters the orphaned resource whose target no
+		// longer exists. It should detect the missing target and clean up
+		// the resource via the "deleted out-of-band" path.
+		err = m.ForceSync()
+		require.NoError(t, err)
+
+		// ── Step 6: Verify cleanup ──────────────────────────────────────
+		assert.Eventually(t, func() bool {
+			unmanaged, err := m.Datastore.LoadResourcesByStack("$unmanaged")
+			if err != nil {
+				return false
+			}
+			return len(unmanaged) == 0
+		}, 10*time.Second, 100*time.Millisecond,
+			"orphaned unmanaged resource should be cleaned up by sync after target deletion")
 	})
 }


### PR DESCRIPTION
## Summary

- When a target with discovered (unmanaged) resources is destroyed, the resources remain in the DB referencing the now-deleted target. The sync cycle would then crash with a nil pointer dereference or produce repeated `UnforeseenError` logs on every tick.

## Fix

There were different options here all with trade-offs. In theory the synchronizer can detect when a target doesn't exist anymore in the `GenerateResourceUpdates` function, but then the synchronizer would have to clean up the resources and we would:
- introduce coupling between the synchronizer and the resource persister
- have to add extra code to the resource persister to delete resources from the DB (or tombstone them) via this path

Instead we:
- Set a sentinel target in sync generator: when `existingTargetMap[resource.Target]` is nil, pass an empty `Target{Label: ...}` instead of dereferencing nil.
- Short-circuit in ResourceUpdater: when `ResourceTarget.Config` is nil (sentinel), skip the plugin call and produce a synthetic NotFound result. The existing "deleted OOB" path in the ResourcePersister then removes the resource from the DB.

This PR also removes the per-resource sync registration from startResourceUpdate: sync exclusion is already handled in bulk by registerAllResourcesWithSynchronizer at changeset start and unregisterAllResourcesFromSynchronizer at changeset end. The per-resource registration was redundant for user changesets (already covered by bulk) and leaked entries for discovery changesets (no corresponding unregister), permanently blocking discovered resources from future sync cycles. Bulk registration guarantees atomic protection for the entire stack.
