### PR TITLE
feat(plugin): raise MinFormaeVersion floor to 0.85.0

### DIFF
--- a/pkg/plugin/version.go
+++ b/pkg/plugin/version.go
@@ -7,7 +7,7 @@ package plugin
 // MinFormaeVersion is the minimum formae agent version compatible with this SDK.
 // Plugins built against this SDK should check this at startup to ensure
 // the agent they're running under is compatible.
-const MinFormaeVersion = "0.84.0"
+const MinFormaeVersion = "0.85.0"
 
 // SDKVersion is the version of this SDK package.
 // It is embedded in plugin manifests and used for compatibility checks.

--- a/pkg/plugin/version_test.go
+++ b/pkg/plugin/version_test.go
@@ -17,7 +17,7 @@ import (
 func TestMinFormaeVersion_IsValidSemver(t *testing.T) {
 	v, err := semver.NewVersion(MinFormaeVersion)
 	require.NoError(t, err, "MinFormaeVersion should be a valid semver string")
-	assert.Equal(t, "0.84.0", v.String())
+	assert.Equal(t, "0.85.0", v.String())
 }
 
 func TestSDKVersion_IsValidSemver(t *testing.T) {


### PR DESCRIPTION
## Summary

- Bumps `MinFormaeVersion` in `pkg/plugin/version.go` from `0.84.0` to `0.85.0` so plugins built against this SDK enforce an agent floor that knows about `FieldHint.attachesTo` (introduced in formae 0.85.0).
- Required by the upcoming `formae-plugin-aws` PR that re-adds `attachesTo = true` on `ECS::Service.LoadBalancer.targetGroupArn` and `VpcLatticeConfiguration.targetGroupArn` (closes the LGTM destroy wedge). Without this floor, agents on `0.84.x` would silently drop the new field at JSON unmarshal and the destroy-wedge fix would no-op.
- Updates `TestMinFormaeVersion_IsValidSemver` fixture to match.

The agent's `formae.Version` is stable-suffix-stripped at build time (`Makefile` cuts everything past the first `-` from `git describe`), so any `0.85.0-dev.N` build satisfies this floor cleanly.

## Test Plan

- [x] `go test -tags=unit ./pkg/plugin/...` — all packages pass
- [x] `make lint` — 0 issues
- [ ] Reviewer confirms no other in-tree consumer of `MinFormaeVersion` needs adjustment

## Follow-up

Before the next stable release, `pkg/plugin` should be tagged at a clean semver (`v0.2.2` or `v0.3.0`) so downstream plugins can pin without pseudo-versions. Tracked in engineering notes.