### PR TITLE
fix(datastore): URL-encode userinfo in postgres connection string

### DIFF
--- a/internal/datastore/postgres/connstr_test.go
+++ b/internal/datastore/postgres/connstr_test.go
@@ -9,7 +9,9 @@ package postgres
 import (
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildConnStr_TCPHost(t *testing.T) {
@@ -38,4 +40,41 @@ func TestBuildConnStr_CloudSQLSocket(t *testing.T) {
 	want := "host=/cloudsql/my-project:us-central1:my-instance user=postgres password=secret dbname=formae"
 
 	assert.Equal(t, want, got)
+}
+
+// Reserved characters in passwords (e.g. those produced by RDS-managed master
+// credential generation) must be percent-encoded so that the resulting URI
+// parses unambiguously and pgx recovers the original password byte-for-byte
+// during SASL auth.
+func TestBuildConnStr_PasswordWithReservedChars(t *testing.T) {
+	cases := []struct {
+		name string
+		pw   string
+	}{
+		{"rds-style", "Ql1b!9<(u2eWPA#4!bUBXAZos*L("},
+		{"colon-and-at", "p:a@s/s?w#o[r]d"},
+		{"percent-and-plus", "abc%def+ghi"},
+		{"empty", ""},
+		{"only-reserved", "!*'();:@&=+$,/?#[]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := BuildConnStr("db.example.com", 5432, "formae", tc.pw, "formae")
+			cfg, err := pgx.ParseConfig(s)
+			require.NoError(t, err, "pgx must accept the produced connection string")
+			assert.Equal(t, tc.pw, cfg.Password, "password must round-trip through pgx parser")
+			assert.Equal(t, "formae", cfg.User)
+			assert.Equal(t, "db.example.com", cfg.Host)
+			assert.Equal(t, uint16(5432), cfg.Port)
+			assert.Equal(t, "formae", cfg.Database)
+		})
+	}
+}
+
+func TestBuildConnStr_UserWithReservedChars(t *testing.T) {
+	s := BuildConnStr("db.example.com", 5432, "user@with:reserved", "pw", "db")
+	cfg, err := pgx.ParseConfig(s)
+	require.NoError(t, err)
+	assert.Equal(t, "user@with:reserved", cfg.User)
+	assert.Equal(t, "pw", cfg.Password)
 }

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strings"
 	"time"
 
@@ -56,11 +57,21 @@ type DatastorePostgres struct {
 // BuildConnStr constructs a PostgreSQL connection string from config fields.
 // Unix socket hosts (starting with /) use DSN key-value format to avoid
 // URI parsing issues with colons in paths like /cloudsql/project:region:instance.
+//
+// User and password are percent-encoded per RFC 3986 userinfo rules so that
+// passwords containing reserved characters (e.g. RDS-managed master passwords
+// with `!`, `<`, `(`, `:`, `#`, `*`) round-trip cleanly through pgx's URL parser.
 func BuildConnStr(host string, port int, user, password, database string) string {
 	if strings.HasPrefix(host, "/") {
 		return fmt.Sprintf("host=%s user=%s password=%s dbname=%s", host, user, password, database)
 	}
-	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s", user, password, host, port, database)
+	u := url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(user, password),
+		Host:   fmt.Sprintf("%s:%d", host, port),
+		Path:   "/" + database,
+	}
+	return u.String()
 }
 
 // This can be only used in tests or in setups where we have access to admin (non-production)


### PR DESCRIPTION
## Summary
- `BuildConnStr` produced an unparseable URI when the password contained URL-reserved characters (`:`, `@`, `/`, `?`, `#`, `[`, `]`, `!`, `(`, `)`, `<`, `*`, `%`, ...). RDS-managed master credentials routinely include several of these, which broke the prod agent on every rotation with SQLSTATE 28P01 SASL auth failures.
- Switch to `net/url.URL` with `url.UserPassword` so user and password are percent-encoded per RFC 3986 userinfo rules. pgx percent-decodes back to the original bytes before SASL auth, so operators no longer need to pre-encode passwords in stored config.
- Add tests covering RDS-style passwords, all sub-delim/reserved chars, empty password, and pgx round-trip parsing.