### PR TITLE
fix(release): map dev.N tag suffixes to dev channel in Makefile + justfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,19 @@
 
 DEBUG_GOFLAGS := -gcflags="all=-N -l"
 
-# The latest tag, possibly carrying a `-channel` suffix (e.g., 0.85.0-dev).
+# The latest tag, possibly carrying a `-channel` suffix (e.g., 0.85.0-dev.2).
 RAW_VERSION := $(shell git describe --tags --abbrev=0 --match "[0-9]*" --match "v[0-9]*")
 # Canonical semver — everything before the first `-`. Used as the artifact
 # version for binaries and the PKL package. Mirrors the convention already
 # in justfile and container.yml.
 VERSION := $(shell echo "$(RAW_VERSION)" | cut -d'-' -f1)
-# Channel — everything after the first `-`, or `stable` if the tag has no
-# suffix. Used for orbital channel routing. PKL schemas are always published
-# to a flat URL regardless of channel; channel only affects binary/container
-# release routing.
-#
-# Implemented in pure Make builtins so it parses on GNU make 3.81 (the
-# macOS-default in CI) as well as 4.x (Linux). `subst` turns "0.85.0-dev"
-# into "0.85.0 dev"; `word 2` extracts "dev". `or` returns the first
-# non-empty arg, defaulting to "stable" when there is no `-channel`
-# suffix.
-CHANNEL := $(or $(word 2,$(subst -, ,$(RAW_VERSION))),stable)
+# Channel — `stable` for tags shaped X.Y.Z, `dev` for tags shaped
+# X.Y.Z-dev[.N]. Used for orbital channel routing. Mirrors the regex in
+# formae-actions/plugin-build.yml and container.yml: an earlier shape that
+# took everything after the first `-` produced literal `dev.2` for
+# `0.85.0-dev.2`, which orbital writes as a real channel name and breaks
+# downstream installs.
+CHANNEL := $(shell echo "$(RAW_VERSION)" | grep -q -- '-' && echo dev || echo stable)
 
 clean:
 	rm -rf .out/

--- a/justfile
+++ b/justfile
@@ -7,13 +7,12 @@ set shell := ["bash", "-cu"]
 export VERSION := `git describe --tags --abbrev=0 --match "[0-9]*" --match "v[0-9]*" | cut -d'-' -f1`
 
 export CHANNEL := ```
+    # Channel — `stable` for X.Y.Z tags, `dev` for X.Y.Z-dev[.N] tags.
+    # An earlier shape took everything after the first `-` (cut -d'-' -f2-)
+    # and produced literal `dev.2` for `0.85.0-dev.2`, which orbital wrote
+    # as a real channel name and broke downstream installs.
     version=$(git describe --tags --abbrev=0 --match "[0-9]*" --match "v[0-9]*")
-    channel=$(echo $version | cut -d'-' -f2-)
-    if [[ "$channel" == "$version" ]]; then
-        echo "stable"
-    else
-        echo $channel
-    fi
+    if echo "$version" | grep -q -- '-'; then echo dev; else echo stable; fi
 ```
 
 GITHUB := env("GITHUB_ACTIONS", "false")


### PR DESCRIPTION
## Summary

The formae release pipeline derives CHANNEL from the git tag in three places: `container.yml`, `Makefile`, and `justfile`. The container.yml fix landed earlier (#444), but the Makefile and justfile still took everything after the first `-` in the tag:

```makefile
# Makefile (was)
CHANNEL := $(or $(word 2,$(subst -, ,$(RAW_VERSION))),stable)
```

```bash
# justfile (was)
channel=$(echo $version | cut -d'-' -f2-)
```

For tag `0.85.0-dev.2`, both produced `CHANNEL=dev.2`. The `pkg_opkg` matrix in formae-release.yml passes `--channel ${CHANNEL}` to `ops publish`, so every recent dev release was published into a phantom `dev.2` channel instead of the expected `dev` channel.

End-user impact: `pelmgr install --channel dev formae` only sees a stale April 25 build (the only formae@0.85.0 entry sitting on the real `dev` channel). Worse, that S3 object has been replaced by later builds with the same `formae@0.85.0_<timestamp>` shape, so signature validation now fails:

```
ERRO failed: formae@0.85.0_20260425T180908Z
ERROR Failed to validate signature and contents:
formae@0.85.0_20260425T180908Z-darwin-arm64.opkg.
```

## Fix

Replace the cut/subst-based derivation in both files with the simpler "tag has a `-` suffix → `dev`" check (`grep -q -- '-'`). Matches the shape already in `container.yml` after #444, and keeps the formae release pipeline behaviorally aligned with `formae-actions/plugin-build.yml`'s stricter regex form.

Tested locally against both `0.85.0-dev.2` (→ `dev`) and `0.85.0` (→ `stable`).

## After merge

Re-tag `0.85.0-dev.2` once more to trigger a release build that actually publishes into the real `dev` channel. The mac install (`setup.sh ... install --channel dev formae`) starts working as soon as the metadata refresh propagates.

The phantom `dev.2` channel entries in the orbital metadata are still there but harmless — nothing references that channel string. Cleaning them up is a separate operational task.