### PR TITLE
feat(querier): same-field or-matching and wildcard matching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,13 @@ build: helm-reader
 ## discovers it via exec.LookPath.
 helm-reader:
 	@HELM_READER_VERSION=$(HELM_READER_VERSION) ./scripts/install-helm-reader.sh
+	
+## dev-install: Stage the locally built formae into an installer-shaped tree at ./dist/dev so the agent's orbital-tree check passes without a sudo write to /opt/pel. Plugins still resolve from ~/.pel/formae/plugins/.
+dev-install: build
+	@mkdir -p $(CURDIR)/dist/dev/bin $(CURDIR)/dist/dev/.ops
+	@cp $(CURDIR)/formae $(CURDIR)/dist/dev/bin/formae
+	@echo "Staged at $(CURDIR)/dist/dev/bin/formae"
+	@echo "Run: $(CURDIR)/dist/dev/bin/formae agent start"
 
 ## install-gremlins: Install the gremlins mutation testing tool
 install-gremlins:
@@ -261,4 +268,4 @@ add-license:
 
 all: clean build gen-pkl api-docs
 
-.PHONY: api-docs clean build install-gremlins build-debug pkg-bin publish-bin gen-pkl pkg-pkl publish-pkl run tidy-all test-build test-all test-unit test-unit-postgres test-unit-auroradataapi test-unit-summary test-integration test-e2e test-property mutation-test test-descriptors-pkl verify-schema-fakeaws version full-e2e lint lint-reuse add-license postgres-up postgres-down local-data-api-up local-data-api-down all
+.PHONY: api-docs clean build dev-install install-gremlins build-debug pkg-bin publish-bin gen-pkl pkg-pkl publish-pkl run tidy-all test-build test-all test-unit test-unit-postgres test-unit-auroradataapi test-unit-summary test-integration test-e2e test-property mutation-test test-descriptors-pkl verify-schema-fakeaws version full-e2e lint lint-reuse add-license postgres-up postgres-down local-data-api-up local-data-api-down all

