### PR TITLE
feat(cli): pre-scaffold plugin name availability check in plugin init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ __debug*
 # bin
 /formae
 !*/formae
+/cmd/formae/formae
 
 # tools
 /ppm

--- a/internal/cli/plugin/hub_client.go
+++ b/internal/cli/plugin/hub_client.go
@@ -47,6 +47,7 @@ func (e *HubUnreachableError) Unwrap() error { return e.Cause }
 
 func NewHubClient(baseURL string) HubClient {
 	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout: hubDialTimeout,
 		}).DialContext,
@@ -86,6 +87,21 @@ func (c *httpHubClient) CheckPluginAvailability(ctx context.Context, name string
 
 	switch resp.StatusCode {
 	case http.StatusNotFound:
+		var body struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			return AvailabilityResult{}, fmt.Errorf(
+				"hub returned 404 but body is not valid JSON: %w — is --hub pointing at the right service?",
+				err)
+		}
+		if body.Error.Code != "plugin_not_found" {
+			return AvailabilityResult{}, fmt.Errorf(
+				"hub returned 404 with error.code=%q (expected plugin_not_found) — is --hub pointing at the right service?",
+				body.Error.Code)
+		}
 		return AvailabilityResult{Available: true}, nil
 	case http.StatusOK:
 		var body struct {

--- a/internal/cli/plugin/hub_client.go
+++ b/internal/cli/plugin/hub_client.go
@@ -78,8 +78,21 @@ func (c *httpHubClient) CheckPluginAvailability(ctx context.Context, name string
 	}
 	resp, err := c.http.Do(req)
 	if err != nil {
+		// Caller-driven cancellation: propagate unchanged so the wider
+		// command flow can react to it (interactive Ctrl-C, parent
+		// deadline). We check ctx.Err() rather than errors.Is on the
+		// network error because http.Client's own timeout also surfaces
+		// as context.DeadlineExceeded — distinguishable by whether the
+		// caller's context has itself errored.
+		if ctx.Err() != nil {
+			return AvailabilityResult{}, ctx.Err()
+		}
 		if isTrustError(err) {
 			return AvailabilityResult{}, fmt.Errorf("hub TLS validation failed: %w", err)
+		}
+		if isProtocolMismatchError(err) {
+			return AvailabilityResult{}, fmt.Errorf(
+				"hub protocol mismatch (is --hub using the right scheme?): %w", err)
 		}
 		return AvailabilityResult{}, &HubUnreachableError{Cause: err}
 	}
@@ -143,6 +156,15 @@ func isTrustError(err error) bool {
 	return errors.As(err, &verifyErr) ||
 		errors.As(err, &unknownAuth) ||
 		errors.As(err, &hostErr)
+}
+
+// isProtocolMismatchError detects deterministic protocol mismatches
+// (e.g. --hub points HTTPS at a plain-HTTP server, surfaced by the
+// stdlib as http.ErrSchemeMismatch). These are not transient and must
+// hard-fail so the user fixes their config rather than silently
+// scaffolding.
+func isProtocolMismatchError(err error) bool {
+	return errors.Is(err, http.ErrSchemeMismatch)
 }
 
 // validateHubURL normalizes and validates a hub base URL. Used by

--- a/internal/cli/plugin/hub_client.go
+++ b/internal/cli/plugin/hub_client.go
@@ -1,0 +1,153 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package plugin
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const DefaultHubURL = "https://hub.platform.engineering"
+
+const (
+	hubDialTimeout           = 1 * time.Second
+	hubTLSHandshakeTimeout   = 1 * time.Second
+	hubResponseHeaderTimeout = 2 * time.Second
+	hubTotalTimeout          = 3 * time.Second
+)
+
+type AvailabilityResult struct {
+	Available     bool
+	GitHubRepoURL string
+}
+
+type HubClient interface {
+	CheckPluginAvailability(ctx context.Context, name string) (AvailabilityResult, error)
+}
+
+// HubUnreachableError signals a transient inability to talk to the hub.
+// Callers downgrade to a warning. Trust and protocol-mismatch errors do
+// NOT use this type — they bubble up as plain errors so the caller can
+// hard-fail.
+type HubUnreachableError struct{ Cause error }
+
+func (e *HubUnreachableError) Error() string { return e.Cause.Error() }
+func (e *HubUnreachableError) Unwrap() error { return e.Cause }
+
+func NewHubClient(baseURL string) HubClient {
+	transport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: hubDialTimeout,
+		}).DialContext,
+		TLSHandshakeTimeout:   hubTLSHandshakeTimeout,
+		ResponseHeaderTimeout: hubResponseHeaderTimeout,
+		ExpectContinueTimeout: 1 * time.Second,
+		ForceAttemptHTTP2:     true,
+	}
+	return &httpHubClient{
+		baseURL: baseURL,
+		http:    &http.Client{Transport: transport, Timeout: hubTotalTimeout},
+	}
+}
+
+type httpHubClient struct {
+	baseURL string
+	http    *http.Client
+}
+
+func (c *httpHubClient) CheckPluginAvailability(ctx context.Context, name string) (AvailabilityResult, error) {
+	u, err := url.JoinPath(c.baseURL, "api", "v1", "plugins", url.PathEscape(name))
+	if err != nil {
+		return AvailabilityResult{}, fmt.Errorf("invalid hub base URL %q: %w", c.baseURL, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return AvailabilityResult{}, &HubUnreachableError{Cause: err}
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		if isTrustError(err) {
+			return AvailabilityResult{}, fmt.Errorf("hub TLS validation failed: %w", err)
+		}
+		return AvailabilityResult{}, &HubUnreachableError{Cause: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return AvailabilityResult{Available: true}, nil
+	case http.StatusOK:
+		var body struct {
+			Name          string `json:"name"`
+			GitHubRepoURL string `json:"github_repo_url"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			return AvailabilityResult{}, fmt.Errorf("hub returned 200 but body is not valid JSON: %w", err)
+		}
+		if body.Name == "" || body.GitHubRepoURL == "" {
+			return AvailabilityResult{}, fmt.Errorf("hub returned 200 but response is missing required fields (name, github_repo_url)")
+		}
+		if body.Name != name {
+			return AvailabilityResult{}, fmt.Errorf(
+				"hub returned 200 for %q but body.name=%q — is --hub pointing at the right service?",
+				name, body.Name)
+		}
+		return AvailabilityResult{Available: false, GitHubRepoURL: body.GitHubRepoURL}, nil
+	case http.StatusRequestTimeout, http.StatusTooManyRequests:
+		return AvailabilityResult{}, &HubUnreachableError{
+			Cause: fmt.Errorf("hub returned HTTP %d", resp.StatusCode),
+		}
+	default:
+		if resp.StatusCode >= 500 {
+			return AvailabilityResult{}, &HubUnreachableError{
+				Cause: fmt.Errorf("hub returned HTTP %d", resp.StatusCode),
+			}
+		}
+		return AvailabilityResult{}, fmt.Errorf(
+			"hub returned unexpected HTTP %d — is --hub pointing at the right service?",
+			resp.StatusCode)
+	}
+}
+
+func isTrustError(err error) bool {
+	var verifyErr *tls.CertificateVerificationError
+	var unknownAuth x509.UnknownAuthorityError
+	var hostErr x509.HostnameError
+	return errors.As(err, &verifyErr) ||
+		errors.As(err, &unknownAuth) ||
+		errors.As(err, &hostErr)
+}
+
+// validateHubURL normalizes and validates a hub base URL. Used by
+// resolveHubURL in init.go before constructing a HubClient.
+func validateHubURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("hub URL is empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("hub URL %q is not a valid URL: %w", raw, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("hub URL %q has unsupported scheme %q (want http or https)", raw, u.Scheme)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("hub URL %q is missing a host", raw)
+	}
+	if u.User != nil {
+		return "", fmt.Errorf("hub URL %q must not embed credentials", raw)
+	}
+	return strings.TrimRight(u.String(), "/"), nil
+}

--- a/internal/cli/plugin/hub_client.go
+++ b/internal/cli/plugin/hub_client.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -36,10 +37,25 @@ type HubClient interface {
 	CheckPluginAvailability(ctx context.Context, name string) (AvailabilityResult, error)
 }
 
-// HubUnreachableError signals a transient inability to talk to the hub.
-// Callers downgrade to a warning. Trust and protocol-mismatch errors do
-// NOT use this type — they bubble up as plain errors so the caller can
-// hard-fail.
+// HubTransientError signals a definitely-temporary inability to reach the hub:
+// HTTP timeouts (including dial/read timeouts) and HTTP 408/429/5xx responses.
+// Callers always downgrade to a warning and continue, regardless of whether
+// the hub URL was explicit or the default.
+type HubTransientError struct{ Cause error }
+
+func (e *HubTransientError) Error() string { return e.Cause.Error() }
+func (e *HubTransientError) Unwrap() error { return e.Cause }
+
+// HubUnreachableError signals a transport-level failure that is NOT
+// definitively temporary: DNS resolution failures and connection-refused
+// errors. The hub host either doesn't exist or nothing is listening.
+//
+// Callers must distinguish whether the hub URL was explicitly configured:
+//   - explicit URL (--hub flag / FORMAE_HUB_URL env var) → hard-fail
+//   - default URL → downgrade to warning (same as HubTransientError)
+//
+// Trust and protocol-mismatch errors do NOT use this type — they bubble up
+// as plain errors so the caller can always hard-fail.
 type HubUnreachableError struct{ Cause error }
 
 func (e *HubUnreachableError) Error() string { return e.Cause.Error() }
@@ -94,7 +110,10 @@ func (c *httpHubClient) CheckPluginAvailability(ctx context.Context, name string
 			return AvailabilityResult{}, fmt.Errorf(
 				"hub protocol mismatch (is --hub using the right scheme?): %w", err)
 		}
-		return AvailabilityResult{}, &HubUnreachableError{Cause: err}
+		if isDefinitiveTransportError(err) {
+			return AvailabilityResult{}, &HubUnreachableError{Cause: err}
+		}
+		return AvailabilityResult{}, &HubTransientError{Cause: err}
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -134,12 +153,12 @@ func (c *httpHubClient) CheckPluginAvailability(ctx context.Context, name string
 		}
 		return AvailabilityResult{Available: false, GitHubRepoURL: body.GitHubRepoURL}, nil
 	case http.StatusRequestTimeout, http.StatusTooManyRequests:
-		return AvailabilityResult{}, &HubUnreachableError{
+		return AvailabilityResult{}, &HubTransientError{
 			Cause: fmt.Errorf("hub returned HTTP %d", resp.StatusCode),
 		}
 	default:
 		if resp.StatusCode >= 500 {
-			return AvailabilityResult{}, &HubUnreachableError{
+			return AvailabilityResult{}, &HubTransientError{
 				Cause: fmt.Errorf("hub returned HTTP %d", resp.StatusCode),
 			}
 		}
@@ -177,6 +196,42 @@ func isProtocolMismatchError(err error) bool {
 	if err != nil && strings.Contains(err.Error(), "malformed HTTP response") {
 		return true
 	}
+	return false
+}
+
+// isDefinitiveTransportError returns true when err is a transport-level
+// failure that is definitively not transient: DNS resolution failures or
+// connection-refused errors. These indicate the host does not exist or
+// nothing is listening, rather than a temporary overload or timeout.
+//
+// Timeout errors are intentionally excluded — they are transient and
+// handled by returning HubTransientError instead.
+func isDefinitiveTransportError(err error) bool {
+	// Unwrap url.Error to get at the underlying net.Error / syscall.Errno.
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		err = urlErr.Unwrap()
+	}
+
+	// DNS lookup failure.
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		// IsNotFound: NXDOMAIN — definitively not transient.
+		// IsTimeout: treated as transient (server-side DNS timeout, not our fault).
+		if dnsErr.IsNotFound {
+			return true
+		}
+		// Timeout DNS errors are transient; server-not-found is definitive.
+		return false
+	}
+
+	// Connection refused (ECONNREFUSED) or no route to host (ENETUNREACH / EHOSTUNREACH).
+	if errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ENETUNREACH) ||
+		errors.Is(err, syscall.EHOSTUNREACH) {
+		return true
+	}
+
 	return false
 }
 

--- a/internal/cli/plugin/hub_client.go
+++ b/internal/cli/plugin/hub_client.go
@@ -159,12 +159,25 @@ func isTrustError(err error) bool {
 }
 
 // isProtocolMismatchError detects deterministic protocol mismatches
-// (e.g. --hub points HTTPS at a plain-HTTP server, surfaced by the
-// stdlib as http.ErrSchemeMismatch). These are not transient and must
-// hard-fail so the user fixes their config rather than silently
-// scaffolding.
+// where --hub points at the wrong scheme.
+//
+//   - HTTPS client → HTTP server: net/http returns http.ErrSchemeMismatch.
+//   - HTTP client → HTTPS server: net/http has no exported sentinel;
+//     the transport surfaces strings like "malformed HTTP response"
+//     when it tries to parse TLS handshake bytes as an HTTP response.
+//     We match on the prefix as a deliberate string-coupling to the
+//     stdlib for this specific case.
+//
+// These are not transient and must hard-fail so the user fixes their
+// config rather than silently scaffolding.
 func isProtocolMismatchError(err error) bool {
-	return errors.Is(err, http.ErrSchemeMismatch)
+	if errors.Is(err, http.ErrSchemeMismatch) {
+		return true
+	}
+	if err != nil && strings.Contains(err.Error(), "malformed HTTP response") {
+		return true
+	}
+	return false
 }
 
 // validateHubURL normalizes and validates a hub base URL. Used by

--- a/internal/cli/plugin/hub_client_test.go
+++ b/internal/cli/plugin/hub_client_test.go
@@ -219,3 +219,24 @@ func TestHubClient_200_MissingFields_HardFail(t *testing.T) {
 	assert.False(t, errors.As(err, &unreachable))
 	assert.Contains(t, err.Error(), "missing required fields")
 }
+
+func TestHubClient_TLSHostnameMismatch_HardFail(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Use the real NewHubClient so the production TLS verification is
+	// exercised — the test client used elsewhere lacks a Transport and
+	// would inherit DefaultTransport, which does verify TLS by default
+	// but doesn't carry our other phase timeouts. Casting back to the
+	// concrete type just to keep the call path identical.
+	c := NewHubClient(srv.URL).(*httpHubClient)
+
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable), "TLS validation failure must NOT be HubUnreachableError")
+	assert.Contains(t, err.Error(), "TLS validation failed")
+}

--- a/internal/cli/plugin/hub_client_test.go
+++ b/internal/cli/plugin/hub_client_test.go
@@ -240,3 +240,44 @@ func TestHubClient_TLSHostnameMismatch_HardFail(t *testing.T) {
 	assert.False(t, errors.As(err, &unreachable), "TLS validation failure must NOT be HubUnreachableError")
 	assert.Contains(t, err.Error(), "TLS validation failed")
 }
+
+func TestValidateHubURL(t *testing.T) {
+	t.Run("empty rejected", func(t *testing.T) {
+		_, err := validateHubURL("")
+		assert.Error(t, err)
+	})
+
+	t.Run("whitespace-only rejected", func(t *testing.T) {
+		_, err := validateHubURL("   ")
+		assert.Error(t, err)
+	})
+
+	t.Run("parse error rejected", func(t *testing.T) {
+		_, err := validateHubURL("not a url://")
+		assert.Error(t, err)
+	})
+
+	t.Run("unsupported scheme rejected", func(t *testing.T) {
+		_, err := validateHubURL("ftp://hub.example.com")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "scheme")
+	})
+
+	t.Run("credentials rejected", func(t *testing.T) {
+		_, err := validateHubURL("https://user:pass@hub.example.com")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "credentials")
+	})
+
+	t.Run("trailing slash trimmed", func(t *testing.T) {
+		got, err := validateHubURL("https://hub.example.com/")
+		require.NoError(t, err)
+		assert.Equal(t, "https://hub.example.com", got)
+	})
+
+	t.Run("valid URL passes through", func(t *testing.T) {
+		got, err := validateHubURL("https://hub.platform.engineering")
+		require.NoError(t, err)
+		assert.Equal(t, "https://hub.platform.engineering", got)
+	})
+}

--- a/internal/cli/plugin/hub_client_test.go
+++ b/internal/cli/plugin/hub_client_test.go
@@ -86,9 +86,11 @@ func TestHubClient_500_Transient(t *testing.T) {
 	_, err := c.CheckPluginAvailability(context.Background(), "foo")
 
 	require.Error(t, err)
-	var unreachable *HubUnreachableError
-	assert.True(t, errors.As(err, &unreachable))
+	var transient *HubTransientError
+	assert.True(t, errors.As(err, &transient), "5xx must be HubTransientError")
 	assert.Contains(t, err.Error(), "500")
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable), "5xx must NOT be HubUnreachableError")
 }
 
 func TestHubClient_429_Transient(t *testing.T) {
@@ -101,8 +103,10 @@ func TestHubClient_429_Transient(t *testing.T) {
 	_, err := c.CheckPluginAvailability(context.Background(), "foo")
 
 	require.Error(t, err)
+	var transient *HubTransientError
+	assert.True(t, errors.As(err, &transient), "429 must be HubTransientError")
 	var unreachable *HubUnreachableError
-	assert.True(t, errors.As(err, &unreachable))
+	assert.False(t, errors.As(err, &unreachable), "429 must NOT be HubUnreachableError")
 }
 
 func TestHubClient_408_Transient(t *testing.T) {
@@ -115,8 +119,10 @@ func TestHubClient_408_Transient(t *testing.T) {
 	_, err := c.CheckPluginAvailability(context.Background(), "foo")
 
 	require.Error(t, err)
+	var transient *HubTransientError
+	assert.True(t, errors.As(err, &transient), "408 must be HubTransientError")
 	var unreachable *HubUnreachableError
-	assert.True(t, errors.As(err, &unreachable))
+	assert.False(t, errors.As(err, &unreachable), "408 must NOT be HubUnreachableError")
 }
 
 func TestHubClient_ReadTimeout_Transient(t *testing.T) {
@@ -129,8 +135,46 @@ func TestHubClient_ReadTimeout_Transient(t *testing.T) {
 	_, err := c.CheckPluginAvailability(context.Background(), "foo")
 
 	require.Error(t, err)
+	var transient *HubTransientError
+	assert.True(t, errors.As(err, &transient), "dial/read timeout must be HubTransientError")
 	var unreachable *HubUnreachableError
-	assert.True(t, errors.As(err, &unreachable))
+	assert.False(t, errors.As(err, &unreachable), "timeout must NOT be HubUnreachableError")
+}
+
+// TestHubClient_DNSFailure_Unreachable verifies that a DNS resolution failure
+// produces HubUnreachableError (not HubTransientError). This is a
+// "transport-but-not-temporary" failure: the host simply doesn't exist.
+func TestHubClient_DNSFailure_Unreachable(t *testing.T) {
+	// .invalid is an IANA-reserved TLD guaranteed to never resolve.
+	c := NewHubClient("http://nonexistent.invalid:1").(*httpHubClient)
+
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.True(t, errors.As(err, &unreachable), "DNS failure must be HubUnreachableError")
+	var transient *HubTransientError
+	assert.False(t, errors.As(err, &transient), "DNS failure must NOT be HubTransientError")
+}
+
+// TestHubClient_ConnectionRefused_Unreachable verifies that a refused connection
+// (nothing listening) produces HubUnreachableError (not HubTransientError).
+func TestHubClient_ConnectionRefused_Unreachable(t *testing.T) {
+	// Start a server then immediately close it so the port is freed.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	ln.Close() // port is now closed; connecting to it will be refused
+
+	c := NewHubClient("http://" + addr).(*httpHubClient)
+
+	_, err = c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.True(t, errors.As(err, &unreachable), "connection refused must be HubUnreachableError")
+	var transient *HubTransientError
+	assert.False(t, errors.As(err, &transient), "connection refused must NOT be HubTransientError")
 }
 
 func TestHubClient_401_HardFail(t *testing.T) {

--- a/internal/cli/plugin/hub_client_test.go
+++ b/internal/cli/plugin/hub_client_test.go
@@ -72,3 +72,60 @@ func TestHubClient_NameMismatch_HardFail(t *testing.T) {
 	assert.Contains(t, err.Error(), "foo")
 	assert.Contains(t, err.Error(), "otherplugin")
 }
+
+func TestHubClient_500_Transient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.True(t, errors.As(err, &unreachable))
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestHubClient_429_Transient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.True(t, errors.As(err, &unreachable))
+}
+
+func TestHubClient_408_Transient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusRequestTimeout)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.True(t, errors.As(err, &unreachable))
+}
+
+func TestHubClient_ReadTimeout_Transient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 50*time.Millisecond)
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.True(t, errors.As(err, &unreachable))
+}

--- a/internal/cli/plugin/hub_client_test.go
+++ b/internal/cli/plugin/hub_client_test.go
@@ -9,6 +9,7 @@ package plugin
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -389,6 +390,51 @@ func TestHubClient_DeadlineExceeded_PropagatesAsIs(t *testing.T) {
 	assert.False(t, errors.As(err, &unreachable))
 	assert.True(t, errors.Is(err, context.DeadlineExceeded),
 		"underlying error must remain context.DeadlineExceeded")
+}
+
+func TestHubClient_ProtocolMismatch_HTTPAtHTTPSServer_HardFail(t *testing.T) {
+	// Simulate an HTTPS server by opening a raw TCP listener that writes back
+	// TLS ServerHello bytes when an HTTP client connects. Go's httptest.NewTLSServer
+	// cannot be used here because it detects the plain HTTP request before the
+	// TLS handshake and replies with HTTP 400 — the transport never sees malformed
+	// bytes. A raw TCP server that immediately echoes a TLS record header causes
+	// net/http to emit "malformed HTTP response" exactly as a real HTTPS server
+	// (nginx, etc.) would when it receives an unencrypted request.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 1024)
+				_, _ = c.Read(buf)
+				// TLS record header bytes — what a real HTTPS server returns to an
+				// HTTP client. The net/http transport tries to parse this as
+				// "HTTP/1.x ..." and emits: malformed HTTP response "\x16\x03..."
+				_, _ = c.Write([]byte{0x16, 0x03, 0x03, 0x00, 0x59})
+			}(conn)
+		}
+	}()
+
+	httpURL := "http://" + ln.Addr().String()
+
+	// Use the real NewHubClient so the production transport (with
+	// timeouts and the Proxy resolver) is exercised.
+	c := NewHubClient(httpURL).(*httpHubClient)
+
+	_, err = c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable),
+		"HTTP request against HTTPS server must NOT be HubUnreachableError")
+	assert.Contains(t, err.Error(), "protocol mismatch")
 }
 
 func TestHubClient_ProtocolMismatch_HTTPSAtPlainHTTPServer_HardFail(t *testing.T) {

--- a/internal/cli/plugin/hub_client_test.go
+++ b/internal/cli/plugin/hub_client_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -345,4 +346,69 @@ func TestNewHubClient_HonorsProxyEnv(t *testing.T) {
 	got := reflect.ValueOf(transport.Proxy).Pointer()
 	want := reflect.ValueOf(http.ProxyFromEnvironment).Pointer()
 	assert.Equal(t, want, got, "transport.Proxy must be http.ProxyFromEnvironment")
+}
+
+func TestHubClient_ContextCanceled_PropagatesAsIs(t *testing.T) {
+	// Use a server that sleeps so the request is in-flight when we cancel.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	c := newTestClient(srv.URL, 5*time.Second)
+	_, err := c.CheckPluginAvailability(ctx, "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable),
+		"context.Canceled must NOT be wrapped in HubUnreachableError")
+	assert.True(t, errors.Is(err, context.Canceled),
+		"underlying error must remain context.Canceled")
+}
+
+func TestHubClient_DeadlineExceeded_PropagatesAsIs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	c := newTestClient(srv.URL, 5*time.Second)
+	_, err := c.CheckPluginAvailability(ctx, "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable))
+	assert.True(t, errors.Is(err, context.DeadlineExceeded),
+		"underlying error must remain context.DeadlineExceeded")
+}
+
+func TestHubClient_ProtocolMismatch_HTTPSAtPlainHTTPServer_HardFail(t *testing.T) {
+	// Start a plain-HTTP server, then point an HTTPS client at it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	httpsURL := strings.Replace(srv.URL, "http://", "https://", 1)
+
+	// Use the real NewHubClient so we exercise the production transport
+	// (including the timeouts and Proxy resolver).
+	c := NewHubClient(httpsURL).(*httpHubClient)
+
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable),
+		"protocol mismatch must NOT be wrapped in HubUnreachableError")
+	assert.Contains(t, err.Error(), "protocol mismatch")
 }

--- a/internal/cli/plugin/hub_client_test.go
+++ b/internal/cli/plugin/hub_client_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -280,4 +281,68 @@ func TestValidateHubURL(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "https://hub.platform.engineering", got)
 	})
+}
+
+func TestHubClient_404_NonJSON_HardFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("404 page not found"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable),
+		"404 with non-JSON body must NOT be HubUnreachableError")
+	assert.Contains(t, err.Error(), "not valid JSON")
+}
+
+func TestHubClient_404_WrongErrorCode_HardFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":"route_not_found"}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable))
+	assert.Contains(t, err.Error(), "route_not_found")
+}
+
+func TestHubClient_404_MissingErrorObject_HardFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"nope"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable))
+	// Empty code → message should reference the empty value
+	assert.Contains(t, err.Error(), "expected plugin_not_found")
+}
+
+func TestNewHubClient_HonorsProxyEnv(t *testing.T) {
+	c := NewHubClient("https://example.com").(*httpHubClient)
+	transport, ok := c.http.Transport.(*http.Transport)
+	require.True(t, ok, "expected *http.Transport")
+	require.NotNil(t, transport.Proxy, "transport must have a Proxy resolver set")
+
+	// Compare the function pointer to http.ProxyFromEnvironment so a
+	// future refactor that swaps in a no-op resolver fails this test.
+	got := reflect.ValueOf(transport.Proxy).Pointer()
+	want := reflect.ValueOf(http.ProxyFromEnvironment).Pointer()
+	assert.Equal(t, want, got, "transport.Proxy must be http.ProxyFromEnvironment")
 }

--- a/internal/cli/plugin/hub_client_test.go
+++ b/internal/cli/plugin/hub_client_test.go
@@ -1,0 +1,74 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package plugin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestClient(serverURL string, totalTimeout time.Duration) *httpHubClient {
+	return &httpHubClient{
+		baseURL: serverURL,
+		http:    &http.Client{Timeout: totalTimeout},
+	}
+}
+
+func TestHubClient_Available_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/plugins/foo", r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":"plugin_not_found"}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	res, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.NoError(t, err)
+	assert.True(t, res.Available)
+	assert.Empty(t, res.GitHubRepoURL)
+}
+
+func TestHubClient_Conflict_200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"foo","github_repo_url":"https://github.com/x/y"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	res, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.NoError(t, err)
+	assert.False(t, res.Available)
+	assert.Equal(t, "https://github.com/x/y", res.GitHubRepoURL)
+}
+
+func TestHubClient_NameMismatch_HardFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"name":"otherplugin","github_repo_url":"https://github.com/x/y"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable), "name mismatch must NOT be HubUnreachableError")
+	assert.Contains(t, err.Error(), "foo")
+	assert.Contains(t, err.Error(), "otherplugin")
+}

--- a/internal/cli/plugin/hub_client_test.go
+++ b/internal/cli/plugin/hub_client_test.go
@@ -129,3 +129,93 @@ func TestHubClient_ReadTimeout_Transient(t *testing.T) {
 	var unreachable *HubUnreachableError
 	assert.True(t, errors.As(err, &unreachable))
 }
+
+func TestHubClient_401_HardFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable))
+	assert.Contains(t, err.Error(), "401")
+}
+
+func TestHubClient_403_HardFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable))
+	assert.Contains(t, err.Error(), "403")
+}
+
+func TestHubClient_405_HardFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable))
+	assert.Contains(t, err.Error(), "405")
+}
+
+func TestHubClient_400_HardFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable))
+}
+
+func TestHubClient_200_NonJSON_HardFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html>not the right hub</html>"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable))
+	assert.Contains(t, err.Error(), "not valid JSON")
+}
+
+func TestHubClient_200_MissingFields_HardFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"foo":"bar"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 1*time.Second)
+	_, err := c.CheckPluginAvailability(context.Background(), "foo")
+
+	require.Error(t, err)
+	var unreachable *HubUnreachableError
+	assert.False(t, errors.As(err, &unreachable))
+	assert.Contains(t, err.Error(), "missing required fields")
+}

--- a/internal/cli/plugin/init.go
+++ b/internal/cli/plugin/init.go
@@ -205,6 +205,11 @@ func getTemplateTarballURL(version string) string {
 	)
 }
 
+// runPluginInitFn is the entrypoint cobra calls. Tests swap it to
+// capture the constructed PluginInitOptions, then restore it via a
+// t.Cleanup.
+var runPluginInitFn = runPluginInit
+
 func PluginInitCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "init",
@@ -228,12 +233,15 @@ Template repository: github.com/platform-engineering-labs/formae-plugin-template
 			opts.License, _ = c.Flags().GetString("license")
 			opts.OutputDir, _ = c.Flags().GetString("output-dir")
 			opts.NoInput, _ = c.Flags().GetBool("no-input")
+			opts.Hub, _ = c.Flags().GetString("hub")
+			opts.NoAvailabilityCheck, _ = c.Flags().GetBool("no-availability-check")
+			opts.AllowConflict, _ = c.Flags().GetBool("allow-conflict")
 
 			if err := validatePluginInitOptions(opts); err != nil {
 				return err
 			}
 
-			return runPluginInit(opts)
+			return runPluginInitFn(c.Context(), opts)
 		},
 		SilenceErrors: true,
 	}
@@ -246,11 +254,17 @@ Template repository: github.com/platform-engineering-labs/formae-plugin-template
 	command.Flags().String("license", "", "SPDX license identifier (default: Apache-2.0)")
 	command.Flags().String("output-dir", "", "Target directory (default: ./<name>)")
 	command.Flags().Bool("no-input", false, "Disable interactive prompts; error if required flags are missing")
+	command.Flags().String("hub", "",
+		fmt.Sprintf("Hub base URL (default: $FORMAE_HUB_URL or %s)", DefaultHubURL))
+	command.Flags().Bool("no-availability-check", false,
+		"Skip the hub availability check (use for offline scaffolding or tests)")
+	command.Flags().Bool("allow-conflict", false,
+		"Scaffold even if the hub reports the plugin name is already registered")
 
 	return command
 }
 
-func runPluginInit(opts *PluginInitOptions) error {
+func runPluginInit(ctx context.Context, opts *PluginInitOptions) error {
 	p := prompter.NewBasicPrompter()
 
 	// In non-interactive mode, all values are already set and validated
@@ -279,6 +293,21 @@ func runPluginInit(opts *PluginInitOptions) error {
 			return err
 		}
 		config.Name = name
+	}
+
+	// Hub availability check (runs immediately after name is resolved, before further prompts)
+	if !opts.NoAvailabilityCheck {
+		hubURL, err := resolveHubURL(opts)
+		if err != nil {
+			return err
+		}
+		client := opts.HubClient
+		if client == nil {
+			client = NewHubClient(hubURL)
+		}
+		if err := runAvailabilityCheck(ctx, client, config.Name, opts.AllowConflict); err != nil {
+			return err
+		}
 	}
 
 	// Namespace (required)
@@ -394,7 +423,11 @@ func runPluginInit(opts *PluginInitOptions) error {
 
 	// Download and extract the template
 	fmt.Printf("%s\n", display.Grey("Downloading template from GitHub..."))
-	if err := (httpTemplateDownloader{}).Download(context.Background(), config.OutputDir); err != nil {
+	downloader := opts.TemplateDownloader
+	if downloader == nil {
+		downloader = httpTemplateDownloader{}
+	}
+	if err := downloader.Download(ctx, config.OutputDir); err != nil {
 		return fmt.Errorf("failed to download template: %w", err)
 	}
 

--- a/internal/cli/plugin/init.go
+++ b/internal/cli/plugin/init.go
@@ -300,7 +300,7 @@ func runPluginInit(ctx context.Context, opts *PluginInitOptions) error {
 
 	// Hub availability check (runs immediately after name is resolved, before further prompts)
 	if !opts.NoAvailabilityCheck {
-		hubURL, err := resolveHubURL(opts)
+		hubURL, explicit, err := resolveHubURL(opts)
 		if err != nil {
 			return err
 		}
@@ -308,7 +308,7 @@ func runPluginInit(ctx context.Context, opts *PluginInitOptions) error {
 		if client == nil {
 			client = NewHubClient(hubURL)
 		}
-		if err := runAvailabilityCheck(ctx, client, config.Name, opts.AllowConflict); err != nil {
+		if err := runAvailabilityCheck(ctx, client, config.Name, opts.AllowConflict, explicit); err != nil {
 			return err
 		}
 	}
@@ -505,19 +505,27 @@ func validateOutputDir(dir string) error {
 	return nil
 }
 
-func resolveHubURL(opts *PluginInitOptions) (string, error) {
+// resolveHubURL returns the normalized hub URL and whether it was set
+// explicitly by the caller (via --hub flag or FORMAE_HUB_URL env var).
+// When explicit is false the URL is the built-in default.
+func resolveHubURL(opts *PluginInitOptions) (hubURL string, explicit bool, err error) {
 	candidate := opts.Hub
-	if candidate == "" {
+	if candidate != "" {
+		explicit = true
+	} else {
 		candidate = os.Getenv("FORMAE_HUB_URL")
+		if candidate != "" {
+			explicit = true
+		}
 	}
 	if candidate == "" {
 		candidate = DefaultHubURL
 	}
-	normalized, err := validateHubURL(candidate)
-	if err != nil {
-		return "", cmd.FlagErrorf("invalid hub URL: %s", err)
+	normalized, valErr := validateHubURL(candidate)
+	if valErr != nil {
+		return "", false, cmd.FlagErrorf("invalid hub URL: %s", valErr)
 	}
-	return normalized, nil
+	return normalized, explicit, nil
 }
 
 func runAvailabilityCheck(
@@ -525,6 +533,7 @@ func runAvailabilityCheck(
 	client HubClient,
 	name string,
 	allowConflict bool,
+	explicitHub bool,
 ) error {
 	res, err := client.CheckPluginAvailability(ctx, name)
 	if err != nil {
@@ -535,8 +544,24 @@ func runAvailabilityCheck(
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
+		// HubTransientError: definitely temporary (timeout, 408, 429, 5xx).
+		// Always warn-and-continue regardless of whether the hub was explicit.
+		var transient *HubTransientError
+		if errors.As(err, &transient) {
+			fmt.Fprintln(os.Stderr, display.Grey(fmt.Sprintf(
+				"Hub availability check skipped: %s. Hub will re-validate at registration time.",
+				transient.Cause)))
+			return nil
+		}
+		// HubUnreachableError: transport failure that is not definitively
+		// temporary (DNS NXDOMAIN, connection refused). Fail closed when
+		// the caller explicitly configured the hub URL — they likely have a
+		// typo. Warn-and-continue only for the built-in default.
 		var unreachable *HubUnreachableError
 		if errors.As(err, &unreachable) {
+			if explicitHub {
+				return fmt.Errorf("hub availability check failed: %w", err)
+			}
 			fmt.Fprintln(os.Stderr, display.Grey(fmt.Sprintf(
 				"Hub availability check skipped: %s. Hub will re-validate at registration time.",
 				unreachable.Cause)))

--- a/internal/cli/plugin/init.go
+++ b/internal/cli/plugin/init.go
@@ -283,6 +283,9 @@ func runPluginInit(ctx context.Context, opts *PluginInitOptions) error {
 
 	// Plugin name (required)
 	if opts.Name != "" {
+		if err := validatePluginName(opts.Name); err != nil {
+			return cmd.FlagErrorf("invalid plugin name: %s", err.Error())
+		}
 		config.Name = opts.Name
 	} else {
 		name, err := p.PromptString("Plugin name")

--- a/internal/cli/plugin/init.go
+++ b/internal/cli/plugin/init.go
@@ -57,11 +57,87 @@ type PluginInitOptions struct {
 	TemplateDownloader TemplateDownloader
 }
 
-// TemplateDownloader is a placeholder; the full definition with
-// httpTemplateDownloader lands in Task 9 of the plan. Defined here
-// only so PluginInitOptions can carry the test seam.
+// TemplateDownloader fetches the plugin template tarball and extracts
+// it into outputDir. Production uses httpTemplateDownloader; tests
+// inject a spy via PluginInitOptions.TemplateDownloader.
 type TemplateDownloader interface {
 	Download(ctx context.Context, outputDir string) error
+}
+
+type httpTemplateDownloader struct{}
+
+func (httpTemplateDownloader) Download(ctx context.Context, outputDir string) error {
+	branch := DefaultBranch
+	url := getTemplateTarballURL(branch)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to build template request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to download template: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download template: HTTP %d", resp.StatusCode)
+	}
+
+	gzr, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+	defer func() { _ = gzr.Close() }()
+
+	tr := tar.NewReader(gzr)
+
+	rootPrefix := fmt.Sprintf("%s-%s/", TemplateRepoName, branch)
+
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read tar entry: %w", err)
+		}
+
+		if !strings.HasPrefix(header.Name, rootPrefix) {
+			continue
+		}
+
+		relPath := strings.TrimPrefix(header.Name, rootPrefix)
+		if relPath == "" {
+			continue
+		}
+
+		targetPath := filepath.Join(outputDir, relPath)
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(targetPath, os.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", targetPath, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+				return fmt.Errorf("failed to create parent directory for %s: %w", targetPath, err)
+			}
+			outFile, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
+			if err != nil {
+				return fmt.Errorf("failed to create file %s: %w", targetPath, err)
+			}
+			if _, err := io.Copy(outFile, tr); err != nil {
+				_ = outFile.Close()
+				return fmt.Errorf("failed to write file %s: %w", targetPath, err)
+			}
+			if err := outFile.Close(); err != nil {
+				return fmt.Errorf("failed to close file %s: %w", targetPath, err)
+			}
+		}
+	}
+
+	return nil
 }
 
 // validatePluginInitOptions validates the options and applies defaults.
@@ -318,7 +394,7 @@ func runPluginInit(opts *PluginInitOptions) error {
 
 	// Download and extract the template
 	fmt.Printf("%s\n", display.Grey("Downloading template from GitHub..."))
-	if err := downloadAndExtractTemplate(config.OutputDir); err != nil {
+	if err := (httpTemplateDownloader{}).Download(context.Background(), config.OutputDir); err != nil {
 		return fmt.Errorf("failed to download template: %w", err)
 	}
 
@@ -458,86 +534,6 @@ func expandTilde(path string) string {
 	return path
 }
 
-func downloadAndExtractTemplate(outputDir string) error {
-	branch := DefaultBranch
-	url := getTemplateTarballURL(branch)
-
-	// Download the tarball
-	resp, err := http.Get(url)
-	if err != nil {
-		return fmt.Errorf("failed to download template: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download template: HTTP %d", resp.StatusCode)
-	}
-
-	// Create a gzip reader
-	gzr, err := gzip.NewReader(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to create gzip reader: %w", err)
-	}
-	defer func() { _ = gzr.Close() }()
-
-	// Create a tar reader
-	tr := tar.NewReader(gzr)
-
-	// GitHub tarballs have a root directory named "{repo}-{branch}/"
-	// We need to strip this prefix when extracting
-	rootPrefix := fmt.Sprintf("%s-%s/", TemplateRepoName, branch)
-
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("failed to read tar entry: %w", err)
-		}
-
-		// Skip entries that don't start with the expected prefix
-		if !strings.HasPrefix(header.Name, rootPrefix) {
-			continue
-		}
-
-		// Strip the root directory prefix
-		relPath := strings.TrimPrefix(header.Name, rootPrefix)
-		if relPath == "" {
-			continue
-		}
-
-		targetPath := filepath.Join(outputDir, relPath)
-
-		switch header.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(targetPath, os.FileMode(header.Mode)); err != nil {
-				return fmt.Errorf("failed to create directory %s: %w", targetPath, err)
-			}
-		case tar.TypeReg:
-			// Ensure parent directory exists
-			if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
-				return fmt.Errorf("failed to create parent directory for %s: %w", targetPath, err)
-			}
-
-			// Create the file
-			outFile, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
-			if err != nil {
-				return fmt.Errorf("failed to create file %s: %w", targetPath, err)
-			}
-
-			if _, err := io.Copy(outFile, tr); err != nil {
-				_ = outFile.Close()
-				return fmt.Errorf("failed to write file %s: %w", targetPath, err)
-			}
-			if err := outFile.Close(); err != nil {
-				return fmt.Errorf("failed to close file %s: %w", targetPath, err)
-			}
-		}
-	}
-
-	return nil
-}
 
 func transformTemplateFiles(config *PluginConfig) error {
 	// Walk the output directory and transform files

--- a/internal/cli/plugin/init.go
+++ b/internal/cli/plugin/init.go
@@ -534,7 +534,6 @@ func expandTilde(path string) string {
 	return path
 }
 
-
 func transformTemplateFiles(config *PluginConfig) error {
 	// Walk the output directory and transform files
 	return filepath.Walk(config.OutputDir, func(path string, info os.FileInfo, err error) error {

--- a/internal/cli/plugin/init.go
+++ b/internal/cli/plugin/init.go
@@ -525,6 +525,13 @@ func runAvailabilityCheck(
 ) error {
 	res, err := client.CheckPluginAvailability(ctx, name)
 	if err != nil {
+		// Propagate cancellation as-is so cobra surfaces the right exit.
+		// The hub client returns ctx.Err() directly for caller-driven
+		// cancellation, so checking ctx.Err() here correctly distinguishes
+		// caller cancellation from hub-client-internal timeouts.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		var unreachable *HubUnreachableError
 		if errors.As(err, &unreachable) {
 			fmt.Fprintln(os.Stderr, display.Grey(fmt.Sprintf(

--- a/internal/cli/plugin/init.go
+++ b/internal/cli/plugin/init.go
@@ -8,6 +8,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -405,6 +406,37 @@ func resolveHubURL(opts *PluginInitOptions) (string, error) {
 		return "", cmd.FlagErrorf("invalid hub URL: %s", err)
 	}
 	return normalized, nil
+}
+
+func runAvailabilityCheck(
+	ctx context.Context,
+	client HubClient,
+	name string,
+	allowConflict bool,
+) error {
+	res, err := client.CheckPluginAvailability(ctx, name)
+	if err != nil {
+		var unreachable *HubUnreachableError
+		if errors.As(err, &unreachable) {
+			fmt.Fprintln(os.Stderr, display.Grey(fmt.Sprintf(
+				"Hub availability check skipped: %s. Hub will re-validate at registration time.",
+				unreachable.Cause)))
+			return nil
+		}
+		return fmt.Errorf("hub availability check failed: %w", err)
+	}
+	if !res.Available {
+		if allowConflict {
+			fmt.Fprintln(os.Stderr, display.Grey(fmt.Sprintf(
+				"Warning: plugin name %q is already registered by %s. Continuing because --allow-conflict was set; registration will fail at confirm time.",
+				name, res.GitHubRepoURL)))
+			return nil
+		}
+		return fmt.Errorf(
+			"plugin name %q is already registered by %s. Pick a different name (or pass --allow-conflict to scaffold anyway)",
+			name, res.GitHubRepoURL)
+	}
+	return nil
 }
 
 // expandTilde expands ~ to the user's home directory

--- a/internal/cli/plugin/init.go
+++ b/internal/cli/plugin/init.go
@@ -7,6 +7,7 @@ package plugin
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -44,6 +45,22 @@ type PluginInitOptions struct {
 	License     string
 	OutputDir   string
 	NoInput     bool
+
+	// Hub availability check
+	Hub                 string
+	NoAvailabilityCheck bool
+	AllowConflict       bool
+
+	// Test seams — nil in production paths
+	HubClient          HubClient
+	TemplateDownloader TemplateDownloader
+}
+
+// TemplateDownloader is a placeholder; the full definition with
+// httpTemplateDownloader lands in Task 9 of the plan. Defined here
+// only so PluginInitOptions can carry the test seam.
+type TemplateDownloader interface {
+	Download(ctx context.Context, outputDir string) error
 }
 
 // validatePluginInitOptions validates the options and applies defaults.
@@ -373,6 +390,21 @@ func validateOutputDir(dir string) error {
 	}
 
 	return nil
+}
+
+func resolveHubURL(opts *PluginInitOptions) (string, error) {
+	candidate := opts.Hub
+	if candidate == "" {
+		candidate = os.Getenv("FORMAE_HUB_URL")
+	}
+	if candidate == "" {
+		candidate = DefaultHubURL
+	}
+	normalized, err := validateHubURL(candidate)
+	if err != nil {
+		return "", cmd.FlagErrorf("invalid hub URL: %s", err)
+	}
+	return normalized, nil
 }
 
 // expandTilde expands ~ to the user's home directory

--- a/internal/cli/plugin/init.go
+++ b/internal/cli/plugin/init.go
@@ -327,10 +327,10 @@ func runPluginInit(opts *PluginInitOptions) error {
 }
 
 func validatePluginName(name string) error {
-	// Must start with letter, contain only letters/numbers/hyphens (no spaces)
-	pattern := regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]*$`)
+	// Must start with lowercase letter, contain only lowercase letters/digits/hyphens (hub manifest rule)
+	pattern := regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 	if !pattern.MatchString(name) {
-		return fmt.Errorf("plugin name must start with a letter and contain only letters, numbers, and hyphens (no spaces)")
+		return fmt.Errorf("plugin name must start with a lowercase letter and contain only lowercase letters, digits, and hyphens (hub manifest rule)")
 	}
 	return nil
 }

--- a/internal/cli/plugin/init_cobra_test.go
+++ b/internal/cli/plugin/init_cobra_test.go
@@ -1,0 +1,102 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func swapRunPluginInitFn(t *testing.T, capture *PluginInitOptions) {
+	t.Helper()
+	original := runPluginInitFn
+	runPluginInitFn = func(_ context.Context, opts *PluginInitOptions) error {
+		*capture = *opts
+		return nil
+	}
+	t.Cleanup(func() { runPluginInitFn = original })
+}
+
+func TestPluginInitCmd_FlagBinding_Hub(t *testing.T) {
+	var captured PluginInitOptions
+	swapRunPluginInitFn(t, &captured)
+
+	cmd := PluginInitCmd()
+	cmd.SetArgs([]string{
+		"--no-input",
+		"--name", "myplugin",
+		"--namespace", "MYNS",
+		"--description", "desc",
+		"--author", "me",
+		"--module-path", "github.com/x/y",
+		"--hub", "https://example.com",
+	})
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, "https://example.com", captured.Hub)
+}
+
+func TestPluginInitCmd_FlagBinding_NoAvailabilityCheck(t *testing.T) {
+	var captured PluginInitOptions
+	swapRunPluginInitFn(t, &captured)
+
+	cmd := PluginInitCmd()
+	cmd.SetArgs([]string{
+		"--no-input",
+		"--name", "myplugin",
+		"--namespace", "MYNS",
+		"--description", "desc",
+		"--author", "me",
+		"--module-path", "github.com/x/y",
+		"--no-availability-check",
+	})
+	require.NoError(t, cmd.Execute())
+
+	assert.True(t, captured.NoAvailabilityCheck)
+}
+
+func TestPluginInitCmd_FlagBinding_AllowConflict(t *testing.T) {
+	var captured PluginInitOptions
+	swapRunPluginInitFn(t, &captured)
+
+	cmd := PluginInitCmd()
+	cmd.SetArgs([]string{
+		"--no-input",
+		"--name", "myplugin",
+		"--namespace", "MYNS",
+		"--description", "desc",
+		"--author", "me",
+		"--module-path", "github.com/x/y",
+		"--allow-conflict",
+	})
+	require.NoError(t, cmd.Execute())
+
+	assert.True(t, captured.AllowConflict)
+}
+
+func TestPluginInitCmd_FlagBinding_Defaults(t *testing.T) {
+	var captured PluginInitOptions
+	swapRunPluginInitFn(t, &captured)
+
+	cmd := PluginInitCmd()
+	cmd.SetArgs([]string{
+		"--no-input",
+		"--name", "myplugin",
+		"--namespace", "MYNS",
+		"--description", "desc",
+		"--author", "me",
+		"--module-path", "github.com/x/y",
+	})
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, "", captured.Hub)
+	assert.False(t, captured.NoAvailabilityCheck)
+	assert.False(t, captured.AllowConflict)
+}

--- a/internal/cli/plugin/init_test.go
+++ b/internal/cli/plugin/init_test.go
@@ -7,12 +7,16 @@
 package plugin
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/cli/cmd"
 )
 
 func TestValidatePluginInitOptions(t *testing.T) {
@@ -265,4 +269,47 @@ open module example.Config
 	if !strings.Contains(result, `type = "sftp"`) {
 		t.Errorf("expected type = sftp")
 	}
+}
+
+func TestResolveHubURL(t *testing.T) {
+	t.Run("flag set with valid URL wins", func(t *testing.T) {
+		t.Setenv("FORMAE_HUB_URL", "https://env.example.com")
+		opts := &PluginInitOptions{Hub: "https://flag.example.com"}
+		got, err := resolveHubURL(opts)
+		require.NoError(t, err)
+		assert.Equal(t, "https://flag.example.com", got)
+	})
+
+	t.Run("flag empty falls back to env", func(t *testing.T) {
+		t.Setenv("FORMAE_HUB_URL", "https://env.example.com")
+		opts := &PluginInitOptions{}
+		got, err := resolveHubURL(opts)
+		require.NoError(t, err)
+		assert.Equal(t, "https://env.example.com", got)
+	})
+
+	t.Run("flag and env empty falls back to default", func(t *testing.T) {
+		t.Setenv("FORMAE_HUB_URL", "")
+		opts := &PluginInitOptions{}
+		got, err := resolveHubURL(opts)
+		require.NoError(t, err)
+		assert.Equal(t, DefaultHubURL, got)
+	})
+
+	t.Run("flag with bad scheme returns FlagError", func(t *testing.T) {
+		opts := &PluginInitOptions{Hub: "ftp://hub.example.com"}
+		_, err := resolveHubURL(opts)
+		require.Error(t, err)
+		var flagErr *cmd.FlagError
+		assert.True(t, errors.As(err, &flagErr))
+	})
+
+	t.Run("env with bad scheme returns FlagError", func(t *testing.T) {
+		t.Setenv("FORMAE_HUB_URL", "ftp://hub.example.com")
+		opts := &PluginInitOptions{}
+		_, err := resolveHubURL(opts)
+		require.Error(t, err)
+		var flagErr *cmd.FlagError
+		assert.True(t, errors.As(err, &flagErr))
+	})
 }

