### PR TITLE
fix(docker): run plugin migration as pel user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,11 @@ RUN apt-get update &&  \
     apt-get clean && \
     /opt/pel/bin/formae clean --all
 
-# Temp Fix: Trigger plugin migration so resource plugins are baked into the image.
-RUN PATH=/opt/pel/bin:$PATH HOME=/home/pel \
-    /opt/pel/bin/formae agent start >/dev/null 2>&1 & sleep 5 && \
-    /opt/pel/formae/bin/formae agent stop >/dev/null 2>&1 || true && \
-    chown -R pel:pel /home/pel/.pel /home/pel/.config && \
+# Trigger plugin migration so resource plugins are baked into the image.
+# Run as the pel user so files/pid files are created with correct ownership.
+# Running as root would leave a root-owned /tmp/formae.pid that the pel user
+# cannot read or delete at container runtime, breaking agent startup.
+RUN su - pel -c "PATH=/opt/pel/bin:$PATH HOME=/home/pel /opt/pel/bin/formae agent start >/dev/null 2>&1 & sleep 5 && /opt/pel/bin/formae agent stop >/dev/null 2>&1 || true" && \
     test -d /home/pel/.pel/formae/plugins && \
     test "$(ls -A /home/pel/.pel/formae/plugins)" || \
     (echo "ERROR: plugin migration failed" && exit 1)


### PR DESCRIPTION
## Summary

The plugin migration step in the Dockerfile starts the agent briefly to copy resource plugins into the user directory. Running this as root leaves a root-owned `/tmp/formae.pid` in the image, which the runtime `pel` user cannot read or delete due to /tmp's sticky bit.

In 0.84.0, the agent added a PID file check at startup. On ECS (and any runtime using the container), the agent fails with:

```
Error starting agent: agent appears to be already running (PID file exists but unreadable): open /tmp/formae.pid: permission denied
```

## Fix

Run the migration as the `pel` user via `su - pel -c ...`. This means:
- Plugin files and the PID file are created with correct ownership
- The `chown -R` workaround for `/home/pel/.pel` and `/home/pel/.config` is no longer needed
- The stale PID file is written to a writable location owned by `pel`, so even if the check runs at container startup, it can be cleaned up