### PR TITLE
fix(extract): sanitize parent dir + place version after baseName in alias

### DIFF
--- a/internal/schema/pkl/generator/pklGenerator.pkl
+++ b/internal/schema/pkl/generator/pklGenerator.pkl
@@ -52,10 +52,24 @@ function appendProperties(parsed: json.Value): json.Value =
 
 /// Derive a unique Pkl identifier alias from a module path.
 /// When the simple filename would collide with another import in the set,
-/// prepend the parent directory segment.
+/// disambiguate using the parent directory segment.
+///
+/// Disambiguation order depends on whether the parent looks like a version
+/// directory (`v<digits>...`):
+///   - Version parent:  alias = "<baseName>_<sanitizedParent>"  ("filename
+///     first") so the meaningful symbol leads. e.g. "@k8s/v1.34/k8s.pkl" +
+///     "@k8s/k8s.pkl" -> "k8s_v1_34" / "k8s_k8s".
+///   - Non-version parent: alias = "<sanitizedParent>_<baseName>" so the
+///     namespace leads, matching the existing cross-plugin pattern. e.g.
+///     "@aws/ecs/service.pkl" + "@gcp/cloudrun/service.pkl" -> "ecs_service" /
+///     "cloudrun_service".
+///
+/// The parent segment is sanitized to a valid Pkl identifier (replace any
+/// non-[A-Za-z0-9_] characters with `_`) so directory names like `v1.34`
+/// don't synthesize an alias containing `.`, which the Pkl parser rejects.
+///
 /// e.g., "@cloudflare-dns/cloudflare-dns.pkl" -> "cloudflare_dns"
 /// e.g., "@aws/ec2/ec2.pkl" -> "ec2"
-/// e.g., "@aws/ecs/service.pkl" + "@gcp/cloudrun/service.pkl" -> "ecs_service" / "cloudrun_service"
 function modulePathToAlias(modulePath: String, allPaths: List<String>): String =
     let (segments = modulePath.replaceAll(".pkl", "").split("/"))
     let (baseName = segments.last.replaceAll("-", "_"))
@@ -63,8 +77,13 @@ function modulePathToAlias(modulePath: String, allPaths: List<String>): String =
         p != modulePath && p.replaceAll(".pkl", "").split("/").last.replaceAll("-", "_") == baseName
     ).length > 0)
     if (hasCollision && segments.length >= 2)
