### PR TITLE
fix(discovery): skip child list ops when parent properties are missing

### DIFF
--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -755,23 +755,13 @@ func discoverChildren(parents []*pkgmodel.Resource, op ListOperation, data Disco
 
 	for _, parent := range parents {
 		for childNode, mappingProps := range parentNode.children {
-			listParams := make(map[string]plugin.ListParam)
-			for _, param := range mappingProps {
-				value, found := parent.GetProperty(param.ParentProperty)
-				if found {
-					// Extract the actual value if this is a JSON reference object.
-					// This handles cases like OCI resources where parent properties (e.g. CompartmentID)
-					// are serialized as {"$ref":"...","$value":"..."} reference objects.
-					// We need only the value for the List API call.
-					actualValue := extractActualValue(value)
-					listParams[param.ListProperty] = plugin.ListParam{
-						ParentProperty: param.ParentProperty,
-						ListParam:      param.ListProperty,
-						ListValue:      actualValue,
-					}
-				} else {
-					proc.Log().Error("Missing parent property property=%s parent_id=%s", param.ParentProperty, parent.NativeID)
-				}
+			listParams, ok := buildChildListParams(parent, mappingProps)
+			if !ok {
+				// At least one required mapping property is missing on the parent.
+				// Skip queueing — a List call without the required filter parameters
+				// would be rejected by the cloud API (e.g. AWS CloudControl).
+				proc.Log().Error("Skipping child discovery - parent missing required property childType=%s parentType=%s parentNativeID=%s", childNode.resourceType, parent.Type, parent.NativeID)
+				continue
 			}
 			data.queuedListOperations[data.targets[op.TargetLabel].Namespace] = append(data.queuedListOperations[data.targets[op.TargetLabel].Namespace], ListOperation{
 				ResourceType: childNode.resourceType,
@@ -791,6 +781,28 @@ func discoverChildren(parents []*pkgmodel.Resource, op ListOperation, data Disco
 	}
 
 	return nil
+}
+
+// buildChildListParams resolves each parent property listed in mappingProps into a
+// plugin.ListParam keyed by the child's list parameter name. It returns (nil, false)
+// if any required parent property is missing, so callers can skip queueing a child
+// list operation that would otherwise issue an API call with incomplete filters.
+// Parent properties serialized as resolvable reference objects
+// ({"$ref":..., "$value":...}) are unwrapped to their underlying value.
+func buildChildListParams(parent *pkgmodel.Resource, mappingProps []plugin.ListParameter) (map[string]plugin.ListParam, bool) {
+	params := make(map[string]plugin.ListParam, len(mappingProps))
+	for _, p := range mappingProps {
+		value, found := parent.GetProperty(p.ParentProperty)
+		if !found {
+			return nil, false
+		}
+		params[p.ListProperty] = plugin.ListParam{
+			ParentProperty: p.ParentProperty,
+			ListParam:      p.ListProperty,
+			ListValue:      extractActualValue(value),
+		}
+	}
+	return params, true
 }
 
 func syncCompleted(from gen.PID, state gen.Atom, data DiscoveryData, message changeset.ChangesetCompleted, proc gen.Process) (gen.Atom, DiscoveryData, []statemachine.Action, error) {

--- a/internal/metastructure/discovery/discovery_test.go
+++ b/internal/metastructure/discovery/discovery_test.go
@@ -5,12 +5,14 @@
 package discovery
 
 import (
+	"encoding/json"
 	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
 )
 
@@ -143,6 +145,62 @@ func TestMultipleNamespacesMerge(t *testing.T) {
 
 	ociVcn := hierarchy["OCI::VCN::VCN"]
 	assert.Len(t, ociVcn.children, 1)
+}
+
+func TestBuildChildListParams(t *testing.T) {
+	mappingProps := []plugin.ListParameter{
+		{ParentProperty: "ServiceName", ListProperty: "Service"},
+		{ParentProperty: "Cluster", ListProperty: "Cluster"},
+	}
+
+	t.Run("returns populated params and ok when all parent properties resolve", func(t *testing.T) {
+		parent := &pkgmodel.Resource{
+			Type:       "AWS::ECS::Service",
+			Properties: json.RawMessage(`{"ServiceName":"my-service","Cluster":"my-cluster"}`),
+		}
+
+		params, ok := buildChildListParams(parent, mappingProps)
+
+		assert.True(t, ok)
+		assert.Equal(t, map[string]plugin.ListParam{
+			"Service": {ParentProperty: "ServiceName", ListParam: "Service", ListValue: "my-service"},
+			"Cluster": {ParentProperty: "Cluster", ListParam: "Cluster", ListValue: "my-cluster"},
+		}, params)
+	})
+
+	t.Run("returns not-ok when any required parent property is missing", func(t *testing.T) {
+		parent := &pkgmodel.Resource{
+			Type:       "AWS::ECS::Service",
+			Properties: json.RawMessage(`{"ServiceName":"my-service"}`),
+		}
+
+		_, ok := buildChildListParams(parent, mappingProps)
+
+		assert.False(t, ok, "should refuse to build params when Cluster is missing")
+	})
+
+	t.Run("returns not-ok when parent properties are empty", func(t *testing.T) {
+		parent := &pkgmodel.Resource{
+			Type:       "AWS::ECS::Service",
+			Properties: json.RawMessage(`{}`),
+		}
+
+		_, ok := buildChildListParams(parent, mappingProps)
+
+		assert.False(t, ok)
+	})
+
+	t.Run("extracts value from resolvable reference objects", func(t *testing.T) {
+		parent := &pkgmodel.Resource{
+			Type:       "AWS::ECS::Service",
+			Properties: json.RawMessage(`{"ServiceName":"my-service","Cluster":{"$ref":"formae://cluster-ksuid#/Arn","$value":"my-cluster-arn"}}`),
+		}
+
+		params, ok := buildChildListParams(parent, mappingProps)
+
+		assert.True(t, ok)
+		assert.Equal(t, "my-cluster-arn", params["Cluster"].ListValue)
+	})
 }
 
 func TestInjectResolvables(t *testing.T) {


### PR DESCRIPTION
## Summary

- Child list operations in `discoverChildren` were queued even when the parent resource was missing one or more of the required mapping properties. That produced List API calls with incomplete filters.
- Concretely, AWS CloudControl rejected `ListResources` for `AWS::ECS::TaskSet` with `Missing Or Invalid ResourceModel property ... Required property: [Cluster, Service, Id]` on every discovery cycle.
- Extract the parent → `ListParams` resolution into `buildChildListParams` and have `discoverChildren` skip queueing when any required mapping property is absent. Emits a clear log line so operators can distinguish missing parent data from other listing failures.
- Unit tests cover the happy path, missing-property skip, empty-parent skip, and `$ref`/`$value` resolvable unwrapping.