### PR TITLE
fix(apply): merge live plugin hints into forma schema before patch generation

### DIFF
--- a/internal/metastructure/auto_reconciler.go
+++ b/internal/metastructure/auto_reconciler.go
@@ -336,6 +336,7 @@ func prepareReconcile(ds datastore.Datastore, stackLabel string, clientID string
 		resource_update.FormaCommandSourcePolicyAutoReconcile,
 		existingTargets,
 		ds,
+		nil, // livePluginSchemas: auto-reconciler uses DB-sourced forma, schemas already stored
 		nil, nil,
 	)
 	if err != nil {

--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -656,7 +656,7 @@ func synchronizeResources(op ListOperation, namespace string, target pkgmodel.Ta
 		return "", fmt.Errorf("failed to load targets: %w", err)
 	}
 
-	resourceUpdates, err := resource_update.GenerateResourceUpdates(&forma, pkgmodel.CommandSync, formaCommandConfig.Mode, resource_update.FormaCommandSourceDiscovery, existingTargets, data.ds, nil, nil)
+	resourceUpdates, err := resource_update.GenerateResourceUpdates(&forma, pkgmodel.CommandSync, formaCommandConfig.Mode, resource_update.FormaCommandSourceDiscovery, existingTargets, data.ds, nil, nil, nil)
 	if err != nil {
 		proc.Log().Error("failed to generate resource updates: %v", err)
 		return "", fmt.Errorf("failed to generate resource updates: %w", err)

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -264,6 +264,40 @@ func (m *Metastructure) callActor(targetPID gen.ProcessID, message any) (any, er
 	}
 }
 
+// fetchLivePluginSchemas queries the PluginCoordinator for the current Schema of
+// every resource type referenced in the forma, keyed by resource type. Returns an
+// empty (but non-nil) map on any lookup failure so callers can pass through safely
+// — a missing live schema means the stored/CLI schema is used, which is the
+// pre-existing behavior.
+func (m *Metastructure) fetchLivePluginSchemas(forma *pkgmodel.Forma) map[string]pkgmodel.Schema {
+	result := make(map[string]pkgmodel.Schema)
+	if forma == nil {
+		return result
+	}
+	namespaces := make(map[string]struct{})
+	for _, r := range forma.Resources {
+		namespaces[r.Namespace()] = struct{}{}
+	}
+	for ns := range namespaces {
+		response, err := m.callActor(
+			gen.ProcessID{Name: actornames.PluginCoordinator, Node: m.Node.Name()},
+			messages.GetPluginInfo{Namespace: ns},
+		)
+		if err != nil {
+			slog.Debug("fetchLivePluginSchemas: GetPluginInfo failed", "namespace", ns, "error", err)
+			continue
+		}
+		info, ok := response.(messages.PluginInfoResponse)
+		if !ok || !info.Found {
+			continue
+		}
+		for rtype, schema := range info.ResourceSchemas {
+			result[rtype] = schema
+		}
+	}
+	return result
+}
+
 func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string) (*apimodel.SubmitCommandResponse, error) {
 	m.commandMu.Lock()
 	defer m.commandMu.Unlock()
@@ -280,7 +314,8 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 		}
 	}
 
