### PR TITLE
fix(cli): correct user-facing log strings

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -136,7 +136,7 @@ func (c *Client) ApplyForma(forma *pkgmodel.Forma, mode pkgmodel.FormaApplyMode,
 	case http.StatusBadRequest, http.StatusConflict, http.StatusUnprocessableEntity:
 		return c.parseSubmitCommandErrorResponse(resp.Body)
 	default:
-		return nil, fmt.Errorf("unexpected response code from the forma agent: %d - %s", resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("unexpected response code from the formae agent: %d - %s", resp.StatusCode(), resp.String())
 	}
 }
 
@@ -175,7 +175,7 @@ func (c *Client) DestroyForma(forma *pkgmodel.Forma, simulate bool, clientID str
 	case http.StatusBadRequest, http.StatusConflict:
 		return c.parseSubmitCommandErrorResponse(resp.Body)
 	default:
-		return nil, fmt.Errorf("unexpected response code from the forma agent: %d - %s", resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("unexpected response code from the formae agent: %d - %s", resp.StatusCode(), resp.String())
 	}
 }
 
@@ -206,7 +206,7 @@ func (c *Client) DestroyByQuery(query string, simulate bool, clientID string) (*
 	case http.StatusBadRequest, http.StatusConflict:
 		return c.parseSubmitCommandErrorResponse(resp.Body)
 	default:
-		return nil, fmt.Errorf("unexpected response code from the forma agent: %d - %s", resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("unexpected response code from the formae agent: %d - %s", resp.StatusCode(), resp.String())
 	}
 }
 
@@ -237,7 +237,7 @@ func (c *Client) CancelCommands(query string, clientID string) (*apimodel.Cancel
 	case http.StatusBadRequest:
 		return c.parseCancelCommandsErrorResponse(resp.Body)
 	default:
-		return nil, fmt.Errorf("unexpected response code from the forma agent: %d - %s", resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("unexpected response code from the formae agent: %d - %s", resp.StatusCode(), resp.String())
 	}
 }
 
@@ -481,7 +481,7 @@ func (c *Client) ExtractResources(query string) (*pkgmodel.Forma, error) {
 		return c.parseListResourcesErrorResponse(resp.Body)
 
 	default:
-		return nil, fmt.Errorf("unexpected response code from the forma agent: %d - %s", resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("unexpected response code from the formae agent: %d - %s", resp.StatusCode(), resp.String())
 	}
 }
 
@@ -504,7 +504,7 @@ func (c *Client) ListTargets(query string) ([]*pkgmodel.Target, error) {
 	case http.StatusNotFound:
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("unexpected response code from the forma agent: %d - %s", resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("unexpected response code from the formae agent: %d - %s", resp.StatusCode(), resp.String())
 	}
 }
 
@@ -526,7 +526,7 @@ func (c *Client) ListStacks() ([]*pkgmodel.Stack, error) {
 	case http.StatusNotFound:
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("unexpected response code from the forma agent: %d - %s", resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("unexpected response code from the formae agent: %d - %s", resp.StatusCode(), resp.String())
 	}
 }
 
@@ -548,7 +548,7 @@ func (c *Client) ListPolicies() ([]apimodel.PolicyInventoryItem, error) {
 	case http.StatusNotFound:
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("unexpected response code from the forma agent: %d - %s", resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("unexpected response code from the formae agent: %d - %s", resp.StatusCode(), resp.String())
 	}
 }
 
@@ -591,7 +591,7 @@ func (c *Client) ForceReconcile(stackLabel string) (*apimodel.ForceReconcileResp
 	case http.StatusForbidden:
 		return nil, fmt.Errorf("stack does not have an auto-reconcile policy attached; force-reconcile requires one")
 	default:
-		return nil, fmt.Errorf("unexpected response code from the forma agent: %d - %s", resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("unexpected response code from the formae agent: %d - %s", resp.StatusCode(), resp.String())
 	}
 }
 
@@ -612,6 +612,6 @@ func (c *Client) ForceCheckTTL() (*apimodel.ForceCheckTTLResponse, error) {
 		}
 		return &result, nil
 	default:
-		return nil, fmt.Errorf("unexpected response code from the forma agent: %d - %s", resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("unexpected response code from the formae agent: %d - %s", resp.StatusCode(), resp.String())
 	}
 }

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -44,7 +44,7 @@ func (cliconfig) DataDirectory() string {
 func (cliconfig) EnsureConfigDirectory() error {
 	configPath := Config.ConfigDirectory()
 	if configPath == "" {
-		return fmt.Errorf("failed to ensure formae config directory")
+		return fmt.Errorf("failed to ensure config directory")
 	}
 
 	return os.MkdirAll(configPath, 0700)
@@ -53,7 +53,7 @@ func (cliconfig) EnsureConfigDirectory() error {
 func (cliconfig) EnsureDataDirectory() error {
 	dataPath := Config.DataDirectory()
 	if dataPath == "" {
-		return fmt.Errorf("failed to ensure formae data directory")
+		return fmt.Errorf("failed to ensure data directory")
 	}
 
 	return os.MkdirAll(dataPath, 0700)
@@ -62,7 +62,7 @@ func (cliconfig) EnsureDataDirectory() error {
 func (cliconfig) EnsureId(id string) error {
 	configPath := Config.DataDirectory()
 	if configPath == "" {
-		return fmt.Errorf("failed to ensure formae directory")
+		return fmt.Errorf("failed to ensure data directory")
 	}
 
 	idFile := filepath.Join(configPath, id)
@@ -89,7 +89,7 @@ func (cliconfig) EnsureAgentID() error {
 func (cliconfig) ClientID() (string, error) {
 	configPath := Config.DataDirectory()
 	if configPath == "" {
-		return "", fmt.Errorf("failed to retrieve formae directory")
+		return "", fmt.Errorf("failed to retrieve data directory")
 	}
 
 	clientIDFile := filepath.Join(configPath, "cli_client_id")
@@ -104,7 +104,7 @@ func (cliconfig) ClientID() (string, error) {
 func (cliconfig) AgentID() (string, error) {
 	configPath := Config.DataDirectory()
 	if configPath == "" {
-		return "", fmt.Errorf("failed to retrieve formae directory")
+		return "", fmt.Errorf("failed to retrieve data directory")
 	}
 
 	agentIDFile := filepath.Join(configPath, "agent_id")


### PR DESCRIPTION
- Replace "the forma agent" with "the formae agent" in HTTP client error messages under`internal/api/client.go`
- Drop the redundant "formae" qualifier from error strings in `internal/cli/config/config.go`