### PR TITLE
feat(conformance): allow custom testdata dir via FORMAE_TEST_TESTDATA_DIR

### DIFF
--- a/pkg/plugin-conformance-tests/discovery.go
+++ b/pkg/plugin-conformance-tests/discovery.go
@@ -21,10 +21,49 @@ type TestCase struct {
 	ResourceType string // e.g., "s3-bucket"
 }
 
+// ResolveTestDataDir returns the directory containing test PKL files for a plugin.
+//
+// Resolution order:
+//   - If FORMAE_TEST_TESTDATA_DIR is set, that value is used. Absolute paths are
+//     used as-is; relative paths are resolved against pluginPath.
+//   - Otherwise, defaults to <pluginPath>/testdata.
+func ResolveTestDataDir(pluginPath string) string {
+	if custom := os.Getenv("FORMAE_TEST_TESTDATA_DIR"); custom != "" {
+		if filepath.IsAbs(custom) {
+			return custom
+		}
+		return filepath.Join(pluginPath, custom)
+	}
+	return filepath.Join(pluginPath, "testdata")
+}
+
+// FindPklProjectRoot walks up from dir (inclusive) and returns the first
+// ancestor that contains a PklProject file. Returns "" if none is found
+// before reaching the filesystem root.
+func FindPklProjectRoot(dir string) string {
+	cur, err := filepath.Abs(dir)
+	if err != nil {
+		return ""
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(cur, "PklProject")); err == nil {
+			return cur
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return ""
+		}
+		cur = parent
+	}
+}
+
 // DiscoverTestData finds all PKL files in a plugin's testdata directory
