### PR TITLE
feat(pkl): auto-register pkl-reader-helm when discoverable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,10 @@ internal/schema/pkl/generator/imports.pkl
 internal/schema/pkl/generator/resources.pkl
 internal/schema/pkl/generator/resolvables.pkl
 
+# Bundled pkl-reader-helm binary (downloaded by make build via
+# scripts/install-helm-reader.sh; shipped via pkg-bin → dist/pel/bin/).
+pkl-reader-helm
+
 # semver files generated during build
 version.semver
 

--- a/Makefile
+++ b/Makefile
@@ -20,19 +20,35 @@ VERSION := $(shell echo "$(RAW_VERSION)" | cut -d'-' -f1)
 # downstream installs.
 CHANNEL := $(shell echo "$(RAW_VERSION)" | grep -q -- '-' && echo dev || echo stable)
 
+# Pinned pkl-reader-helm version. Must track the `pkl-readers/helm@<ver>`
+# dep declared by every plugin that uses helm-via-pkl (today: k8s).
+# Override per-build with HELM_READER_VERSION=<ver>.
+HELM_READER_VERSION ?= 0.1.2
+
 clean:
 	rm -rf .out/
 	rm -rf dist/
 	rm -rf formae
 	rm -rf fcfg
+	rm -rf pkl-reader-helm
 	rm -rf version.semver
 
 clean-pel:
 	rm -rf ~/.pel/*
 
-build:
+build: helm-reader
 	go build -ldflags="-X 'github.com/platform-engineering-labs/formae.Version=${VERSION}'" -o formae cmd/formae/main.go
 	go build -o fcfg cmd/formae-config/main.go
+
+## helm-reader: Download the pinned pkl-reader-helm binary into the
+## repo root so `build` ships it next to the formae binary and
+## `pkg-bin` includes it in dist/pel/bin/. Idempotent — skips the
+## download when the right version is already present. Required by
+## any forma that imports `@formae-helm/v<X.Y>/HelmChart.pkl`;
+## formae's auto-register code (internal/schema/pkl/helm_reader.go)
+## discovers it via exec.LookPath.
+helm-reader:
+	@HELM_READER_VERSION=$(HELM_READER_VERSION) ./scripts/install-helm-reader.sh
 
 ## install-gremlins: Install the gremlins mutation testing tool
 install-gremlins:
@@ -47,6 +63,7 @@ pkg-bin: clean build
 	mkdir -p ./dist/pel/bin
 	cp -Rp ./formae ./dist/pel/bin
 	cp -Rp ./fcfg ./dist/pel/bin
+	cp -Rp ./pkl-reader-helm ./dist/pel/bin
 
 gen-pkl:
 	echo '${VERSION}' > ./version.semver

--- a/internal/schema/pkl/helm_reader.go
+++ b/internal/schema/pkl/helm_reader.go
@@ -1,0 +1,60 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package pkl
+
+import (
+	"os/exec"
+	"sync"
+
+	pklgo "github.com/apple/pkl-go/pkl"
+)
+
+// helmReaderScheme is the Pkl URI scheme that the pkl-reader-helm binary
+// advertises. The reader emits URIs like `reader+helm:/?request=...`,
+// and the scheme passed to WithExternalResourceReader must match the
+// full URI scheme (everything before the first `:`), including the
+// `reader+` prefix. Pkl's resource allowlist is matched on this same
+// string, so getting the scheme wrong silently blocks the read with
+// an "allowlist" error rather than a "no reader" error.
+const helmReaderScheme = "reader+helm"
+
+// helmReaderBinaryName is the executable name we look for on PATH.
+const helmReaderBinaryName = "pkl-reader-helm"
+
+var (
+	// helmReaderOnce is a pointer so tests can swap it for a fresh
+	// sync.Once without tripping the copylocks vet check (sync.Once
+	// contains a noCopy sentinel and can't be assigned by value).
+	helmReaderOnce = &sync.Once{}
+	helmReaderOpt  func(*pklgo.EvaluatorOptions)
+)
+
+// helmReaderOption returns a pkl-go option that registers the
+// `reader+helm:` external resource reader when a `pkl-reader-helm`
+// binary is reachable on PATH. Returns nil when no binary is found, so
+// callers can append unconditionally — users without helm tooling pay
+// nothing.
+//
+// PATH is the only discovery channel: opkg installs land the reader at
+// the orbital tree's `bin/` (added to PATH by `ops setup`); package
+// managers (brew, apt) install to a standard PATH location; manual
+// installs document dropping the binary on PATH explicitly. Operators
+// with unusual layouts can prepend a directory to PATH themselves.
+//
+// The lookup is cached for the process lifetime: PATH state doesn't
+// change mid-run, and the alternative is exec.LookPath on every
+// evaluator construction (twice per `formae apply`).
+func helmReaderOption() func(*pklgo.EvaluatorOptions) {
+	helmReaderOnce.Do(func() {
+		path, err := exec.LookPath(helmReaderBinaryName)
+		if err != nil {
+			return
+		}
+		helmReaderOpt = pklgo.WithExternalResourceReader(helmReaderScheme, pklgo.ExternalReader{
+			Executable: path,
+		})
+	})
+	return helmReaderOpt
+}

--- a/internal/schema/pkl/helm_reader_test.go
+++ b/internal/schema/pkl/helm_reader_test.go
@@ -1,0 +1,84 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package pkl
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+
+	pklgo "github.com/apple/pkl-go/pkl"
+)
+
+func TestHelmReaderOption_RegistersWhenOnPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits behave differently on Windows")
+	}
+
+	tmp := t.TempDir()
+	exe := filepath.Join(tmp, helmReaderBinaryName)
+	mustExecutable(t, exe)
+
+	resetHelmReaderCache(t)
+	t.Setenv("PATH", tmp)
+
+	opt := helmReaderOption()
+	if opt == nil {
+		t.Fatal("expected non-nil option when reader is on PATH")
+	}
+
+	// Apply the option to a fresh EvaluatorOptions and inspect the
+	// registration. Confirms both that the reader scheme was wired up
+	// and that the executable path matches the PATH hit.
+	opts := &pklgo.EvaluatorOptions{}
+	opt(opts)
+	got, ok := opts.ExternalResourceReaders[helmReaderScheme]
+	if !ok {
+		t.Fatalf("expected reader registered under scheme %q, have %v",
+			helmReaderScheme, opts.ExternalResourceReaders)
+	}
+	if got.Executable != exe {
+		t.Fatalf("expected executable %q, got %q", exe, got.Executable)
+	}
+}
+
+func TestHelmReaderOption_NilWhenNotOnPath(t *testing.T) {
+	resetHelmReaderCache(t)
+	t.Setenv("PATH", t.TempDir()) // empty dir — no binary
+
+	if opt := helmReaderOption(); opt != nil {
+		t.Fatal("expected nil option when reader is not reachable")
+	}
+}
+
+// resetHelmReaderCache clears the process-wide sync.Once so each test
+// can re-discover the reader against its own PATH. Restores the
+// pre-test state on cleanup so other tests in the package aren't
+// affected. Swaps the *sync.Once by pointer to avoid the copylocks vet
+// check (sync.Once embeds a noCopy sentinel).
+func resetHelmReaderCache(t *testing.T) {
+	t.Helper()
+	prevOnce := helmReaderOnce
+	prevOpt := helmReaderOpt
+	helmReaderOnce = &sync.Once{}
+	helmReaderOpt = nil
+	t.Cleanup(func() {
+		helmReaderOnce = prevOnce
+		helmReaderOpt = prevOpt
+	})
+}
+
+// mustExecutable creates a 0755 file at path (with parents).
+func mustExecutable(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/schema/pkl/pkl.go
+++ b/internal/schema/pkl/pkl.go
@@ -150,6 +150,14 @@ func (p PKL) FormaeConfig(path string) (*pkgmodel.Config, error) {
 	}
 	opts = append(opts, pklgo.WithResourceReader(tfvarsReader{baseDir: tfvarsBaseDir}))
 
+	// Auto-register pkl-reader-helm as an external resource reader when
+	// it's discoverable on PATH or under an installed plugin's bin/. Lets
+	// formas use `import "@helm/helm.pkl"` without each project declaring
+	// the reader in evaluatorSettings.
+	if helmOpt := helmReaderOption(); helmOpt != nil {
+		opts = append(opts, helmOpt)
+	}
+
 	var cleanup func()
 	if projectDir != "" {
 		evaluator, cleanup, err = newSafeProjectEvaluator(
@@ -423,32 +431,32 @@ func (p PKL) Evaluate(path string, cmd pkgmodel.Command, mode pkgmodel.FormaAppl
 	formaDir := filepath.Dir(path)
 	projectDir := WalkForProjectFile(formaDir)
 
+	evalOpts := []func(*pklgo.EvaluatorOptions){
+		pklgo.PreconfiguredOptions,
+		pklgo.WithResourceReader(libExtension{}),
+		pklgo.WithResourceReader(tfvarsReader{baseDir: formaDir}),
+		func(opts *pklgo.EvaluatorOptions) {
+			opts.Properties = props
+			opts.OutputFormat = "json"
+		},
+	}
+	// Auto-register pkl-reader-helm if discoverable; harmless when no
+	// helm imports are present in the forma.
+	if helmOpt := helmReaderOption(); helmOpt != nil {
+		evalOpts = append(evalOpts, helmOpt)
+	}
+
 	var cleanup func()
 	if projectDir != "" {
 		evaluator, cleanup, err = newSafeProjectEvaluator(
 			context.Background(),
 			&url.URL{Scheme: "file", Path: projectDir},
-			pklgo.PreconfiguredOptions,
-			pklgo.WithResourceReader(libExtension{}),
-			pklgo.WithResourceReader(tfvarsReader{baseDir: formaDir}),
-			func(opts *pklgo.EvaluatorOptions) {
-				opts.Properties = props
-				opts.OutputFormat = "json"
-			})
-
+			evalOpts...,
+		)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		evalOpts := []func(*pklgo.EvaluatorOptions){
-			pklgo.PreconfiguredOptions,
-			pklgo.WithResourceReader(libExtension{}),
-			pklgo.WithResourceReader(tfvarsReader{baseDir: formaDir}),
-			func(opts *pklgo.EvaluatorOptions) {
-				opts.Properties = props
-				opts.OutputFormat = "json"
-			},
-		}
 		if pklCmd := bundledPklCommand(); pklCmd != nil {
 			evaluator, err = pklgo.NewEvaluatorWithCommand(context.Background(), pklCmd, evalOpts...)
 		} else {

--- a/scripts/install-helm-reader.sh
+++ b/scripts/install-helm-reader.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# © 2026 Platform Engineering Labs Inc.
+#
+# SPDX-License-Identifier: FSL-1.1-ALv2
+#
+# install-helm-reader.sh — download a pinned pkl-reader-helm binary
+# into the formae repo root so `make build` ships it next to the
+# formae binary. The reader is needed at runtime to evaluate any
+# forma that imports `@formae-helm/v<X.Y>/HelmChart.pkl`; formae's
+# auto-register code (internal/schema/pkl/helm_reader.go) discovers
+# it via exec.LookPath, so bundling it next to the formae binary
+# means `pkg-bin` ships a self-contained dist/pel/bin/ tree.
+#
+# Pin policy: HELM_READER_VERSION env var (default tracks whatever
+# the k8s plugin's `helm/PklProject` declares for `pkl-readers/helm`).
+# Override for one-off testing.
+#
+# Output: ./pkl-reader-helm (chmod 755). Re-running is a no-op when
+# the binary's `version` subcommand already reports the requested pin.
+#
+# Usage:
+#   scripts/install-helm-reader.sh                  # use the pinned version
+#   HELM_READER_VERSION=0.1.3 scripts/install-helm-reader.sh
+
+set -euo pipefail
+
+# Resolve repo root from this script's location so the target works
+# regardless of the caller's CWD.
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "$SCRIPT_DIR/.." && pwd)
+
+DEFAULT_VERSION="0.1.2"
+VERSION=${HELM_READER_VERSION:-$DEFAULT_VERSION}
+
+TARGET="$REPO_ROOT/pkl-reader-helm"
+
+# Map the running platform to apple/pkl-readers release asset names.
+# macOS ships a universal binary; Linux is split by arch. Other
+# platforms are unsupported — the helm reader isn't built for them.
+case "$(uname -s)-$(uname -m)" in
+  Darwin-*)                   ASSET="pkl-reader-helm-macos.bin" ;;
+  Linux-x86_64)               ASSET="pkl-reader-helm-linux-amd64.bin" ;;
+  Linux-aarch64|Linux-arm64)  ASSET="pkl-reader-helm-linux-aarch64.bin" ;;
+  *)
+    echo "install-helm-reader: unsupported platform $(uname -s)-$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+URL="https://github.com/apple/pkl-readers/releases/download/helm@${VERSION}/${ASSET}"
+
+# Skip the download when ./pkl-reader-helm already reports the
+# requested version. `pkl-reader-helm version` (subcommand, not flag)
+# prints `pkl-reader-helm <ver>` on its first line — match the second
+# token loosely so future format tweaks don't churn the install.
+if [[ -x "$TARGET" ]]; then
+  if existing_version=$("$TARGET" version 2>/dev/null | awk 'NR==1 {print $2}'); then
+    if [[ "$existing_version" == "$VERSION" ]]; then
+      echo "install-helm-reader: pkl-reader-helm @ $VERSION already present"
+      exit 0
+    fi
+    if [[ -n "$existing_version" ]]; then
+      echo "install-helm-reader: replacing $existing_version -> $VERSION"
+    fi
+  fi
+fi
+
+# Download to a sibling temp file and rename atomically. Avoids leaving
+# a half-written `pkl-reader-helm` behind if the user Ctrl-Cs mid-curl.
+TMP=$(mktemp "$REPO_ROOT/.pkl-reader-helm.XXXXXX")
+trap 'rm -f "$TMP"' EXIT
+
+echo "install-helm-reader: downloading $URL"
+if ! curl -fsSL "$URL" -o "$TMP"; then
+  echo "install-helm-reader: download failed" >&2
+  exit 1
+fi
+
+chmod 755 "$TMP"
+mv "$TMP" "$TARGET"
+trap - EXIT
+
+echo "install-helm-reader: installed $TARGET (version $VERSION)"
+"$TARGET" version 2>/dev/null | head -1 || true


### PR DESCRIPTION
## Summary

Two changes:

1. **Auto-register** the `reader+helm:` external resource reader at evaluator construction when a `pkl-reader-helm` binary is reachable on PATH. Drops the per-project `evaluatorSettings.externalResourceReaders` boilerplate.
2. **Bundle** the pinned `pkl-reader-helm` binary inside the formae release. `make build` downloads it into the repo root next to the formae binary, `pkg-bin` packages it into `dist/pel/bin/`. Operators get a self-contained tarball — no separate reader install required.

## Auto-register: discovery

`exec.LookPath(\"pkl-reader-helm\")`. That's it.

PATH covers every supported install method:

- **Bundled release** — `dist/pel/bin/pkl-reader-helm` lives next to `formae` and `fcfg`; orbital's tree-root `bin/` ends up on PATH after `ops setup`
- **Package managers** — `brew install pkl-reader-helm` and similar drop the binary on a standard PATH dir
- **Manual installs** — documented as placing the binary on PATH explicitly

When no binary is found, `helmReaderOption()` returns nil and callers append nothing — users without Helm tooling are unaffected. Lookup is cached process-wide via a `*sync.Once`.

## Build / pkg-bin bundling

- `HELM_READER_VERSION ?= 0.1.2` Makefile variable, tracks the `pkl-readers/helm@<ver>` Pkl dep declared by helm-using plugins (k8s today)
- `make build` now depends on a new `helm-reader` target — `scripts/install-helm-reader.sh` fetches the pinned binary from `apple/pkl-readers` releases (platform-aware, idempotent, atomic rename) into `./pkl-reader-helm`
- `make pkg-bin` adds `cp ./pkl-reader-helm ./dist/pel/bin/` so the release tarball ships all three binaries together
- `make clean` removes `./pkl-reader-helm`
- `.gitignore` updated; binary never committed

## Scheme constant gotcha

The pkl-reader-helm binary advertises the URI scheme `reader+helm:` (full string, including the `reader+` prefix). Pkl's resource allowlist matches on the same string, so passing `\"helm\"` to `WithExternalResourceReader` registers the reader but silently blocks the read with an \"allowlist\" error. The constant is `\"reader+helm\"` — comment in the source documents the surprise.

## Test plan

- [x] Unit tests cover: registers when reader on PATH (asserts both the scheme registration and the resolved executable path); returns nil when PATH has no reader. Tests fake the binary via `t.TempDir()` + a `0755`-mode shell script header — no real `pkl-reader-helm` dependency required in CI.
- [x] `go test ./...` 420 passed, 82 packages
- [x] `go vet ./internal/schema/pkl/` clean (copylocks fix: `helmReaderOnce` is `*sync.Once` so tests can swap by pointer)
- [x] End-to-end build / pkg-bin: `make clean && make build && make pkg-bin` produces `dist/pel/bin/{formae, fcfg, pkl-reader-helm}` with the bundled reader at version 0.1.2
- [x] End-to-end `formae apply` of a Helm-chart-rendered forma against a kind v1.34 cluster after stripping `evaluatorSettings` from the project — log shows `INFO starting external reader name=pkl-reader-helm version=0.1.2` and apply lands 7/7 resources
- [x] Negative: stock `pkl eval` of the same project fails with \"does not match resource allowlist\" — proves the project no longer carries the reader config and that formae is doing the wiring