### PR TITLE
feat(conformance): add FORMAE_TEST_OOB_DELETE_TIMEOUT env var

### DIFF
--- a/pkg/plugin-conformance-tests/runner.go
+++ b/pkg/plugin-conformance-tests/runner.go
@@ -212,12 +212,12 @@ func getDiscoveryTimeout() time.Duration {
 	return 2 * time.Minute // Default timeout
 }
 
-// getOOBTimeout returns the timeout duration for the OOB-delete phase's
+// getOOBDeleteTimeout returns the timeout duration for the OOB-delete phase's
 // wait-for-inventory-removal step (sync must tombstone the out-of-band
-// deletion). It reads from FORMAE_TEST_OOB_TIMEOUT (in minutes).
+// deletion). It reads from FORMAE_TEST_OOB_DELETE_TIMEOUT (in minutes).
 // Default is 2 minutes. Raise for slow backends (e.g. managed Kubernetes).
-func getOOBTimeout() time.Duration {
-	if val := os.Getenv("FORMAE_TEST_OOB_TIMEOUT"); val != "" {
+func getOOBDeleteTimeout() time.Duration {
+	if val := os.Getenv("FORMAE_TEST_OOB_DELETE_TIMEOUT"); val != "" {
 		if minutes, err := strconv.Atoi(val); err == nil && minutes > 0 {
 			return time.Duration(minutes) * time.Minute
 		}
@@ -251,7 +251,7 @@ func getOOBTimeout() time.Duration {
 //     When set to "discovery", CRUD tests are skipped.
 //   - FORMAE_TEST_TIMEOUT: Timeout in minutes for long-running operations (optional).
 //     Default is 5 minutes. Set to 15 for slow resources like Cloud SQL.
-//   - FORMAE_TEST_OOB_TIMEOUT: Timeout in minutes for the OOB-delete phase's
+//   - FORMAE_TEST_OOB_DELETE_TIMEOUT: Timeout in minutes for the OOB-delete phase's
 //     wait-for-inventory-removal step (optional). Default is 2 minutes. Raise
 //     for slow backends (e.g. managed Kubernetes).
 //
@@ -1524,7 +1524,7 @@ func runCRUDTest(t *testing.T, tc TestCase, rc *ResultCollector) {
 
 	// === Step 24: Verify resource is removed from inventory (tombstoned by sync) ===
 	t.Log("Step 24: Waiting for resource to be removed from inventory after OOB delete...")
-	if err := harness.WaitForResourceRemovedFromInventory(actualResourceType, oobNativeID, getOOBTimeout()); err != nil {
+	if err := harness.WaitForResourceRemovedFromInventory(actualResourceType, oobNativeID, getOOBDeleteTimeout()); err != nil {
 		rc.CRUDFatalf(t, idx, PhaseOOBDelete, "Resource should be removed from inventory after OOB delete + sync: %v", err)
 	}
 	t.Log("OOB delete detection verified - sync correctly tombstoned the resource!")

--- a/pkg/plugin-conformance-tests/runner.go
+++ b/pkg/plugin-conformance-tests/runner.go
@@ -212,6 +212,19 @@ func getDiscoveryTimeout() time.Duration {
 	return 2 * time.Minute // Default timeout
 }
 
+// getOOBTimeout returns the timeout duration for the OOB-delete phase's
+// wait-for-inventory-removal step (sync must tombstone the out-of-band
+// deletion). It reads from FORMAE_TEST_OOB_TIMEOUT (in minutes).
+// Default is 2 minutes. Raise for slow backends (e.g. managed Kubernetes).
+func getOOBTimeout() time.Duration {
+	if val := os.Getenv("FORMAE_TEST_OOB_TIMEOUT"); val != "" {
+		if minutes, err := strconv.Atoi(val); err == nil && minutes > 0 {
+			return time.Duration(minutes) * time.Minute
+		}
+	}
+	return 2 * time.Minute // Default timeout
+}
+
 // RunCRUDTests discovers test cases from the testdata directory and runs
 // the standard CRUD lifecycle test for each resource type.
 //
@@ -238,6 +251,9 @@ func getDiscoveryTimeout() time.Duration {
 //     When set to "discovery", CRUD tests are skipped.
 //   - FORMAE_TEST_TIMEOUT: Timeout in minutes for long-running operations (optional).
 //     Default is 5 minutes. Set to 15 for slow resources like Cloud SQL.
+//   - FORMAE_TEST_OOB_TIMEOUT: Timeout in minutes for the OOB-delete phase's
+//     wait-for-inventory-removal step (optional). Default is 2 minutes. Raise
+//     for slow backends (e.g. managed Kubernetes).
 //
 // This function should be called from a plugin's conformance_test.go:
 //
@@ -1508,7 +1524,7 @@ func runCRUDTest(t *testing.T, tc TestCase, rc *ResultCollector) {
 
 	// === Step 24: Verify resource is removed from inventory (tombstoned by sync) ===
 	t.Log("Step 24: Waiting for resource to be removed from inventory after OOB delete...")
-	if err := harness.WaitForResourceRemovedFromInventory(actualResourceType, oobNativeID, 2*time.Minute); err != nil {
+	if err := harness.WaitForResourceRemovedFromInventory(actualResourceType, oobNativeID, getOOBTimeout()); err != nil {
 		rc.CRUDFatalf(t, idx, PhaseOOBDelete, "Resource should be removed from inventory after OOB delete + sync: %v", err)
 	}
 	t.Log("OOB delete detection verified - sync correctly tombstoned the resource!")


### PR DESCRIPTION
## Summary

- The conformance-test OOB-delete phase's wait-for-inventory-removal step (`runner.go` Step 24, after sync is expected to tombstone an out-of-band deletion) had a hardcoded `2 * time.Minute` timeout.
- Unlike the other two timeouts in this file (`FORMAE_TEST_TIMEOUT`, `FORMAE_TEST_DISCOVERY_TIMEOUT`), there was no env-var override, so plugin authors on slow backends could not extend it.
- Real failure observed in [`formae-plugin-ovh` run 24887482714](https://github.com/platform-engineering-labs/formae-plugin-ovh/actions/runs/24887482714) on the `kube-cluster` job:
  ```
  [OOB Del] Resource should be removed from inventory after OOB delete + sync:
  timeout waiting for resource OVH/4b5c01ab-... (type: OVH::Kube::Cluster)
  to be removed from inventory after 2m0s
  ```
  OVH managed Kubernetes delete + sync routinely exceeds 2 minutes.

Adds `FORMAE_TEST_OOB_DELETE_TIMEOUT` (in minutes, default 2). Named explicitly for the delete phase because the OOB-create path (discovery test) already honors `FORMAE_TEST_DISCOVERY_TIMEOUT`.

## Test plan

- [x] `go vet ./...` and `go build ./...` in `pkg/plugin-conformance-tests`
- [x] Downstream: set `FORMAE_TEST_OOB_DELETE_TIMEOUT=5` in `formae-plugin-ovh` CI for `kube-cluster` and re-run to confirm the OOB-delete phase completes.