### PR TITLE
fix(cli): render composite patch values as JSON in remove ops

### DIFF
--- a/internal/cli/renderer/patches.go
+++ b/internal/cli/renderer/patches.go
@@ -505,6 +505,17 @@ func formatValueForDisplay(value any) string {
 		}
 	}
 
+	// Composite values (objects and arrays) must render as JSON to match
+	// the add-side formatter (formatPatchValue). Without this, remove ops
+	// use Go's default `map[k:v]` syntax while add ops use JSON, making
+	// array-set diffs visually uncomparable.
+	switch v := value.(type) {
+	case map[string]any, []any:
+		if bytes, err := json.Marshal(v); err == nil {
+			return string(bytes)
+		}
+	}
+
 	return fmt.Sprintf("%v", value)
 }
 

--- a/internal/cli/renderer/patches.go
+++ b/internal/cli/renderer/patches.go
@@ -509,6 +509,9 @@ func formatValueForDisplay(value any) string {
 	// the add-side formatter (formatPatchValue). Without this, remove ops
 	// use Go's default `map[k:v]` syntax while add ops use JSON, making
 	// array-set diffs visually uncomparable.
+	// Note: json.Marshal sorts map keys alphabetically, so both sides are
+	// key-aligned regardless of source order — that alignment is what makes
+	// the diff readable.
 	switch v := value.(type) {
 	case map[string]any, []any:
 		if bytes, err := json.Marshal(v); err == nil {

--- a/internal/cli/renderer/patches_test.go
+++ b/internal/cli/renderer/patches_test.go
@@ -7,6 +7,7 @@ package renderer
 import (
 	"encoding/json"
 	"iter"
+	"strings"
 	"testing"
 
 	"github.com/ddddddO/gtree"
@@ -277,6 +278,72 @@ func TestFormatPatchDocument_OpaqueWriteOnlyField(t *testing.T) {
 		assert.Contains(t, nodes[1].Name(), "opaque value")
 		assert.Contains(t, nodes[1].Name(), `set property "SecretString"`)
 		assert.NotContains(t, nodes[1].Name(), "L4clqcm50IFl")
+	})
+}
+
+func TestFormatPatchDocument_RemoveArrayObject_RendersAsJSON(t *testing.T) {
+	// Regression test: remove ops on array-of-objects were previously rendered
+	// using Go's default map formatter (`map[k:v ...]`), while add ops used
+	// JSON. That made array-set diffs visually uncomparable. Both sides must
+	// now emit JSON.
+	node := gtree.NewRoot("")
+	patchDoc := []map[string]any{
+		{
+			"op":   "remove",
+			"path": "/volumeClaimTemplates/0",
+		},
+	}
+	serialized, err := json.Marshal(patchDoc)
+	assert.NoError(t, err)
+
+	previousProperties := json.RawMessage(`{
+		"volumeClaimTemplates": [
+			{"metadata": {"name": "data"}, "spec": {"accessModes": ["ReadWriteOnce"], "volumeMode": "Filesystem"}}
+		]
+	}`)
+
+	FormatPatchDocument(node, serialized, json.RawMessage("{}"), previousProperties, map[string]string{}, "")
+
+	nodes, err := collectNodes(gtree.WalkIterFromRoot(node))
+	assert.NoError(t, err)
+
+	// Expect one line like: `remove entry "<json>" from "volumeClaimTemplates"`
+	var removeLine string
+	for _, n := range nodes {
+		if name := n.Name(); strings.Contains(name, "remove entry") {
+			removeLine = name
+			break
+		}
+	}
+	assert.NotEmpty(t, removeLine, "expected a 'remove entry' line in rendered output")
+	assert.Contains(t, removeLine, `"metadata":{"name":"data"}`,
+		"remove entry should render the removed object as JSON, not Go map syntax")
+	assert.NotContains(t, removeLine, "map[metadata:",
+		"remove entry must not leak Go's default map formatter")
+}
+
+func TestFormatValueForDisplay_CompositeValuesAsJSON(t *testing.T) {
+	t.Run("map renders as JSON", func(t *testing.T) {
+		v := map[string]any{"k": "v", "n": float64(1)}
+		got := formatValueForDisplay(v)
+		// json.Marshal sorts map keys alphabetically, so output is deterministic.
+		assert.Equal(t, `{"k":"v","n":1}`, got)
+	})
+
+	t.Run("slice renders as JSON", func(t *testing.T) {
+		v := []any{"a", float64(2), map[string]any{"k": "v"}}
+		got := formatValueForDisplay(v)
+		assert.Equal(t, `["a",2,{"k":"v"}]`, got)
+	})
+
+	t.Run("scalar still uses %v", func(t *testing.T) {
+		assert.Equal(t, "42", formatValueForDisplay(42))
+		assert.Equal(t, "hello", formatValueForDisplay("hello"))
+	})
+
+	t.Run("opaque Value wrapper still returns opaque marker", func(t *testing.T) {
+		v := map[string]any{"$visibility": "Opaque", "$value": "secret"}
+		assert.Equal(t, "(opaque value)", formatValueForDisplay(v))
 	})
 }
 


### PR DESCRIPTION
## Summary

In the plan-preview output, \`add entry\` values were rendered as JSON but \`remove entry\` values were rendered using Go's default map formatter (\`map[k:v ...]\`). Same shape of data, two formats, visually uncomparable.

**Example — K8s StatefulSet `volumeClaimTemplates` diff:**

Before:
```
├── remove entry "map[metadata:map[name:data] spec:map[accessModes:[ReadWriteOnce] resources:map[requests:map[storage:20Gi]] volumeMode:Filesystem]]" from "spec.volumeClaimTemplates"
└── add new entry "{\"metadata\":{\"name\":\"data\"},\"spec\":{\"accessModes\":[\"ReadWriteOnce\"],\"resources\":{\"requests\":{\"storage\":\"20Gi\"}}}}" to "spec.volumeClaimTemplates"
```

After (both sides JSON — you can see at a glance that \`volumeMode: "Filesystem"\` is the only real diff):
```
├── remove entry "{\"metadata\":{\"name\":\"data\"},\"spec\":{\"accessModes\":[\"ReadWriteOnce\"],\"resources\":{\"requests\":{\"storage\":\"20Gi\"}},\"volumeMode\":\"Filesystem\"}}" from "spec.volumeClaimTemplates"
└── add new entry "{\"metadata\":{\"name\":\"data\"},\"spec\":{\"accessModes\":[\"ReadWriteOnce\"],\"resources\":{\"requests\":{\"storage\":\"20Gi\"}}}}" to "spec.volumeClaimTemplates"
```

## Cause

`internal/cli/renderer/patches.go` has two value formatters:

- `formatPatchValue` (add path) — has a `case map[string]any, []any: json.Marshal(v)` branch.
- `formatValueForDisplay` (remove path, via `extractPreviousValue` → `gjson.GetBytes` → `formatValueForDisplay`) — falls through to `fmt.Sprintf("%v\, value)` for composites.

Fix: add the same `json.Marshal` branch to `formatValueForDisplay`.

## Scope / Non-goals

- Rendering-only fix, 5 lines of code, two formatters now consistent.
- **Not** unifying the two formatters into one — they have different concerns (refs, opaque values).
- **Not** addressing the separate semantic issue that `volumeClaimTemplates` diffs produce a full remove+add (jsonpatch's set-based comparison because the K8s schema doesn't key the collection on `metadata.name`). That's a plugin-schema concern for a separate change.
- **Not** addressing that `volumeMode: "Filesystem"` is a K8s-provided default that could be stripped via `hasProviderDefault`. Also plugin-schema concern.

## Test plan

- [x] New unit test: `TestFormatPatchDocument_RemoveArrayObject_RendersAsJSON` — builds a remove op on an array-of-objects, asserts the rendered line contains JSON and not `map[...:...]` syntax.
- [x] New unit test: `TestFormatValueForDisplay_CompositeValuesAsJSON` — covers map, slice, scalar (still uses `%v`), and opaque-value wrapper (still returns `(opaque value)` marker).
- [x] Full `internal/cli/renderer/` suite passes — no regressions.