### PR TITLE
fix(datastore): compare resource version under COLLATE "C" consistently

### DIFF
--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -1159,7 +1159,7 @@ func (d *DatastoreAuroraDataAPI) CountResourcesInStack(label string) (int, error
 		AND NOT EXISTS (
 			SELECT 1 FROM resources r2
 			WHERE r1.uri = r2.uri
-			AND r2.version > r1.version
+			AND r2.version COLLATE "C" > r1.version COLLATE "C"
 		)
 		AND operation != :operation
 	`
@@ -1194,7 +1194,7 @@ func (d *DatastoreAuroraDataAPI) LoadAllResourcesByStack() (map[string][]*pkgmod
 			SELECT 1
 			FROM resources r2
 			WHERE r1.uri = r2.uri
-			AND r2.version > r1.version
+			AND r2.version COLLATE "C" > r1.version COLLATE "C"
 		)
 		AND operation != :operation
 	`
@@ -1253,7 +1253,7 @@ func (d *DatastoreAuroraDataAPI) LoadResourcesByStack(stackLabel string) ([]*pkg
 			SELECT 1
 			FROM resources r2
 			WHERE r1.uri = r2.uri
-			AND r2.version > r1.version
+			AND r2.version COLLATE "C" > r1.version COLLATE "C"
 		)
 		AND operation != :operation
 	`
@@ -1304,7 +1304,7 @@ func (d *DatastoreAuroraDataAPI) CountResourcesInTarget(targetLabel string) (int
 		AND NOT EXISTS (
 			SELECT 1 FROM resources r2
 			WHERE r1.uri = r2.uri
-			AND r2.version > r1.version
+			AND r2.version COLLATE "C" > r1.version COLLATE "C"
 		)
 		AND operation != :operation
 	`

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -1602,7 +1602,7 @@ func (d DatastorePostgres) CountResourcesInStack(label string) (int, error) {
 		AND NOT EXISTS (
 			SELECT 1 FROM resources r2
 			WHERE r1.uri = r2.uri
-			AND r2.version > r1.version
+			AND r2.version COLLATE "C" > r1.version COLLATE "C"
 		)
 		AND operation != $2
 	`
@@ -3257,7 +3257,7 @@ func (d DatastorePostgres) CountResourcesInTarget(targetLabel string) (int, erro
 		AND NOT EXISTS (
 			SELECT 1 FROM resources r2
 			WHERE r1.uri = r2.uri
-			AND r2.version > r1.version
+			AND r2.version COLLATE "C" > r1.version COLLATE "C"
 		)
 		AND operation != $2
 	`

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -103,11 +103,6 @@ func TestLoadResourcesByStack_ExcludesDeletedResourceWhenVersionsMixCase(t *test
 	require.NoError(t, err)
 	defer conn.Close(ctx) //nolint:errcheck
 
-	// Create the stack row first so downstream code that joins against stacks works.
-	_, err = conn.Exec(ctx, `INSERT INTO stacks (ksuid, version, label, description) VALUES ($1, $2, $3, $4)`,
-		"stack-ksuid", "v1", "test-stack", "")
-	require.NoError(t, err)
-
 	// Earlier update row with an uppercase letter in the version's locale-significant position.
 	updateVersion := "2wQUVeqpcVTSF4ROlhC9N4kMUPk"
 	// Chronologically-later delete row with a lowercase letter. Byte order puts this after

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -8,6 +8,7 @@ package postgres_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -16,6 +17,8 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/datastore/dstest"
 	"github.com/platform-engineering-labs/formae/internal/datastore/postgres"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDatastore(t *testing.T) {
@@ -53,4 +56,87 @@ func TestDatastore(t *testing.T) {
 			},
 		}
 	})
+}
+
+// Latest-version subqueries (`r2.version > r1.version`) on the resources table
+// depend on byte-order semantics because KSUIDs are base62 (mixed case) and only
+// sort chronologically under byte ordering. Under the default Postgres collation,
+// locale rules can put an uppercase-letter version before a chronologically-later
+// lowercase-letter version, causing the "latest" filter to pick the wrong row.
+// When the true latest is a delete and the locale-latest is an update, the
+// resource leaks back through as "managed" even after destroy.
+//
+// Scenario: `update` row has version "2wQUVeqpc…" (uppercase 'U' at position 3),
+// `delete` row has a chronologically-later version "2wQfTRyui…" (lowercase 'f').
+// Byte order: delete > update (correct — delete is latest, exclude resource).
+// Locale order: update > delete (wrong — update appears latest, resource leaks).
+func TestLoadResourcesByStack_ExcludesDeletedResourceWhenVersionsMixCase(t *testing.T) {
+	ctx := context.Background()
+
+	adminConn, err := pgx.Connect(ctx, "postgres://postgres:admin@localhost:5432/postgres")
+	if err != nil {
+		t.Skipf("Postgres not available: %v", err)
+	}
+	adminConn.Close(ctx)
+
+	cfg := &pkgmodel.DatastoreConfig{
+		DatastoreType: pkgmodel.PostgresDatastore,
+		Postgres: pkgmodel.PostgresConfig{
+			Host:     "localhost",
+			Port:     5432,
+			User:     "postgres",
+			Password: "admin",
+			Database: fmt.Sprintf("test_collate_%s", mksuid.New().String()),
+		},
+	}
+	ds, err := postgres.NewDatastorePostgresEnsureDatabase(ctx, cfg, "test")
+	require.NoError(t, err)
+	defer func() {
+		if d, ok := ds.(postgres.DatastorePostgres); ok {
+			_ = d.CleanUp()
+		}
+	}()
+
+	// Open a second connection for direct INSERT to control the version column precisely.
+	connStr := postgres.BuildConnStr(cfg.Postgres.Host, cfg.Postgres.Port, cfg.Postgres.User, cfg.Postgres.Password, cfg.Postgres.Database)
+	conn, err := pgx.Connect(ctx, connStr)
+	require.NoError(t, err)
+	defer conn.Close(ctx) //nolint:errcheck
+
+	// Create the stack row first so downstream code that joins against stacks works.
+	_, err = conn.Exec(ctx, `INSERT INTO stacks (ksuid, version, label, description) VALUES ($1, $2, $3, $4)`,
+		"stack-ksuid", "v1", "test-stack", "")
+	require.NoError(t, err)
+
+	// Earlier update row with an uppercase letter in the version's locale-significant position.
+	updateVersion := "2wQUVeqpcVTSF4ROlhC9N4kMUPk"
+	// Chronologically-later delete row with a lowercase letter. Byte order puts this after
+	// updateVersion (correct); locale order puts it before (the bug).
+	deleteVersion := "2wQfTRyuifVOB5LKSwee7d8aErH"
+
+	uri := "formae://test-ksuid"
+	data := json.RawMessage(`{"Schema":{},"Properties":{}}`)
+
+	_, err = conn.Exec(ctx, `INSERT INTO resources (uri, version, command_id, operation, native_id, stack, type, label, target, data, managed, ksuid)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+		uri, updateVersion, "cmd-1", "update", "native-1", "test-stack", "type-1", "label-1", "", data, true, "test-ksuid")
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx, `INSERT INTO resources (uri, version, command_id, operation, native_id, stack, type, label, target, data, managed, ksuid)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+		uri, deleteVersion, "cmd-2", "delete", "native-1", "test-stack", "type-1", "label-1", "", data, true, "test-ksuid")
+	require.NoError(t, err)
+
+	// Sanity check: under the default collation, 'U' > 'f' — the bug's precondition.
+	var localeGT bool
+	err = conn.QueryRow(ctx, `SELECT 'U' > 'f'`).Scan(&localeGT)
+	require.NoError(t, err)
+	require.True(t, localeGT, "test precondition: default collation must treat 'U' as greater than 'f'")
+
+	results, err := ds.LoadResourcesByStack("test-stack")
+	require.NoError(t, err)
+
+	assert.Empty(t, results,
+		"resource with a later delete row must be excluded from LoadResourcesByStack, "+
+			"but uncollated version comparison picked the earlier update row as 'latest'")
 }


