### PR TITLE
fix(conformance): mirror forward-loop empty-skip in compareMap/compareProperties reverse loops

### DIFF
--- a/pkg/plugin-conformance-tests/runner.go
+++ b/pkg/plugin-conformance-tests/runner.go
@@ -921,9 +921,23 @@ func compareMap(r testReporter, name string, expected, actual map[string]any, co
 			}
 		}
 	}
-	// Reverse: actual → expected — flag extra keys not in hasProviderDefault
-	for key := range actual {
+	// Reverse: actual → expected — flag extra keys not in hasProviderDefault.
+	// Mirror the forward loop's "skip if structurally absent" forgiveness:
+	// nil / empty array / empty map values are semantically equivalent to
+	// the key being omitted (cloud providers commonly return [] / {} for
+	// fields the user didn't set, which shouldn't trigger drift detection).
+	// Real drift — non-empty unexpected values — is still flagged.
+	for key, actualValue := range actual {
 		if _, inExpected := expected[key]; inExpected {
+			continue
+		}
+		if actualValue == nil {
+			continue
+		}
+		if arr, isArr := actualValue.([]any); isArr && len(arr) == 0 {
+			continue
+		}
+		if m, isMap := actualValue.(map[string]any); isMap && len(m) == 0 {
 			continue
 		}
 		fieldPath := name + "." + key
@@ -1012,9 +1026,22 @@ func compareProperties(r testReporter, expectedProperties map[string]any, actual
 		}
 	}
 
-	// Reverse: actual → expected — flag extra keys not in hasProviderDefault
-	for key := range actualProperties {
+	// Reverse: actual → expected — flag extra keys not in hasProviderDefault.
+	// Skip when the actual value is structurally absent (nil / empty array
+	// / empty map) — cloud providers commonly return [] / {} for fields
+	// the user didn't set, and that's semantically equivalent to the key
+	// being omitted. Real drift (non-empty unexpected values) still flagged.
+	for key, actualValue := range actualProperties {
 		if _, inExpected := expectedProperties[key]; inExpected {
+			continue
+		}
+		if actualValue == nil {
+			continue
+		}
+		if arr, isArr := actualValue.([]any); isArr && len(arr) == 0 {
+			continue
+		}
+		if m, isMap := actualValue.(map[string]any); isMap && len(m) == 0 {
 			continue
 		}
 		if !isProviderDefault(key, providerDefaults) {

--- a/pkg/plugin-conformance-tests/runner_test.go
+++ b/pkg/plugin-conformance-tests/runner_test.go
@@ -589,6 +589,52 @@ func TestCompareMap(t *testing.T) {
 			t.Error("compareMap should fail when expected key is missing from actual")
 		}
 	})
+
+	// Cloud providers commonly return [] / {} for fields the user didn't
+	// set; that's semantically equivalent to the key being omitted and
+	// must NOT be flagged as drift. The forward loop already has this
+	// forgiveness — these cases verify the reverse loop matches it.
+	t.Run("extra empty array in actual passes", func(t *testing.T) {
+		expected := map[string]any{"Name": "my-app"}
+		actual := map[string]any{"Name": "my-app", "Tags": []any{}}
+		if !compareMap(t, "Config", expected, actual, "test", map[string]providerDefault{}) {
+			t.Error("compareMap should pass when actual has an extra key with an empty array value")
+		}
+	})
+
+	t.Run("extra empty map in actual passes", func(t *testing.T) {
+		expected := map[string]any{"Name": "my-app"}
+		actual := map[string]any{"Name": "my-app", "Labels": map[string]any{}}
+		if !compareMap(t, "Config", expected, actual, "test", map[string]providerDefault{}) {
+			t.Error("compareMap should pass when actual has an extra key with an empty map value")
+		}
+	})
+
+	t.Run("extra nil value in actual passes", func(t *testing.T) {
+		expected := map[string]any{"Name": "my-app"}
+		actual := map[string]any{"Name": "my-app", "Optional": nil}
+		if !compareMap(t, "Config", expected, actual, "test", map[string]providerDefault{}) {
+			t.Error("compareMap should pass when actual has an extra key with a nil value")
+		}
+	})
+
+	t.Run("extra non-empty array in actual still fails", func(t *testing.T) {
+		fakeT := &testing.T{}
+		expected := map[string]any{"Name": "my-app"}
+		actual := map[string]any{"Name": "my-app", "Tags": []any{"prod"}}
+		if compareMap(fakeT, "Config", expected, actual, "test", map[string]providerDefault{}) {
+			t.Error("compareMap should still fail when actual has an extra key with a non-empty value (real drift)")
+		}
+	})
+
+	t.Run("extra non-empty map in actual still fails", func(t *testing.T) {
+		fakeT := &testing.T{}
+		expected := map[string]any{"Name": "my-app"}
+		actual := map[string]any{"Name": "my-app", "Labels": map[string]any{"env": "prod"}}
+		if compareMap(fakeT, "Config", expected, actual, "test", map[string]providerDefault{}) {
+			t.Error("compareMap should still fail when actual has an extra key with a non-empty map value (real drift)")
+		}
+	})
 }
 
 // TestCompareProperties_ResolvableNestedInArray verifies that compareProperties
@@ -797,6 +843,40 @@ func TestCompareProperties_ExtraTopLevelNonProviderDefault(t *testing.T) {
 	result := compareProperties(inner, expectedProperties, actualResource, "after create", providerDefaults)
 	if result {
 		t.Error("should fail when extra top-level key is not a provider default")
+	}
+}
+
+// Cloud providers commonly return [] / {} at the top level for fields the
+// user didn't set; that's semantically equivalent to the key being omitted
+// and must NOT be flagged as drift. Real drift (non-empty extras) still flagged.
+func TestCompareProperties_ExtraTopLevelEmptyValuesAllowed(t *testing.T) {
+	expectedProperties := map[string]any{"Name": "my-app"}
+	actualResource := map[string]any{
+		"Properties": map[string]any{
+			"Name":           "my-app",
+			"Tags":           []any{},
+			"DockerLabels":   map[string]any{},
+			"OptionalScalar": nil,
+		},
+	}
+	providerDefaults := map[string]providerDefault{}
+	if !compareProperties(t, expectedProperties, actualResource, "after create", providerDefaults) {
+		t.Error("compareProperties should pass when extra top-level keys hold structurally-absent values (nil / [] / {})")
+	}
+}
+
+func TestCompareProperties_ExtraTopLevelNonEmptyStillFails(t *testing.T) {
+	expectedProperties := map[string]any{"Name": "my-app"}
+	actualResource := map[string]any{
+		"Properties": map[string]any{
+			"Name": "my-app",
+			"Tags": []any{"prod"},
+		},
+	}
+	providerDefaults := map[string]providerDefault{}
+	inner := &testing.T{}
+	if compareProperties(inner, expectedProperties, actualResource, "after create", providerDefaults) {
+		t.Error("compareProperties should still fail when extra top-level key has a non-empty value")
 	}
 }
 

--- a/tests/e2e/go/setup_pkl.sh
+++ b/tests/e2e/go/setup_pkl.sh
@@ -37,11 +37,17 @@ fi
 FORMAE_VERSION=$(cat "$VERSION_FILE")
 FORMAE_URI="package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@${FORMAE_VERSION}"
 
-# hub_uri reads the baseUri and version from an installed plugin's schema
-# PklProject and emits a PklProject dependency line using the hub URI.
+# plugin_dep emits a PklProject dependency line for an installed plugin.
+#
+# Released versions (no pre-release suffix) resolve via the hub URI — the
+# corresponding schema package has been published by schema-prerelease.
+# Pre-release builds (e.g. `make install` of a plugin repo's HEAD produces
+# `v0.1.8-dev.0`) only exist on the runner's filesystem, so we point the
+# dependency at the plugin's on-disk PklProject. Same shape as
+# `formae extract --schema-location local` emits.
 #
 # Args: <namespace_dir> <pkl_alias> <required: true|false>
-hub_uri() {
+plugin_dep() {
     local ns_dir="$1"
     local alias="$2"
     local required="${3:-true}"
@@ -60,28 +66,35 @@ hub_uri() {
         fi
     fi
 
-    local base_uri version
-    base_uri=$(pkl eval -x 'package.baseUri' "$plugin_dir/schema/pkl/PklProject")
+    local version
     version=$(pkl eval -x 'version' "$plugin_dir/formae-plugin.pkl")
-    echo "Using $alias plugin v$version from hub ($base_uri)" >&2
-    echo "  [\"$alias\"] { uri = \"$base_uri@$version\" }"
+
+    if [[ "$version" == *-* ]]; then
+        echo "Using $alias plugin v$version from local install ($plugin_dir/schema/pkl)" >&2
+        echo "  [\"$alias\"] = import(\"$plugin_dir/schema/pkl/PklProject\")"
+    else
+        local base_uri
+        base_uri=$(pkl eval -x 'package.baseUri' "$plugin_dir/schema/pkl/PklProject")
+        echo "Using $alias plugin v$version from hub ($base_uri)" >&2
+        echo "  [\"$alias\"] { uri = \"$base_uri@$version\" }"
+    fi
 }
 
-# Resolve plugin schemas from the hub. All plugins are optional at this
-# level — the e2e workflow installs only the plugins each test needs (matrix
-# .plugins), so a single setup_pkl.sh run is shared across tests with
-# different plugin sets. Fixtures that import a plugin not installed will
-# fail to evaluate with a clear PKL error, which is the right failure mode.
-AWS_DEP=$(hub_uri "aws" "aws" false)
-AZURE_DEP=$(hub_uri "azure" "azure" false)
-COMPOSE_DEP=$(hub_uri "compose" "compose" false)
-GRAFANA_DEP=$(hub_uri "grafana" "grafana" false)
+# Resolve plugin deps. All plugins are optional at this level — the e2e
+# workflow installs only the plugins each test needs (matrix .plugins), so a
+# single setup_pkl.sh run is shared across tests with different plugin sets.
+# Fixtures that import a plugin not installed will fail to evaluate with a
+# clear PKL error, which is the right failure mode.
+AWS_DEP=$(plugin_dep "aws" "aws" false)
+AZURE_DEP=$(plugin_dep "azure" "azure" false)
+COMPOSE_DEP=$(plugin_dep "compose" "compose" false)
+GRAFANA_DEP=$(plugin_dep "grafana" "grafana" false)
 
-# Generate PklProject. Both formae core and plugins are pinned via hub URIs
-# — matches a real user's setup, and avoids the PKL type-identity split that
-# would happen if the fixture's formae and a plugin's formae were declared
-# at different URIs. Each plugin dep is included only if its hub_uri call
-# returned non-empty (i.e. the plugin is installed in $PLUGINS_DIR).
+# Generate PklProject. formae core is always pinned via hub URI (matches a
+# real user's setup); each plugin is resolved by plugin_dep, which picks hub
+# vs. local based on whether the installed version is a released semver. A
+# plugin dep is included only if its plugin_dep call returned non-empty
+# (i.e. the plugin is installed in $PLUGINS_DIR).
 cat > "$PKLPROJECT_PATH" << EOF
 amends "pkl:Project"
 


### PR DESCRIPTION
## Summary

The forward direction of `compareMap` and `compareProperties` skips when the expected value is structurally absent (`nil` / empty array / empty map):

\`\`\`go
if !exists {
    if expectedValue == nil { continue }
    if arr, ok := expectedValue.([]any); ok && len(arr) == 0 { continue }
    if m, ok := expectedValue.(map[string]any); ok && len(m) == 0 { continue }
    r.Errorf(\"Property %s should exist...\")
}
\`\`\`

The reverse direction had no equivalent forgiveness — any actual key absent from expected was flagged as drift unless the schema marked the field as `hasProviderDefault`. Cloud providers commonly return `[]` for unset list fields and `{}` for unset map fields; that's semantically equivalent to the key being omitted, but the harness was flagging it.

This forced plugin authors into a bad tradeoff for **user-canonical** fields:
- Mark `hasProviderDefault` on the schema → satisfies the harness, but formae core's strip-provider-default pass then drops the field symmetrically from apply diffs, **silently losing user changes** (the f8bcba4 problem in `formae-plugin-aws`)
- Set explicit empty literals in testdata → loses test coverage clarity and bloats fixtures

Mirroring the forward loop's empty-skip in the reverse direction removes the false-positive **without weakening real drift detection**: non-empty unexpected values are still flagged, which is the case that matters for both OOB changes and missed `hasProviderDefault` annotations.

## How it surfaces in practice

`AWS::ECS::TaskDefinition` conformance test in `formae-plugin-aws` — 18 `ContainerDefinitions[0].*` fields and `Tags` came back from CCAPI as `[]` / `{}`. Same shape on `AWS::ECS::TaskSet`'s `Tags`, `AWS::SES::EmailIdentity.Tags`, and probably others. Commit `cfd292b` in `formae-plugin-aws` ships a testdata workaround (explicit empty literals on every such field) that becomes unnecessary once this lands.

## What ships

- Two reverse loops in `pkg/plugin-conformance-tests/runner.go` updated symmetrically.
- Five regression tests added covering the new behavior (extra empty array passes, extra empty map passes, extra nil passes, extra non-empty array still fails, extra non-empty map still fails) + matching tests for top-level `compareProperties`.