### PR TITLE
fix(extract): include registered plugins in dependency resolution

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -78,45 +78,58 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Each matrix entry installs plugins via one or both of:
+        #   system_plugins: orbital install (`formae plugin install`) — lands
+        #                   in the binary's SystemPluginDir.
+        #   user_plugins:   make install from the plugin repo — lands in
+        #                   ~/.pel/formae/plugins (cfg.PluginDir).
+        # The agent's multi-source discovery finds plugins from both dirs.
         include:
           - test: TestReconcileApply
-            plugins: aws azure
+            system_plugins: aws azure
           - test: TestPatchApply
-            plugins: aws azure
+            system_plugins: aws azure
           - test: TestDiscovery
-            plugins: aws azure
+            system_plugins: aws azure
           - test: TestSoftReconcile
-            plugins: aws azure
+            system_plugins: aws azure
           - test: TestHardReconcile
-            plugins: aws azure
+            system_plugins: aws azure
           - test: TestReplace
-            plugins: aws azure
+            system_plugins: aws azure
           - test: TestAutoReconcile
-            plugins: aws
+            system_plugins: aws
           - test: TestTTL
-            plugins: aws
+            system_plugins: aws
           - test: TestCancelCommand
-            plugins: aws
+            system_plugins: aws
           - test: TestCascadeDelete
-            plugins: aws
+            system_plugins: aws
           - test: TestTargetResolvable
-            plugins: compose grafana
+            system_plugins: compose grafana
           - test: TestProjectInit
-            plugins: aws azure
+            system_plugins: aws azure
           - test: TestSimulateApply
-            plugins: aws
+            system_plugins: aws
           - test: TestExtractAndReapply
-            plugins: aws
+            system_plugins: aws
           - test: TestEvalDefault
-            plugins: aws
+            system_plugins: aws
           - test: TestEvalSchemaLocationLocal
-            plugins: aws
+            system_plugins: aws
           - test: TestExtractSchemaLocationLocal
-            plugins: aws
+            system_plugins: aws
+          # User-install variant: aws is `make install`'d from its repo
+          # (not in orbital's tree) so the merge code path in
+          # listPluginsHandler is the only thing that can surface its
+          # LocalPath for --schema-location local. Catches regressions in
+          # the orbital-vs-registered union.
+          - test: TestExtractSchemaLocationLocal
+            user_plugins: aws
           - test: TestAuthBasic
-            plugins: auth-basic
+            system_plugins: auth-basic
           - test: TestPluginConfig
-            plugins: sftp
+            system_plugins: sftp
 
     steps:
       - uses: actions/checkout@v4
@@ -170,7 +183,8 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Install plugins via orbital
+      - name: Install system plugins via orbital
+        if: ${{ matrix.system_plugins }}
         run: |
           set -euo pipefail
 
@@ -229,22 +243,43 @@ jobs:
           # Install only the plugins this test needs. The agent refreshes
           # orbital's repository cache at startup, so the install candidate
           # solver has fresh metadata to work with.
-          dist/e2e/bin/formae plugin install ${{ matrix.plugins }} --channel stable
+          dist/e2e/bin/formae plugin install ${{ matrix.system_plugins }} --channel stable
 
           # Stop the bootstrap agent so the test harness can spawn its own.
           kill -TERM "$AGENT_PID" || true
           wait "$AGENT_PID" 2>/dev/null || true
           rm -f /tmp/bootstrap.pid /tmp/bootstrap.db /tmp/bootstrap.conf.pkl
 
