### PR TITLE
fix(pkl-schema): emit hints for fields under SubResources without a FieldHint

### DIFF
--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -468,13 +468,9 @@ class Fq {
             })
             Pair(key, baseHint)
         ))
-        let(nestedHints = resourceClass.properties.filter((_, v) ->
-            v.allAnnotations.filterIsInstance(FieldHint).length > 0 &&
-            isSubResourceType(v.type)
-        ).flatMap((k, v) ->
-
+        let(nestedHints = resourceClass.properties.filter((_, v) -> isSubResourceType(v.type)).flatMap((k, v) ->
             let(fieldHint = v.allAnnotations.filterIsInstance(FieldHint).firstOrNull)
-            let(parentKey = if(fieldHint.outputField != null) fieldHint.outputField else resourceHint.outputKeyTransformation.apply(k))
+            let(parentKey = if(fieldHint != null && fieldHint.outputField != null) fieldHint.outputField else resourceHint.outputKeyTransformation.apply(k))
             let(subResourceClass = getSubResourceClass(v.type))
 
             let(subHintsMap = subHints(subResourceClass))
@@ -506,12 +502,9 @@ class Fq {
             })
             Pair(key, baseHint)
         ))
-        let(nestedHints = subResourceClass.properties.filter((_, v) ->
-            v.allAnnotations.filterIsInstance(FieldHint).length > 0 &&
-            isSubResourceType(v.type)
-        ).flatMap((k, v) ->
+        let(nestedHints = subResourceClass.properties.filter((_, v) -> isSubResourceType(v.type)).flatMap((k, v) ->
             let(fieldHint = v.allAnnotations.filterIsInstance(FieldHint).firstOrNull)
-            let(parentKey = if(fieldHint.outputField != null) fieldHint.outputField else outputKeyTransformation.apply(k))
+            let(parentKey = if(fieldHint != null && fieldHint.outputField != null) fieldHint.outputField else outputKeyTransformation.apply(k))
             let(nestedSubResourceClass = getSubResourceClass(v.type))
             let(nestedSubHints = subHintsWithVisited(nestedSubResourceClass, nextVisited))
 

--- a/internal/schema/pkl/schema/tests/formae.pkl
+++ b/internal/schema/pkl/schema/tests/formae.pkl
@@ -204,6 +204,59 @@ local testTaskDefNoContainers = new TestTaskDef {
     family = "my-family"
 }
 
+// Test that hints propagate through a sub-resource whose field
+// declaration carries NO @FieldHint on the parent sub-resource.
+// Mirrors AWS::ECS::TaskDefinition's Volumes.EFSVolumeConfiguration.RootDirectory
+// pattern: the outer field (Volumes) is annotated, the inner SubResource
+// type (EFSVolumeConfiguration) has @SubResourceHint on its class but no
+// @FieldHint on the Volume.eFSVolumeConfiguration declaration, and the
+// deepest field (rootDirectory) carries @FieldHint{hasProviderDefault=true}.
+@formae.SubResourceHint {
+    outputKeyTransformation = (it) -> it.capitalize()
+}
+local class TestDeepLeaf extends formae.SubResource {
+    @formae.FieldHint{hasProviderDefault = true}
+    rootDirectory: String?
+}
+
+@formae.SubResourceHint {
+    outputKeyTransformation = (it) -> it.capitalize()
+}
+local class TestVolume extends formae.SubResource {
+    // Intentionally no @formae.FieldHint on this declaration.
+    // The inner SubResource class carries @SubResourceHint itself, and
+    // its fields carry @FieldHint, so their hints MUST still propagate.
+    efsVolumeConfiguration: TestDeepLeaf?
+
+    @formae.FieldHint
+    name: String
+}
+
+@formae.ResourceHint {
+    type = "Test::DeepNested"
+    identifier = "Ref"
+    outputKeyTransformation = (it) -> it.capitalize()
+}
+local class TestDeepNested extends formae.Resource {
+    @formae.FieldHint{
+        createOnly = true
+        hasProviderDefault = true
+    }
+    volumes: Listing<TestVolume>?
+}
+
+local testDeepNested = new TestDeepNested {
+    label = "test-deep-nested"
+    volumes = new Listing {
+        new TestVolume {
+            name = "wal"
+            efsVolumeConfiguration = new TestDeepLeaf {
+                rootDirectory = "/"
+            }
+        }
+    }
+}
+
 // Test config class with ConfigFieldHint annotations
 local class TestConfig {
     hidden fixed type: String = "TestProvider"
@@ -441,6 +494,18 @@ facts {
         hints["ContainerDefinitions.Cpu"].HasProviderDefault == true &&
         hints.containsKey("ContainerDefinitions.Name") &&
         hints.containsKey("ContainerDefinitions.Image")
+    }
+
+    ["Hints propagate through SubResource nested inside SubResource without intermediate FieldHint"] {
+        let (hints = testDeepNested.hints())
+        // Top-level and 2-level hints still work
+        hints.containsKey("Volumes") &&
+        hints["Volumes"].CreateOnly == true &&
+        hints.containsKey("Volumes.Name") &&
+        // 3-level hint must emit even though TestVolume.efsVolumeConfiguration
+        // has no @FieldHint on its declaration.
+        hints.containsKey("Volumes.EfsVolumeConfiguration.RootDirectory") &&
+        hints["Volumes.EfsVolumeConfiguration.RootDirectory"].HasProviderDefault == true
     }
 
     ["Nullable Mapping renders as empty map when null"] {


### PR DESCRIPTION
## Summary

- The PKL hints flattener in `internal/schema/pkl/schema/formae.pkl` skipped any nested SubResource-typed field whose declaration did not carry its own `@FieldHint`. `@FieldHint` annotations on fields three or more levels deep — e.g. `Volumes.EFSVolumeConfiguration.RootDirectory` on `AWS::ECS::TaskDefinition` — never reached the compiled schema.
- Consequence: the recursive patch-time stripper had no hint path to walk, AWS-populated provider defaults stayed in stored state, and any `createOnly` ancestor triggered a spurious resource replacement on reapply. This is the root cause behind the lgtm-task spurious-replace investigation on `fix/ecs-spurious-replace-investigation` and the reason the plugin-side annotation added in [formae-plugin-aws#47](https://github.com/platform-engineering-labs/formae-plugin-aws/pull/47) appeared to have no effect end-to-end.
- Fix: descend into any SubResource-typed field regardless of whether the declaration has an `@FieldHint`, and fall back to the default key transformation when no `FieldHint` is present to supply `outputField`. Same change in both `hints()` and the recursive `subHintsWithVisited()`.
- Regression test added under `internal/schema/pkl/schema/tests/formae.pkl` that models the ECS pattern (outer field annotated, intermediate SubResource field unannotated, deepest field annotated) and asserts the 3-level hint emits with its annotations intact. The full `test-pkl`, `lint`, and `test-all` suites pass.