### PR TITLE
fix(conformance): make OOB plugin RPC timeout configurable, default to 30m

### DIFF
--- a/pkg/plugin-conformance-tests/harness.go
+++ b/pkg/plugin-conformance-tests/harness.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -1618,17 +1619,17 @@ type pluginOperationResult struct {
 // OOB create/delete attempt. Slow cloud resources (e.g. AWS::EKS::Cluster,
 // which legitimately takes 10–15 min to reach ACTIVE) need a generous budget,
 // so the default is 30 min. Plugin authors with even slower resources can
-// override via FORMAE_CONFORMANCE_OOB_TIMEOUT (any Go duration string, e.g.
-// "45m" or "1h").
-const defaultOOBOperationTimeout = 30 * time.Minute
+// override via the FORMAE_TEST_OOB_TIMEOUT environment variable (integer
+// minutes, matching FORMAE_TEST_TIMEOUT / FORMAE_TEST_DISCOVERY_TIMEOUT).
+const defaultOOBOperationTimeoutMinutes = 30
 
 func oobOperationTimeout() time.Duration {
-	if v := os.Getenv("FORMAE_CONFORMANCE_OOB_TIMEOUT"); v != "" {
-		if d, err := time.ParseDuration(v); err == nil && d > 0 {
-			return d
+	if val := os.Getenv("FORMAE_TEST_OOB_TIMEOUT"); val != "" {
+		if minutes, err := strconv.Atoi(val); err == nil && minutes > 0 {
+			return time.Duration(minutes) * time.Minute
 		}
 	}
-	return defaultOOBOperationTimeout
+	return defaultOOBOperationTimeoutMinutes * time.Minute
 }
 
 // retryOnRecoverable executes a plugin operation (create/delete) with retries on recoverable errors.

--- a/pkg/plugin-conformance-tests/harness.go
+++ b/pkg/plugin-conformance-tests/harness.go
@@ -1614,6 +1614,23 @@ type pluginOperationResult struct {
 	err             string // non-empty if the coordinator returned an error
 }
 
+// oobOperationTimeout caps how long retryOnRecoverable will wait on a single
+// OOB create/delete attempt. Slow cloud resources (e.g. AWS::EKS::Cluster,
+// which legitimately takes 10–15 min to reach ACTIVE) need a generous budget,
+// so the default is 30 min. Plugin authors with even slower resources can
+// override via FORMAE_CONFORMANCE_OOB_TIMEOUT (any Go duration string, e.g.
+// "45m" or "1h").
+const defaultOOBOperationTimeout = 30 * time.Minute
+
+func oobOperationTimeout() time.Duration {
+	if v := os.Getenv("FORMAE_CONFORMANCE_OOB_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultOOBOperationTimeout
+}
+
 // retryOnRecoverable executes a plugin operation (create/delete) with retries on recoverable errors.
 // The opFn performs the actor call and returns the initial result. The caller's label is used for logging.
 func (h *TestHarness) retryOnRecoverable(label string, opFn func() (*pluginOperationResult, error)) (resource.ProgressResult, error) {
@@ -1631,8 +1648,8 @@ func (h *TestHarness) retryOnRecoverable(label string, opFn func() (*pluginOpera
 
 		progress := res.initialProgress
 		if progress.OperationStatus == resource.OperationStatusInProgress {
-			h.t.Logf("%s in progress, waiting for completion...", label)
-			progress, err = h.waitForOperationProgress(res.operatorPID, progress, 10*time.Minute)
+			h.t.Logf("%s in progress, waiting for completion (timeout %s)...", label, oobOperationTimeout())
+			progress, err = h.waitForOperationProgress(res.operatorPID, progress, oobOperationTimeout())
 			if err != nil {
 				return resource.ProgressResult{}, fmt.Errorf("waiting for %s to complete: %w", label, err)
 			}

--- a/pkg/plugin-conformance-tests/harness.go
+++ b/pkg/plugin-conformance-tests/harness.go
@@ -1616,11 +1616,17 @@ type pluginOperationResult struct {
 }
 
 // oobOperationTimeout caps how long retryOnRecoverable will wait on a single
-// OOB create/delete attempt. Slow cloud resources (e.g. AWS::EKS::Cluster,
-// which legitimately takes 10–15 min to reach ACTIVE) need a generous budget,
-// so the default is 30 min. Plugin authors with even slower resources can
-// override via the FORMAE_TEST_OOB_TIMEOUT environment variable (integer
-// minutes, matching FORMAE_TEST_TIMEOUT / FORMAE_TEST_DISCOVERY_TIMEOUT).
+// OOB Create or Delete RPC attempt to the plugin (via waitForOperationProgress).
+// Slow cloud resources — AWS::EKS::Cluster is ~10–15 min to reach ACTIVE,
+// RDS clusters and managed Kubernetes clusters on other providers are
+// similar — need a generous budget, so the default is 30 min. Plugin
+// authors can override via FORMAE_TEST_OOB_TIMEOUT (integer minutes,
+// matching FORMAE_TEST_TIMEOUT / FORMAE_TEST_DISCOVERY_TIMEOUT).
+//
+// This is distinct from FORMAE_TEST_OOB_DELETE_TIMEOUT, which bounds the
+// *post-sync inventory tombstone wait* after an OOB delete has already
+// returned from the plugin — a separate, much shorter wait handled in
+// runner.go's Step 24.
 const defaultOOBOperationTimeoutMinutes = 30
 
 func oobOperationTimeout() time.Duration {

--- a/pkg/plugin-conformance-tests/runner.go
+++ b/pkg/plugin-conformance-tests/runner.go
@@ -251,6 +251,11 @@ func getOOBDeleteTimeout() time.Duration {
 //     When set to "discovery", CRUD tests are skipped.
 //   - FORMAE_TEST_TIMEOUT: Timeout in minutes for long-running operations (optional).
 //     Default is 5 minutes. Set to 15 for slow resources like Cloud SQL.
+//   - FORMAE_TEST_OOB_TIMEOUT: Timeout in minutes for a single OOB Create or
+//     Delete RPC to the plugin during the discovery test's CreateOOB phase
+//     (optional). Default is 30 minutes. Raise for resources with longer
+//     provisioning times (e.g. AWS::EKS::Cluster, managed-Kubernetes on
+//     other providers).
 //   - FORMAE_TEST_OOB_DELETE_TIMEOUT: Timeout in minutes for the OOB-delete phase's
 //     wait-for-inventory-removal step (optional). Default is 2 minutes. Raise
 //     for slow backends (e.g. managed Kubernetes).


### PR DESCRIPTION
## Summary

The conformance framework's `retryOnRecoverable` helper hard-codes a
10-minute deadline on the single-attempt wait for an OOB Create or
Delete RPC to the plugin (`h.waitForOperationProgress`). Resources
that legitimately take longer to reach a terminal state — most
notably `AWS::EKS::Cluster`, which typically needs 10–15 min to
become `ACTIVE`, and similarly slow managed-Kubernetes clusters on
other providers — fail the discovery test's `CreateOOB` step purely
because the deadline fires before the cloud API finishes
provisioning. The outer retry loop then burns through its budget on
subsequent attempts until the matrix job's 2h cap cancels the run.

This PR:

- Raises the default to **30 minutes**, which covers the cloud
  resources we've actually exercised.
- Makes it overridable via `FORMAE_TEST_OOB_TIMEOUT` (integer
  minutes — matches the existing `FORMAE_TEST_TIMEOUT` and
  `FORMAE_TEST_DISCOVERY_TIMEOUT` convention) so plugin authors with
  even slower resources can extend it without code changes.

Scope-wise this bounds **both** the OOB Create and OOB Delete plugin
RPCs (both flow through `retryOnRecoverable`). It is **distinct from**
[#436](https://github.com/platform-engineering-labs/formae/pull/436)'s
`FORMAE_TEST_OOB_DELETE_TIMEOUT`, which bounds the post-sync
inventory-tombstone wait (runner.go Step 24) — a separate, much
shorter wait that runs after the plugin-side Delete RPC has already
returned. Both PRs can land independently.

Pairs with the AWS plugin fixes shipped in
[platform-engineering-labs/formae-plugin-aws#47](https://github.com/platform-engineering-labs/formae-plugin-aws/pull/47).
Once this lands and a pseudo-version or tagged release is available,
`formae-plugin-aws` can bump its dependency to pick up the fix —
that should get `eks-cluster` off the timeout list.