### PR TITLE
fix(extract): add Float type handler to Pkl generator classHandlers

### DIFF
--- a/internal/schema/pkl/generator/gen.pkl
+++ b/internal/schema/pkl/generator/gen.pkl
@@ -60,6 +60,15 @@ hidden classHandlers: Mapping<Class, (List<reflect.Type>, Any) -> Any|Generation
     else
       Unexpected("Dynamic|Collection", value.getClass().simpleName)
 
+  [Float] = (_, value) ->
+    if (value is Float) value
+    else if (value is Int) value.toFloat()
+    else if (value is String)
+      let (parsed = value.toFloatOrNull())
+        if (parsed != null) parsed
+        else Unexpected("Float", "String('\(value)') that cannot be parsed as Float")
+    else Unexpected("Float", value.getClass().simpleName)
+
   [Number] = (_, value) ->
     if (value is Number) value
     else if (value is String)

--- a/internal/schema/pkl/generator/tests/gen.pkl
+++ b/internal/schema/pkl/generator/tests/gen.pkl
@@ -34,6 +34,13 @@ local class ComplexBar extends formae.Resource {
 }
 
 @formae.ResourceHint
+local class FloatResource extends formae.Resource {
+    percentage: Float
+    count: Int
+    name: String
+}
+
+@formae.ResourceHint
 local class TestResource extends formae.Resource {
     type = "FakePlugin::Service::TestResource"
 
@@ -62,6 +69,13 @@ local complexProperties: Dynamic = new Dynamic {
     //}
     optional = "optional value"
     label = "complex"
+}
+
+local floatProperties: Dynamic = new Dynamic {
+    percentage = 0.75
+    count = 10
+    name = "float-test"
+    label = "float-res"
 }
 
 local resourceProperties: Dynamic = new Dynamic {
@@ -131,6 +145,11 @@ facts {
     ["Simple class application preserves values"] {
         let (result = gen.apply(SimpleFoo, simpleProperties))
         result.x == 42 && result.name == "test"
+    }
+
+    ["Float class application preserves float values"] {
+        let (result = gen.apply(FloatResource, floatProperties))
+        result.percentage == 0.75 && result.count == 10 && result.name == "float-test"
     }
 
     ["Complex class handles collections"] {


### PR DESCRIPTION
Extract fails on resources with a Float property (e.g. GKE Container::Cluster's batchPercentage). 

Added Float handler that accepts Float, and parses String.

- 1 new Pkl test (TDD: confirmed failure without fix, pass with fix)
- All 27 generator tests pass

Repro: `formae extract --query 'managed:false'` against any inventory with GKE resources.
