### PR TITLE
fix(packaging): chown /opt/pel to pel so orbital runs rootless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,19 @@ RUN apt-get update &&  \
     apt-get clean && \
     /opt/pel/bin/formae clean --all
 
-RUN chown -R pel:pel /home/pel
+# Make the install tree owned by `pel`. Orbital's tree library considers any
+# path owned by uid 0 "Privileged" and tries to escalate via sudo on every
+# read/write — but the image runs as `pel` and sudo is not installed, so the
+# agent fails to start with:
+#
+#   privileged user required to manage path: /opt/pel
+#   Plugin manager initialization failed; refusing to start
+#   exec: "sudo": executable file not found in $PATH
+#
+# Once /opt/pel is owned by `pel`, orbital's privileged() check returns false,
+# no sudo is invoked, and runtime plugin install/upgrade/uninstall continue
+# to work because new files inherit the pel ownership.
+RUN chown -R pel:pel /home/pel /opt/pel
 
 USER pel
 WORKDIR /home/pel


### PR DESCRIPTION
## Summary
- The agent container runs as user `pel`, but the install step (run as root at build time) populates `/opt/pel` with root ownership. Orbital's tree library treats any uid 0 path as "Privileged" and tries to escalate via sudo on every read/write — sudo isn't installed in the image, so the agent fails to start with `Plugin manager initialization failed; refusing to start` and `exec: "sudo": executable file not found in $PATH`.
- Extend the existing `chown -R pel:pel` to also cover `/opt/pel`. Orbital's `privileged()` check (`opm/tree/tree.go:630`, returns true iff the path is owned by uid 0) then returns false; no sudo escalation at startup, and runtime plugin install/upgrade/uninstall continue to work because new files orbital writes as user `pel` inherit pel ownership.