--- a/internal/cli/plugin/init_test.go
+++ b/internal/cli/plugin/init_test.go
@@ -277,30 +277,33 @@ func TestResolveHubURL(t *testing.T) {
 	t.Run("flag set with valid URL wins", func(t *testing.T) {
 		t.Setenv("FORMAE_HUB_URL", "https://env.example.com")
 		opts := &PluginInitOptions{Hub: "https://flag.example.com"}
-		got, err := resolveHubURL(opts)
+		got, explicit, err := resolveHubURL(opts)
 		require.NoError(t, err)
 		assert.Equal(t, "https://flag.example.com", got)
+		assert.True(t, explicit, "flag-provided URL must be explicit")
 	})
 
 	t.Run("flag empty falls back to env", func(t *testing.T) {
 		t.Setenv("FORMAE_HUB_URL", "https://env.example.com")
 		opts := &PluginInitOptions{}
-		got, err := resolveHubURL(opts)
+		got, explicit, err := resolveHubURL(opts)
 		require.NoError(t, err)
 		assert.Equal(t, "https://env.example.com", got)
+		assert.True(t, explicit, "env-provided URL must be explicit")
 	})
 
 	t.Run("flag and env empty falls back to default", func(t *testing.T) {
 		t.Setenv("FORMAE_HUB_URL", "")
 		opts := &PluginInitOptions{}
-		got, err := resolveHubURL(opts)
+		got, explicit, err := resolveHubURL(opts)
 		require.NoError(t, err)
 		assert.Equal(t, DefaultHubURL, got)
+		assert.False(t, explicit, "default URL must not be explicit")
 	})
 
 	t.Run("flag with bad scheme returns FlagError", func(t *testing.T) {
 		opts := &PluginInitOptions{Hub: "ftp://hub.example.com"}
-		_, err := resolveHubURL(opts)
+		_, _, err := resolveHubURL(opts)
 		require.Error(t, err)
 		var flagErr *cmd.FlagError
 		assert.True(t, errors.As(err, &flagErr))
@@ -309,7 +312,7 @@ func TestResolveHubURL(t *testing.T) {
 	t.Run("env with bad scheme returns FlagError", func(t *testing.T) {
 		t.Setenv("FORMAE_HUB_URL", "ftp://hub.example.com")
 		opts := &PluginInitOptions{}
-		_, err := resolveHubURL(opts)
+		_, _, err := resolveHubURL(opts)
 		require.Error(t, err)
 		var flagErr *cmd.FlagError
 		assert.True(t, errors.As(err, &flagErr))
@@ -332,7 +335,7 @@ func TestRunAvailabilityCheck(t *testing.T) {
 
 	t.Run("conflict, no allowConflict, returns plain error mentioning name and url and --allow-conflict", func(t *testing.T) {
 		fc := &fakeHubClient{res: AvailabilityResult{Available: false, GitHubRepoURL: "https://github.com/x/y"}}
-		err := runAvailabilityCheck(ctx, fc, "foo", false)
+		err := runAvailabilityCheck(ctx, fc, "foo", false, false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "foo")
 		assert.Contains(t, err.Error(), "https://github.com/x/y")
@@ -341,25 +344,44 @@ func TestRunAvailabilityCheck(t *testing.T) {
 
 	t.Run("conflict, allowConflict=true, returns nil", func(t *testing.T) {
 		fc := &fakeHubClient{res: AvailabilityResult{Available: false, GitHubRepoURL: "https://github.com/x/y"}}
-		err := runAvailabilityCheck(ctx, fc, "foo", true)
+		err := runAvailabilityCheck(ctx, fc, "foo", true, false)
 		assert.NoError(t, err)
 	})
 
 	t.Run("available returns nil", func(t *testing.T) {
 		fc := &fakeHubClient{res: AvailabilityResult{Available: true}}
-		err := runAvailabilityCheck(ctx, fc, "foo", false)
+		err := runAvailabilityCheck(ctx, fc, "foo", false, false)
 		assert.NoError(t, err)
 	})
 
-	t.Run("HubUnreachableError downgrades to nil", func(t *testing.T) {
-		fc := &fakeHubClient{err: &HubUnreachableError{Cause: errors.New("dial tcp: timeout")}}
-		err := runAvailabilityCheck(ctx, fc, "foo", false)
+	t.Run("HubTransientError always downgrades to nil (default hub)", func(t *testing.T) {
+		fc := &fakeHubClient{err: &HubTransientError{Cause: errors.New("hub returned HTTP 503")}}
+		err := runAvailabilityCheck(ctx, fc, "foo", false, false)
 		assert.NoError(t, err)
+	})
+
+	t.Run("HubTransientError always downgrades to nil (explicit hub)", func(t *testing.T) {
+		fc := &fakeHubClient{err: &HubTransientError{Cause: errors.New("hub returned HTTP 503")}}
+		err := runAvailabilityCheck(ctx, fc, "foo", false, true)
+		assert.NoError(t, err)
+	})
+
+	t.Run("HubUnreachableError with default hub downgrades to nil", func(t *testing.T) {
+		fc := &fakeHubClient{err: &HubUnreachableError{Cause: errors.New("dial tcp: connection refused")}}
+		err := runAvailabilityCheck(ctx, fc, "foo", false, false)
+		assert.NoError(t, err, "unreachable default hub must warn-and-continue")
+	})
+
+	t.Run("HubUnreachableError with explicit hub is hard-fail", func(t *testing.T) {
+		fc := &fakeHubClient{err: &HubUnreachableError{Cause: errors.New("dial tcp: connection refused")}}
+		err := runAvailabilityCheck(ctx, fc, "foo", false, true)
+		require.Error(t, err, "unreachable explicit hub must hard-fail")
+		assert.Contains(t, err.Error(), "hub availability check failed")
 	})
 
 	t.Run("plain error (trust/protocol) is hard-fail", func(t *testing.T) {
 		fc := &fakeHubClient{err: errors.New("hub TLS validation failed: x")}
-		err := runAvailabilityCheck(ctx, fc, "foo", false)
+		err := runAvailabilityCheck(ctx, fc, "foo", false, false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "TLS")
 	})
@@ -368,7 +390,7 @@ func TestRunAvailabilityCheck(t *testing.T) {
 		canceledCtx, cancel := context.WithCancel(context.Background())
 		cancel() // immediately cancel so ctx.Err() == context.Canceled
 		fc := &fakeHubClient{err: context.Canceled}
-		err := runAvailabilityCheck(canceledCtx, fc, "foo", false)
+		err := runAvailabilityCheck(canceledCtx, fc, "foo", false, false)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, context.Canceled))
 		// Must not be wrapped under "hub availability check failed: ..."
@@ -380,7 +402,7 @@ func TestRunAvailabilityCheck(t *testing.T) {
 		defer cancel()
 		time.Sleep(1 * time.Millisecond) // ensure the deadline has passed
 		fc := &fakeHubClient{err: context.DeadlineExceeded}
-		err := runAvailabilityCheck(expiredCtx, fc, "foo", false)
+		err := runAvailabilityCheck(expiredCtx, fc, "foo", false, false)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, context.DeadlineExceeded))
 	})

--- a/internal/cli/plugin/init_test.go
+++ b/internal/cli/plugin/init_test.go
@@ -7,6 +7,7 @@
 package plugin
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -311,5 +312,54 @@ func TestResolveHubURL(t *testing.T) {
 		require.Error(t, err)
 		var flagErr *cmd.FlagError
 		assert.True(t, errors.As(err, &flagErr))
+	})
+}
+
+type fakeHubClient struct {
+	res   AvailabilityResult
+	err   error
+	calls int
+}
+
+func (f *fakeHubClient) CheckPluginAvailability(ctx context.Context, name string) (AvailabilityResult, error) {
+	f.calls++
+	return f.res, f.err
+}
+
+func TestRunAvailabilityCheck(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("conflict, no allowConflict, returns plain error mentioning name and url and --allow-conflict", func(t *testing.T) {
+		fc := &fakeHubClient{res: AvailabilityResult{Available: false, GitHubRepoURL: "https://github.com/x/y"}}
+		err := runAvailabilityCheck(ctx, fc, "foo", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "foo")
+		assert.Contains(t, err.Error(), "https://github.com/x/y")
+		assert.Contains(t, err.Error(), "--allow-conflict")
+	})
+
+	t.Run("conflict, allowConflict=true, returns nil", func(t *testing.T) {
+		fc := &fakeHubClient{res: AvailabilityResult{Available: false, GitHubRepoURL: "https://github.com/x/y"}}
+		err := runAvailabilityCheck(ctx, fc, "foo", true)
+		assert.NoError(t, err)
+	})
+
+	t.Run("available returns nil", func(t *testing.T) {
+		fc := &fakeHubClient{res: AvailabilityResult{Available: true}}
+		err := runAvailabilityCheck(ctx, fc, "foo", false)
+		assert.NoError(t, err)
+	})
+
+	t.Run("HubUnreachableError downgrades to nil", func(t *testing.T) {
+		fc := &fakeHubClient{err: &HubUnreachableError{Cause: errors.New("dial tcp: timeout")}}
+		err := runAvailabilityCheck(ctx, fc, "foo", false)
+		assert.NoError(t, err)
+	})
+
+	t.Run("plain error (trust/protocol) is hard-fail", func(t *testing.T) {
+		fc := &fakeHubClient{err: errors.New("hub TLS validation failed: x")}
+		err := runAvailabilityCheck(ctx, fc, "foo", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TLS")
 	})
 }

--- a/internal/cli/plugin/init_test.go
+++ b/internal/cli/plugin/init_test.go
@@ -385,3 +385,17 @@ func TestRunAvailabilityCheck(t *testing.T) {
 		assert.True(t, errors.Is(err, context.DeadlineExceeded))
 	})
 }
+
+func TestRunPluginInit_FlagNameValidatedInInteractiveMode(t *testing.T) {
+	opts := &PluginInitOptions{
+		Name:                "Foo", // uppercase: violates the lowercase-only rule
+		NoInput:             false, // interactive mode
+		NoAvailabilityCheck: true,  // skip hub call for this test
+	}
+	err := runPluginInit(context.Background(), opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lowercase")
+	var flagErr *cmd.FlagError
+	assert.True(t, errors.As(err, &flagErr),
+		"flag-supplied name validation error should be a *cmd.FlagError so cobra prints usage")
+}

--- a/internal/cli/plugin/init_test.go
+++ b/internal/cli/plugin/init_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -361,5 +362,26 @@ func TestRunAvailabilityCheck(t *testing.T) {
 		err := runAvailabilityCheck(ctx, fc, "foo", false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "TLS")
+	})
+
+	t.Run("context.Canceled propagates as-is (not wrapped in cmd.FlagError)", func(t *testing.T) {
+		canceledCtx, cancel := context.WithCancel(context.Background())
+		cancel() // immediately cancel so ctx.Err() == context.Canceled
+		fc := &fakeHubClient{err: context.Canceled}
+		err := runAvailabilityCheck(canceledCtx, fc, "foo", false)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, context.Canceled))
+		// Must not be wrapped under "hub availability check failed: ..."
+		assert.NotContains(t, err.Error(), "hub availability check failed")
+	})
+
+	t.Run("context.DeadlineExceeded propagates as-is", func(t *testing.T) {
+		expiredCtx, cancel := context.WithTimeout(context.Background(), 1)
+		defer cancel()
+		time.Sleep(1 * time.Millisecond) // ensure the deadline has passed
+		fc := &fakeHubClient{err: context.DeadlineExceeded}
+		err := runAvailabilityCheck(expiredCtx, fc, "foo", false)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, context.DeadlineExceeded))
 	})
 }