+      - name: Install user plugins via make install
+        if: ${{ matrix.user_plugins }}
+        run: |
+          set -euo pipefail
+
+          # Mirror the dev workflow: clone the plugin repo, run `make install`.
+          # Lands in ~/.pel/formae/plugins/<name>/v<version>/, which is
+          # cfg.PluginDir's default — the test agent's multi-source discovery
+          # finds it without any config override. Crucially, orbital has no
+          # record of these plugins, so the agent surfaces them only via the
+          # PluginCoordinator-registered merge path in listPluginsHandler.
+          for plugin in ${{ matrix.user_plugins }}; do
+            git clone --depth=1 \
+              "https://github.com/platform-engineering-labs/formae-plugin-${plugin}.git" \
+              "/tmp/formae-plugin-${plugin}"
+            (cd "/tmp/formae-plugin-${plugin}" && make install)
+          done
+
       - name: Running ${{ matrix.test }}
         env:
           AWS_PROFILE: e2e-test
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          # Point setup_pkl.sh at the orbital-installed plugins. The agent's
-          # own multi-source discovery already finds them via the binary's
-          # SystemPluginDir, but setup_pkl.sh is a shell script that needs
-          # an explicit dir to read PklProject manifests from.
-          FORMAE_PLUGIN_DIR: ${{ github.workspace }}/dist/e2e/formae/plugins
+          # Point setup_pkl.sh at whichever tree has plugins. system_plugins
+          # land in dist/e2e/formae/plugins (orbital's SystemPluginDir);
+          # user_plugins land in ~/.pel/formae/plugins (make install
+          # default), which is also setup_pkl.sh's default — leave the
+          # var unset so the script's default applies.
+          FORMAE_PLUGIN_DIR: >-
+            ${{ matrix.user_plugins && ''
+                || format('{0}/dist/e2e/formae/plugins', github.workspace) }}
         run: >-
           make test-e2e
           E2E_RUN_FLAGS="-run ${{ matrix.test }}"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -274,11 +274,12 @@ jobs:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           # Point setup_pkl.sh at whichever tree has plugins. system_plugins
           # land in dist/e2e/formae/plugins (orbital's SystemPluginDir);
-          # user_plugins land in ~/.pel/formae/plugins (make install
-          # default), which is also setup_pkl.sh's default — leave the
-          # var unset so the script's default applies.
+          # user_plugins land in /home/runner/.pel/formae/plugins (make
+          # install default on ubuntu-latest). Hardcoded paths because
+          # GHA expressions can't read $HOME, and the empty-string
+          # alternative is falsy in `&& ''`/`|| ...` chains.
           FORMAE_PLUGIN_DIR: >-
