### PR TITLE
fix(docker): split formae and standard into separate install calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,21 @@ ENV PATH=/opt/pel/bin:$PATH
 
 RUN useradd -m -s /bin/bash pel
 
-# Install formae + the standard metapackage. The metapackage's `requires`
-# resolve at install time and pull in the curated default plugin set
-# (aws, azure, gcp, oci, ovh, auth-basic) — replacing the legacy bundled-
-# plugins-from-binary extraction step.
+# Two-step install. The formae binary lives in the pel repo at the
+# release's CHANNEL (stable for X.Y.Z, dev for X.Y.Z-dev[.N]); the
+# standard metapackage and its constituent plugins always come from
+# community#stable. Plugins are released independently of formae and
+# don't carry a parallel dev channel — even dev formae containers ship
+# with stable plugins. Pelmgr applies one channel per install call, so
+# they have to be separate invocations.
+#
+# Standard's `requires` resolve at install time and pull in the curated
+# default plugin set (aws, azure, gcp, oci, ovh, auth-basic) —
+# replacing the legacy bundled-plugins-from-binary extraction step.
 RUN apt-get update &&  \
     apt-get install -y jq curl && \
-    HOME=/home/pel /bin/bash -e -c "$(curl -fsSL https://hub.platform.engineering/get/setup.sh)" -- install --yes --channel ${CHANNEL} formae@${VERSION} standard && \
+    HOME=/home/pel /bin/bash -e -c "$(curl -fsSL https://hub.platform.engineering/get/setup.sh)" -- install --yes --channel ${CHANNEL} formae@${VERSION} && \
+    HOME=/home/pel /bin/bash -e -c "$(curl -fsSL https://hub.platform.engineering/get/setup.sh)" -- install --yes --channel stable standard && \
     apt-get remove -y jq curl && \
     apt-get autoremove -y --purge && \
     apt-get clean && \


### PR DESCRIPTION
## Summary

Pelmgr applies one channel per install call. With both formae and `standard` in a single `pelmgr install ...` invocation, the dev container fails because:

- formae binary lives at `pel#dev` for `0.85.0-dev.N` releases.
- `standard` (and the plugins it pulls in) lives only at `community#stable` — there is no parallel `community#dev` channel.

Split the install into two calls in the Dockerfile:

1. `formae@${VERSION}` from `--channel ${CHANNEL}` (the release tag's channel: stable for `X.Y.Z`, dev for `X.Y.Z-dev[.N]`).
2. `standard` from `--channel stable`, always.

Plugins are released independently of the formae binary and don't carry a parallel dev channel; even dev formae containers ship with the latest stable plugin set. This is the policy.

Smoke-tested locally with `--build-arg VERSION=0.85.0 --build-arg CHANNEL=dev`: both pelmgr calls succeed, the second one resolves `standard@0.1.0` from `community#stable`, and all 6 constituent plugins install. Existing stable-only builds (`CHANNEL=stable`) are unchanged behaviorally.