--- a/internal/cli/cancel/cancel.go
+++ b/internal/cli/cancel/cancel.go
@@ -71,7 +71,7 @@ before transitioning to 'Canceled' state to avoid orphaned resources.`,
 
 	command.SetUsageTemplate(cmd.SimpleCmdUsageTemplate)
 
-	command.Flags().String("query", "", "Query to select commands to cancel. If not provided, cancels the most recent command.")
+	command.Flags().String("query", "", "Query to select commands to cancel. If not provided, cancels the most recent command. Use * as a wildcard anywhere (e.g. foo*, *foo, *foo*, foo*bar). ? and regex are not yet supported.")
 	command.Flags().BoolP("watch", "w", false, "Watch the status of canceled commands until they complete")
 	command.Flags().String("status-output-layout", string(status.StatusOutputSummary), fmt.Sprintf("What to print as status output (%s | %s)", status.StatusOutputSummary, status.StatusOutputDetailed))
 	command.Flags().String("output-consumer", string(printer.ConsumerHuman), "Consumer of the command result (human | machine)")

--- a/internal/cli/cmd/cmd.go
+++ b/internal/cli/cmd/cmd.go
@@ -40,6 +40,8 @@ var RootCmdUsageTemplate = display.Grey("Usage: ") + display.Green("{{.CommandPa
 
 var SimpleCmdUsageTemplate = display.Grey("Usage: ") + display.Green("{{.CommandPath}}{{if .HasAvailableLocalFlags}} [OPTIONS]{{end}}{{if .HasAvailableSubCommands}} [COMMAND]{{end}}") +
 	display.Green("{{if index .Annotations \"args\"}} {{index .Annotations \"args\"}}{{end}}") + "\n" +
+	"{{if index .Annotations \"examples\"}}\n" + display.Gold("Examples:") + "\n  " +
+	display.Grey("{{formatExamplesMultiline (index .Annotations \"examples\") .}}") + "\n{{end}}" +
 	"{{if .HasAvailableSubCommands}}\n" + display.Gold("Commands:") +
 	"{{range $cmd := .Commands}}\n  " + display.Green("{{rpad $cmd.Name $cmd.NamePadding}}") + "       {{$cmd.Short}}" +
 	"{{if (index $cmd.Annotations \"examples\")}}\n                   " +

--- a/internal/cli/destroy/destroy.go
+++ b/internal/cli/destroy/destroy.go
@@ -80,16 +80,18 @@ func DestroyCmd() *cobra.Command {
 			return runDestroy(app, opts)
 		},
 		Annotations: map[string]string{
-			"type":     "Forma",
-			"examples": "{{.Name}} {{.Command}} forma.pkl",
-			"args":     "<forma file>",
+			"type": "Forma",
+			"examples": "formae destroy forma.pkl" +
+				" | formae destroy --query 'stack:test-* managed:false'" +
+				" | formae destroy --query 'type:AWS::S3::Bucket stack:scratch' --yes",
+			"args": "<forma file>",
 		},
 		SilenceErrors: true,
 	}
 
 	command.SetUsageTemplate(cmd.SimpleCmdUsageTemplate)
 
-	command.Flags().String("query", " ", "Query that allows to find resources by their attributes. Only used when no forma file is provided.")
+	command.Flags().String("query", " ", "Query that allows to find resources by their attributes. Only used when no forma file is provided. Use * as a wildcard anywhere (e.g. foo*, *foo, *foo*, foo*bar). ? and regex are not yet supported.")
 	command.Flags().String("output-consumer", string(printer.ConsumerHuman), "Consumer of the command result (human | machine)")
 	command.Flags().String("output-schema", "json", "The schema to use for the result output (json | yaml)")
 	command.Flags().Bool("simulate", false, "Simulate the command rather than make actual changes")

--- a/internal/cli/extract/extract.go
+++ b/internal/cli/extract/extract.go
@@ -59,16 +59,18 @@ func ExtractCmd() *cobra.Command {
 			return runExtract(app, opts)
 		},
 		Annotations: map[string]string{
-			"type":     "Forma",
-			"examples": "{{.Name}} {{.Command}} ./code.pkl  |  {{.Name}} {{.Command}} --query 'type:AWS::S3::Bucket' ./buckets.pkl",
-			"args":     "<target file>",
+			"type": "Forma",
+			"examples": "formae extract --query 'type:AWS::S3::Bucket' ./buckets.pkl" +
+				" | formae extract --query 'type:GCP::Compute::* managed:false' ./gcp-unmanaged.pkl" +
+				" | formae extract --query 'stack:prod target:eu target:us' ./prod.pkl",
+			"args": "<target file>",
 		},
 		SilenceErrors: true,
 	}
 
 	command.SetUsageTemplate(cmd.SimpleCmdUsageTemplate)
 
-	command.Flags().String("query", " ", "Query that allows to find resources by their attributes")
+	command.Flags().String("query", " ", "Query that allows to find resources by their attributes. Use * as a wildcard anywhere (e.g. foo*, *foo, *foo*, foo*bar). ? and regex are not yet supported.")
 	command.Flags().Bool("yes", false, "Overwrite existing files without prompting")
 	command.Flags().String("output-schema", "pkl", "Output schema (only 'pkl' is currently supported)")
 	command.Flags().String("schema-location", "remote", "How plugin PKL schemas are referenced in the generated PklProject. 'remote' (default) emits package:// URIs that PKL fetches from the hub. 'local' emits local file imports against the agent's on-disk PklProject paths; requires CLI and agent to share a filesystem.")

--- a/internal/cli/inventory/inventory.go
+++ b/internal/cli/inventory/inventory.go
@@ -67,12 +67,15 @@ func resourcesCmd() *cobra.Command {
 			return runResources(app, opts)
 		},
 		Annotations: map[string]string{
-			"examples": "{{.Name}} {{.Command}} inventory resources --query 'type:AWS::S3::Bucket' --max-results 50",
+			"examples": "formae inventory resources --query 'type:AWS::S3::Bucket'" +
+				" | formae inventory resources --query 'type:GCP::Compute::* stack:prod'" +
+				" | formae inventory resources --query 'target:eu target:us managed:false'" +
+				" | formae inventory resources --max-results 50",
 		},
 		SilenceErrors: true,
 	}
 
-	command.Flags().String("query", "", "Query that allows to find resources by their attributes")
+	command.Flags().String("query", "", "Query that allows to find resources by their attributes. Use * as a wildcard anywhere (e.g. foo*, *foo, *foo*, foo*bar). ? and regex are not yet supported.")
 	command.Flags().String("output-consumer", string(printer.ConsumerHuman), "Consumer of the command output (human | machine)")
 	command.Flags().String("output-schema", "json", "The schema to use for the machine output (json | yaml)")
 	command.Flags().Int("max-results", 10, "Maximum number of resources to display in the table (0 = unlimited)")
@@ -172,12 +175,14 @@ func targetsCmd() *cobra.Command {
 			return runTargets(app, opts)
 		},
 		Annotations: map[string]string{
-			"examples": "{{.Name}} {{.Command}} inventory targets --query 'discoverable:true' --max-results 50",
+			"examples": "formae inventory targets --query 'discoverable:true'" +
+				" | formae inventory targets --query 'namespace:AWS label:prod-*'" +
+				" | formae inventory targets --max-results 50",
 		},
 		SilenceErrors: true,
 	}
 
-	command.Flags().String("query", "", "Query that allows to find targets by their attributes (e.g., 'namespace:AWS', 'discoverable:true', 'label:prod-us-east-1')")
+	command.Flags().String("query", "", "Query that allows to find targets by their attributes (e.g., 'namespace:AWS', 'discoverable:true', 'label:prod-us-east-1'). Use * as a wildcard anywhere (e.g. foo*, *foo, *foo*, foo*bar). ? and regex are not yet supported.")
 	command.Flags().String("output-consumer", string(printer.ConsumerHuman), "Consumer of the command output (human | machine)")
 	command.Flags().String("output-schema", "json", "The schema to use for the machine output (json | yaml)")
 	command.Flags().Int("max-results", 10, "Maximum number of targets to display in the table (0 = unlimited)")
@@ -242,7 +247,8 @@ func stacksCmd() *cobra.Command {
 			return runStacks(app, opts)
 		},
 		Annotations: map[string]string{
-			"examples": "{{.Name}} {{.Command}} inventory stacks --max-results 50",
+			"examples": "formae inventory stacks" +
+				" | formae inventory stacks --max-results 50",
 		},
 		SilenceErrors: true,
 	}
@@ -289,7 +295,8 @@ func policiesCmd() *cobra.Command {
 			return runPolicies(app, opts)
 		},
 		Annotations: map[string]string{
-			"examples": "{{.Name}} {{.Command}} inventory policies --max-results 50",
+			"examples": "formae inventory policies" +
+				" | formae inventory policies --max-results 50",
 		},
 		SilenceErrors: true,
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -101,6 +101,21 @@ func init() {
 		return strings.ReplaceAll(replaced, "{{.Command}}", cmdName)
 	})
 
+	// formatExamplesMultiline renders pipe-separated examples one per line
+	// for the leaf-command help view. Subcommand listing keeps the single-
+	// line form via formatExamples.
+	cobra.AddTemplateFunc("formatExamplesMultiline", func(examples string, cmd *cobra.Command) string {
+		cliName := cmd.Root().Name()
+		cmdName := cmd.Name()
+		replaced := strings.ReplaceAll(examples, "{{.Name}}", cliName)
+		replaced = strings.ReplaceAll(replaced, "{{.Command}}", cmdName)
+		parts := strings.Split(replaced, "|")
+		for i, p := range parts {
+			parts[i] = strings.TrimSpace(p)
+		}
+		return strings.Join(parts, "\n  ")
+	})
+
 	cobra.AddTemplateFunc("formatDoc", func(doc string, cmd *cobra.Command) string {
 		lines := strings.Split(doc, "\n")
 		for i, line := range lines {

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -74,7 +74,10 @@ func CommandCmd() *cobra.Command {
 			return runStatus(app, opts)
 		},
 		Annotations: map[string]string{
-			"examples": "{{.Name}} status {{.Command}} --query 'state:inprogress' --max-results 10 |  {{.Name}} status {{.Command}} --watch",
+			"examples": "formae status command --query 'status:InProgress' --max-results 10" +
+				" | formae status command --query 'client:me command:apply'" +
+				" | formae status command --query 'stack:prod status:Success'" +
+				" | formae status command --watch",
 		},
 		SilenceErrors: true,
 	}
@@ -83,7 +86,7 @@ func CommandCmd() *cobra.Command {
 
 	command.Flags().String("output-consumer", string(printer.ConsumerHuman), "Consumer of the command result (human | machine)")
 	command.Flags().String("output-schema", "json", "The schema to use for the machine output (json | yaml)")
-	command.Flags().String("query", " ", "Query that allows to find past and current commands by their attributes")
+	command.Flags().String("query", " ", "Query that allows to find past and current commands by their attributes. Use * as a wildcard anywhere (e.g. foo*, *foo, *foo*, foo*bar). ? and regex are not yet supported.")
 	command.Flags().Bool("watch", false, "Continuously refresh and print the status until completion")
 	command.Flags().String("output-layout", string(StatusOutputSummary), fmt.Sprintf("What to print as status output (%s | %s)", StatusOutputSummary, StatusOutputDetailed))
 	command.Flags().Int("max-results", 10, "Maximum number of command results to return when using a query")
@@ -332,8 +335,10 @@ func StatusCmd() *cobra.Command {
 		Use:   "status",
 		Short: "Various status retrieval commands",
 		Annotations: map[string]string{
-			"type":     "Information",
-			"examples": "{{.Name}} {{.Command}} agent  |  {{.Name}} {{.Command}} command --query 'state:inprogress'",
+			"type": "Information",
+			"examples": "formae status agent" +
+				" | formae status command --query 'status:InProgress'" +
+				" | formae status command --query 'client:me'",
 		},
 		SilenceErrors: true,
 	}

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -44,6 +44,147 @@ func init() {
 	})
 }
 
+// appendAuroraStringClause appends a WHERE clause for a string-valued query
+// item (with optional multi-value via ExtraItems and `*` wildcards). column
+// is the SQL column name; paramPrefix is used for the named-parameter labels
+// (`:<paramPrefix>_N`). lowerWrap wraps both column and placeholder in
+// LOWER() for case-insensitive matching. Returns the extended query string,
+// extended params, and the next paramIdx.
+func appendAuroraStringClause(
+	queryStr string,
+	params []types.SqlParameter,
+	paramIdx int,
+	column, paramPrefix string,
+	lowerWrap bool,
+	qi *datastore.QueryItem[string],
+) (string, []types.SqlParameter, int) {
+	if qi == nil {
+		return queryStr, params, paramIdx
+	}
+
+	values := append([]string{qi.Item}, qi.ExtraItems...)
+	isExcluded := qi.Constraint == datastore.Excluded
+
+	clauses := make([]string, 0, len(values))
+	for _, v := range values {
+		op, operand, _ := auroraOpAndOperand(v, isExcluded)
+		paramName := fmt.Sprintf("%s_%d", paramPrefix, paramIdx)
+		paramIdx++
+
+		lhs := column
+		rhs := ":" + paramName
+		if lowerWrap {
+			lhs = "LOWER(" + lhs + ")"
+			rhs = "LOWER(" + rhs + ")"
+		}
+		clauses = append(clauses, fmt.Sprintf("%s %s %s", lhs, op, rhs))
+		params = append(params, types.SqlParameter{
+			Name:  aws.String(paramName),
+			Value: &types.FieldMemberStringValue{Value: operand},
+		})
+	}
+
+	glue := " OR "
+	if isExcluded {
+		glue = " AND "
+	}
+	if len(clauses) == 1 {
+		queryStr += " AND " + clauses[0]
+	} else {
+		queryStr += " AND (" + strings.Join(clauses, glue) + ")"
+	}
+	return queryStr, params, paramIdx
+}
+
+// appendAuroraExistsClause appends a WHERE clause whose check is wrapped in
+// an EXISTS sub-query — used for `stack:` filtering against resource_updates
+// in QueryFormaCommands. existsBody is the SQL between EXISTS ( and the
+// `<op> :<param>)` tail. Multi-value support emits multiple OR'd EXISTS
+// sub-queries; for typical single-value queries it produces one.
+func appendAuroraExistsClause(
+	queryStr string,
+	params []types.SqlParameter,
+	paramIdx int,
+	existsBody, paramPrefix string,
+	qi *datastore.QueryItem[string],
+) (string, []types.SqlParameter, int) {
+	if qi == nil {
+		return queryStr, params, paramIdx
+	}
+	values := append([]string{qi.Item}, qi.ExtraItems...)
+	isExcluded := qi.Constraint == datastore.Excluded
+
+	clauses := make([]string, 0, len(values))
+	for _, v := range values {
+		op, operand, _ := auroraOpAndOperand(v, isExcluded)
+		paramName := fmt.Sprintf("%s_%d", paramPrefix, paramIdx)
+		paramIdx++
+		clauses = append(clauses, fmt.Sprintf("EXISTS (%s %s :%s)", existsBody, op, paramName))
+		params = append(params, types.SqlParameter{
+			Name:  aws.String(paramName),
+			Value: &types.FieldMemberStringValue{Value: operand},
+		})
+	}
+
+	glue := " OR "
+	if isExcluded {
+		glue = " AND "
+	}
+	if len(clauses) == 1 {
+		queryStr += " AND " + clauses[0]
+	} else {
+		queryStr += " AND (" + strings.Join(clauses, glue) + ")"
+	}
+	return queryStr, params, paramIdx
+}
+
+// appendAuroraBoolClause appends a WHERE clause for a bool-valued query item.
+// Bool fields don't support multi-value or wildcards, so this is the simple
+// equality/inequality form. Returns the extended query string, extended
+// params, and the next paramIdx.
+func appendAuroraBoolClause(
+	queryStr string,
+	params []types.SqlParameter,
+	paramIdx int,
+	column, paramPrefix string,
+	qi *datastore.QueryItem[bool],
+) (string, []types.SqlParameter, int) {
+	if qi == nil {
+		return queryStr, params, paramIdx
+	}
+	op := "="
+	if qi.Constraint == datastore.Excluded {
+		op = "!="
+	}
+	paramName := fmt.Sprintf("%s_%d", paramPrefix, paramIdx)
+	queryStr += fmt.Sprintf(" AND %s %s :%s", column, op, paramName)
+	params = append(params, types.SqlParameter{
+		Name:  aws.String(paramName),
+		Value: &types.FieldMemberBooleanValue{Value: qi.Item},
+	})
+	return queryStr, params, paramIdx + 1
+}
+
+// auroraOpAndOperand resolves the SQL operator and bound value for one
+// string term, accounting for exclusion and `*` wildcards. Any `*` in the
+// value (anywhere) flips the operator to LIKE and translates to `%`.
+func auroraOpAndOperand(s string, isExcluded bool) (op string, operand string, isLike bool) {
+	if !strings.Contains(s, "*") {
+		if isExcluded {
+			return "!=", s, false
+		}
+		return "=", s, false
+	}
+	likeOp := "LIKE"
+	if isExcluded {
+		likeOp = "NOT LIKE"
+	}
+	escaped := strings.ReplaceAll(s, "\\", "\\\\")
+	escaped = strings.ReplaceAll(escaped, "%", "\\%")
+	escaped = strings.ReplaceAll(escaped, "_", "\\_")
+	return likeOp, strings.ReplaceAll(escaped, "*", "%"), true
+}
+
 type DatastoreAuroraDataAPI struct {
 	client     *rdsdata.Client
 	clusterARN string
@@ -891,71 +1032,26 @@ func (d *DatastoreAuroraDataAPI) QueryFormaCommands(statusQuery *datastore.Statu
 	params := []types.SqlParameter{}
 	paramIdx := 1
 
-	if statusQuery.CommandID != nil {
-		paramName := fmt.Sprintf("command_id_%d", paramIdx)
-		op := "="
-		if statusQuery.CommandID.Constraint == datastore.Excluded {
-			op = "!="
-		}
-		queryStr += fmt.Sprintf(" AND command_id %s :%s", op, paramName)
-		params = append(params, types.SqlParameter{
-			Name: aws.String(paramName), Value: &types.FieldMemberStringValue{Value: statusQuery.CommandID.Item},
-		})
-		paramIdx++
-	}
-
-	if statusQuery.ClientID != nil {
-		paramName := fmt.Sprintf("client_id_%d", paramIdx)
-		op := "="
-		if statusQuery.ClientID.Constraint == datastore.Excluded {
-			op = "!="
-		}
-		queryStr += fmt.Sprintf(" AND client_id %s :%s", op, paramName)
-		params = append(params, types.SqlParameter{
-			Name: aws.String(paramName), Value: &types.FieldMemberStringValue{Value: statusQuery.ClientID.Item},
-		})
-		paramIdx++
-	}
+	queryStr, params, paramIdx = appendAuroraStringClause(queryStr, params, paramIdx, "command_id", "command_id", false, statusQuery.CommandID)
+	queryStr, params, paramIdx = appendAuroraStringClause(queryStr, params, paramIdx, "client_id", "client_id", false, statusQuery.ClientID)
 
 	if statusQuery.Command != nil {
-		paramName := fmt.Sprintf("command_%d", paramIdx)
-		op := "="
-		if statusQuery.Command.Constraint == datastore.Excluded {
-			op = "!="
-		}
-		queryStr += fmt.Sprintf(" AND LOWER(command) %s LOWER(:%s)", op, paramName)
-		params = append(params, types.SqlParameter{
-			Name: aws.String(paramName), Value: &types.FieldMemberStringValue{Value: statusQuery.Command.Item},
-		})
-		paramIdx++
+		queryStr, params, paramIdx = appendAuroraStringClause(queryStr, params, paramIdx, "command", "command", true, statusQuery.Command)
 	} else {
 		queryStr += fmt.Sprintf(" AND command != '%s'", pkgmodel.CommandSync)
 	}
 
+	// stack filter routes through a sub-EXISTS against resource_updates.
 	if statusQuery.Stack != nil {
-		paramName := fmt.Sprintf("stack_%d", paramIdx)
-		op := "="
-		if statusQuery.Stack.Constraint == datastore.Excluded {
-			op = "!="
-		}
-		queryStr += fmt.Sprintf(" AND EXISTS (SELECT 1 FROM resource_updates ru WHERE ru.command_id = forma_commands.command_id AND ru.stack_label %s :%s)", op, paramName)
-		params = append(params, types.SqlParameter{
-			Name: aws.String(paramName), Value: &types.FieldMemberStringValue{Value: statusQuery.Stack.Item},
-		})
-		paramIdx++
+		queryStr, params, paramIdx = appendAuroraExistsClause(
+			queryStr, params, paramIdx,
+			"SELECT 1 FROM resource_updates ru WHERE ru.command_id = forma_commands.command_id AND ru.stack_label",
+			"stack",
+			statusQuery.Stack,
+		)
 	}
 
-	if statusQuery.Status != nil {
-		paramName := fmt.Sprintf("status_%d", paramIdx)
-		op := "="
-		if statusQuery.Status.Constraint == datastore.Excluded {
-			op = "!="
-		}
-		queryStr += fmt.Sprintf(" AND LOWER(state) %s LOWER(:%s)", op, paramName)
-		params = append(params, types.SqlParameter{
-			Name: aws.String(paramName), Value: &types.FieldMemberStringValue{Value: statusQuery.Status.Item},
-		})
-	}
+	queryStr, params, _ = appendAuroraStringClause(queryStr, params, paramIdx, "state", "status", true, statusQuery.Status)
 
 	queryStr += " ORDER BY timestamp DESC"
 
@@ -1007,83 +1103,14 @@ func (d *DatastoreAuroraDataAPI) QueryResources(query *datastore.ResourceQuery) 
 	params := []types.SqlParameter{
 		{Name: aws.String("operation"), Value: &types.FieldMemberStringValue{Value: string(resource_update.OperationDelete)}},
 	}
-
-	// Build dynamic query with named parameters
 	paramIdx := 1
-	if query.NativeID != nil && query.NativeID.Constraint != datastore.Excluded {
-		paramName := fmt.Sprintf("native_id_%d", paramIdx)
-		if query.NativeID.Constraint == datastore.Required {
-			queryStr += fmt.Sprintf(" AND native_id = :%s", paramName)
-		} else {
-			queryStr += fmt.Sprintf(" AND (native_id = :%s OR native_id IS NULL)", paramName)
-		}
-		params = append(params, types.SqlParameter{
-			Name: aws.String(paramName), Value: &types.FieldMemberStringValue{Value: query.NativeID.Item},
-		})
-		paramIdx++
-	}
 
-	if query.Stack != nil && query.Stack.Constraint != datastore.Excluded {
-		paramName := fmt.Sprintf("stack_%d", paramIdx)
-		if query.Stack.Constraint == datastore.Required {
-			queryStr += fmt.Sprintf(" AND stack = :%s", paramName)
-		} else {
-			queryStr += fmt.Sprintf(" AND (stack = :%s OR stack IS NULL)", paramName)
-		}
-		params = append(params, types.SqlParameter{
-			Name: aws.String(paramName), Value: &types.FieldMemberStringValue{Value: query.Stack.Item},
-		})
-		paramIdx++
-	}
-
-	if query.Type != nil && query.Type.Constraint != datastore.Excluded {
-		paramName := fmt.Sprintf("type_%d", paramIdx)
-		if query.Type.Constraint == datastore.Required {
-			queryStr += fmt.Sprintf(" AND LOWER(type) = LOWER(:%s)", paramName)
-		} else {
-			queryStr += fmt.Sprintf(" AND (LOWER(type) = LOWER(:%s) OR type IS NULL)", paramName)
-		}
-		params = append(params, types.SqlParameter{
-			Name: aws.String(paramName), Value: &types.FieldMemberStringValue{Value: query.Type.Item},
-		})
-		paramIdx++
-	}
-
-	if query.Label != nil && query.Label.Constraint != datastore.Excluded {
-		paramName := fmt.Sprintf("label_%d", paramIdx)
-		if query.Label.Constraint == datastore.Required {
-			queryStr += fmt.Sprintf(" AND label = :%s", paramName)
-		} else {
-			queryStr += fmt.Sprintf(" AND (label = :%s OR label IS NULL)", paramName)
-		}
-		params = append(params, types.SqlParameter{
-			Name: aws.String(paramName), Value: &types.FieldMemberStringValue{Value: query.Label.Item},
-		})
-		paramIdx++
-	}
-
-	if query.Target != nil && query.Target.Constraint != datastore.Excluded {
-		paramName := fmt.Sprintf("target_%d", paramIdx)
-		if query.Target.Constraint == datastore.Required {
-			queryStr += fmt.Sprintf(" AND target = :%s", paramName)
-		} else {
-			queryStr += fmt.Sprintf(" AND (target = :%s OR target IS NULL)", paramName)
-		}
-		params = append(params, types.SqlParameter{
-			Name: aws.String(paramName), Value: &types.FieldMemberStringValue{Value: query.Target.Item},
-		})
-		paramIdx++
-	}
-
-	if query.Managed != nil && query.Managed.Constraint != datastore.Excluded {
-		paramName := fmt.Sprintf("managed_%d", paramIdx)
-		if query.Managed.Constraint == datastore.Required {
-			queryStr += fmt.Sprintf(" AND managed = :%s", paramName)
-		}
-		params = append(params, types.SqlParameter{
-			Name: aws.String(paramName), Value: &types.FieldMemberBooleanValue{Value: query.Managed.Item},
-		})
-	}
+	queryStr, params, paramIdx = appendAuroraStringClause(queryStr, params, paramIdx, "native_id", "native_id", false, query.NativeID)
+	queryStr, params, paramIdx = appendAuroraStringClause(queryStr, params, paramIdx, "stack", "stack", false, query.Stack)
+	queryStr, params, paramIdx = appendAuroraStringClause(queryStr, params, paramIdx, "type", "type", true, query.Type)
+	queryStr, params, paramIdx = appendAuroraStringClause(queryStr, params, paramIdx, "label", "label", false, query.Label)
+	queryStr, params, paramIdx = appendAuroraStringClause(queryStr, params, paramIdx, "target", "target", false, query.Target)
+	queryStr, params, _ = appendAuroraBoolClause(queryStr, params, paramIdx, "managed", "managed", query.Managed)
 
 	queryStr += " ORDER BY type, label"
 
@@ -2447,31 +2474,9 @@ func (d *DatastoreAuroraDataAPI) QueryTargets(targetQuery *datastore.TargetQuery
 	params := []types.SqlParameter{}
 	paramIdx := 1
 
-	if targetQuery.Label != nil && targetQuery.Label.Constraint != datastore.Excluded {
-		paramName := fmt.Sprintf("label_%d", paramIdx)
-		queryStr += fmt.Sprintf(" AND label = :%s", paramName)
-		params = append(params, types.SqlParameter{
-			Name: aws.String(paramName), Value: &types.FieldMemberStringValue{Value: targetQuery.Label.Item},
-		})
-		paramIdx++
-	}
-
-	if targetQuery.Namespace != nil && targetQuery.Namespace.Constraint != datastore.Excluded {
-		paramName := fmt.Sprintf("namespace_%d", paramIdx)
-		queryStr += fmt.Sprintf(" AND namespace = :%s", paramName)
-		params = append(params, types.SqlParameter{
-			Name: aws.String(paramName), Value: &types.FieldMemberStringValue{Value: targetQuery.Namespace.Item},
-		})
-		paramIdx++
-	}
-
-	if targetQuery.Discoverable != nil && targetQuery.Discoverable.Constraint != datastore.Excluded {
-		paramName := fmt.Sprintf("discoverable_%d", paramIdx)
-		queryStr += fmt.Sprintf(" AND discoverable = :%s", paramName)
-		params = append(params, types.SqlParameter{
-			Name: aws.String(paramName), Value: &types.FieldMemberBooleanValue{Value: targetQuery.Discoverable.Item},
-		})
-	}
+	queryStr, params, paramIdx = appendAuroraStringClause(queryStr, params, paramIdx, "label", "label", false, targetQuery.Label)
+	queryStr, params, paramIdx = appendAuroraStringClause(queryStr, params, paramIdx, "namespace", "namespace", false, targetQuery.Namespace)
+	queryStr, params, _ = appendAuroraBoolClause(queryStr, params, paramIdx, "discoverable", "discoverable", targetQuery.Discoverable)
 
 	queryStr += " ORDER BY label"
 

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -26,8 +26,18 @@ const (
 
 type QueryItemConstraint int
 
+// QueryItem is one filter clause in a query.
+//
+// Item plus ExtraItems form the value set: a single-valued filter has
+// ExtraItems == nil. A multi-valued filter (e.g. `target:eu target:us` for
+// "target IN (eu, us)") puts the first value in Item and additional values
+// in ExtraItems. The SQL renderer combines them with OR / IN as appropriate.
+//
+// String values may carry leading or trailing `*` wildcards (e.g. `*foo`,
+// `foo*`) which the renderer translates to SQL LIKE patterns.
 type QueryItem[T any] struct {
 	Item       T
+	ExtraItems []T
 	Constraint QueryItemConstraint
 }
 

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -31,6 +31,7 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunGetMostRecentFormaCommandByClientID(t, newDS)
 	RunGetMostRecentNonReconcileFormaCommandsByStack(t, newDS)
 	RunQueryFormaCommands(t, newDS)
+	RunQueryFormaCommands_StackWildcardEscape(t, newDS)
 
 	RunStoreResource(t, newDS)
 	RunUpdateResource(t, newDS)

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -36,6 +36,7 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunUpdateResource(t, newDS)
 	RunDeleteResource(t, newDS)
 	RunQueryResources(t, newDS)
+	RunQueryResources_LikeMetacharsAreLiteral(t, newDS)
 	RunStoreResourceSameResourceTwice(t, newDS)
 	RunLoadResourceByNativeID(t, newDS)
 	RunLoadResourceByNativeIDDifferentTypes(t, newDS)

--- a/internal/datastore/dstest/suite_forma_commands.go
+++ b/internal/datastore/dstest/suite_forma_commands.go
@@ -658,3 +658,67 @@ func RunQueryFormaCommands(t *testing.T, newDS func(t *testing.T) TestDatastore)
 		}
 	})
 }
+
+// RunQueryFormaCommands_StackWildcardEscape verifies that wildcards in
+// `stack:` queries — which route through an EXISTS subquery against
+// resource_updates — produce valid SQL with the ESCAPE clause positioned
+// correctly *inside* the EXISTS parens. A naive append-to-end places
+// `ESCAPE '\'` after the closing `)`, which is a syntax error.
+func RunQueryFormaCommands_StackWildcardEscape(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("QueryFormaCommands_StackWildcardEscape", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		// Two commands with different stack labels. A wildcard query
+		// `stack:life*` should match the lifecycle one only.
+		commands := []*forma_command.FormaCommand{
+			{
+				Description: pkgmodel.Description{},
+				ClientID:    "client-a",
+				StartTs:     util.TimeNow(),
+				Command:     pkgmodel.CommandApply,
+				State:       forma_command.CommandStateInProgress,
+				ResourceUpdates: []resource_update.ResourceUpdate{
+					{
+						DesiredState: pkgmodel.Resource{Stack: "lifecycle-prod", Properties: json.RawMessage(`{}`)},
+						StackLabel:   "lifecycle-prod",
+						State:        resource_update.ResourceUpdateStateSuccess,
+					},
+				},
+			},
+			{
+				Description: pkgmodel.Description{},
+				ClientID:    "client-b",
+				StartTs:     util.TimeNow(),
+				Command:     pkgmodel.CommandApply,
+				State:       forma_command.CommandStateInProgress,
+				ResourceUpdates: []resource_update.ResourceUpdate{
+					{
+						DesiredState: pkgmodel.Resource{Stack: "other-prod", Properties: json.RawMessage(`{}`)},
+						StackLabel:   "other-prod",
+						State:        resource_update.ResourceUpdateStateSuccess,
+					},
+				},
+			},
+		}
+		for i, c := range commands {
+			c.ID = fmt.Sprintf("cmd-stack-wildcard-%d", i)
+			err := ds.StoreFormaCommand(c, c.ID)
+			assert.NoError(t, err)
+		}
+
+		query := &datastore.StatusQuery{
+			Stack: &datastore.QueryItem[string]{
+				Item:       "life*",
+				Constraint: datastore.Required,
+			},
+		}
+		results, err := ds.QueryFormaCommands(query)
+		assert.NoError(t, err, "stack wildcard must produce valid SQL inside the EXISTS clause")
+		assert.Len(t, results, 1)
+		if len(results) == 1 {
+			assert.Equal(t, "client-a", results[0].ClientID)
+		}
+	})
+}

