### PR TITLE
fix(plugin-operator): preserve plugin error messages on update/delete/resume failures

### DIFF
--- a/internal/workflow_tests/local/resource_updater_test.go
+++ b/internal/workflow_tests/local/resource_updater_test.go
@@ -8,6 +8,7 @@ package workflow_tests_local
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -542,6 +543,91 @@ func TestResourceUpdater_DeleteOperationFailsWhenPluginCrashes(t *testing.T) {
 	})
 }
 
+// Sibling to TestResourceUpdater_PreservesPluginErrorMessageOnUpdateFailure — verifies
+// the same StatusMessage propagation for the delete handler.
+func TestResourceUpdater_PreservesPluginErrorMessageOnDeleteFailure(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const pluginErr = "simulated AWS API failure on DeleteResource"
+		overrides := &plugin.ResourcePluginOverrides{
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{
+					ResourceType: "FakeAWS::S3::Bucket",
+					Properties:   `{"foo":"bar","baz":"qux","a":[3,4,2]}`,
+				}, nil
+			},
+			Delete: func(request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+				return nil, errors.New(pluginErr)
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		if err != nil {
+			t.Fatalf("Failed to create metastructure: %v", err)
+			return
+		}
+
+		messages := make(chan any, 1)
+		_, err = testutil.StartTestHelperActor(m.Node, messages)
+		assert.NoError(t, err)
+
+		initialResource := successfullyFinishedResourceUpdateCreatingS3Bucket()
+		testutil.Call(m.Node, "FormaCommandPersister", forma_persister.StoreNewFormaCommand{
+			Command: forma_command.FormaCommand{
+				ID:      "test-forma-command-delete-error-message",
+				State:   forma_command.CommandStateNotStarted,
+				StartTs: util.TimeNow(),
+				ResourceUpdates: []resource_update.ResourceUpdate{
+					{
+						Operation: resource_update.OperationDelete,
+						DesiredState: pkgmodel.Resource{
+							Label: "test-resource",
+							Type:  "FakeAWS::S3::Bucket",
+							Stack: "test-stack",
+							Ksuid: initialResource.DesiredState.Ksuid,
+						},
+					},
+				},
+			},
+		})
+
+		hash, err := testutil.Call(m.Node, "ResourcePersister", resource_update.PersistResourceUpdate{
+			PluginOperation: resource.OperationCreate,
+			ResourceUpdate:  *initialResource,
+		})
+		assert.NoError(t, err)
+		assert.NotEmpty(t, hash)
+
+		deleteResource := resourceUpdateDeletingS3Bucket(initialResource.DesiredState.Ksuid)
+		_, err = testutil.Call(m.Node, "ResourceUpdaterSupervisor", resource_update.EnsureResourceUpdater{
+			ResourceURI: initialResource.DesiredState.URI(),
+			CommandID:   "test-forma-command-delete-error-message",
+			Operation:   string(deleteResource.Operation),
+		})
+		assert.NoError(t, err)
+
+		testutil.Send(m.Node, actornames.ResourceUpdater(initialResource.DesiredState.URI(), string(deleteResource.Operation), "test-forma-command-delete-error-message"), resource_update.StartResourceUpdate{
+			ResourceUpdate: *deleteResource,
+			CommandID:      "test-forma-command-delete-error-message",
+		})
+
+		testutil.ExpectMessageWithPredicate(t, messages, 10*time.Second, func(msg resource_update.ResourceUpdateFinished) bool {
+			return msg.Uri == initialResource.DesiredState.URI() && msg.State == resource_update.ResourceUpdateStateFailed
+		})
+
+		commandRes, err := testutil.Call(m.Node, "FormaCommandPersister", forma_persister.LoadFormaCommand{
+			CommandID: "test-forma-command-delete-error-message",
+		})
+		assert.NoError(t, err)
+
+		command, ok := commandRes.(*forma_command.FormaCommand)
+		assert.True(t, ok)
+		assert.Len(t, command.ResourceUpdates, 1)
+		assert.Contains(t, command.ResourceUpdates[0].MostRecentFailureMessage(), pluginErr,
+			"plugin error message must propagate to MostRecentFailureMessage so operators can debug Delete failures")
+	})
+}
+
 func TestResourceUpdater_SuccessfullyCreatesAResource(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		overrides := &plugin.ResourcePluginOverrides{
@@ -833,6 +919,94 @@ func TestResourceUpdater_SuccessfullyUpdatesAResource(t *testing.T) {
 		assert.Equal(t, forma_command.CommandStateSuccess, command.State)
 		assert.Len(t, command.ResourceUpdates, 1)
 		assert.Equal(t, resource_update.ResourceUpdateStateSuccess, command.ResourceUpdates[0].State)
+	})
+}
+
+// When the plugin returns a plain error from Update, the PluginOperator must
+// preserve err.Error() as the TrackedProgress.StatusMessage so operators can
+// see what went wrong. Without this, every plugin Update failure surfaces as
+// `UnforeseenError` with no message — operators cannot tell an AWS API rejection
+// apart from a panic or a type assertion failure.
+func TestResourceUpdater_PreservesPluginErrorMessageOnUpdateFailure(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const pluginErr = "simulated AWS API failure on UpdateResource"
+		overrides := &plugin.ResourcePluginOverrides{
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{
+					ResourceType: "FakeAWS::S3::Bucket",
+					Properties:   `{"foo":"bar","baz":"qux","a":[3,4,2]}`,
+				}, nil
+			},
+			Update: func(request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				return nil, errors.New(pluginErr)
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		if err != nil {
+			t.Fatalf("Failed to create metastructure: %v", err)
+			return
+		}
+
+		messages := make(chan any, 1)
+		_, err = testutil.StartTestHelperActor(m.Node, messages)
+		assert.NoError(t, err)
+
+		initialResource := successfullyFinishedResourceUpdateCreatingS3Bucket()
+		hash, err := testutil.Call(m.Node, "ResourcePersister", resource_update.PersistResourceUpdate{
+			PluginOperation: resource.OperationCreate,
+			ResourceUpdate:  *initialResource,
+		})
+		assert.NoError(t, err)
+		assert.NotEmpty(t, hash)
+
+		testutil.Call(m.Node, "FormaCommandPersister", forma_persister.StoreNewFormaCommand{
+			Command: forma_command.FormaCommand{
+				ID:      "test-forma-command-update-error-message",
+				State:   forma_command.CommandStateNotStarted,
+				StartTs: util.TimeNow(),
+				ResourceUpdates: []resource_update.ResourceUpdate{
+					{
+						Operation: resource_update.OperationUpdate,
+						DesiredState: pkgmodel.Resource{
+							Label: "test-resource",
+							Type:  "FakeAWS::S3::Bucket",
+							Stack: "test-stack",
+							Ksuid: initialResource.DesiredState.Ksuid,
+						},
+					},
+				},
+			},
+		})
+
+		updateResource := resourceUpdateModifyingS3Bucket(initialResource.DesiredState.Ksuid)
+		_, err = testutil.Call(m.Node, "ResourceUpdaterSupervisor", resource_update.EnsureResourceUpdater{
+			ResourceURI: initialResource.DesiredState.URI(),
+			CommandID:   "test-forma-command-update-error-message",
+			Operation:   string(updateResource.Operation),
+		})
+		assert.NoError(t, err)
+
+		testutil.Send(m.Node, actornames.ResourceUpdater(initialResource.DesiredState.URI(), string(updateResource.Operation), "test-forma-command-update-error-message"), resource_update.StartResourceUpdate{
+			ResourceUpdate: *updateResource,
+			CommandID:      "test-forma-command-update-error-message",
+		})
+
+		testutil.ExpectMessageWithPredicate(t, messages, 10*time.Second, func(msg resource_update.ResourceUpdateFinished) bool {
+			return msg.Uri == initialResource.DesiredState.URI() && msg.State == resource_update.ResourceUpdateStateFailed
+		})
+
+		commandRes, err := testutil.Call(m.Node, "FormaCommandPersister", forma_persister.LoadFormaCommand{
+			CommandID: "test-forma-command-update-error-message",
+		})
+		assert.NoError(t, err)
+
+		command, ok := commandRes.(*forma_command.FormaCommand)
+		assert.True(t, ok)
+		assert.Len(t, command.ResourceUpdates, 1)
+		assert.Contains(t, command.ResourceUpdates[0].MostRecentFailureMessage(), pluginErr,
+			"plugin error message must propagate to MostRecentFailureMessage so operators can debug Update failures")
 	})
 }
 