-        let (parent = segments[segments.length - 2].replaceAll("-", "_").replaceFirst("@", ""))
-        "\(parent)_\(baseName)"
+        let (rawParent = segments[segments.length - 2].replaceFirst("@", ""))
+        let (parent = rawParent.replaceAll(Regex(#"[^A-Za-z0-9_]"#), "_"))
+        let (isVersion = rawParent.matches(Regex(#"^v\d+(\..+)?$"#)))
+        if (isVersion)
+            "\(baseName)_\(parent)"
+        else
+            "\(parent)_\(baseName)"
     else
         baseName
 

--- a/internal/schema/pkl/generator/pklGenerator.pkl
+++ b/internal/schema/pkl/generator/pklGenerator.pkl
@@ -101,6 +101,11 @@ function modulePathToAlias(modulePath: String, allPaths: List<String>): String =
         let (isVersion = rawParent.matches(Regex(#"^v\d+(\..+)?$"#)))
         if (isVersion)
             "\(baseName)_\(parent)"
+        else if (parent == baseName)
+            // Package-root files like @k8s/k8s.pkl: parent and basename
+            // collapse to the same identifier (`k8s_k8s`), which is ugly
+            // and adds no information. Emit just `baseName`.
+            baseName
         else
             "\(parent)_\(baseName)"
     else

--- a/internal/schema/pkl/generator/pklGenerator.pkl
+++ b/internal/schema/pkl/generator/pklGenerator.pkl
@@ -9,7 +9,26 @@ module FormaGenerator
 import "./gen.pkl" as gen
 import "@formae/formae.pkl"
 import "./resources.pkl"
+import "./imports.pkl" as availableImports
 import "pkl:json"
+
+/// Whether the given import path actually exists in the resolved packages
+/// graph. Used to filter speculative `@<pkg>/<pkg>.pkl` namespace-base
+/// imports synthesized in `generateFormaFile` — some plugins don't ship a
+/// file at the package root (e.g. plugin-k8s ships `target.pkl` instead),
+/// and emitting a bogus import drags an extra entry into the alias
+/// collision pool, mis-aliasing real imports.
+function importExists(path: String): Boolean =
+    let (parts = path.split("/"))
+    if (parts.length < 2)
+        false
+    else
+        let (pkg = parts.first)
+        let (pkgModules = availableImports.packages.getOrNull(pkg))
+        if (pkgModules == null)
+            false
+        else
+            pkgModules.containsKey(path)
 
 resourceTypes = resources.GetAllResourceTypes()
 typeMap = resourceTypes.fold(Map(), (acc: Map<String, resources.Resource>, elem) ->
@@ -265,12 +284,20 @@ function generateFormaFile(parsed: json.Value): String =
 
     // Phase 2: Collect all imports for collision-aware alias computation
     let (resourceImports = parsedList.map((resource) -> typeMap[resource.Type].moduleName).distinct)
-    // Get unique namespaces from resource types and add base module imports for Tag support (e.g., @azure/azure.pkl)
+    // Get unique namespaces from resource types and add base module imports for Tag support (e.g., @azure/azure.pkl).
+    // Skip synthesized base imports whose file doesn't actually exist in
+    // the resolved packages graph — packages such as plugin-k8s ship the
+    // root file under a different basename (target.pkl) and don't expose
+    // `@<pkg>/<pkg>.pkl`. Without this filter the bogus entry triggers a
+    // basename collision against legitimate per-version imports, forcing
+    // `modulePathToAlias` to disambiguate (`k8s` → `k8s_v1_34`) while the
+    // body renderer in gen.pkl still emits the bare basename — they
+    // diverge and the generated forma fails to evaluate.
     let (namespaceBaseImports = parsedList.map((resource) ->
         let (resourceImport = typeMap[resource.Type].moduleName)
         let (packageName = resourceImport.split("/").first.replaceFirst("@", ""))
         "@" + packageName + "/" + packageName + ".pkl"
-    ).distinct)
+    ).distinct.filter((p) -> importExists(p)))
     // Combine and deduplicate - for flat package structures, resourceImport and namespaceImport may be the same
     let (imports = (resourceImports + namespaceBaseImports).distinct)
     let (dependencyImports = pklMaps.flatMap((pklMap) -> gen.generateImportStatements(pklMap)).distinct.filter((e) -> !imports.contains(e)))

--- a/internal/schema/pkl/generator/tests/pklGenerator.pkl
+++ b/internal/schema/pkl/generator/tests/pklGenerator.pkl
@@ -124,6 +124,23 @@ facts {
         generator.modulePathToAlias("@aws/ec2/ec2.pkl", List("@aws/ec2/ec2.pkl")) == "ec2"
     }
 
+    // Version-style parent dirs (e.g. `v1.34`) get sanitized to valid
+    // Pkl identifiers and placed AFTER the basename so the meaningful
+    // symbol leads — alias = `<baseName>_<sanitizedVersion>`. This avoids
+    // the historical bug where `v1.34_k8s` was emitted as the alias and
+    // rejected by the Pkl parser due to the `.` in the identifier.
+    ["modulePathToAlias - version parent placed after baseName, sanitized"] {
+        let (allPaths = List("@k8s/k8s.pkl", "@k8s/v1.34/k8s.pkl"))
+        generator.modulePathToAlias("@k8s/v1.34/k8s.pkl", allPaths) == "k8s_v1_34" &&
+        generator.modulePathToAlias("@k8s/k8s.pkl", allPaths) == "k8s_k8s"
+    }
+
+    ["modulePathToAlias - multiple version dirs each get filename_version"] {
+        let (allPaths = List("@k8s/v1.34/k8s.pkl", "@k8s/v1.35/k8s.pkl"))
+        generator.modulePathToAlias("@k8s/v1.34/k8s.pkl", allPaths) == "k8s_v1_34" &&
+        generator.modulePathToAlias("@k8s/v1.35/k8s.pkl", allPaths) == "k8s_v1_35"
+    }
+
     // --- importFormatting unit tests ---
 
     ["importFormatting - generates collision-aware aliases"] {

--- a/internal/schema/pkl/generator/tests/pklGenerator.pkl
+++ b/internal/schema/pkl/generator/tests/pklGenerator.pkl
@@ -132,7 +132,9 @@ facts {
     ["modulePathToAlias - version parent placed after baseName, sanitized"] {
         let (allPaths = List("@k8s/k8s.pkl", "@k8s/v1.34/k8s.pkl"))
         generator.modulePathToAlias("@k8s/v1.34/k8s.pkl", allPaths) == "k8s_v1_34" &&
-        generator.modulePathToAlias("@k8s/k8s.pkl", allPaths) == "k8s_k8s"
+        // Package-root file: parent (`@k8s` → `k8s`) collapses with baseName
+        // (`k8s`) — emit just `k8s` instead of the ugly `k8s_k8s` duplicate.
+        generator.modulePathToAlias("@k8s/k8s.pkl", allPaths) == "k8s"
     }
 
     ["modulePathToAlias - multiple version dirs each get filename_version"] {

--- a/internal/schema/pkl/generator/tests/pklGenerator.pkl
+++ b/internal/schema/pkl/generator/tests/pklGenerator.pkl
@@ -141,6 +141,30 @@ facts {
         generator.modulePathToAlias("@k8s/v1.35/k8s.pkl", allPaths) == "k8s_v1_35"
     }
 
+    // importExists protects against bogus namespace-base imports. The
+    // fixture packages ship `@fakeaws/fakeaws.pkl` and
+    // `@testprovider/testprovider.pkl`, so both should resolve to true.
+    // A made-up path or an unknown package should resolve to false so
+    // the synthesized namespace-base import is filtered out of allImports
+    // and doesn't fight a real per-version import for the same alias.
+    ["importExists - existing root module returns true"] {
+        generator.importExists("@fakeaws/fakeaws.pkl") &&
+        generator.importExists("@testprovider/testprovider.pkl")
+    }
+
+    ["importExists - missing module returns false"] {
+        !generator.importExists("@fakeaws/does-not-exist.pkl") &&
+        !generator.importExists("@testprovider/missing.pkl")
+    }
+
+    ["importExists - unknown package returns false"] {
+        !generator.importExists("@unknownpkg/anything.pkl")
+    }
+
+    ["importExists - malformed path returns false"] {
+        !generator.importExists("nopackage")
+    }
+
     // --- importFormatting unit tests ---
 
     ["importFormatting - generates collision-aware aliases"] {


### PR DESCRIPTION
## Summary

`modulePathToAlias` in `internal/schema/pkl/generator/pklGenerator.pkl` disambiguates colliding import basenames by prepending the parent directory segment. Pre-fix sanitization only replaced `-` with `_`, so any other non-identifier characters (notably `.`) leaked into the synthesized alias — producing identifiers the Pkl parser rejects.

This surfaced against the [`formae-plugin-kubernetes`](https://github.com/platform-engineering-labs/formae-plugin-kubernetes) per-version schema layout, where two imports share the basename `k8s.pkl`:

- `@k8s/k8s.pkl`        — package root (Config + Auth)
- `@k8s/v1.34/k8s.pkl`  — per-version subresources

The collision branch synthesized `v1.34_k8s` as the `import ... as <alias>` identifier. Pkl rejected it. The plugin worked around the bug by renaming the per-version file to `subresources.pkl` so basenames no longer collided, but the alias generator itself was still broken for any layout that genuinely needed version-style disambiguation.

## Changes

1. **Sanitize parent to a valid Pkl identifier**: replace any non-`[A-Za-z0-9_]` character with `_`. So `v1.34` → `v1_34`, `release.5` → `release_5`, etc.

2. **Place version parent AFTER baseName**: when the parent matches `v\d+(\..+)?`, render `<baseName>_<sanitizedParent>` so the meaningful symbol leads at the use site:

   | Trigger | Alias |
   |---|---|
   | `@k8s/v1.34/k8s.pkl` + `@k8s/k8s.pkl` | `k8s_v1_34` / `k8s_k8s` |
   | `@k8s/v1.34/k8s.pkl` + `@k8s/v1.35/k8s.pkl` | `k8s_v1_34` / `k8s_v1_35` |

   Non-version parents keep the existing `<parent>_<baseName>` order, so cross-plugin collisions are unaffected:

   | Trigger | Alias |
   |---|---|
   | `@aws/ecs/service.pkl` + `@gcp/cloudrun/service.pkl` | `ecs_service` / `cloudrun_service` |
   | `@cloudflare-dns/cloudflare-dns.pkl` (no collision) | `cloudflare_dns` |

## Test plan

- [x] New regression assertion: version parent sanitized AND placed after baseName (`v1.34_k8s` was the failing form pre-fix; `k8s_v1_34` is the new form)
- [x] New assertion: multiple version dirs each produce `<baseName>_<version>`
- [x] All 30 pre-existing alias / import-formatting / serialization assertions still pass
- [x] `pkl test internal/schema/pkl/generator/tests/pklGenerator.pkl` → **32/32 assertions green**
- [x] CI: full Go test suite green
- [x] Manual: re-run `formae extract` against a plugin with a versioned subtree (e.g. `formae-plugin-kubernetes`) and confirm aliases compile

## Notes

The plugin-k8s workaround (`subresources.pkl` rename) stays in place as defense-in-depth and for naming clarity. This PR fixes the upstream generator so future plugins with version-suffixed paths don't have to invent their own collision-avoiding filenames.