### PR TITLE
fix(ci): map dev.N tag suffixes to the dev orbital channel

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -33,14 +33,25 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set VERSION and CHANNEL
+        # Tag-to-channel mapping mirrors formae-actions/plugin-build.yml:
+        #   X.Y.Z         -> stable
+        #   X.Y.Z-dev[.N] -> dev
+        # The channel must match an orbital channel exactly; an earlier
+        # version of this script forwarded `dev.N` verbatim, which orbital
+        # rejects ("No install candidates found").
+        shell: bash
         run: |
-          echo VERSION=$(git describe --tags --abbrev=0 --match "[0-9]*" --match "v[0-9]*" | cut -d'-' -f1) >> $GITHUB_ENV
-          version=$(git describe --tags --abbrev=0 --match "[0-9]*" --match "v[0-9]*")
-          channel=$(echo $version | cut -d'-' -f2-)
-          if [[ "$channel" == "$version" ]]; then
-            echo CHANNEL=stable >> $GITHUB_ENV
+          tag=$(git describe --tags --abbrev=0 --match "[0-9]*" --match "v[0-9]*")
+          version="${tag#v}"
+          if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "CHANNEL=stable" >> "$GITHUB_ENV"
+            echo "VERSION=$version" >> "$GITHUB_ENV"
+          elif [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-dev(\.[0-9]+)?$ ]]; then
+            echo "CHANNEL=dev" >> "$GITHUB_ENV"
+            echo "VERSION=${BASH_REMATCH[1]}" >> "$GITHUB_ENV"
           else
-            echo CHANNEL=$channel >> $GITHUB_ENV
+            echo "::error::unsupported tag pattern '${tag}'; expected X.Y.Z or X.Y.Z-dev[.N]"
+            exit 1
           fi
 
       - name: Set up QEMU


### PR DESCRIPTION
## Summary

The container build's channel-derivation script took everything after the first `-` in the git tag and forwarded it verbatim as `--channel`. For a tag like `0.85.0-dev.2` that produced `CHANNEL=dev.2`, but orbital only knows two channels (`stable` and `dev`); `pelmgr install --channel dev.2 ... standard` failed with "No install candidates found" on the 0.85.0-dev.2 release run.

Switch to the same regex-based mapping that `formae-actions/plugin-build.yml` uses:

* `X.Y.Z` → `stable`
* `X.Y.Z-dev[.N]` → `dev`
* anything else → script error (rather than silent miscategorization)

Strip an optional `v`-prefix from VERSION while we're here.

## Why now

Surfaced by the 0.85.0-dev.2 release run after #430 merged. Same shape would break every future `-dev.N` tag.