### PR TITLE
  fix(target-update): ignore $value when classifying config changes

### DIFF
--- a/internal/metastructure/target_update/classify_config_change.go
+++ b/internal/metastructure/target_update/classify_config_change.go
@@ -29,6 +29,12 @@ const (
 // When schema has no hints (backwards compat), any change is treated as immutable.
 // Fields without a hint in the schema are treated as immutable (createOnly=true).
 func ClassifyConfigChange(existing, new json.RawMessage, schema pkgmodel.ConfigSchema) ConfigChangeType {
+	// Drop cached $value entries up front so a config with $ref+$value compares
+	// equal to one with only $ref. Without this, the early-return branches below
+	// would treat a cache-only diff as a real change.
+	existing = stripResolvableValuesRaw(existing)
+	new = stripResolvableValuesRaw(new)
+
 	if util.JsonEqualRaw(existing, new) {
 		return ConfigNoChange
 	}
@@ -91,6 +97,25 @@ func jsonBytesEqual(a, b json.RawMessage) bool {
 	aBytes, _ := json.Marshal(aVal)
 	bBytes, _ := json.Marshal(bVal)
 	return string(aBytes) == string(bBytes)
+}
+
+// stripResolvableValuesRaw returns a copy of raw with $value stripped from
+// every object that also carries a $ref. If raw is not valid JSON, it is
+// returned unchanged.
+func stripResolvableValuesRaw(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return raw
+	}
+	stripResolvableValues(v)
+	out, err := json.Marshal(v)
+	if err != nil {
+		return raw
+	}
+	return out
 }
 
 // stripResolvableValues recursively removes $value from any object that

--- a/internal/metastructure/target_update/classify_config_change_test.go
+++ b/internal/metastructure/target_update/classify_config_change_test.go
@@ -148,6 +148,17 @@ func TestClassifyConfigChange_ResolvableValueIgnored(t *testing.T) {
 	assert.Equal(t, ConfigMutableChange, result)
 }
 
+func TestClassifyConfigChange_ResolvableValueIgnored_NoHints(t *testing.T) {
+	// Stored config has resolved $value, new config only has $ref, and schema
+	// carries no hints. The sole diff is the cached $value, so the result
+	// should be NoChange — not ImmutableChange from the empty-hints early return.
+	existing := json.RawMessage(`{"Auth": {"Endpoint":{"$ref":"formae://abc#/Endpoint","$value":"https://cluster.eks.amazonaws.com"}}}`)
+	new := json.RawMessage(`{"Auth": {"Endpoint":{"$ref":"formae://abc#/Endpoint"}}}`)
+
+	result := ClassifyConfigChange(existing, new, pkgmodel.ConfigSchema{})
+	assert.Equal(t, ConfigNoChange, result)
+}
+
 func TestClassifyConfigChange_ResolvableDifferentRef_IsImmutable(t *testing.T) {
 	// Different $ref means genuinely different config
 	existing := json.RawMessage(`{"Auth": {"Endpoint":{"$ref":"formae://abc#/Endpoint","$value":"https://old.com"}}}`)


### PR DESCRIPTION
Resubmitting a target whose config carries resolvable `$ref` entries was showing a false diff: the stored config has `$ref`+`$value` (the cached resolved value), while the forma only declares `$ref`, so `ClassifyConfigChange` flagged the target as changed                                                                                                                                                                                                                                                                                                                                                                                        