--- a/internal/datastore/dstest/suite_resources.go
+++ b/internal/datastore/dstest/suite_resources.go
@@ -378,6 +378,44 @@ func RunQueryResources(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	})
 }
 
+// RunQueryResources_LikeMetacharsAreLiteral verifies that `_` and `%` in
+// user-supplied values are matched literally rather than acting as SQL LIKE
+// wildcards. Without explicit escape handling, `label:my_svc*` would match
+// rows whose label contains `my<anychar>svc...` because `_` is the LIKE
+// single-char wildcard in every supported backend.
+func RunQueryResources_LikeMetacharsAreLiteral(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("QueryResources_LikeMetacharsAreLiteral", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		// Two labels, distinguished only by the literal `_` vs `X` between
+		// `my` and `svc`. A correctly-escaped query for `my_svc*` should
+		// only match the underscore variant.
+		resources := []*pkgmodel.Resource{
+			{NativeID: "n-literal", Stack: "s", Type: "t", Label: "my_svc-prod", Properties: json.RawMessage(`{}`)},
+			{NativeID: "n-wildcard", Stack: "s", Type: "t", Label: "myXsvc-prod", Properties: json.RawMessage(`{}`)},
+		}
+		for _, r := range resources {
+			_, err := ds.StoreResource(r, "test-cmd")
+			assert.NoError(t, err)
+		}
+
+		query := &datastore.ResourceQuery{
+			Label: &datastore.QueryItem[string]{
+				Item:       "my_svc*",
+				Constraint: datastore.Optional,
+			},
+		}
+		results, err := ds.QueryResources(query)
+		assert.NoError(t, err)
+		assert.Len(t, results, 1, "underscore should match literally, not as a single-char wildcard")
+		if len(results) == 1 {
+			assert.Equal(t, "my_svc-prod", results[0].Label)
+		}
+	})
+}
+
 func RunStoreResourceSameResourceTwice(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	t.Run("StoreResource_SameResourceTwiceReturnsSameVersionId", func(t *testing.T) {
 		td := newDS(t)

--- a/internal/datastore/dstest/suite_resources.go
+++ b/internal/datastore/dstest/suite_resources.go
@@ -314,6 +314,67 @@ func RunQueryResources(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 		assert.NoError(t, err)
 		assert.NotEmpty(t, results)
 		assert.Len(t, results, 5)
+
+		// Multi-value (Item + ExtraItems): stack:stack-0 stack:stack-2 → IN.
+		// stack-0 has rows for i=0,3,6,9 (4 rows); stack-2 has rows for i=2,5,8
+		// (3 rows); union = 7 rows.
+		query = &datastore.ResourceQuery{
+			Stack: &datastore.QueryItem[string]{
+				Item:       "stack-0",
+				ExtraItems: []string{"stack-2"},
+				Constraint: datastore.Optional,
+			},
+		}
+		results, err = ds.QueryResources(query)
+		assert.NoError(t, err)
+		assert.Len(t, results, 7)
+		for _, r := range results {
+			assert.Contains(t, []string{"stack-0", "stack-2"}, r.Stack)
+		}
+
+		// Multi-value with Excluded: -stack:stack-0 -stack:stack-2 →
+		// rows where stack is neither. Only stack-1 remains: i=1,4,7 (3 rows).
+		query = &datastore.ResourceQuery{
+			Stack: &datastore.QueryItem[string]{
+				Item:       "stack-0",
+				ExtraItems: []string{"stack-2"},
+				Constraint: datastore.Excluded,
+			},
+		}
+		results, err = ds.QueryResources(query)
+		assert.NoError(t, err)
+		assert.Len(t, results, 3)
+		for _, r := range results {
+			assert.Equal(t, "stack-1", r.Stack)
+		}
+
+		// Wildcard prefix: type starts with "type-1" (4 type-buckets exist,
+		// so type-1 alone is rows for i=1,5,9 — 3 rows). Use "type-1*" to
+		// confirm trailing-wildcard works.
+		query = &datastore.ResourceQuery{
+			Type: &datastore.QueryItem[string]{
+				Item:       "type-1*",
+				Constraint: datastore.Optional,
+			},
+		}
+		results, err = ds.QueryResources(query)
+		assert.NoError(t, err)
+		assert.Len(t, results, 3)
+		for _, r := range results {
+			assert.Equal(t, "type-1", r.Type)
+		}
+
+		// Wildcard suffix: native_id ends with "-7" (single row, i=7).
+		query = &datastore.ResourceQuery{
+			NativeID: &datastore.QueryItem[string]{
+				Item:       "*-7",
+				Constraint: datastore.Optional,
+			},
+		}
+		results, err = ds.QueryResources(query)
+		assert.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "native-7", results[0].NativeID)
 	})
 }
 
