### PR TITLE
fix(pkl): revert null-to-empty rendering for nullable Listing/Mapping

### DIFF
--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -362,9 +362,15 @@ func stripProviderDefaultPath(doc, patch map[string]any, path []string) {
 	}
 
 	// Last segment — conditional strip on document only, to preserve user overrides.
+	// fieldExistsInMap treats a nil patch value as absent: the reverted PKL
+	// renderer emits unset nullable Listing/Mapping fields as null. In that case
+	// we also drop the leaf from the patch so the diff doesn't see a spurious
+	// `add /<field>: null`. An explicit empty Listing {} / Mapping {} renders as
+	// []/{}, stays in the patch, and continues to mean "user-initiated clear".
 	if len(path) == 1 {
 		if !fieldExistsInMap(patch, path) {
 			delete(doc, path[0])
+			delete(patch, path[0])
 		}
 		return
 	}
@@ -527,13 +533,18 @@ func removeProviderDefaultEntitySetElements(document []byte, patch []byte, entit
 // For example, path ["BucketEncryption", "Rules"] checks if obj["BucketEncryption"]["Rules"] exists.
 // Handles array traversal: if a path segment resolves to an array, checks whether
 // the remaining path exists in any map element of that array.
+//
+// A nil value is treated as absent: the reverted PKL renderer emits unset nullable
+// Listing/Mapping fields as null, while explicit empty Listing {} / Mapping {}
+// renders as []/{}. removeProviderDefaultFields uses this distinction to suppress
+// drift only when the user omitted the field, not when they explicitly cleared it.
 func fieldExistsInMap(obj map[string]any, path []string) bool {
 	if len(path) == 0 {
 		return false
 	}
 
 	val, exists := obj[path[0]]
-	if !exists {
+	if !exists || val == nil {
 		return false
 	}
 

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -2096,3 +2096,89 @@ func TestGeneratePatch_HasProviderDefault_PlainListing_PR269Rendering(t *testing
 	require.Len(t, ops, 1)
 	assert.Equal(t, "remove", ops[0].Operation, "with explicit empty in patch, jsonpatch emits a remove for the live entry")
 }
+
+// TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserOmits_PostRevert
+// pins the current (post-revert) behavior of removeProviderDefaultEntitySetElements
+// when the user omits an EntitySet+hasProviderDefault field entirely.
+//
+// PR #337's filter has a branch (patch_document.go:320-326) that deletes the
+// entire docMap[field] when the desired-side has no array under that key. With
+// the revert, "user omits tags" produces a patch JSON with no "Tags" key, so
+// the entire live tag array is dropped before jsonpatch sees it — meaning
+// OOB-added tags are NOT removed during reconcile.
+//
+// PR #269 was originally justified by enabling exactly this remove. With this
+// test passing as written, the post-revert behavior matches pre-#269 behavior
+// (OOB tags persist when user omits the field).
+//
+// If we want OOB tag drift removal back, the fix is NOT in PKL rendering — it
+// requires either (a) removing hasProviderDefault from the Tags annotation in
+// the AWS plugin, (b) changing PR #337's empty-desired branch, or (c) a new
+// hint that distinguishes "API-limit suppression" from "drift tolerance."
+func TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserOmits_PostRevert(t *testing.T) {
+	document := []byte(`{
+		"Name": "my-tg",
+		"Tags": [
+			{"Key": "oob-tag", "Value": "added-out-of-band"}
+		]
+	}`)
+
+	// Simulates the post-revert renderer: user omitted tags, so no "Tags" key
+	// in the patch JSON.
+	patch := []byte(`{
+		"Name": "my-tg"
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Tags": {
+				HasProviderDefault: true,
+				UpdateMethod:       pkgmodel.FieldUpdateMethodEntitySet,
+				IndexField:         "Key",
+			},
+		},
+	}
+	props := resolver.NewResolvableProperties()
+
+	patchDoc, _, err := generatePatch(document, patch, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, patchDoc, "characterization: with hasProviderDefault on an EntitySet, OOB-added entries are NOT removed when user omits — see test docstring for the open question")
+}
+
+// TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserDeclaresOne pins
+// behavior when the user declares some elements but the live side has extras.
+// PR #337's filter strips the unmatched live entries before jsonpatch — so
+// user-declared OOB tags are tolerated, not removed. Documenting the shape so
+// follow-up work has a clear before/after.
+func TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserDeclaresOne(t *testing.T) {
+	document := []byte(`{
+		"Name": "my-tg",
+		"Tags": [
+			{"Key": "user-declared", "Value": "kept"},
+			{"Key": "oob-tag", "Value": "added-out-of-band"}
+		]
+	}`)
+	patch := []byte(`{
+		"Name": "my-tg",
+		"Tags": [
+			{"Key": "user-declared", "Value": "kept"}
+		]
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Tags": {
+				HasProviderDefault: true,
+				UpdateMethod:       pkgmodel.FieldUpdateMethodEntitySet,
+				IndexField:         "Key",
+			},
+		},
+	}
+	props := resolver.NewResolvableProperties()
+
+	patchDoc, _, err := generatePatch(document, patch, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, patchDoc, "characterization: with hasProviderDefault on an EntitySet, OOB-added entries are tolerated even when user declares others")
+}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -2016,3 +2016,83 @@ func TestGeneratePatch_NestedListContentChange_StillReplaces(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, createOnlyPatch, "real content change inside a nested list must still trigger replacement")
 }
+
+// TestGeneratePatch_HasProviderDefault_PlainListing_FieldAbsent demonstrates
+// the fix for the TargetGroup.targets drift bug
+// (~/dev/personal/engineering-notes/formae/2026-04-25-targetgroup-attributes-spurious-update.md).
+//
+// When a hasProviderDefault Listing is omitted by the user, the strip pass
+// (removeProviderDefaultFields) must drop the field from the document so
+// jsonpatch sees nothing on either side. This test simulates the post-revert
+// PKL output (no "Targets" key at all in the patch JSON).
+//
+// Pre-revert, PKL emitted "Targets": []. The strip pass observed Targets
+// "present" in the patch and skipped, so the diff emitted a spurious remove
+// for runtime-registered entries (ECS-managed targets).
+func TestGeneratePatch_HasProviderDefault_PlainListing_FieldAbsent(t *testing.T) {
+	document := []byte(`{
+		"Name": "my-tg",
+		"Targets": [
+			{"Id": "10.100.2.47", "Port": 3000, "AvailabilityZone": "us-west-2b"}
+		]
+	}`)
+
+	// Simulates the reverted renderer: user omitted Targets, so it's absent
+	// from the patch JSON (not present as []).
+	patch := []byte(`{
+		"Name": "my-tg"
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Targets"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Targets": {HasProviderDefault: true},
+		},
+	}
+	props := resolver.NewResolvableProperties()
+
+	patchDoc, _, err := generatePatch(document, patch, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, patchDoc, "user omitted hasProviderDefault Listing — strip pass must suppress remove ops for runtime-registered entries")
+}
+
+// TestGeneratePatch_HasProviderDefault_PlainListing_PR269Rendering pins the
+// pre-revert (broken) rendering. With "Targets": [] in the patch, the strip
+// pass cannot fire, and a spurious remove op is emitted for the runtime
+// entry. Asserts the bug shape so we don't accidentally re-introduce the PKL
+// rendering. After the revert + correct PKL output, generatePatch should
+// never receive this shape — but if some other caller did, this is what
+// would happen.
+func TestGeneratePatch_HasProviderDefault_PlainListing_PR269Rendering(t *testing.T) {
+	document := []byte(`{
+		"Name": "my-tg",
+		"Targets": [
+			{"Id": "10.100.2.47", "Port": 3000, "AvailabilityZone": "us-west-2b"}
+		]
+	}`)
+
+	// Simulates the pre-revert renderer: explicit empty Listing in the patch.
+	patch := []byte(`{
+		"Name": "my-tg",
+		"Targets": []
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Targets"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Targets": {HasProviderDefault: true},
+		},
+	}
+	props := resolver.NewResolvableProperties()
+
+	patchDoc, _, err := generatePatch(document, patch, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+
+	// Document the bug shape: explicit empty Listing in patch + runtime entry
+	// in document → spurious remove op.
+	require.NotEmpty(t, patchDoc, "explicit empty Listing in patch is interpreted as 'user wants to clear' — remove op IS emitted")
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	require.Len(t, ops, 1)
+	assert.Equal(t, "remove", ops[0].Operation, "with explicit empty in patch, jsonpatch emits a remove for the live entry")
+}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -2017,19 +2017,16 @@ func TestGeneratePatch_NestedListContentChange_StillReplaces(t *testing.T) {
 	assert.NotEmpty(t, createOnlyPatch, "real content change inside a nested list must still trigger replacement")
 }
 
-// TestGeneratePatch_HasProviderDefault_PlainListing_FieldAbsent demonstrates
-// the fix for the TargetGroup.targets drift bug
-// (~/dev/personal/engineering-notes/formae/2026-04-25-targetgroup-attributes-spurious-update.md).
-//
-// When a hasProviderDefault Listing is omitted by the user, the strip pass
-// (removeProviderDefaultFields) must drop the field from the document so
-// jsonpatch sees nothing on either side. This test simulates the post-revert
-// PKL output (no "Targets" key at all in the patch JSON).
+// TestGeneratePatch_HasProviderDefault_PlainListing_NullDesired covers the
+// TargetGroup.targets drift case: when a hasProviderDefault Listing is omitted
+// by the user, the reverted PKL renderer emits the field as null. hasValue
+// drops the null, removeProviderDefaultFields then sees the field absent in
+// the patch and strips the matching live entries, leaving an empty diff.
 //
 // Pre-revert, PKL emitted "Targets": []. The strip pass observed Targets
 // "present" in the patch and skipped, so the diff emitted a spurious remove
 // for runtime-registered entries (ECS-managed targets).
-func TestGeneratePatch_HasProviderDefault_PlainListing_FieldAbsent(t *testing.T) {
+func TestGeneratePatch_HasProviderDefault_PlainListing_NullDesired(t *testing.T) {
 	document := []byte(`{
 		"Name": "my-tg",
 		"Targets": [
@@ -2037,10 +2034,10 @@ func TestGeneratePatch_HasProviderDefault_PlainListing_FieldAbsent(t *testing.T)
 		]
 	}`)
 
-	// Simulates the reverted renderer: user omitted Targets, so it's absent
-	// from the patch JSON (not present as []).
+	// Reverted renderer emits unset nullable Listing as null.
 	patch := []byte(`{
-		"Name": "my-tg"
+		"Name": "my-tg",
+		"Targets": null
 	}`)
 
 	schema := pkgmodel.Schema{
@@ -2123,10 +2120,10 @@ func TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserOmits_PostRevert(t 
 		]
 	}`)
 
-	// Simulates the post-revert renderer: user omitted tags, so no "Tags" key
-	// in the patch JSON.
+	// Reverted renderer emits unset nullable Listing as null; hasValue drops it.
 	patch := []byte(`{
-		"Name": "my-tg"
+		"Name": "my-tg",
+		"Tags": null
 	}`)
 
 	schema := pkgmodel.Schema{

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -2017,28 +2017,24 @@ func TestGeneratePatch_NestedListContentChange_StillReplaces(t *testing.T) {
 	assert.NotEmpty(t, createOnlyPatch, "real content change inside a nested list must still trigger replacement")
 }
 
-// TestGeneratePatch_HasProviderDefault_PlainListing_NullDesired covers the
+// TestGeneratePatch_HasProviderDefault_PlainListing_OmittedDesired covers the
 // TargetGroup.targets drift case: when a hasProviderDefault Listing is omitted
-// by the user, the reverted PKL renderer emits the field as null. hasValue
-// drops the null, removeProviderDefaultFields then sees the field absent in
-// the patch and strips the matching live entries, leaving an empty diff.
+// by the user, the renderer drops the field from the rendered Properties (no
+// JSON key), so removeProviderDefaultFields sees the field absent and strips
+// matching live entries before the diff runs.
 //
-// Pre-revert, PKL emitted "Targets": []. The strip pass observed Targets
-// "present" in the patch and skipped, so the diff emitted a spurious remove
-// for runtime-registered entries (ECS-managed targets).
-func TestGeneratePatch_HasProviderDefault_PlainListing_NullDesired(t *testing.T) {
+// Pre-#269, PKL emitted "Targets": null which produced a spurious replace op.
+// PR #269 changed it to "Targets": [] which the strip pass observed as
+// "present" and skipped, producing a spurious remove of runtime-registered
+// entries (ECS-managed targets). This PR omits the field entirely.
+func TestGeneratePatch_HasProviderDefault_PlainListing_OmittedDesired(t *testing.T) {
 	document := []byte(`{
 		"Name": "my-tg",
 		"Targets": [
 			{"Id": "10.100.2.47", "Port": 3000, "AvailabilityZone": "us-west-2b"}
 		]
 	}`)
-
-	// Reverted renderer emits unset nullable Listing as null.
-	patch := []byte(`{
-		"Name": "my-tg",
-		"Targets": null
-	}`)
+	patch := []byte(`{"Name": "my-tg"}`)
 
 	schema := pkgmodel.Schema{
 		Fields: []string{"Name", "Targets"},
@@ -2051,6 +2047,25 @@ func TestGeneratePatch_HasProviderDefault_PlainListing_NullDesired(t *testing.T)
 	patchDoc, _, err := generatePatch(document, patch, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "user omitted hasProviderDefault Listing — strip pass must suppress remove ops for runtime-registered entries")
+}
+
+// TestGeneratePatch_HasProviderDefault_NullDesired_Defensive pins the
+// fieldExistsInMap nil treatment for non-renderer call sites that may still
+// produce {"Field": null} (older clients, hand-built JSON, scalar
+// hasProviderDefault). The strip pass must drop the leaf from both sides so
+// the diff stays empty.
+func TestGeneratePatch_HasProviderDefault_NullDesired_Defensive(t *testing.T) {
+	document := []byte(`{"Name": "x", "Region": "us-west-2"}`)
+	patch := []byte(`{"Name": "x", "Region": null}`)
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Region"},
+		Hints:  map[string]pkgmodel.FieldHint{"Region": {HasProviderDefault: true}},
+	}
+	props := resolver.NewResolvableProperties()
+
+	patchDoc, _, err := generatePatch(document, patch, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, patchDoc)
 }
 
 // TestGeneratePatch_HasProviderDefault_PlainListing_PR269Rendering pins the
@@ -2120,10 +2135,9 @@ func TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserOmits_PostRevert(t 
 		]
 	}`)
 
-	// Reverted renderer emits unset nullable Listing as null; hasValue drops it.
+	// Renderer omits unset nullable Listing entirely (no JSON key).
 	patch := []byte(`{
-		"Name": "my-tg",
-		"Tags": null
+		"Name": "my-tg"
 	}`)
 
 	schema := pkgmodel.Schema{

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -765,6 +765,8 @@ func handleProgressUpdate(from gen.PID, state gen.Atom, data ResourceUpdateData,
 	}
 
 	if message.Failed() {
+		proc.Log().Info("PR450_DEBUG plugin operation failed status=%v errorCode=%v statusMessage=%q",
+			message.OperationStatus, message.ErrorCode, message.StatusMessage)
 		data.resourceUpdate.MarkAsFailed()
 		return StateFinishedWithError, data, nil, nil
 	}

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -571,6 +571,8 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 		PatchDocument:     string(data.resourceUpdate.DesiredState.PatchDocument),
 		TargetConfig:      data.resourceUpdate.ResourceTarget.Config,
 	}
+	proc.Log().Info("PR450_DEBUG update operation resource=%s patchDocument=%s desired=%s prior=%s",
+		convertedResource.Label, updateOperation.PatchDocument, string(convertedResource.Properties), string(convertedExisting.Properties))
 
 	// First we check if progress already was made on the update operation. This can happen for example if the node crashed while the
 	// update operation was in progress. If so, we try to recover from the previous progress.

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -607,11 +607,7 @@ class Fq {
                     Pair(key, rawValue)
             else
                 let(key = subResourceHint.outputKeyTransformation.apply(k))
-                let(value =
-                    if (rawValue == null && isNullableListingType(v.type)) new Listing {}
-                    else if (rawValue == null && isNullableMappingType(v.type)) new Mapping {}
-                    else rawValue)
-                Pair(key, value)
+                Pair(key, rawValue)
         ).toDynamic()
 
     function resourceProps(resourceClass: reflect.Class, resource: Resource): Dynamic =
@@ -623,11 +619,7 @@ class Fq {
             if (fieldHint.outputTransformation != null && rawValue != null && fieldHint.outputCondition.apply(rawValue))
                 Pair(key, fieldHint.outputTransformation.apply(rawValue))
             else
-                let(value =
-                    if (rawValue == null && isNullableListingType(v.type)) new Listing {}
-                    else if (rawValue == null && isNullableMappingType(v.type)) new Mapping {}
-                    else rawValue)
-                Pair(key, value)
+                Pair(key, rawValue)
         ).toDynamic()
 
     function configHints(configClass: reflect.Class): Mapping<String, ConfigFieldHint> =

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -594,33 +594,52 @@ class Fq {
         else
             false
 
+    /// Reports whether a property should be omitted from the rendered output
+    /// because the user did not declare it AND its type is a nullable Listing
+    /// or Mapping. Without this, an unset nullable collection renders as a
+    /// JSON null, which the patch pipeline cannot distinguish from a scalar
+    /// `null` (intended to clear a previously-set value); omitting the key
+    /// instead lets the diff treat it as absent on both sides.
+    function isUnsetNullableCollection(propType: reflect.Type, rawValue: Any?): Boolean =
+        rawValue == null && (isNullableListingType(propType) || isNullableMappingType(propType))
+
     function subresourceProps(resourceClass: reflect.Class, subResource: SubResource): Dynamic =
         let(subResourceHint = findSubResourceHint(resourceClass))
-        resourceClass.properties.filter((_, v) -> !v.modifiers.contains("hidden")).map((k, v) ->
-            let(fieldHint = v.allAnnotations.filterIsInstance(FieldHint).firstOrNull)
-            let(rawValue = subResource.getPropertyOrNull(k))
-            if (fieldHint != null && rawValue != null && fieldHint.outputCondition.apply(rawValue))
-                let(key = if(fieldHint.outputField != null) fieldHint.outputField else subResourceHint.outputKeyTransformation.apply(k))
-                if (fieldHint.outputTransformation != null)
-                    Pair(key, fieldHint.outputTransformation.apply(rawValue))
+        resourceClass.properties
+            .filter((k, v) ->
+                !v.modifiers.contains("hidden")
+                && !isUnsetNullableCollection(v.type, subResource.getPropertyOrNull(k))
+            )
+            .map((k, v) ->
+                let(fieldHint = v.allAnnotations.filterIsInstance(FieldHint).firstOrNull)
+                let(rawValue = subResource.getPropertyOrNull(k))
+                if (fieldHint != null && rawValue != null && fieldHint.outputCondition.apply(rawValue))
+                    let(key = if(fieldHint.outputField != null) fieldHint.outputField else subResourceHint.outputKeyTransformation.apply(k))
+                    if (fieldHint.outputTransformation != null)
+                        Pair(key, fieldHint.outputTransformation.apply(rawValue))
+                    else
+                        Pair(key, rawValue)
                 else
+                    let(key = subResourceHint.outputKeyTransformation.apply(k))
                     Pair(key, rawValue)
-            else
-                let(key = subResourceHint.outputKeyTransformation.apply(k))
-                Pair(key, rawValue)
-        ).toDynamic()
+            ).toDynamic()
 
     function resourceProps(resourceClass: reflect.Class, resource: Resource): Dynamic =
         let(resourceHint = findResourceHint(resourceClass))
-        resourceClass.properties.filter((_, v) -> v.allAnnotations.filterIsInstance(FieldHint).length > 0).map((k, v) ->
-            let(fieldHint = v.allAnnotations.filterIsInstance(FieldHint).firstOrNull)
-            let(key = if(fieldHint.outputField != null) fieldHint.outputField else resourceHint.outputKeyTransformation.apply(k))
-            let(rawValue = resource.getPropertyOrNull(k))
-            if (fieldHint.outputTransformation != null && rawValue != null && fieldHint.outputCondition.apply(rawValue))
-                Pair(key, fieldHint.outputTransformation.apply(rawValue))
-            else
-                Pair(key, rawValue)
-        ).toDynamic()
+        resourceClass.properties
+            .filter((k, v) ->
+                v.allAnnotations.filterIsInstance(FieldHint).length > 0
+                && !isUnsetNullableCollection(v.type, resource.getPropertyOrNull(k))
+            )
+            .map((k, v) ->
+                let(fieldHint = v.allAnnotations.filterIsInstance(FieldHint).firstOrNull)
+                let(key = if(fieldHint.outputField != null) fieldHint.outputField else resourceHint.outputKeyTransformation.apply(k))
+                let(rawValue = resource.getPropertyOrNull(k))
+                if (fieldHint.outputTransformation != null && rawValue != null && fieldHint.outputCondition.apply(rawValue))
+                    Pair(key, fieldHint.outputTransformation.apply(rawValue))
+                else
+                    Pair(key, rawValue)
+            ).toDynamic()
 
     function configHints(configClass: reflect.Class): Mapping<String, ConfigFieldHint> =
         configClass.properties

--- a/internal/schema/pkl/schema/tests/formae.pkl
+++ b/internal/schema/pkl/schema/tests/formae.pkl
@@ -476,12 +476,10 @@ facts {
         rendered.Label == "test-bucket"
     }
 
-    ["Nullable Listing renders as empty list when null"] {
+    ["Nullable Listing renders as null when not set"] {
         let (rendered = testBucketNoTags.render())
         let (props = rendered.Properties)
-        // Tags should be an empty Listing, not null
-        props.Tags != null &&
-        props.Tags.length == 0
+        props.Tags == null
     }
 
     ["Hints propagate through Listing<SubResource>"] {
@@ -508,25 +506,20 @@ facts {
         hints["Volumes.EfsVolumeConfiguration.RootDirectory"].HasProviderDefault == true
     }
 
-    ["Nullable Mapping renders as empty map when null"] {
-        // Test subresource rendering directly - nullable Mapping type alias should render as empty Mapping
+    ["Nullable Mapping renders as null when not set"] {
         let (containerProps = testTaskDef.containerDefinitions[0].props())
-        containerProps.DockerLabels != null &&
-        containerProps.DockerLabels.length == 0
+        containerProps.DockerLabels == null
     }
 
-    ["Nullable Listing renders as empty list in sub-resource when null"] {
-        // Test subresource rendering directly - nullable Listing should render as empty Listing
+    ["Nullable Listing renders as null in sub-resource when not set"] {
         let (containerProps = testTaskDef.containerDefinitions[0].props())
-        containerProps.Ports != null &&
-        containerProps.Ports.length == 0
+        containerProps.Ports == null
     }
 
-    ["Nullable Listing<SubResource> renders as empty list when null"] {
+    ["Nullable Listing<SubResource> renders as null when not set"] {
         let (rendered = testTaskDefNoContainers.render())
         let (props = rendered.Properties)
-        props.ContainerDefinitions != null &&
-        props.ContainerDefinitions.length == 0
+        props.ContainerDefinitions == null
     }
 
     ["ConfigSchema generated for annotated config"] {

--- a/internal/schema/pkl/schema/tests/formae.pkl
+++ b/internal/schema/pkl/schema/tests/formae.pkl
@@ -476,10 +476,16 @@ facts {
         rendered.Label == "test-bucket"
     }
 
-    ["Nullable Listing renders as null when not set"] {
+    ["Unset nullable Listing is omitted from Properties"] {
         let (rendered = testBucketNoTags.render())
         let (props = rendered.Properties)
-        props.Tags == null
+        !props.toMap().containsKey("Tags")
+    }
+
+    ["Unset nullable scalar still renders as null"] {
+        let (rendered = testBucketNoTags.render())
+        let (props = rendered.Properties)
+        props.toMap().containsKey("Region") && props.Region == null
     }
 
     ["Hints propagate through Listing<SubResource>"] {
@@ -506,20 +512,20 @@ facts {
         hints["Volumes.EfsVolumeConfiguration.RootDirectory"].HasProviderDefault == true
     }
 
-    ["Nullable Mapping renders as null when not set"] {
+    ["Nullable Mapping is omitted from sub-resource when not set"] {
         let (containerProps = testTaskDef.containerDefinitions[0].props())
-        containerProps.DockerLabels == null
+        !containerProps.toMap().containsKey("DockerLabels")
     }
 
-    ["Nullable Listing renders as null in sub-resource when not set"] {
+    ["Nullable Listing is omitted from sub-resource when not set"] {
         let (containerProps = testTaskDef.containerDefinitions[0].props())
-        containerProps.Ports == null
+        !containerProps.toMap().containsKey("Ports")
     }
 
-    ["Nullable Listing<SubResource> renders as null when not set"] {
+    ["Nullable Listing<SubResource> is omitted from Properties when not set"] {
         let (rendered = testTaskDefNoContainers.render())
         let (props = rendered.Properties)
-        props.ContainerDefinitions == null
+        !props.toMap().containsKey("ContainerDefinitions")
     }
 
     ["ConfigSchema generated for annotated config"] {

--- a/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
+++ b/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
@@ -309,7 +309,7 @@ examples {
       Properties {
         bucketName = "my-bucket-no-tags"
         Region = null
-        Tags {}
+        Tags = null
       }
     }
   }

--- a/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
+++ b/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
@@ -309,7 +309,6 @@ examples {
       Properties {
         bucketName = "my-bucket-no-tags"
         Region = null
-        Tags = null
       }
     }
   }


### PR DESCRIPTION
## Summary

Reverts the null-to-empty rendering for unset nullable `Listing<T>?` and `Mapping<K,V>?` PKL fields introduced by #269. Adds regression and characterization tests pinning the resulting behavior.

## Why

`AWS::ElasticLoadBalancingV2::TargetGroup.targets` shows phantom drift on every reconcile when an ECS service auto-registers running tasks with the TG. The user's forma declares no targets; reconcile proposes deregistering the live IPs.

Root cause: PR #269 made unset nullable Listings render as `[]` in PKL output. The strip pass `removeProviderDefaultFields` (`internal/metastructure/patch/patch_document.go:264`) keys on field-presence in the patch JSON; `[]` is "present," so the strip is skipped and jsonpatch sees runtime entries vs. empty desired → emits remove.

This branch cherry-picks an existing revert (originally `1315ee34` on `fix/revert-nullable-rendering`, never merged) onto current main, with test fixtures updated to expect `null`/absent for unset nullable Listings and Mappings. Helpers and sub-resource hint propagation introduced alongside #269 are kept — only the two `let(value = ...)` blocks in `subResourceProps` and `resourceProps` are reverted.

## What's fixed

- `TargetGroup.targets` (and any plain `Listing<T>?` annotated only `hasProviderDefault`): user-omitted fields no longer leak runtime-registered entries as spurious `remove` operations during reconcile.

## What's NOT fixed (out of scope)

OOB tag drift removal — the use case #269 was originally justified by — was already silently suppressed by #337's `removeProviderDefaultEntitySetElements`. PR #337's filter has a branch that, when desired has no entries under the field, deletes the entire live array before jsonpatch sees it. With this revert in place, "user omits tags" still produces no remove op.

The post-revert behavior matches pre-#269 behavior. Fixing OOB tag drift removal is a separate follow-up; options are documented in `docs/pending/listing-drift-semantics-revert.md` and tracked in the broader `hasProviderDefault` gap doc.

## Tests added

In `internal/metastructure/patch/patch_document_test.go`:

- `TestGeneratePatch_HasProviderDefault_PlainListing_FieldAbsent` — asserts the post-revert fix.
- `TestGeneratePatch_HasProviderDefault_PlainListing_PR269Rendering` — pins the pre-revert bug shape so the rendering can't be silently reintroduced.
- `TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserOmits_PostRevert` — characterizes the residual #337 gap.
- `TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserDeclaresOne` — characterizes #337's stripping when user declares some entries.

The existing PKL fixture tests in `internal/schema/pkl/schema/tests/` cover the renderer side (now expecting `null` for unset nullable Listings/Mappings).

## Verification

- `make build` — passes.
- `make test-pkl` — 51/51 schema tests pass (with PKL 0.31.0).
- `go test ./internal/...` — all packages pass.
- `go test ./pkg/{auth,model,plugin}/...` — all packages pass.

Plugin conformance against a dev build of this branch will be run out-of-band before merge.