-	fa, err := FormaCommandFromForma(forma, config, pkgmodel.CommandApply, m.Datastore, clientID, resource_update.FormaCommandSourceUser)
+	livePluginSchemas := m.fetchLivePluginSchemas(forma)
+	fa, err := FormaCommandFromForma(forma, config, pkgmodel.CommandApply, m.Datastore, clientID, resource_update.FormaCommandSourceUser, livePluginSchemas)
 	if err != nil {
 		if requiredFieldsErr, ok := err.(apimodel.RequiredFieldMissingOnCreateError); ok {
 			return nil, requiredFieldsErr
@@ -693,7 +728,7 @@ func (m *Metastructure) DestroyForma(forma *pkgmodel.Forma, config *config.Forma
 		}
 	}
 
-	fa, err := FormaCommandFromForma(forma, config, pkgmodel.CommandDestroy, m.Datastore, clientID, resource_update.FormaCommandSourceUser)
+	fa, err := FormaCommandFromForma(forma, config, pkgmodel.CommandDestroy, m.Datastore, clientID, resource_update.FormaCommandSourceUser, nil)
 	if err != nil {
 		slog.Error("Failed to create destroy from forma", "error", err)
 		return nil, err
@@ -1820,12 +1855,20 @@ func checkForEmptyStackCreation(command *forma_command.FormaCommand) error {
 	return nil
 }
 
+// FormaCommandFromForma builds a FormaCommand from a user-supplied Forma.
+//
+// livePluginSchemas, when non-nil, carries the agent's live per-resource-type Schema
+// keyed by resource type. It is forwarded to GenerateResourceUpdates to override any
+// stale client-side PKL schema the CLI may have compiled against an older formae SDK
+// — required so the patch-time recursive provider-default stripper can walk new
+// Hint paths added to the schema on the agent side.
 func FormaCommandFromForma(forma *pkgmodel.Forma,
 	formaCommandConfig *config.FormaCommandConfig,
 	command pkgmodel.Command,
 	ds datastore.Datastore,
 	clientID string,
-	source resource_update.FormaCommandSource) (*forma_command.FormaCommand, error) {
+	source resource_update.FormaCommandSource,
+	livePluginSchemas map[string]pkgmodel.Schema) (*forma_command.FormaCommand, error) {
 
 	if formaCommandConfig.Mode == "" {
 		formaCommandConfig.Mode = pkgmodel.FormaApplyModePatch
@@ -1871,7 +1914,7 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 		}
 	}
 
-	resourceUpdates, err := resource_update.GenerateResourceUpdates(forma, command, formaCommandConfig.Mode, source, existingTargets, ds, replacedTargets, deletedTargets)
+	resourceUpdates, err := resource_update.GenerateResourceUpdates(forma, command, formaCommandConfig.Mode, source, existingTargets, ds, livePluginSchemas, replacedTargets, deletedTargets)
 	if err != nil {
 		if requiredFieldsErr, ok := err.(apimodel.RequiredFieldMissingOnCreateError); ok {
 			return nil, requiredFieldsErr

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -20,7 +20,16 @@ import (
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
-// GenerateResourceUpdates converts a Forma and command parameters into ResourceUpdates that can be executed
+// GenerateResourceUpdates converts a Forma and command parameters into ResourceUpdates that can be executed.
+//
+// livePluginSchemas, when non-nil, provides the agent's live per-resource-type Schema
+// keyed by resource type (e.g. "AWS::ECS::TaskDefinition"). Any forma resource whose
+// type matches a key in the map has its Schema replaced with the live schema before
+// patch generation. This overrides any stale client-side PKL schema the CLI compiled
+// against an older formae SDK — critical when a new Schema.Hint on the agent side is
+// required for the recursive provider-default stripper to neutralize AWS-populated
+// values in existing state. Callers that don't have a live schema source (e.g. the
+// Synchronizer, which stamps fresh schemas inline) may pass nil.
 func GenerateResourceUpdates(
 	forma *pkgmodel.Forma,
 	command pkgmodel.Command,
@@ -28,9 +37,35 @@ func GenerateResourceUpdates(
 	source FormaCommandSource,
 	existingTargets []*pkgmodel.Target,
 	ds ResourceDataLookup,
+	livePluginSchemas map[string]pkgmodel.Schema,
 	replacedTargets map[string]bool,
 	deletedTargets map[string]bool,
 ) ([]ResourceUpdate, error) {
+
+	// Merge the agent's live per-resource-type Hints into each forma resource's Schema
+	// before patch generation. The CLI compiles its forma against whichever formae SDK
+	// version its PklProject pins — which may lag behind the SDK bundled with the running
+	// agent. Newly-added hasProviderDefault annotations on deep sub-resource fields are
+	// required by the patch-time recursive provider-default stripper; without this merge,
+	// stored state containing an AWS-populated default can't be neutralized and a
+	// createOnly ancestor trips a spurious replacement on reapply.
+	//
+	// Semantics: live hints are added to (and, on key collision, override) the CLI-supplied
+	// hints. Only Hints are touched — Fields, Identifier, Portable, and the rest of the
+	// Schema reflect the resource instance's property shape (e.g. classifying properties as
+	// regular vs read-only) and must keep the form in which the CLI produced them.
+	for i := range forma.Resources {
+		fresh, ok := livePluginSchemas[forma.Resources[i].Type]
+		if !ok || len(fresh.Hints) == 0 {
+			continue
+		}
+		if forma.Resources[i].Schema.Hints == nil {
+			forma.Resources[i].Schema.Hints = make(map[string]pkgmodel.FieldHint, len(fresh.Hints))
+		}
+		for k, v := range fresh.Hints {
+			forma.Resources[i].Schema.Hints[k] = v
+		}
+	}
 
 	var referenceLabels map[string]string
 	var err error

--- a/internal/metastructure/resource_update/resource_update_generator_destroy_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_destroy_test.go
@@ -335,6 +335,7 @@ func TestGenerateResourceUpdatesForDestroy(t *testing.T) {
 				ds,
 				nil,
 				nil,
+				nil,
 			)
 
 			if tt.expectedError != "" {

--- a/internal/metastructure/resource_update/resource_update_generator_reconcile_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_reconcile_test.go
@@ -295,6 +295,7 @@ func TestGenerateResourceUpdatesForReconcile(t *testing.T) {
 				ds,
 				nil,
 				nil,
+				nil,
 			)
 
 			if tt.expectedError != "" {
@@ -1114,6 +1115,92 @@ func TestGenerateResourceUpdatesForReconcile_ImplicitDelete(t *testing.T) {
 	assert.Equal(t, "my-s3-bucket-delete", updates[0].DesiredState.Label)
 }
 
+// Verifies that livePluginSchemas merges deep hasProviderDefault hints into the
+// CLI-supplied forma schema so the recursive provider-default stripper neutralizes
+// existing-state defaults on fields the CLI schema doesn't know about. Without the
+// merge, a createOnly ancestor trips a full replacement because the stripper has no
+// hint path to walk into the deep sub-resource.
+func TestGenerateResourceUpdatesForReconcile_LivePluginSchemaOverridesFormaSchema_StripsProviderDefault(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	staleSchema := pkgmodel.Schema{
+		Identifier: "Ref",
+		Hints: map[string]pkgmodel.FieldHint{
+			"Volumes": {CreateOnly: true, HasProviderDefault: true},
+		},
+		Fields: []string{"Volumes"},
+	}
+
+	existing := pkgmodel.Resource{
+		Label:  "my-task",
+		Type:   "Test::TaskDef",
+		Stack:  "infra",
+		Target: "test-target",
+		Schema: staleSchema,
+		Properties: json.RawMessage(`{
+			"Volumes": [
+				{"Name": "wal", "EFSVolumeConfiguration": {"RootDirectory": "/"}}
+			]
+		}`),
+	}
+
+	formaResource := pkgmodel.Resource{
+		Label:  "my-task",
+		Type:   "Test::TaskDef",
+		Stack:  "infra",
+		Target: "test-target",
+		Schema: staleSchema,
+		Properties: json.RawMessage(`{
+			"Volumes": [
+				{"Name": "wal", "EFSVolumeConfiguration": {}}
+			]
+		}`),
+	}
+
+	// Agent's live plugin schema — includes the deep hint the stale CLI schema lacks.
+	livePluginSchemas := map[string]pkgmodel.Schema{
+		"Test::TaskDef": {
+			Identifier: "Ref",
+			Hints: map[string]pkgmodel.FieldHint{
+				"Volumes":                                      {CreateOnly: true, HasProviderDefault: true},
+				"Volumes.EFSVolumeConfiguration.RootDirectory": {HasProviderDefault: true},
+			},
+			Fields: []string{"Volumes"},
+		},
+	}
+
+	_, err := ds.StoreStack(&pkgmodel.Forma{
+		Stacks:    []pkgmodel.Stack{{Label: "infra"}},
+		Resources: []pkgmodel.Resource{existing},
+	}, "test-cmd-1")
+	assert.NoError(t, err)
+
+	forma := &pkgmodel.Forma{
+		Stacks:    []pkgmodel.Stack{{Label: "infra"}},
+		Resources: []pkgmodel.Resource{formaResource},
+	}
+
+	existingTargets := []*pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-west-2"}`), Namespace: "test"},
+	}
+
+	updates, err := GenerateResourceUpdates(
+		forma,
+		pkgmodel.CommandApply,
+		pkgmodel.FormaApplyModeReconcile,
+		FormaCommandSourceUser,
+		existingTargets,
+		ds,
+		livePluginSchemas,
+		nil, nil,
+	)
+	assert.NoError(t, err)
+	for _, u := range updates {
+		assert.NotEqual(t, OperationDelete, u.Operation, "must not emit delete for replace: live schema should strip the provider-default diff")
+		assert.NotEqual(t, OperationCreate, u.Operation, "must not emit create for replace: live schema should strip the provider-default diff")
+	}
+}
+
 func TestGenerateResourceUpdatesForReconcile_Update(t *testing.T) {
 	ds, _ := GetDeps(t)
 
@@ -1386,7 +1473,7 @@ func TestGenerateResourceUpdatesForReconcile_ForwardReferenceToNewResource(t *te
 		{Label: "aws-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "aws"},
 	}
 
-	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, existingTargets, ds, nil, nil)
+	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, existingTargets, ds, nil, nil, nil)
 
 	assert.NoError(t, err, "forward reference to new resource should not cause an error")
 	assert.NotEmpty(t, updates, "should produce resource updates")
@@ -1482,7 +1569,7 @@ func TestGenerateResourceUpdatesForReconcile_AddNewResourceWithForwardReference(
 		{Label: "aws-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "aws"},
 	}
 
-	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, existingTargets, ds, nil, nil)
+	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, existingTargets, ds, nil, nil, nil)
 
 	assert.NoError(t, err, "adding new resource with forward reference should not cause an error")
 	assert.NotEmpty(t, updates, "should produce resource updates")

--- a/internal/metastructure/resource_update/resource_update_generator_stack_transition_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_stack_transition_test.go
@@ -265,7 +265,7 @@ func generateUpdates(t *testing.T, ds *mockDatastore, forma *pkgmodel.Forma) []R
 	t.Helper()
 	targets := []*pkgmodel.Target{{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}}
 	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
-		FormaCommandSourceUser, targets, ds, nil, nil)
+		FormaCommandSourceUser, targets, ds, nil, nil, nil)
 	require.NoError(t, err)
 	return updates
 }

--- a/internal/metastructure/resource_update/resource_update_generator_target_replace_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_target_replace_test.go
@@ -64,7 +64,7 @@ func TestGenerateResourceUpdates_TargetReplace_Reconcile_StackInForma(t *testing
 	replacedTargets := map[string]bool{"aws-prod": true}
 
 	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
-		FormaCommandSourceUser, existingTargets, ds, replacedTargets, nil)
+		FormaCommandSourceUser, existingTargets, ds, nil, replacedTargets, nil)
 
 	require.NoError(t, err)
 
@@ -119,7 +119,7 @@ func TestGenerateResourceUpdates_TargetReplace_Reconcile_StackNotInForma(t *test
 	replacedTargets := map[string]bool{"aws-prod": true}
 
 	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
-		FormaCommandSourceUser, existingTargets, ds, replacedTargets, nil)
+		FormaCommandSourceUser, existingTargets, ds, nil, replacedTargets, nil)
 
 	require.NoError(t, err)
 
@@ -198,7 +198,7 @@ func TestGenerateResourceUpdates_TargetReplace_Patch(t *testing.T) {
 	replacedTargets := map[string]bool{"aws-prod": true}
 
 	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModePatch,
-		FormaCommandSourceUser, existingTargets, ds, replacedTargets, nil)
+		FormaCommandSourceUser, existingTargets, ds, nil, replacedTargets, nil)
 
 	require.NoError(t, err)
 

--- a/internal/metastructure/resource_update/resource_update_generator_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_test.go
@@ -429,7 +429,7 @@ func TestGenerateResourceUpdatesWithTranslation(t *testing.T) {
 		},
 	}
 
