### PR TITLE
fix(blackbox): revert authoritative seeding in early-completion corrected map

### DIFF
--- a/tests/blackbox/executor.go
+++ b/tests/blackbox/executor.go
@@ -345,18 +345,7 @@ func (h *TestHarness) reconcileCompletedAcceptedCommands(t *testing.T, model *St
 	// Process completed commands in REVERSE order (most recent first) so
 	// later command outcomes take precedence over earlier ones. This matches
 	// DrainPendingCommands' reverse-order processing.
-	//
-	// Seed the corrected map from authoritative slots so that stale commands
-	// (accepted before a TTL destroy or similar authoritative event) cannot
-	// override ground truth established by ForceCheckTTLAndWait.
 	corrected := make(map[struct{ stackIdx, slotIdx int }]bool)
-	for s, stack := range model.Stacks {
-		for idx := range stack.Resources {
-			if model.IsAuthoritativeSlot(s, idx) {
-				corrected[struct{ stackIdx, slotIdx int }{s, idx}] = true
-			}
-		}
-	}
 	for i := len(completed) - 1; i >= 0; i-- {
 		cc := completed[i]
 		t.Logf("reconcileCompletedAcceptedCommands: command %s completed early (state=%s)", cc.ac.CommandID, cc.cmd.State)


### PR DESCRIPTION
The authoritative seeding in reconcileCompletedAcceptedCommands caused
false negatives: new commands accepted after a TTL destroy (which clears
authoritative via ApplyCreatedResolved) would not be protected by the
seeded corrected map, making the model miss legitimate creates.

Reverts the seeding. The original TTL + stale create race needs a
different fix (tracking command acceptance order relative to TTL events).

Fixes the nightly FullChaos failure on main.