### PR TITLE
chore(deps): demote statemachine timeout logs to debug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests
 
 replace github.com/platform-engineering-labs/formae/tests/testcontrol => ./tests/testcontrol
 
-replace ergo.services/actor/statemachine => github.com/JeroenSoeters/actor/statemachine v0.0.0-20260319024748-85c28f9f660b
+replace ergo.services/actor/statemachine => github.com/JeroenSoeters/actor/statemachine v0.0.0-20260415213736-97867d619df3
 
 replace github.com/platform-engineering-labs/formae/pkg/auth => ./pkg/auth
 

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/k
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/DataDog/zstd v1.5.7 h1:ybO8RBeh29qrxIhCA9E8gKY6xfONU9T6G6aP9DTKfLE=
 github.com/DataDog/zstd v1.5.7/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/JeroenSoeters/actor/statemachine v0.0.0-20260319024748-85c28f9f660b h1:HBny9tCyJDRftwBjIYPO2cHJu2faBhmyfvFMeGda/cU=
-github.com/JeroenSoeters/actor/statemachine v0.0.0-20260319024748-85c28f9f660b/go.mod h1:pZkasfR9a9QIG3HbjvI5dDZpv07YQFgYXiXqCctIrmg=
+github.com/JeroenSoeters/actor/statemachine v0.0.0-20260415213736-97867d619df3 h1:HrWd6pGzjADOKrueCuQvJr+xptRNwJR0uFgRzC4VE/I=
+github.com/JeroenSoeters/actor/statemachine v0.0.0-20260415213736-97867d619df3/go.mod h1:XbiEudzYCbg5YvbIMqylWXH2iWnUeKagDTfPR7uOaqg=
 github.com/JeroenSoeters/ergo v1.999.320-pel.1 h1:f+FhIqLSeK81oArXJ9QkaOhHjahyW9Ec0T50xlGVxI4=
 github.com/JeroenSoeters/ergo v1.999.320-pel.1/go.mod h1:bLQ6PoO6Mz/8gVuzvPv3xfMfo1P9w6rZV1WnMXMeMdg=
 github.com/JeroenSoeters/pkl-go v0.12.1-pel.1 h1:g0UYRvQlzoK3v/frW8jvHD+i/A21jEPkXRV7AWhf7ws=


### PR DESCRIPTION
## Summary
- Updates statemachine fork to demote state timeout lifecycle logs (scheduled, canceling, replacing) from Warning to Debug level
- These logs represent normal FSM mechanics (safety timeouts for PluginOperator/ResolveCache), not actual problems

## Test plan
- [ ] Deploy agent and verify the timeout logs no longer appear at Warning level
- [ ] Confirm actual timeout handler behavior (PluginOperatorMissingInAction, ResolveCacheMissingInAction) still works correctly