### PR TITLE
refactor(docker): drop /opt/pel chown workaround for pel user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,12 @@ RUN useradd -m -s /bin/bash pel
 # Standard's `requires` resolve at install time and pull in the curated
 # default plugin set (aws, azure, gcp, oci, ovh, auth-basic) —
 # replacing the legacy bundled-plugins-from-binary extraction step.
+#
+# Install runs as root so /opt/pel ends up root-owned — the canonical
+# system-install layout. The agent process itself runs as `pel`
+# (unprivileged) and only reads from /opt/pel; runtime plugin
+# install/update/uninstall is performed via the `formae plugin ...` CLI,
+# which prompts for sudo when writing to the root-owned plugin store.
 RUN apt-get update &&  \
     apt-get install -y jq curl && \
     HOME=/home/pel /bin/bash -e -c "$(curl -fsSL https://hub.platform.engineering/get/setup.sh)" -- install --yes --channel ${CHANNEL} formae@${VERSION} && \
@@ -29,19 +35,11 @@ RUN apt-get update &&  \
     apt-get clean && \
     /opt/pel/bin/formae clean --all
 
-# Make the install tree owned by `pel`. Orbital's tree library considers any
-# path owned by uid 0 "Privileged" and tries to escalate via sudo on every
-# read/write — but the image runs as `pel` and sudo is not installed, so the
-# agent fails to start with:
-#
-#   privileged user required to manage path: /opt/pel
-#   Plugin manager initialization failed; refusing to start
-#   exec: "sudo": executable file not found in $PATH
-#
-# Once /opt/pel is owned by `pel`, orbital's privileged() check returns false,
-# no sudo is invoked, and runtime plugin install/upgrade/uninstall continue
-# to work because new files inherit the pel ownership.
-RUN chown -R pel:pel /home/pel /opt/pel
+# The installer ran as root with HOME=/home/pel, so anything written
+# under /home/pel (pelmgr config, caches, etc.) needs ownership fixed
+# so the agent — which runs as `pel` — can read and write its data
+# directory at /home/pel/.pel/formae.
+RUN chown -R pel:pel /home/pel
 
 USER pel
 WORKDIR /home/pel


### PR DESCRIPTION
## Summary

- Plugin install/update/uninstall now run locally via the `formae plugin ...` CLI and prompt for sudo when writing to a root-owned plugin store, so the agent no longer needs write access to `/opt/pel`.
- Keep `/opt/pel` root-owned (the canonical system-install layout) and only fix ownership on `/home/pel` so the agent — which still runs as the unprivileged `pel` user — can write its data directory at `/home/pel/.pel/formae`.
- The agent only reads from `/opt/pel`, which a 755 root-owned tree allows without sudo, so the previous "chown the whole tree to pel" workaround is no longer necessary.