### PR TITLE
fix(cli): remove broken documentation deep links

### DIFF
--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -411,7 +411,7 @@ func (a *App) runBeforeCommand(client *api.Client, transmitStats bool) (bool, *a
 	}
 
 	if stats.Version != formae.Version {
-		return false, nil, nil, fmt.Errorf("incompatible agent version: expected %s, got %s\n\n%s %s%s", formae.Version, stats.Version, display.Gold("Configuration documentation:"), display.DocRoot, "operations")
+		return false, nil, nil, fmt.Errorf("incompatible agent version: expected %s, got %s\n\n%s %s", formae.Version, stats.Version, display.Gold("Configuration documentation:"), display.DocRoot)
 	}
 
 	if transmitStats && !a.Config.Cli.DisableUsageReporting {

--- a/internal/cli/cmd/cmd.go
+++ b/internal/cli/cmd/cmd.go
@@ -35,7 +35,7 @@ var RootCmdUsageTemplate = display.Grey("Usage: ") + display.Green("{{.CommandPa
 	"{{if .HasAvailableLocalFlags}}\n" + display.Gold("Options:\n") +
 	"{{range .LocalFlags | optionsUsage}}{{.}}\n{{end}}" +
 	"{{end}}" +
-	display.Links("Docs", "cli/{{.Name}}") +
+	display.DefaultLinks() +
 	"\n"
 
 var SimpleCmdUsageTemplate = display.Grey("Usage: ") + display.Green("{{.CommandPath}}{{if .HasAvailableLocalFlags}} [OPTIONS]{{end}}{{if .HasAvailableSubCommands}} [COMMAND]{{end}}") +
@@ -53,7 +53,7 @@ var SimpleCmdUsageTemplate = display.Grey("Usage: ") + display.Green("{{.Command
 	"{{if .LocalFlags | hasPropertyFlags}}\n" + display.Gold("Properties:\n") +
 	"{{range .LocalFlags | propertyUsage}}{{.}}\n{{end}}" +
 	"{{end}}" +
-	display.Links("Docs", "cli/{{.Name}}") +
+	display.DefaultLinks() +
 	"\n"
 
 var PropertyCommands = []string{
@@ -68,7 +68,7 @@ func AppFromContext(ctx context.Context, configFilePath, endpoint string, cmd *c
 
 		err := app.LoadConfig(configFilePath, filepath.Join(config.Config.ConfigDirectory(), config.ConfigFileNamePrefix))
 		if err != nil {
-			return nil, fmt.Errorf("%w%s", err, display.Links("Configuration docs", "configuration"))
+			return nil, fmt.Errorf("%w\n\n%s %s", err, display.Gold("Configuration docs:"), display.DocRoot+"/configuration")
 		}
 
 		return app, nil

--- a/internal/cli/display/display.go
+++ b/internal/cli/display/display.go
@@ -58,16 +58,7 @@ func Error(msg string) {
 }
 
 func DefaultLinks() string {
-	return Links("Docs", "")
-}
-
-func Links(docLinkName string, deepLinkName string) string {
-	deepLink := DocRoot
-	if deepLinkName != "" {
-		deepLink += "/" + deepLinkName
-	}
-
 	return "\n" + Gold("Code: ") + "https://github.com/platform-engineering-labs/formae" +
-		"\n" + Gold(fmt.Sprintf("%s: ", docLinkName)) + deepLink +
+		"\n" + Gold("Docs: ") + DocRoot +
 		"\n" + Gold("Bugs: ") + "https://github.com/platform-engineering-labs/formae/issues"
 }


### PR DESCRIPTION
## Summary
- Fix broken CLI doc links that appended non-existent paths like `/cli/formae` and `/operations` to the docs root URL (closes #397)
- Remove the unused `Links()` function, replace with `DefaultLinks()` which links to the docs root
- Inline the one working deep link (`/configuration`) directly at its call site