### PR TITLE
test(pkl): verify tfvars reader accepts absolute paths

### DIFF
--- a/internal/schema/pkl/pkl_test.go
+++ b/internal/schema/pkl/pkl_test.go
@@ -8,6 +8,8 @@ package pkl
 
 import (
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -111,6 +113,37 @@ func TestPkl_TFVarsIntegration(t *testing.T) {
 	assert.Equal(t, "us-west-2", gjson.Get(jsonString, "Targets.0.Config.Region").String())
 	// The queue name should interpolate the region from tfvars
 	assert.Equal(t, "demo-us-west-2-queue", gjson.Get(jsonString, "Resources.0.Properties.QueueName").String())
+}
+
+func TestPkl_TFVarsIntegration_AbsolutePathOutsidePklFolder(t *testing.T) {
+	// Place a .tfvars file at an absolute path OUTSIDE the testdata/forma
+	// directory (where the .pkl lives) and outside the internal/schema/pkl
+	// tree entirely. This verifies that tfvarsReader.Read accepts absolute
+	// paths and does not reject them or re-anchor them on baseDir.
+	tmpDir := t.TempDir()
+	absTfvars := filepath.Join(tmpDir, "external.tfvars")
+	content := []byte(`region         = "eu-west-1"
+instance_count = 2
+enable_logging = false
+instance_type  = "t3.small"
+
+tags = {
+  Name        = "abs-path"
+  Environment = "test"
+}
+
+availability_zones = ["eu-west-1a"]
+`)
+	require.NoError(t, os.WriteFile(absTfvars, content, 0644))
+
+	p := PKL{}
+	props := map[string]string{"tfvarsAbsPath": absTfvars}
+	forma, err := p.Evaluate("./testdata/forma/tfvars_absolute_test.pkl", model.CommandApply, model.FormaApplyModeReconcile, props)
+	require.NoError(t, err)
+
+	jsonString := forma.ToJSON()
+	assert.Equal(t, "eu-west-1", gjson.Get(jsonString, "Targets.0.Config.Region").String())
+	assert.Equal(t, "demo-eu-west-1-queue", gjson.Get(jsonString, "Resources.0.Properties.QueueName").String())
 }
 
 func TestPkl_FormaeConfig(t *testing.T) {

--- a/internal/schema/pkl/testdata/forma/tfvars_absolute_test.pkl
+++ b/internal/schema/pkl/testdata/forma/tfvars_absolute_test.pkl
@@ -1,0 +1,39 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+import "@formae/ext/terraform.pkl"
+import "@fakeaws/fakeaws.pkl"
+import "@fakeaws/sqs/queue.pkl"
+
+local tfvars = terraform.readTFVars(read("prop:tfvarsAbsPath"))
+
+properties {
+  name = new formae.Prop {
+    flag = "name"
+    default = "tfvars-abs-demo"
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = "pel-tfvars-abs-demo"
+    description = "Absolute-path tfvars test"
+  }
+
+  new formae.Target {
+    label = "default-aws-target"
+    config = new fakeaws.Config {
+      region = tfvars.region
+    }
+  }
+
+  new queue.Queue {
+    label = "demo-queue"
+    queueName = "demo-\(tfvars.region)-queue"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds integration test that confirms the new tfvars resource reader (introduced in 6b456585) accepts absolute `.tfvars` paths outside the calling `.pkl` file's directory.
- New `tfvars_absolute_test.pkl` fixture reads the path via `read(\"prop:tfvarsAbsPath\")`, so the Go test can point it at a `t.TempDir()` location that lives outside `internal/schema/pkl/`.
- Verifies the `!filepath.IsAbs(path)` branch in `internal/schema/pkl/tfvars_reader.go:52` — previously only the relative-path branch had coverage.

## Test plan
- [x] `go test -tags integration -run TestPkl_TFVarsIntegration_AbsolutePathOutsidePklFolder ./internal/schema/pkl/`
- [x] Existing `TestPkl_TFVarsIntegration` still passes