### PR TITLE
feat(labeler): support comma-separated JSONPath queries in DefaultQuery

### DIFF
--- a/internal/metastructure/resource_update/resource_labeler.go
+++ b/internal/metastructure/resource_update/resource_labeler.go
@@ -69,13 +69,10 @@ func (l *ResourceLabeler) LabelForUnmanagedResource(
 // extractLabelFromQuery evaluates a JSONPath query against properties and returns
 // concatenated string results. When the query returns multiple values (e.g., from
 // a filter with OR conditions), all values are joined with the label separator.
+// Supports comma-separated queries (e.g., "$.metadata.namespace,$.metadata.name")
+// where each query is evaluated independently and results are joined.
 func (l *ResourceLabeler) extractLabelFromQuery(properties json.RawMessage, query string) string {
 	if len(properties) == 0 {
-		return ""
-	}
-
-	path, err := labelJSONPathParser.Parse(query)
-	if err != nil {
 		return ""
 	}
 
@@ -84,15 +81,30 @@ func (l *ResourceLabeler) extractLabelFromQuery(properties json.RawMessage, quer
 		return ""
 	}
 
-	results := path.Select(data)
-	if len(results) == 0 {
-		return ""
+	var parts []string
+	for _, q := range strings.Split(query, ",") {
+		q = strings.TrimSpace(q)
+		if q == "" {
+			continue
+		}
+		for _, s := range l.evaluateQuery(data, q) {
+			parts = append(parts, s)
+		}
 	}
 
-	// Collect all string values from results
+	return strings.Join(parts, labelSeparator)
+}
+
+// evaluateQuery runs a single JSONPath query and returns string results.
+func (l *ResourceLabeler) evaluateQuery(data any, query string) []string {
+	path, err := labelJSONPathParser.Parse(query)
+	if err != nil {
+		return nil
+	}
+
+	results := path.Select(data)
 	var parts []string
 	for _, result := range results {
-		// Handle array result (e.g., from tag filter query)
 		if arr, ok := result.([]any); ok {
 			for _, item := range arr {
 				if str, ok := item.(string); ok && str != "" {
@@ -101,14 +113,11 @@ func (l *ResourceLabeler) extractLabelFromQuery(properties json.RawMessage, quer
 			}
 			continue
 		}
-
-		// Handle direct string result
 		if str, ok := result.(string); ok && str != "" {
 			parts = append(parts, str)
 		}
 	}
-
-	return strings.Join(parts, labelSeparator)
+	return parts
 }
 
 // extractLabelFromLegacyTagKeys extracts a label using the legacy tag-based approach.

--- a/internal/metastructure/resource_update/resource_labeler_test.go
+++ b/internal/metastructure/resource_update/resource_labeler_test.go
@@ -206,6 +206,31 @@ func TestLabelForUnmanagedResource_JSONPathQueryTakesPrecedenceOverLegacyTagKeys
 	assert.Equal(t, "FromJSONPath", label)
 }
 
+func TestLabelForUnmanagedResource_CommaSeparatedQueryJoinsResults(t *testing.T) {
+	nativeId := "canary-defaults/canary-svc"
+	properties := json.RawMessage(`{"metadata":{"namespace":"canary-defaults","name":"canary-svc"}}`)
+	labelConfig := pkgmodel.LabelConfig{
+		DefaultQuery: "$.metadata.namespace,$.metadata.name",
+	}
+
+	l := newResourceLabelerForTest(t)
+	label := l.LabelForUnmanagedResource(nativeId, "K8S::Core::Service", properties, labelConfig, nil)
+	assert.Equal(t, "canary-defaults-canary-svc", label)
+}
+
+func TestLabelForUnmanagedResource_CommaSeparatedQuerySingleResult(t *testing.T) {
+	nativeId := "canary-clusterrole"
+	properties := json.RawMessage(`{"metadata":{"name":"canary-clusterrole"}}`)
+	labelConfig := pkgmodel.LabelConfig{
+		DefaultQuery: "$.metadata.namespace,$.metadata.name",
+	}
+
+	l := newResourceLabelerForTest(t)
+	label := l.LabelForUnmanagedResource(nativeId, "K8S::Rbac::ClusterRole", properties, labelConfig, nil)
+	// Cluster-scoped: no namespace, only name
+	assert.Equal(t, "canary-clusterrole", label)
+}
+
 func newResourceLabelerForTest(t *testing.T, setup ...func(datastore.Datastore)) *resource_update.ResourceLabeler {
 	t.Helper()
 


### PR DESCRIPTION
Allows comma-separated JSONPath expressions in LabelConfig.DefaultQuery.

Each expression is evaluated independently and results are joined with `-`.

This enables K8s-style labels like `namespace-name` from a single query string: `$.metadata.namespace,$.metadata.name`. Cluster-scoped resources (no namespace) naturally produce just the name since the missing field returns no result and is skipped

Previously, DefaultQuery only accepted a single JSONPath. Plugins needing multi-field labels had no option — K8s resources collided when a Service and its auto-created Endpoints shared the same name.

- 2 new tests (comma-separated with namespace+name, single-field fallback)
- All 15 labeler tests pass

