### PR TITLE
feat(changeset): add AttachesTo field hint for reachability-aware destroy

### DIFF
--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -216,31 +216,60 @@ func (p *ExecutionDAG) buildTargetResourceEdges(targetUpdates []target_update.Ta
 	}
 }
 
-// buildDeleteDependencies creates REVERSED dependencies for delete operations
+// buildDeleteDependencies creates dependencies for delete operations.
+// For most refs the direction is REVERSED (construction-reversed): the
+// dependency is deleted after the consumer. For refs annotated with
+// HostsOn=true the direction is FORWARD (reachability order): the
+// host resource is deleted first, then the hosted resource.
 func (p *ExecutionDAG) buildDeleteDependencies(allOps []resource_update.ResourceUpdate) {
 	deleteOps := make(map[pkgmodel.FormaeURI]resource_update.ResourceUpdate)
-
-	// Collect all delete operations
 	for _, op := range allOps {
 		if op.Operation == resource_update.OperationDelete {
 			deleteOps[op.URI()] = op
 		}
 	}
 
-	// Build REVERSED dependencies for deletes
 	for _, deleteOp := range deleteOps {
 		dependentOpURI := createOperationURI(deleteOp.URI(), resource_update.OperationDelete)
 		dependentGroup := p.Nodes[dependentOpURI]
+		if dependentGroup == nil {
+			continue
+		}
+
+		// Build a lookup map from referenced-resource-ksuid → TargetPath using
+		// the actual Properties JSON. This lets us find the field hint for each
+		// reference. We fall back gracefully when a ref isn't found in the map.
+		refPathByKsuid := make(map[string]string)
+		for _, ref := range resolver.ExtractResolvableRefs(deleteOp.DesiredState) {
+			// ExtractResolvableRefs returns URIs of the form "formae://<ksuid>" (no
+			// fragment). Extract just the ksuid part.
+			ksuid := strings.TrimPrefix(string(ref.URI), "formae://")
+			if ksuid != "" {
+				refPathByKsuid[ksuid] = ref.TargetPath
+			}
+		}
 
 		for _, resolvableURI := range deleteOp.RemainingResolvables {
-			dependencyBaseURI := resolvableURI.Stripped()
+			depBase := resolvableURI.Stripped()
+			if _, exists := deleteOps[depBase]; !exists {
+				continue
+			}
+			depNode := p.Nodes[createOperationURI(depBase, resource_update.OperationDelete)]
+			if depNode == nil {
+				continue
+			}
 
-			if _, exists := deleteOps[dependencyBaseURI]; exists {
-				dependencyOpURI := createOperationURI(dependencyBaseURI, resource_update.OperationDelete)
-				dependencyGroup := p.Nodes[dependencyOpURI]
-
-				// REVERSE: dependency delete waits for dependent delete to complete
-				dependencyGroup.LinkWith(dependentGroup)
+			// Look up the field hint for this reference by ksuid.
+			targetPath := refPathByKsuid[depBase.KSUID()]
+			hint := fieldHintForPath(deleteOp.DesiredState.Schema, targetPath)
+			if hint.HostsOn {
+				// Reachability edge: the hosting resource waits for the hosted-on
+				// resource's delete. Destroy order: hosted-on first, hosting second.
+				dependentGroup.LinkWith(depNode)
+			} else {
+				// Construction-reversed edge (existing behavior): B.delete waits
+				// for A.delete. Destroy order: consumer first, producer second.
+				depNode.LinkWith(dependentGroup)
 			}
 		}
 	}

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -219,7 +219,7 @@ func (p *ExecutionDAG) buildTargetResourceEdges(targetUpdates []target_update.Ta
 // buildDeleteDependencies creates dependencies for delete operations.
 // For most refs the direction is REVERSED (construction-reversed): the
 // dependency is deleted after the consumer. For refs annotated with
-// HostsOn=true the direction is FORWARD (reachability order): the
+// AttachesTo=true the direction is FORWARD (reachability order): the
 // host resource is deleted first, then the hosted resource.
 func (p *ExecutionDAG) buildDeleteDependencies(allOps []resource_update.ResourceUpdate) {
 	deleteOps := make(map[pkgmodel.FormaeURI]resource_update.ResourceUpdate)
@@ -262,7 +262,7 @@ func (p *ExecutionDAG) buildDeleteDependencies(allOps []resource_update.Resource
 			// Look up the field hint for this reference by ksuid.
 			targetPath := refPathByKsuid[depBase.KSUID()]
 			hint := fieldHintForPath(deleteOp.DesiredState.Schema, targetPath)
-			if hint.HostsOn {
+			if hint.AttachesTo {
 				// Reachability edge: the hosting resource waits for the hosted-on
 				// resource's delete. Destroy order: hosted-on first, hosting second.
 				dependentGroup.LinkWith(depNode)

--- a/internal/metastructure/changeset/changeset_test.go
+++ b/internal/metastructure/changeset/changeset_test.go
@@ -5,6 +5,7 @@
 package changeset
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -2078,4 +2079,164 @@ func TestChangeset_SyncReadFailureDoesNotCascade(t *testing.T) {
 	remaining := cs.GetExecutableUpdates("AWS", 10)
 	require.Len(t, remaining, 1)
 	assert.NotEqual(t, failed.NodeURI(), remaining[0].NodeURI())
+}
+
+// dagNodeForOp returns the DAG node for (URI, operation).
+func dagNodeForOp(t *testing.T, dag *ExecutionDAG, uri pkgmodel.FormaeURI, op resource_update.OperationType) *DAGNode {
+	t.Helper()
+	opURI := createOperationURI(uri, op)
+	node, ok := dag.Nodes[opURI]
+	if !ok {
+		t.Fatalf("DAG missing node %s", opURI)
+	}
+	return node
+}
+
+// hasDependency reports whether `child` has `parent` in its Dependencies list.
+func hasDependency(child, parent *DAGNode) bool {
+	for _, d := range child.Dependencies {
+		if d == parent {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildDeleteDependencies_HostsOnInvertsEdgeDirection(t *testing.T) {
+	var (
+		aURI = pkgmodel.NewFormaeURI("A1", "")
+		bURI = pkgmodel.NewFormaeURI("B1", "")
+	)
+
+	build := func(t *testing.T, hint pkgmodel.FieldHint) *ExecutionDAG {
+		t.Helper()
+		aResource := pkgmodel.Resource{
+			Ksuid: "A1", Label: "a", Type: "Test::A", Stack: "s",
+			Schema: pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"f1": hint}},
+			Properties: json.RawMessage(`{
+				"f1": {"$ref":"formae://B1#/Out","$value":"v"}
+			}`),
+		}
+		bResource := pkgmodel.Resource{
+			Ksuid: "B1", Label: "b", Type: "Test::B", Stack: "s",
+			Properties: json.RawMessage(`{}`),
+		}
+
+		aDelete := resource_update.ResourceUpdate{
+			DesiredState:         aResource,
+			Operation:            resource_update.OperationDelete,
+			RemainingResolvables: []pkgmodel.FormaeURI{bURI},
+		}
+		bDelete := resource_update.ResourceUpdate{
+			DesiredState: bResource,
+			Operation:    resource_update.OperationDelete,
+		}
+		cs, err := NewChangeset([]resource_update.ResourceUpdate{aDelete, bDelete}, nil, "c1", pkgmodel.CommandApply)
+		if err != nil {
+			t.Fatalf("NewChangeset: %v", err)
+		}
+		return cs.DAG
+	}
+
+	t.Run("no hint: B.delete waits for A.delete (reverse construction)", func(t *testing.T) {
+		dag := build(t, pkgmodel.FieldHint{})
+		bNode := dagNodeForOp(t, dag, bURI, resource_update.OperationDelete)
+		aNode := dagNodeForOp(t, dag, aURI, resource_update.OperationDelete)
+		if !hasDependency(bNode, aNode) {
+			t.Fatalf("expected B.delete to depend on A.delete")
+		}
+		if hasDependency(aNode, bNode) {
+			t.Fatalf("did not expect A.delete to depend on B.delete without HostsOn")
+		}
+	})
+
+	t.Run("HostsOn: A.delete waits for B.delete (reachability order)", func(t *testing.T) {
+		dag := build(t, pkgmodel.FieldHint{HostsOn: true})
+		bNode := dagNodeForOp(t, dag, bURI, resource_update.OperationDelete)
+		aNode := dagNodeForOp(t, dag, aURI, resource_update.OperationDelete)
+		if !hasDependency(aNode, bNode) {
+			t.Fatalf("expected A.delete to depend on B.delete under HostsOn")
+		}
+		if hasDependency(bNode, aNode) {
+			t.Fatalf("did not expect B.delete to depend on A.delete under HostsOn")
+		}
+	})
+}
+
+func TestBuildDeleteDependencies_MixedRefsOnOneResourceGetIndependentDirections(t *testing.T) {
+	// A has two refs: f1 → B (HostsOn), f2 → C (no hint).
+	// Expected: A.delete waits for B.delete (HostsOn) AND C.delete waits for A.delete (reverse construction).
+	var (
+		aURI = pkgmodel.NewFormaeURI("A1", "")
+		bURI = pkgmodel.NewFormaeURI("B1", "")
+		cURI = pkgmodel.NewFormaeURI("C1", "")
+	)
+	aResource := pkgmodel.Resource{
+		Ksuid: "A1", Label: "a", Type: "Test::A", Stack: "s",
+		Schema: pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{
+			"f1": {HostsOn: true},
+			// "f2" intentionally absent → plain construction
+		}},
+		Properties: json.RawMessage(`{
+			"f1": {"$ref":"formae://B1#/Out","$value":"v"},
+			"f2": {"$ref":"formae://C1#/Out","$value":"v"}
+		}`),
+	}
+	bResource := pkgmodel.Resource{Ksuid: "B1", Label: "b", Type: "Test::B", Stack: "s", Properties: json.RawMessage(`{}`)}
+	cResource := pkgmodel.Resource{Ksuid: "C1", Label: "c", Type: "Test::C", Stack: "s", Properties: json.RawMessage(`{}`)}
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{
+			{DesiredState: aResource, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{bURI, cURI}},
+			{DesiredState: bResource, Operation: resource_update.OperationDelete},
+			{DesiredState: cResource, Operation: resource_update.OperationDelete},
+		}, nil, "c2", pkgmodel.CommandApply)
+	if err != nil {
+		t.Fatalf("NewChangeset: %v", err)
+	}
+
+	aNode := dagNodeForOp(t, cs.DAG, aURI, resource_update.OperationDelete)
+	bNode := dagNodeForOp(t, cs.DAG, bURI, resource_update.OperationDelete)
+	cNode := dagNodeForOp(t, cs.DAG, cURI, resource_update.OperationDelete)
+
+	if !hasDependency(aNode, bNode) {
+		t.Errorf("A.delete should depend on B.delete (HostsOn edge)")
+	}
+	if !hasDependency(cNode, aNode) {
+		t.Errorf("C.delete should depend on A.delete (reverse construction edge)")
+	}
+	if hasDependency(bNode, aNode) {
+		t.Errorf("B.delete should not depend on A.delete (HostsOn inverts this edge)")
+	}
+}
+
+func TestBuildDeleteDependencies_MissingHintFallsBackToConstructionReverse(t *testing.T) {
+	// A refs B via f1 but A's Schema.Hints is empty/nil. Expected: default
+	// construction-reverse behavior (B.delete waits for A.delete). No panic
+	// when the hint map is nil for the stripped path.
+	var (
+		aURI = pkgmodel.NewFormaeURI("A1", "")
+		bURI = pkgmodel.NewFormaeURI("B1", "")
+	)
+	aResource := pkgmodel.Resource{
+		Ksuid: "A1", Label: "a", Type: "Test::A", Stack: "s",
+		Schema:     pkgmodel.Schema{}, // no Hints map at all
+		Properties: json.RawMessage(`{"f1": {"$ref":"formae://B1#/Out","$value":"v"}}`),
+	}
+	bResource := pkgmodel.Resource{Ksuid: "B1", Label: "b", Type: "Test::B", Stack: "s", Properties: json.RawMessage(`{}`)}
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{
+			{DesiredState: aResource, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{bURI}},
+			{DesiredState: bResource, Operation: resource_update.OperationDelete},
+		}, nil, "c3", pkgmodel.CommandApply)
+	if err != nil {
+		t.Fatalf("NewChangeset: %v", err)
+	}
+
+	aNode := dagNodeForOp(t, cs.DAG, aURI, resource_update.OperationDelete)
+	bNode := dagNodeForOp(t, cs.DAG, bURI, resource_update.OperationDelete)
+	if !hasDependency(bNode, aNode) {
+		t.Fatalf("missing hint should fall through to construction-reverse: B.delete must depend on A.delete")
+	}
 }

--- a/internal/metastructure/changeset/changeset_test.go
+++ b/internal/metastructure/changeset/changeset_test.go
@@ -2102,7 +2102,7 @@ func hasDependency(child, parent *DAGNode) bool {
 	return false
 }
 
-func TestBuildDeleteDependencies_HostsOnInvertsEdgeDirection(t *testing.T) {
+func TestBuildDeleteDependencies_AttachesToInvertsEdgeDirection(t *testing.T) {
 	var (
 		aURI = pkgmodel.NewFormaeURI("A1", "")
 		bURI = pkgmodel.NewFormaeURI("B1", "")
@@ -2146,26 +2146,26 @@ func TestBuildDeleteDependencies_HostsOnInvertsEdgeDirection(t *testing.T) {
 			t.Fatalf("expected B.delete to depend on A.delete")
 		}
 		if hasDependency(aNode, bNode) {
-			t.Fatalf("did not expect A.delete to depend on B.delete without HostsOn")
+			t.Fatalf("did not expect A.delete to depend on B.delete without AttachesTo")
 		}
 	})
 
-	t.Run("HostsOn: A.delete waits for B.delete (reachability order)", func(t *testing.T) {
-		dag := build(t, pkgmodel.FieldHint{HostsOn: true})
+	t.Run("AttachesTo: A.delete waits for B.delete (reachability order)", func(t *testing.T) {
+		dag := build(t, pkgmodel.FieldHint{AttachesTo: true})
 		bNode := dagNodeForOp(t, dag, bURI, resource_update.OperationDelete)
 		aNode := dagNodeForOp(t, dag, aURI, resource_update.OperationDelete)
 		if !hasDependency(aNode, bNode) {
-			t.Fatalf("expected A.delete to depend on B.delete under HostsOn")
+			t.Fatalf("expected A.delete to depend on B.delete under AttachesTo")
 		}
 		if hasDependency(bNode, aNode) {
-			t.Fatalf("did not expect B.delete to depend on A.delete under HostsOn")
+			t.Fatalf("did not expect B.delete to depend on A.delete under AttachesTo")
 		}
 	})
 }
 
 func TestBuildDeleteDependencies_MixedRefsOnOneResourceGetIndependentDirections(t *testing.T) {
-	// A has two refs: f1 → B (HostsOn), f2 → C (no hint).
-	// Expected: A.delete waits for B.delete (HostsOn) AND C.delete waits for A.delete (reverse construction).
+	// A has two refs: f1 → B (AttachesTo), f2 → C (no hint).
+	// Expected: A.delete waits for B.delete (AttachesTo) AND C.delete waits for A.delete (reverse construction).
 	var (
 		aURI = pkgmodel.NewFormaeURI("A1", "")
 		bURI = pkgmodel.NewFormaeURI("B1", "")
@@ -2174,7 +2174,7 @@ func TestBuildDeleteDependencies_MixedRefsOnOneResourceGetIndependentDirections(
 	aResource := pkgmodel.Resource{
 		Ksuid: "A1", Label: "a", Type: "Test::A", Stack: "s",
 		Schema: pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{
-			"f1": {HostsOn: true},
+			"f1": {AttachesTo: true},
 			// "f2" intentionally absent → plain construction
 		}},
 		Properties: json.RawMessage(`{
@@ -2200,13 +2200,13 @@ func TestBuildDeleteDependencies_MixedRefsOnOneResourceGetIndependentDirections(
 	cNode := dagNodeForOp(t, cs.DAG, cURI, resource_update.OperationDelete)
 
 	if !hasDependency(aNode, bNode) {
-		t.Errorf("A.delete should depend on B.delete (HostsOn edge)")
+		t.Errorf("A.delete should depend on B.delete (AttachesTo edge)")
 	}
 	if !hasDependency(cNode, aNode) {
 		t.Errorf("C.delete should depend on A.delete (reverse construction edge)")
 	}
 	if hasDependency(bNode, aNode) {
-		t.Errorf("B.delete should not depend on A.delete (HostsOn inverts this edge)")
+		t.Errorf("B.delete should not depend on A.delete (AttachesTo inverts this edge)")
 	}
 }
 

--- a/internal/metastructure/changeset/path_hint.go
+++ b/internal/metastructure/changeset/path_hint.go
@@ -1,0 +1,55 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package changeset
+
+import (
+	"strings"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// stripArrayIndices removes dot-separated numeric segments from a field path,
+// producing a key suitable for looking up a FieldHint.
+//
+// The resolver emits TargetPath values like "LoadBalancers.0.TargetGroupArn"
+// (dot-separated, array indices as plain integers). Plugin schemas declare
+// Hints keyed by the indexless field path ("LoadBalancers.TargetGroupArn"),
+// so lookups must strip indices before consulting the map.
+// Note: numeric segments at the root (e.g., "42") are preserved.
+func stripArrayIndices(path string) string {
+	if path == "" {
+		return path
+	}
+
+	parts := strings.Split(path, ".")
+	var filtered []string
+	for _, part := range parts {
+		// Only skip numeric parts if they are not the only part (root level).
+		if isNumeric(part) && len(parts) > 1 {
+			continue
+		}
+		filtered = append(filtered, part)
+	}
+	return strings.Join(filtered, ".")
+}
+
+// isNumeric returns true if all characters in s are digits.
+func isNumeric(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// fieldHintForPath looks up the FieldHint for a TargetPath in the resource's
+// schema. Returns the zero value if no hint is declared for the (stripped) path.
+func fieldHintForPath(schema pkgmodel.Schema, targetPath string) pkgmodel.FieldHint {
+	return schema.Hints[stripArrayIndices(targetPath)]
+}

--- a/internal/metastructure/changeset/path_hint_test.go
+++ b/internal/metastructure/changeset/path_hint_test.go
@@ -1,3 +1,7 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
 package changeset
 
 import (

--- a/internal/metastructure/changeset/path_hint_test.go
+++ b/internal/metastructure/changeset/path_hint_test.go
@@ -1,0 +1,47 @@
+package changeset
+
+import (
+	"testing"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func TestStripArrayIndices(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"LoadBalancers.0.TargetGroupArn", "LoadBalancers.TargetGroupArn"},
+		{"Statement.0", "Statement"},
+		{"a.0.b.1.c", "a.b.c"},
+		{"no.indices.here", "no.indices.here"},
+		{"", ""},
+		{"42", "42"}, // a bare number at the root is unusual but should be preserved
+		{"Tags.10.Key", "Tags.Key"},
+	}
+	for _, tc := range cases {
+		got := stripArrayIndices(tc.in)
+		if got != tc.want {
+			t.Errorf("stripArrayIndices(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFieldHintForPath_MatchesAfterStripping(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Hints: map[string]pkgmodel.FieldHint{
+			"LoadBalancers.TargetGroupArn": {HostsOn: true},
+		},
+	}
+	got := fieldHintForPath(schema, "LoadBalancers.0.TargetGroupArn")
+	if !got.HostsOn {
+		t.Fatalf("expected HostsOn=true after index stripping, got %#v", got)
+	}
+}
+
+func TestFieldHintForPath_ReturnsZeroWhenUnknown(t *testing.T) {
+	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{}}
+	got := fieldHintForPath(schema, "Missing.Field")
+	if got.HostsOn || got.CreateOnly || got.Required {
+		t.Fatalf("expected zero hint for unknown path, got %#v", got)
+	}
+}

--- a/internal/metastructure/changeset/path_hint_test.go
+++ b/internal/metastructure/changeset/path_hint_test.go
@@ -29,19 +29,19 @@ func TestStripArrayIndices(t *testing.T) {
 func TestFieldHintForPath_MatchesAfterStripping(t *testing.T) {
 	schema := pkgmodel.Schema{
 		Hints: map[string]pkgmodel.FieldHint{
-			"LoadBalancers.TargetGroupArn": {HostsOn: true},
+			"LoadBalancers.TargetGroupArn": {AttachesTo: true},
 		},
 	}
 	got := fieldHintForPath(schema, "LoadBalancers.0.TargetGroupArn")
-	if !got.HostsOn {
-		t.Fatalf("expected HostsOn=true after index stripping, got %#v", got)
+	if !got.AttachesTo {
+		t.Fatalf("expected AttachesTo=true after index stripping, got %#v", got)
 	}
 }
 
 func TestFieldHintForPath_ReturnsZeroWhenUnknown(t *testing.T) {
 	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{}}
 	got := fieldHintForPath(schema, "Missing.Field")
-	if got.HostsOn || got.CreateOnly || got.Required {
+	if got.AttachesTo || got.CreateOnly || got.Required {
 		t.Fatalf("expected zero hint for unknown path, got %#v", got)
 	}
 }

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -46,6 +46,30 @@ func ExtractResolvableURIs(resource pkgmodel.Resource) []pkgmodel.FormaeURI {
 	return resolver.getResolvableURIs()
 }
 
+// ResolvableRef pairs a resolvable's target resource URI with the field-path
+// at which the reference appears in the consuming resource. Consumers that
+// need to look up per-field schema hints use this instead of ExtractResolvableURIs.
+type ResolvableRef struct {
+	URI        pkgmodel.FormaeURI // resource being referenced
+	TargetPath string             // dot-separated path within the consuming resource
+}
+
+// ExtractResolvableRefs returns every resolvable in the resource along with
+// the path at which it sits. Supersedes ExtractResolvableURIs for callers that
+// need TargetPath; the URI-only helper is retained for existing callers.
+func ExtractResolvableRefs(resource pkgmodel.Resource) []ResolvableRef {
+	pr := newPropertyResolverFromResource(resource)
+	out := make([]ResolvableRef, 0, len(pr.refs))
+	for _, refs := range pr.refs {
+		for _, ref := range refs {
+			// Construct URI without fragment (just scheme://ksuid)
+			uri := pkgmodel.FormaeURI(fmt.Sprintf("formae://%s", ref.ResourceURI.KSUID()))
+			out = append(out, ResolvableRef{URI: uri, TargetPath: ref.TargetPath})
+		}
+	}
+	return out
+}
+
 // ExtractResolvableURIsFromJSON extracts all resolvable URIs from raw JSON.
 // Used for target Config fields.
 func ExtractResolvableURIsFromJSON(data json.RawMessage) []pkgmodel.FormaeURI {

--- a/internal/metastructure/resolver/resolver_test.go
+++ b/internal/metastructure/resolver/resolver_test.go
@@ -19,6 +19,34 @@ import (
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
+func TestExtractResolvableRefs_ReturnsTargetPathsForEachRef(t *testing.T) {
+	props := json.RawMessage(`{
+		"Cluster": {"$ref": "formae://CL#/Arn", "$value": "arn-cluster"},
+		"LoadBalancers": [
+			{"TargetGroupArn": {"$ref": "formae://LN#/DefaultActions.0.TargetGroupArn", "$value": "arn-tg"}}
+		],
+		"Name": "static"
+	}`)
+	res := pkgmodel.Resource{Properties: props}
+
+	refs := ExtractResolvableRefs(res)
+
+	// Build an easy-to-assert map of TargetPath → ResourceURI.
+	got := map[string]pkgmodel.FormaeURI{}
+	for _, r := range refs {
+		got[r.TargetPath] = r.URI
+	}
+	if got["Cluster"] != "formae://CL" {
+		t.Errorf("Cluster: got %q", got["Cluster"])
+	}
+	if got["LoadBalancers.0.TargetGroupArn"] != "formae://LN" {
+		t.Errorf("LoadBalancers.0.TargetGroupArn: got %q", got["LoadBalancers.0.TargetGroupArn"])
+	}
+	if len(refs) != 2 {
+		t.Errorf("expected 2 refs, got %d: %+v", len(refs), refs)
+	}
+}
+
 func TestResolvePropertyReferences(t *testing.T) {
 	t.Run("resolves basic reference", func(t *testing.T) {
 		vpcRef := newTestRef("VpcId")

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -176,6 +176,7 @@ open class FieldHint extends Annotation {
     hidden required: Boolean = false
     hidden requiredOnCreate: Boolean = false
     hidden hasProviderDefault: Boolean = false
+    hidden hostsOn: Boolean = false
     hidden indexField: String?
     hidden updateMethod: FieldUpdateMethod?
 
@@ -189,6 +190,7 @@ open class FieldHint extends Annotation {
     fixed Required: Boolean = required
     fixed RequiredOnCreate: Boolean = requiredOnCreate
     fixed HasProviderDefault: Boolean = hasProviderDefault
+    fixed HostsOn: Boolean = hostsOn
     fixed UpdateMethod: String = updateMethod ?? ""
     fixed IndexField: String = indexField ?? ""
 }

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -176,7 +176,7 @@ open class FieldHint extends Annotation {
     hidden required: Boolean = false
     hidden requiredOnCreate: Boolean = false
     hidden hasProviderDefault: Boolean = false
-    hidden hostsOn: Boolean = false
+    hidden attachesTo: Boolean = false
     hidden indexField: String?
     hidden updateMethod: FieldUpdateMethod?
 
@@ -190,7 +190,7 @@ open class FieldHint extends Annotation {
     fixed Required: Boolean = required
     fixed RequiredOnCreate: Boolean = requiredOnCreate
     fixed HasProviderDefault: Boolean = hasProviderDefault
-    fixed HostsOn: Boolean = hostsOn
+    fixed AttachesTo: Boolean = attachesTo
     fixed UpdateMethod: String = updateMethod ?? ""
     fixed IndexField: String = indexField ?? ""
 }

--- a/internal/schema/pkl/schema/tests/formae.pkl
+++ b/internal/schema/pkl/schema/tests/formae.pkl
@@ -577,19 +577,19 @@ facts {
         type == "AWS::S3::Bucket"
     }
 
-    ["FieldHint exposes HostsOn"] {
-        testHostsOnSchema.Hints["F1"].HostsOn == true
+    ["FieldHint exposes AttachesTo"] {
+        testAttachesToSchema.Hints["F1"].AttachesTo == true
     }
 
-    ["FieldHint HostsOn defaults to false"] {
-        (new formae.FieldHint {}).HostsOn == false
+    ["FieldHint AttachesTo defaults to false"] {
+        (new formae.FieldHint {}).AttachesTo == false
     }
 }
 
-local testHostsOnSchema = new formae.Schema {
+local testAttachesToSchema = new formae.Schema {
     Identifier = "AWS::Test::Thing"
     Fields = new Listing { "F1" }
     Hints = new Mapping {
-        ["F1"] = new formae.FieldHint { hostsOn = true }
+        ["F1"] = new formae.FieldHint { attachesTo = true }
     }
 }

--- a/internal/schema/pkl/schema/tests/formae.pkl
+++ b/internal/schema/pkl/schema/tests/formae.pkl
@@ -576,4 +576,20 @@ facts {
         schema.Identifier == "BucketName" &&
         type == "AWS::S3::Bucket"
     }
+
+    ["FieldHint exposes HostsOn"] {
+        testHostsOnSchema.Hints["F1"].HostsOn == true
+    }
+
+    ["FieldHint HostsOn defaults to false"] {
+        (new formae.FieldHint {}).HostsOn == false
+    }
+}
+
+local testHostsOnSchema = new formae.Schema {
+    Identifier = "AWS::Test::Thing"
+    Fields = new Listing { "F1" }
+    Hints = new Mapping {
+        ["F1"] = new formae.FieldHint { hostsOn = true }
+    }
 }

--- a/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
+++ b/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
@@ -90,7 +90,7 @@ examples {
         Required = true
         RequiredOnCreate = false
         HasProviderDefault = false
-        HostsOn = false
+        AttachesTo = false
         UpdateMethod = ""
         IndexField = ""
       }
@@ -100,7 +100,7 @@ examples {
         Required = false
         RequiredOnCreate = false
         HasProviderDefault = false
-        HostsOn = false
+        AttachesTo = false
         UpdateMethod = ""
         IndexField = ""
       }
@@ -110,7 +110,7 @@ examples {
         Required = false
         RequiredOnCreate = false
         HasProviderDefault = false
-        HostsOn = false
+        AttachesTo = false
         UpdateMethod = ""
         IndexField = ""
       }
@@ -131,7 +131,7 @@ examples {
           Required = true
           RequiredOnCreate = false
           HasProviderDefault = false
-          HostsOn = false
+          AttachesTo = false
           UpdateMethod = ""
           IndexField = ""
         }
@@ -141,7 +141,7 @@ examples {
           Required = false
           RequiredOnCreate = false
           HasProviderDefault = false
-          HostsOn = false
+          AttachesTo = false
           UpdateMethod = ""
           IndexField = ""
         }
@@ -151,7 +151,7 @@ examples {
           Required = false
           RequiredOnCreate = false
           HasProviderDefault = false
-          HostsOn = false
+          AttachesTo = false
           UpdateMethod = ""
           IndexField = ""
         }
@@ -200,7 +200,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
-            HostsOn = false
+            AttachesTo = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -210,7 +210,7 @@ examples {
             Required = false
             RequiredOnCreate = false
             HasProviderDefault = false
-            HostsOn = false
+            AttachesTo = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -220,7 +220,7 @@ examples {
             Required = false
             RequiredOnCreate = false
             HasProviderDefault = false
-            HostsOn = false
+            AttachesTo = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -277,7 +277,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
-            HostsOn = false
+            AttachesTo = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -287,7 +287,7 @@ examples {
             Required = false
             RequiredOnCreate = false
             HasProviderDefault = false
-            HostsOn = false
+            AttachesTo = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -297,7 +297,7 @@ examples {
             Required = false
             RequiredOnCreate = false
             HasProviderDefault = false
-            HostsOn = false
+            AttachesTo = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -339,7 +339,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
-            HostsOn = false
+            AttachesTo = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -349,7 +349,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
-            HostsOn = false
+            AttachesTo = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -359,7 +359,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
-            HostsOn = false
+            AttachesTo = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -369,7 +369,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
-            HostsOn = false
+            AttachesTo = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -379,7 +379,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
-            HostsOn = false
+            AttachesTo = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -389,7 +389,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
-            HostsOn = false
+            AttachesTo = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -399,7 +399,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
-            HostsOn = false
+            AttachesTo = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -436,7 +436,7 @@ examples {
         Required = true
         RequiredOnCreate = false
         HasProviderDefault = false
-        HostsOn = false
+        AttachesTo = false
         UpdateMethod = ""
         IndexField = ""
       }
@@ -446,7 +446,7 @@ examples {
         Required = false
         RequiredOnCreate = false
         HasProviderDefault = false
-        HostsOn = false
+        AttachesTo = false
         UpdateMethod = ""
         IndexField = ""
       }
@@ -456,7 +456,7 @@ examples {
         Required = false
         RequiredOnCreate = false
         HasProviderDefault = false
-        HostsOn = false
+        AttachesTo = false
         UpdateMethod = ""
         IndexField = ""
       }
@@ -477,7 +477,7 @@ examples {
           Required = true
           RequiredOnCreate = false
           HasProviderDefault = false
-          HostsOn = false
+          AttachesTo = false
           UpdateMethod = ""
           IndexField = ""
         }
@@ -487,7 +487,7 @@ examples {
           Required = false
           RequiredOnCreate = false
           HasProviderDefault = false
-          HostsOn = false
+          AttachesTo = false
           UpdateMethod = ""
           IndexField = ""
         }
@@ -497,7 +497,7 @@ examples {
           Required = false
           RequiredOnCreate = false
           HasProviderDefault = false
-          HostsOn = false
+          AttachesTo = false
           UpdateMethod = ""
           IndexField = ""
         }

--- a/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
+++ b/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
@@ -90,6 +90,7 @@ examples {
         Required = true
         RequiredOnCreate = false
         HasProviderDefault = false
+        HostsOn = false
         UpdateMethod = ""
         IndexField = ""
       }
@@ -99,6 +100,7 @@ examples {
         Required = false
         RequiredOnCreate = false
         HasProviderDefault = false
+        HostsOn = false
         UpdateMethod = ""
         IndexField = ""
       }
@@ -108,6 +110,7 @@ examples {
         Required = false
         RequiredOnCreate = false
         HasProviderDefault = false
+        HostsOn = false
         UpdateMethod = ""
         IndexField = ""
       }
@@ -128,6 +131,7 @@ examples {
           Required = true
           RequiredOnCreate = false
           HasProviderDefault = false
+          HostsOn = false
           UpdateMethod = ""
           IndexField = ""
         }
@@ -137,6 +141,7 @@ examples {
           Required = false
           RequiredOnCreate = false
           HasProviderDefault = false
+          HostsOn = false
           UpdateMethod = ""
           IndexField = ""
         }
@@ -146,6 +151,7 @@ examples {
           Required = false
           RequiredOnCreate = false
           HasProviderDefault = false
+          HostsOn = false
           UpdateMethod = ""
           IndexField = ""
         }
@@ -194,6 +200,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
+            HostsOn = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -203,6 +210,7 @@ examples {
             Required = false
             RequiredOnCreate = false
             HasProviderDefault = false
+            HostsOn = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -212,6 +220,7 @@ examples {
             Required = false
             RequiredOnCreate = false
             HasProviderDefault = false
+            HostsOn = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -268,6 +277,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
+            HostsOn = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -277,6 +287,7 @@ examples {
             Required = false
             RequiredOnCreate = false
             HasProviderDefault = false
+            HostsOn = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -286,6 +297,7 @@ examples {
             Required = false
             RequiredOnCreate = false
             HasProviderDefault = false
+            HostsOn = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -327,6 +339,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
+            HostsOn = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -336,6 +349,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
+            HostsOn = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -345,6 +359,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
+            HostsOn = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -354,6 +369,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
+            HostsOn = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -363,6 +379,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
+            HostsOn = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -372,6 +389,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
+            HostsOn = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -381,6 +399,7 @@ examples {
             Required = true
             RequiredOnCreate = false
             HasProviderDefault = false
+            HostsOn = false
             UpdateMethod = ""
             IndexField = ""
           }
@@ -417,6 +436,7 @@ examples {
         Required = true
         RequiredOnCreate = false
         HasProviderDefault = false
+        HostsOn = false
         UpdateMethod = ""
         IndexField = ""
       }
@@ -426,6 +446,7 @@ examples {
         Required = false
         RequiredOnCreate = false
         HasProviderDefault = false
+        HostsOn = false
         UpdateMethod = ""
         IndexField = ""
       }
@@ -435,6 +456,7 @@ examples {
         Required = false
         RequiredOnCreate = false
         HasProviderDefault = false
+        HostsOn = false
         UpdateMethod = ""
         IndexField = ""
       }
@@ -455,6 +477,7 @@ examples {
           Required = true
           RequiredOnCreate = false
           HasProviderDefault = false
+          HostsOn = false
           UpdateMethod = ""
           IndexField = ""
         }
@@ -464,6 +487,7 @@ examples {
           Required = false
           RequiredOnCreate = false
           HasProviderDefault = false
+          HostsOn = false
           UpdateMethod = ""
           IndexField = ""
         }
@@ -473,6 +497,7 @@ examples {
           Required = false
           RequiredOnCreate = false
           HasProviderDefault = false
+          HostsOn = false
           UpdateMethod = ""
           IndexField = ""
         }

--- a/internal/testplugin/fakeaws/fake_aws.go
+++ b/internal/testplugin/fakeaws/fake_aws.go
@@ -106,6 +106,9 @@ func (s *FakeAWS) SchemaForResourceType(resourceType string) (model.Schema, erro
 				"Ipv6NetmaskLength",
 				"Ipv6Pool",
 				"VpcId"},
+			Hints: map[string]model.FieldHint{
+				"VpcId": {HostsOn: true},
+			},
 		}, nil
 	default:
 		return model.Schema{

--- a/internal/testplugin/fakeaws/fake_aws.go
+++ b/internal/testplugin/fakeaws/fake_aws.go
@@ -107,7 +107,7 @@ func (s *FakeAWS) SchemaForResourceType(resourceType string) (model.Schema, erro
 				"Ipv6Pool",
 				"VpcId"},
 			Hints: map[string]model.FieldHint{
-				"VpcId": {HostsOn: true},
+				"VpcId": {AttachesTo: true},
 			},
 		}, nil
 	default:

--- a/internal/workflow_tests/local/apply_forma/attaches_to_destroy_test.go
+++ b/internal/workflow_tests/local/apply_forma/attaches_to_destroy_test.go
@@ -25,17 +25,17 @@ import (
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
-// TestHostsOnInvertDestroyOrder verifies that when Schema.Hints["VpcId"].HostsOn=true
+// TestAttachesToInvertDestroyOrder verifies that when Schema.Hints["VpcId"].AttachesTo=true
 // on FakeAWS::EC2::VPCCidrBlock, destroying a stack containing a VPC and a CIDR block
 // (where CIDR's VpcId references the VPC) produces the inverted delete order:
 // VPC deletes BEFORE CIDR block (instead of usual reverse-construction "child first").
 //
-// Without HostsOn, the destroy order is: cidr.delete → vpc.delete (reverse construction).
-// With HostsOn on VpcId, the destroy order is: vpc.delete → cidr.delete (inverted).
-func TestHostsOnInvertDestroyOrder(t *testing.T) {
+// Without AttachesTo, the destroy order is: cidr.delete → vpc.delete (reverse construction).
+// With AttachesTo on VpcId, the destroy order is: vpc.delete → cidr.delete (inverted).
+func TestAttachesToInvertDestroyOrder(t *testing.T) {
 	// Deterministic KSUID for the VPC so the CIDR block can $ref it.
 	// Without a $ref, the resolver sees no edge between the resources
-	// and the DAG builder has no ref on which to apply the HostsOn hint.
+	// and the DAG builder has no ref on which to apply the AttachesTo hint.
 	const vpcKsuid = "2MiD2rA1SJbLMGZgTL0hCxjkjjr"
 
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
@@ -110,16 +110,16 @@ func TestHostsOnInvertDestroyOrder(t *testing.T) {
 					Schema: pkgmodel.Schema{
 						Identifier: "Id",
 						Fields:     []string{"Id", "CidrBlock", "VpcId"},
-						// HostsOn semantically inverts destroy-edge direction:
+						// AttachesTo semantically inverts destroy-edge direction:
 						// cidr.delete waits for vpc.delete instead of the default
 						// reverse-construction order (vpc.delete waits for cidr.delete).
 						// The plugin schema in fake_aws.go carries the same hint.
 						Hints: map[string]pkgmodel.FieldHint{
-							"VpcId": {HostsOn: true},
+							"VpcId": {AttachesTo: true},
 						},
 					},
 					// VpcId is a $ref so the resolver produces an edge the DAG
-					// builder can apply the HostsOn hint to. A plain string here
+					// builder can apply the AttachesTo hint to. A plain string here
 					// would produce no edge and the test would assert nothing useful.
 					Properties: json.RawMessage(fmt.Sprintf(`{
 						"Id": "cidr-1",
@@ -201,11 +201,11 @@ func TestHostsOnInvertDestroyOrder(t *testing.T) {
 		vpcModifiedTs := modifiedTsOfResource("vpc")
 		cidrModifiedTs := modifiedTsOfResource("cidr")
 
-		// The key assertion: with HostsOn on VpcId, vpc.delete should complete BEFORE cidr.delete
+		// The key assertion: with AttachesTo on VpcId, vpc.delete should complete BEFORE cidr.delete
 		// (inverted from the normal reverse-construction order).
 		assert.True(t,
 			vpcModifiedTs.Before(cidrModifiedTs),
-			"vpc.delete must complete before cidr.delete under HostsOn annotation (vpc=%v cidr=%v)",
+			"vpc.delete must complete before cidr.delete under AttachesTo annotation (vpc=%v cidr=%v)",
 			vpcModifiedTs, cidrModifiedTs)
 
 		// Also verify that the state is Success (not Failed or other terminal states)

--- a/internal/workflow_tests/local/apply_forma/hosts_on_destroy_test.go
+++ b/internal/workflow_tests/local/apply_forma/hosts_on_destroy_test.go
@@ -8,6 +8,7 @@ package workflow_tests_local
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -32,6 +33,11 @@ import (
 // Without HostsOn, the destroy order is: cidr.delete → vpc.delete (reverse construction).
 // With HostsOn on VpcId, the destroy order is: vpc.delete → cidr.delete (inverted).
 func TestHostsOnInvertDestroyOrder(t *testing.T) {
+	// Deterministic KSUID for the VPC so the CIDR block can $ref it.
+	// Without a $ref, the resolver sees no edge between the resources
+	// and the DAG builder has no ref on which to apply the HostsOn hint.
+	const vpcKsuid = "2MiD2rA1SJbLMGZgTL0hCxjkjjr"
+
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		// Create resource overrides for successful Create and Delete operations.
 		overrides := &plugin.ResourcePluginOverrides{
@@ -45,10 +51,21 @@ func TestHostsOnInvertDestroyOrder(t *testing.T) {
 				}}, nil
 			},
 			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
-				return &resource.ReadResult{
-					ResourceType: request.ResourceType,
-					Properties:   "{}",
-				}, nil
+				// Return the same Properties that were created; this lets the
+				// resolver find the VPC's Id when the CIDR block $refs it.
+				switch request.ResourceType {
+				case "FakeAWS::EC2::VPC":
+					return &resource.ReadResult{
+						ResourceType: request.ResourceType,
+						Properties:   `{"Id":"vpc-1","CidrBlock":"10.0.0.0/16"}`,
+					}, nil
+				case "FakeAWS::EC2::VPCCidrBlock":
+					return &resource.ReadResult{
+						ResourceType: request.ResourceType,
+						Properties:   `{"Id":"cidr-1","CidrBlock":"10.0.1.0/24","VpcId":"vpc-1"}`,
+					}, nil
+				}
+				return &resource.ReadResult{ResourceType: request.ResourceType, Properties: "{}"}, nil
 			},
 			Delete: func(request *resource.DeleteRequest) (*resource.DeleteResult, error) {
 				return &resource.DeleteResult{ProgressResult: &resource.ProgressResult{
@@ -77,6 +94,7 @@ func TestHostsOnInvertDestroyOrder(t *testing.T) {
 					Stack:   "test",
 					Target:  "provider",
 					Managed: true,
+					Ksuid:   vpcKsuid,
 					Schema:  pkgmodel.Schema{Identifier: "Id", Fields: []string{"Id", "CidrBlock"}},
 					Properties: json.RawMessage(`{
 						"Id": "vpc-1",
@@ -92,19 +110,22 @@ func TestHostsOnInvertDestroyOrder(t *testing.T) {
 					Schema: pkgmodel.Schema{
 						Identifier: "Id",
 						Fields:     []string{"Id", "CidrBlock", "VpcId"},
-						// This hint indicates that VpcId "hosts" a dependency on the VPC resource,
-						// which should invert the delete order during destroy.
-						// The plugin schema (in fake_aws.go) has the same hint.
+						// HostsOn semantically inverts destroy-edge direction:
+						// cidr.delete waits for vpc.delete instead of the default
+						// reverse-construction order (vpc.delete waits for cidr.delete).
+						// The plugin schema in fake_aws.go carries the same hint.
 						Hints: map[string]pkgmodel.FieldHint{
 							"VpcId": {HostsOn: true},
 						},
 					},
-					// Simple properties with VpcId matching the VPC's Id
-					Properties: json.RawMessage(`{
+					// VpcId is a $ref so the resolver produces an edge the DAG
+					// builder can apply the HostsOn hint to. A plain string here
+					// would produce no edge and the test would assert nothing useful.
+					Properties: json.RawMessage(fmt.Sprintf(`{
 						"Id": "cidr-1",
 						"CidrBlock": "10.0.1.0/24",
-						"VpcId": "vpc-1"
-					}`),
+						"VpcId": {"$ref":"formae://%s#/Id","$value":"vpc-1"}
+					}`, vpcKsuid)),
 				},
 			},
 			Targets: []pkgmodel.Target{

--- a/internal/workflow_tests/local/apply_forma/hosts_on_destroy_test.go
+++ b/internal/workflow_tests/local/apply_forma/hosts_on_destroy_test.go
@@ -1,0 +1,196 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// TestHostsOnInvertDestroyOrder verifies that when Schema.Hints["VpcId"].HostsOn=true
+// on FakeAWS::EC2::VPCCidrBlock, destroying a stack containing a VPC and a CIDR block
+// (where CIDR's VpcId references the VPC) produces the inverted delete order:
+// VPC deletes BEFORE CIDR block (instead of usual reverse-construction "child first").
+//
+// Without HostsOn, the destroy order is: cidr.delete → vpc.delete (reverse construction).
+// With HostsOn on VpcId, the destroy order is: vpc.delete → cidr.delete (inverted).
+func TestHostsOnInvertDestroyOrder(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		// Create resource overrides for successful Create and Delete operations.
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          "1234",
+					NativeID:           "native-" + request.Label,
+					ResourceProperties: request.Properties,
+				}}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{
+					ResourceType: request.ResourceType,
+					Properties:   "{}",
+				}, nil
+			},
+			Delete: func(request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+				return &resource.DeleteResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationDelete,
+					OperationStatus: resource.OperationStatusSuccess,
+					RequestID:       "delete-123",
+					NativeID:        request.NativeID,
+				}}, nil
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err, "Failed to create metastructure")
+
+		// Build the forma with VPC and CIDR block.
+		// The CIDR block's VpcId is a plain string matching the VPC's Id.
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{
+				{Label: "test"},
+			},
+			Resources: []pkgmodel.Resource{
+				{
+					Label:   "vpc",
+					Type:    "FakeAWS::EC2::VPC",
+					Stack:   "test",
+					Target:  "provider",
+					Managed: true,
+					Schema:  pkgmodel.Schema{Identifier: "Id", Fields: []string{"Id", "CidrBlock"}},
+					Properties: json.RawMessage(`{
+						"Id": "vpc-1",
+						"CidrBlock": "10.0.0.0/16"
+					}`),
+				},
+				{
+					Label:   "cidr",
+					Type:    "FakeAWS::EC2::VPCCidrBlock",
+					Stack:   "test",
+					Target:  "provider",
+					Managed: true,
+					Schema: pkgmodel.Schema{
+						Identifier: "Id",
+						Fields:     []string{"Id", "CidrBlock", "VpcId"},
+						// This hint indicates that VpcId "hosts" a dependency on the VPC resource,
+						// which should invert the delete order during destroy.
+						// The plugin schema (in fake_aws.go) has the same hint.
+						Hints: map[string]pkgmodel.FieldHint{
+							"VpcId": {HostsOn: true},
+						},
+					},
+					// Simple properties with VpcId matching the VPC's Id
+					Properties: json.RawMessage(`{
+						"Id": "cidr-1",
+						"CidrBlock": "10.0.1.0/24",
+						"VpcId": "vpc-1"
+					}`),
+				},
+			},
+			Targets: []pkgmodel.Target{
+				{
+					Label:     "provider",
+					Namespace: "FakeAWS",
+					Config:    json.RawMessage(`{"region":"us-east-1"}`),
+				},
+			},
+		}
+
+		// Step 1: Apply the forma
+		_, err = m.ApplyForma(
+			forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
+			"test-client-id")
+		require.NoError(t, err, "ApplyForma should not error")
+
+		// Wait for apply to complete
+		assert.Eventually(t, func() bool {
+			incomplete, err := m.Datastore.LoadIncompleteFormaCommands()
+			require.NoError(t, err)
+			return len(incomplete) == 0
+		}, 10*time.Second, 100*time.Millisecond, "apply should complete")
+
+		// Verify both resources exist in the datastore
+		resources, err := m.Datastore.LoadResourcesByStack("test")
+		require.NoError(t, err)
+		require.Len(t, resources, 2, "should have vpc and cidr resources")
+
+		// Step 2: Destroy the forma (all resources in the stack are removed)
+		_, err = m.DestroyForma(
+			forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
+			"test-client-id")
+		require.NoError(t, err, "DestroyForma should not error")
+
+		// Wait for destroy to complete
+		assert.Eventually(t, func() bool {
+			cmds, err := m.Datastore.LoadFormaCommands()
+			require.NoError(t, err)
+			incomplete, err := m.Datastore.LoadIncompleteFormaCommands()
+			require.NoError(t, err)
+			// Should have exactly 2 commands: apply and destroy
+			return len(cmds) == 2 && len(incomplete) == 0
+		}, 10*time.Second, 100*time.Millisecond, "destroy should complete")
+
+		// Step 3: Load the destroy command and verify the resource update order
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+
+		var destroyCmd *forma_command.FormaCommand
+		for _, cmd := range cmds {
+			if cmd.Command == pkgmodel.CommandDestroy {
+				destroyCmd = cmd
+				break
+			}
+		}
+		require.NotNil(t, destroyCmd, "should have a destroy command")
+		require.Len(t, destroyCmd.ResourceUpdates, 2, "destroy command should have 2 resource updates")
+
+		// Find ModifiedTs for each resource
+		modifiedTsOfResource := func(label string) time.Time {
+			for _, ru := range destroyCmd.ResourceUpdates {
+				if ru.DesiredState.Label == label {
+					return ru.ModifiedTs
+				}
+			}
+			t.Fatalf("no ResourceUpdate for %q", label)
+			return time.Time{}
+		}
+
+		vpcModifiedTs := modifiedTsOfResource("vpc")
+		cidrModifiedTs := modifiedTsOfResource("cidr")
+
+		// The key assertion: with HostsOn on VpcId, vpc.delete should complete BEFORE cidr.delete
+		// (inverted from the normal reverse-construction order).
+		assert.True(t,
+			vpcModifiedTs.Before(cidrModifiedTs),
+			"vpc.delete must complete before cidr.delete under HostsOn annotation (vpc=%v cidr=%v)",
+			vpcModifiedTs, cidrModifiedTs)
+
+		// Also verify that the state is Success (not Failed or other terminal states)
+		for _, ru := range destroyCmd.ResourceUpdates {
+			assert.Equal(t, resource_update.ResourceUpdateStateSuccess, ru.State,
+				"ResourceUpdate for %q should be successful", ru.DesiredState.Label)
+		}
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/target_resolvables_test.go
+++ b/internal/workflow_tests/local/apply_forma/target_resolvables_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
 	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
@@ -337,6 +338,212 @@ func TestApplyForma_DestroyThenReapplyTargetWithResolvables(t *testing.T) {
 		resources, err = m.Datastore.LoadResourcesByStack("infra")
 		require.NoError(t, err)
 		assert.Len(t, resources, 1, "cluster resource should be re-created")
+	})
+}
+
+// TestApplyForma_DestroyOrder_TargetReachabilityComposesWithAttachesTo is a
+// composition test: the pre-existing target-reachability edge and the new
+// AttachesTo edge must chain correctly so that when a plugin target points at
+// a resource R and another resource S attaches to R, destroying the stack
+// deletes things in the order:
+//
+//  1. resource on target (needs the target alive to CRUD via plugin)
+//  2. target (waits for #1 via buildTargetResourceEdges)
+//  3. R — the resource the target points at (waits for target via buildTargetResolvableEdges)
+//  4. S — attaches to R (waits for R via AttachesTo)
+//
+// This is the exact topology that produces the LGTM "endpoint goes dark
+// mid-destroy" bug when the AttachesTo edge is missing: S would delete in
+// parallel with #1, taking down the control-plane that the plugin target
+// depends on before the plugin has finished CRUD'ing the things on that target.
+//
+// Mapping to the LGTM case:
+//
+//	dashboard  ↔ Grafana dashboard / folder
+//	grafana    ↔ lgtm-grafana target
+//	vpc        ↔ lgtm-listener (what the target's URL points at)
+//	cidr       ↔ lgtm-service (attaches to the listener's TG; AttachesTo)
+//
+// We reuse FakeAWS::EC2::VPC and FakeAWS::EC2::VPCCidrBlock because
+// VPCCidrBlock.VpcId already carries AttachesTo=true in the fakeaws schema.
+func TestApplyForma_DestroyOrder_TargetReachabilityComposesWithAttachesTo(t *testing.T) {
+	const vpcKsuid = "2MiD2rA1SJbLMGZgTL0hCxjkjjr"
+
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          "1234",
+					NativeID:           "native-" + request.Label,
+					ResourceProperties: request.Properties,
+				}}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				switch request.ResourceType {
+				case "FakeAWS::EC2::VPC":
+					return &resource.ReadResult{
+						ResourceType: request.ResourceType,
+						Properties:   `{"Id":"vpc-1","CidrBlock":"10.0.0.0/16"}`,
+					}, nil
+				case "FakeAWS::EC2::VPCCidrBlock":
+					return &resource.ReadResult{
+						ResourceType: request.ResourceType,
+						Properties:   `{"Id":"cidr-1","CidrBlock":"10.0.1.0/24","VpcId":"vpc-1"}`,
+					}, nil
+				case "FakeAWS::S3::Bucket":
+					return &resource.ReadResult{
+						ResourceType: request.ResourceType,
+						Properties:   `{"BucketName":"dashboard","Endpoint":"https://dashboard.example.com"}`,
+					}, nil
+				}
+				return &resource.ReadResult{ResourceType: request.ResourceType, Properties: "{}"}, nil
+			},
+			Delete: func(request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+				return &resource.DeleteResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationDelete,
+					OperationStatus: resource.OperationStatusSuccess,
+					NativeID:        request.NativeID,
+				}}, nil
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "test"}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label:   "vpc",
+					Type:    "FakeAWS::EC2::VPC",
+					Stack:   "test",
+					Target:  "provider",
+					Managed: true,
+					Ksuid:   vpcKsuid,
+					Schema:  pkgmodel.Schema{Identifier: "Id", Fields: []string{"Id", "CidrBlock"}},
+					Properties: json.RawMessage(`{
+						"Id": "vpc-1",
+						"CidrBlock": "10.0.0.0/16"
+					}`),
+				},
+				{
+					Label:   "cidr",
+					Type:    "FakeAWS::EC2::VPCCidrBlock",
+					Stack:   "test",
+					Target:  "provider",
+					Managed: true,
+					Schema: pkgmodel.Schema{
+						Identifier: "Id",
+						Fields:     []string{"Id", "CidrBlock", "VpcId"},
+						// AttachesTo here must keep cidr alive until vpc is gone.
+						Hints: map[string]pkgmodel.FieldHint{"VpcId": {AttachesTo: true}},
+					},
+					Properties: json.RawMessage(fmt.Sprintf(`{
+						"Id": "cidr-1",
+						"CidrBlock": "10.0.1.0/24",
+						"VpcId": {"$ref":"formae://%s#/Id","$value":"vpc-1"}
+					}`, vpcKsuid)),
+				},
+				{
+					// "dashboard" stands in for a Grafana resource on the plugin target.
+					// It does not $ref anything — it's just a resource on the "grafana"
+					// target, so its delete must happen before the target's delete.
+					Label:   "dashboard",
+					Type:    "FakeAWS::S3::Bucket",
+					Stack:   "test",
+					Target:  "grafana",
+					Managed: true,
+					Schema:  pkgmodel.Schema{Identifier: "BucketName", Portable: true},
+					Properties: json.RawMessage(`{
+						"BucketName": "dashboard",
+						"Endpoint": "https://dashboard.example.com"
+					}`),
+				},
+			},
+			Targets: []pkgmodel.Target{
+				{Label: "provider", Namespace: "FakeAWS", Config: json.RawMessage(`{"region":"us-east-1"}`)},
+				{
+					// "grafana" target's endpoint $refs vpc.Id — this produces the
+					// target-reachability edge that pins vpc.delete after the
+					// target.delete (which itself waits for "dashboard").
+					Label:     "grafana",
+					Namespace: "FakeAWS",
+					Config: json.RawMessage(fmt.Sprintf(`{
+						"endpoint": {"$ref":"formae://%s#/Id","$value":"vpc-1"}
+					}`, vpcKsuid)),
+				},
+			},
+		}
+
+		// Apply
+		_, err = m.ApplyForma(forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
+			"test-client-id")
+		require.NoError(t, err)
+		assert.Eventually(t, func() bool {
+			incomplete, _ := m.Datastore.LoadIncompleteFormaCommands()
+			return len(incomplete) == 0
+		}, 15*time.Second, 100*time.Millisecond, "apply should complete")
+
+		resources, err := m.Datastore.LoadResourcesByStack("test")
+		require.NoError(t, err)
+		require.Len(t, resources, 3, "vpc, cidr and dashboard should all be created")
+
+		// Destroy
+		_, err = m.DestroyForma(forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
+			"test-client-id")
+		require.NoError(t, err)
+		assert.Eventually(t, func() bool {
+			cmds, _ := m.Datastore.LoadFormaCommands()
+			incomplete, _ := m.Datastore.LoadIncompleteFormaCommands()
+			return len(cmds) == 2 && len(incomplete) == 0
+		}, 15*time.Second, 100*time.Millisecond, "destroy should complete")
+
+		// Find the destroy command and extract ModifiedTs per label.
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+
+		var destroy *forma_command.FormaCommand
+		for _, cmd := range cmds {
+			if cmd.Command == pkgmodel.CommandDestroy {
+				destroy = cmd
+				break
+			}
+		}
+		require.NotNil(t, destroy, "destroy command should be persisted")
+		require.Len(t, destroy.ResourceUpdates, 3)
+
+		modifiedTsOf := func(label string) time.Time {
+			for _, ru := range destroy.ResourceUpdates {
+				if ru.DesiredState.Label == label {
+					return ru.ModifiedTs
+				}
+			}
+			t.Fatalf("no ResourceUpdate for %q", label)
+			return time.Time{}
+		}
+		dashboardTs := modifiedTsOf("dashboard")
+		vpcTs := modifiedTsOf("vpc")
+		cidrTs := modifiedTsOf("cidr")
+
+		// Assertion 1 — pre-existing target-reachability edge:
+		// vpc must outlive the dashboard, because dashboard's target ("grafana")
+		// refs vpc, and the target can only be deleted after its users are gone.
+		assert.True(t,
+			dashboardTs.Before(vpcTs),
+			"dashboard.delete must complete before vpc.delete via target-reachability (dashboard=%v vpc=%v)",
+			dashboardTs, vpcTs)
+
+		// Assertion 2 — the new AttachesTo edge:
+		// cidr attaches to vpc; its delete must wait for vpc.delete.
+		assert.True(t,
+			vpcTs.Before(cidrTs),
+			"vpc.delete must complete before cidr.delete via AttachesTo (vpc=%v cidr=%v)",
+			vpcTs, cidrTs)
 	})
 }
 

--- a/pkg/model/schema.go
+++ b/pkg/model/schema.go
@@ -19,6 +19,7 @@ type FieldHint struct {
 	Required           bool `json:"Required" pkl:"Required"`
 	RequiredOnCreate   bool `json:"RequiredOnCreate" pkl:"RequiredOnCreate"`
 	HasProviderDefault bool `json:"HasProviderDefault" pkl:"HasProviderDefault"`
+	HostsOn            bool `json:"HostsOn" pkl:"HostsOn"`
 
 	IndexField   string            `json:"IndexField" pkl:"IndexField"`
 	UpdateMethod FieldUpdateMethod `json:"UpdateMethod" pkl:"UpdateMethod"`

--- a/pkg/model/schema.go
+++ b/pkg/model/schema.go
@@ -19,7 +19,7 @@ type FieldHint struct {
 	Required           bool `json:"Required" pkl:"Required"`
 	RequiredOnCreate   bool `json:"RequiredOnCreate" pkl:"RequiredOnCreate"`
 	HasProviderDefault bool `json:"HasProviderDefault" pkl:"HasProviderDefault"`
-	HostsOn            bool `json:"HostsOn" pkl:"HostsOn"`
+	AttachesTo            bool `json:"AttachesTo" pkl:"AttachesTo"`
 
 	IndexField   string            `json:"IndexField" pkl:"IndexField"`
 	UpdateMethod FieldUpdateMethod `json:"UpdateMethod" pkl:"UpdateMethod"`

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -7,29 +7,26 @@ package model
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFieldHintHostsOnJSONRoundTrip(t *testing.T) {
 	original := FieldHint{HostsOn: true}
+
 	data, err := json.Marshal(original)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
+	require.NoError(t, err)
+
 	var decoded FieldHint
-	if err := json.Unmarshal(data, &decoded); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if !decoded.HostsOn {
-		t.Fatalf("expected HostsOn=true, got %#v (raw=%s)", decoded, string(data))
-	}
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.True(t, decoded.HostsOn, "HostsOn should round-trip through JSON (raw=%s)", string(data))
 }
 
 func TestFieldHintHostsOnDefaultsFalse(t *testing.T) {
 	var decoded FieldHint
-	if err := json.Unmarshal([]byte(`{"CreateOnly":true}`), &decoded); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if decoded.HostsOn {
-		t.Fatalf("expected HostsOn default false for pre-existing stored schemas, got true")
-	}
+	require.NoError(t, json.Unmarshal([]byte(`{"CreateOnly":true}`), &decoded))
+
+	assert.False(t, decoded.HostsOn, "HostsOn should default false for pre-existing stored schemas")
 }

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFieldHintHostsOnJSONRoundTrip(t *testing.T) {
-	original := FieldHint{HostsOn: true}
+func TestFieldHintAttachesToJSONRoundTrip(t *testing.T) {
+	original := FieldHint{AttachesTo: true}
 
 	data, err := json.Marshal(original)
 	require.NoError(t, err)
@@ -21,12 +21,12 @@ func TestFieldHintHostsOnJSONRoundTrip(t *testing.T) {
 	var decoded FieldHint
 	require.NoError(t, json.Unmarshal(data, &decoded))
 
-	assert.True(t, decoded.HostsOn, "HostsOn should round-trip through JSON (raw=%s)", string(data))
+	assert.True(t, decoded.AttachesTo, "AttachesTo should round-trip through JSON (raw=%s)", string(data))
 }
 
-func TestFieldHintHostsOnDefaultsFalse(t *testing.T) {
+func TestFieldHintAttachesToDefaultsFalse(t *testing.T) {
 	var decoded FieldHint
 	require.NoError(t, json.Unmarshal([]byte(`{"CreateOnly":true}`), &decoded))
 
-	assert.False(t, decoded.HostsOn, "HostsOn should default false for pre-existing stored schemas")
+	assert.False(t, decoded.AttachesTo, "AttachesTo should default false for pre-existing stored schemas")
 }

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -1,0 +1,35 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package model
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFieldHintHostsOnJSONRoundTrip(t *testing.T) {
+	original := FieldHint{HostsOn: true}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded FieldHint
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !decoded.HostsOn {
+		t.Fatalf("expected HostsOn=true, got %#v (raw=%s)", decoded, string(data))
+	}
+}
+
+func TestFieldHintHostsOnDefaultsFalse(t *testing.T) {
+	var decoded FieldHint
+	if err := json.Unmarshal([]byte(`{"CreateOnly":true}`), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.HostsOn {
+		t.Fatalf("expected HostsOn default false for pre-existing stored schemas, got true")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new \`AttachesTo\` field hint so plugin authors can mark \`\$ref\`-bearing fields that express "the owning resource attaches as a backend/server/consumer to the referenced resource." The changeset DAG builder consults this hint in \`buildDeleteDependencies\` and inverts its usual construction-reverse edge direction: the attaching resource waits for the attached-to resource to delete first.

This eliminates a class of cascading-failure bugs where a plugin's control-plane endpoint goes dark mid-destroy because its backing infrastructure was torn down in parallel. Concrete trigger: LGTM-on-ECS forma where the Grafana plugin's API is served by an ECS service; today the ECS service is eligible to delete in parallel with the Grafana resources, so Grafana API calls hang → \`ResourceUpdater\` actors enter \`finished_with_error\` → late \`plugin.TrackedProgress\` callbacks panic the actor → \`ChangesetExecutor\` cascade-fails the whole stack.

Related: **RFC-0034** (https://github.com/platform-engineering-labs/rfcs/pull/14).

## Changes

| File | Change |
|---|---|
| \`pkg/model/schema.go\` | + \`AttachesTo bool\` on \`FieldHint\` |
| \`internal/schema/pkl/schema/formae.pkl\` | + \`attachesTo\` / \`fixed AttachesTo\` on the PKL \`FieldHint\` class |
| \`internal/schema/pkl/schema/tests/formae.pkl(-expected.pcf)\` | Test facts + expected PCF blocks updated for the new field |
| \`internal/metastructure/resolver/resolver.go\` | New \`ResolvableRef\` type + \`ExtractResolvableRefs\` helper preserving \`TargetPath\` (existing \`ExtractResolvableURIs\` untouched) |
| \`internal/metastructure/changeset/path_hint.go\` | New \`stripArrayIndices\` + \`fieldHintForPath\` helpers |
| \`internal/metastructure/changeset/changeset.go\` | \`buildDeleteDependencies\` branches on \`hint.AttachesTo\` — 4 new table-driven tests covering no-hint, hint, mixed, missing-hint cases |
| \`internal/testplugin/fakeaws/fake_aws.go\` | One-line hint on \`FakeAWS::EC2::VPCCidrBlock.VpcId\` for the integration test |
| \`internal/workflow_tests/local/apply_forma/attaches_to_destroy_test.go\` | End-to-end test — applies a VPC + CidrBlock forma (CidrBlock \`\$ref\`s VPC), destroys, asserts \`vpc.delete\` completes before \`cidr.delete\` (inverted order under \`AttachesTo\`) |

## What this does NOT do

- Does not annotate any real plugin (\`formae-plugin-aws\` gets \`AttachesTo: true\` on \`AWS::ECS::Service.LoadBalancers.TargetGroupArn\` in a follow-up PR on that repo).
- Does not alter create-order behaviour. \`AttachesTo\` is destroy-order only.
- Does not touch \`ConfigFieldHint\` on targets. Target-config \`\$ref\`s are already reachability refs via \`buildTargetResolvableEdges\` — out of scope here.

## Compatibility

- \`FieldHint.AttachesTo\` defaults to \`false\` on JSON unmarshal of existing stored schemas.
- PKL schemas that don't declare \`attachesTo\` compile cleanly (optional field with default).
- SQLite / Postgres / Aurora store \`resources.schema\` as a JSON blob — no migration needed.
- Zero change to any forma file. Zero change to consumers that don't opt in.

## Rollout order (for the LGTM motivating case)

1. Merge this PR.
2. Cut \`0.85.0-dev\` tag (depends on #437 for the channel-aware PKL publish to land first, otherwise the pre-release semver leaks into the package URL).
3. \`formae-plugin-aws\` annotation PR + dev-channel tag.
4. Roll the resident agent + bump the LGTM forma's \`PklProject.deps.json\`.
5. Validate with apply + destroy + re-apply + simulate-no-op.

## Notes

- The RFC branch (\`rfc-0034-hosts-on-hint\` on \`platform-engineering-labs/rfcs\`) kept its historical name for traceability; the file inside was renamed to \`rfc-0034-attaches-to-hint.md\` and the RFC body prose updated.
- \`internal/workflow_tests/local\` has a known flake when run in the full \`make test-all\` suite (\`TestMetastructure_StorePatchStack\` / \`TestMetastructure_StackOnlyForma_UpdateDescription\` occasionally fail in-suite but consistently pass in isolation and across N=3+ reruns). Pre-existing — not caused by this PR.