-// and their optional -update.pkl and -replace.pkl variants
+// and their optional -update.pkl and -replace.pkl variants.
+//
+// The directory is resolved via ResolveTestDataDir, which honors
+// FORMAE_TEST_TESTDATA_DIR.
 func DiscoverTestData(pluginPath string) ([]TestCase, error) {
-	testDataDir := filepath.Join(pluginPath, "testdata")
+	testDataDir := ResolveTestDataDir(pluginPath)
 
 	// Check if testdata directory exists
 	if _, err := os.Stat(testDataDir); os.IsNotExist(err) {

--- a/pkg/plugin-conformance-tests/discovery_test.go
+++ b/pkg/plugin-conformance-tests/discovery_test.go
@@ -1,0 +1,104 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package conformance
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveTestDataDir(t *testing.T) {
+	plugin := t.TempDir()
+
+	t.Run("default", func(t *testing.T) {
+		t.Setenv("FORMAE_TEST_TESTDATA_DIR", "")
+		got := ResolveTestDataDir(plugin)
+		want := filepath.Join(plugin, "testdata")
+		if got != want {
+			t.Fatalf("default: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("relative override", func(t *testing.T) {
+		t.Setenv("FORMAE_TEST_TESTDATA_DIR", "testdata/integration")
+		got := ResolveTestDataDir(plugin)
+		want := filepath.Join(plugin, "testdata/integration")
+		if got != want {
+			t.Fatalf("relative: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("absolute override", func(t *testing.T) {
+		abs := filepath.Join(t.TempDir(), "elsewhere")
+		t.Setenv("FORMAE_TEST_TESTDATA_DIR", abs)
+		got := ResolveTestDataDir(plugin)
+		if got != abs {
+			t.Fatalf("absolute: got %q, want %q", got, abs)
+		}
+	})
+}
+
+func TestFindPklProjectRoot(t *testing.T) {
+	root := t.TempDir()
+	testdata := filepath.Join(root, "testdata")
+	subdir := filepath.Join(testdata, "integration", "deep")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(testdata, "PklProject"), []byte("amends \"pkl:Project\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("self contains PklProject", func(t *testing.T) {
+		got := FindPklProjectRoot(testdata)
+		if got != testdata {
+			t.Fatalf("got %q, want %q", got, testdata)
+		}
+	})
+
+	t.Run("walks up to ancestor", func(t *testing.T) {
+		got := FindPklProjectRoot(subdir)
+		if got != testdata {
+			t.Fatalf("got %q, want %q", got, testdata)
+		}
+	})
+
+	t.Run("returns empty when none found", func(t *testing.T) {
+		isolated := t.TempDir()
+		got := FindPklProjectRoot(isolated)
+		if got != "" {
+			t.Fatalf("expected empty, got %q", got)
+		}
+	})
+}
+
+func TestDiscoverTestData_HonorsOverride(t *testing.T) {
+	plugin := t.TempDir()
+	custom := filepath.Join(plugin, "alt-testdata")
+	if err := os.MkdirAll(custom, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(custom, "thing.pkl"), []byte("foo = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("FORMAE_TEST_TESTDATA_DIR", "alt-testdata")
+
+	cases, err := DiscoverTestData(plugin)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(cases) != 1 {
+		t.Fatalf("got %d cases, want 1", len(cases))
+	}
+	if cases[0].ResourceType != "thing" {
+		t.Fatalf("resource type: got %q, want %q", cases[0].ResourceType, "thing")
+	}
+	wantPath := filepath.Join(custom, "thing.pkl")
+	if cases[0].PKLFile != wantPath {
+		t.Fatalf("PKLFile: got %q, want %q", cases[0].PKLFile, wantPath)
+	}
+}

--- a/pkg/plugin-conformance-tests/harness.go
+++ b/pkg/plugin-conformance-tests/harness.go
@@ -126,8 +126,16 @@ func NewTestHarness(t *testing.T) *TestHarness {
 		t.Fatalf("failed to get working directory: %v", err)
 	}
 	schemaDir := filepath.Join(pluginDir, "schema", "pkl")
-	testdataDir := filepath.Join(pluginDir, "testdata")
-	restorePKL := ResolvePKLDependencies(t, "", schemaDir, testdataDir)
+	testdataDir := ResolveTestDataDir(pluginDir)
+	// Find the nearest PklProject for the testdata dir. When a custom
+	// FORMAE_TEST_TESTDATA_DIR points at a subdir without its own PklProject,
+	// walk up to the parent project root (typically <pluginDir>/testdata) so
+	// `pkl project resolve` runs against the correct project.
+	testdataProject := FindPklProjectRoot(testdataDir)
+	if testdataProject == "" {
+		testdataProject = testdataDir
+	}
+	restorePKL := ResolvePKLDependencies(t, "", schemaDir, testdataProject)
 	t.Cleanup(restorePKL)
 
 	// Set up test environment (temp dir and config)

--- a/pkg/plugin-conformance-tests/runner.go
+++ b/pkg/plugin-conformance-tests/runner.go
@@ -259,6 +259,11 @@ func getOOBDeleteTimeout() time.Duration {
 //   - FORMAE_TEST_OOB_DELETE_TIMEOUT: Timeout in minutes for the OOB-delete phase's
 //     wait-for-inventory-removal step (optional). Default is 2 minutes. Raise
 //     for slow backends (e.g. managed Kubernetes).
+//   - FORMAE_TEST_TESTDATA_DIR: Override the directory containing test PKL files
+//     (optional). Absolute paths are used as-is; relative paths are resolved
+//     against the plugin directory. Defaults to "testdata". When the override
+//     points at a subdirectory without its own PklProject, the nearest ancestor
+//     containing one is used for `pkl project resolve`.
 //
 // This function should be called from a plugin's conformance_test.go:
 //


### PR DESCRIPTION
## Summary

- Adds `FORMAE_TEST_TESTDATA_DIR` env var to override the default `testdata/` location used by the plugin conformance test harness.
- Absolute paths used as-is; relative paths resolve against the plugin directory.
- When the override targets a subdirectory without its own `PklProject`, the nearest ancestor containing one is used for `pkl project resolve`, so PKL dependency resolution keeps working unchanged.

## Why

The k8s plugin (and others with large/grouped fixture sets) needs to point conformance runs at a specific testdata folder without renaming or copying files. Using an env var follows the existing `FORMAE_TEST_*` pattern (`FORMAE_TEST_FILTER`, `FORMAE_TEST_TYPE`, etc.).

## Changes

- `pkg/plugin-conformance-tests/discovery.go`: new `ResolveTestDataDir(pluginPath)` and `FindPklProjectRoot(dir)` helpers; `DiscoverTestData` honors the env var.
- `pkg/plugin-conformance-tests/harness.go`: `NewTestHarness` resolves testdata via the env var and walks up to the nearest `PklProject` for `pkl project resolve`.
- `pkg/plugin-conformance-tests/runner.go`: documents the new env var in `RunCRUDTests`.
- `pkg/plugin-conformance-tests/discovery_test.go`: unit tests for resolution, walk-up, and end-to-end discovery with override.

## Backwards compatibility

Unset env var = identical behavior to before (`<plugin>/testdata`). All existing plugins keep working with no change.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (101 passed: 9 new + 92 existing)
- [x] Run a real plugin's conformance suite (e.g. k8s) with `FORMAE_TEST_TESTDATA_DIR` set to a subdirectory and confirm only those fixtures are picked up.