### PR TITLE
fix(plugin): address code review findings from PR #415

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -105,7 +105,7 @@ func (a *Agent) Start() error {
 		pluginDir := util.ExpandHomePath(a.cfg.PluginDir)
 		resourceInfos := plugindiscovery.DiscoverPlugins(pluginDir, plugindiscovery.Resource)
 		resourceInfos = plugindiscovery.FilterCompatiblePlugins(
-			resourceInfos, formae.Version, plugin.MinFormaeVersion,
+			resourceInfos, formae.Version, plugin.MinFormaeVersion, plugin.SDKVersion,
 		)
 		externalResourcePlugins := make([]plugin.ResourcePluginInfo, len(resourceInfos))
 		for i, p := range resourceInfos {
@@ -139,7 +139,7 @@ func (a *Agent) Start() error {
 				return
 			}
 			compatibleAuth := plugindiscovery.FilterCompatiblePlugins(
-				[]plugindiscovery.PluginInfo{*matchedPlugin}, formae.Version, pkgauth.MinFormaeVersion,
+				[]plugindiscovery.PluginInfo{*matchedPlugin}, formae.Version, pkgauth.MinFormaeVersion, pkgauth.SDKVersion,
 			)
 			if len(compatibleAuth) == 0 {
 				slog.Error("Auth plugin installed but incompatible — refusing to start",

--- a/pkg/plugin-conformance-tests/setup.go
+++ b/pkg/plugin-conformance-tests/setup.go
@@ -79,8 +79,8 @@ func EnsureFormaeBinary(t *testing.T) (binaryPath string, cleanup func()) {
 	version := extractVersion(t, binPath)
 	t.Logf("formae binary version: %s", version)
 
-	os.Setenv("FORMAE_VERSION", version)
-	os.Setenv("FORMAE_BINARY", binPath)
+	t.Setenv("FORMAE_VERSION", version)
+	t.Setenv("FORMAE_BINARY", binPath)
 
 	return binPath, cleanup
 }
@@ -109,6 +109,11 @@ func ResolvePKLDependencies(t *testing.T, version string, projectDirs ...string)
 
 	for _, dir := range projectDirs {
 		pklPath := filepath.Join(dir, "PklProject")
+
+		if _, err := os.Stat(pklPath); os.IsNotExist(err) {
+			t.Logf("No PklProject found in %s, skipping", dir)
+			continue
+		}
 
 		original, err := os.ReadFile(pklPath)
 		if err != nil {

--- a/pkg/plugin/discovery/discovery.go
+++ b/pkg/plugin/discovery/discovery.go
@@ -206,7 +206,7 @@ func discoverHighestVersion(pluginPath, pluginName string, pluginType PluginType
 // Plugins with an empty or unparseable MinFormaeVersion are skipped with a
 // warning. If agentVersion or sdkMinFormaeVersion cannot be parsed, all
 // plugins are skipped.
-func FilterCompatiblePlugins(plugins []PluginInfo, agentVersion, sdkMinFormaeVersion string) []PluginInfo {
+func FilterCompatiblePlugins(plugins []PluginInfo, agentVersion, sdkMinFormaeVersion, sdkVersion string) []PluginInfo {
 	if len(plugins) == 0 {
 		return nil
 	}
@@ -259,11 +259,11 @@ func FilterCompatiblePlugins(plugins []PluginInfo, agentVersion, sdkMinFormaeVer
 
 		// Check 2: plugin built against an older, unsupported SDK
 		if pluginMinVer.LessThan(sdkMinVer) {
-			slog.Warn("plugin built against older SDK; skipping — upgrade to SDK "+plugin.SDKVersion,
+			slog.Warn("plugin built against older SDK; skipping — upgrade to SDK "+sdkVersion,
 				"plugin", p.Name, "version", p.Version,
 				"pluginMinFormaeVersion", p.MinFormaeVersion,
 				"sdkMinFormaeVersion", sdkMinFormaeVersion,
-				"currentSDKVersion", plugin.SDKVersion)
+				"currentSDKVersion", sdkVersion)
 			continue
 		}
 

--- a/pkg/plugin/discovery/discovery_test.go
+++ b/pkg/plugin/discovery/discovery_test.go
@@ -231,7 +231,7 @@ func TestFilterCompatiblePlugins(t *testing.T) {
 
 	// agentVersion=1.0.0 is >= compatible's minFormaeVersion (0.80.0)
 	// sdkMinFormaeVersion=0.50.0 is <= compatible's minFormaeVersion (0.80.0)
-	result := FilterCompatiblePlugins(allPlugins, "1.0.0", "0.50.0")
+	result := FilterCompatiblePlugins(allPlugins, "1.0.0", "0.50.0", "0.2.1")
 
 	require.Len(t, result, 1)
 	assert.Equal(t, "aws", result[0].Name)
@@ -245,7 +245,7 @@ func TestFilterCompatiblePlugins_UnparseableAgentVersion(t *testing.T) {
 		},
 	}
 
-	result := FilterCompatiblePlugins(plugins, "not-a-version", "0.50.0")
+	result := FilterCompatiblePlugins(plugins, "not-a-version", "0.50.0", "0.2.1")
 	assert.Empty(t, result)
 }
 
@@ -257,7 +257,7 @@ func TestFilterCompatiblePlugins_UnparseablePluginMinFormaeVersion(t *testing.T)
 		},
 	}
 
-	result := FilterCompatiblePlugins(plugins, "1.0.0", "0.50.0")
+	result := FilterCompatiblePlugins(plugins, "1.0.0", "0.50.0", "0.2.1")
 	assert.Empty(t, result)
 }
 
@@ -269,7 +269,7 @@ func TestFilterCompatiblePlugins_UnparseableSDKMinFormaeVersion(t *testing.T) {
 		},
 	}
 
-	result := FilterCompatiblePlugins(plugins, "1.0.0", "bad-version")
+	result := FilterCompatiblePlugins(plugins, "1.0.0", "bad-version", "0.2.1")
 	assert.Empty(t, result)
 }
 
@@ -280,12 +280,12 @@ func TestFilterCompatiblePlugins_DevBuildSkipsChecks(t *testing.T) {
 	}
 
 	// Dev builds use version "0.0.0" — all plugins should be loaded
-	result := FilterCompatiblePlugins(plugins, "0.0.0", "0.84.0")
+	result := FilterCompatiblePlugins(plugins, "0.0.0", "0.84.0", "0.2.1")
 	require.Len(t, result, 2)
 }
 
 func TestFilterCompatiblePlugins_EmptyInput(t *testing.T) {
-	result := FilterCompatiblePlugins(nil, "1.0.0", "0.50.0")
+	result := FilterCompatiblePlugins(nil, "1.0.0", "0.50.0", "0.2.1")
 	assert.Nil(t, result)
 }
 
@@ -295,6 +295,6 @@ func TestFilterCompatiblePlugins_AllCompatible(t *testing.T) {
 		{Name: "gcp", MinFormaeVersion: "0.90.0"},
 	}
 
-	result := FilterCompatiblePlugins(plugins, "1.0.0", "0.50.0")
+	result := FilterCompatiblePlugins(plugins, "1.0.0", "0.50.0", "0.2.1")
 	require.Len(t, result, 2)
 }

--- a/tests/blackbox/executor.go
+++ b/tests/blackbox/executor.go
@@ -2198,6 +2198,32 @@ func (h *TestHarness) ForceCheckTTLAndWait(t *testing.T, model *StateModel) {
 		}
 		model.Stacks[stackIdx].TTLExpired = false
 		t.Logf("ForceCheckTTLAndWait: stack %s command %s completed: %s", expiredLabel, commandID, cmd.State)
+
+		if cmd.State == "Success" {
+			// Purge accepted commands whose requested slots all fall within
+			// the destroyed stack. Their outcomes are stale — the TTL destroy
+			// is the ground truth. Without this, reconcileCompletedAcceptedCommands
+			// or DrainPendingCommands would process the stale command response
+			// (e.g. op=create from a SetTTLPolicy reconcile-apply) and override
+			// the model state set by the TTL destroy.
+			filtered := model.AcceptedCommands[:0]
+			for _, ac := range model.AcceptedCommands {
+				superseded := len(ac.RequestedSlots) > 0
+				for _, ref := range ac.RequestedSlots {
+					if ref.StackIndex != stackIdx {
+						superseded = false
+						break
+					}
+				}
+				if superseded {
+					t.Logf("ForceCheckTTLAndWait: purging superseded command %s (all slots in destroyed stack %s)",
+						ac.CommandID, expiredLabel)
+				} else {
+					filtered = append(filtered, ac)
+				}
+			}
+			model.AcceptedCommands = filtered
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Use `t.Setenv` instead of `os.Setenv` in conformance test setup to prevent env var leaks across parallel tests
- Handle missing `PklProject` gracefully in `ResolvePKLDependencies` — skip with a log instead of fataling, supporting minimal plugins without `testdata/PklProject`
- Pass `sdkVersion` as parameter to `FilterCompatiblePlugins` so auth plugins show `pkg/auth` SDK version in upgrade messages instead of `pkg/plugin` version