-	updates, err := GenerateResourceUpdates(forma, command, mode, FormaCommandSourceUser, []*pkgmodel.Target{}, ds, nil, nil)
+	updates, err := GenerateResourceUpdates(forma, command, mode, FormaCommandSourceUser, []*pkgmodel.Target{}, ds, nil, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, updates, 2)
 
@@ -597,7 +597,7 @@ func TestGenerateResourceUpdates_PopulatesReferenceLabels(t *testing.T) {
 		},
 	}
 
-	updates, err := GenerateResourceUpdates(forma, command, mode, FormaCommandSourceUser, []*pkgmodel.Target{}, ds, nil, nil)
+	updates, err := GenerateResourceUpdates(forma, command, mode, FormaCommandSourceUser, []*pkgmodel.Target{}, ds, nil, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, updates, 2)
 
@@ -649,7 +649,7 @@ func TestGenerateResourceUpdates_ReferenceLabelsEdge(t *testing.T) {
 			},
 		}
 
-		updates, err := GenerateResourceUpdates(forma, command, mode, FormaCommandSourceUser, []*pkgmodel.Target{}, ds, nil, nil)
+		updates, err := GenerateResourceUpdates(forma, command, mode, FormaCommandSourceUser, []*pkgmodel.Target{}, ds, nil, nil, nil)
 		require.NoError(t, err)
 		require.Len(t, updates, 1)
 
