### PR TITLE
build(pkl): route publish-pkl to per-channel S3 sub-path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,17 @@
 .DEFAULT_GOAL := all
 
 DEBUG_GOFLAGS := -gcflags="all=-N -l"
-VERSION := $(shell git describe --tags --abbrev=0 --match "[0-9]*" --match "v[0-9]*")
+
+# The latest tag, possibly carrying a `-channel` suffix (e.g., 0.85.0-dev).
+RAW_VERSION := $(shell git describe --tags --abbrev=0 --match "[0-9]*" --match "v[0-9]*")
+# Canonical semver — everything before the first `-`. Used as the artifact
+# version for binaries, the PKL package, and the `formae --version` string.
+VERSION := $(shell echo "$(RAW_VERSION)" | cut -d'-' -f1)
+# Channel — everything after the first `-`, or `stable` if the tag has no
+# suffix. Mirrors the convention already used in justfile and container.yml.
+# The channel is a namespace (URL sub-path for PKL, --channel flag for
+# OPS/orbital), NOT part of the build identity.
+CHANNEL := $(shell t="$(RAW_VERSION)"; c="$${t#*-}"; if [ "$$c" = "$$t" ]; then echo stable; else echo "$$c"; fi)
 
 # External plugin Git repositories to bundle.
 # Append @branch or @tag to pin a specific ref (e.g., ...aws.git@feat/msgpack).
@@ -189,9 +199,13 @@ gen-pkl:
 pkg-pkl:
 	pkl project package ./internal/schema/pkl/schema --skip-publish-check
 
-## publish-pkl: Publish core formae schema to S3
+## publish-pkl: Publish core formae schema to S3.
+## The stable channel publishes to /formae/ (back-compat with existing plugin
+## pins). Other channels publish to /formae/<channel>/ so consumers can opt
+## into non-stable schema by URL — PKL has no native channel concept, so the
+## namespacing is encoded in the path.
 publish-pkl:
-	aws s3 sync .out/formae@${VERSION} s3://hub.platform.engineering/plugins/pkl/schema/pkl/formae/
+	aws s3 sync .out/formae@${VERSION} s3://hub.platform.engineering/plugins/pkl/schema/pkl/formae$(if $(filter-out stable,$(CHANNEL)),/$(CHANNEL),)/
 
 ## gen-external-pkl: Resolve external plugin PKL schemas (requires formae to be published first)
 gen-external-pkl: fetch-external-plugins

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,12 @@ VERSION := $(shell echo "$(RAW_VERSION)" | cut -d'-' -f1)
 # OPS/orbital), NOT part of the build identity.
 CHANNEL := $(shell t="$(RAW_VERSION)"; c="$${t#*-}"; if [ "$$c" = "$$t" ]; then echo stable; else echo "$$c"; fi)
 
+# Channels we accept publishing to. orbital's `ops publish` silently creates
+# unknown channels, so a tag typo would materialise a real channel in the
+# package index. Gate the publish on an explicit allowlist to make typos
+# loud instead of silent.
+ALLOWED_CHANNELS := stable dev
+
 # External plugin Git repositories to bundle.
 # Append @branch or @tag to pin a specific ref (e.g., ...aws.git@feat/msgpack).
 # Without @ref, the default branch (main) is used.
@@ -199,12 +205,21 @@ gen-pkl:
 pkg-pkl:
 	pkl project package ./internal/schema/pkl/schema --skip-publish-check
 
+## check-channel: Fail if the tag's channel is not in ALLOWED_CHANNELS.
+## A separate target so any publish step that relies on CHANNEL can depend on it.
+check-channel:
+	@if [ -z "$(filter $(CHANNEL),$(ALLOWED_CHANNELS))" ]; then \
+	    echo "ERROR: channel '$(CHANNEL)' (from tag '$(RAW_VERSION)') is not in ALLOWED_CHANNELS: $(ALLOWED_CHANNELS)" >&2; \
+	    echo "       Use a bare semver tag for stable (e.g. 0.85.0) or a '-dev' suffix (e.g. 0.85.0-dev)." >&2; \
+	    exit 1; \
+	fi
+
 ## publish-pkl: Publish core formae schema to S3.
 ## The stable channel publishes to /formae/ (back-compat with existing plugin
 ## pins). Other channels publish to /formae/<channel>/ so consumers can opt
 ## into non-stable schema by URL — PKL has no native channel concept, so the
 ## namespacing is encoded in the path.
-publish-pkl:
+publish-pkl: check-channel
 	aws s3 sync .out/formae@${VERSION} s3://hub.platform.engineering/plugins/pkl/schema/pkl/formae$(if $(filter-out stable,$(CHANNEL)),/$(CHANNEL),)/
 
 ## gen-external-pkl: Resolve external plugin PKL schemas (requires formae to be published first)


### PR DESCRIPTION
## Summary

- Split the raw git-tag into a canonical semver \`VERSION\` plus a \`CHANNEL\` (\`stable\` if the tag has no \`-<channel>\` suffix). Mirrors the convention already in \`justfile\` and \`container.yml\`.
- \`publish-pkl\` routes to \`/formae/<channel>/\` for non-stable channels while keeping \`/formae/\` for stable — existing plugin pins (e.g. \`package://.../formae/formae@0.85.0\`) keep resolving unchanged.
- PKL has no native channel concept; the channel has to be encoded in the URL. Plugin authors can pin e.g. \`package://.../formae/dev/formae@0.85.0\` to consume the dev-channel schema.
- \`formae.Version\` (ldflag) now uses the stripped semver, so the binary's build identity stops leaking the channel suffix. Channel is addressing, not identity.
- **Allowlist** (\`ALLOWED_CHANNELS := stable dev\`) gates \`publish-pkl\` on an explicit set. orbital's \`ops publish\` silently creates unknown channels ([opm/metadata/metadata.go:376-410](https://github.com/platform-engineering/orbital) — channel created if \`storm.ErrNotFound\`), so a tag typo would materialise a phantom channel. The allowlist turns that into a loud failure.

## Behaviour today vs. after

| Tag | Today's PKL upload path | After this PR |
|---|---|---|
| \`0.85.0\` | \`/formae/formae@0.85.0.zip\` | \`/formae/formae@0.85.0.zip\` (unchanged) |
| \`0.85.0-dev\` | \`/formae/formae@0.85.0-dev.zip\` (pre-release suffix) | \`/formae/dev/formae@0.85.0.zip\` |
| \`0.85.0-ev\` (typo) | \`/formae/formae@0.85.0-ev.zip\` (silent phantom channel) | \`publish-pkl\` refuses, error message points at the fix |

## Notes

- No change to the \`pkg_pkl\` job wiring in \`release.yml\` — the Makefile target does the routing + gating.
- \`schema-prerelease.yml\` still refuses non-semver versions; unchanged in this PR, worth a follow-up so dev schema pre-releases go through the same channel-aware path.
- Sister repos (\`formae-plugin-*\`, \`formae-helm\`) will need equivalent Makefile splits + allowlist for their own channel publishes.
- \`ALLOWED_CHANNELS\` is easy to extend later — add a new channel name to the list and re-deploy.