### PR TITLE
fix(conformance): update config for per-plugin discovery and top-level pluginDir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,14 @@ VERSION := $(shell git describe --tags --abbrev=0 --match "[0-9]*" --match "v[0-
 # Without @ref, the default branch (main) is used.
 EXTERNAL_PLUGIN_REPOS ?= \
     https://github.com/platform-engineering-labs/formae-plugin-auth-basic.git \
-    https://github.com/platform-engineering-labs/formae-plugin-aws.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-azure.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-compose.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-gcp.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-grafana.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-oci.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-ovh.git@feat/msgpack-serialization \
-    https://github.com/platform-engineering-labs/formae-plugin-sftp.git@feat/msgpack-serialization
+    https://github.com/platform-engineering-labs/formae-plugin-aws.git \
+    https://github.com/platform-engineering-labs/formae-plugin-azure.git \
+    https://github.com/platform-engineering-labs/formae-plugin-compose.git \
+    https://github.com/platform-engineering-labs/formae-plugin-gcp.git \
+    https://github.com/platform-engineering-labs/formae-plugin-grafana.git \
+    https://github.com/platform-engineering-labs/formae-plugin-oci.git \
+    https://github.com/platform-engineering-labs/formae-plugin-ovh.git \
+    https://github.com/platform-engineering-labs/formae-plugin-sftp.git
 
 # Directory for cloned plugins
 PLUGINS_CACHE := .plugins

--- a/pkg/plugin-conformance-tests/harness.go
+++ b/pkg/plugin-conformance-tests/harness.go
@@ -534,7 +534,7 @@ func (h *TestHarness) ConfigureDiscovery(resourceTypes []string) error {
 		resourceTypesList += fmt.Sprintf("            %q\n", rt)
 	}
 
-	// Determine plugin name from discovered plugins for per-plugin config block
+	// Determine plugin name and PascalCase alias from discovered plugins
 	pluginName := ""
 	if len(h.externalResourcePlugins) > 0 {
 		pluginName = h.externalResourcePlugins[0].Name
@@ -542,10 +542,12 @@ func (h *TestHarness) ConfigureDiscovery(resourceTypes []string) error {
 	if pluginName == "" {
 		return fmt.Errorf("no external resource plugins discovered; cannot configure per-plugin discovery")
 	}
+	pluginAlias := pluginNameToPascalCase(pluginName)
 
 	// Generate updated config file with discovery enabled
 	// Use unique nodename per test to enable parallel test execution
 	// resourceTypesToDiscover is configured per-plugin via agent.resourcePlugins
+	// using the typed PluginConfig from the plugin's schema/Config.pkl
 	configContent := fmt.Sprintf(`/*
  * © 2025 Platform Engineering Labs Inc.
  *
@@ -555,17 +557,19 @@ func (h *TestHarness) ConfigureDiscovery(resourceTypes []string) error {
 // Auto-generated test configuration
 amends "formae:/Config.pkl"
 
+import "plugins:/%s.pkl" as %s
+
 agent {
     server {
-        port = %d
-        ergoPort = %d
-        registrarPort = %d
-        secret = %q
-        nodename = "formae-%s"
+        port = %%d
+        ergoPort = %%d
+        registrarPort = %%d
+        secret = %%q
+        nodename = "formae-%%s"
     }
     datastore {
         sqlite {
-            filePath = %q
+            filePath = %%q
         }
     }
     synchronization {
@@ -576,27 +580,28 @@ agent {
     }
     logging {
         consoleLogLevel = "debug"
-        filePath = %q
+        filePath = %%q
         fileLogLevel = "debug"
     }
     resourcePlugins {
-        new {
-            type = %q
+        new %s.PluginConfig {
             resourceTypesToDiscover {
-%s            }
+%%s            }
         }
     }
 }
 
 cli {
     api {
-        port = %d
+        port = %%d
     }
 	disableUsageReporting = true
 }
 
 pluginDir = "~/.pel/formae/plugins"
-`, h.agentPort, h.ergoPort, h.registrarPort, h.networkCookie, h.testRunID, dbPath, h.logFile, pluginName, resourceTypesList, h.agentPort)
+`, pluginAlias, pluginAlias, pluginAlias)
+
+	configContent = fmt.Sprintf(configContent, h.agentPort, h.ergoPort, h.registrarPort, h.networkCookie, h.testRunID, dbPath, h.logFile, resourceTypesList, h.agentPort)
 
 	// Overwrite the config file
 	if err := os.WriteFile(h.configFile, []byte(configContent), 0644); err != nil {
@@ -1994,4 +1999,21 @@ func (h *TestHarness) WaitForResourceRemovedFromInventory(resourceType, nativeID
 	}
 
 	return fmt.Errorf("timeout waiting for resource %s (type: %s) to be removed from inventory after %v", nativeID, resourceType, timeout)
+}
+
+// pluginNameToPascalCase converts a hyphenated plugin name to PascalCase
+// for use in PKL import aliases. For example: "aws" -> "Aws", "auth-basic" -> "AuthBasic".
+func pluginNameToPascalCase(name string) string {
+	parts := strings.Split(name, "-")
+	var b strings.Builder
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		b.WriteString(strings.ToUpper(part[:1]))
+		if len(part) > 1 {
+			b.WriteString(part[1:])
+		}
+	}
+	return b.String()
 }

--- a/pkg/plugin-conformance-tests/harness.go
+++ b/pkg/plugin-conformance-tests/harness.go
@@ -528,14 +528,24 @@ func (h *TestHarness) ConfigureDiscovery(resourceTypes []string) error {
 	// Create database path in temp directory
 	dbPath := filepath.Join(h.tempDir, "formae-test.db")
 
-	// Build the resourceTypesToDiscover listing
+	// Build the resourceTypesToDiscover listing for per-plugin config
 	resourceTypesList := ""
 	for _, rt := range resourceTypes {
-		resourceTypesList += fmt.Sprintf("        %q\n", rt)
+		resourceTypesList += fmt.Sprintf("            %q\n", rt)
+	}
+
+	// Determine plugin name from discovered plugins for per-plugin config block
+	pluginName := ""
+	if len(h.externalResourcePlugins) > 0 {
+		pluginName = h.externalResourcePlugins[0].Name
+	}
+	if pluginName == "" {
+		return fmt.Errorf("no external resource plugins discovered; cannot configure per-plugin discovery")
 	}
 
 	// Generate updated config file with discovery enabled
 	// Use unique nodename per test to enable parallel test execution
+	// resourceTypesToDiscover is configured per-plugin via agent.resourcePlugins
 	configContent := fmt.Sprintf(`/*
  * © 2025 Platform Engineering Labs Inc.
  *
@@ -563,13 +573,18 @@ agent {
     }
     discovery {
         enabled = true
-        resourceTypesToDiscover {
-%s        }
     }
     logging {
         consoleLogLevel = "debug"
         filePath = %q
         fileLogLevel = "debug"
+    }
+    resourcePlugins {
+        new {
+            type = %q
+            resourceTypesToDiscover {
+%s            }
+        }
     }
 }
 
@@ -579,7 +594,9 @@ cli {
     }
 	disableUsageReporting = true
 }
-`, h.agentPort, h.ergoPort, h.registrarPort, h.networkCookie, h.testRunID, dbPath, resourceTypesList, h.logFile, h.agentPort)
+
+pluginDir = "~/.pel/formae/plugins"
+`, h.agentPort, h.ergoPort, h.registrarPort, h.networkCookie, h.testRunID, dbPath, h.logFile, pluginName, resourceTypesList, h.agentPort)
 
 	// Overwrite the config file
 	if err := os.WriteFile(h.configFile, []byte(configContent), 0644); err != nil {


### PR DESCRIPTION
## Summary

Updates the conformance test harness config generation to match the new config schema from the extensions refactor and per-plugin config (PR #398).

**Changes:**
- Move `resourceTypesToDiscover` from `agent.discovery` to per-plugin `agent.resourcePlugins` block
- Use typed plugin import (`import "plugins:/<Plugin>.pkl" as <Plugin>`) and `new <Plugin>.PluginConfig { ... }` instead of instantiating `BaseResourcePluginConfig` directly
- Add `pluginNameToPascalCase` helper to derive the import alias from the plugin name
- Add top-level `pluginDir` to the discovery config template (was missing)

**Requires:** Each plugin must have `schema/Config.pkl` extending `BaseResourcePluginConfig` with a typed `PluginConfig` class. All plugins except formae-plugin-aws already have this on main.

**Root cause:** The extensions refactor (`0cacd56`) moved `pluginDir` to top-level and PR #398 introduced per-plugin `resourceTypesToDiscover` via `agent.resourcePlugins`. The harness was generating the old format, causing every conformance test to fail with formae >= v0.84.0.

**Tested:** Generated config template validated with `pkl eval` against the grafana plugin's `Config.pkl`.

## Test plan

- [ ] Merge and tag new `pkg/plugin-conformance-tests` version
- [ ] Add `schema/Config.pkl` to formae-plugin-aws
- [ ] Bump conformance-tests dependency in formae-plugin-aws and re-run CI