@@ -686,7 +686,7 @@ func TestGenerateResourceUpdates_ReferenceLabelsEdge(t *testing.T) {
 			},
 		}
 
-		_, err := GenerateResourceUpdates(forma, command, mode, FormaCommandSourceUser, []*pkgmodel.Target{}, ds, nil, nil)
+		_, err := GenerateResourceUpdates(forma, command, mode, FormaCommandSourceUser, []*pkgmodel.Target{}, ds, nil, nil, nil)
 		require.Error(t, err)
 
 		var notFoundErr apimodel.FormaReferencedResourcesNotFoundError
@@ -723,7 +723,7 @@ func TestGenerateResourceUpdates_ReferenceLabelsEdge(t *testing.T) {
 			},
 		}
 
-		_, err := GenerateResourceUpdates(forma, command, mode, FormaCommandSourceUser, []*pkgmodel.Target{}, ds, nil, nil)
+		_, err := GenerateResourceUpdates(forma, command, mode, FormaCommandSourceUser, []*pkgmodel.Target{}, ds, nil, nil, nil)
 		require.Error(t, err)
 
 		var notFoundErr apimodel.FormaReferencedResourcesNotFoundError
@@ -765,7 +765,7 @@ func TestGenerateResourceUpdates_ReferenceLabelsEdge(t *testing.T) {
 			},
 		}
 