### PR DESCRIPTION
## Summary

- KSUIDs are base62 with mixed case and only sort chronologically under byte-order. Several subqueries on the `resources` table compared `r2.version > r1.version` without an explicit collation, so Postgres and Aurora fell back to the database's locale-aware default. In locale order `'U' > 'f'` while in byte order `'U' < 'f'`, so a chronologically-later KSUID can lose the "is this the latest version?" check to an earlier KSUID that happens to have an uppercase letter in a locale-significant position.
- Observed effect: `LoadResourcesByStack`, `LoadAllResourcesByStack`, and the `CountResources*` variants use a "latest row is not a delete" filter via a `NOT EXISTS` subquery. Under locale ordering, a prior `update` row with an uppercase-in-position-N version can sort ahead of the chronologically-later `delete` row, the filter picks the update as latest, `operation != 'delete'` passes, and the destroyed resource leaks back through as managed. Concretely: a `lgtm-task` row from a destroyed stack reappeared in a reconcile plan on the resident agent as a spurious delete, and earlier today the Synchronizer was emitting Read updates for the same destroyed ksuid.
- `COLLATE "C"` is already used on the same comparison in many queries in both `postgres.go` and `aurora.go`; the affected subqueries were the ones that slipped through. Postgres + Aurora only — SQLite's default collation is byte-order, so neither workflow tests nor local dev reproduce this.
- Adds a `postgres_test` that inserts two rows for a single ksuid — an earlier `update` with a locale-greater version (`'U'` at position 3) and a chronologically-later `delete` with a locale-lesser version (`'f'` at position 3) — and asserts `LoadResourcesByStack` returns nothing. The test skips when no local Postgres is available so it doesn't spuriously fail on dev machines without one, but CI runs it against a live Postgres.