### PR TITLE
fix(conformance): pass --schema-location local to formae extract

### DIFF
--- a/pkg/plugin-conformance-tests/harness.go
+++ b/pkg/plugin-conformance-tests/harness.go
@@ -884,7 +884,20 @@ func (h *TestHarness) Eval(pklFile string) (string, error) {
 	return stdout.String(), nil
 }
 
-// Extract runs `formae extract` with the given query and output file
+// Extract runs `formae extract` with the given query and output file.
+//
+// `--schema-location local` is required: the conformance harness installs
+// the plugin under test into the agent's local plugin tree (no published
+// hub package), so versioned schema dispatch
+// (internal/schema/pkl.resolveSchemaVersions) only fires when the CLI is
+// told to read schemas from disk. Without the flag, extract emits an
+// unrestricted `@<ns>/**` glob that matches zero modules under the
+// install's `v*/` subtree layout, and every K8s resource type lookup
+// fails with `Cannot find key "K8S::..."`.
+//
+// TODO: drop this once the formae CLI distinguishes "user passed
+// --schema-location remote" from "no flag, default to remote" so
+// versioned dispatch can keep working in the unset case.
 func (h *TestHarness) Extract(query string, outputFile string) error {
 	h.t.Logf("Running formae extract with query '%s' to %s", query, outputFile)
 
@@ -892,6 +905,7 @@ func (h *TestHarness) Extract(query string, outputFile string) error {
 		h.formaeBinary,
 		"extract",
 		"--config", h.configFile,
+		"--schema-location", "local",
 		"--query", query,
 		outputFile,
 	)


### PR DESCRIPTION
## Summary

Versioned schema dispatch (`resolveSchemaVersions` in `internal/schema/pkl/pkl_serialize.go`) is gated on `SchemaLocation == Local` after #452's review-feedback round. The conformance harness shells out `formae extract` without the flag, so `opts.SchemaLocation` defaults to `Remote` and `resolveSchemaVersions` returns nil — the generator emits an unrestricted `@<ns>/**` glob that matches zero modules under the install's `v*/` subtree layout, and every K8s resource type lookup fails with `Cannot find key "K8S::..."`.

This PR adds `--schema-location local` to the harness's `Extract` invocation. The conformance harness installs the plugin under test into the agent's local plugin tree (no published hub package), so `local` is the correct mode anyway.

## Repro

Before this PR, on `main @ <post-#452 SHA>`:

```
$ FORMAE_BINARY=/opt/pel/bin/formae \
  FORMAE_TEST_TESTDATA_DIR=testdata/generated/v1.31/shared \
  FORMAE_TEST_TYPE=crud FORMAE_TEST_FILTER=namespace \
  go test -tags=conformance -run TestPluginConformance .
...
0 passed, 35 failed, 0 skipped (7m 24s)
```

Every test fails at Step 6 (extract) with:

```
Cannot find key `"K8S::Core::Namespace"`.
```

After this PR (same command):

```
1 passed, 0 failed, 0 skipped
```

## TODO

Drop this flag once the formae CLI distinguishes "user passed `--schema-location remote`" from "no flag, default to remote" so versioned dispatch keeps working in the unset case. The current default-to-Remote at `pkl.go:485` erases that distinction; the proper fix is to treat the empty-string case as eligible for dispatch and only opt out when the user explicitly requests Remote.