-		_, err := GenerateResourceUpdates(forma, command, mode, FormaCommandSourceUser, []*pkgmodel.Target{}, ds, nil, nil)
+		_, err := GenerateResourceUpdates(forma, command, mode, FormaCommandSourceUser, []*pkgmodel.Target{}, ds, nil, nil, nil)
 		require.Error(t, err)
 
 		var notFoundErr apimodel.FormaReferencedResourcesNotFoundError
@@ -811,7 +811,7 @@ func TestGenerateResourceUpdates_TargetValidation(t *testing.T) {
 			},
 		}
 
-		updates, err := GenerateResourceUpdates(&forma, command, mode, FormaCommandSourceUser, existingTargets, ds, nil, nil)
+		updates, err := GenerateResourceUpdates(&forma, command, mode, FormaCommandSourceUser, existingTargets, ds, nil, nil, nil)
 		assert.NoError(t, err)
 		assert.Len(t, updates, 1)
 		assert.Equal(t, "test-target", updates[0].ResourceTarget.Label)
@@ -837,7 +837,7 @@ func TestGenerateResourceUpdates_TargetValidation(t *testing.T) {
 			},
 		}
 
-		updates, err := GenerateResourceUpdates(&forma, command, mode, FormaCommandSourceUser, existingTargets, ds, nil, nil)
+		updates, err := GenerateResourceUpdates(&forma, command, mode, FormaCommandSourceUser, existingTargets, ds, nil, nil, nil)
 		assert.Error(t, err)
 		assert.Nil(t, updates)
 	})
@@ -862,7 +862,7 @@ func TestGenerateResourceUpdates_TargetValidation(t *testing.T) {
 			},
 		}
 
-		updates, err := GenerateResourceUpdates(&forma, command, mode, FormaCommandSourceUser, existingTargets, ds, nil, nil)
+		updates, err := GenerateResourceUpdates(&forma, command, mode, FormaCommandSourceUser, existingTargets, ds, nil, nil, nil)
 		assert.Error(t, err)
 		assert.Nil(t, updates)
 	})
