### PR TITLE
fix(patch): strip hasProviderDefault fields recursively through arrays

### DIFF
--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -141,12 +141,17 @@ func createPatchDocument(document []byte, patch []byte, schemaFields []string, w
 		return nil, err
 	}
 
-	// Remove provider default fields from the document (existing state) if they are not in the desired state (patch).
-	// Provider default fields are optional fields that cloud providers assign default values to.
-	// If the user didn't specify the field in their PKL, we don't want to generate a "remove" operation
-	// that would delete the provider-assigned default. By removing these fields from the document
-	// before comparison (only when they're not in the desired state), we prevent oscillation.
-	documentWithoutProviderDefaults, err := removeProviderDefaultFields(documentWithoutWriteOnly, patchWithSchemaFieldsOnly, hasProviderDefaultFields)
+	// Remove provider default fields. For top-level paths we only strip from the
+	// document when the field is absent from the patch (preserves user
+	// overrides). For paths that traverse a list — e.g. `ContainerDefinitions.Cpu`
+	// — we strip the leaf key from BOTH sides in every array element, because
+	// jsonpatch's default set-based array comparison cannot reliably pair a
+	// document element that carries the provider-populated value with a patch
+	// element that omits it. Symmetric stripping makes those sub-fields
+	// invisible to the diff regardless of their value, which is the behavior we
+	// want for a hasProviderDefault annotation on a sub-field of a list
+	// element. See removeProviderDefaultFields for details.
+	patchWithSchemaFieldsOnly, documentWithoutProviderDefaults, err := removeProviderDefaultFieldsBoth(documentWithoutWriteOnly, patchWithSchemaFieldsOnly, hasProviderDefaultFields)
 	if err != nil {
 		return nil, err
 	}
@@ -258,38 +263,175 @@ func removeNestedField(obj map[string]any, path []string) {
 	}
 }
 
-// removeProviderDefaultFields removes fields from the document (actual state) that have provider defaults,
-// but only if those fields are NOT present in the patch (desired state).
-// This prevents "remove" operations for fields where the cloud provider assigns default values.
+// removeProviderDefaultFields removes fields with provider defaults from the
+// document (actual state) — and, for fields nested inside array elements,
+// symmetrically from the patch (desired state) too.
+//
+// Two regimes are at play:
+//
+//  1. Pure-object paths (e.g. "BucketEncryption" or "Config.Encryption"):
+//     the field is removed from the document only when it is absent from the
+//     patch. This preserves a user's explicit override of the provider
+//     default — their desired value remains in the patch and diffs normally.
+//
+//  2. Array-traversing paths (e.g. "ContainerDefinitions.Cpu" or
+//     "ContainerDefinitions.PortMappings.HostPort"): the leaf key is stripped
+//     from BOTH sides, in every reachable array element. This is necessary
+//     because jsonpatch compares array elements as opaque JSON blobs under
+//     its default set semantics, so a document element that carries the
+//     provider-populated value (e.g. Cpu:0) won't match a patch element that
+//     omits it — even though the user-intended shape is identical. The mixed
+//     case (one element sets the field, the other doesn't) cannot be fixed
+//     by stripping the document alone, because set-comparison has no stable
+//     pairing between elements. Symmetric stripping makes the provider-
+//     populated sub-field invisible to the diff regardless of value, which
+//     is the correct semantic for a hasProviderDefault annotation inside a
+//     collection of heterogeneous sub-resources.
 func removeProviderDefaultFields(document []byte, patch []byte, hasProviderDefaultFields []string) ([]byte, error) {
+	_, stripped, err := removeProviderDefaultFieldsBoth(document, patch, hasProviderDefaultFields)
+	return stripped, err
+}
+
+// removeProviderDefaultFieldsBoth is the two-sided counterpart used by the
+// patch pipeline: it returns the stripped patch as well as the stripped
+// document so that array-nested provider defaults are removed symmetrically.
+// Callers that only need the document side can use removeProviderDefaultFields.
+func removeProviderDefaultFieldsBoth(document []byte, patch []byte, hasProviderDefaultFields []string) ([]byte, []byte, error) {
 	if len(hasProviderDefaultFields) == 0 {
-		return document, nil
+		return patch, document, nil
 	}
 
 	var docMap map[string]any
 	if err := json.Unmarshal(document, &docMap); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal document: %w", err)
+		return nil, nil, fmt.Errorf("failed to unmarshal document: %w", err)
 	}
 
 	var patchMap map[string]any
 	if err := json.Unmarshal(patch, &patchMap); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal patch: %w", err)
