### PR TITLE
build(container): add pel_n workflow input for custom plugin builds

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -2,8 +2,19 @@ name: formae-container
 
 on:
   workflow_dispatch:
+    inputs:
+      pel_n:
+        description: 'PEL build revision. If set, the image tag becomes <git-tag>-pel-<pel_n>. Leave empty for the plain <git-tag> name used by the release flow.'
+        required: false
+        type: string
+        default: ''
   workflow_call:
-    
+    inputs:
+      pel_n:
+        type: string
+        required: false
+        default: ''
+
 jobs:
 
   container_linux:
@@ -53,18 +64,30 @@ jobs:
             echo "::error::unsupported tag pattern '${tag}'; expected X.Y.Z or X.Y.Z-dev[.N]"
             exit 1
           fi
+          # The image tag is the original git tag, plus an optional -pel-N
+          # suffix when pel_n is set (workflow_dispatch invocations that
+          # bake in custom plugins on top of an upstream release).
+          if [[ -n "${{ inputs.pel_n }}" ]]; then
+            echo "IMAGE_TAG=${tag}-pel-${{ inputs.pel_n }}" >> "$GITHUB_ENV"
+          else
+            echo "IMAGE_TAG=${tag}" >> "$GITHUB_ENV"
+          fi
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ env.IMAGE_TAG }}
+          flavor: |
+            latest=false
 
       - name: Build and push container image
         id: push


### PR DESCRIPTION
## Summary

- Adds an optional `pel_n` input to `container.yml` (both `workflow_dispatch` and `workflow_call`). When set, the image tag becomes `<git-tag>-pel-<N>`; when empty (the default), the tag is the plain `<git-tag>` used by the existing release flow.
- Overrides the `docker/metadata-action` tag list to a single `type=raw` value derived from the computed `IMAGE_TAG` env var, with `flavor: latest=false` to suppress the branch-named default tag that workflow_dispatch invocations would otherwise produce.
- Purely additive on the contract — `release.yml`'s `workflow_call` invocation continues to work unchanged (the `pel_n` input is optional with default `""`).

## Why

Operators building custom agent images that bake in plugin versions not yet shipped in the standard metapackage (e.g. the 2026-05-08 `0.85.0-dev.9-pel-1` and the 2026-05-13 `0.85.0-dev.12-pel-1` builds) need a tag that doesn't collide with the upstream release. The `-pel-<N>` suffix is the convention we already use for the deployed image name; this PR lets the workflow produce that tag directly instead of every operator re-applying the same workflow change to their per-build branch.