### PR TITLE
fix(discovery): reset recentlyDiscoveredResourceIDs between cycles

### DIFF
--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -290,6 +290,7 @@ func discover(from gen.PID, state gen.Atom, data DiscoveryData, message Discover
 	// Clear per-cycle state at start of each discovery cycle
 	data.pluginInfoCache = make(map[string]*messages.PluginInfoResponse)
 	data.typesWithChildrenQueued = make(map[string]struct{})
+	data.recentlyDiscoveredResourceIDs = make(map[string]struct{})
 	proc.Log().Debug("Starting resource discovery timestamp=%v", data.timeStarted)
 
 	allTargets, err := data.ds.LoadDiscoverableTargets()


### PR DESCRIPTION
## Summary

- `recentlyDiscoveredResourceIDs` (cross-target dedup state used by `resourceExists` in `internal/metastructure/discovery/discovery.go`) was initialized once at actor start (`:176`) and never cleared between discovery sweeps.
- Effect: the map grew unbounded, and `resourceExists` would short-circuit on stale entries from prior cycles — a resource deleted and recreated out-of-band would be skipped instead of re-discovered.
- Fix: reset at the same per-cycle clear block (`:290-292`) that already wipes `pluginInfoCache` and `typesWithChildrenQueued`. One-line change.