@@ -874,9 +935,9 @@ func RunStoreResourceAfterDeleteWithSameNativeID(t *testing.T, newDS func(t *tes
 // RunStoreResourceWithDifferentKSUIDSameData reproduces the KSUID mismatch bug.
 //
 // The scenario:
-//   1. User deploys chart A (e.g. keycloak) — a namespace gets KSUID-A in the DB
-//   2. User switches to chart B (e.g. nginx) via reconcile — chart A's resources get deleted
-//   3. User switches back to chart A — the SAME namespace is re-created
+//  1. User deploys chart A (e.g. keycloak) — a namespace gets KSUID-A in the DB
+//  2. User switches to chart B (e.g. nginx) via reconcile — chart A's resources get deleted
+//  3. User switches back to chart A — the SAME namespace is re-created
 //
 // What goes wrong on step 3:
 //   - Formae assigns a new KSUID-B to the namespace (the old one was deleted from its bookkeeping)
@@ -889,10 +950,11 @@ func RunStoreResourceAfterDeleteWithSameNativeID(t *testing.T, newDS func(t *tes
 //   - That ref can't be resolved because KSUID-B was never stored → crash
 //
 // Why this test doesn't use delete+recreate:
-//   DeleteResource stores data as "{}", so the next store always sees different data
-//   and the early return never fires. The bug only triggers when the native_id+type lookup
-//   finds a row with IDENTICAL data but a DIFFERENT KSUID — which is what this test sets up
-//   directly by storing twice with different KSUIDs.
+//
+//	DeleteResource stores data as "{}", so the next store always sees different data
+//	and the early return never fires. The bug only triggers when the native_id+type lookup
+//	finds a row with IDENTICAL data but a DIFFERENT KSUID — which is what this test sets up
+//	directly by storing twice with different KSUIDs.
 func RunStoreResourceWithDifferentKSUIDSameData(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	t.Run("StoreResource_WithDifferentKSUIDSameData", func(t *testing.T) {
 		td := newDS(t)
@@ -961,4 +1023,3 @@ func RunStoreResourceWithDifferentKSUIDSameData(t *testing.T, newDS func(t *test
 		}
 	})
 }
-

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -547,35 +547,100 @@ func (d DatastorePostgres) GetMostRecentFormaCommandByClientID(clientID string) 
 	return commands[0], nil
 }
 
+// extendPostgresQueryString appends a WHERE clause to queryStr for the given
+// query item.
+//
+// sqlPart is a template that takes two %-verbs — the comparison operator and
+// the positional parameter index — e.g. " AND command_id %s $%d".
+//
+// For multi-valued items the inner clause is replicated once per value and
+// joined with OR (or AND when the constraint is Excluded). String values may
+// carry leading or trailing `*` for wildcard matching, which becomes a SQL
+// LIKE pattern.
 func extendPostgresQueryString[T any](queryStr string, queryItem *datastore.QueryItem[T], sqlPart string, args *[]any) string {
-	if queryItem != nil {
-		var operator string
+	if queryItem == nil {
+		return queryStr
+	}
 
-		if queryItem.Constraint == datastore.Excluded {
-			operator = "!="
-		} else if queryItem.Constraint == datastore.Required || queryItem.Constraint == datastore.Optional {
-			operator = "="
-		}
+	values := allQueryItemValues(queryItem)
+	if len(values) == 0 {
+		return queryStr
+	}
 
-		queryStr += fmt.Sprintf(sqlPart, operator, len(*args)+1)
-		operand := ""
-		switch v := any(queryItem.Item).(type) {
-		case bool:
-			if v {
-				operand = "1"
-			} else {
-				operand = "0"
-			}
-		case string:
-			operand = v
-		default:
-			operand = fmt.Sprintf("%v", v)
-		}
+	isExcluded := queryItem.Constraint == datastore.Excluded
 
+	if len(values) == 1 {
+		op, operand, _ := pgOpAndOperand(values[0], isExcluded)
+		queryStr += fmt.Sprintf(sqlPart, op, len(*args)+1)
+		*args = append(*args, operand)
+		return queryStr
+	}
+
+	innerTemplate := strings.TrimPrefix(sqlPart, " AND ")
+	clauses := make([]string, 0, len(values))
+	for _, v := range values {
+		op, operand, _ := pgOpAndOperand(v, isExcluded)
+		clauses = append(clauses, fmt.Sprintf(innerTemplate, op, len(*args)+1))
 		*args = append(*args, operand)
 	}
 
-	return queryStr
+	glue := " OR "
+	if isExcluded {
+		glue = " AND "
+	}
+	return queryStr + " AND (" + strings.Join(clauses, glue) + ")"
+}
+
+// allQueryItemValues flattens Item + ExtraItems into a single []any.
+func allQueryItemValues[T any](qi *datastore.QueryItem[T]) []any {
+	values := make([]any, 0, 1+len(qi.ExtraItems))
+	values = append(values, any(qi.Item))
+	for _, e := range qi.ExtraItems {
+		values = append(values, any(e))
+	}
+	return values
+}
+
+// pgOpAndOperand resolves the operator and bound value for one term,
+// accounting for exclusion and `*` wildcards on strings. Any `*` in the
+// value (anywhere) flips the operator to LIKE and translates to `%`.
+func pgOpAndOperand(v any, isExcluded bool) (op string, operand any, isLike bool) {
+	s, isString := v.(string)
+	if !isString {
+		if b, ok := v.(bool); ok {
+			if b {
+				return pgEqOp(isExcluded), "1", false
+			}
+			return pgEqOp(isExcluded), "0", false
+		}
+		return pgEqOp(isExcluded), fmt.Sprintf("%v", v), false
+	}
+
+	if !strings.Contains(s, "*") {
+		return pgEqOp(isExcluded), s, false
+	}
+
+	likeOp := "LIKE"
+	if isExcluded {
+		likeOp = "NOT LIKE"
+	}
+	return likeOp, pgLikePattern(s), true
+}
+
+func pgEqOp(isExcluded bool) string {
+	if isExcluded {
+		return "!="
+	}
+	return "="
+}
+
+// pgLikePattern translates every `*` in s into a SQL LIKE `%`. Literal `%`,
+// `_`, and `\` are escaped so they match as themselves.
+func pgLikePattern(s string) string {
+	escaped := strings.ReplaceAll(s, "\\", "\\\\")
+	escaped = strings.ReplaceAll(escaped, "%", "\\%")
+	escaped = strings.ReplaceAll(escaped, "_", "\\_")
+	return strings.ReplaceAll(escaped, "*", "%")
 }
 
 func (d DatastorePostgres) QueryFormaCommands(query *datastore.StatusQuery) ([]*forma_command.FormaCommand, error) {

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -654,10 +654,7 @@ func extendSQLiteQueryString[T any](queryStr string, queryItem *datastore.QueryI
 	// when no multi-value or wildcard handling is needed.
 	if len(values) == 1 {
 		op, operand, isLike := sqlOpAndOperand(values[0], isExcluded)
-		clause := fmt.Sprintf(sqlPart, op)
-		if isLike {
-			clause += sqliteLikeEscapeSuffix
-		}
+		clause := resolveEscapeMarker(fmt.Sprintf(sqlPart, op), isLike)
 		queryStr += clause
 		*args = append(*args, operand)
 		return queryStr
@@ -669,10 +666,7 @@ func extendSQLiteQueryString[T any](queryStr string, queryItem *datastore.QueryI
 	clauses := make([]string, 0, len(values))
 	for _, v := range values {
 		op, operand, isLike := sqlOpAndOperand(v, isExcluded)
-		clause := fmt.Sprintf(innerTemplate, op)
-		if isLike {
-			clause += sqliteLikeEscapeSuffix
-		}
+		clause := resolveEscapeMarker(fmt.Sprintf(innerTemplate, op), isLike)
 		clauses = append(clauses, clause)
 		*args = append(*args, operand)
 	}
@@ -730,12 +724,31 @@ func eqOp(isExcluded bool) string {
 	return "="
 }
 
-// sqliteLikeEscapeSuffix is appended after the `?` placeholder of every LIKE
-// clause emitted by this package. SQLite has no default escape character for
-// LIKE — without `ESCAPE '\'`, the backslashes produced by sqlLikePattern are
-// treated as literals while `_` and `%` still act as wildcards. See
-// https://www.sqlite.org/lang_expr.html#like.
+// escapeMarker is the sentinel placed in `sqlPart` templates at the exact
+// position where the LIKE ESCAPE clause must land — immediately after the
+// LIKE pattern expression. Templates without a LIKE position simply omit it.
+// For LIKE clauses we substitute the actual ESCAPE fragment; for `=` we
+// substitute an empty string.
+//
+// This indirection exists because SQLite has no default escape character for
+// LIKE (https://www.sqlite.org/lang_expr.html#like) and the ESCAPE clause's
+// correct position varies by template:
+//   - bare:        `... ru.stack_label LIKE ?{esc})`  → after `?`, BEFORE `)`
+//   - LOWER-wrap:  `... LOWER(type) LIKE LOWER(?){esc}` → after `LOWER(?)`
+//
+// A naive trailing append or `?` replace gets one of these wrong.
+const escapeMarker = "{esc}"
+
 const sqliteLikeEscapeSuffix = ` ESCAPE '\'`
+
+// resolveEscapeMarker substitutes the escapeMarker in clause with either the
+// ESCAPE suffix (when isLike) or an empty string.
+func resolveEscapeMarker(clause string, isLike bool) string {
+	if isLike {
+		return strings.ReplaceAll(clause, escapeMarker, sqliteLikeEscapeSuffix)
+	}
+	return strings.ReplaceAll(clause, escapeMarker, "")
+}
 
 // sqlLikePattern translates every `*` in s into a SQL LIKE `%`. Any literal
 // `%`, `_`, or `\` in the user value is escaped with `\` so it matches as a
@@ -756,16 +769,16 @@ func (d DatastoreSQLite) QueryFormaCommands(query *datastore.StatusQuery) ([]*fo
 	subqueryStr := "SELECT command_id FROM forma_commands WHERE 1=1"
 	args := []any{}
 
-	subqueryStr = extendSQLiteQueryString(subqueryStr, query.CommandID, " AND command_id %s ?", &args)
-	subqueryStr = extendSQLiteQueryString(subqueryStr, query.ClientID, " AND client_id %s ?", &args)
-	subqueryStr = extendSQLiteQueryString(subqueryStr, query.Command, " AND LOWER(command) %s LOWER(?)", &args)
+	subqueryStr = extendSQLiteQueryString(subqueryStr, query.CommandID, " AND command_id %s ?{esc}", &args)
+	subqueryStr = extendSQLiteQueryString(subqueryStr, query.ClientID, " AND client_id %s ?{esc}", &args)
+	subqueryStr = extendSQLiteQueryString(subqueryStr, query.Command, " AND LOWER(command) %s LOWER(?){esc}", &args)
 	if query.Command == nil {
 		subqueryStr += fmt.Sprintf(" AND command != '%s'", pkgmodel.CommandSync)
 	}
 
 	// Stack filter uses the normalized resource_updates table
-	subqueryStr = extendSQLiteQueryString(subqueryStr, query.Stack, " AND EXISTS (SELECT 1 FROM resource_updates ru WHERE ru.command_id = forma_commands.command_id AND ru.stack_label %s ?)", &args)
-	subqueryStr = extendSQLiteQueryString(subqueryStr, query.Status, " AND LOWER(state) %s LOWER(?)", &args)
+	subqueryStr = extendSQLiteQueryString(subqueryStr, query.Stack, " AND EXISTS (SELECT 1 FROM resource_updates ru WHERE ru.command_id = forma_commands.command_id AND ru.stack_label %s ?{esc})", &args)
+	subqueryStr = extendSQLiteQueryString(subqueryStr, query.Status, " AND LOWER(state) %s LOWER(?){esc}", &args)
 
 	subqueryStr += " ORDER BY timestamp DESC"
 	if query.N > 0 {
@@ -815,12 +828,12 @@ func (d DatastoreSQLite) QueryResources(query *datastore.ResourceQuery) ([]*pkgm
 		AND r1.operation != '%s'`, string(resource_update.OperationDelete))
 	args := []any{}
 
-	queryStr = extendSQLiteQueryString(queryStr, query.NativeID, " AND native_id %s ?", &args)
-	queryStr = extendSQLiteQueryString(queryStr, query.Stack, " AND stack %s ?", &args)
-	queryStr = extendSQLiteQueryString(queryStr, query.Type, " AND LOWER(type) %s LOWER(?)", &args)
-	queryStr = extendSQLiteQueryString(queryStr, query.Label, " AND label %s ?", &args)
-	queryStr = extendSQLiteQueryString(queryStr, query.Target, " AND target %s ?", &args)
-	queryStr = extendSQLiteQueryString(queryStr, query.Managed, " AND managed %s ?", &args)
+	queryStr = extendSQLiteQueryString(queryStr, query.NativeID, " AND native_id %s ?{esc}", &args)
+	queryStr = extendSQLiteQueryString(queryStr, query.Stack, " AND stack %s ?{esc}", &args)
+	queryStr = extendSQLiteQueryString(queryStr, query.Type, " AND LOWER(type) %s LOWER(?){esc}", &args)
+	queryStr = extendSQLiteQueryString(queryStr, query.Label, " AND label %s ?{esc}", &args)
+	queryStr = extendSQLiteQueryString(queryStr, query.Target, " AND target %s ?{esc}", &args)
+	queryStr = extendSQLiteQueryString(queryStr, query.Managed, " AND managed %s ?{esc}", &args)
 	queryStr += " ORDER BY type, label"
 
 	rows, err := d.conn.Query(queryStr, args...)
@@ -2804,9 +2817,9 @@ func (d DatastoreSQLite) QueryTargets(query *datastore.TargetQuery) ([]*pkgmodel
 		)`
 	args := []any{}
 
-	queryStr = extendSQLiteQueryString(queryStr, query.Label, " AND label %s ?", &args)
-	queryStr = extendSQLiteQueryString(queryStr, query.Namespace, " AND namespace %s ?", &args)
-	queryStr = extendSQLiteQueryString(queryStr, query.Discoverable, " AND discoverable %s ?", &args)
+	queryStr = extendSQLiteQueryString(queryStr, query.Label, " AND label %s ?{esc}", &args)
+	queryStr = extendSQLiteQueryString(queryStr, query.Namespace, " AND namespace %s ?{esc}", &args)
+	queryStr = extendSQLiteQueryString(queryStr, query.Discoverable, " AND discoverable %s ?{esc}", &args)
 	queryStr += " ORDER BY label"
 
 	slog.Debug("QueryTargets", "queryStr", queryStr, "args", args)

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -621,35 +621,118 @@ func closeRows(rows *sql.Rows) {
 	}
 }
 
+// extendSQLiteQueryString appends a WHERE clause to queryStr for the given
+// query item.
+//
+// sqlPart is a template that takes one %s — the comparison operator — and
+// includes a literal `?` placeholder. Examples:
+//
+//	" AND command_id %s ?"
+//	" AND LOWER(command) %s LOWER(?)"
+//	" AND EXISTS (SELECT 1 FROM resource_updates ru ... AND ru.stack_label %s ?)"
+//
+// For multi-valued items (Item + ExtraItems) the inner clause is replicated
+// once per value and joined with OR (or AND when the constraint is Excluded
+// — i.e. -stack:a -stack:b means "neither a nor b").
+//
+// String values may carry leading or trailing `*` for wildcard matching:
+// `foo*` → `LIKE 'foo%'`, `*foo` → `LIKE '%foo'`. Internal `_` and `%` in the
+// matched value are escaped with `\` (paired with `ESCAPE '\'` on the LIKE).
 func extendSQLiteQueryString[T any](queryStr string, queryItem *datastore.QueryItem[T], sqlPart string, args *[]any) string {
-	if queryItem != nil {
-		var operator string
+	if queryItem == nil {
+		return queryStr
+	}
 
-		if queryItem.Constraint == datastore.Excluded {
-			operator = "!="
-		} else if queryItem.Constraint == datastore.Required || queryItem.Constraint == datastore.Optional {
-			operator = "="
-		}
+	values := allQueryItemValues(queryItem)
+	if len(values) == 0 {
+		return queryStr
+	}
 
-		queryStr += fmt.Sprintf(sqlPart, operator)
-		operand := ""
-		switch v := any(queryItem.Item).(type) {
-		case bool:
-			if v {
-				operand = "1"
-			} else {
-				operand = "0"
-			}
-		case string:
-			operand = v
-		default:
-			operand = fmt.Sprintf("%v", v)
-		}
+	isExcluded := queryItem.Constraint == datastore.Excluded
 
+	// Single value: keep the original template-driven path. Avoids reformatting
+	// when no multi-value or wildcard handling is needed.
+	if len(values) == 1 {
+		op, operand, _ := sqlOpAndOperand(values[0], isExcluded)
+		queryStr += fmt.Sprintf(sqlPart, op)
+		*args = append(*args, operand)
+		return queryStr
+	}
+
+	// Multi-value: replicate the template's inner clause once per value, join
+	// with OR (or AND for Excluded), wrap in parens, and re-prepend " AND ".
+	innerTemplate := strings.TrimPrefix(sqlPart, " AND ")
+	clauses := make([]string, 0, len(values))
+	for _, v := range values {
+		op, operand, _ := sqlOpAndOperand(v, isExcluded)
+		clauses = append(clauses, fmt.Sprintf(innerTemplate, op))
 		*args = append(*args, operand)
 	}
 
-	return queryStr
+	glue := " OR "
+	if isExcluded {
+		glue = " AND "
+	}
+	return queryStr + " AND (" + strings.Join(clauses, glue) + ")"
+}
+
+// allQueryItemValues flattens a QueryItem's Item and ExtraItems into a single
+// slice. Returns []any to handle both string and bool fields uniformly.
+func allQueryItemValues[T any](qi *datastore.QueryItem[T]) []any {
+	values := make([]any, 0, 1+len(qi.ExtraItems))
+	values = append(values, any(qi.Item))
+	for _, e := range qi.ExtraItems {
+		values = append(values, any(e))
+	}
+	return values
+}
+
+// sqlOpAndOperand resolves the SQL operator and bound value for one query
+// term, accounting for exclusion and `*` wildcards on strings. Any `*` in
+// the value (anywhere) flips the operator to LIKE and translates to `%`.
+// The third return value is whether the operator uses LIKE (vs =).
+func sqlOpAndOperand(v any, isExcluded bool) (op string, operand any, isLike bool) {
+	s, isString := v.(string)
+	if !isString {
+		// Bool path mirrors the original switch: true→"1", false→"0".
+		if b, ok := v.(bool); ok {
+			if b {
+				return eqOp(isExcluded), "1", false
+			}
+			return eqOp(isExcluded), "0", false
+		}
+		return eqOp(isExcluded), fmt.Sprintf("%v", v), false
+	}
+
+	if !strings.Contains(s, "*") {
+		return eqOp(isExcluded), s, false
+	}
+
+	likeOp := "LIKE"
+	if isExcluded {
+		likeOp = "NOT LIKE"
+	}
+	return likeOp, sqlLikePattern(s), true
+}
+
+func eqOp(isExcluded bool) string {
+	if isExcluded {
+		return "!="
+	}
+	return "="
+}
+
+// sqlLikePattern translates every `*` in s into a SQL LIKE `%`. Any literal
+// `%`, `_`, or `\` in the user value is escaped so it matches literally rather
+// than acting as a LIKE wildcard. (The escapes work without an explicit
+// ESCAPE clause for SQLite/Postgres because `\` is not a LIKE metacharacter
+// by default — but with the literal chars escaped this way, the SQL engine
+// matches them as-is.)
+func sqlLikePattern(s string) string {
+	escaped := strings.ReplaceAll(s, "\\", "\\\\")
+	escaped = strings.ReplaceAll(escaped, "%", "\\%")
+	escaped = strings.ReplaceAll(escaped, "_", "\\_")
+	return strings.ReplaceAll(escaped, "*", "%")
 }
 
 func (d DatastoreSQLite) QueryFormaCommands(query *datastore.StatusQuery) ([]*forma_command.FormaCommand, error) {

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -653,8 +653,12 @@ func extendSQLiteQueryString[T any](queryStr string, queryItem *datastore.QueryI
 	// Single value: keep the original template-driven path. Avoids reformatting
 	// when no multi-value or wildcard handling is needed.
 	if len(values) == 1 {
-		op, operand, _ := sqlOpAndOperand(values[0], isExcluded)
-		queryStr += fmt.Sprintf(sqlPart, op)
+		op, operand, isLike := sqlOpAndOperand(values[0], isExcluded)
+		clause := fmt.Sprintf(sqlPart, op)
+		if isLike {
+			clause += sqliteLikeEscapeSuffix
+		}
+		queryStr += clause
 		*args = append(*args, operand)
 		return queryStr
 	}
@@ -664,8 +668,12 @@ func extendSQLiteQueryString[T any](queryStr string, queryItem *datastore.QueryI
 	innerTemplate := strings.TrimPrefix(sqlPart, " AND ")
 	clauses := make([]string, 0, len(values))
 	for _, v := range values {
-		op, operand, _ := sqlOpAndOperand(v, isExcluded)
-		clauses = append(clauses, fmt.Sprintf(innerTemplate, op))
+		op, operand, isLike := sqlOpAndOperand(v, isExcluded)
+		clause := fmt.Sprintf(innerTemplate, op)
+		if isLike {
+			clause += sqliteLikeEscapeSuffix
+		}
+		clauses = append(clauses, clause)
 		*args = append(*args, operand)
 	}
 
@@ -722,12 +730,17 @@ func eqOp(isExcluded bool) string {
 	return "="
 }
 
+// sqliteLikeEscapeSuffix is appended after the `?` placeholder of every LIKE
+// clause emitted by this package. SQLite has no default escape character for
+// LIKE — without `ESCAPE '\'`, the backslashes produced by sqlLikePattern are
+// treated as literals while `_` and `%` still act as wildcards. See
+// https://www.sqlite.org/lang_expr.html#like.
+const sqliteLikeEscapeSuffix = ` ESCAPE '\'`
+
 // sqlLikePattern translates every `*` in s into a SQL LIKE `%`. Any literal
-// `%`, `_`, or `\` in the user value is escaped so it matches literally rather
-// than acting as a LIKE wildcard. (The escapes work without an explicit
-// ESCAPE clause for SQLite/Postgres because `\` is not a LIKE metacharacter
-// by default — but with the literal chars escaped this way, the SQL engine
-// matches them as-is.)
+// `%`, `_`, or `\` in the user value is escaped with `\` so it matches as a
+// literal char. The emitted clause must be paired with `ESCAPE '\'` — see
+// sqliteLikeEscapeSuffix.
 func sqlLikePattern(s string) string {
 	escaped := strings.ReplaceAll(s, "\\", "\\\\")
 	escaped = strings.ReplaceAll(escaped, "%", "\\%")

--- a/internal/metastructure/querier/bluge_querier.go
+++ b/internal/metastructure/querier/bluge_querier.go
@@ -86,9 +86,35 @@ func (b *BlugeQuerier) processStatusQueryNode(q bluge.Query, sq *datastore.Statu
 		return nil
 	case *bluge.MatchQuery:
 		return b.assignTermToStatusQuery(v.Field(), v.Match(), sq, clientID, constraint)
+	case *bluge.WildcardQuery:
+		field, value, err := unwrapWildcard(v)
+		if err != nil {
+			return err
+		}
+		return b.assignTermToStatusQuery(field, value, sq, clientID, constraint)
 	default:
 		return apimodel.InvalidQueryError{Reason: fmt.Sprintf("unsupported query type: %T", q)}
 	}
+}
+
+// unwrapWildcard validates a Bluge WildcardQuery and returns the field plus
+// the wildcard string with `*` preserved. The SQL renderer translates every
+// `*` into a `%` for LIKE matching, so any pattern of stars works:
+// `foo*`, `*foo`, `*foo*` (substring), and `foo*bar` (middle).
+//
+// Rejected:
+//   - `?` — no clean LIKE equivalent (`_` matches one char but conflicts
+//     with our literal-character escape).
+//   - bare `*` — matches every row, almost always user error.
+func unwrapWildcard(w *bluge.WildcardQuery) (string, string, error) {
+	value := w.Wildcard()
+	if strings.Contains(value, "?") {
+		return "", "", apimodel.InvalidQueryError{Reason: fmt.Sprintf("'?' wildcard is not yet supported: %q", value)}
+	}
+	if value == "*" {
+		return "", "", apimodel.InvalidQueryError{Reason: "bare '*' matches every row; provide at least one non-wildcard character"}
+	}
+	return w.Field(), value, nil
 }
 
 func (b *BlugeQuerier) assignTermToStatusQuery(field string, value any, sq *datastore.StatusQuery, clientID string, constraint datastore.QueryItemConstraint) error {
@@ -98,18 +124,18 @@ func (b *BlugeQuerier) assignTermToStatusQuery(field string, value any, sq *data
 
 	switch strings.ToLower(field) {
 	case "id":
-		sq.CommandID = queryItem(value.(string), constraint)
+		sq.CommandID = appendStringValue(sq.CommandID, value.(string), constraint)
 	case "client":
 		if value == "me" {
 			value = clientID
 		}
-		sq.ClientID = queryItem(value.(string), constraint)
+		sq.ClientID = appendStringValue(sq.ClientID, value.(string), constraint)
 	case "command":
-		sq.Command = queryItem(value.(string), constraint)
+		sq.Command = appendStringValue(sq.Command, value.(string), constraint)
 	case "status":
-		sq.Status = queryItem(value.(string), constraint)
+		sq.Status = appendStringValue(sq.Status, value.(string), constraint)
 	case "stack":
-		sq.Stack = queryItem(value.(string), constraint)
+		sq.Stack = appendStringValue(sq.Stack, value.(string), constraint)
 	case "managed":
 		sq.Managed = queryItem(value.(bool), constraint)
 	default:
@@ -194,6 +220,12 @@ func (b *BlugeQuerier) processResourceQueryNode(q bluge.Query, rq *datastore.Res
 		return nil
 	case *bluge.MatchQuery:
 		return b.assignTermToResourceQuery(v.Field(), v.Match(), rq, constraint)
+	case *bluge.WildcardQuery:
+		field, value, err := unwrapWildcard(v)
+		if err != nil {
+			return err
+		}
+		return b.assignTermToResourceQuery(field, value, rq, constraint)
 	default:
 		return apimodel.InvalidQueryError{Reason: fmt.Sprintf("unsupported query type: %T", q)}
 	}
@@ -206,13 +238,13 @@ func (b *BlugeQuerier) assignTermToResourceQuery(field string, value any, rq *da
 
 	switch strings.ToLower(field) {
 	case "stack":
-		rq.Stack = queryItem(value.(string), constraint)
+		rq.Stack = appendStringValue(rq.Stack, value.(string), constraint)
 	case "type":
-		rq.Type = queryItem(value.(string), constraint)
+		rq.Type = appendStringValue(rq.Type, value.(string), constraint)
 	case "label":
-		rq.Label = queryItem(value.(string), constraint)
+		rq.Label = appendStringValue(rq.Label, value.(string), constraint)
 	case "target":
-		rq.Target = queryItem(value.(string), constraint)
+		rq.Target = appendStringValue(rq.Target, value.(string), constraint)
 	case "managed":
 		boolVal, err := strconv.ParseBool(fmt.Sprintf("%v", value))
 		if err != nil {
@@ -223,6 +255,21 @@ func (b *BlugeQuerier) assignTermToResourceQuery(field string, value any, rq *da
 		return apimodel.InvalidQueryError{Reason: fmt.Sprintf("unknown field for ResourceQuery: '%s'", field)}
 	}
 	return nil
+}
+
+// appendStringValue accumulates string values for a single field. The first
+// occurrence sets Item; subsequent occurrences with the same constraint
+// append to ExtraItems. This is how multi-value queries like
+// `target:eu target:us` (target IN ('eu','us')) are captured.
+//
+// A new constraint replaces the prior QueryItem entirely — `stack:a +stack:b`
+// is treated as the user replacing their previous filter, not mixing them.
+func appendStringValue(existing *datastore.QueryItem[string], value string, constraint datastore.QueryItemConstraint) *datastore.QueryItem[string] {
+	if existing == nil || existing.Constraint != constraint {
+		return queryItem(value, constraint)
+	}
+	existing.ExtraItems = append(existing.ExtraItems, value)
+	return existing
 }
 
 func (b *BlugeQuerier) QueryResourcesForDestroy(queryString string) ([]*pkgmodel.Resource, error) {
@@ -290,6 +337,12 @@ func (b *BlugeQuerier) processDestroyResourcesQueryNode(q bluge.Query, dq *datas
 		return nil
 	case *bluge.MatchQuery:
 		return b.assignTermToDestroyResourcesQuery(v.Field(), v.Match(), dq, constraint)
+	case *bluge.WildcardQuery:
+		field, value, err := unwrapWildcard(v)
+		if err != nil {
+			return err
+		}
+		return b.assignTermToDestroyResourcesQuery(field, value, dq, constraint)
 	default:
 		return apimodel.InvalidQueryError{Reason: fmt.Sprintf("unsupported query type: %T", q)}
 	}
@@ -302,15 +355,15 @@ func (b *BlugeQuerier) assignTermToDestroyResourcesQuery(field string, value any
 
 	switch strings.ToLower(field) {
 	case "stack":
-		dq.Stack = queryItem(value.(string), constraint)
+		dq.Stack = appendStringValue(dq.Stack, value.(string), constraint)
 	case "type":
-		dq.Type = queryItem(value.(string), constraint)
+		dq.Type = appendStringValue(dq.Type, value.(string), constraint)
 	case "label":
-		dq.Label = queryItem(value.(string), constraint)
+		dq.Label = appendStringValue(dq.Label, value.(string), constraint)
 	case "target":
-		dq.Target = queryItem(value.(string), constraint)
+		dq.Target = appendStringValue(dq.Target, value.(string), constraint)
 	case "native_id":
-		dq.NativeID = queryItem(value.(string), constraint)
+		dq.NativeID = appendStringValue(dq.NativeID, value.(string), constraint)
 	case "managed":
 		return apimodel.InvalidQueryError{Reason: "managed field cannot be used in destroy queries"}
 	default:

--- a/internal/metastructure/querier/bluge_querier_test.go
+++ b/internal/metastructure/querier/bluge_querier_test.go
@@ -258,6 +258,155 @@ func TestBlugeQuerier_resourceQuery_ExcludedStack(t *testing.T) {
 	assert.Equal(t, expectedResourceQuery, resourceQuery)
 }
 
+func TestBlugeQuerier_resourceQuery_RepeatedFieldIsMultiValue(t *testing.T) {
+	querier := &BlugeQuerier{}
+
+	queryString := "stack:alpha stack:beta"
+	expected := &datastore.ResourceQuery{
+		Stack: &datastore.QueryItem[string]{
+			Item:       "alpha",
+			ExtraItems: []string{"beta"},
+			Constraint: datastore.Optional,
+		},
+	}
+
+	got, err := querier.resourceQuery(queryString)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestBlugeQuerier_resourceQuery_RepeatedExcludedField(t *testing.T) {
+	querier := &BlugeQuerier{}
+
+	queryString := "-stack:alpha -stack:beta"
+	expected := &datastore.ResourceQuery{
+		Stack: &datastore.QueryItem[string]{
+			Item:       "alpha",
+			ExtraItems: []string{"beta"},
+			Constraint: datastore.Excluded,
+		},
+	}
+
+	got, err := querier.resourceQuery(queryString)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+// Bluge's query_string library wraps any term containing `*` or `?` in a
+// *bluge.WildcardQuery before our walker sees it. The walker has to unwrap
+// it back to a plain field/value with the `*` preserved so the SQL renderer
+// can translate to LIKE.
+func TestBlugeQuerier_resourceQuery_TrailingWildcard(t *testing.T) {
+	querier := &BlugeQuerier{}
+
+	queryString := "label:prod-*"
+	expected := &datastore.ResourceQuery{
+		Label: &datastore.QueryItem[string]{
+			Item:       "prod-*",
+			Constraint: datastore.Optional,
+		},
+	}
+
+	got, err := querier.resourceQuery(queryString)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+// `::` in resource type values needs the QueryResources escape to survive
+// Bluge's tokenizer, then come back out alongside the wildcard. Verify the
+// full path end-to-end.
+func TestBlugeQuerier_QueryResources_TypeWithWildcardSurvivesColonEscape(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		ds := newTestDatastoreSQLite()
+		querier := NewBlugeQuerier(ds)
+
+		stack := &pkgmodel.Forma{
+			Resources: []pkgmodel.Resource{
+				{Label: "bucket-a", Type: "AWS::S3::Bucket", Stack: "test", Properties: json.RawMessage(`{}`)},
+				{Label: "instance-a", Type: "AWS::EC2::Instance", Stack: "test", Properties: json.RawMessage(`{}`)},
+			},
+		}
+		for i := range stack.Resources {
+			_, err := ds.StoreResource(&stack.Resources[i], "test")
+			assert.NoError(t, err)
+		}
+
+		results, err := querier.QueryResources("type:AWS::S3::*")
+		assert.NoError(t, err)
+		assert.Len(t, results, 1)
+		if len(results) == 1 {
+			assert.Equal(t, "bucket-a", results[0].Label)
+		}
+	})
+}
+
+func TestBlugeQuerier_resourceQuery_LeadingWildcard(t *testing.T) {
+	querier := &BlugeQuerier{}
+
+	queryString := "label:*-prod"
+	expected := &datastore.ResourceQuery{
+		Label: &datastore.QueryItem[string]{
+			Item:       "*-prod",
+			Constraint: datastore.Optional,
+		},
+	}
+
+	got, err := querier.resourceQuery(queryString)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+// `?` (single-char wildcard) has no clean SQL LIKE equivalent (would need _
+// which conflicts with the literal-character escape). Reject it.
+func TestBlugeQuerier_resourceQuery_QuestionMarkRejected(t *testing.T) {
+	querier := &BlugeQuerier{}
+
+	_, err := querier.resourceQuery("label:foo?")
+	assert.Error(t, err)
+}
+
+// Bare `*` alone matches everything, almost always user error — reject it.
+func TestBlugeQuerier_resourceQuery_BareWildcardRejected(t *testing.T) {
+	querier := &BlugeQuerier{}
+
+	_, err := querier.resourceQuery("label:*")
+	assert.Error(t, err)
+}
+
+// `*foo*` (substring), `foo*bar` (middle), and other multi-star patterns map
+// cleanly to SQL LIKE (`%foo%`, `foo%bar`). Accept them.
+func TestBlugeQuerier_resourceQuery_SubstringWildcard(t *testing.T) {
+	querier := &BlugeQuerier{}
+
+	queryString := "label:*foo*"
+	expected := &datastore.ResourceQuery{
+		Label: &datastore.QueryItem[string]{
+			Item:       "*foo*",
+			Constraint: datastore.Optional,
+		},
+	}
+
+	got, err := querier.resourceQuery(queryString)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestBlugeQuerier_resourceQuery_MiddleWildcard(t *testing.T) {
+	querier := &BlugeQuerier{}
+
+	queryString := "label:foo*bar"
+	expected := &datastore.ResourceQuery{
+		Label: &datastore.QueryItem[string]{
+			Item:       "foo*bar",
+			Constraint: datastore.Optional,
+		},
+	}
+
+	got, err := querier.resourceQuery(queryString)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
 func newTestCfg() *pkgmodel.DatastoreConfig {
 	return &pkgmodel.DatastoreConfig{
 		DatastoreType: pkgmodel.SqliteDatastore,


### PR DESCRIPTION
- Same-field repetition ORs
- `*` wildcard anywhere in a value (prefix/suffix/substring/middle)
- `?` and bare `*` rejected with clear err messaging
- `Examples` section now renders on subcommand helps `-h` 
- Fixed existing `formae resources inventory resources ...` duplication
- `make dev-install` stages the local binary per orbital shape

