### PR TITLE
fix(patch): bump jsonpatch for EntitySet-absent-on-desired-side fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.6
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.0.0-00010101000000-000000000000
 	github.com/platform-engineering-labs/formae/tests/testcontrol v0.0.0-00010101000000-000000000000
-	github.com/platform-engineering-labs/jsonpatch v0.0.0-20260421221004-fb6f96b174b5
+	github.com/platform-engineering-labs/jsonpatch v0.0.0-20260509215119-2aad56a9d57b
 	github.com/platform-engineering-labs/orbital v0.1.38
 	github.com/posthog/posthog-go v1.6.3
 	github.com/pressly/goose/v3 v3.26.0

--- a/go.sum
+++ b/go.sum
@@ -369,8 +369,8 @@ github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/sftp v1.13.6 h1:JFZT4XbOU7l77xGSpOdW+pwIMqP044IyjXX6FGyEKFo=
 github.com/pkg/sftp v1.13.6/go.mod h1:tz1ryNURKu77RL+GuCzmoJYxQczL3wLNNpPWagdg4Qk=
-github.com/platform-engineering-labs/jsonpatch v0.0.0-20260421221004-fb6f96b174b5 h1:WRE1Dm9G920XZ+QPQBmwwU52WDJFf0bXQ1nnFFxfXuc=
-github.com/platform-engineering-labs/jsonpatch v0.0.0-20260421221004-fb6f96b174b5/go.mod h1:pKZWs1WAxW55mYtE0kAtpvrIMPzaQhZoBWSKqUMndvY=
+github.com/platform-engineering-labs/jsonpatch v0.0.0-20260509215119-2aad56a9d57b h1:Y3RJPd1/aZNnb3+wGu2vFnUmGkDh5u5AtCivg3h9EXE=
+github.com/platform-engineering-labs/jsonpatch v0.0.0-20260509215119-2aad56a9d57b/go.mod h1:pKZWs1WAxW55mYtE0kAtpvrIMPzaQhZoBWSKqUMndvY=
 github.com/platform-engineering-labs/orbital v0.1.38 h1:YRAYL9OWb+uiJc/qlPCB1u5wYpT6VUdHMUOnl2oQUV8=
 github.com/platform-engineering-labs/orbital v0.1.38/go.mod h1:wwVPqOmW5RO78dDzL/G5CN1Ioao0P/aUsOZVrPVx64s=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -571,8 +571,6 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 		PatchDocument:     string(data.resourceUpdate.DesiredState.PatchDocument),
 		TargetConfig:      data.resourceUpdate.ResourceTarget.Config,
 	}
-	proc.Log().Info("PR450_DEBUG update operation resource=%s patchDocument=%s desired=%s prior=%s",
-		convertedResource.Label, updateOperation.PatchDocument, string(convertedResource.Properties), string(convertedExisting.Properties))
 
 	// First we check if progress already was made on the update operation. This can happen for example if the node crashed while the
 	// update operation was in progress. If so, we try to recover from the previous progress.
@@ -765,8 +763,6 @@ func handleProgressUpdate(from gen.PID, state gen.Atom, data ResourceUpdateData,
 	}
 
 	if message.Failed() {
-		proc.Log().Info("PR450_DEBUG plugin operation failed status=%v errorCode=%v statusMessage=%q",
-			message.OperationStatus, message.ErrorCode, message.StatusMessage)
 		data.resourceUpdate.MarkAsFailed()
 		return StateFinishedWithError, data, nil, nil
 	}


### PR DESCRIPTION
## Summary

- `jsonpatch.CreatePatch` in `ExactMatch` mode previously only iterated keys present on the desired side of the diff. An EntitySet collection that was populated on the actual side but absent from the desired side silently produced **zero** patch ops, violating ExactMatch's "match desired exactly" promise.
- In formae this manifested as drift rejection failing: an out-of-band tag added to a resource whose IaC declared no `tags` was absorbed by sync, but the next `formae apply --mode reconcile` (no `--force`) generated no resource update for the role, `filterUnabsorbedModifications` classified the modification as absorbed, and the apply succeeded instead of being rejected. Symptom: `TestSoftReconcile` / `TestHardReconcile` / `TestSimulateApply` failing across every PR since 2026-05-09T13:17Z.
- The bug was latent: pre-#450 the PKL renderer emitted unset nullable Listings as `[]`, so the diff went through the populated-EntitySet branch and produced the right ops. PR #450 (`66fa3408`) made unset Listings absent from the rendered JSON, exposing the missing branch deterministically.
- Upstream fix: [`platform-engineering-labs/jsonpatch@2aad56a`](https://github.com/platform-engineering-labs/jsonpatch/commit/2aad56a) — emit a `remove` op when an EntitySet is populated on actual but absent from desired in ExactMatch mode. Scoped to EntitySet only so Arrays / Atomics / plain object keys keep the existing "we don't remove keys from objects" contract that other callers rely on.
- Verified end-to-end on the bisection probe (closed #457): `TestSoftReconcile`, `TestHardReconcile`, and `TestSimulateApply` all green with this dependency bump alone.
- Also drops two leftover `PR450_DEBUG` `slog.Info` lines in `internal/metastructure/resource_update/resource_updater.go` that were committed by mistake in 66fa3408.