@@ -882,7 +882,7 @@ func TestGenerateResourceUpdates_TargetValidation(t *testing.T) {
 
 		existingTargets := []*pkgmodel.Target{} // No existing targets
 
-		updates, err := GenerateResourceUpdates(&forma, command, mode, FormaCommandSourceUser, existingTargets, ds, nil, nil)
+		updates, err := GenerateResourceUpdates(&forma, command, mode, FormaCommandSourceUser, existingTargets, ds, nil, nil, nil)
 		assert.NoError(t, err)
 		assert.Len(t, updates, 1)
 		assert.Equal(t, "new-target", updates[0].ResourceTarget.Label)

--- a/internal/metastructure/stack_expirer.go
+++ b/internal/metastructure/stack_expirer.go
@@ -223,6 +223,7 @@ func prepareDestroyExpiredStack(ds datastore.Datastore, stackInfo datastore.Expi
 		resource_update.FormaCommandSourceUser, // Treat expiration as user-initiated
 		existingTargets,
 		ds,
+		nil, // livePluginSchemas: destroy uses stored schema, no fresh stamping needed
 		nil, nil,
 	)
 	if err != nil {

--- a/internal/metastructure/synchronizer.go
+++ b/internal/metastructure/synchronizer.go
@@ -235,6 +235,7 @@ func synchronizeAllResources(state gen.Atom, data SynchronizerData, proc gen.Pro
 			resource_update.FormaCommandSourceSynchronize,
 			existingTargets,
 			data.datastore,
+			nil, // livePluginSchemas: Synchronizer already stamps fresh schemas inline above
 			nil, nil,
 		)
 		if err != nil {

--- a/internal/workflow_tests/local/stack_test.go
+++ b/internal/workflow_tests/local/stack_test.go
@@ -357,7 +357,7 @@ func TestMetastructure_StackForApplyImplicitReplaceModeWithRemoveOfOneResource(t
 
 		formaCommand, _ := FormaCommandFromForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, pkgmodel.CommandApply, m.Datastore, "test", resource_update.FormaCommandSourceUser)
+		}, pkgmodel.CommandApply, m.Datastore, "test", resource_update.FormaCommandSourceUser, nil)
 
 		assert.Equal(t, formaCommand.ResourceUpdates[0].State, forma_command.CommandStateNotStarted)
 
@@ -406,7 +406,7 @@ func TestMetastructure_StackForApplyImplicitReplaceModeWithRenameLabelOfResource
 
 		formaCommand, _ := FormaCommandFromForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, pkgmodel.CommandApply, m.Datastore, "test", resource_update.FormaCommandSourceUser)
+		}, pkgmodel.CommandApply, m.Datastore, "test", resource_update.FormaCommandSourceUser, nil)
 
 		assert.Equal(t, formaCommand.ResourceUpdates[0].State, resource_update.ResourceUpdateStateNotStarted)
 

--- a/internal/workflow_tests/local/stack_transition_test.go
+++ b/internal/workflow_tests/local/stack_transition_test.go
@@ -58,6 +58,7 @@ func TestStackTransition_Integration(t *testing.T) {
 				m.Datastore,
 				nil,
 				nil,
+				nil,
 			)
 			require.NoError(t, err)
 			require.Len(t, updates, 1)
@@ -101,6 +102,7 @@ func TestStackTransition_Integration(t *testing.T) {
 				resource_update.FormaCommandSourceUser,
 				[]*pkgmodel.Target{&target},
 				m.Datastore,
+				nil,
 				nil,
 				nil,
 			)


### PR DESCRIPTION
## Summary

- The apply/simulate path generated patches against whatever `Schema.Hints` the CLI baked into the forma at PKL eval time. Those hints come from the formae SDK version the client's `PklProject` pins, which may lag behind the SDK bundled with the running agent. Newly-added Hint paths on the agent side (e.g. a `hasProviderDefault` on a deep sub-resource field, such as the one added in #428 for `Volumes.EFSVolumeConfiguration.RootDirectory`) were absent from the CLI-supplied schema, so the recursive provider-default stripper had nothing to walk. Stored state carrying an AWS-populated default stayed untouched and a `createOnly` ancestor tripped a full replacement on every reapply.
- Previously, only the `Synchronizer` refreshed schemas before patch generation. Sync-driven refreshes only write a row when OOB drift is detected, so any resource whose cloud-side read equals its stored state never had its schema refreshed — stored `Schema.Hints` stayed frozen at the SDK version in play when the resource was created.
- Fetch the live per-resource-type `Schema` from the `PluginCoordinator` in `ApplyForma`, then merge its `Hints` into each forma resource before `GenerateResourceUpdates` runs. Hints are merged, not wholesale-replaced: live hints override on key collision; CLI-supplied hints the live schema doesn't know about are preserved. `Fields`, `Identifier`, `Portable`, and the rest of the `Schema` are deliberately untouched — those reflect the resource instance's property shape (e.g. classifying properties as regular vs read-only) and must stay in the form the CLI produced.
- New reconcile test in `resource_update_generator_reconcile_test.go` mirrors the ECS `AWS::ECS::TaskDefinition.Volumes.EFSVolumeConfiguration.RootDirectory` shape: a CLI-supplied Schema missing the deep `hasProviderDefault` hint, a stored resource carrying the AWS-populated default, and a live plugin schema that has the hint. With the merge in place the stripper neutralizes the default symmetrically and no replacement is emitted.
- Callers that don't have (or don't need) agent-side refresh — `Synchronizer` (already stamps fresh schemas inline upstream), `Discovery`, `AutoReconciler`, `StackExpirer` — pass `nil` for the new parameter. `ApplyForma` and `DestroyForma` thread the fetched schemas through `FormaCommandFromForma`.