### PR TITLE
fix(patch): normalize createOnly hint paths so nested fields are detected

### DIFF
--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -713,9 +713,19 @@ func extractCreateOnlyFields(patchOps []jsonpatch.JsonPatchOperation, createOnly
 // isCreateOnlyPath checks if a patch path targets a createOnly field.
 // Matches both the field itself ("/DomainName") and nested paths within
 // it ("/ContainerDefinitions/0/Name").
+//
+// Schema Hints from `formae.fq.hints()` use dot-separated keys for
+// nested fields ("Spec.Selector"), but jsonpatch operation paths use
+// slash separators per RFC 6902 ("/Spec/Selector/MatchLabels/foo").
+// Normalize the schema-side keys to slash form before comparison so
+// nested createOnly fields on SubResources are detected. Without the
+// normalization the check silently no-ops for any path deeper than a
+// top-level field — which leaves createOnly violations on nested
+// fields undetected until the cloud API rejects them at apply time.
 func isCreateOnlyPath(path string, createOnlyFields []string) bool {
 	for _, field := range createOnlyFields {
-		if path == field || strings.HasPrefix(path, field+"/") {
+		f := strings.ReplaceAll(field, ".", "/")
+		if path == f || strings.HasPrefix(path, f+"/") {
 			return true
 		}
 	}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -380,6 +380,75 @@ func TestGeneratePatch(t *testing.T) {
 	assert.Equal(t, "/val2", replOps[0].Path)
 }
 
+// TestGeneratePatch_NestedCreateOnlyTriggersReplacement exercises a
+// createOnly field declared on a nested SubResource. Schema Hints from
+// `formae.fq.hints()` emit dot-separated keys for nested fields
+// ("spec.selector") but jsonpatch operation paths are slash-separated
+// per RFC 6902 ("/spec/selector/matchLabels/foo"). The createOnly
+// detection must normalize the two so changes to nested immutable
+// fields trigger a replacement instead of being silently shipped to
+// the plugin as a mutable patch.
+//
+// Regression: before the fix, isCreateOnlyPath compared dot-paths to
+// slash-paths raw, so nested createOnly violations weren't caught.
+// Users only learned about the immutability when the cloud API
+// rejected the apply (e.g. K8s "spec.selector: field is immutable"
+// on Deployment).
+func TestGeneratePatch_NestedCreateOnlyTriggersReplacement(t *testing.T) {
+	document := []byte(`{
+		"label": "deploy",
+		"stack": "s",
+		"spec": {
+			"selector": {
+				"matchLabels": {"app": "demo"}
+			},
+			"replicas": 2
+		}
+	}`)
+
+	// Add a new key under spec.selector.matchLabels (createOnly) AND
+	// bump replicas (mutable). The createOnly change should be
+	// extracted into createOnlyPatch; the replicas change should
+	// remain in the mutable patchDoc.
+	patch := []byte(`{
+		"label": "deploy",
+		"stack": "s",
+		"spec": {
+			"selector": {
+				"matchLabels": {"app": "demo", "foo": "bar"}
+			},
+			"replicas": 3
+		}
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"label", "stack", "spec"},
+		Hints: map[string]pkgmodel.FieldHint{
+			// Dot-separated key as emitted by `formae.fq.hints()` for a
+			// SubResource field. The fix must normalize this to the
+			// slash-form jsonpatch uses.
+			"spec.selector": {CreateOnly: true},
+		},
+	}
+
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	require.NoError(t, err)
+	require.NotEmpty(t, createOnlyPatch, "nested createOnly change must produce a non-empty createOnlyPatch")
+
+	var coOps []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(createOnlyPatch, &coOps))
+	require.Len(t, coOps, 1, "exactly one op should target the nested createOnly field")
+	assert.Equal(t, "/spec/selector/matchLabels/foo", coOps[0].Path,
+		"the matchLabels addition must end up in createOnlyPatch, not in the mutable patch")
+
+	var mutableOps []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &mutableOps))
+	for _, op := range mutableOps {
+		assert.NotContains(t, op.Path, "/spec/selector",
+			"no op under spec.selector may remain in the mutable patch")
+	}
+}
+
 // Test that createPatch will resolve references in json objects amd arrays of json objects
 func TestGeneratePatch_ShouldResolveRefs(t *testing.T) {
 	resourceKsuid := util.NewID()


### PR DESCRIPTION
## Summary

`isCreateOnlyPath` compared schema-side createOnly hint keys to jsonpatch operation paths without normalising the separator:

- Schema Hints from \`formae.fq.hints()\` emit **dot-separated** keys for nested SubResource fields (e.g. \`Spec.Selector\`)
- jsonpatch operation paths are **slash-separated** per RFC 6902 (\`/Spec/Selector/MatchLabels/foo\`)

The raw \`path == field || strings.HasPrefix(path, field+\"/\")\` comparison silently no-op'd for any path deeper than one level, so nested createOnly violations were never extracted into the createOnly patch — they were shipped to the plugin as mutable ops, and the cloud API rejected them at apply time.

## Repro before the fix

Plugin schema:

\`\`\`pkl
class DeploymentSpec extends formae.SubResource {
  @k8s.FieldHint { required = true; createOnly = true }
  selector: k8s.LabelSelector
}
\`\`\`

User flow:

1. \`formae extract --query=...\`
2. Add a key under \`spec.selector.matchLabels\`
3. \`formae apply --mode patch ...\`

Expected: formae rejects (or plans a replace) at plan time, citing the createOnly violation.
Actual: formae plans a normal update, ships the op to the plugin, K8s SSA returns \`spec.selector: field is immutable\`.

Reported while testing the K8s plugin's new createOnly annotations on workload selectors (Deployment / StatefulSet / DaemonSet / ReplicaSet / Service / PVC / RoleBinding / etc.).

## The fix

Normalize \`.\` → \`/\` on the schema-side keys before the prefix match in \`isCreateOnlyPath\`. Top-level createOnly fields stay unaffected (no separator in the key).

\`\`\`go
for _, field := range createOnlyFields {
    f := strings.ReplaceAll(field, \".\", \"/\")
    if path == f || strings.HasPrefix(path, f+\"/\") {
        return true
    }
}
\`\`\`

## Test plan

- [x] New regression test \`TestGeneratePatch_NestedCreateOnlyTriggersReplacement\` exercises a nested createOnly field (\`spec.selector\`) with a change at \`spec.selector.matchLabels.foo\` plus a sibling mutable change (\`spec.replicas\`). Asserts:
  - \`createOnlyPatch\` is non-empty
  - It contains exactly one op targeting \`/spec/selector/matchLabels/foo\`
  - No op under \`/spec/selector\` remains in the mutable patch
- [x] Confirmed the new test FAILS on main without this commit (createOnlyPatch comes back empty) and PASSES with it
- [x] Full test suite: 421 passed, 82 packages
- [x] \`go vet\` clean, gofmt clean

## Affected schemas

Any plugin schema with createOnly on a nested SubResource. The K8s plugin's new schema updates (commit pending in formae-plugin-k8s) declare createOnly on:

- Workload \`spec.selector\` (Deployment, StatefulSet, DaemonSet, ReplicaSet)
- Service \`spec.clusterIP\`, \`spec.clusterIPs\`, \`spec.ipFamilies\`, \`spec.ipFamilyPolicy\`, \`spec.loadBalancerClass\`
- PVC \`spec.accessModes\`, \`spec.storageClassName\`, \`spec.volumeMode\`, \`spec.volumeName\`, \`spec.selector\`, \`spec.dataSource\`
- JobSpec \`template\`, \`selector\`, \`completions\`, \`completionMode\`, \`manualSelector\`, \`podFailurePolicy\`, \`successPolicy\`
- RoleBinding / ClusterRoleBinding \`roleRef\`
- StorageClass \`provisioner\`, \`parameters\`, \`reclaimPolicy\`, \`volumeBindingMode\`
- CSIDriver entire spec
- PriorityClass \`value\`, \`globalDefault\`, \`preemptionPolicy\`
- IngressClass \`controller\`
- RuntimeClass \`handler\`, \`overhead\`, \`scheduling\`

None of these would have been detected before this fix.

## Notes

AWS-style flat schemas (e.g. \`BucketName\` as a top-level createOnly) work fine on main because the key happens to be a single segment — \`/BucketName\` after \`cleanPath\` becomes \`BucketName\`, which directly equals the hint key. That's why the bug slipped through until K8s schemas with deeply nested createOnly fields surfaced it.