--- a/pkg/plugin/plugin_operator.go
+++ b/pkg/plugin/plugin_operator.go
@@ -574,7 +574,9 @@ func update(from gen.PID, state gen.Atom, data PluginUpdateData, operation Updat
 	})
 	if err != nil {
 		proc.Log().Error("PluginOperator: failed to update resource: %v", err)
-		return StateFinishedWithError, data, data.newUnforeseenError(), nil, nil
+		errProgress := data.newUnforeseenError()
+		errProgress.StatusMessage = err.Error()
+		return StateFinishedWithError, data, errProgress, nil, nil
 	}
 
 	return handlePluginResult(data, operation, proc, result.ProgressResult)
@@ -594,7 +596,9 @@ func delete(from gen.PID, state gen.Atom, data PluginUpdateData, operation Delet
 	})
 	if err != nil {
 		proc.Log().Error("PluginOperator: failed to delete resource: %v", err)
-		return StateFinishedWithError, data, data.newUnforeseenError(), nil, nil
+		errProgress := data.newUnforeseenError()
+		errProgress.StatusMessage = err.Error()
+		return StateFinishedWithError, data, errProgress, nil, nil
 	}
 
 	return handlePluginResult(data, operation, proc, result.ProgressResult)
@@ -677,7 +681,9 @@ func resume(from gen.PID, state gen.Atom, data PluginUpdateData, operation Resum
 	})
 	if err != nil {
 		proc.Log().Error("PluginOperator: failed to get resume waiting for resource: %v", err)
-		return StateFinishedWithError, data, data.newUnforeseenError(), nil, nil
+		errProgress := data.newUnforeseenError()
+		errProgress.StatusMessage = err.Error()
+		return StateFinishedWithError, data, errProgress, nil, nil
 	}
 
 	return handlePluginResult(data, operation.Request, proc, result.ProgressResult)


