### PR TITLE
fix(plugins): make install/uninstall/upgrade local-only

### DIFF
--- a/internal/cli/plugin/install.go
+++ b/internal/cli/plugin/install.go
@@ -13,35 +13,32 @@ import (
 
 	"github.com/platform-engineering-labs/formae/internal/cli/cmd"
 	"github.com/platform-engineering-labs/formae/internal/cli/display"
-	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
 )
 
-// parsePackageRefs parses "name" or "name@version" strings into PackageRefs.
-func parsePackageRefs(args []string) []apimodel.PackageRef {
-	refs := make([]apimodel.PackageRef, 0, len(args))
-	for _, arg := range args {
-		name, version, _ := strings.Cut(arg, "@")
-		refs = append(refs, apimodel.PackageRef{Name: name, Version: version})
+// pluginNamesFromArgs returns the bare plugin names from "name@version"
+// args. Orbital install accepts the @version form on the wire too, so
+// this is mainly for echoing the requested set back to the user.
+func pluginNamesFromArgs(args []string) []string {
+	out := make([]string, 0, len(args))
+	for _, a := range args {
+		name, _, _ := strings.Cut(a, "@")
+		out = append(out, name)
 	}
-	return refs
-}
-
-// filterAuthOps returns the names of auth-type plugin operations.
-func filterAuthOps(ops []apimodel.PluginOperation) []string {
-	var names []string
-	for _, op := range ops {
-		if op.Type == "auth" {
-			names = append(names, op.Name)
-		}
-	}
-	return names
+	return out
 }
 
 func PluginInstallCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "install <name>[@<version>]...",
-		Short: "Install plugins on the agent (and locally for auth plugins)",
-		Args:  cobra.MinimumNArgs(1),
+		Short: "Install plugins on this host",
+		Long: `Install plugins on this host's local orbital tree.
+
+formae plugin install runs orbital locally — it does not call the agent.
+Resource plugins must be installed on the host that runs the agent (run
+this command there, typically under sudo). Auth plugins run on both
+sides of the CLI⇄agent exchange, so install them on every host that
+runs either.`,
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cc *cobra.Command, args []string) error {
 			channel, _ := cc.Flags().GetString("channel")
 			app, err := cmd.AppFromContext(cc.Context(), "", "", cc)
@@ -49,54 +46,26 @@ func PluginInstallCmd() *cobra.Command {
 				return err
 			}
 
-			req := apimodel.InstallPluginsRequest{
-				Packages: parsePackageRefs(args),
-				Channel:  channel,
-			}
-			resp, err := app.InstallPlugins(req)
+			mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, channel)
 			if err != nil {
 				return err
 			}
-
-			// Build the CLI-local manager BEFORE printing the agent install
-			// results. Constructing the local orbital manager can trigger
-			// sudo elevation when the binary lives at a privileged path
-			// (orbital.tree.New → InvokeSelfWithSudo → syscall.Exec). The
-			// re-execed process restarts from main and re-runs this whole
-			// command — printing the agent results before the elevation
-			// would produce duplicated lines. By deferring the prints
-			// until after the elevation has happened, the original process
-			// exits silently via syscall.Exec and only the privileged
-			// re-exec emits user-facing output.
-			authNames := filterAuthOps(resp.Operations)
-			var localMgr *CLIPluginManager
-			if len(authNames) > 0 {
-				localMgr, err = NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories)
-				if err != nil {
-					fmt.Printf("  %s CLI-side install failed: %s\n", display.Gold("!"), err.Error())
-					fmt.Printf("  Retry with: formae plugin install %s\n", strings.Join(authNames, " "))
-					return err
-				}
+			if mgr == nil {
+				return fmt.Errorf("no artifact repositories configured; set artifacts.repositories in your formae config")
 			}
 
-			for _, op := range resp.Operations {
-				fmt.Printf("  %s Installed %s %s on agent\n", display.Green("✓"), op.Name, op.Version)
+			// orbital may re-exec under sudo when the tree path is
+			// privileged. The re-exec restarts main and re-runs this
+			// command, so we keep all user-visible output below the
+			// install call to avoid duplicated lines.
+			if err := mgr.LocalInstall(args); err != nil {
+				return err
 			}
 
-			if localMgr != nil {
-				if localErr := localMgr.LocalInstall(authNames); localErr != nil {
-					fmt.Printf("  %s CLI-side install failed: %s\n", display.Gold("!"), localErr.Error())
-					fmt.Printf("  Agent has the plugins. Retry with: formae plugin install %s\n", strings.Join(authNames, " "))
-					return localErr
-				}
-				for _, name := range authNames {
-					fmt.Printf("  %s Installed %s on cli\n", display.Green("✓"), name)
-				}
+			for _, name := range pluginNamesFromArgs(args) {
+				fmt.Printf("  %s Installed %s\n", display.Green("✓"), name)
 			}
-
-			if resp.RequiresRestart {
-				fmt.Printf("\n  %s Restart the agent to load the new plugins: formae agent restart\n", display.Gold("!"))
-			}
+			fmt.Printf("\n  %s If this host runs the formae agent, restart it to load the new plugins: formae agent restart\n", display.Gold("!"))
 			return nil
 		},
 		SilenceErrors: true,

--- a/internal/cli/plugin/manager.go
+++ b/internal/cli/plugin/manager.go
@@ -5,35 +5,54 @@
 package plugin
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/platform-engineering-labs/formae/internal/opsmgr"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/orbital/mgr"
+	"github.com/platform-engineering-labs/orbital/opm/records"
+	"github.com/platform-engineering-labs/orbital/ops"
 )
 
-// CLIPluginManager manages plugin operations on the CLI host's local
-// orbital tree. Used for dual-installing auth plugins that need to
-// run on both the agent and the CLI.
+// CLIPluginManager runs orbital against the local /opt/pel tree. While
+// /opt/pel is root-owned, mutating operations re-exec the CLI under sudo
+// via orbital's tree.New flow. Read-only listing does not.
 type CLIPluginManager struct {
 	orb    *mgr.Manager
 	logger *slog.Logger
 }
 
-// NewCLIPluginManager creates a local plugin manager from the CLI's config.
-// Returns nil, nil if no plugin repositories are configured.
-func NewCLIPluginManager(logger *slog.Logger, repos []pkgmodel.Repository) (*CLIPluginManager, error) {
+// NewCLIPluginManager constructs a manager from the CLI config. Both
+// binary and formae-plugin repositories are loaded so the SAT solver can
+// resolve cross-repo dependencies (e.g., a plugin's `depends: formae >=
+// 0.85`). When channel is non-empty it overrides the URI fragment for
+// every repo.
+//
+// Returns nil, nil if no repositories are configured — callers treat that
+// as "no local install path available" rather than as an error. Returns
+// an error if an orbital tree is configured but not initialized at the
+// resolved path (orbital leaves cache/pki/lock nil in that case, and
+// every later call would panic). Mirrors the agent-side
+// plugin_manager.New guard so dev binaries get a clear message rather
+// than a nil-pointer crash.
+func NewCLIPluginManager(logger *slog.Logger, repos []pkgmodel.Repository, channel string) (*CLIPluginManager, error) {
 	if len(repos) == 0 {
 		return nil, nil
 	}
-	orb, err := opsmgr.NewFromRepositories(logger, repos, "")
+	orb, err := opsmgr.NewFromRepositories(logger, repos, channel)
 	if err != nil {
 		return nil, err
+	}
+	if !orb.Ready() {
+		return nil, fmt.Errorf("orbital tree not initialized at %s; install formae via the orbital installer or set %s to point at an initialized tree (e.g. /opt/pel)", orb.Path, opsmgr.FormaePelRootEnv)
 	}
 	return &CLIPluginManager{orb: orb, logger: logger}, nil
 }
 
-// LocalInstall installs packages on the CLI host's orbital tree.
+// LocalInstall installs packages on the local orbital tree. orbital
+// re-execs the process under sudo when the tree path is privileged.
 func (pm *CLIPluginManager) LocalInstall(names []string) error {
 	if err := pm.orb.Refresh(); err != nil {
 		pm.logger.Warn("failed to refresh local repos", "error", err)
@@ -41,15 +60,91 @@ func (pm *CLIPluginManager) LocalInstall(names []string) error {
 	return pm.orb.Install(names...)
 }
 
-// LocalUninstall removes packages from the CLI host's orbital tree.
+// LocalUninstall removes packages from the local orbital tree.
 func (pm *CLIPluginManager) LocalUninstall(names []string) error {
 	return pm.orb.Remove(names...)
 }
 
-// LocalUpgrade upgrades packages on the CLI host's orbital tree.
+// LocalUpgrade upgrades the named packages, or — when names is empty —
+// every installed package. orbital's Update treats "no packages" as
+// "everything", which matches the user-facing `formae plugin upgrade`
+// (no args) semantics.
 func (pm *CLIPluginManager) LocalUpgrade(names []string) error {
 	if err := pm.orb.Refresh(); err != nil {
 		pm.logger.Warn("failed to refresh local repos", "error", err)
 	}
 	return pm.orb.Update(names...)
+}
+
+// ListInstalled returns the plugin packages installed in the local
+// orbital tree. Filtering matches the agent-side plugin manager: only
+// packages whose Metadata["display"]["kind"] is "plugin" or "metapackage"
+// are considered plugins. The formae binary and other tooling are
+// skipped.
+func (pm *CLIPluginManager) ListInstalled() ([]apimodel.Plugin, error) {
+	pkgs, err := pm.orb.List()
+	if err != nil {
+		return nil, fmt.Errorf("listing installed packages: %w", err)
+	}
+	plugins := make([]apimodel.Plugin, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		if !isPluginPackage(pkg) {
+			continue
+		}
+		plugins = append(plugins, pluginFromPackage(pkg))
+	}
+	return plugins, nil
+}
+
+func isPluginPackage(pkg *records.Package) bool {
+	if pkg == nil || pkg.Header == nil {
+		return false
+	}
+	disp, ok := pkg.Metadata["display"]
+	if !ok {
+		return false
+	}
+	kind := disp["kind"]
+	return kind == "plugin" || kind == "metapackage"
+}
+
+func pluginFromPackage(pkg *records.Package) apimodel.Plugin {
+	p := apimodel.Plugin{
+		Name:        pkg.Name,
+		Publisher:   pkg.Publisher,
+		License:     pkg.License,
+		Summary:     pkg.Summary,
+		Description: pkg.Description,
+		Frozen:      pkg.Frozen,
+		Metadata:    pkg.Metadata,
+	}
+	if disp, ok := pkg.Metadata["display"]; ok {
+		p.Category = disp["category"]
+		p.Kind = disp["kind"]
+	}
+	if pi, ok := pkg.Metadata["plugin"]; ok {
+		p.Type = pi["type"]
+		p.Namespace = pi["namespace"]
+	}
+	if pkg.Version != nil {
+		p.InstalledVersion = versionString(pkg.Version)
+	}
+	return p
+}
+
+// versionString matches plugin_manager.versionString — orbital's
+// Version.Short drops PreRelease/Build, but channels live in PreRelease
+// so we always render the full identifier.
+func versionString(v *ops.Version) string {
+	if v == nil {
+		return ""
+	}
+	s := fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+	if v.PreRelease != "" {
+		s += "-" + v.PreRelease
+	}
+	if v.Build != "" {
+		s += "+" + v.Build
+	}
+	return s
 }

--- a/internal/cli/plugin/plugin.go
+++ b/internal/cli/plugin/plugin.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/platform-engineering-labs/formae/internal/cli/app"
 	"github.com/platform-engineering-labs/formae/internal/cli/cmd"
 	"github.com/platform-engineering-labs/formae/internal/cli/display"
 	"github.com/platform-engineering-labs/formae/internal/opsmgr"
@@ -43,46 +44,84 @@ func PluginCmd() *cobra.Command {
 func PluginListCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "list",
-		Short: "List installed plugins (agent + local)",
+		Short: "List installed plugins",
 		RunE: func(command *cobra.Command, args []string) error {
 			app, err := cmd.AppFromContext(command.Context(), "", "", command)
 			if err != nil {
 				return err
 			}
 
-			// Agent-side view: best-effort. The agent may be unreachable
-			// (e.g., on a CLI-only host), in which case we still want to
-			// show what's installed locally rather than fail outright.
-			var agentPlugins []apimodel.Plugin
-			if client, cerr := app.NewClient(); cerr == nil {
-				if resp, lerr := client.ListPlugins("installed", "", "", "", ""); lerr == nil {
-					agentPlugins = resp.Plugins
-				}
+			// Two best-effort sources of truth for what's installed on
+			// this host: the agent (free, no sudo) and a local read of
+			// the orbital tree. On a single-host deployment they're
+			// reading the same store and agree by definition; on a CLI
+			// box the agent may be unreachable; on a split deployment
+			// the auth-plugin set may diverge across hosts. The renderer
+			// only annotates rows when the two arms disagree — matching
+			// rows render plain so the typical single-host case isn't
+			// noisy.
+			agentPlugins, agentNote := fetchAgentPlugins(app)
+			localPlugins, localNote := fetchLocalPlugins(app)
+
+			agentReached := agentNote == ""
+			localScanned := localNote == ""
+
+			if !agentReached && !localScanned {
+				return fmt.Errorf("couldn't list installed plugins:\n  - agent: %s\n  - local: %s", agentNote, localNote)
 			}
 
-			// CLI-side view: read straight from the local orbital tree.
-			// Skipped when the tree is root-owned and we're not — orbital
-			// would re-exec under sudo just to read, and a read-only `list`
-			// shouldn't force a privilege prompt. The agent already covers
-			// the same view on a single-host setup; we surface a hint so
-			// users on split deployments know how to see the local arm.
-			var localPlugins []apimodel.Plugin
-			localSkipped := false
-			if opsmgr.TreeRequiresElevation() {
-				localSkipped = true
-			} else if mgr, merr := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, ""); merr == nil && mgr != nil {
-				localPlugins, _ = mgr.ListInstalled()
+			fmt.Print(renderPluginList(agentPlugins, localPlugins, agentReached, localScanned))
+			if agentReached && !localScanned {
+				fmt.Printf("\n  %s Local view skipped: %s\n", display.Grey("ℹ"), localNote)
 			}
-
-			fmt.Print(renderPluginList(agentPlugins, localPlugins))
-			if localSkipped {
-				fmt.Printf("\n  %s Local view skipped (tree is root-owned). Re-run under sudo to include this host's /opt/pel.\n", display.Grey("ℹ"))
+			if !agentReached && localScanned {
+				fmt.Printf("\n  %s Agent unreachable; showing local view only: %s\n", display.Grey("ℹ"), agentNote)
 			}
 			return nil
 		},
 		SilenceErrors: true,
 	}
 	return command
+}
+
+// fetchAgentPlugins returns (plugins, "") on success, or (nil, reason)
+// when the agent is unreachable or the API call failed. Agent-side
+// listing is read-only and works without sudo, so it's the cheap
+// path; the local arm is a fallback for hosts where no agent is
+// reachable.
+func fetchAgentPlugins(app *app.App) ([]apimodel.Plugin, string) {
+	client, cerr := app.NewClient()
+	if cerr != nil {
+		return nil, cerr.Error()
+	}
+	resp, lerr := client.ListPlugins("installed", "", "", "", "")
+	if lerr != nil {
+		return nil, lerr.Error()
+	}
+	return resp.Plugins, ""
+}
+
+// fetchLocalPlugins reads the local orbital tree directly. Skipped
+// when the tree is root-owned and we're not — orbital would re-exec
+// under sudo just to read, and `list` shouldn't force a privilege
+// prompt. Returns ("re-run under sudo …") in that case so the caller
+// can surface a clear hint.
+func fetchLocalPlugins(app *app.App) ([]apimodel.Plugin, string) {
+	if opsmgr.TreeRequiresElevation() {
+		return nil, "tree is root-owned, re-run under sudo to read /opt/pel"
+	}
+	mgr, merr := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, "")
+	if merr != nil {
+		return nil, merr.Error()
+	}
+	if mgr == nil {
+		return nil, "no artifact repositories configured"
+	}
+	plugins, lerr := mgr.ListInstalled()
+	if lerr != nil {
+		return nil, lerr.Error()
+	}
+	return plugins, ""
 }
 
 func PluginSearchCmd() *cobra.Command {

--- a/internal/cli/plugin/plugin.go
+++ b/internal/cli/plugin/plugin.go
@@ -6,10 +6,14 @@ package plugin
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/spf13/cobra"
 
 	"github.com/platform-engineering-labs/formae/internal/cli/cmd"
+	"github.com/platform-engineering-labs/formae/internal/cli/display"
+	"github.com/platform-engineering-labs/formae/internal/opsmgr"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
 )
 
 func PluginCmd() *cobra.Command {
@@ -39,24 +43,41 @@ func PluginCmd() *cobra.Command {
 func PluginListCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "list",
-		Short: "List installed plugins",
+		Short: "List installed plugins (agent + local)",
 		RunE: func(command *cobra.Command, args []string) error {
 			app, err := cmd.AppFromContext(command.Context(), "", "", command)
 			if err != nil {
 				return err
 			}
 
-			client, err := app.NewClient()
-			if err != nil {
-				return err
+			// Agent-side view: best-effort. The agent may be unreachable
+			// (e.g., on a CLI-only host), in which case we still want to
+			// show what's installed locally rather than fail outright.
+			var agentPlugins []apimodel.Plugin
+			if client, cerr := app.NewClient(); cerr == nil {
+				if resp, lerr := client.ListPlugins("installed", "", "", "", ""); lerr == nil {
+					agentPlugins = resp.Plugins
+				}
 			}
 
-			resp, err := client.ListPlugins("installed", "", "", "", "")
-			if err != nil {
-				return err
+			// CLI-side view: read straight from the local orbital tree.
+			// Skipped when the tree is root-owned and we're not — orbital
+			// would re-exec under sudo just to read, and a read-only `list`
+			// shouldn't force a privilege prompt. The agent already covers
+			// the same view on a single-host setup; we surface a hint so
+			// users on split deployments know how to see the local arm.
+			var localPlugins []apimodel.Plugin
+			localSkipped := false
+			if opsmgr.TreeRequiresElevation() {
+				localSkipped = true
+			} else if mgr, merr := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, ""); merr == nil && mgr != nil {
+				localPlugins, _ = mgr.ListInstalled()
 			}
 
-			fmt.Print(renderPluginList(resp.Plugins))
+			fmt.Print(renderPluginList(agentPlugins, localPlugins))
+			if localSkipped {
+				fmt.Printf("\n  %s Local view skipped (tree is root-owned). Re-run under sudo to include this host's /opt/pel.\n", display.Grey("ℹ"))
+			}
 			return nil
 		},
 		SilenceErrors: true,

--- a/internal/cli/plugin/render.go
+++ b/internal/cli/plugin/render.go
@@ -6,37 +6,80 @@ package plugin
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/platform-engineering-labs/formae/internal/cli/display"
 	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
 )
 
-func renderPluginList(agentPlugins []apimodel.Plugin) string {
-	if len(agentPlugins) == 0 {
+// mergedPlugin tracks where a plugin is installed and the version on
+// each side. When agent and CLI report the same plugin at the same
+// version, the renderer collapses both into a single `(agent + cli)`
+// row; when versions differ, it surfaces the mismatch inline so
+// dual-install drift on auth plugins is visible at a glance.
+type mergedPlugin struct {
+	plugin       apimodel.Plugin
+	agentVersion string
+	cliVersion   string
+}
+
+func (m mergedPlugin) onAgent() bool { return m.agentVersion != "" }
+func (m mergedPlugin) onCLI() bool   { return m.cliVersion != "" }
+
+func renderPluginList(agentPlugins, localPlugins []apimodel.Plugin) string {
+	if len(agentPlugins) == 0 && len(localPlugins) == 0 {
 		return "No plugins installed.\n"
 	}
 
-	var sb strings.Builder
+	// Merge by name. Agent-reported metadata wins for the descriptor
+	// fields (Type, Kind, Category, ManagedBy) since the agent
+	// canonicalizes those; CLI-only plugins fall back to whatever the
+	// local orbital records carry.
+	merged := map[string]*mergedPlugin{}
+	for _, p := range agentPlugins {
+		m := merged[p.Name]
+		if m == nil {
+			m = &mergedPlugin{plugin: p}
+			merged[p.Name] = m
+		}
+		m.plugin = p
+		m.agentVersion = p.InstalledVersion
+	}
+	for _, p := range localPlugins {
+		m := merged[p.Name]
+		if m == nil {
+			m = &mergedPlugin{plugin: p}
+			merged[p.Name] = m
+		}
+		m.cliVersion = p.InstalledVersion
+	}
 
 	// Group by kind/type. Bundles get their own section so users can see
 	// what curated collections they have installed alongside the
 	// individual plugins those bundles pulled in. Internally orbital
 	// calls these "metapackages"; we render them as "bundles" in the CLI
 	// for friendlier vocabulary.
-	var resource, auth, bundles []apimodel.Plugin
-	for _, p := range agentPlugins {
+	var resource, auth, bundles []*mergedPlugin
+	for _, m := range merged {
 		switch {
-		case p.Kind == "metapackage":
-			bundles = append(bundles, p)
-		case p.Type == "auth":
-			auth = append(auth, p)
+		case m.plugin.Kind == "metapackage":
+			bundles = append(bundles, m)
+		case m.plugin.Type == "auth":
+			auth = append(auth, m)
 		default:
-			resource = append(resource, p)
+			resource = append(resource, m)
 		}
 	}
+	sortByName := func(s []*mergedPlugin) {
+		sort.Slice(s, func(i, j int) bool { return s[i].plugin.Name < s[j].plugin.Name })
+	}
+	sortByName(resource)
+	sortByName(auth)
+	sortByName(bundles)
 
-	emit := func(header string, plugins []apimodel.Plugin, addLeadingNewline bool) {
+	var sb strings.Builder
+	emit := func(header string, plugins []*mergedPlugin, addLeadingNewline bool) {
 		if len(plugins) == 0 {
 			return
 		}
@@ -44,15 +87,8 @@ func renderPluginList(agentPlugins []apimodel.Plugin) string {
 			sb.WriteString("\n")
 		}
 		sb.WriteString(display.LightBlue(header) + "\n")
-		for _, p := range plugins {
-			line := fmt.Sprintf("  %s %s  %s",
-				display.Green("✓"),
-				padRight(p.Name, 14),
-				display.Grey(p.InstalledVersion))
-			if p.ManagedBy != "" {
-				line += display.Grey("  (" + p.ManagedBy + ")")
-			}
-			sb.WriteString(line + "\n")
+		for _, m := range plugins {
+			sb.WriteString(renderMergedRow(m) + "\n")
 		}
 	}
 
@@ -61,6 +97,33 @@ func renderPluginList(agentPlugins []apimodel.Plugin) string {
 	emit("Bundles:", bundles, len(resource) > 0 || len(auth) > 0)
 
 	return sb.String()
+}
+
+func renderMergedRow(m *mergedPlugin) string {
+	name := padRight(m.plugin.Name, 14)
+	managedBy := ""
+	if m.plugin.ManagedBy != "" {
+		managedBy = display.Grey("  (" + m.plugin.ManagedBy + ")")
+	}
+	switch {
+	case m.onAgent() && m.onCLI() && m.agentVersion == m.cliVersion:
+		return fmt.Sprintf("  %s %s  %s  %s%s",
+			display.Green("✓"), name, display.Grey(m.agentVersion),
+			display.Grey("(agent + cli)"), managedBy)
+	case m.onAgent() && m.onCLI() && m.agentVersion != m.cliVersion:
+		return fmt.Sprintf("  %s %s  %s  %s%s",
+			display.Gold("⚠"), name,
+			display.Grey(fmt.Sprintf("agent %s / cli %s", m.agentVersion, m.cliVersion)),
+			display.Gold("version mismatch"), managedBy)
+	case m.onAgent():
+		return fmt.Sprintf("  %s %s  %s  %s%s",
+			display.Green("✓"), name, display.Grey(m.agentVersion),
+			display.Grey("(agent)"), managedBy)
+	default:
+		return fmt.Sprintf("  %s %s  %s  %s%s",
+			display.Green("✓"), name, display.Grey(m.cliVersion),
+			display.Grey("(cli)"), managedBy)
+	}
 }
 
 func renderPluginSearch(plugins []apimodel.Plugin) string {

--- a/internal/cli/plugin/render.go
+++ b/internal/cli/plugin/render.go
@@ -27,7 +27,14 @@ type mergedPlugin struct {
 func (m mergedPlugin) onAgent() bool { return m.agentVersion != "" }
 func (m mergedPlugin) onCLI() bool   { return m.cliVersion != "" }
 
-func renderPluginList(agentPlugins, localPlugins []apimodel.Plugin) string {
+// renderPluginList merges the agent and local views into a single
+// listing. Annotations are driven by *divergence*: when both arms
+// returned data, matching rows render plain — the typical single-host
+// install where agent and CLI share the orbital tree by definition is
+// not noisy. Only one arm reachable: every row carries that arm's
+// label ((agent) or (cli)) for consistency, and the caller surfaces a
+// hint explaining why the other arm is missing.
+func renderPluginList(agentPlugins, localPlugins []apimodel.Plugin, agentReached, localScanned bool) string {
 	if len(agentPlugins) == 0 && len(localPlugins) == 0 {
 		return "No plugins installed.\n"
 	}
@@ -88,7 +95,7 @@ func renderPluginList(agentPlugins, localPlugins []apimodel.Plugin) string {
 		}
 		sb.WriteString(display.LightBlue(header) + "\n")
 		for _, m := range plugins {
-			sb.WriteString(renderMergedRow(m) + "\n")
+			sb.WriteString(renderMergedRow(m, agentReached, localScanned) + "\n")
 		}
 	}
 
@@ -99,31 +106,63 @@ func renderPluginList(agentPlugins, localPlugins []apimodel.Plugin) string {
 	return sb.String()
 }
 
-func renderMergedRow(m *mergedPlugin) string {
+func renderMergedRow(m *mergedPlugin, agentReached, localScanned bool) string {
 	name := padRight(m.plugin.Name, 14)
 	managedBy := ""
 	if m.plugin.ManagedBy != "" {
 		managedBy = display.Grey("  (" + m.plugin.ManagedBy + ")")
 	}
-	switch {
-	case m.onAgent() && m.onCLI() && m.agentVersion == m.cliVersion:
-		return fmt.Sprintf("  %s %s  %s  %s%s",
-			display.Green("✓"), name, display.Grey(m.agentVersion),
-			display.Grey("(agent + cli)"), managedBy)
-	case m.onAgent() && m.onCLI() && m.agentVersion != m.cliVersion:
+
+	// Both arms reached + version mismatch is the only case that
+	// breaks the single-version rendering: surface both versions
+	// inline, mark with a warning glyph.
+	if agentReached && localScanned && m.onAgent() && m.onCLI() && m.agentVersion != m.cliVersion {
 		return fmt.Sprintf("  %s %s  %s  %s%s",
 			display.Gold("⚠"), name,
 			display.Grey(fmt.Sprintf("agent %s / cli %s", m.agentVersion, m.cliVersion)),
 			display.Gold("version mismatch"), managedBy)
-	case m.onAgent():
-		return fmt.Sprintf("  %s %s  %s  %s%s",
-			display.Green("✓"), name, display.Grey(m.agentVersion),
-			display.Grey("(agent)"), managedBy)
-	default:
-		return fmt.Sprintf("  %s %s  %s  %s%s",
-			display.Green("✓"), name, display.Grey(m.cliVersion),
-			display.Grey("(cli)"), managedBy)
 	}
+
+	version := m.agentVersion
+	if version == "" {
+		version = m.cliVersion
+	}
+	annotation := annotateRow(m, agentReached, localScanned)
+
+	line := fmt.Sprintf("  %s %s  %s",
+		display.Green("✓"), name, display.Grey(version))
+	if annotation != "" {
+		line += "  " + display.Grey(annotation)
+	}
+	return line + managedBy
+}
+
+// annotateRow decides what to put after the version, encoding the
+// "annotate only what's notable" rule:
+//
+//	both arms reached, plugin on both:    no annotation (boring case)
+//	both arms reached, agent only:        (agent only)
+//	both arms reached, cli only:          (cli only)
+//	only agent reached:                   (agent)         — every row
+//	only local scanned:                   (cli)           — every row
+//
+// The version-mismatch case is handled by the caller because it also
+// changes the version display.
+func annotateRow(m *mergedPlugin, agentReached, localScanned bool) string {
+	if agentReached && localScanned {
+		switch {
+		case m.onAgent() && !m.onCLI():
+			return "(agent only)"
+		case m.onCLI() && !m.onAgent():
+			return "(cli only)"
+		default:
+			return ""
+		}
+	}
+	if agentReached {
+		return "(agent)"
+	}
+	return "(cli)"
 }
 
 func renderPluginSearch(plugins []apimodel.Plugin) string {

--- a/internal/cli/plugin/uninstall.go
+++ b/internal/cli/plugin/uninstall.go
@@ -12,57 +12,41 @@ import (
 
 	"github.com/platform-engineering-labs/formae/internal/cli/cmd"
 	"github.com/platform-engineering-labs/formae/internal/cli/display"
-	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
 )
 
 func PluginUninstallCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:     "uninstall <name>...",
 		Aliases: []string{"remove"},
-		Short:   "Uninstall plugins from the agent (and locally for auth plugins)",
-		Args:    cobra.MinimumNArgs(1),
+		Short:   "Uninstall plugins from this host",
+		Long: `Remove plugins from this host's local orbital tree.
+
+formae plugin uninstall runs orbital locally — it does not call the
+agent. Run it on the host where the plugin is installed; for auth
+plugins, run it on every host where the plugin lives.`,
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cc *cobra.Command, args []string) error {
 			app, err := cmd.AppFromContext(cc.Context(), "", "", cc)
 			if err != nil {
 				return err
 			}
 
-			refs := make([]apimodel.PackageRef, 0, len(args))
-			for _, name := range args {
-				refs = append(refs, apimodel.PackageRef{Name: name})
-			}
-
-			resp, err := app.UninstallPlugins(apimodel.UninstallPluginsRequest{Packages: refs})
+			mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, "")
 			if err != nil {
 				return err
 			}
-
-			// Build the CLI-local manager before printing the agent results
-			// to avoid duplicated output if orbital re-execs us under sudo.
-			// See install.go for the full explanation.
-			authNames := filterAuthOps(resp.Operations)
-			var localMgr *CLIPluginManager
-			if len(authNames) > 0 {
-				localMgr, _ = NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories)
+			if mgr == nil {
+				return fmt.Errorf("no artifact repositories configured; set artifacts.repositories in your formae config")
 			}
 
-			for _, op := range resp.Operations {
-				fmt.Printf("  %s Removed %s from agent\n", display.Green("✓"), op.Name)
+			if err := mgr.LocalUninstall(args); err != nil {
+				return err
 			}
 
-			if localMgr != nil {
-				if localErr := localMgr.LocalUninstall(authNames); localErr != nil {
-					fmt.Printf("  %s CLI-side uninstall failed: %s\n", display.Gold("!"), localErr.Error())
-				} else {
-					for _, name := range authNames {
-						fmt.Printf("  %s Removed %s from cli\n", display.Green("✓"), name)
-					}
-				}
+			for _, name := range args {
+				fmt.Printf("  %s Removed %s\n", display.Green("✓"), name)
 			}
-
-			if resp.RequiresRestart {
-				fmt.Printf("\n  %s Restart the agent to unload the plugins: formae agent restart\n", display.Gold("!"))
-			}
+			fmt.Printf("\n  %s If this host runs the formae agent, restart it to unload the plugins: formae agent restart\n", display.Gold("!"))
 			return nil
 		},
 		SilenceErrors: true,

--- a/internal/cli/plugin/upgrade.go
+++ b/internal/cli/plugin/upgrade.go
@@ -7,20 +7,22 @@ package plugin
 import (
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/platform-engineering-labs/formae/internal/cli/cmd"
 	"github.com/platform-engineering-labs/formae/internal/cli/display"
-	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
 )
 
 func PluginUpgradeCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "upgrade [<name>[@<version>]...]",
-		Short: "Upgrade plugins on the agent (and locally for auth plugins)",
-		Long:  "Upgrade one or more plugins. If no arguments are given, all installed plugins are upgraded.",
+		Short: "Upgrade plugins on this host",
+		Long: `Upgrade plugins on this host's local orbital tree. With no
+arguments, every installed plugin is considered for upgrade.
+
+formae plugin upgrade runs orbital locally — it does not call the
+agent. Run it on every host where the plugin is installed.`,
 		RunE: func(cc *cobra.Command, args []string) error {
 			channel, _ := cc.Flags().GetString("channel")
 			app, err := cmd.AppFromContext(cc.Context(), "", "", cc)
@@ -28,52 +30,26 @@ func PluginUpgradeCmd() *cobra.Command {
 				return err
 			}
 
-			req := apimodel.UpgradePluginsRequest{
-				Packages: parsePackageRefs(args),
-				Channel:  channel,
-			}
-			resp, err := app.UpgradePlugins(req)
+			mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, channel)
 			if err != nil {
 				return err
 			}
-
-			if len(resp.Operations) == 0 {
-				fmt.Println("  All plugins are up to date.")
-				return nil
+			if mgr == nil {
+				return fmt.Errorf("no artifact repositories configured; set artifacts.repositories in your formae config")
 			}
 
-			// Build the CLI-local manager before printing the agent results
-			// to avoid duplicated output if orbital re-execs us under sudo.
-			// See install.go for the full explanation.
-			authNames := filterAuthOps(resp.Operations)
-			var localMgr *CLIPluginManager
-			if len(authNames) > 0 {
-				localMgr, err = NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories)
-				if err != nil {
-					fmt.Printf("  %s CLI-side upgrade failed: %s\n", display.Gold("!"), err.Error())
-					fmt.Printf("  Retry with: formae plugin upgrade %s\n", strings.Join(authNames, " "))
-					return err
+			if err := mgr.LocalUpgrade(args); err != nil {
+				return err
+			}
+
+			if len(args) == 0 {
+				fmt.Printf("  %s Upgraded all installed plugins\n", display.Green("✓"))
+			} else {
+				for _, name := range pluginNamesFromArgs(args) {
+					fmt.Printf("  %s Upgraded %s\n", display.Green("✓"), name)
 				}
 			}
-
-			for _, op := range resp.Operations {
-				fmt.Printf("  %s Upgraded %s to %s on agent\n", display.Green("✓"), op.Name, op.Version)
-			}
-
-			if localMgr != nil {
-				if localErr := localMgr.LocalUpgrade(authNames); localErr != nil {
-					fmt.Printf("  %s CLI-side upgrade failed: %s\n", display.Gold("!"), localErr.Error())
-					fmt.Printf("  Agent has the updated plugins. Retry with: formae plugin upgrade %s\n", strings.Join(authNames, " "))
-					return localErr
-				}
-				for _, name := range authNames {
-					fmt.Printf("  %s Upgraded %s on cli\n", display.Green("✓"), name)
-				}
-			}
-
-			if resp.RequiresRestart {
-				fmt.Printf("\n  %s Restart the agent to load the updated plugins: formae agent restart\n", display.Gold("!"))
-			}
+			fmt.Printf("\n  %s If this host runs the formae agent, restart it to load the upgraded plugins: formae agent restart\n", display.Gold("!"))
 			return nil
 		},
 		SilenceErrors: true,

--- a/internal/opsmgr/opsmgr.go
+++ b/internal/opsmgr/opsmgr.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/orbital/mgr"
@@ -54,10 +55,20 @@ func NewFromRepositoriesFiltered(logger *slog.Logger, repos []pkgmodel.Repositor
 	return newManager(logger, filtered, channel)
 }
 
+// FormaePelRootEnv overrides the orbital tree root that opsmgr would
+// otherwise derive from os.Executable(). The default derivation
+// (filepath.Dir(filepath.Dir(binPath))) only points at a real tree when
+// the binary is installed under /opt/pel/bin/formae; a freshly built
+// binary run from a worktree resolves to a path with no tree, leaving
+// orbital's internal cache/pki/lock fields nil — first call panics. Set
+// FORMAE_PEL_ROOT=/opt/pel (or any other initialized tree) to unblock
+// dev runs and isolated tests.
+const FormaePelRootEnv = "FORMAE_PEL_ROOT"
+
 func newManager(logger *slog.Logger, repos []pkgmodel.Repository, channel string) (*mgr.Manager, error) {
-	binPath, err := os.Executable()
+	treePath, err := resolveTreePath()
 	if err != nil {
-		return nil, fmt.Errorf("could not determine binary path: %w", err)
+		return nil, err
 	}
 
 	opsRepos := make([]ops.Repository, 0, len(repos))
@@ -73,10 +84,54 @@ func newManager(logger *slog.Logger, repos []pkgmodel.Repository, channel string
 		return nil, fmt.Errorf("no repositories configured")
 	}
 
-	return mgr.New(logger, filepath.Dir(filepath.Dir(binPath)), &tree.Config{
+	return mgr.New(logger, treePath, &tree.Config{
 		OS:           platform.Current().OS,
 		Arch:         platform.Current().Arch,
 		Security:     security.Default,
 		Repositories: opsRepos,
 	})
+}
+
+// resolveTreePath returns FORMAE_PEL_ROOT when set, otherwise the
+// directory two levels above the running binary (matches the
+// /opt/pel/bin/formae → /opt/pel install layout).
+func resolveTreePath() (string, error) {
+	if root := os.Getenv(FormaePelRootEnv); root != "" {
+		return root, nil
+	}
+	binPath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("could not determine binary path: %w", err)
+	}
+	return filepath.Dir(filepath.Dir(binPath)), nil
+}
+
+// TreeRequiresElevation reports whether constructing an orbital manager
+// against the configured tree would re-exec the process under sudo.
+// orbital's tree.New triggers a sudo re-exec whenever the tree path is
+// root-owned and the caller is not root — including for read-only
+// operations like List(). Callers that want to remain unprivileged
+// (e.g. `plugin list`) check this first and skip the local arm when it
+// would force a sudo prompt.
+//
+// Returns false (with no error) if the tree path can't be stat'd; the
+// caller can then attempt orbital construction and rely on the existing
+// Ready() guard.
+func TreeRequiresElevation() bool {
+	path, err := resolveTreePath()
+	if err != nil {
+		return false
+	}
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	sys, ok := stat.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	if sys.Uid != 0 {
+		return false
+	}
+	return os.Geteuid() != 0
 }


### PR DESCRIPTION
## Summary

- `formae plugin install / uninstall / upgrade` now run locally against the host's `/opt/pel` tree instead of routing through the agent. Orbital re-execs under `sudo` to write into the privileged tree, the same way `ops install` already does. Auth plugins on split CLI/agent deployments must be installed on each host (no automatic dual install in 0.85). The agent-side REST endpoints are kept registered as forward-compat scaffolding.
- The agent runs as the unprivileged `pel` user, so having it own plugin installs would have it write into root-owned `/opt/pel`. Walking that back keeps the daemon unprivileged. A future release will restore the single-command UX behind a properly privileged install path.
- `plugin list` keeps the merged agent + local view with `(agent + cli)` / `(agent)` / `(cli)` annotations and version-mismatch warnings. The local arm is gated on tree privilege so a read-only `list` doesn't trigger a sudo prompt; when gated, prints a hint to re-run under sudo to include the local view.
- Adds `FORMAE_PEL_ROOT` to `opsmgr` so dev binaries can point at `/opt/pel` (or any initialized tree) instead of the path orbital derives from `os.Executable()` — this unblocks running `formae` from the worktree against a real tree, useful for both manual testing and the agent dev loop.
- Adds a `Ready()` guard in `CLIPluginManager` mirroring the agent's `plugin_manager.New` guard, so a missing tree produces a clean error instead of orbital's nil-pointer panic on first `Lock()`.

Companion docs change: [`docs(0.85.0): plugin install/uninstall/upgrade go local-only`](https://github.com/platform-engineering-labs/formae-docs/commit/67d5984) on `formae-docs` `release/0.85.0`.