+		return nil, nil, fmt.Errorf("failed to unmarshal patch: %w", err)
 	}
 
 	for _, fieldPath := range hasProviderDefaultFields {
 		pathParts := strings.Split(fieldPath, ".")
-		// Only remove from document if the field is NOT in the desired state (patch)
-		if !fieldExistsInMap(patchMap, pathParts) {
-			removeNestedField(docMap, pathParts)
+		stripProviderDefaultPath(docMap, patchMap, pathParts)
+	}
+
+	patchSerialized, err := json.Marshal(patchMap)
+	if err != nil {
+		return nil, nil, err
+	}
+	docSerialized, err := json.Marshal(docMap)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return patchSerialized, docSerialized, nil
+}
+
+// stripProviderDefaultPath walks a dotted field path through parallel document
+// and patch maps. Whenever the walk descends through an array, it iterates the
+// array on BOTH sides and applies the remaining path to every element,
+// dropping the leaf key symmetrically (see the comment on
+// removeProviderDefaultFields for the rationale). For walks that never enter
+// an array, it falls back to the original conditional behavior: the leaf is
+// stripped from the document only when it is absent in the patch.
+func stripProviderDefaultPath(doc, patch map[string]any, path []string) {
+	if len(path) == 0 || doc == nil {
+		return
+	}
+
+	// Last segment — conditional strip on document only, to preserve user overrides.
+	if len(path) == 1 {
+		if !fieldExistsInMap(patch, path) {
+			delete(doc, path[0])
+		}
+		return
+	}
+
+	head, tail := path[0], path[1:]
+
+	docVal, docHas := doc[head]
+	patchVal := any(nil)
+	if patch != nil {
+		patchVal = patch[head]
+	}
+
+	// Array on either side: walk into each element symmetrically.
+	if docArr, ok := docVal.([]any); ok {
+		patchArr, _ := patchVal.([]any)
+		stripProviderDefaultInsideArray(docArr, patchArr, tail)
+		return
+	}
+	if patchArr, ok := patchVal.([]any); ok {
+		// Document doesn't have this key (or has it as a non-array).
+		// Still strip from every patch element to keep both sides symmetric.
+		stripProviderDefaultInsideArray(nil, patchArr, tail)
+		return
+	}
+
+	// Pure object traversal — recurse.
+	if !docHas {
+		return
+	}
+	docNested, ok := docVal.(map[string]any)
+	if !ok {
+		return
+	}
+	var patchNested map[string]any
+	if p, ok := patchVal.(map[string]any); ok {
+		patchNested = p
+	}
+	stripProviderDefaultPath(docNested, patchNested, tail)
+}
+
+// stripProviderDefaultInsideArray walks the remaining path into each element
+// of the doc and patch arrays in parallel (by position where available, else
+// independently) and removes the leaf key from BOTH sides in every reachable
+// element. Elements that aren't objects (or don't match the expected shape)
+// are left alone.
+func stripProviderDefaultInsideArray(docArr, patchArr []any, path []string) {
+	if len(path) == 0 {
+		return
+	}
+
+	for _, elem := range docArr {
+		if elemMap, ok := elem.(map[string]any); ok {
+			stripProviderDefaultInArrayElem(elemMap, path)
 		}
 	}
+	for _, elem := range patchArr {
+		if elemMap, ok := elem.(map[string]any); ok {
+			stripProviderDefaultInArrayElem(elemMap, path)
+		}
+	}
+}
 