### PR DESCRIPTION
## Summary

When the plugin returned an error from `Update`, `Delete`, or `Status` (during resume), the `PluginOperator` dropped `err.Error()` on the floor and returned a bare `UnforeseenError` with no `StatusMessage`. Operators then had no information to debug failed applies — the only signal was the opaque error code, and the underlying message (AWS API rejection, panic, type assertion failure, etc.) was lost.

`read` and `create` already preserved the message; this brings `update`, `delete`, and `resume` in line by populating `errProgress.StatusMessage = err.Error()` before returning.

## Why

Surfaced during a prod-lgtm reapply where an `AWS::ElasticLoadBalancingV2::TargetGroup` Update failed with `ErrorCode: "UnforeseenError"` and an empty body — leaving the operator with no way to tell whether it was an AWS rejection, a plugin panic, or a code-path the plugin didn't anticipate.

## Coverage

Added two workflow tests in `internal/workflow_tests/local/resource_updater_test.go`:

- `TestResourceUpdater_PreservesPluginErrorMessageOnUpdateFailure` — fails the plugin's Update, asserts the error string surfaces via `ResourceUpdate.MostRecentFailureMessage()`.
- `TestResourceUpdater_PreservesPluginErrorMessageOnDeleteFailure` — same shape for Delete.

The `resume` path is identical in shape; its recovery scenarios are exercised by existing tests, so no dedicated test was added.

## Out of scope

- The `status` handler (line 618) returns `nil` instead of `TrackedProgress` on plugin error and doesn't notify the caller at all — that's a separate, larger bug that needs a state-machine redesign.
- Plugin stderr → CloudWatch and capturing the full request/response in `progress_result` are also separate (operational and SDK-shape changes respectively).