### PR TITLE
fix(pkl): make published package's manifest channel-aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ docs/design/
 
 # External plugin cache (cloned plugin repos during build)
 .plugins/
+channel

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ build-debug:
 
 pkg-bin: clean build build-external-plugins
 	echo '${VERSION}' > ./version.semver
+	echo '${CHANNEL}' > ./channel
 	mkdir -p ./dist/pel/bin
 	mkdir -p ./dist/pel/formae/plugins
 	cp -Rp ./formae ./dist/pel/bin
@@ -196,6 +197,7 @@ pkg-bin: clean build build-external-plugins
 
 gen-pkl:
 	echo '${VERSION}' > ./version.semver
+	echo '${CHANNEL}' > ./channel
 	pkl project resolve internal/schema/pkl/schema
 	pkl project resolve internal/schema/pkl/generator
 	pkl project resolve internal/schema/pkl/testdata/forma

--- a/internal/schema/pkl/schema/PklProject
+++ b/internal/schema/pkl/schema/PklProject
@@ -1,8 +1,19 @@
 amends "pkl:Project"
 
+// Channel: written by `make gen-pkl` from the Makefile's CHANNEL variable
+// (derived from the git tag suffix). Defaults to "stable" if the file is
+// absent — matches the behaviour of an untagged or stable build.
+//
+// PKL has no native channel concept, so the channel must be encoded in the
+// package URL path. When channel != "stable" the package's self-declared
+// baseUri/packageZipUrl gain a `<channel>/` prefix, mirroring where
+// `make publish-pkl` syncs the artefacts to.
+local channel: String = read?("../../../../channel")?.text?.trim() ?? "stable"
+local channelPrefix: String = if (channel == "stable") "" else "\(channel)/"
+
 package {
   name = "formae"
-  baseUri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/\(name)/\(name)"
+  baseUri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/\(name)/\(channelPrefix)\(name)"
   version = read("../../../../version.semver").text.trim()
-  packageZipUrl = "https://hub.platform.engineering/plugins/pkl/schema/pkl/\(name)/\(name)@\(version).zip"
+  packageZipUrl = "https://hub.platform.engineering/plugins/pkl/schema/pkl/\(name)/\(channelPrefix)\(name)@\(version).zip"
 }


### PR DESCRIPTION
## Summary

PR #437 routes \`publish-pkl\` to \`/formae/<channel>/\` for non-stable channels, but the published package's **internal manifest** still hardcoded flat-path URLs because \`internal/schema/pkl/schema/PklProject\` baked \`baseUri\` and \`packageZipUrl\` from \`\(name)\` alone.

Result observed against \`formae@0.85.0\` published to \`/formae/dev/\` via #439's schema-prerelease workflow:

\`\`\`
$ curl -s https://hub.platform.engineering/.../formae/dev/formae@0.85.0
{
  "packageUri":   "package://hub.platform.engineering/.../formae/formae@0.85.0",         ← wrong
  "packageZipUrl": "https://hub.platform.engineering/.../formae/formae@0.85.0.zip"      ← wrong
}
\`\`\`

PKL's resolver then trusts the manifest's self-declared URLs and fetches \`/formae/formae@0.85.0.zip\` → 404. The \`/dev/\` zip is unreachable to consumers.

## Fix

- \`make gen-pkl\` and \`pkg-bin\` now write \`\${CHANNEL}\` to \`./channel\` alongside the existing \`./version.semver\`.
- \`PklProject\` reads \`./channel\` via \`read?\` (defaults to \`stable\` when absent), and prefixes \`baseUri\` and \`packageZipUrl\` with \`<channel>/\` when \`channel != stable\`.

After this lands and the schema-prerelease workflow re-runs, manifests match where the artefacts actually live:

| Tag | \`packageZipUrl\` |
|---|---|
| \`0.85.0\` (stable) | \`https://.../formae/formae@0.85.0.zip\` (unchanged) |
| \`0.85.0-dev\` | \`https://.../formae/dev/formae@0.85.0.zip\` |

## Local verification

Tagged HEAD as \`0.85.0\` then \`0.85.0-dev\`, ran \`make gen-pkl pkg-pkl\` for each. Manifest at \`.out/formae@0.85.0/formae@0.85.0\` confirmed:

- Stable: URLs unchanged from pre-PR-437 behaviour, no \`/dev/\` segment.
- Dev: both \`packageUri\` and \`packageZipUrl\` carry the \`/dev/\` segment.

\`make test-pkl\`, \`make lint\`, \`make lint-reuse\` all green.

## What re-runs needed after merge

1. Re-trigger \`schema-prerelease\` workflow with \`version=0.85.0-dev\` → manifest now self-consistent.
2. Then the \`formae-plugin-aws\` PR can resolve \`@formae\` cleanly against \`package://.../formae/dev/formae@0.85.0\`.