--- a/internal/cli/plugin/init_test.go
+++ b/internal/cli/plugin/init_test.go
@@ -209,6 +209,34 @@ func TestValidateOutputDir(t *testing.T) {
 	})
 }
 
+func TestValidatePluginName_HubRegex(t *testing.T) {
+	t.Run("lowercase + hyphen + digits accepted", func(t *testing.T) {
+		assert.NoError(t, validatePluginName("my-plugin-2"))
+	})
+
+	t.Run("uppercase first letter rejected", func(t *testing.T) {
+		err := validatePluginName("Foo")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "lowercase")
+	})
+
+	t.Run("internal uppercase rejected", func(t *testing.T) {
+		err := validatePluginName("myPlugin")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "lowercase")
+	})
+
+	t.Run("all caps rejected", func(t *testing.T) {
+		err := validatePluginName("FOO")
+		assert.Error(t, err)
+	})
+
+	t.Run("underscore still rejected (regression)", func(t *testing.T) {
+		err := validatePluginName("invalid_name")
+		assert.Error(t, err)
+	})
+}
+
 func TestTransformContent_ConfigPKL(t *testing.T) {
 	config := &PluginConfig{
 		Name:      "sftp",

--- a/internal/cli/plugin/init_wiring_test.go
+++ b/internal/cli/plugin/init_wiring_test.go
@@ -8,6 +8,7 @@ package plugin
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -152,4 +153,42 @@ func TestWiring_NoAvailabilityCheck_DoesNotCallHub(t *testing.T) {
 	_ = runPluginInit(context.Background(), opts)
 
 	assert.Equal(t, 1, dl.calls)
+}
+
+// TestWiring_ExplicitHub_DNSFailure_HardFails asserts that when the user
+// explicitly passes --hub with a non-existent hostname, a DNS failure
+// hard-fails the command (downloader NOT called).
+func TestWiring_ExplicitHub_DNSFailure_HardFails(t *testing.T) {
+	dl := &spyDownloader{}
+	// Use an explicit (non-default) hub URL pointing at an unresolvable host.
+	opts := newWiringOpts(t, "http://nonexistent.invalid:1", dl, nil)
+
+	err := runPluginInit(context.Background(), opts)
+
+	require.Error(t, err, "explicit hub with DNS failure must hard-fail")
+	assert.Equal(t, 0, dl.calls, "downloader must NOT be called when explicit hub is unreachable")
+}
+
+// TestWiring_DefaultHub_DNSFailure_WarnsAndContinues asserts that when the
+// default hub URL is used and it's unreachable (simulated via injected client),
+// the command warns and continues scaffolding (downloader IS called).
+func TestWiring_DefaultHub_DNSFailure_WarnsAndContinues(t *testing.T) {
+	dl := &spyDownloader{}
+	// Inject a fake HubClient that returns HubUnreachableError directly,
+	// simulating what happens when the default hub is unreachable.
+	opts := newWiringOpts(t, "", dl, func(o *PluginInitOptions) {
+		o.Hub = "" // no explicit hub — will fall through to DefaultHubURL
+		o.HubClient = &fakeUnreachableHubClient{}
+	})
+
+	_ = runPluginInit(context.Background(), opts)
+
+	assert.Equal(t, 1, dl.calls, "downloader must be called when default hub is unreachable (warn-and-continue)")
+}
+
+// fakeUnreachableHubClient always returns HubUnreachableError.
+type fakeUnreachableHubClient struct{}
+
+func (f *fakeUnreachableHubClient) CheckPluginAvailability(_ context.Context, _ string) (AvailabilityResult, error) {
+	return AvailabilityResult{}, &HubUnreachableError{Cause: fmt.Errorf("simulated: connection refused")}
 }

--- a/internal/cli/plugin/init_wiring_test.go
+++ b/internal/cli/plugin/init_wiring_test.go
@@ -1,0 +1,155 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package plugin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type spyDownloader struct {
+	calls     int
+	gotDir    string
+	returnErr error
+}
+
+func (s *spyDownloader) Download(ctx context.Context, outputDir string) error {
+	s.calls++
+	s.gotDir = outputDir
+	return s.returnErr
+}
+
+type recordingServer struct {
+	*httptest.Server
+	requestCount int32
+	lastPath     string
+}
+
+func newRecordingServer(t *testing.T, status int, body string) *recordingServer {
+	rs := &recordingServer{}
+	rs.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&rs.requestCount, 1)
+		rs.lastPath = r.URL.Path
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(rs.Close)
+	return rs
+}
+
+func newWiringOpts(t *testing.T, hubURL string, downloader TemplateDownloader, overrides func(*PluginInitOptions)) *PluginInitOptions {
+	t.Helper()
+	opts := &PluginInitOptions{
+		Name:               "foo",
+		Namespace:          "FOO",
+		Description:        "test",
+		Author:             "Tester",
+		ModulePath:         "github.com/test/formae-plugin-foo",
+		License:            "Apache-2.0",
+		OutputDir:          filepath.Join(t.TempDir(), "scaffold"),
+		NoInput:            true,
+		Hub:                hubURL,
+		TemplateDownloader: downloader,
+	}
+	if overrides != nil {
+		overrides(opts)
+	}
+	return opts
+}
+
+func TestWiring_Conflict_AbortsBeforeScaffold(t *testing.T) {
+	srv := newRecordingServer(t, http.StatusOK,
+		`{"name":"foo","github_repo_url":"https://github.com/x/y"}`)
+	dl := &spyDownloader{}
+	opts := newWiringOpts(t, srv.URL, dl, nil)
+
+	err := runPluginInit(context.Background(), opts)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "foo")
+	assert.Contains(t, err.Error(), "https://github.com/x/y")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&srv.requestCount), "hub must have been called exactly once")
+	assert.Equal(t, "/api/v1/plugins/foo", srv.lastPath)
+	assert.Equal(t, 0, dl.calls, "downloader must NOT be called on conflict")
+}
+
+func TestWiring_Available_ProceedsToScaffold(t *testing.T) {
+	srv := newRecordingServer(t, http.StatusNotFound,
+		`{"error":{"code":"plugin_not_found"}}`)
+	dl := &spyDownloader{}
+	opts := newWiringOpts(t, srv.URL, dl, nil)
+
+	_ = runPluginInit(context.Background(), opts)
+	// Don't assert on the return value: with the spy returning nil,
+	// later steps (transformTemplateFiles, finalizeLicense) operate on
+	// an empty dir and may fail. We assert on the contract this test
+	// defends.
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&srv.requestCount), "hub must have been called")
+	assert.Equal(t, 1, dl.calls, "downloader must be called exactly once on 404")
+	assert.Equal(t, opts.OutputDir, dl.gotDir)
+}
+
+func TestWiring_TransientHubError_ProceedsToScaffold(t *testing.T) {
+	srv := newRecordingServer(t, http.StatusInternalServerError, "")
+	dl := &spyDownloader{}
+	opts := newWiringOpts(t, srv.URL, dl, nil)
+
+	_ = runPluginInit(context.Background(), opts)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&srv.requestCount))
+	assert.Equal(t, 1, dl.calls, "downloader must be called even when hub returns 5xx")
+}
+
+func TestWiring_ProtocolMismatch_HardFailsBeforeScaffold(t *testing.T) {
+	srv := newRecordingServer(t, http.StatusUnauthorized, "")
+	dl := &spyDownloader{}
+	opts := newWiringOpts(t, srv.URL, dl, nil)
+
+	err := runPluginInit(context.Background(), opts)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+	assert.Equal(t, 0, dl.calls, "downloader must NOT be called on protocol mismatch")
+}
+
+func TestWiring_NoAvailabilityCheck_ShortCircuitsBadEnv(t *testing.T) {
+	t.Setenv("FORMAE_HUB_URL", "not a url://")
+	dl := &spyDownloader{}
+	opts := newWiringOpts(t, "", dl, func(o *PluginInitOptions) {
+		o.NoAvailabilityCheck = true
+		o.HubClient = nil // would normally trigger NewHubClient(resolveHubURL(...))
+	})
+
+	_ = runPluginInit(context.Background(), opts)
+
+	assert.Equal(t, 1, dl.calls,
+		"downloader must be called — feature was opted out, the bad FORMAE_HUB_URL must not block")
+}
+
+func TestWiring_NoAvailabilityCheck_DoesNotCallHub(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("hub must not receive any request, got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	dl := &spyDownloader{}
+	opts := newWiringOpts(t, srv.URL, dl, func(o *PluginInitOptions) {
+		o.NoAvailabilityCheck = true
+	})
+
+	_ = runPluginInit(context.Background(), opts)
+
+	assert.Equal(t, 1, dl.calls)
+}


### PR DESCRIPTION
## Summary

`formae plugin init <name>` now queries `formae-hub`'s public read endpoint (`GET /api/v1/plugins/{name}`, shipped in hub v0.1.15) immediately after the plugin name is resolved, so a colliding name fails fast — before the user fills in metadata, downloads the template, or touches the filesystem. Previously the collision surfaced only at registration time.

Behavior, broken out by hub response:

- **404 with `error.code = "plugin_not_found"`** — silent pass-through; scaffold continues.
- **200 with `name`/`github_repo_url`/matching name** — hard-fail by default with the conflicting repo URL. `--allow-conflict` overrides for the rare "scaffold anyway" case.
- **5xx / 408 / 429 / dial timeouts / DNS failures** — warn to stderr (grey) and continue. The hub will re-validate at registration anyway; we don't let a flaky network block scaffolding.
- **401 / 403 / 405 / 400 / JSON shape mismatches / wrong-name response** — hard-fail with "is `--hub` pointing at the right service?". A reachable-but-wrong control plane shouldn't masquerade as available.
- **TLS validation failures (cert verify, hostname mismatch, unknown CA, scheme mismatch in either direction)** — hard-fail. Same intent: don't silently disable the safeguard against an untrusted endpoint.
- **`context.Canceled` / `context.DeadlineExceeded`** — propagate as-is so Ctrl-C and parent deadlines actually stop the command.

New flags:

- `--hub <url>` — override the hub base URL. Falls back to `$FORMAE_HUB_URL`, then `https://hub.platform.engineering`. Validated up-front (scheme, host, no embedded credentials).
- `--no-availability-check` — skip the call entirely. Short-circuits **before** URL resolution, so a stale `FORMAE_HUB_URL` doesn't block the opt-out path.
- `--allow-conflict` — proceed despite a confirmed conflict.

`validatePluginName` is tightened from `^[a-zA-Z][a-zA-Z0-9-]*$` to `^[a-z][a-z0-9-]*$` to match the hub's manifest validator (`pluginManifest.ts:32`). Without this, `formae plugin init Foo` would query `/plugins/Foo` (case-sensitive against the hub), get 404, scaffold cleanly, and only fail at registration. Applied consistently to both the `--no-input` validation path and the interactive-mode flag-supplied path.

Internal seams:

- `TemplateDownloader` interface extracted from `downloadAndExtractTemplate`, so wiring tests can spy on the downloader call without hitting GitHub.
- `runPluginInitFn` package-level var so cobra-driven tests can prove each new flag binds correctly.

The HTTP transport explicitly sets phase timeouts (dial 1s, TLS handshake 1s, response header 2s, total 3s) and `Proxy: http.ProxyFromEnvironment` so corporate networks with `HTTPS_PROXY` aren't degraded to permanent warnings.

## Known follow-ups

- The hub's `plugin.namespace` column is globally `UNIQUE`, but the public read endpoint only allows lookup by name. A symmetric namespace pre-check requires a new hub endpoint (e.g. `GET /api/v1/namespaces/{namespace}`) — out of scope here. Note: the `NamespaceService` claim semantics ("namespace owned per-org, multiple plugins per org") and the DB constraint (globally unique) are also inconsistent on the hub side; that's a separate hub-repo issue.
- An archived plugin's name still reserves the slot (DB `UNIQUE`), but the public read endpoint filters `status = 'ready'` and returns 404 for archived rows. The CLI therefore reports "available" for an archived collision; the failure surfaces only at registration time. Same as today's behavior, so not a regression. A hub-side fix would either expose `archived` distinctly (410?) or add a dedicated availability endpoint.
- `validateNamespace` has the same case-mismatch with the hub (`^[a-zA-Z]...` here, `^[A-Z]...` on the hub). Deferred to a focused follow-up with its own deprecation messaging since namespace isn't on the availability lookup path.
- `httpTemplateDownloader.Download` and its caller in `runPluginInit` both wrap errors with `"failed to download template: %w"`, producing a doubled prefix. Pre-existing on `main`; not introduced or fixed here.