### PR TITLE
fix(plugin): unblock agent start on root-owned tree; rename plugin upgrade -> update

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -197,6 +197,12 @@ func (a *Agent) Start() error {
 		slog.Info("Agent started")
 
 		apiServer := api.NewServer(a.ctx, ms, authHandle, &a.cfg.Agent.Server, a.cfg.Network, metricsHandler)
+		// Plugin install/uninstall/update run locally on the CLI host
+		// (see internal/cli/plugin), so the agent does not construct an
+		// orbital-backed PluginManager. The installed-plugin listing
+		// endpoint serves from the in-process registry and a filesystem
+		// scan of these dirs — no orbital tree, no sudo re-exec.
+		apiServer.SetPluginDirs([]string{devPluginDir, systemPluginDir})
 
 		imwg.Add(apiServer)
 		imwg.Go(func() {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -21,7 +21,6 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/imconc"
 	"github.com/platform-engineering-labs/formae/internal/logging"
 	"github.com/platform-engineering-labs/formae/internal/metastructure"
-	"github.com/platform-engineering-labs/formae/internal/metastructure/plugin_manager"
 	_ "github.com/platform-engineering-labs/formae/internal/network/all"
 	_ "github.com/platform-engineering-labs/formae/internal/schema/all"
 	"github.com/platform-engineering-labs/formae/internal/util"
@@ -195,22 +194,9 @@ func (a *Agent) Start() error {
 			}
 		}
 
-		// Construct the plugin manager before announcing startup. Plugin
-		// distribution is the only install/upgrade path in 0.85, so an agent
-		// without one is not useful — and CLI users (often on a different
-		// host than the agent) would only see opaque 503s instead of this
-		// log line. Fail loudly here so the operator fixes config or the
-		// orbital tree before retrying.
-		pm, err := plugin_manager.New(slog.Default(), a.cfg.Artifacts.Repositories, []string{devPluginDir, systemPluginDir})
-		if err != nil {
-			slog.Error("Plugin manager initialization failed; refusing to start", "error", err)
-			return
-		}
-
 		slog.Info("Agent started")
 
 		apiServer := api.NewServer(a.ctx, ms, authHandle, &a.cfg.Agent.Server, a.cfg.Network, metricsHandler)
-		apiServer.SetPluginManager(pm)
 
 		imwg.Add(apiServer)
 		imwg.Go(func() {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -725,11 +725,11 @@ func (c *Client) UninstallPlugins(req apimodel.UninstallPluginsRequest) (*apimod
 	return &result, nil
 }
 
-func (c *Client) UpgradePlugins(req apimodel.UpgradePluginsRequest) (*apimodel.UpgradePluginsResponse, error) {
+func (c *Client) UpdatePlugins(req apimodel.UpdatePluginsRequest) (*apimodel.UpdatePluginsResponse, error) {
 	resp, err := c.resty.R().
 		SetHeader("Content-Type", "application/json").
 		SetBody(req).
-		Post(c.endpoint + "/api/v1/plugins/upgrade")
+		Post(c.endpoint + "/api/v1/plugins/update")
 	if err != nil {
 		return nil, err
 	}
@@ -738,10 +738,10 @@ func (c *Client) UpgradePlugins(req apimodel.UpgradePluginsRequest) (*apimodel.U
 	defer resp.Body.Close()
 
 	if resp.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("plugin upgrade failed: %d - %s", resp.StatusCode(), resp.String())
+		return nil, fmt.Errorf("plugin update failed: %d - %s", resp.StatusCode(), resp.String())
 	}
 
-	var result apimodel.UpgradePluginsResponse
+	var result apimodel.UpdatePluginsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}

--- a/internal/api/plugin_handlers.go
+++ b/internal/api/plugin_handlers.go
@@ -143,26 +143,26 @@ func (s *Server) uninstallPluginsHandler(c echo.Context) error {
 	})
 }
 
-func (s *Server) upgradePluginsHandler(c echo.Context) error {
+func (s *Server) updatePluginsHandler(c echo.Context) error {
 	pm, err := s.requirePluginManager(c)
 	if err != nil {
 		return err
 	}
 
-	var req apimodel.UpgradePluginsRequest
+	var req apimodel.UpdatePluginsRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
 	}
 
-	pmReq := plugin_manager.UpgradeRequest{
+	pmReq := plugin_manager.UpdateRequest{
 		Packages: toManagerPackageRefs(req.Packages),
 		Channel:  req.Channel,
 	}
-	resp, err := pm.Upgrade(pmReq)
+	resp, err := pm.Update(pmReq)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusOK, apimodel.UpgradePluginsResponse{
+	return c.JSON(http.StatusOK, apimodel.UpdatePluginsResponse{
 		Operations:      toAPIOperations(resp.Operations),
 		RequiresRestart: resp.RequiresRestart,
 		Warnings:        resp.Warnings,

--- a/internal/api/plugin_handlers.go
+++ b/internal/api/plugin_handlers.go
@@ -6,6 +6,8 @@ package api
 
 import (
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -13,6 +15,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/plugin_manager"
 	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/discovery"
 )
 
 func (s *Server) requirePluginManager(c echo.Context) (*plugin_manager.PluginManager, error) {
@@ -22,12 +25,31 @@ func (s *Server) requirePluginManager(c echo.Context) (*plugin_manager.PluginMan
 	return s.pluginManager, nil
 }
 
-func (s *Server) listPluginsHandler(c echo.Context) error {
-	pm, err := s.requirePluginManager(c)
-	if err != nil {
-		return err
+// discoverLocalPluginPaths scans the configured plugin dirs and returns
+// a map from lowercase plugin name to the absolute path of the plugin's
+// PklProject file. Mirrors PluginManager.DiscoverLocalPaths, but lives
+// in api so the installed-plugin listing path can serve LocalPath
+// without depending on an orbital-backed PluginManager.
+func discoverLocalPluginPaths(pluginDirs []string) map[string]string {
+	if len(pluginDirs) == 0 {
+		return map[string]string{}
 	}
+	infos := discovery.DiscoverPluginsMulti(pluginDirs, discovery.Resource)
+	authInfos := discovery.DiscoverPluginsMulti(pluginDirs, discovery.Auth)
+	infos = append(infos, authInfos...)
+	out := make(map[string]string, len(infos))
+	for _, info := range infos {
+		base := filepath.Dir(info.BinaryPath)
+		pklProject := filepath.Join(base, "schema", "pkl", "PklProject")
+		if _, err := os.Stat(pklProject); err != nil {
+			continue
+		}
+		out[strings.ToLower(info.Name)] = pklProject
+	}
+	return out
+}
 
+func (s *Server) listPluginsHandler(c echo.Context) error {
 	scope := c.QueryParam("scope")
 	if scope == "" {
 		scope = "installed"
@@ -36,10 +58,18 @@ func (s *Server) listPluginsHandler(c echo.Context) error {
 	var plugins []plugin_manager.Plugin
 	switch scope {
 	case "installed":
-		localPaths := pm.DiscoverLocalPaths()
-		plugins, err = pm.ListWithLocalPaths(localPaths)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		// Installed listing is served from the in-process plugin
+		// registry (populated by PluginProcessSupervisor at startup) and
+		// a filesystem scan for PklProject paths. No orbital is required,
+		// so the endpoint stays usable even when /opt/pel is root-owned
+		// and the agent runs unprivileged.
+		localPaths := discoverLocalPluginPaths(s.pluginDirs)
+		if s.pluginManager != nil {
+			pmPlugins, err := s.pluginManager.ListWithLocalPaths(localPaths)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+			}
+			plugins = pmPlugins
 		}
 		registered, regErr := s.metastructure.RegisteredPlugins()
 		if regErr != nil {
@@ -48,7 +78,11 @@ func (s *Server) listPluginsHandler(c echo.Context) error {
 		}
 		plugins = mergeRegisteredPlugins(plugins, registered, localPaths)
 	case "available":
-		plugins, err = pm.Available(plugin_manager.AvailableFilter{
+		pm, err := s.requirePluginManager(c)
+		if err != nil {
+			return err
+		}
+		availablePlugins, err := pm.Available(plugin_manager.AvailableFilter{
 			Query:    c.QueryParam("q"),
 			Category: c.QueryParam("category"),
 			Type:     c.QueryParam("type"),
@@ -57,6 +91,7 @@ func (s *Server) listPluginsHandler(c echo.Context) error {
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
+		plugins = availablePlugins
 	default:
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid scope: must be 'installed' or 'available'")
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -56,7 +56,7 @@ const (
 	PluginRoute          = BasePath + "/plugins/:name"
 	PluginInstallRoute   = BasePath + "/plugins/install"
 	PluginUninstallRoute = BasePath + "/plugins/uninstall"
-	PluginUpgradeRoute   = BasePath + "/plugins/upgrade"
+	PluginUpdateRoute    = BasePath + "/plugins/update"
 
 	HealthRoute  = BasePath + "/health"
 	MetricsRoute = "/metrics"
@@ -228,7 +228,7 @@ func (s *Server) configureEcho() *echo.Echo {
 	e.GET(PluginsRoute, s.listPluginsHandler)
 	e.POST(PluginInstallRoute, s.installPluginsHandler)
 	e.POST(PluginUninstallRoute, s.uninstallPluginsHandler)
-	e.POST(PluginUpgradeRoute, s.upgradePluginsHandler)
+	e.POST(PluginUpdateRoute, s.updatePluginsHandler)
 	e.GET(PluginRoute, s.getPluginHandler)
 
 	// Prometheus metrics endpoint (if enabled)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -67,6 +67,7 @@ type Server struct {
 	echo           *echo.Echo
 	metastructure  metastructure.MetastructureAPI
 	pluginManager  *plugin_manager.PluginManager // nil if not configured
+	pluginDirs     []string                      // for filesystem-only installed-plugin discovery
 	ctx            context.Context
 	authHandle     *auth.AuthPluginHandle
 	serverConfig   *pkgmodel.ServerConfig
@@ -75,10 +76,21 @@ type Server struct {
 }
 
 // SetPluginManager configures the optional plugin manager for the server.
-// When set, the plugin management REST endpoints become active; otherwise
-// they return 503 Service Unavailable.
+// When set, the orbital-backed plugin endpoints (search, info, install,
+// uninstall, update) become active; otherwise they return 503 Service
+// Unavailable. The installed-plugin listing path does not need a plugin
+// manager — it serves from the registered-plugin set plus filesystem
+// discovery via SetPluginDirs.
 func (s *Server) SetPluginManager(pm *plugin_manager.PluginManager) {
 	s.pluginManager = pm
+}
+
+// SetPluginDirs configures the directories scanned to attach LocalPath
+// to plugins surfaced by the installed-plugin listing endpoint. Must
+// match the dirs the agent passes to PluginProcessSupervisor so the
+// listing reflects the same on-disk set the agent is actually running.
+func (s *Server) SetPluginDirs(dirs []string) {
+	s.pluginDirs = dirs
 }
 
 func NewServer(ctx context.Context, metastructure metastructure.MetastructureAPI, authHandle *auth.AuthPluginHandle, serverConfig *pkgmodel.ServerConfig, networkConfig *pkgmodel.NetworkConfig, metricsHandler http.Handler) *Server {

--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -483,7 +483,7 @@ func (a *App) installedResourcePlugins() (map[string]PluginInfo, error) {
 	return result, nil
 }
 
-func (a *App) UpgradePlugins(req apimodel.UpgradePluginsRequest) (*apimodel.UpgradePluginsResponse, error) {
+func (a *App) UpdatePlugins(req apimodel.UpdatePluginsRequest) (*apimodel.UpdatePluginsResponse, error) {
 	auth, net, err := a.getAuthAndNetHandlers()
 	if err != nil {
 		return nil, err
@@ -494,7 +494,7 @@ func (a *App) UpgradePlugins(req apimodel.UpgradePluginsRequest) (*apimodel.Upgr
 		return nil, err
 	}
 
-	return client.UpgradePlugins(req)
+	return client.UpdatePlugins(req)
 }
 
 func (a *App) Stats() (*apimodel.Stats, []string, error) {

--- a/internal/cli/plugin/manager.go
+++ b/internal/cli/plugin/manager.go
@@ -65,11 +65,11 @@ func (pm *CLIPluginManager) LocalUninstall(names []string) error {
 	return pm.orb.Remove(names...)
 }
 
-// LocalUpgrade upgrades the named packages, or — when names is empty —
+// LocalUpdate updates the named packages, or — when names is empty —
 // every installed package. orbital's Update treats "no packages" as
-// "everything", which matches the user-facing `formae plugin upgrade`
+// "everything", which matches the user-facing `formae plugin update`
 // (no args) semantics.
-func (pm *CLIPluginManager) LocalUpgrade(names []string) error {
+func (pm *CLIPluginManager) LocalUpdate(names []string) error {
 	if err := pm.orb.Refresh(); err != nil {
 		pm.logger.Warn("failed to refresh local repos", "error", err)
 	}

--- a/internal/cli/plugin/plugin.go
+++ b/internal/cli/plugin/plugin.go
@@ -23,14 +23,18 @@ func PluginCmd() *cobra.Command {
 		Short: "Execute commands on plugins",
 		Annotations: map[string]string{
 			"type":     "Plugins",
-			"examples": "{{.Name}} {{.Command}} list\n{{.Name}} {{.Command}} search aws\n{{.Name}} {{.Command}} install aws\n{{.Name}} {{.Command}} init",
+			"examples": "{{.Name}} {{.Command}} install aws\n{{.Name}} {{.Command}} init",
 		},
 		SilenceErrors: true,
 	}
 
-	command.AddCommand(PluginListCmd())
-	command.AddCommand(PluginSearchCmd())
-	command.AddCommand(PluginInfoCmd())
+	// list/search/info are temporarily unregistered: they depend on the
+	// agent's plugin manager, which only wires up when the orbital tree
+	// is reachable without sudo elevation. Until the deployment story
+	// is settled (agent running as the tree owner on a pel-owned tree),
+	// exposing them just produces opaque 503s. Re-register the three
+	// AddCommand calls below when the agent reliably has a plugin
+	// manager wired up.
 	command.AddCommand(PluginInstallCmd())
 	command.AddCommand(PluginUninstallCmd())
 	command.AddCommand(PluginUpdateCmd())

--- a/internal/cli/plugin/plugin.go
+++ b/internal/cli/plugin/plugin.go
@@ -33,7 +33,7 @@ func PluginCmd() *cobra.Command {
 	command.AddCommand(PluginInfoCmd())
 	command.AddCommand(PluginInstallCmd())
 	command.AddCommand(PluginUninstallCmd())
-	command.AddCommand(PluginUpgradeCmd())
+	command.AddCommand(PluginUpdateCmd())
 	command.AddCommand(PluginInitCmd())
 
 	command.SetUsageTemplate(cmd.SimpleCmdUsageTemplate)

--- a/internal/cli/plugin/update.go
+++ b/internal/cli/plugin/update.go
@@ -14,14 +14,14 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/cli/display"
 )
 
-func PluginUpgradeCmd() *cobra.Command {
+func PluginUpdateCmd() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "upgrade [<name>[@<version>]...]",
-		Short: "Upgrade plugins on this host",
-		Long: `Upgrade plugins on this host's local orbital tree. With no
-arguments, every installed plugin is considered for upgrade.
+		Use:   "update [<name>[@<version>]...]",
+		Short: "Update plugins on this host",
+		Long: `Update plugins on this host's local orbital tree. With no
+arguments, every installed plugin is considered for update.
 
-formae plugin upgrade runs orbital locally — it does not call the
+formae plugin update runs orbital locally — it does not call the
 agent. Run it on every host where the plugin is installed.`,
 		RunE: func(cc *cobra.Command, args []string) error {
 			channel, _ := cc.Flags().GetString("channel")
@@ -38,22 +38,22 @@ agent. Run it on every host where the plugin is installed.`,
 				return fmt.Errorf("no artifact repositories configured; set artifacts.repositories in your formae config")
 			}
 
-			if err := mgr.LocalUpgrade(args); err != nil {
+			if err := mgr.LocalUpdate(args); err != nil {
 				return err
 			}
 
 			if len(args) == 0 {
-				fmt.Printf("  %s Upgraded all installed plugins\n", display.Green("✓"))
+				fmt.Printf("  %s Updated all installed plugins\n", display.Green("✓"))
 			} else {
 				for _, name := range pluginNamesFromArgs(args) {
-					fmt.Printf("  %s Upgraded %s\n", display.Green("✓"), name)
+					fmt.Printf("  %s Updated %s\n", display.Green("✓"), name)
 				}
 			}
-			fmt.Printf("\n  %s If this host runs the formae agent, restart it to load the upgraded plugins: formae agent restart\n", display.Gold("!"))
+			fmt.Printf("\n  %s If this host runs the formae agent, restart it to load the updated plugins: formae agent restart\n", display.Gold("!"))
 			return nil
 		},
 		SilenceErrors: true,
 	}
-	c.Flags().String("channel", "", "Upgrade from a different channel")
+	c.Flags().String("channel", "", "Update from a different channel")
 	return c
 }

--- a/internal/metastructure/plugin_manager/helpers_test.go
+++ b/internal/metastructure/plugin_manager/helpers_test.go
@@ -20,7 +20,7 @@ func newForTesting(logger *slog.Logger, orb orbitalClient) *PluginManager {
 // newForTestingWithFactory creates a PluginManager with an explicit factory
 // for channel-specific tests. listOrb is used for List/Uninstall (channel-
 // agnostic), while factory(channel) is consulted for Available/Info/Install/
-// Upgrade.
+// Update.
 func newForTestingWithFactory(logger *slog.Logger, listOrb orbitalClient, factory orbitalFactory) *PluginManager {
 	return &PluginManager{logger: logger, listOrb: listOrb, factory: factory}
 }

--- a/internal/metastructure/plugin_manager/plugin_manager.go
+++ b/internal/metastructure/plugin_manager/plugin_manager.go
@@ -84,7 +84,7 @@ type Operation struct {
 	Action  string // "install" | "remove" | "noop"
 }
 
-// Response is the result of an Install, Uninstall, or Upgrade call.
+// Response is the result of an Install, Uninstall, or Update call.
 type Response struct {
 	Operations      []Operation
 	RequiresRestart bool
@@ -100,8 +100,8 @@ type InstallRequest struct {
 // UninstallRequest is the input to Uninstall.
 type UninstallRequest struct{ Packages []PackageRef }
 
-// UpgradeRequest is the input to Upgrade.
-type UpgradeRequest struct {
+// UpdateRequest is the input to Update.
+type UpdateRequest struct {
 	Packages []PackageRef
 	Channel  string
 }
@@ -120,7 +120,7 @@ type orbitalFactory func(channel string) (orbitalClient, error)
 // listOrb is the long-lived client used for inspecting locally-installed
 // packages (List/Uninstall) — those operations are channel-agnostic. Per-call
 // factory invocations build channel-specific clients for queries that depend
-// on a remote channel (Available/Info/Install/Upgrade).
+// on a remote channel (Available/Info/Install/Update).
 //
 // pluginDirs are the directories the agent scans for on-disk plugin
 // installs. The same dirs the agent scans at startup to populate the
@@ -436,16 +436,16 @@ func (pm *PluginManager) Uninstall(req UninstallRequest) (Response, error) {
 	return pm.buildResponse(pm.listOrb, req.Packages, "remove")
 }
 
-// Upgrade updates the requested packages via orbital. req.Channel selects
-// which channel to upgrade against; empty resolves to DefaultChannel.
-func (pm *PluginManager) Upgrade(req UpgradeRequest) (Response, error) {
+// Update updates the requested packages via orbital. req.Channel selects
+// which channel to update against; empty resolves to DefaultChannel.
+func (pm *PluginManager) Update(req UpdateRequest) (Response, error) {
 	orb, err := pm.clientFor(req.Channel)
 	if err != nil {
 		return Response{}, fmt.Errorf("building orbital client for channel: %w", err)
 	}
 	specs := packageSpecs(req.Packages)
 	if err := orb.Update(specs...); err != nil {
-		return Response{}, fmt.Errorf("upgrading packages: %w", err)
+		return Response{}, fmt.Errorf("updating packages: %w", err)
 	}
 	return pm.buildResponse(orb, req.Packages, "install")
 }

--- a/internal/metastructure/plugin_manager/plugin_manager_test.go
+++ b/internal/metastructure/plugin_manager/plugin_manager_test.go
@@ -709,10 +709,10 @@ func TestUninstall_Error(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Upgrade
+// Update
 // ---------------------------------------------------------------------------
 
-func TestUpgrade_Success(t *testing.T) {
+func TestUpdate_Success(t *testing.T) {
 	fake := &fakeOrbitalClient{
 		available: map[string]*records.Status{
 			"formae-plugin-aws": {
@@ -727,7 +727,7 @@ func TestUpgrade_Success(t *testing.T) {
 	}
 	pm := newForTesting(slog.Default(), fake)
 
-	resp, err := pm.Upgrade(UpgradeRequest{
+	resp, err := pm.Update(UpdateRequest{
 		Packages: []PackageRef{{Name: "formae-plugin-aws", Version: "2.0.0"}},
 	})
 	require.NoError(t, err)
@@ -737,15 +737,15 @@ func TestUpgrade_Success(t *testing.T) {
 	assert.Equal(t, []string{"formae-plugin-aws@2.0.0"}, fake.updatedSpecs)
 }
 
-func TestUpgrade_Error(t *testing.T) {
+func TestUpdate_Error(t *testing.T) {
 	fake := &fakeOrbitalClient{updateErr: errors.New("no update")}
 	pm := newForTesting(slog.Default(), fake)
 
-	_, err := pm.Upgrade(UpgradeRequest{
+	_, err := pm.Update(UpdateRequest{
 		Packages: []PackageRef{{Name: "x"}},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "upgrading packages")
+	assert.Contains(t, err.Error(), "updating packages")
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/api/model/types.go
+++ b/pkg/api/model/types.go
@@ -268,12 +268,12 @@ type UninstallPluginsResponse struct {
 	Warnings        []string          `json:"warnings,omitempty"`
 }
 
-type UpgradePluginsRequest struct {
+type UpdatePluginsRequest struct {
 	Packages []PackageRef `json:"packages,omitempty"`
 	Channel  string       `json:"channel,omitempty"`
 }
 
-type UpgradePluginsResponse struct {
+type UpdatePluginsResponse struct {
 	Operations      []PluginOperation `json:"operations"`
 	RequiresRestart bool              `json:"requiresRestart"`
 	Warnings        []string          `json:"warnings,omitempty"`


### PR DESCRIPTION
## Summary

- **fix(agent)**: stop wiring up a `PluginManager` at agent startup. The construction went through `orbital.tree.New`, which calls `InvokeSelfWithSudo → syscall.Exec` when the tree path is root-owned and the agent isn't running as root. That replaced the running agent with `sudo formae agent start`, which then errored on the existing PID file -- leaving the original ergo node dead and no agent running.

- **feat(agent)**: rework `/api/v1/plugins?scope=installed` to serve from `PluginCoordinator`'s registered-plugin view (populated by `PluginProcessSupervisor` at startup) plus a filesystem scan of the configured plugin dirs for `PklProject` paths. This is the data extract/eval/project init consume via `client.ListPlugins("installed", ...)`, so the endpoint stays usable regardless of orbital tree ownership. The `available`/`info`/`install`/`uninstall`/`update` endpoints continue to require an orbital-backed `PluginManager` and return 503 when one is not configured -- those operations have no in-agent fallback and are now CLI-local concerns post-#459.

- **refactor(plugin)**: renamed `plugin upgrade` to `plugin update` end-to-end (CLI subcommand, API route, request/response types, client method, server handler, `CLIPluginManager.LocalUpgrade`, `plugin_manager.Upgrade` + `UpgradeRequest`, tests). Aligns the subcommand with the top-level `formae update` and with orbital's underlying `Update` method. No aliases -- neither the CLI subcommand nor the agent route shipped in a released version, so there's no compatibility surface to preserve.

- **chore(plugin)**: temporarily unregistered `plugin search` and `plugin info` (and `plugin list` for symmetry, though `list` now works again after the installed-endpoint rework). They depend on the orbital-backed agent endpoints. Implementation kept in place; re-enabling `plugin list` is a one-liner and can ship as a follow-up once we want it user-visible.