-	serialized, err := json.Marshal(docMap)
-	if err != nil {
-		return nil, err
+// stripProviderDefaultInArrayElem handles the remaining path INSIDE an array
+// element. Any further array traversal recurses via
+// stripProviderDefaultInsideArray; object traversal continues into the
+// nested map; the leaf key is deleted unconditionally, because once we are
+// inside an array element the provider-populated value cannot be reliably
+// matched to a counterpart on the other side (set semantics).
+func stripProviderDefaultInArrayElem(elem map[string]any, path []string) {
+	if len(path) == 0 || elem == nil {
+		return
+	}
+	if len(path) == 1 {
+		delete(elem, path[0])
+		return
 	}
 
-	return serialized, nil
+	head, tail := path[0], path[1:]
+	val, has := elem[head]
+	if !has {
+		return
+	}
+	switch v := val.(type) {
+	case map[string]any:
+		stripProviderDefaultInArrayElem(v, tail)
+	case []any:
+		stripProviderDefaultInsideArray(v, nil, tail)
+	}
 }
 
 // removeProviderDefaultEntitySetElements filters EntitySet arrays in the document (actual state)

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -1080,7 +1080,13 @@ func TestHasValue(t *testing.T) {
 func TestRemoveProviderDefaultFields_NestedFieldInsideArray(t *testing.T) {
 	// Simulates ECS ContainerDefinitions: provider default fields (Cpu, Essential)
 	// are nested inside an array of sub-resources. The path "ContainerDefinitions.Cpu"
-	// must traverse the array and remove Cpu from each element.
+	// must traverse the array and remove Cpu from every element.
+	//
+	// For array-traversing provider-default paths, stripping is symmetric on
+	// both sides (see removeProviderDefaultFields doc): jsonpatch's set-based
+	// array comparison cannot pair a document element carrying a provider-
+	// populated sub-field with a patch element that omits it, so we remove the
+	// key unconditionally, even if one patch element happens to mention it.
 	document := []byte(`{
 		"Family": "my-task",
 		"ContainerDefinitions": [
@@ -1097,8 +1103,6 @@ func TestRemoveProviderDefaultFields_NestedFieldInsideArray(t *testing.T) {
 		]
 	}`)
 
-	// Cpu has provider default and is NOT in desired state → should be removed from document
-	// Essential has provider default but IS in desired state → should NOT be removed
 	result, err := removeProviderDefaultFields(document, patch, []string{"ContainerDefinitions.Cpu", "ContainerDefinitions.Essential"})
 	require.NoError(t, err)
 
@@ -1109,20 +1113,21 @@ func TestRemoveProviderDefaultFields_NestedFieldInsideArray(t *testing.T) {
 	containers := resultMap["ContainerDefinitions"].([]any)
 	require.Len(t, containers, 2)
 
-	// Cpu should be removed from both containers (not in desired state)
+	// Both Cpu (absent from patch) and Essential (present in patch) must be
+	// removed from every document element — array-nested provider defaults
+	// are stripped symmetrically.
 	container0 := containers[0].(map[string]any)
-	_, hasCpu0 := container0["Cpu"]
-	assert.False(t, hasCpu0, "Cpu should be removed from first container when not in desired state")
-
 	container1 := containers[1].(map[string]any)
-	_, hasCpu1 := container1["Cpu"]
-	assert.False(t, hasCpu1, "Cpu should be removed from second container when not in desired state")
 
-	// Essential should be kept (present in desired state)
+	_, hasCpu0 := container0["Cpu"]
+	assert.False(t, hasCpu0, "Cpu should be removed from first document element")
+	_, hasCpu1 := container1["Cpu"]
+	assert.False(t, hasCpu1, "Cpu should be removed from second document element")
+
 	_, hasEssential0 := container0["Essential"]
-	assert.True(t, hasEssential0, "Essential should be kept when present in desired state")
+	assert.False(t, hasEssential0, "Essential should be stripped symmetrically from the document even when present in patch (array-nested provider default)")
 	_, hasEssential1 := container1["Essential"]
-	assert.True(t, hasEssential1, "Essential should be kept when present in desired state")
+	assert.False(t, hasEssential1, "Essential should be stripped symmetrically from the document even when present in patch (array-nested provider default)")
 }
 
 func TestFieldExistsInMap_ArrayTraversal(t *testing.T) {
@@ -1547,6 +1552,274 @@ func TestGeneratePatch_EntitySetProviderDefaults_WithUserChange(t *testing.T) {
 	require.Len(t, ops, 1, "Expected exactly one patch operation for the changed attribute")
 	assert.Equal(t, "replace", ops[0].Operation)
 	assert.Contains(t, ops[0].Path, "Value")
+}
+
+// Reproduces the exact bug from the issue: re-applying an unchanged ECS
+// TaskDefinition triggers a REPLACE because the provider populates
+// ContainerDefinition.Cpu=0 on Read, and the diff through jsonpatch's set
+// semantics treats the document element {Name:x, Cpu:0} as different from
+// the desired element {Name:x}. Because ContainerDefinitions is createOnly,
+// any add/remove on that path triggers needsReplacement=true.
+//
+// This test passes with a single-element array today (the existing
+// fieldExistsInMap short-circuits "Cpu not anywhere in patch" = strip).
+// The next test exercises the mixed case where at least one sibling does
+// set Cpu, which is what the production bug looks like.
+func TestGeneratePatch_ProviderDefaultInsideArray_SingleElement_NoReplace(t *testing.T) {
+	document := []byte(`{
+		"Family": "my-task",
+		"ContainerDefinitions": [
+			{"Name": "grafana", "Image": "grafana/grafana:latest", "Cpu": 0}
+		]
+	}`)
+
+	patch := []byte(`{
+		"Family": "my-task",
+		"ContainerDefinitions": [
+			{"Name": "grafana", "Image": "grafana/grafana:latest"}
+		]
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"Family", "ContainerDefinitions"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"ContainerDefinitions":     {CreateOnly: true},
+			"ContainerDefinitions.Cpu": {HasProviderDefault: true},
+		},
+	}
+
+	patchDoc, needsReplacement, err := generatePatch(
+		document, patch, resolver.NewResolvableProperties(), schema,
+		pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+	assert.False(t, needsReplacement, "provider-default Cpu inside createOnly list should not trigger replacement")
+	assert.Empty(t, patchDoc, "no patch expected when the only diff is a provider-default sub-field")
+}
+
+// Mixed case: one container sets Cpu, another does not. fieldExistsInMap
+// returns true (Cpu is in at least one patch element) so the existing
+// top-level-only stripping leaves Cpu=0 on the second container in the
+// document. jsonpatch's set comparison then fails to match the sidecar
+// element, emits add/remove on /ContainerDefinitions, and createOnly
+// detection trips needsReplacement.
+func TestGeneratePatch_ProviderDefaultInsideArray_MixedElements_NoReplace(t *testing.T) {
+	document := []byte(`{
+		"Family": "my-task",
+		"ContainerDefinitions": [
+			{"Name": "app", "Image": "nginx", "Cpu": 512},
+			{"Name": "sidecar", "Image": "envoy", "Cpu": 0}
+		]
+	}`)
+
+	patch := []byte(`{
+		"Family": "my-task",
+		"ContainerDefinitions": [
+			{"Name": "app", "Image": "nginx", "Cpu": 512},
+			{"Name": "sidecar", "Image": "envoy"}
+		]
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"Family", "ContainerDefinitions"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"ContainerDefinitions":     {CreateOnly: true},
+			"ContainerDefinitions.Cpu": {HasProviderDefault: true},
+		},
+	}
+
+	patchDoc, needsReplacement, err := generatePatch(
+		document, patch, resolver.NewResolvableProperties(), schema,
+		pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+
+	if !assert.False(t, needsReplacement, "mixed-element provider-default sub-field should not trigger replacement") {
+		var ops []jsonpatch.JsonPatchOperation
+		_ = json.Unmarshal(patchDoc, &ops)
+		for _, op := range ops {
+			t.Logf("  unexpected op: %s %s = %v", op.Operation, op.Path, op.Value)
+		}
+	}
+	assert.Empty(t, patchDoc, "expected no patch when only diff is a provider-default sub-field")
+}
+
+// Mixed variant of the HostPort case: one PortMapping sets HostPort, the
+// other doesn't. Exercises the same pair-wise pathology as
+// TestGeneratePatch_ProviderDefaultInsideArray_MixedElements_NoReplace but
+// two levels deep.
+func TestGeneratePatch_ProviderDefaultInsideNestedArray_PortMappingHostPort_Mixed(t *testing.T) {
+	document := []byte(`{
+		"Family": "my-task",
+		"ContainerDefinitions": [
+			{
+				"Name": "app",
+				"Image": "nginx",
+				"PortMappings": [
+					{"ContainerPort": 80, "HostPort": 8080, "Protocol": "tcp"},
+					{"ContainerPort": 443, "HostPort": 0, "Protocol": "tcp"}
+				]
+			}
+		]
+	}`)
+
+	patch := []byte(`{
+		"Family": "my-task",
+		"ContainerDefinitions": [
+			{
+				"Name": "app",
+				"Image": "nginx",
+				"PortMappings": [
+					{"ContainerPort": 80, "HostPort": 8080, "Protocol": "tcp"},
+					{"ContainerPort": 443, "Protocol": "tcp"}
+				]
+			}
+		]
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"Family", "ContainerDefinitions"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"ContainerDefinitions": {CreateOnly: true},
+			"ContainerDefinitions.PortMappings.HostPort": {HasProviderDefault: true},
+		},
+	}
+
+	patchDoc, needsReplacement, err := generatePatch(
+		document, patch, resolver.NewResolvableProperties(), schema,
+		pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+
+	if !assert.False(t, needsReplacement, "mixed HostPort inside nested array should not trigger replacement") {
+		var ops []jsonpatch.JsonPatchOperation
+		_ = json.Unmarshal(patchDoc, &ops)
+		for _, op := range ops {
+			t.Logf("  unexpected op: %s %s = %v", op.Operation, op.Path, op.Value)
+		}
+	}
+	assert.Empty(t, patchDoc, "expected no patch when only diff is a provider-default sub-field two levels deep")
+}
+
+// Same shape as above but with a deeper path: PortMapping.HostPort is a
+// sub-field inside ContainerDefinition.PortMappings — two levels of
+// array-nesting.
+func TestGeneratePatch_ProviderDefaultInsideNestedArray_PortMappingHostPort(t *testing.T) {
+	document := []byte(`{
+		"Family": "my-task",
+		"ContainerDefinitions": [
+			{
+				"Name": "app",
+				"Image": "nginx",
+				"PortMappings": [
+					{"ContainerPort": 80, "HostPort": 0, "Protocol": "tcp"},
+					{"ContainerPort": 443, "HostPort": 0, "Protocol": "tcp"}
+				]
+			}
+		]
+	}`)
+
+	patch := []byte(`{
+		"Family": "my-task",
+		"ContainerDefinitions": [
+			{
+				"Name": "app",
+				"Image": "nginx",
+				"PortMappings": [
+					{"ContainerPort": 80, "Protocol": "tcp"},
+					{"ContainerPort": 443, "Protocol": "tcp"}
+				]
+			}
+		]
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"Family", "ContainerDefinitions"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"ContainerDefinitions": {CreateOnly: true},
+			"ContainerDefinitions.PortMappings.HostPort": {HasProviderDefault: true},
+		},
+	}
+
+	patchDoc, needsReplacement, err := generatePatch(
+		document, patch, resolver.NewResolvableProperties(), schema,
+		pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+
+	if !assert.False(t, needsReplacement, "provider-default sub-field two levels deep should not trigger replacement") {
+		var ops []jsonpatch.JsonPatchOperation
+		_ = json.Unmarshal(patchDoc, &ops)
+		for _, op := range ops {
+			t.Logf("  unexpected op: %s %s = %v", op.Operation, op.Path, op.Value)
+		}
+	}
+	assert.Empty(t, patchDoc, "expected no patch when only diff is a provider-default sub-field inside a nested array")
+}
+
+// Negative test: a genuinely user-changed field inside a list element must
+// still produce a replacement.
+func TestGeneratePatch_UserChangedFieldInsideArray_StillReplaces(t *testing.T) {
+	document := []byte(`{
+		"Family": "my-task",
+		"ContainerDefinitions": [
+			{"Name": "app", "Image": "nginx:1.25", "Cpu": 0}
+		]
+	}`)
+
+	// User changed the image tag — this is a real change to a createOnly field,
+	// should trigger a replacement.
+	patch := []byte(`{
+		"Family": "my-task",
+		"ContainerDefinitions": [
+			{"Name": "app", "Image": "nginx:1.27"}
+		]
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"Family", "ContainerDefinitions"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"ContainerDefinitions":     {CreateOnly: true},
+			"ContainerDefinitions.Cpu": {HasProviderDefault: true},
+		},
+	}
+
+	_, needsReplacement, err := generatePatch(
+		document, patch, resolver.NewResolvableProperties(), schema,
+		pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+	assert.True(t, needsReplacement, "user-changed field on a createOnly list element should still trigger replacement")
+}
+
+// Negative test: at the top level, stripping must remain conditional. A user
+// who explicitly overrides a provider-default value should still see a diff
+// (this is the BucketEncryption override case we already test elsewhere,
+// repeated here to guard against regressions from the new recursive logic).
+func TestGeneratePatch_TopLevelProviderDefaultOverride_StillDiffs(t *testing.T) {
+	document := []byte(`{
+		"BucketName": "my-bucket",
+		"BucketEncryption": {"SSEAlgorithm": "AES256"}
+	}`)
+
+	patch := []byte(`{
+		"BucketName": "my-bucket",
+		"BucketEncryption": {"SSEAlgorithm": "aws:kms"}
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"BucketName", "BucketEncryption"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"BucketEncryption": {HasProviderDefault: true},
+		},
+	}
+
+	patchDoc, _, err := generatePatch(
+		document, patch, resolver.NewResolvableProperties(), schema,
+		pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, patchDoc, "user-overridden top-level provider-default must still diff")
 }
 
 func TestGeneratePatch_EntitySetProviderDefaults_ReconcileMode(t *testing.T) {

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -1680,7 +1680,7 @@ func TestGeneratePatch_ProviderDefaultInsideNestedArray_PortMappingHostPort_Mixe
 	schema := pkgmodel.Schema{
 		Fields: []string{"Family", "ContainerDefinitions"},
 		Hints: map[string]pkgmodel.FieldHint{
-			"ContainerDefinitions": {CreateOnly: true},
+			"ContainerDefinitions":                       {CreateOnly: true},
 			"ContainerDefinitions.PortMappings.HostPort": {HasProviderDefault: true},
 		},
 	}
@@ -1736,7 +1736,7 @@ func TestGeneratePatch_ProviderDefaultInsideNestedArray_PortMappingHostPort(t *t
 	schema := pkgmodel.Schema{
 		Fields: []string{"Family", "ContainerDefinitions"},
 		Hints: map[string]pkgmodel.FieldHint{
-			"ContainerDefinitions": {CreateOnly: true},
+			"ContainerDefinitions":                       {CreateOnly: true},
 			"ContainerDefinitions.PortMappings.HostPort": {HasProviderDefault: true},
 		},
 	}


### PR DESCRIPTION
## Summary

Re-applying an unchanged forma could silently destroy working stateful resources. The most visible case: adding any unrelated resource to a forma that contains an `AWS::ECS::Service` triggered a full **replace** of the Service (5–10 min outage), even though the Service's own inputs hadn't changed.

Root cause was in the patch-generation path's handling of provider-defaulted sub-fields inside nested list elements:

- `AWS::ECS::ContainerDefinition.Cpu` is annotated `hasProviderDefault = true`. AWS Read returns `Cpu: 0` even when the user didn't set it. Desired state (from PKL eval) omits the field.
- `jsonpatch` compares list-valued fields as sets by default — serializing each element to JSON bytes. `{"Cpu":0,…}` ≠ `{…}` as bytes, so container elements fail to match their counterparts.
- `compareArray` then emits `add`/`remove` patch ops against `/ContainerDefinitions/N`. That path is `createOnly` → `needsReplacement = true` → resource replace.
- The Service replaces in turn because its `TaskDefinition` resolvable diffs.

The existing `hasProviderDefault` stripping worked only at the top level — not on sub-fields inside list elements.

## Change

Replace the prior document-only stripper with a two-sided walker (`stripProviderDefaultPath`) that descends a dotted schema path through both the document and the patch simultaneously:

- **Pure object paths** (e.g. `BucketEncryption`): preserve the original conditional behaviour — strip from the document only when the field is absent from the patch, so user overrides still diff.
- **Any path that traverses an array**: strip the leaf key from **both** sides on every reachable element. This is the only correct semantic under set-based list comparison — there's no reliable pairing between doc and patch array elements.
- Applies recursively, so arbitrarily deep paths like `ContainerDefinitions.PortMappings.HostPort` work.

A new helper `removeProviderDefaultFieldsBoth` returns both stripped buffers; `createPatchDocument` uses it in place of the prior document-only call. The pre-existing public `removeProviderDefaultFields` is kept for callers that only need the document side.

## Tests

New cases in `patch_document_test.go`:

- `TestGeneratePatch_ProviderDefaultInsideArray_SingleElement_NoReplace` — Grafana-style repro, single `ContainerDefinition`, `Cpu: 0` vs absent.
- `TestGeneratePatch_ProviderDefaultInsideArray_MixedElements_NoReplace` — two containers, one sets `Cpu`, the other doesn't.
- `TestGeneratePatch_ProviderDefaultInsideNestedArray_PortMappingHostPort` and `..._Mixed` — two levels of array nesting (`ContainerDefinitions.PortMappings.HostPort`).
- `TestGeneratePatch_UserChangedFieldInsideArray_StillReplaces` — negative test: a real user change to a `createOnly` list element still trips `needsReplacement`.
- `TestGeneratePatch_TopLevelProviderDefaultOverride_StillDiffs` — guard against regressing the existing top-level override semantic.

Updated: `TestRemoveProviderDefaultFields_NestedFieldInsideArray` — the old assertion required that an array-nested provider-default field present only in the patch be preserved in the document. That semantic was the bug under set-comparison. The test now asserts symmetric stripping, with a comment explaining why.

Full `go test -tags=unit ./...` suite green locally, including `internal/workflow_tests`.

## Related

- Companion schema fix on `formae-plugin-aws@main` (commit `073270f`) annotates `PortMapping.hostPort` with `hasProviderDefault = true` so the PKL emitter surfaces the new path.
- Engineering note with full root-cause trace: `formae-plugin-aws/2026-04-20-ecs-spurious-replace-on-reapply.md`.