-            ${{ matrix.user_plugins && ''
+            ${{ matrix.user_plugins && '/home/runner/.pel/formae/plugins'
                 || format('{0}/dist/e2e/formae/plugins', github.workspace) }}
         run: >-
           make test-e2e

--- a/internal/api/plugin_handlers.go
+++ b/internal/api/plugin_handlers.go
@@ -6,9 +6,11 @@ package api
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/plugin_manager"
 	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
 )
@@ -35,6 +37,17 @@ func (s *Server) listPluginsHandler(c echo.Context) error {
 	switch scope {
 	case "installed":
 		plugins, err = pm.List()
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+		registered, regErr := s.metastructure.RegisteredPlugins()
+		if regErr != nil {
+			// A registry hiccup shouldn't fail the listing; orbital
+			// data is still useful. Log and continue.
+			c.Logger().Warnf("plugin registry lookup failed: %v", regErr)
+			registered = nil
+		}
+		plugins = mergeRegisteredPlugins(plugins, registered, pm.DiscoverLocalPaths())
 	case "available":
 		plugins, err = pm.Available(plugin_manager.AvailableFilter{
 			Query:    c.QueryParam("q"),
@@ -42,11 +55,11 @@ func (s *Server) listPluginsHandler(c echo.Context) error {
 			Type:     c.QueryParam("type"),
 			Channel:  c.QueryParam("channel"),
 		})
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
 	default:
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid scope: must be 'installed' or 'available'")
-	}
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	return c.JSON(http.StatusOK, apimodel.ListPluginsResponse{
@@ -207,4 +220,43 @@ func toManagerPackageRefs(refs []apimodel.PackageRef) []plugin_manager.PackageRe
 		result = append(result, plugin_manager.PackageRef{Name: r.Name, Version: r.Version})
 	}
 	return result
+}
+
+// mergeRegisteredPlugins appends synthetic Plugin entries for any
+// registered namespace not already represented in the orbital list. This
+// is the `make install` from a plugin repo case: the agent has loaded
+// the plugin but orbital has no record. LocalPath is filled from disk
+// discovery so extract --schema-location local can resolve the schema.
+//
+// Orbital wins on overlap because it carries display-quality metadata
+// (Name, Category, Channel) the registry doesn't track. Empty namespaces
+// are skipped — they have nothing to route on and would collide on the
+// empty-string dedupe key.
+func mergeRegisteredPlugins(orbital []plugin_manager.Plugin, registered []messages.RegisteredPluginInfo, paths map[string]string) []plugin_manager.Plugin {
+	seen := make(map[string]bool, len(orbital))
+	for _, p := range orbital {
+		if ns := strings.ToLower(p.Namespace); ns != "" {
+			seen[ns] = true
+		}
+	}
+	for _, r := range registered {
+		ns := strings.ToLower(r.Namespace)
+		if ns == "" || seen[ns] {
+			continue
+		}
+		seen[ns] = true
+		orbital = append(orbital, plugin_manager.Plugin{
+			Name:             r.Namespace,
+			Kind:             "plugin",
+			Type:             "resource",
+			Namespace:        r.Namespace,
+			InstalledVersion: r.Version,
+			LocalPath:        paths[ns],
+			Metadata: map[string]map[string]string{
+				"display": {"kind": "plugin"},
+				"plugin":  {"type": "resource", "namespace": r.Namespace},
+			},
+		})
+	}
+	return orbital
 }

--- a/internal/api/plugin_handlers.go
+++ b/internal/api/plugin_handlers.go
@@ -36,18 +36,17 @@ func (s *Server) listPluginsHandler(c echo.Context) error {
 	var plugins []plugin_manager.Plugin
 	switch scope {
 	case "installed":
-		plugins, err = pm.List()
+		localPaths := pm.DiscoverLocalPaths()
+		plugins, err = pm.ListWithLocalPaths(localPaths)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
 		registered, regErr := s.metastructure.RegisteredPlugins()
 		if regErr != nil {
-			// A registry hiccup shouldn't fail the listing; orbital
-			// data is still useful. Log and continue.
 			c.Logger().Warnf("plugin registry lookup failed: %v", regErr)
 			registered = nil
 		}
-		plugins = mergeRegisteredPlugins(plugins, registered, pm.DiscoverLocalPaths())
+		plugins = mergeRegisteredPlugins(plugins, registered, localPaths)
 	case "available":
 		plugins, err = pm.Available(plugin_manager.AvailableFilter{
 			Query:    c.QueryParam("q"),
@@ -223,39 +222,29 @@ func toManagerPackageRefs(refs []apimodel.PackageRef) []plugin_manager.PackageRe
 }
 
 // mergeRegisteredPlugins appends synthetic Plugin entries for any
-// registered namespace not already represented in the orbital list. This
-// is the `make install` from a plugin repo case: the agent has loaded
-// the plugin but orbital has no record. LocalPath is filled from disk
-// discovery so extract --schema-location local can resolve the schema.
-//
-// Orbital wins on overlap because it carries display-quality metadata
-// (Name, Category, Channel) the registry doesn't track. Empty namespaces
-// are skipped — they have nothing to route on and would collide on the
-// empty-string dedupe key.
+// registered plugin not already represented in the orbital list — the
+// `make install` case. Dedupe is by plugin name (multiple plugins may
+// share a namespace).
 func mergeRegisteredPlugins(orbital []plugin_manager.Plugin, registered []messages.RegisteredPluginInfo, paths map[string]string) []plugin_manager.Plugin {
 	seen := make(map[string]bool, len(orbital))
 	for _, p := range orbital {
-		if ns := strings.ToLower(p.Namespace); ns != "" {
-			seen[ns] = true
+		if name := strings.ToLower(p.Name); name != "" {
+			seen[name] = true
 		}
 	}
 	for _, r := range registered {
-		ns := strings.ToLower(r.Namespace)
-		if ns == "" || seen[ns] {
+		name := strings.ToLower(r.Name)
+		if name == "" || seen[name] {
 			continue
 		}
-		seen[ns] = true
+		seen[name] = true
 		orbital = append(orbital, plugin_manager.Plugin{
-			Name:             r.Namespace,
+			Name:             r.Name,
 			Kind:             "plugin",
 			Type:             "resource",
 			Namespace:        r.Namespace,
 			InstalledVersion: r.Version,
-			LocalPath:        paths[ns],
-			Metadata: map[string]map[string]string{
-				"display": {"kind": "plugin"},
-				"plugin":  {"type": "resource", "namespace": r.Namespace},
-			},
+			LocalPath:        paths[name],
 		})
 	}
 	return orbital

--- a/internal/api/plugin_handlers_test.go
+++ b/internal/api/plugin_handlers_test.go
@@ -1,0 +1,107 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/plugin_manager"
+)
+
+func TestMergeRegisteredPlugins_OrbitalOnly(t *testing.T) {
+	orbital := []plugin_manager.Plugin{
+		{Name: "formae-plugin-aws", Namespace: "aws", InstalledVersion: "1.2.3", Type: "resource"},
+	}
+	got := mergeRegisteredPlugins(orbital, nil, nil)
+
+	assert.Equal(t, orbital, got)
+}
+
+// The make-install case: agent has registered the plugin, orbital has no
+// record. mergeRegisteredPlugins must surface a synthetic entry with the
+// disk-discovered LocalPath so extract --schema-location local can resolve
+// the schema.
+func TestMergeRegisteredPlugins_RegisteredNotInOrbital(t *testing.T) {
+	registered := []messages.RegisteredPluginInfo{
+		{Namespace: "azure", Version: "0.1.0"},
+	}
+	paths := map[string]string{"azure": "/plugins/azure/v0.1.0/schema/pkl/PklProject"}
+
+	got := mergeRegisteredPlugins(nil, registered, paths)
+
+	assert.Len(t, got, 1)
+	assert.Equal(t, "azure", got[0].Namespace)
+	assert.Equal(t, "azure", got[0].Name)
+	assert.Equal(t, "resource", got[0].Type)
+	assert.Equal(t, "plugin", got[0].Kind)
+	assert.Equal(t, "0.1.0", got[0].InstalledVersion)
+	assert.Equal(t, "/plugins/azure/v0.1.0/schema/pkl/PklProject", got[0].LocalPath)
+}
+
+// A registered plugin without a schema PklProject on disk (auth plugin, or
+// half-installed resource plugin) still surfaces, with empty LocalPath. A
+// downstream `--schema-location local` request will fail with the same-box
+// error rather than silently producing a broken URI.
+func TestMergeRegisteredPlugins_RegisteredWithoutLocalPath(t *testing.T) {
+	registered := []messages.RegisteredPluginInfo{
+		{Namespace: "azure", Version: "0.1.0"},
+	}
+
+	got := mergeRegisteredPlugins(nil, registered, map[string]string{})
+
+	assert.Len(t, got, 1)
+	assert.Equal(t, "azure", got[0].Namespace)
+	assert.Empty(t, got[0].LocalPath)
+}
+
+// A plugin known to both orbital and the registry must appear once. Orbital
+// is the canonical source for metadata (display name, category, channel),
+// so the orbital entry wins.
+func TestMergeRegisteredPlugins_OverlappingNamespace(t *testing.T) {
+	orbital := []plugin_manager.Plugin{
+		{Name: "formae-plugin-aws", Namespace: "aws", InstalledVersion: "1.2.3", Type: "resource"},
+	}
+	registered := []messages.RegisteredPluginInfo{
+		{Namespace: "aws", Version: "1.2.3"},
+	}
+
+	got := mergeRegisteredPlugins(orbital, registered, nil)
+
+	assert.Len(t, got, 1)
+	assert.Equal(t, "formae-plugin-aws", got[0].Name)
+}
+
+// Namespace match is case-insensitive: PluginCoordinator can register
+// either "Azure" or "azure" depending on the manifest, while orbital
+// metadata is conventionally lowercase. The merge must dedupe regardless.
+func TestMergeRegisteredPlugins_OverlappingNamespaceCaseInsensitive(t *testing.T) {
+	orbital := []plugin_manager.Plugin{
+		{Name: "formae-plugin-azure", Namespace: "azure", InstalledVersion: "0.1.0", Type: "resource"},
+	}
+	registered := []messages.RegisteredPluginInfo{
+		{Namespace: "Azure", Version: "0.1.0"},
+	}
+
+	got := mergeRegisteredPlugins(orbital, registered, nil)
+
+	assert.Len(t, got, 1)
+}
+
+// Registered entries with empty namespace are skipped — there's nothing to
+// route on, and they would collide on the empty-string key.
+func TestMergeRegisteredPlugins_SkipsEmptyNamespace(t *testing.T) {
+	registered := []messages.RegisteredPluginInfo{
+		{Namespace: "", Version: "0.1.0"},
+	}
+
+	got := mergeRegisteredPlugins(nil, registered, nil)
+
+	assert.Empty(t, got)
+}

--- a/internal/api/plugin_handlers_test.go
+++ b/internal/api/plugin_handlers_test.go
@@ -24,69 +24,55 @@ func TestMergeRegisteredPlugins_OrbitalOnly(t *testing.T) {
 	assert.Equal(t, orbital, got)
 }
 
-// The make-install case: agent has registered the plugin, orbital has no
-// record. mergeRegisteredPlugins must surface a synthetic entry with the
-// disk-discovered LocalPath so extract --schema-location local can resolve
-// the schema.
 func TestMergeRegisteredPlugins_RegisteredNotInOrbital(t *testing.T) {
 	registered := []messages.RegisteredPluginInfo{
-		{Namespace: "azure", Version: "0.1.0"},
+		{Name: "azure", Namespace: "azure", Version: "0.1.0"},
 	}
 	paths := map[string]string{"azure": "/plugins/azure/v0.1.0/schema/pkl/PklProject"}
 
 	got := mergeRegisteredPlugins(nil, registered, paths)
 
 	assert.Len(t, got, 1)
-	assert.Equal(t, "azure", got[0].Namespace)
 	assert.Equal(t, "azure", got[0].Name)
+	assert.Equal(t, "azure", got[0].Namespace)
 	assert.Equal(t, "resource", got[0].Type)
 	assert.Equal(t, "plugin", got[0].Kind)
 	assert.Equal(t, "0.1.0", got[0].InstalledVersion)
 	assert.Equal(t, "/plugins/azure/v0.1.0/schema/pkl/PklProject", got[0].LocalPath)
+	assert.Nil(t, got[0].Metadata)
 }
 
-// A registered plugin without a schema PklProject on disk (auth plugin, or
-// half-installed resource plugin) still surfaces, with empty LocalPath. A
-// downstream `--schema-location local` request will fail with the same-box
-// error rather than silently producing a broken URI.
 func TestMergeRegisteredPlugins_RegisteredWithoutLocalPath(t *testing.T) {
 	registered := []messages.RegisteredPluginInfo{
-		{Namespace: "azure", Version: "0.1.0"},
+		{Name: "azure", Namespace: "azure", Version: "0.1.0"},
 	}
 
 	got := mergeRegisteredPlugins(nil, registered, map[string]string{})
 
 	assert.Len(t, got, 1)
-	assert.Equal(t, "azure", got[0].Namespace)
 	assert.Empty(t, got[0].LocalPath)
 }
 
-// A plugin known to both orbital and the registry must appear once. Orbital
-// is the canonical source for metadata (display name, category, channel),
-// so the orbital entry wins.
-func TestMergeRegisteredPlugins_OverlappingNamespace(t *testing.T) {
+func TestMergeRegisteredPlugins_OverlappingName(t *testing.T) {
 	orbital := []plugin_manager.Plugin{
-		{Name: "formae-plugin-aws", Namespace: "aws", InstalledVersion: "1.2.3", Type: "resource"},
+		{Name: "aws", Namespace: "aws", InstalledVersion: "1.2.3", Type: "resource"},
 	}
 	registered := []messages.RegisteredPluginInfo{
-		{Namespace: "aws", Version: "1.2.3"},
+		{Name: "aws", Namespace: "aws", Version: "1.2.3"},
 	}
 
 	got := mergeRegisteredPlugins(orbital, registered, nil)
 
 	assert.Len(t, got, 1)
-	assert.Equal(t, "formae-plugin-aws", got[0].Name)
+	assert.Equal(t, "aws", got[0].Name)
 }
 
-// Namespace match is case-insensitive: PluginCoordinator can register
-// either "Azure" or "azure" depending on the manifest, while orbital
-// metadata is conventionally lowercase. The merge must dedupe regardless.
-func TestMergeRegisteredPlugins_OverlappingNamespaceCaseInsensitive(t *testing.T) {
+func TestMergeRegisteredPlugins_OverlappingNameCaseInsensitive(t *testing.T) {
 	orbital := []plugin_manager.Plugin{
-		{Name: "formae-plugin-azure", Namespace: "azure", InstalledVersion: "0.1.0", Type: "resource"},
+		{Name: "azure", Namespace: "azure", InstalledVersion: "0.1.0", Type: "resource"},
 	}
 	registered := []messages.RegisteredPluginInfo{
-		{Namespace: "Azure", Version: "0.1.0"},
+		{Name: "Azure", Namespace: "azure", Version: "0.1.0"},
 	}
 
 	got := mergeRegisteredPlugins(orbital, registered, nil)
@@ -94,11 +80,22 @@ func TestMergeRegisteredPlugins_OverlappingNamespaceCaseInsensitive(t *testing.T
 	assert.Len(t, got, 1)
 }
 
-// Registered entries with empty namespace are skipped — there's nothing to
-// route on, and they would collide on the empty-string key.
-func TestMergeRegisteredPlugins_SkipsEmptyNamespace(t *testing.T) {
+// Two plugins sharing a namespace but with different names must both
+// surface — dedupe is on plugin name, not namespace.
+func TestMergeRegisteredPlugins_MultiplePluginsPerNamespace(t *testing.T) {
 	registered := []messages.RegisteredPluginInfo{
-		{Namespace: "", Version: "0.1.0"},
+		{Name: "azure-storage", Namespace: "azure", Version: "0.1.0"},
+		{Name: "azure-network", Namespace: "azure", Version: "0.1.0"},
+	}
+
+	got := mergeRegisteredPlugins(nil, registered, nil)
+
+	assert.Len(t, got, 2)
+}
+
+func TestMergeRegisteredPlugins_SkipsEmptyName(t *testing.T) {
+	registered := []messages.RegisteredPluginInfo{
+		{Name: "", Namespace: "azure", Version: "0.1.0"},
 	}
 
 	got := mergeRegisteredPlugins(nil, registered, nil)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/changeset"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/stretchr/testify/assert"
@@ -65,15 +66,15 @@ type WrappedCheckTTLResponse struct {
 }
 
 type FakeMetastructure struct {
-	applyResponses      []WrappedCommandResponse
-	destroyResponses    []WrappedCommandResponse
-	extractResponses    []WrappedExtractResponse
-	targetResponses     []WrappedTargetResponse
-	listResponses       []WrappedListResponse
-	cancelResponses     []WrappedCancelResponse
-	driftResponses      []WrappedDriftResponse
-	reconcileResponses  []WrappedReconcileResponse
-	checkTTLResponses   []WrappedCheckTTLResponse
+	applyResponses     []WrappedCommandResponse
+	destroyResponses   []WrappedCommandResponse
+	extractResponses   []WrappedExtractResponse
+	targetResponses    []WrappedTargetResponse
+	listResponses      []WrappedListResponse
+	cancelResponses    []WrappedCancelResponse
+	driftResponses     []WrappedDriftResponse
+	reconcileResponses []WrappedReconcileResponse
+	checkTTLResponses  []WrappedCheckTTLResponse
 }
 
 func (m *FakeMetastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string) (*apimodel.SubmitCommandResponse, error) {
@@ -172,6 +173,10 @@ func (m *FakeMetastructure) Stats() (*apimodel.Stats, error) {
 		Version: "1.0.0",
 		AgentID: "test-agent",
 	}, nil
+}
+
+func (m *FakeMetastructure) RegisteredPlugins() ([]messages.RegisteredPluginInfo, error) {
+	return nil, nil
 }
 
 func TestServer_ApplyFormaSuccessResponse(t *testing.T) {

--- a/internal/metastructure/messages/plugin.go
+++ b/internal/metastructure/messages/plugin.go
@@ -70,6 +70,7 @@ type GetRegisteredPlugins struct{}
 // RegisteredPluginInfo contains basic information about a registered plugin
 // including the merged config (plugin defaults + user overrides).
 type RegisteredPluginInfo struct {
+	Name                    string
 	Namespace               string
 	Version                 string
 	NodeName                string

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -63,6 +63,7 @@ type MetastructureAPI interface {
 	ForceCheckTTL() (*apimodel.ForceCheckTTLResponse, error)
 	ListDrift(stack string) (*apimodel.ModifiedStack, error)
 	Stats() (*apimodel.Stats, error)
+	RegisteredPlugins() ([]messages.RegisteredPluginInfo, error)
 }
 
 type Metastructure struct {
@@ -1918,31 +1919,47 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 	), nil
 }
 
+// RegisteredPlugins returns plugins currently registered with the
+// PluginCoordinator. Used by Stats() and by the plugins API handler to
+// surface plugins the agent has loaded but orbital has no record of
+// (the `make install` from a plugin repo case).
+func (m *Metastructure) RegisteredPlugins() ([]messages.RegisteredPluginInfo, error) {
+	result, err := m.callActor(gen.ProcessID{Name: actornames.PluginCoordinator, Node: m.Node.Name()}, messages.GetRegisteredPlugins{})
+	if err != nil {
+		return nil, err
+	}
+	r, ok := result.(messages.GetRegisteredPluginsResult)
+	if !ok {
+		return nil, fmt.Errorf("unexpected response type %T from PluginCoordinator", result)
+	}
+	return r.Plugins, nil
+}
+
 func (m *Metastructure) Stats() (*apimodel.Stats, error) {
 	stats, err := m.Datastore.Stats()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get stats from datastore: %w", err)
 	}
 
-	// Get registered plugins from PluginCoordinator
-	var plugins []apimodel.PluginInfo
-	result, err := m.callActor(gen.ProcessID{Name: actornames.PluginCoordinator, Node: m.Node.Name()}, messages.GetRegisteredPlugins{})
-	if err == nil {
-		if pluginsResult, ok := result.(messages.GetRegisteredPluginsResult); ok {
-			for _, p := range pluginsResult.Plugins {
-				plugins = append(plugins, apimodel.PluginInfo{
-					Namespace:               p.Namespace,
-					Version:                 p.Version,
-					NodeName:                p.NodeName,
-					MaxRequestsPerSecond:    p.MaxRequestsPerSecond,
-					ResourceCount:           p.ResourceCount,
-					ResourceTypesToDiscover: p.ResourceTypesToDiscover,
-					RetryConfig:             p.RetryConfig,
-					LabelConfig:             &p.LabelConfig,
-					DiscoveryFilters:        p.DiscoveryFilters,
-				})
-			}
-		}
+	registered, regErr := m.RegisteredPlugins()
+	if regErr != nil {
+		// A registry hiccup shouldn't take down /stats; the rest of the
+		// payload is still useful. Log and continue with no plugins.
+		slog.Warn("plugin registry lookup failed; stats response will omit plugins", "error", regErr)
+	}
+	plugins := make([]apimodel.PluginInfo, 0, len(registered))
+	for _, p := range registered {
+		plugins = append(plugins, apimodel.PluginInfo{
+			Namespace:               p.Namespace,
+			Version:                 p.Version,
+			NodeName:                p.NodeName,
+			MaxRequestsPerSecond:    p.MaxRequestsPerSecond,
+			ResourceCount:           p.ResourceCount,
+			ResourceTypesToDiscover: p.ResourceTypesToDiscover,
+			RetryConfig:             p.RetryConfig,
+			LabelConfig:             &p.LabelConfig,
+			DiscoveryFilters:        p.DiscoveryFilters,
+		})
 	}
 
 	return &apimodel.Stats{

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator.go
@@ -36,6 +36,7 @@ type PluginCoordinator struct {
 
 // RegisteredPlugin contains information about a registered plugin
 type RegisteredPlugin struct {
+	Name                 string
 	Namespace            string
 	Version              string
 	NodeName             gen.Atom // Ergo node where plugin runs (for remote spawn)
@@ -204,6 +205,7 @@ func (c *PluginCoordinator) HandleMessage(from gen.PID, message any) error {
 		c.Log().Debug("Received capabilities for namespace %s: %d resources, %d schemas", msg.Namespace, len(caps.SupportedResources), len(caps.ResourceSchemas))
 
 		announced := RegisteredPlugin{
+			Name:                 msg.Name,
 			Namespace:            msg.Namespace,
 			Version:              msg.Version,
 			NodeName:             from.Node,
@@ -419,6 +421,7 @@ func (c *PluginCoordinator) getRegisteredPlugins() messages.GetRegisteredPlugins
 
 	for _, registered := range c.plugins {
 		plugins = append(plugins, messages.RegisteredPluginInfo{
+			Name:                    registered.Name,
 			Namespace:               registered.Namespace,
 			Version:                 registered.Version,
 			NodeName:                string(registered.NodeName),

--- a/internal/metastructure/plugin_manager/plugin_manager.go
+++ b/internal/metastructure/plugin_manager/plugin_manager.go
@@ -227,7 +227,7 @@ func (pm *PluginManager) List() ([]Plugin, error) {
 	if err != nil {
 		return nil, fmt.Errorf("listing installed packages: %w", err)
 	}
-	localPaths := pm.discoverLocalPaths()
+	localPaths := pm.DiscoverLocalPaths()
 	plugins := make([]Plugin, 0, len(pkgs))
 	for _, pkg := range pkgs {
 		if !isPluginPackage(pkg) {
@@ -245,12 +245,16 @@ func (pm *PluginManager) List() ([]Plugin, error) {
 	return plugins, nil
 }
 
-// discoverLocalPaths scans the configured plugin dirs and returns a map
+// DiscoverLocalPaths scans the configured plugin dirs and returns a map
 // from lowercase plugin name to the absolute path of the plugin's
 // PklProject file. Errors during scanning are logged and the partial
 // result is returned; an empty map means no on-disk plugins were found
 // (which is a valid state, not an error).
-func (pm *PluginManager) discoverLocalPaths() map[string]string {
+//
+// Public so the API layer can attach LocalPath to plugins surfaced from
+// the runtime registry that orbital does not know about (the `make
+// install` from a plugin repo case).
+func (pm *PluginManager) DiscoverLocalPaths() map[string]string {
 	if len(pm.pluginDirs) == 0 {
 		return map[string]string{}
 	}

--- a/internal/metastructure/plugin_manager/plugin_manager.go
+++ b/internal/metastructure/plugin_manager/plugin_manager.go
@@ -223,11 +223,17 @@ func versionString(v *ops.Version) string {
 // LocalPath="" — consumers should treat that as "no on-disk install
 // available".
 func (pm *PluginManager) List() ([]Plugin, error) {
+	return pm.ListWithLocalPaths(pm.DiscoverLocalPaths())
+}
+
+// ListWithLocalPaths is List() with caller-provided disk-discovery paths.
+// Used by callers that already need the paths map (e.g. the API handler
+// attaching LocalPath to registered-only plugins) to avoid a second scan.
+func (pm *PluginManager) ListWithLocalPaths(localPaths map[string]string) ([]Plugin, error) {
 	pkgs, err := pm.listOrb.List()
 	if err != nil {
 		return nil, fmt.Errorf("listing installed packages: %w", err)
 	}
-	localPaths := pm.DiscoverLocalPaths()
 	plugins := make([]Plugin, 0, len(pkgs))
 	for _, pkg := range pkgs {
 		if !isPluginPackage(pkg) {


### PR DESCRIPTION
Problem: 

`extract --schema-location local` drops make install'd plugins. Orbital has no record, so the agent's listing skips them, even though the plugin is loaded and serving requests just fine

Solution:

Merge the installed-plugin list (orbital view) with the agent's registered-plugin list (same source Stats() already pulls from)