### PR TITLE
feat(engine): typed DAG edges for destroy ordering (EdgeKind + ParentMappings + runtimeDependency)

### DIFF
--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -49,8 +49,8 @@ type ExecutionDAG struct {
 	// baseResources indexes the create/update ResourceUpdate for each stripped
 	// resource URI in the changeset (exactly one per KSUID, since replace is
 	// pre-split into delete+create and create/update are mutually exclusive per
-	// resource). Delete operations are excluded — RFC-0043 childPointsAt uses
-	// this index only for the create-phase URI→type lookup.
+	// resource). Delete operations are excluded — childPointsAt uses this
+	// index only for the create-phase URI→type lookup.
 	baseResources map[pkgmodel.FormaeURI]*resource_update.ResourceUpdate
 }
 
@@ -624,7 +624,7 @@ func (p *ExecutionDAG) Init(resourceUpdates []resource_update.ResourceUpdate, co
 		}
 
 		// Register create/update ops in the base-resource index so consumers
-		// (RFC-0043 childPointsAt create phase) can resolve a stripped URI to
+		// (childPointsAt create phase) can resolve a stripped URI to
 		// the latest desired-state ResourceUpdate in O(1). Delete ops are
 		// intentionally excluded because the index serves DesiredState lookups.
 		switch update.Operation {

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -223,10 +223,16 @@ func (p *ExecutionDAG) buildTargetResourceEdges(targetUpdates []target_update.Ta
 }
 
 // buildDeleteDependencies creates dependencies for delete operations.
-// For most refs the direction is REVERSED (construction-reversed): the
-// dependency is deleted after the consumer. For refs annotated with
-// AttachesTo=true the direction is FORWARD (reachability order): the
-// host resource is deleted first, then the hosted resource.
+// The edge direction is selected per-reference by the field hint's EdgeKind:
+//   - EdgeKindDefault: construction-reversed — the dependency is deleted
+//     after the consumer (consumer first, producer second).
+//   - EdgeKindAttachesTo: reachability order — the producer is deleted first,
+//     then the consumer (consumer waits for producer).
+//   - EdgeKindRuntimeDependency: same default consumer→producer edge, PLUS
+//     edges from the consumer to every containment child of the producer
+//     whose parent identity matches *this* producer instance. The consumer
+//     must complete before the children tear down, so the children become
+//     downstream of the consumer.
 func (p *ExecutionDAG) buildDeleteDependencies(allOps []resource_update.ResourceUpdate) {
 	deleteOps := make(map[pkgmodel.FormaeURI]resource_update.ResourceUpdate)
 	for _, op := range allOps {
@@ -268,11 +274,59 @@ func (p *ExecutionDAG) buildDeleteDependencies(allOps []resource_update.Resource
 			// Look up the field hint for this reference by ksuid.
 			targetPath := refPathByKsuid[depBase.KSUID()]
 			hint := fieldHintForPath(deleteOp.DesiredState.Schema, targetPath)
-			if hint.AttachesTo {
+
+			// Resolve the effective EdgeKind. Schemas published before the
+			// EdgeKind field landed only set the deprecated AttachesTo bool;
+			// JSON unmarshalling normalizes that into EdgeKind, but in-Go
+			// struct-literal callers may still rely on the alias.
+			edgeKind := hint.EdgeKind
+			if edgeKind == "" {
+				if hint.AttachesTo {
+					edgeKind = pkgmodel.EdgeKindAttachesTo
+				} else {
+					edgeKind = pkgmodel.EdgeKindDefault
+				}
+			}
+
+			depResource := deleteOps[depBase]
+
+			switch edgeKind {
+			case pkgmodel.EdgeKindAttachesTo:
 				// Reachability edge: the hosting resource waits for the hosted-on
 				// resource's delete. Destroy order: hosted-on first, hosting second.
 				dependentGroup.LinkWith(depNode)
-			} else {
+
+			case pkgmodel.EdgeKindRuntimeDependency:
+				// Default construction-reversed edge to the producer: consumer
+				// first, producer second.
+				depNode.LinkWith(dependentGroup)
+
+				// PLUS edges to the producer's containment children that point
+				// at *this* producer instance — each child must wait for the
+				// consumer's delete before tearing down (since the consumer
+				// may still be using the producer's runtime state via the
+				// children). Destroy order: consumer first, then children,
+				// then producer.
+				producerType := depResource.DesiredState.Type
+				for _, k := range deleteOps {
+					if k.DesiredState.Schema.Parent != producerType {
+						continue
+					}
+					if k.URI() == deleteOp.URI() {
+						continue
+					}
+					if !childPointsAt(&k, &depResource, resource_update.OperationDelete, nil) {
+						continue
+					}
+					kNode := p.Nodes[createOperationURI(k.URI(), resource_update.OperationDelete)]
+					if kNode == nil {
+						continue
+					}
+					// Child waits for the consumer (consumer first, child second).
+					kNode.LinkWith(dependentGroup)
+				}
+
+			default: // EdgeKindDefault
 				// Construction-reversed edge (existing behavior): B.delete waits
 				// for A.delete. Destroy order: consumer first, producer second.
 				depNode.LinkWith(dependentGroup)

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -248,22 +248,25 @@ func (p *ExecutionDAG) buildDeleteDependencies(allOps []resource_update.Resource
 			continue
 		}
 
-		// Build a lookup map from referenced-resource-ksuid → TargetPath using
-		// the actual Properties JSON. This lets us find the field hint for each
-		// reference. We fall back gracefully when a ref isn't found in the map.
-		refPathByKsuid := make(map[string]string)
+		// Build per-ksuid lists of TargetPaths from the resource's resolvable
+		// refs. A consumer may reference the same producer at multiple paths
+		// (e.g., once with edgeKind=default and once with
+		// edgeKind=runtimeDependency); each path carries its own hint and
+		// must be honored independently. Collapsing to a single
+		// path-per-ksuid would let map iteration order pick which hint wins.
+		pathsByKsuid := make(map[string][]string)
 		for _, ref := range resolver.ExtractResolvableRefs(deleteOp.DesiredState) {
-			// ExtractResolvableRefs returns URIs of the form "formae://<ksuid>" (no
-			// fragment). Extract just the ksuid part.
 			ksuid := strings.TrimPrefix(string(ref.URI), "formae://")
-			if ksuid != "" {
-				refPathByKsuid[ksuid] = ref.TargetPath
+			if ksuid == "" {
+				continue
 			}
+			pathsByKsuid[ksuid] = append(pathsByKsuid[ksuid], ref.TargetPath)
 		}
 
 		for _, resolvableURI := range deleteOp.RemainingResolvables {
 			depBase := resolvableURI.Stripped()
-			if _, exists := deleteOps[depBase]; !exists {
+			depResource, exists := deleteOps[depBase]
+			if !exists {
 				continue
 			}
 			depNode := p.Nodes[createOperationURI(depBase, resource_update.OperationDelete)]
@@ -271,65 +274,78 @@ func (p *ExecutionDAG) buildDeleteDependencies(allOps []resource_update.Resource
 				continue
 			}
 
-			// Look up the field hint for this reference by ksuid.
-			targetPath := refPathByKsuid[depBase.KSUID()]
-			hint := fieldHintForPath(deleteOp.DesiredState.Schema, targetPath)
-
-			// Resolve the effective EdgeKind. Schemas published before the
-			// EdgeKind field landed only set the deprecated AttachesTo bool;
-			// JSON unmarshalling normalizes that into EdgeKind, but in-Go
-			// struct-literal callers may still rely on the alias.
-			edgeKind := hint.EdgeKind
-			if edgeKind == "" {
-				if hint.AttachesTo {
-					edgeKind = pkgmodel.EdgeKindAttachesTo
-				} else {
-					edgeKind = pkgmodel.EdgeKindDefault
-				}
+			// If no paths recorded (e.g., callers that only populate
+			// RemainingResolvables without the matching Properties JSON, as
+			// some unit tests do), fall back to the single-path default
+			// hint shape.
+			paths := pathsByKsuid[depBase.KSUID()]
+			if len(paths) == 0 {
+				paths = []string{""}
 			}
 
-			depResource := deleteOps[depBase]
+			for _, targetPath := range paths {
+				// Look up the field hint for this specific reference path.
+				hint := fieldHintForPath(deleteOp.DesiredState.Schema, targetPath)
 
-			switch edgeKind {
-			case pkgmodel.EdgeKindAttachesTo:
-				// Reachability edge: the hosting resource waits for the hosted-on
-				// resource's delete. Destroy order: hosted-on first, hosting second.
-				dependentGroup.LinkWith(depNode)
-
-			case pkgmodel.EdgeKindRuntimeDependency:
-				// Default construction-reversed edge to the producer: consumer
-				// first, producer second.
-				depNode.LinkWith(dependentGroup)
-
-				// PLUS edges to the producer's containment children that point
-				// at *this* producer instance — each child must wait for the
-				// consumer's delete before tearing down (since the consumer
-				// may still be using the producer's runtime state via the
-				// children). Destroy order: consumer first, then children,
-				// then producer.
-				producerType := depResource.DesiredState.Type
-				for _, k := range deleteOps {
-					if k.DesiredState.Schema.Parent != producerType {
-						continue
+				// Resolve the effective EdgeKind. Schemas published before
+				// the EdgeKind field landed only set the deprecated
+				// AttachesTo bool; JSON unmarshalling normalizes that into
+				// EdgeKind, but in-Go struct-literal callers may still rely
+				// on the alias.
+				edgeKind := hint.EdgeKind
+				if edgeKind == "" {
+					if hint.AttachesTo {
+						edgeKind = pkgmodel.EdgeKindAttachesTo
+					} else {
+						edgeKind = pkgmodel.EdgeKindDefault
 					}
-					if k.URI() == deleteOp.URI() {
-						continue
-					}
-					if !childPointsAt(&k, &depResource, resource_update.OperationDelete, nil) {
-						continue
-					}
-					kNode := p.Nodes[createOperationURI(k.URI(), resource_update.OperationDelete)]
-					if kNode == nil {
-						continue
-					}
-					// Child waits for the consumer (consumer first, child second).
-					kNode.LinkWith(dependentGroup)
 				}
 
-			default: // EdgeKindDefault
-				// Construction-reversed edge (existing behavior): B.delete waits
-				// for A.delete. Destroy order: consumer first, producer second.
-				depNode.LinkWith(dependentGroup)
+				switch edgeKind {
+				case pkgmodel.EdgeKindAttachesTo:
+					// Reachability edge: the hosting resource waits for the hosted-on
+					// resource's delete. Destroy order: hosted-on first, hosting second.
+					dependentGroup.LinkWith(depNode)
+
+				case pkgmodel.EdgeKindRuntimeDependency:
+					// Default construction-reversed edge to the producer: consumer
+					// first, producer second.
+					depNode.LinkWith(dependentGroup)
+
+					// PLUS edges to the producer's containment children that point
+					// at *this* producer instance — each child must wait for the
+					// consumer's delete before tearing down (since the consumer
+					// may still be using the producer's runtime state via the
+					// children). Destroy order: consumer first, then children,
+					// then producer.
+					producerType := depResource.DesiredState.Type
+					for _, k := range deleteOps {
+						if k.DesiredState.Schema.Parent != producerType {
+							continue
+						}
+						if k.URI() == deleteOp.URI() {
+							continue
+						}
+						if !childPointsAt(&k, &depResource, resource_update.OperationDelete, nil) {
+							continue
+						}
+						// buildDeleteDependencies only enrols ops with Operation
+						// == OperationDelete, so k.Operation is always
+						// OperationDelete here — but use the actual field for
+						// symmetry with the create-side counterpart.
+						kNode := p.Nodes[createOperationURI(k.URI(), k.Operation)]
+						if kNode == nil {
+							continue
+						}
+						// Child waits for the consumer (consumer first, child second).
+						kNode.LinkWith(dependentGroup)
+					}
+
+				default: // EdgeKindDefault
+					// Construction-reversed edge (existing behavior): B.delete waits
+					// for A.delete. Destroy order: consumer first, producer second.
+					depNode.LinkWith(dependentGroup)
+				}
 			}
 		}
 	}
@@ -362,16 +378,19 @@ func (p *ExecutionDAG) buildCreateUpdateDependencies(allOps []resource_update.Re
 		dependentOpURI := createOperationURI(createOp.URI(), createOp.Operation)
 		dependentGroup := p.Nodes[dependentOpURI]
 
-		// Build a lookup map from referenced-resource-ksuid → TargetPath using
-		// the actual Properties JSON. Same pattern as the destroy branch:
-		// lets us find the field hint for each resolvable. Falls back to the
-		// default edge when a ref isn't in the map.
-		refPathByKsuid := make(map[string]string)
+		// Build per-ksuid lists of TargetPaths from the resource's resolvable
+		// refs. A consumer may reference the same producer at multiple paths
+		// (e.g., once with edgeKind=default and once with
+		// edgeKind=runtimeDependency); each path carries its own hint and
+		// must be honored independently. Collapsing to a single
+		// path-per-ksuid would let map iteration order pick which hint wins.
+		pathsByKsuid := make(map[string][]string)
 		for _, ref := range resolver.ExtractResolvableRefs(createOp.DesiredState) {
 			ksuid := strings.TrimPrefix(string(ref.URI), "formae://")
-			if ksuid != "" {
-				refPathByKsuid[ksuid] = ref.TargetPath
+			if ksuid == "" {
+				continue
 			}
+			pathsByKsuid[ksuid] = append(pathsByKsuid[ksuid], ref.TargetPath)
 		}
 
 		for _, resolvableURI := range createOp.RemainingResolvables {
@@ -388,47 +407,64 @@ func (p *ExecutionDAG) buildCreateUpdateDependencies(allOps []resource_update.Re
 			// NORMAL: dependent waits for dependency to complete
 			dependentGroup.LinkWith(dependencyGroup)
 
-			// Resolve the effective EdgeKind. Normalize the deprecated
-			// AttachesTo alias for consistency with the destroy branch even
-			// though only RuntimeDependency triggers extra wiring on the
-			// create phase.
-			targetPath := refPathByKsuid[dependencyBaseURI.KSUID()]
-			hint := fieldHintForPath(createOp.DesiredState.Schema, targetPath)
-			edgeKind := hint.EdgeKind
-			if edgeKind == "" {
-				if hint.AttachesTo {
-					edgeKind = pkgmodel.EdgeKindAttachesTo
-				} else {
-					edgeKind = pkgmodel.EdgeKindDefault
-				}
+			// If no paths recorded (e.g., callers that only populate
+			// RemainingResolvables without the matching Properties JSON, as
+			// some unit tests do), fall back to the single-path default
+			// hint shape.
+			paths := pathsByKsuid[dependencyBaseURI.KSUID()]
+			if len(paths) == 0 {
+				paths = []string{""}
 			}
 
-			if edgeKind != pkgmodel.EdgeKindRuntimeDependency {
-				continue
-			}
+			for _, targetPath := range paths {
+				// Resolve the effective EdgeKind for this specific reference
+				// path. Normalize the deprecated AttachesTo alias for
+				// consistency with the destroy branch even though only
+				// RuntimeDependency triggers extra wiring on the create
+				// phase.
+				hint := fieldHintForPath(createOp.DesiredState.Schema, targetPath)
+				edgeKind := hint.EdgeKind
+				if edgeKind == "" {
+					if hint.AttachesTo {
+						edgeKind = pkgmodel.EdgeKindAttachesTo
+					} else {
+						edgeKind = pkgmodel.EdgeKindDefault
+					}
+				}
 
-			// runtimeDependency: also wire each containment child of the
-			// producer that points at *this* producer instance into the
-			// consumer. The consumer must wait for the children so it observes
-			// fully-realised runtime state. Create order: producer → children
-			// → consumer.
-			producerType := dependencyOp.DesiredState.Type
-			for _, k := range createUpdateOps {
-				if k.DesiredState.Schema.Parent != producerType {
+				if edgeKind != pkgmodel.EdgeKindRuntimeDependency {
 					continue
 				}
-				if k.URI() == createOp.URI() {
-					continue
+
+				// runtimeDependency: also wire each containment child of the
+				// producer that points at *this* producer instance into the
+				// consumer. The consumer must wait for the children so it
+				// observes fully-realised runtime state. Create order:
+				// producer → children → consumer.
+				producerType := dependencyOp.DesiredState.Type
+				for _, k := range createUpdateOps {
+					if k.DesiredState.Schema.Parent != producerType {
+						continue
+					}
+					if k.URI() == createOp.URI() {
+						continue
+					}
+					if !childPointsAt(&k, &dependencyOp, resource_update.OperationCreate, p.baseResources) {
+						continue
+					}
+					// Use the child's actual Operation rather than
+					// hardcoding OperationCreate: an existing resource
+					// updated in the same changeset will be registered under
+					// (uri, OperationUpdate), not (uri, OperationCreate),
+					// and the hardcoded lookup would silently miss it —
+					// dropping the runtimeDependency child edge.
+					kNode := p.Nodes[createOperationURI(k.URI(), k.Operation)]
+					if kNode == nil {
+						continue
+					}
+					// Consumer waits for K (K first, consumer second).
+					dependentGroup.LinkWith(kNode)
 				}
-				if !childPointsAt(&k, &dependencyOp, resource_update.OperationCreate, p.baseResources) {
-					continue
-				}
-				kNode := p.Nodes[createOperationURI(k.URI(), resource_update.OperationCreate)]
-				if kNode == nil {
-					continue
-				}
-				// Consumer waits for K (K first, consumer second).
-				dependentGroup.LinkWith(kNode)
 			}
 		}
 	}

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -335,7 +335,18 @@ func (p *ExecutionDAG) buildDeleteDependencies(allOps []resource_update.Resource
 	}
 }
 
-// buildCreateUpdateDependencies creates NORMAL dependencies for create/update operations
+// buildCreateUpdateDependencies creates NORMAL dependencies for create/update
+// operations. The natural edge per reference is consumer → producer (consumer
+// waits for producer).
+//
+// For runtimeDependency edges, the natural edge is augmented with edges from
+// every containment child of the producer whose parent identity matches *this*
+// producer instance into the consumer. Create order becomes: producer first,
+// then children, then consumer.
+//
+// EdgeKindAttachesTo carries no extra meaning on the create phase (it inverts
+// destroy order but agrees with the default on construction), so we leave it
+// to the default branch.
 func (p *ExecutionDAG) buildCreateUpdateDependencies(allOps []resource_update.ResourceUpdate) {
 	createUpdateOps := make(map[pkgmodel.FormaeURI]resource_update.ResourceUpdate)
 
@@ -351,16 +362,73 @@ func (p *ExecutionDAG) buildCreateUpdateDependencies(allOps []resource_update.Re
 		dependentOpURI := createOperationURI(createOp.URI(), createOp.Operation)
 		dependentGroup := p.Nodes[dependentOpURI]
 
+		// Build a lookup map from referenced-resource-ksuid → TargetPath using
+		// the actual Properties JSON. Same pattern as the destroy branch:
+		// lets us find the field hint for each resolvable. Falls back to the
+		// default edge when a ref isn't in the map.
+		refPathByKsuid := make(map[string]string)
+		for _, ref := range resolver.ExtractResolvableRefs(createOp.DesiredState) {
+			ksuid := strings.TrimPrefix(string(ref.URI), "formae://")
+			if ksuid != "" {
+				refPathByKsuid[ksuid] = ref.TargetPath
+			}
+		}
+
 		for _, resolvableURI := range createOp.RemainingResolvables {
 			dependencyBaseURI := resolvableURI.Stripped()
 
 			// Check if there's a corresponding create/update operation for this dependency
-			if dependencyOp, exists := createUpdateOps[dependencyBaseURI]; exists {
-				dependencyOpURI := createOperationURI(dependencyBaseURI, dependencyOp.Operation)
-				dependencyGroup := p.Nodes[dependencyOpURI]
+			dependencyOp, exists := createUpdateOps[dependencyBaseURI]
+			if !exists {
+				continue
+			}
+			dependencyOpURI := createOperationURI(dependencyBaseURI, dependencyOp.Operation)
+			dependencyGroup := p.Nodes[dependencyOpURI]
 
-				// NORMAL: dependent waits for dependency to complete
-				dependentGroup.LinkWith(dependencyGroup)
+			// NORMAL: dependent waits for dependency to complete
+			dependentGroup.LinkWith(dependencyGroup)
+
+			// Resolve the effective EdgeKind. Normalize the deprecated
+			// AttachesTo alias for consistency with the destroy branch even
+			// though only RuntimeDependency triggers extra wiring on the
+			// create phase.
+			targetPath := refPathByKsuid[dependencyBaseURI.KSUID()]
+			hint := fieldHintForPath(createOp.DesiredState.Schema, targetPath)
+			edgeKind := hint.EdgeKind
+			if edgeKind == "" {
+				if hint.AttachesTo {
+					edgeKind = pkgmodel.EdgeKindAttachesTo
+				} else {
+					edgeKind = pkgmodel.EdgeKindDefault
+				}
+			}
+
+			if edgeKind != pkgmodel.EdgeKindRuntimeDependency {
+				continue
+			}
+
+			// runtimeDependency: also wire each containment child of the
+			// producer that points at *this* producer instance into the
+			// consumer. The consumer must wait for the children so it observes
+			// fully-realised runtime state. Create order: producer → children
+			// → consumer.
+			producerType := dependencyOp.DesiredState.Type
+			for _, k := range createUpdateOps {
+				if k.DesiredState.Schema.Parent != producerType {
+					continue
+				}
+				if k.URI() == createOp.URI() {
+					continue
+				}
+				if !childPointsAt(&k, &dependencyOp, resource_update.OperationCreate, p.baseResources) {
+					continue
+				}
+				kNode := p.Nodes[createOperationURI(k.URI(), resource_update.OperationCreate)]
+				if kNode == nil {
+					continue
+				}
+				// Consumer waits for K (K first, consumer second).
+				dependentGroup.LinkWith(kNode)
 			}
 		}
 	}

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -46,6 +46,12 @@ type Changeset struct {
 
 type ExecutionDAG struct {
 	Nodes map[pkgmodel.FormaeURI]*DAGNode
+	// baseResources indexes the create/update ResourceUpdate for each stripped
+	// resource URI in the changeset (exactly one per KSUID, since replace is
+	// pre-split into delete+create and create/update are mutually exclusive per
+	// resource). Delete operations are excluded — RFC-0043 childPointsAt uses
+	// this index only for the create-phase URI→type lookup.
+	baseResources map[pkgmodel.FormaeURI]*resource_update.ResourceUpdate
 }
 
 type DAGNode struct {
@@ -403,7 +409,8 @@ func (p *ExecutionDAG) buildTargetResolvableEdges() {
 
 func NewExecutionDAG() *ExecutionDAG {
 	return &ExecutionDAG{
-		Nodes: make(map[pkgmodel.FormaeURI]*DAGNode),
+		Nodes:         make(map[pkgmodel.FormaeURI]*DAGNode),
+		baseResources: make(map[pkgmodel.FormaeURI]*resource_update.ResourceUpdate),
 	}
 }
 
@@ -428,7 +435,10 @@ func (p *ExecutionDAG) Init(resourceUpdates []resource_update.ResourceUpdate, co
 		}
 	}
 
-	// Step 2: Create resource update groups with operation-specific URIs
+	// Step 2: Create resource update groups with operation-specific URIs.
+	// allOps must not be appended to past this point — &allOps[i] pointers
+	// are stored in p.Nodes and p.baseResources and would be invalidated
+	// by a backing-array reallocation.
 	for i := range allOps {
 		update := &allOps[i]
 		// Create unique identifier that includes operation
@@ -453,6 +463,15 @@ func (p *ExecutionDAG) Init(resourceUpdates []resource_update.ResourceUpdate, co
 			Update:       update,
 			Dependents:   []*DAGNode{},
 			Dependencies: []*DAGNode{},
+		}
+
+		// Register create/update ops in the base-resource index so consumers
+		// (RFC-0043 childPointsAt create phase) can resolve a stripped URI to
+		// the latest desired-state ResourceUpdate in O(1). Delete ops are
+		// intentionally excluded because the index serves DesiredState lookups.
+		switch update.Operation {
+		case resource_update.OperationCreate, resource_update.OperationUpdate:
+			p.baseResources[update.URI().Stripped()] = update
 		}
 	}
 

--- a/internal/metastructure/changeset/changeset_test.go
+++ b/internal/metastructure/changeset/changeset_test.go
@@ -2151,7 +2151,7 @@ func TestBuildDeleteDependencies_AttachesToInvertsEdgeDirection(t *testing.T) {
 	})
 
 	t.Run("AttachesTo: A.delete waits for B.delete (reachability order)", func(t *testing.T) {
-		dag := build(t, pkgmodel.FieldHint{AttachesTo: true})
+		dag := build(t, pkgmodel.FieldHint{EdgeKind: pkgmodel.EdgeKindAttachesTo})
 		bNode := dagNodeForOp(t, dag, bURI, resource_update.OperationDelete)
 		aNode := dagNodeForOp(t, dag, aURI, resource_update.OperationDelete)
 		if !hasDependency(aNode, bNode) {
@@ -2174,7 +2174,7 @@ func TestBuildDeleteDependencies_MixedRefsOnOneResourceGetIndependentDirections(
 	aResource := pkgmodel.Resource{
 		Ksuid: "A1", Label: "a", Type: "Test::A", Stack: "s",
 		Schema: pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{
-			"f1": {AttachesTo: true},
+			"f1": {EdgeKind: pkgmodel.EdgeKindAttachesTo},
 			// "f2" intentionally absent → plain construction
 		}},
 		Properties: json.RawMessage(`{
@@ -2238,5 +2238,235 @@ func TestBuildDeleteDependencies_MissingHintFallsBackToConstructionReverse(t *te
 	bNode := dagNodeForOp(t, cs.DAG, bURI, resource_update.OperationDelete)
 	if !hasDependency(bNode, aNode) {
 		t.Fatalf("missing hint should fall through to construction-reverse: B.delete must depend on A.delete")
+	}
+}
+
+// TestBuildDeleteDependencies_RuntimeDependency_AddsChildEdges verifies that
+// a runtimeDependency edge from consumer→producer also pulls in edges from
+// the consumer to every containment child of the producer. The destroy order
+// becomes: consumer first, then children, then producer.
+func TestBuildDeleteDependencies_RuntimeDependency_AddsChildEdges(t *testing.T) {
+	var (
+		consumerURI = pkgmodel.NewFormaeURI("CONS1", "")
+		producerURI = pkgmodel.NewFormaeURI("PROD1", "")
+		mtAURI      = pkgmodel.NewFormaeURI("MTA1", "")
+		mtBURI      = pkgmodel.NewFormaeURI("MTB1", "")
+	)
+
+	// Consumer: TaskDef-like, references producer (FileSystem) via filesystemId
+	// with a runtimeDependency edge.
+	consumer := pkgmodel.Resource{
+		Ksuid: "CONS1", Label: "consumer", Type: "Test::TaskDef", Stack: "s",
+		Schema: pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{
+			"filesystemId": {EdgeKind: pkgmodel.EdgeKindRuntimeDependency},
+		}},
+		Properties: json.RawMessage(`{
+			"filesystemId": {"$ref":"formae://PROD1#/FileSystemId","$value":"fs-abc"}
+		}`),
+	}
+
+	// Producer: FileSystem with a literal identifier.
+	producer := pkgmodel.Resource{
+		Ksuid: "PROD1", Label: "fs", Type: "Test::FileSystem", Stack: "s",
+		Schema: pkgmodel.Schema{
+			Identifier: "FileSystemId",
+		},
+		Properties: json.RawMessage(`{"FileSystemId":"fs-abc"}`),
+	}
+
+	// Two MountTargets pointing at the producer by literal FileSystemId.
+	mtA := pkgmodel.Resource{
+		Ksuid: "MTA1", Label: "mtA", Type: "Test::MountTarget", Stack: "s",
+		Schema: pkgmodel.Schema{
+			Parent: "Test::FileSystem",
+			ParentMappings: []pkgmodel.ParentMapping{
+				{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+			},
+		},
+		Properties: json.RawMessage(`{"FileSystemId":"fs-abc"}`),
+	}
+	mtB := pkgmodel.Resource{
+		Ksuid: "MTB1", Label: "mtB", Type: "Test::MountTarget", Stack: "s",
+		Schema: pkgmodel.Schema{
+			Parent: "Test::FileSystem",
+			ParentMappings: []pkgmodel.ParentMapping{
+				{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+			},
+		},
+		Properties: json.RawMessage(`{"FileSystemId":"fs-abc"}`),
+	}
+
+	cs, err := NewChangeset([]resource_update.ResourceUpdate{
+		{DesiredState: consumer, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
+		{DesiredState: producer, Operation: resource_update.OperationDelete},
+		{DesiredState: mtA, Operation: resource_update.OperationDelete},
+		{DesiredState: mtB, Operation: resource_update.OperationDelete},
+	}, nil, "rt1", pkgmodel.CommandApply)
+	if err != nil {
+		t.Fatalf("NewChangeset: %v", err)
+	}
+
+	consNode := dagNodeForOp(t, cs.DAG, consumerURI, resource_update.OperationDelete)
+	prodNode := dagNodeForOp(t, cs.DAG, producerURI, resource_update.OperationDelete)
+	mtANode := dagNodeForOp(t, cs.DAG, mtAURI, resource_update.OperationDelete)
+	mtBNode := dagNodeForOp(t, cs.DAG, mtBURI, resource_update.OperationDelete)
+
+	// Default destroy edge: producer.delete depends on consumer.delete
+	// (consumer first, producer second).
+	if !hasDependency(prodNode, consNode) {
+		t.Errorf("producer.delete should depend on consumer.delete (default destroy edge)")
+	}
+	// New runtimeDependency edges: each MountTarget.delete depends on
+	// consumer.delete (consumer first, child second).
+	if !hasDependency(mtANode, consNode) {
+		t.Errorf("mountTargetA.delete should depend on consumer.delete (runtimeDependency child edge)")
+	}
+	if !hasDependency(mtBNode, consNode) {
+		t.Errorf("mountTargetB.delete should depend on consumer.delete (runtimeDependency child edge)")
+	}
+	// Consumer must not depend on its own producer/children (no cycles).
+	if hasDependency(consNode, prodNode) {
+		t.Errorf("consumer.delete should NOT depend on producer.delete under runtimeDependency")
+	}
+	if hasDependency(consNode, mtANode) {
+		t.Errorf("consumer.delete should NOT depend on mountTargetA.delete (cycle)")
+	}
+}
+
+// TestBuildDeleteDependencies_RuntimeDependency_InstanceSafe verifies that
+// runtimeDependency only pulls in containment children of the *referenced*
+// producer instance, not arbitrary children of the same type.
+func TestBuildDeleteDependencies_RuntimeDependency_InstanceSafe(t *testing.T) {
+	var (
+		consumerURI = pkgmodel.NewFormaeURI("CONS1", "")
+		fs1URI      = pkgmodel.NewFormaeURI("FS1", "")
+		fs2URI      = pkgmodel.NewFormaeURI("FS2", "")
+		mt1AURI     = pkgmodel.NewFormaeURI("MT1A", "")
+		mt1BURI     = pkgmodel.NewFormaeURI("MT1B", "")
+		mt2AURI     = pkgmodel.NewFormaeURI("MT2A", "")
+		mt2BURI     = pkgmodel.NewFormaeURI("MT2B", "")
+	)
+
+	consumer := pkgmodel.Resource{
+		Ksuid: "CONS1", Label: "consumer", Type: "Test::TaskDef", Stack: "s",
+		Schema: pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{
+			"filesystemId": {EdgeKind: pkgmodel.EdgeKindRuntimeDependency},
+		}},
+		Properties: json.RawMessage(`{
+			"filesystemId": {"$ref":"formae://FS1#/FileSystemId","$value":"fs-1"}
+		}`),
+	}
+	fs1 := pkgmodel.Resource{
+		Ksuid: "FS1", Label: "fs1", Type: "Test::FileSystem", Stack: "s",
+		Schema:     pkgmodel.Schema{Identifier: "FileSystemId"},
+		Properties: json.RawMessage(`{"FileSystemId":"fs-1"}`),
+	}
+	fs2 := pkgmodel.Resource{
+		Ksuid: "FS2", Label: "fs2", Type: "Test::FileSystem", Stack: "s",
+		Schema:     pkgmodel.Schema{Identifier: "FileSystemId"},
+		Properties: json.RawMessage(`{"FileSystemId":"fs-2"}`),
+	}
+
+	mountTarget := func(ksuid, label, fsID string) pkgmodel.Resource {
+		return pkgmodel.Resource{
+			Ksuid: ksuid, Label: label, Type: "Test::MountTarget", Stack: "s",
+			Schema: pkgmodel.Schema{
+				Parent: "Test::FileSystem",
+				ParentMappings: []pkgmodel.ParentMapping{
+					{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+				},
+			},
+			Properties: json.RawMessage(`{"FileSystemId":"` + fsID + `"}`),
+		}
+	}
+
+	cs, err := NewChangeset([]resource_update.ResourceUpdate{
+		{DesiredState: consumer, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{fs1URI}},
+		{DesiredState: fs1, Operation: resource_update.OperationDelete},
+		{DesiredState: fs2, Operation: resource_update.OperationDelete},
+		{DesiredState: mountTarget("MT1A", "mt1A", "fs-1"), Operation: resource_update.OperationDelete},
+		{DesiredState: mountTarget("MT1B", "mt1B", "fs-1"), Operation: resource_update.OperationDelete},
+		{DesiredState: mountTarget("MT2A", "mt2A", "fs-2"), Operation: resource_update.OperationDelete},
+		{DesiredState: mountTarget("MT2B", "mt2B", "fs-2"), Operation: resource_update.OperationDelete},
+	}, nil, "rt2", pkgmodel.CommandApply)
+	if err != nil {
+		t.Fatalf("NewChangeset: %v", err)
+	}
+
+	consNode := dagNodeForOp(t, cs.DAG, consumerURI, resource_update.OperationDelete)
+	mt1ANode := dagNodeForOp(t, cs.DAG, mt1AURI, resource_update.OperationDelete)
+	mt1BNode := dagNodeForOp(t, cs.DAG, mt1BURI, resource_update.OperationDelete)
+	mt2ANode := dagNodeForOp(t, cs.DAG, mt2AURI, resource_update.OperationDelete)
+	mt2BNode := dagNodeForOp(t, cs.DAG, mt2BURI, resource_update.OperationDelete)
+	_ = dagNodeForOp(t, cs.DAG, fs2URI, resource_update.OperationDelete) // verify present
+
+	// FS1's children get the runtimeDependency edge from the consumer.
+	if !hasDependency(mt1ANode, consNode) {
+		t.Errorf("mt1A.delete should depend on consumer.delete (FS1's child)")
+	}
+	if !hasDependency(mt1BNode, consNode) {
+		t.Errorf("mt1B.delete should depend on consumer.delete (FS1's child)")
+	}
+	// FS2's children must NOT get the edge — consumer doesn't reference FS2.
+	if hasDependency(mt2ANode, consNode) {
+		t.Errorf("mt2A.delete should NOT depend on consumer.delete (FS2's child, not referenced)")
+	}
+	if hasDependency(mt2BNode, consNode) {
+		t.Errorf("mt2B.delete should NOT depend on consumer.delete (FS2's child, not referenced)")
+	}
+}
+
+// TestBuildDeleteDependencies_RuntimeDependency_NoMatchingChildren_FallsBackToDefault
+// verifies that when a runtimeDependency edge fires but no containment children
+// of the producer are in the changeset, the default consumer→producer edge is
+// still added and no spurious edges appear.
+func TestBuildDeleteDependencies_RuntimeDependency_NoMatchingChildren_FallsBackToDefault(t *testing.T) {
+	var (
+		consumerURI = pkgmodel.NewFormaeURI("CONS1", "")
+		producerURI = pkgmodel.NewFormaeURI("PROD1", "")
+	)
+
+	consumer := pkgmodel.Resource{
+		Ksuid: "CONS1", Label: "consumer", Type: "Test::TaskDef", Stack: "s",
+		Schema: pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{
+			"filesystemId": {EdgeKind: pkgmodel.EdgeKindRuntimeDependency},
+		}},
+		Properties: json.RawMessage(`{
+			"filesystemId": {"$ref":"formae://PROD1#/FileSystemId","$value":"fs-abc"}
+		}`),
+	}
+	producer := pkgmodel.Resource{
+		Ksuid: "PROD1", Label: "fs", Type: "Test::FileSystem", Stack: "s",
+		Schema:     pkgmodel.Schema{Identifier: "FileSystemId"},
+		Properties: json.RawMessage(`{"FileSystemId":"fs-abc"}`),
+	}
+
+	cs, err := NewChangeset([]resource_update.ResourceUpdate{
+		{DesiredState: consumer, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
+		{DesiredState: producer, Operation: resource_update.OperationDelete},
+	}, nil, "rt3", pkgmodel.CommandApply)
+	if err != nil {
+		t.Fatalf("NewChangeset: %v", err)
+	}
+
+	consNode := dagNodeForOp(t, cs.DAG, consumerURI, resource_update.OperationDelete)
+	prodNode := dagNodeForOp(t, cs.DAG, producerURI, resource_update.OperationDelete)
+
+	// Default destroy edge: producer.delete depends on consumer.delete.
+	if !hasDependency(prodNode, consNode) {
+		t.Errorf("producer.delete should still depend on consumer.delete (default edge under runtimeDependency)")
+	}
+	// No reverse edge.
+	if hasDependency(consNode, prodNode) {
+		t.Errorf("consumer.delete should NOT depend on producer.delete")
+	}
+	// Producer should have exactly one dependency (the consumer) — no spurious
+	// edges from absent children.
+	if got := len(prodNode.Dependencies); got != 1 {
+		t.Errorf("producer.delete should have exactly 1 dependency, got %d", got)
+	}
+	// Consumer should have no dependencies (it's the entry point).
+	if got := len(consNode.Dependencies); got != 0 {
+		t.Errorf("consumer.delete should have no dependencies, got %d", got)
 	}
 }

--- a/internal/metastructure/changeset/changeset_test.go
+++ b/internal/metastructure/changeset/changeset_test.go
@@ -2734,3 +2734,204 @@ func TestBuildCreateUpdateDependencies_RuntimeDependency_NoMatchingChildren_Fall
 		t.Errorf("unrelated.create should have no dependencies, got %d", got)
 	}
 }
+
+// TestBuildDeleteDependencies_RuntimeDependency_MultipleRefsToSameProducer_PrefersRuntimeDependency
+// guards against a per-ksuid map collision: when a consumer carries two refs
+// pointing at the same producer KSUID but at different paths — one with
+// EdgeKind=default and one with EdgeKind=runtimeDependency — the planner must
+// honor the runtimeDependency annotation regardless of map iteration order.
+//
+// The original implementation keyed the hint lookup by bare KSUID, so the
+// second path silently overwrote the first; whichever ordering map iteration
+// produced determined which EdgeKind the planner saw. With the per-ref
+// iteration in place, both hints fire and the runtimeDependency child edge
+// is added every time.
+func TestBuildDeleteDependencies_RuntimeDependency_MultipleRefsToSameProducer_PrefersRuntimeDependency(t *testing.T) {
+	var (
+		consumerURI = pkgmodel.NewFormaeURI("CONS1", "")
+		producerURI = pkgmodel.NewFormaeURI("PROD1", "")
+		mtAURI      = pkgmodel.NewFormaeURI("MTA1", "")
+	)
+
+	// Consumer references PROD1 at two paths whose Resolvables point at
+	// different producer properties (so they live under different map keys
+	// in the resolver's internal index, exposing iteration-order sensitivity):
+	//   - "fieldA" → formae://PROD1#/FieldA with EdgeKind=default
+	//   - "fieldB" → formae://PROD1#/FieldB with EdgeKind=runtimeDependency
+	// Both refs share the same producer KSUID — the collision case that the
+	// per-ksuid lookup map exhibited.
+	consumer := pkgmodel.Resource{
+		Ksuid: "CONS1", Label: "consumer", Type: "Test::TaskDef", Stack: "s",
+		Schema: pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{
+			"fieldA": {EdgeKind: pkgmodel.EdgeKindDefault},
+			"fieldB": {EdgeKind: pkgmodel.EdgeKindRuntimeDependency},
+		}},
+		Properties: json.RawMessage(`{
+			"fieldA": {"$ref":"formae://PROD1#/FieldA","$value":"a"},
+			"fieldB": {"$ref":"formae://PROD1#/FieldB","$value":"b"}
+		}`),
+	}
+	producer := pkgmodel.Resource{
+		Ksuid: "PROD1", Label: "fs", Type: "Test::FileSystem", Stack: "s",
+		Schema:     pkgmodel.Schema{Identifier: "FileSystemId"},
+		Properties: json.RawMessage(`{"FileSystemId":"fs-abc"}`),
+	}
+	mtA := pkgmodel.Resource{
+		Ksuid: "MTA1", Label: "mtA", Type: "Test::MountTarget", Stack: "s",
+		Schema: pkgmodel.Schema{
+			Parent: "Test::FileSystem",
+			ParentMappings: []pkgmodel.ParentMapping{
+				{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+			},
+		},
+		Properties: json.RawMessage(`{"FileSystemId":"fs-abc"}`),
+	}
+
+	// Repeat the build several times to exercise non-deterministic map
+	// iteration — Go intentionally randomizes iteration order so one
+	// invocation could happen to pick the "good" ordering by luck.
+	for i := 0; i < 50; i++ {
+		cs, err := NewChangeset([]resource_update.ResourceUpdate{
+			{DesiredState: consumer, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
+			{DesiredState: producer, Operation: resource_update.OperationDelete},
+			{DesiredState: mtA, Operation: resource_update.OperationDelete},
+		}, nil, "rtmulti1", pkgmodel.CommandApply)
+		if err != nil {
+			t.Fatalf("iteration %d NewChangeset: %v", i, err)
+		}
+
+		consNode := dagNodeForOp(t, cs.DAG, consumerURI, resource_update.OperationDelete)
+		mtANode := dagNodeForOp(t, cs.DAG, mtAURI, resource_update.OperationDelete)
+
+		// The runtimeDependency child edge must fire regardless of which
+		// path the planner visited first.
+		if !hasDependency(mtANode, consNode) {
+			t.Fatalf("iteration %d: mountTargetA.delete should depend on consumer.delete (runtimeDependency child edge must survive multi-ref collision)", i)
+		}
+	}
+}
+
+// TestBuildCreateUpdateDependencies_RuntimeDependency_MultipleRefsToSameProducer_PrefersRuntimeDependency
+// is the create-side counterpart of the destroy-side regression test. Same
+// shape: consumer carries two refs to the same producer KSUID — one default,
+// one runtimeDependency — and the planner must honor the runtimeDependency
+// hint regardless of map iteration order.
+func TestBuildCreateUpdateDependencies_RuntimeDependency_MultipleRefsToSameProducer_PrefersRuntimeDependency(t *testing.T) {
+	var (
+		consumerURI = pkgmodel.NewFormaeURI("CONS1", "")
+		producerURI = pkgmodel.NewFormaeURI("PROD1", "")
+		mtAURI      = pkgmodel.NewFormaeURI("MTA1", "")
+	)
+
+	// Consumer references PROD1 at two paths whose Resolvables point at
+	// different producer properties (so they live under different map keys
+	// in the resolver's internal index, exposing iteration-order
+	// sensitivity):
+	//   - "fieldA" → formae://PROD1#/FieldA with EdgeKind=default
+	//   - "fieldB" → formae://PROD1#/FieldB with EdgeKind=runtimeDependency
+	consumer := pkgmodel.Resource{
+		Ksuid: "CONS1", Label: "consumer", Type: "Test::TaskDef", Stack: "s",
+		Schema: pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{
+			"fieldA": {EdgeKind: pkgmodel.EdgeKindDefault},
+			"fieldB": {EdgeKind: pkgmodel.EdgeKindRuntimeDependency},
+		}},
+		Properties: json.RawMessage(`{
+			"fieldA": {"$ref":"formae://PROD1#/FieldA","$value":""},
+			"fieldB": {"$ref":"formae://PROD1#/FieldB","$value":""}
+		}`),
+	}
+	producer := pkgmodel.Resource{
+		Ksuid: "PROD1", Label: "fs", Type: "Test::FileSystem", Stack: "s",
+		Schema:     pkgmodel.Schema{Identifier: "FileSystemId"},
+		Properties: json.RawMessage(`{"FileSystemId":"fs-abc"}`),
+	}
+	mtA := pkgmodel.Resource{
+		Ksuid: "MTA1", Label: "mtA", Type: "Test::MountTarget", Stack: "s",
+		Schema: pkgmodel.Schema{
+			Parent: "Test::FileSystem",
+			ParentMappings: []pkgmodel.ParentMapping{
+				{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+			},
+		},
+		Properties: json.RawMessage(`{"FileSystemId":{"$ref":"formae://PROD1#/FileSystemId","$value":""}}`),
+	}
+
+	for i := 0; i < 50; i++ {
+		cs, err := NewChangeset([]resource_update.ResourceUpdate{
+			{DesiredState: consumer, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
+			{DesiredState: producer, Operation: resource_update.OperationCreate},
+			{DesiredState: mtA, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
+		}, nil, "rtcmulti1", pkgmodel.CommandApply)
+		if err != nil {
+			t.Fatalf("iteration %d NewChangeset: %v", i, err)
+		}
+
+		consNode := dagNodeForOp(t, cs.DAG, consumerURI, resource_update.OperationCreate)
+		mtANode := dagNodeForOp(t, cs.DAG, mtAURI, resource_update.OperationCreate)
+
+		// runtimeDependency child edge: consumer.create depends on mtA.create.
+		if !hasDependency(consNode, mtANode) {
+			t.Fatalf("iteration %d: consumer.create should depend on mountTargetA.create (runtimeDependency child edge must survive multi-ref collision)", i)
+		}
+	}
+}
+
+// TestBuildCreateUpdateDependencies_RuntimeDependency_UpdateChild_StillLinks
+// guards against a hardcoded operation lookup in the create-side
+// runtimeDependency branch: a containment child of the producer that's in
+// the changeset as OperationUpdate (not OperationCreate) must still receive
+// the runtimeDependency edge. The original implementation looked up the
+// child's node under (uri, OperationCreate) regardless of the child's actual
+// operation, silently dropping the edge for child updates.
+func TestBuildCreateUpdateDependencies_RuntimeDependency_UpdateChild_StillLinks(t *testing.T) {
+	var (
+		consumerURI = pkgmodel.NewFormaeURI("CONS1", "")
+		producerURI = pkgmodel.NewFormaeURI("PROD1", "")
+		mtAURI      = pkgmodel.NewFormaeURI("MTA1", "")
+	)
+
+	consumer := pkgmodel.Resource{
+		Ksuid: "CONS1", Label: "consumer", Type: "Test::TaskDef", Stack: "s",
+		Schema: pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{
+			"filesystemId": {EdgeKind: pkgmodel.EdgeKindRuntimeDependency},
+		}},
+		Properties: json.RawMessage(`{
+			"filesystemId": {"$ref":"formae://PROD1#/FileSystemId","$value":""}
+		}`),
+	}
+	producer := pkgmodel.Resource{
+		Ksuid: "PROD1", Label: "fs", Type: "Test::FileSystem", Stack: "s",
+		Schema:     pkgmodel.Schema{Identifier: "FileSystemId"},
+		Properties: json.RawMessage(`{"FileSystemId":"fs-abc"}`),
+	}
+	mtA := pkgmodel.Resource{
+		Ksuid: "MTA1", Label: "mtA", Type: "Test::MountTarget", Stack: "s",
+		Schema: pkgmodel.Schema{
+			Parent: "Test::FileSystem",
+			ParentMappings: []pkgmodel.ParentMapping{
+				{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+			},
+		},
+		Properties: json.RawMessage(`{"FileSystemId":{"$ref":"formae://PROD1#/FileSystemId","$value":""}}`),
+	}
+
+	// mtA is in the changeset as Update, not Create — the hardcoded lookup
+	// would silently miss its node.
+	cs, err := NewChangeset([]resource_update.ResourceUpdate{
+		{DesiredState: consumer, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
+		{DesiredState: producer, Operation: resource_update.OperationCreate},
+		{DesiredState: mtA, Operation: resource_update.OperationUpdate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
+	}, nil, "rtcupd1", pkgmodel.CommandApply)
+	if err != nil {
+		t.Fatalf("NewChangeset: %v", err)
+	}
+
+	consNode := dagNodeForOp(t, cs.DAG, consumerURI, resource_update.OperationCreate)
+	mtANode := dagNodeForOp(t, cs.DAG, mtAURI, resource_update.OperationUpdate)
+
+	// runtimeDependency child edge must fire even when the child is in the
+	// changeset as Update.
+	if !hasDependency(consNode, mtANode) {
+		t.Fatalf("consumer.create should depend on mountTargetA.update (runtimeDependency child edge must follow the child's actual operation, not a hardcoded Create)")
+	}
+}

--- a/internal/metastructure/changeset/changeset_test.go
+++ b/internal/metastructure/changeset/changeset_test.go
@@ -2470,3 +2470,267 @@ func TestBuildDeleteDependencies_RuntimeDependency_NoMatchingChildren_FallsBackT
 		t.Errorf("consumer.delete should have no dependencies, got %d", got)
 	}
 }
+
+// TestBuildCreateUpdateDependencies_RuntimeDependency_AddsChildEdges verifies
+// that a runtimeDependency edge from consumer→producer on the create phase
+// also pulls in edges from each containment child of the producer to the
+// consumer. The create order becomes: producer first, then children, then
+// consumer.
+func TestBuildCreateUpdateDependencies_RuntimeDependency_AddsChildEdges(t *testing.T) {
+	var (
+		consumerURI = pkgmodel.NewFormaeURI("CONS1", "")
+		producerURI = pkgmodel.NewFormaeURI("PROD1", "")
+		mtAURI      = pkgmodel.NewFormaeURI("MTA1", "")
+		mtBURI      = pkgmodel.NewFormaeURI("MTB1", "")
+	)
+
+	// Consumer: TaskDef-like, references producer (FileSystem) via filesystemId
+	// with a runtimeDependency edge.
+	consumer := pkgmodel.Resource{
+		Ksuid: "CONS1", Label: "consumer", Type: "Test::TaskDef", Stack: "s",
+		Schema: pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{
+			"filesystemId": {EdgeKind: pkgmodel.EdgeKindRuntimeDependency},
+		}},
+		Properties: json.RawMessage(`{
+			"filesystemId": {"$ref":"formae://PROD1#/FileSystemId","$value":""}
+		}`),
+	}
+
+	// Producer: FileSystem with a literal identifier.
+	producer := pkgmodel.Resource{
+		Ksuid: "PROD1", Label: "fs", Type: "Test::FileSystem", Stack: "s",
+		Schema: pkgmodel.Schema{
+			Identifier: "FileSystemId",
+		},
+		Properties: json.RawMessage(`{"FileSystemId":"fs-abc"}`),
+	}
+
+	// Two MountTargets whose FileSystemId Resolvable points at the producer
+	// (the create-phase URI-based parent-reference shape).
+	mtA := pkgmodel.Resource{
+		Ksuid: "MTA1", Label: "mtA", Type: "Test::MountTarget", Stack: "s",
+		Schema: pkgmodel.Schema{
+			Parent: "Test::FileSystem",
+			ParentMappings: []pkgmodel.ParentMapping{
+				{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+			},
+		},
+		Properties: json.RawMessage(`{"FileSystemId":{"$ref":"formae://PROD1#/FileSystemId","$value":""}}`),
+	}
+	mtB := pkgmodel.Resource{
+		Ksuid: "MTB1", Label: "mtB", Type: "Test::MountTarget", Stack: "s",
+		Schema: pkgmodel.Schema{
+			Parent: "Test::FileSystem",
+			ParentMappings: []pkgmodel.ParentMapping{
+				{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+			},
+		},
+		Properties: json.RawMessage(`{"FileSystemId":{"$ref":"formae://PROD1#/FileSystemId","$value":""}}`),
+	}
+
+	cs, err := NewChangeset([]resource_update.ResourceUpdate{
+		{DesiredState: consumer, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
+		{DesiredState: producer, Operation: resource_update.OperationCreate},
+		{DesiredState: mtA, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
+		{DesiredState: mtB, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
+	}, nil, "rtc1", pkgmodel.CommandApply)
+	if err != nil {
+		t.Fatalf("NewChangeset: %v", err)
+	}
+
+	consNode := dagNodeForOp(t, cs.DAG, consumerURI, resource_update.OperationCreate)
+	prodNode := dagNodeForOp(t, cs.DAG, producerURI, resource_update.OperationCreate)
+	mtANode := dagNodeForOp(t, cs.DAG, mtAURI, resource_update.OperationCreate)
+	mtBNode := dagNodeForOp(t, cs.DAG, mtBURI, resource_update.OperationCreate)
+
+	// Natural create edge: consumer.create depends on producer.create
+	// (producer first, consumer second).
+	if !hasDependency(consNode, prodNode) {
+		t.Errorf("consumer.create should depend on producer.create (natural create edge)")
+	}
+	// New runtimeDependency edges: consumer.create depends on each
+	// MountTarget.create (children first, consumer second).
+	if !hasDependency(consNode, mtANode) {
+		t.Errorf("consumer.create should depend on mountTargetA.create (runtimeDependency child edge)")
+	}
+	if !hasDependency(consNode, mtBNode) {
+		t.Errorf("consumer.create should depend on mountTargetB.create (runtimeDependency child edge)")
+	}
+	// Children/producer must not depend on the consumer (no cycles).
+	if hasDependency(prodNode, consNode) {
+		t.Errorf("producer.create should NOT depend on consumer.create")
+	}
+	if hasDependency(mtANode, consNode) {
+		t.Errorf("mountTargetA.create should NOT depend on consumer.create (cycle)")
+	}
+	if hasDependency(mtBNode, consNode) {
+		t.Errorf("mountTargetB.create should NOT depend on consumer.create (cycle)")
+	}
+}
+
+// TestBuildCreateUpdateDependencies_RuntimeDependency_InstanceSafe verifies
+// that on the create phase, runtimeDependency only pulls in containment
+// children of the *referenced* producer instance, not arbitrary children of
+// the same type.
+func TestBuildCreateUpdateDependencies_RuntimeDependency_InstanceSafe(t *testing.T) {
+	var (
+		consumerURI = pkgmodel.NewFormaeURI("CONS1", "")
+		fs1URI      = pkgmodel.NewFormaeURI("FS1", "")
+		fs2URI      = pkgmodel.NewFormaeURI("FS2", "")
+		mt1AURI     = pkgmodel.NewFormaeURI("MT1A", "")
+		mt1BURI     = pkgmodel.NewFormaeURI("MT1B", "")
+		mt2AURI     = pkgmodel.NewFormaeURI("MT2A", "")
+		mt2BURI     = pkgmodel.NewFormaeURI("MT2B", "")
+	)
+
+	consumer := pkgmodel.Resource{
+		Ksuid: "CONS1", Label: "consumer", Type: "Test::TaskDef", Stack: "s",
+		Schema: pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{
+			"filesystemId": {EdgeKind: pkgmodel.EdgeKindRuntimeDependency},
+		}},
+		Properties: json.RawMessage(`{
+			"filesystemId": {"$ref":"formae://FS1#/FileSystemId","$value":""}
+		}`),
+	}
+	fs1 := pkgmodel.Resource{
+		Ksuid: "FS1", Label: "fs1", Type: "Test::FileSystem", Stack: "s",
+		Schema:     pkgmodel.Schema{Identifier: "FileSystemId"},
+		Properties: json.RawMessage(`{"FileSystemId":"fs-1"}`),
+	}
+	fs2 := pkgmodel.Resource{
+		Ksuid: "FS2", Label: "fs2", Type: "Test::FileSystem", Stack: "s",
+		Schema:     pkgmodel.Schema{Identifier: "FileSystemId"},
+		Properties: json.RawMessage(`{"FileSystemId":"fs-2"}`),
+	}
+
+	mountTarget := func(ksuid, label, fsKsuid string) pkgmodel.Resource {
+		return pkgmodel.Resource{
+			Ksuid: ksuid, Label: label, Type: "Test::MountTarget", Stack: "s",
+			Schema: pkgmodel.Schema{
+				Parent: "Test::FileSystem",
+				ParentMappings: []pkgmodel.ParentMapping{
+					{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+				},
+			},
+			Properties: json.RawMessage(`{"FileSystemId":{"$ref":"formae://` + fsKsuid + `#/FileSystemId","$value":""}}`),
+		}
+	}
+
+	cs, err := NewChangeset([]resource_update.ResourceUpdate{
+		{DesiredState: consumer, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{fs1URI}},
+		{DesiredState: fs1, Operation: resource_update.OperationCreate},
+		{DesiredState: fs2, Operation: resource_update.OperationCreate},
+		{DesiredState: mountTarget("MT1A", "mt1A", "FS1"), Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{fs1URI}},
+		{DesiredState: mountTarget("MT1B", "mt1B", "FS1"), Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{fs1URI}},
+		{DesiredState: mountTarget("MT2A", "mt2A", "FS2"), Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{fs2URI}},
+		{DesiredState: mountTarget("MT2B", "mt2B", "FS2"), Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{fs2URI}},
+	}, nil, "rtc2", pkgmodel.CommandApply)
+	if err != nil {
+		t.Fatalf("NewChangeset: %v", err)
+	}
+
+	consNode := dagNodeForOp(t, cs.DAG, consumerURI, resource_update.OperationCreate)
+	mt1ANode := dagNodeForOp(t, cs.DAG, mt1AURI, resource_update.OperationCreate)
+	mt1BNode := dagNodeForOp(t, cs.DAG, mt1BURI, resource_update.OperationCreate)
+	mt2ANode := dagNodeForOp(t, cs.DAG, mt2AURI, resource_update.OperationCreate)
+	mt2BNode := dagNodeForOp(t, cs.DAG, mt2BURI, resource_update.OperationCreate)
+	_ = dagNodeForOp(t, cs.DAG, fs2URI, resource_update.OperationCreate) // verify present
+
+	// FS1's children get the runtimeDependency edge into the consumer.
+	if !hasDependency(consNode, mt1ANode) {
+		t.Errorf("consumer.create should depend on mt1A.create (FS1's child)")
+	}
+	if !hasDependency(consNode, mt1BNode) {
+		t.Errorf("consumer.create should depend on mt1B.create (FS1's child)")
+	}
+	// FS2's children must NOT pull the consumer in — consumer doesn't reference FS2.
+	if hasDependency(consNode, mt2ANode) {
+		t.Errorf("consumer.create should NOT depend on mt2A.create (FS2's child, not referenced)")
+	}
+	if hasDependency(consNode, mt2BNode) {
+		t.Errorf("consumer.create should NOT depend on mt2B.create (FS2's child, not referenced)")
+	}
+}
+
+// TestBuildCreateUpdateDependencies_RuntimeDependency_NoMatchingChildren_FallsBackToDefault
+// verifies that when a runtimeDependency edge fires on the create phase but no
+// containment children of the producer are in the changeset, the default
+// natural create edge (consumer depends on producer) is still added and no
+// spurious child edges appear. An unrelated resource is included to confirm
+// that the children-scan loop does not produce false positives.
+func TestBuildCreateUpdateDependencies_RuntimeDependency_NoMatchingChildren_FallsBackToDefault(t *testing.T) {
+	var (
+		consumerURI  = pkgmodel.NewFormaeURI("CONS1", "")
+		producerURI  = pkgmodel.NewFormaeURI("PROD1", "")
+		unrelatedURI = pkgmodel.NewFormaeURI("UNREL1", "")
+	)
+
+	consumer := pkgmodel.Resource{
+		Ksuid: "CONS1", Label: "consumer", Type: "Test::TaskDef", Stack: "s",
+		Schema: pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{
+			"filesystemId": {EdgeKind: pkgmodel.EdgeKindRuntimeDependency},
+		}},
+		Properties: json.RawMessage(`{
+			"filesystemId": {"$ref":"formae://PROD1#/FileSystemId","$value":""}
+		}`),
+	}
+	producer := pkgmodel.Resource{
+		Ksuid: "PROD1", Label: "fs", Type: "Test::FileSystem", Stack: "s",
+		Schema:     pkgmodel.Schema{Identifier: "FileSystemId"},
+		Properties: json.RawMessage(`{"FileSystemId":"fs-abc"}`),
+	}
+	// Unrelated resource with a Resolvable that does NOT reference the producer.
+	// Confirms the children-scan loop doesn't fire spurious edges for resources
+	// whose parent type doesn't match the producer.
+	unrelated := pkgmodel.Resource{
+		Ksuid: "UNREL1", Label: "unrelated", Type: "Test::Other", Stack: "s",
+		Schema: pkgmodel.Schema{
+			Parent: "Test::SomethingElse",
+			ParentMappings: []pkgmodel.ParentMapping{
+				{ParentProperty: "OtherId", ChildProperty: "OtherId"},
+			},
+		},
+		Properties: json.RawMessage(`{"OtherId":"other-1"}`),
+	}
+
+	cs, err := NewChangeset([]resource_update.ResourceUpdate{
+		{DesiredState: consumer, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
+		{DesiredState: producer, Operation: resource_update.OperationCreate},
+		{DesiredState: unrelated, Operation: resource_update.OperationCreate},
+	}, nil, "rtc3", pkgmodel.CommandApply)
+	if err != nil {
+		t.Fatalf("NewChangeset: %v", err)
+	}
+
+	consNode := dagNodeForOp(t, cs.DAG, consumerURI, resource_update.OperationCreate)
+	prodNode := dagNodeForOp(t, cs.DAG, producerURI, resource_update.OperationCreate)
+	unrelNode := dagNodeForOp(t, cs.DAG, unrelatedURI, resource_update.OperationCreate)
+
+	// Default create edge: consumer.create depends on producer.create.
+	if !hasDependency(consNode, prodNode) {
+		t.Errorf("consumer.create should depend on producer.create (default edge under runtimeDependency)")
+	}
+	// No reverse edge.
+	if hasDependency(prodNode, consNode) {
+		t.Errorf("producer.create should NOT depend on consumer.create")
+	}
+	// Consumer should have exactly one dependency (the producer) — no spurious
+	// edges from absent children or unrelated resources.
+	if got := len(consNode.Dependencies); got != 1 {
+		t.Errorf("consumer.create should have exactly 1 dependency, got %d", got)
+	}
+	// Consumer's only dependency is the producer.
+	if consNode.Dependencies[0] != prodNode {
+		t.Errorf("consumer.create's only dependency should be producer.create")
+	}
+	// Producer should have no dependencies (it's the entry point on the create
+	// phase).
+	if got := len(prodNode.Dependencies); got != 0 {
+		t.Errorf("producer.create should have no dependencies, got %d", got)
+	}
+	// Unrelated resource should have no dependencies — it doesn't reference
+	// anything in the changeset.
+	if got := len(unrelNode.Dependencies); got != 0 {
+		t.Errorf("unrelated.create should have no dependencies, got %d", got)
+	}
+}

--- a/internal/metastructure/changeset/child_points_at.go
+++ b/internal/metastructure/changeset/child_points_at.go
@@ -5,8 +5,6 @@
 package changeset
 
 import (
-	"github.com/tidwall/gjson"
-
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
@@ -70,53 +68,25 @@ func childPointsAt(
 // key on the child side. They can diverge — e.g., TaskSet→Service maps
 // "ServiceName"→"Service" — so we look each up separately.
 //
-// Post-apply the resolver leaves cross-resource references in the Resolvable
-// shape `{"$ref": ..., "$value": ...}` rather than collapsing them to a
-// literal scalar. We must unwrap `$value` before comparing — otherwise a child
-// whose ChildProperty is Resolvable and a producer whose ParentProperty is a
-// literal would never compare equal even when they identify the same instance.
+// Post-apply the resolver leaves cross-resource references in the resolved-
+// reference shape `{"$ref": ..., "$value": ...}` rather than collapsing them
+// to a literal scalar. Resource.GetEffectivePropertyValue unwraps that for us
+// — otherwise a child whose ChildProperty is a resolved reference and a
+// producer whose ParentProperty is a literal would never compare equal even
+// when they identify the same instance.
 func destroySideMatches(k, producer *resource_update.ResourceUpdate, m pkgmodel.ParentMapping) bool {
-	kVal, ok := getEffectivePropertyValue(k.DesiredState.Properties, m.ChildProperty)
+	kVal, ok := k.DesiredState.GetEffectivePropertyValue(m.ChildProperty)
 	if !ok {
 		return false
 	}
 
 	// Producer's value is keyed by ParentProperty (which equals Schema.Identifier
 	// when the relationship pins on the parent's primary identifier).
-	pVal, ok := getEffectivePropertyValue(producer.DesiredState.Properties, m.ParentProperty)
+	pVal, ok := producer.DesiredState.GetEffectivePropertyValue(m.ParentProperty)
 	if !ok {
 		return false
 	}
 	return kVal == pVal
-}
-
-// getEffectivePropertyValue returns the unwrapped scalar value of a property.
-//
-// If the property is a Resolvable object (`{"$ref": ..., "$value": ...}`),
-// returns `$value` — this is the shape the resolver leaves on persisted
-// properties post-apply. If the property is a literal scalar, returns it
-// directly.
-//
-// Returns false when the property doesn't exist, isn't a scalar, or is a
-// non-Resolvable object — none of those are valid for parent-mapping equality.
-func getEffectivePropertyValue(props []byte, propName string) (string, bool) {
-	result := gjson.GetBytes(props, propName)
-	if !result.Exists() {
-		return "", false
-	}
-	if result.IsObject() {
-		// Resolvable shape: {"$ref": ..., "$value": ...} — unwrap to $value.
-		if result.Get("$ref").Exists() {
-			v := result.Get("$value")
-			if !v.Exists() {
-				return "", false
-			}
-			return v.String(), true
-		}
-		// Non-Resolvable object — not a valid scalar for parent-mapping comparison.
-		return "", false
-	}
-	return result.String(), true
 }
 
 // createSideMatches is the create-phase counterpart to destroySideMatches.
@@ -153,7 +123,7 @@ func createSideMatches(
 	m pkgmodel.ParentMapping,
 	baseResources map[pkgmodel.FormaeURI]*resource_update.ResourceUpdate,
 ) bool {
-	kRef, ok := extractResolvableURI(k.DesiredState.Properties, m.ChildProperty)
+	kRef, ok := k.DesiredState.GetPropertyReference(m.ChildProperty)
 	if !ok {
 		return false
 	}
@@ -167,31 +137,10 @@ func createSideMatches(
 	// Sibling reference (referenced resource has a different type, or is not
 	// in the current changeset at all). K and producer must point at the same
 	// third resource. Read producer's value at m.ParentProperty — it should
-	// also be a Resolvable.
-	pRef, ok := extractResolvableURI(producer.DesiredState.Properties, m.ParentProperty)
+	// also be a resolved reference.
+	pRef, ok := producer.DesiredState.GetPropertyReference(m.ParentProperty)
 	if !ok {
 		return false
 	}
 	return kRef.Stripped() == pRef.Stripped()
-}
-
-// extractResolvableURI reads `propName` out of `props` (raw JSON) and returns
-// the underlying FormaeURI when the value is a Resolvable object of the form
-// `{"$ref": "<uri>", "$value": ...}`. Returns false for literal values,
-// non-object values, or objects without a `$ref` key — none of which can be
-// chased to a base resource for type discrimination.
-//
-// Uses gjson against the raw Properties JSON (Properties is json.RawMessage,
-// not a parsed map) to match the convention used by the surrounding
-// dependency-extraction code in resolver and resource_update.
-func extractResolvableURI(props []byte, propName string) (pkgmodel.FormaeURI, bool) {
-	field := gjson.GetBytes(props, propName)
-	if !field.IsObject() {
-		return "", false
-	}
-	ref := field.Get("$ref")
-	if !ref.Exists() {
-		return "", false
-	}
-	return pkgmodel.FormaeURI(ref.String()), true
 }

--- a/internal/metastructure/changeset/child_points_at.go
+++ b/internal/metastructure/changeset/child_points_at.go
@@ -1,0 +1,99 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package changeset
+
+import (
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// childPointsAt returns true iff `k`'s parent-reference properties identify
+// `producer` as its parent instance.
+//
+// Returns false when `k.DesiredState.Schema.ParentMappings` is empty: without
+// mappings, instance membership cannot be proven — the rule conservatively
+// does not fire and the engine falls back to default edge behavior.
+//
+// The mappings are AND-combined: every mapping must match for the function
+// to return true. This is what makes the rule "instance-safe" for composite
+// parent relationships (e.g., ECS TaskSet whose parent Service is keyed by
+// ServiceName + Cluster rather than a single ARN).
+//
+// Phases:
+//   - OperationDelete: compares actual property values on both sides — the
+//     destroy planner already operates on the resource snapshot captured in
+//     DesiredState, so we read literal values from there.
+//   - OperationCreate: not yet implemented (Task 2.4). The create branch needs
+//     to chase Resolvable references through baseResources to compare URIs.
+//
+// `baseResources` is the changeset's index from stripped FormaeURI to the
+// base (Create/Replace/Update) ResourceUpdate that produces that URI. It is
+// only consulted in the create branch — destroy passes nil.
+func childPointsAt(
+	k, producer *resource_update.ResourceUpdate,
+	phase resource_update.OperationType,
+	baseResources map[pkgmodel.FormaeURI]*resource_update.ResourceUpdate,
+) bool {
+	mappings := k.DesiredState.Schema.ParentMappings
+	if len(mappings) == 0 {
+		return false
+	}
+	for _, m := range mappings {
+		switch phase {
+		case resource_update.OperationDelete:
+			if !destroySideMatches(k, producer, m) {
+				return false
+			}
+		case resource_update.OperationCreate:
+			if !createSideMatches(k, producer, m, baseResources) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// destroySideMatches checks one parent mapping on the destroy path by reading
+// literal property values from both sides' DesiredState. The destroy planner
+// works off the snapshot of the resource being torn down — which is stored in
+// DesiredState — so we read child and producer values from there.
+//
+// ParentProperty names the key on the producer side, ChildProperty names the
+// key on the child side. They can diverge — e.g., TaskSet→Service maps
+// "ServiceName"→"Service" — so we look each up separately.
+func destroySideMatches(k, producer *resource_update.ResourceUpdate, m pkgmodel.ParentMapping) bool {
+	kVal, ok := k.DesiredState.GetProperty(m.ChildProperty)
+	if !ok {
+		return false
+	}
+
+	// Producer's value is keyed by ParentProperty (which equals Schema.Identifier
+	// when the relationship pins on the parent's primary identifier).
+	producerKey := m.ParentProperty
+
+	pVal, ok := producer.DesiredState.GetProperty(producerKey)
+	if !ok {
+		return false
+	}
+	return kVal == pVal
+}
+
+// createSideMatches is the create-phase counterpart to destroySideMatches.
+// Implemented in Task 2.4. Until then, panics if reached so an out-of-order
+// task land does not silently degrade runtimeDependency create-side edges
+// into default edges.
+func createSideMatches(
+	k, producer *resource_update.ResourceUpdate,
+	m pkgmodel.ParentMapping,
+	baseResources map[pkgmodel.FormaeURI]*resource_update.ResourceUpdate,
+) bool {
+	_ = k
+	_ = producer
+	_ = m
+	_ = baseResources
+	panic("createSideMatches not yet implemented (RFC-0043 Task 2.4)")
+}

--- a/internal/metastructure/changeset/child_points_at.go
+++ b/internal/metastructure/changeset/child_points_at.go
@@ -5,6 +5,8 @@
 package changeset
 
 import (
+	"github.com/tidwall/gjson"
+
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
@@ -83,17 +85,77 @@ func destroySideMatches(k, producer *resource_update.ResourceUpdate, m pkgmodel.
 }
 
 // createSideMatches is the create-phase counterpart to destroySideMatches.
-// Implemented in Task 2.4. Until then, panics if reached so an out-of-order
-// task land does not silently degrade runtimeDependency create-side edges
-// into default edges.
+//
+// At create time the child's parent-reference property does not yet hold a
+// literal (the producer has not been created), but a Resolvable carrying the
+// producer's KSUID-based FormaeURI. We chase that URI through baseResources
+// (the changeset's URI-indexed view of every Create/Replace/Update operation)
+// to compare identities rather than concrete property values.
+//
+// Two reference shapes are possible and they are discriminated by Type:
+//
+//   - **Parent reference** — the K-side URI resolves to a resource whose Type
+//     matches `k.DesiredState.Schema.Parent`. In this case the mapping is
+//     simply asserting "K points at its parent"; the match holds iff the
+//     URI equals `producer`'s URI.
+//   - **Sibling reference** — the K-side URI resolves to some other resource
+//     (typically a peer that K and producer both reference, e.g., an ECS
+//     Cluster shared by TaskSet and Service). In this case the producer must
+//     also carry a Resolvable at `ParentProperty` pointing at the same third
+//     resource; the match holds iff K's and producer's URIs are equal after
+//     stripping property paths.
+//
+// `baseResources` is consulted purely for the type discriminator. A missing
+// entry — e.g., the K-side URI points at a resource outside the current
+// changeset — yields no match: without knowing the referenced resource's
+// type we cannot tell whether this is a parent or sibling reference and must
+// conservatively decline.
 func createSideMatches(
 	k, producer *resource_update.ResourceUpdate,
 	m pkgmodel.ParentMapping,
 	baseResources map[pkgmodel.FormaeURI]*resource_update.ResourceUpdate,
 ) bool {
-	_ = k
-	_ = producer
-	_ = m
-	_ = baseResources
-	panic("createSideMatches not yet implemented (RFC-0043 Task 2.4)")
+	kRef, ok := extractResolvableURI(k.DesiredState.Properties, m.ChildProperty)
+	if !ok {
+		return false
+	}
+
+	kIndexed, found := baseResources[kRef.Stripped()]
+	if !found {
+		return false
+	}
+
+	if kIndexed.DesiredState.Type == k.DesiredState.Schema.Parent {
+		// Parent reference: K's URI must equal producer's URI.
+		return kRef.Stripped() == producer.URI().Stripped()
+	}
+
+	// Sibling reference: K and producer must point at the same third resource.
+	// Read producer's value at m.ParentProperty — it should also be a Resolvable.
+	pRef, ok := extractResolvableURI(producer.DesiredState.Properties, m.ParentProperty)
+	if !ok {
+		return false
+	}
+	return kRef.Stripped() == pRef.Stripped()
+}
+
+// extractResolvableURI reads `propName` out of `props` (raw JSON) and returns
+// the underlying FormaeURI when the value is a Resolvable object of the form
+// `{"$ref": "<uri>", "$value": ...}`. Returns false for literal values,
+// non-object values, or objects without a `$ref` key — none of which can be
+// chased to a base resource for type discrimination.
+//
+// Uses gjson against the raw Properties JSON (Properties is json.RawMessage,
+// not a parsed map) to match the convention used by the surrounding
+// dependency-extraction code in resolver and resource_update.
+func extractResolvableURI(props []byte, propName string) (pkgmodel.FormaeURI, bool) {
+	field := gjson.GetBytes(props, propName)
+	if !field.IsObject() {
+		return "", false
+	}
+	ref := field.Get("$ref")
+	if !ref.Exists() {
+		return "", false
+	}
+	return pkgmodel.FormaeURI(ref.String()), true
 }

--- a/internal/metastructure/changeset/child_points_at.go
+++ b/internal/metastructure/changeset/child_points_at.go
@@ -60,28 +60,61 @@ func childPointsAt(
 }
 
 // destroySideMatches checks one parent mapping on the destroy path by reading
-// literal property values from both sides' DesiredState. The destroy planner
+// effective property values from both sides' DesiredState. The destroy planner
 // works off the snapshot of the resource being torn down — which is stored in
 // DesiredState — so we read child and producer values from there.
 //
 // ParentProperty names the key on the producer side, ChildProperty names the
 // key on the child side. They can diverge — e.g., TaskSet→Service maps
 // "ServiceName"→"Service" — so we look each up separately.
+//
+// Post-apply the resolver leaves cross-resource references in the Resolvable
+// shape `{"$ref": ..., "$value": ...}` rather than collapsing them to a
+// literal scalar. We must unwrap `$value` before comparing — otherwise a child
+// whose ChildProperty is Resolvable and a producer whose ParentProperty is a
+// literal would never compare equal even when they identify the same instance.
 func destroySideMatches(k, producer *resource_update.ResourceUpdate, m pkgmodel.ParentMapping) bool {
-	kVal, ok := k.DesiredState.GetProperty(m.ChildProperty)
+	kVal, ok := getEffectivePropertyValue(k.DesiredState.Properties, m.ChildProperty)
 	if !ok {
 		return false
 	}
 
 	// Producer's value is keyed by ParentProperty (which equals Schema.Identifier
 	// when the relationship pins on the parent's primary identifier).
-	producerKey := m.ParentProperty
-
-	pVal, ok := producer.DesiredState.GetProperty(producerKey)
+	pVal, ok := getEffectivePropertyValue(producer.DesiredState.Properties, m.ParentProperty)
 	if !ok {
 		return false
 	}
 	return kVal == pVal
+}
+
+// getEffectivePropertyValue returns the unwrapped scalar value of a property.
+//
+// If the property is a Resolvable object (`{"$ref": ..., "$value": ...}`),
+// returns `$value` — this is the shape the resolver leaves on persisted
+// properties post-apply. If the property is a literal scalar, returns it
+// directly.
+//
+// Returns false when the property doesn't exist, isn't a scalar, or is a
+// non-Resolvable object — none of those are valid for parent-mapping equality.
+func getEffectivePropertyValue(props []byte, propName string) (string, bool) {
+	result := gjson.GetBytes(props, propName)
+	if !result.Exists() {
+		return "", false
+	}
+	if result.IsObject() {
+		// Resolvable shape: {"$ref": ..., "$value": ...} — unwrap to $value.
+		if result.Get("$ref").Exists() {
+			v := result.Get("$value")
+			if !v.Exists() {
+				return "", false
+			}
+			return v.String(), true
+		}
+		// Non-Resolvable object — not a valid scalar for parent-mapping comparison.
+		return "", false
+	}
+	return result.String(), true
 }
 
 // createSideMatches is the create-phase counterpart to destroySideMatches.

--- a/internal/metastructure/changeset/child_points_at.go
+++ b/internal/metastructure/changeset/child_points_at.go
@@ -27,8 +27,10 @@ import (
 //   - OperationDelete: compares actual property values on both sides — the
 //     destroy planner already operates on the resource snapshot captured in
 //     DesiredState, so we read literal values from there.
-//   - OperationCreate: not yet implemented (Task 2.4). The create branch needs
-//     to chase Resolvable references through baseResources to compare URIs.
+//   - OperationCreate: chases Resolvable references through baseResources to
+//     compare URIs. The child's parent-reference field holds a Resolvable
+//     carrying the producer's KSUID-based FormaeURI rather than a literal at
+//     create time, so identity matching is done on URIs rather than values.
 //
 // `baseResources` is the changeset's index from stripped FormaeURI to the
 // base (Create/Replace/Update) ResourceUpdate that produces that URI. It is
@@ -125,24 +127,27 @@ func getEffectivePropertyValue(props []byte, propName string) (string, bool) {
 // (the changeset's URI-indexed view of every Create/Replace/Update operation)
 // to compare identities rather than concrete property values.
 //
-// Two reference shapes are possible and they are discriminated by Type:
+// Two reference shapes are possible:
 //
-//   - **Parent reference** — the K-side URI resolves to a resource whose Type
-//     matches `k.DesiredState.Schema.Parent`. In this case the mapping is
-//     simply asserting "K points at its parent"; the match holds iff the
-//     URI equals `producer`'s URI.
-//   - **Sibling reference** — the K-side URI resolves to some other resource
-//     (typically a peer that K and producer both reference, e.g., an ECS
-//     Cluster shared by TaskSet and Service). In this case the producer must
-//     also carry a Resolvable at `ParentProperty` pointing at the same third
+//   - **Parent reference** — the K-side URI resolves to a resource (in
+//     baseResources) whose Type matches `k.DesiredState.Schema.Parent`. In
+//     this case the mapping is simply asserting "K points at its parent"; the
+//     match holds iff the URI equals `producer`'s URI.
+//   - **Sibling reference** — the K-side URI does NOT resolve to a parent-
+//     typed resource. This covers two sub-cases: (a) the referenced resource
+//     is in baseResources but has a different type (a peer K and producer
+//     share, e.g., an ECS Cluster), or (b) the referenced resource is outside
+//     the current changeset (unchanged sibling whose KSUID still appears as a
+//     Resolvable on both K and producer). In either sub-case the producer
+//     must also carry a Resolvable at `ParentProperty` pointing at the same
 //     resource; the match holds iff K's and producer's URIs are equal after
 //     stripping property paths.
 //
-// `baseResources` is consulted purely for the type discriminator. A missing
-// entry — e.g., the K-side URI points at a resource outside the current
-// changeset — yields no match: without knowing the referenced resource's
-// type we cannot tell whether this is a parent or sibling reference and must
-// conservatively decline.
+// `baseResources` is consulted only as a type discriminator for the parent-
+// reference shortcut. If the referenced resource is absent we fall through to
+// the sibling comparison rather than declining — otherwise composite-parent
+// matches with an external shared resource (Service+TaskSet both pointing at
+// a Cluster outside the changeset) would never fire.
 func createSideMatches(
 	k, producer *resource_update.ResourceUpdate,
 	m pkgmodel.ParentMapping,
@@ -153,18 +158,16 @@ func createSideMatches(
 		return false
 	}
 
-	kIndexed, found := baseResources[kRef.Stripped()]
-	if !found {
-		return false
-	}
-
-	if kIndexed.DesiredState.Type == k.DesiredState.Schema.Parent {
+	if kIndexed, found := baseResources[kRef.Stripped()]; found &&
+		kIndexed.DesiredState.Type == k.DesiredState.Schema.Parent {
 		// Parent reference: K's URI must equal producer's URI.
 		return kRef.Stripped() == producer.URI().Stripped()
 	}
 
-	// Sibling reference: K and producer must point at the same third resource.
-	// Read producer's value at m.ParentProperty — it should also be a Resolvable.
+	// Sibling reference (referenced resource has a different type, or is not
+	// in the current changeset at all). K and producer must point at the same
+	// third resource. Read producer's value at m.ParentProperty — it should
+	// also be a Resolvable.
 	pRef, ok := extractResolvableURI(producer.DesiredState.Properties, m.ParentProperty)
 	if !ok {
 		return false

--- a/internal/metastructure/changeset/child_points_at_test.go
+++ b/internal/metastructure/changeset/child_points_at_test.go
@@ -129,3 +129,41 @@ func TestChildPointsAt_Destroy_MissingChildProperty_ReturnsFalse(t *testing.T) {
 	}
 	require.False(t, childPointsAt(child, producer, resource_update.OperationDelete, nil))
 }
+
+// TestChildPointsAt_Destroy_Composite_MatchesOnlyCorrectInstance exercises the
+// AND-of-mappings semantics of composite parent mappings. A TaskSet under
+// ECS::Service is identified by (ServiceName, Cluster). Two services share the
+// same ServiceName but live in different clusters; the TaskSet must match only
+// its own parent, distinguished by Cluster.
+func TestChildPointsAt_Destroy_Composite_MatchesOnlyCorrectInstance(t *testing.T) {
+	// Two Services with same ServiceName but different Cluster
+	svc1 := makeResourceUpdate(t, "AWS::ECS::Service", "S1", map[string]any{
+		"Ref":         "arn:aws:ecs:.../foo/c1",
+		"ServiceName": "foo",
+		"Cluster":     "cluster-1",
+	})
+	svc1.DesiredState.Schema.Identifier = "Ref"
+
+	svc2 := makeResourceUpdate(t, "AWS::ECS::Service", "S2", map[string]any{
+		"Ref":         "arn:aws:ecs:.../foo/c2",
+		"ServiceName": "foo",
+		"Cluster":     "cluster-2",
+	})
+	svc2.DesiredState.Schema.Identifier = "Ref"
+
+	// TaskSet under svc1
+	ts1 := makeResourceUpdate(t, "AWS::ECS::TaskSet", "TS1", map[string]any{
+		"Service": "foo",
+		"Cluster": "cluster-1",
+	})
+	ts1.DesiredState.Schema.Parent = "AWS::ECS::Service"
+	ts1.DesiredState.Schema.ParentMappings = []pkgmodel.ParentMapping{
+		{ParentProperty: "ServiceName", ChildProperty: "Service"},
+		{ParentProperty: "Cluster", ChildProperty: "Cluster"},
+	}
+
+	// Matches svc1 (own parent)
+	require.True(t, childPointsAt(ts1, svc1, resource_update.OperationDelete, nil))
+	// Does NOT match svc2 (same ServiceName, different Cluster)
+	require.False(t, childPointsAt(ts1, svc2, resource_update.OperationDelete, nil))
+}

--- a/internal/metastructure/changeset/child_points_at_test.go
+++ b/internal/metastructure/changeset/child_points_at_test.go
@@ -1,0 +1,131 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package changeset
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// makeResourceUpdate constructs a *resource_update.ResourceUpdate suitable for
+// childPointsAt tests. The `properties` map is marshalled into DesiredState.Properties
+// as raw JSON — both create and delete operations read property values from
+// DesiredState (the destroy path treats DesiredState as the snapshot of the
+// resource being torn down). Caller may pass nil for `properties` when no
+// payload is required (e.g., bare producer in create-phase tests).
+//
+// The returned ResourceUpdate has:
+//   - A generated KSUID and matching URI
+//   - DesiredState populated with type, label, and (optional) properties
+//   - An empty Schema; callers override Schema.Identifier / Schema.Parent /
+//     Schema.ParentMappings as needed.
+//
+// Lives in this _test.go file (rather than a dedicated test_helpers file)
+// because Go test helpers in the same package are reachable from sibling
+// _test.go files — future tests (Tasks 2.3, 2.4, 2.5) can call this directly.
+func makeResourceUpdate(t *testing.T, resourceType, label string, properties map[string]any) *resource_update.ResourceUpdate {
+	t.Helper()
+
+	ksuid := util.NewID()
+
+	var propsJSON json.RawMessage
+	if properties != nil {
+		b, err := json.Marshal(properties)
+		require.NoError(t, err, "marshal properties for %s/%s", resourceType, label)
+		propsJSON = b
+	}
+
+	return &resource_update.ResourceUpdate{
+		DesiredState: pkgmodel.Resource{
+			Ksuid:      ksuid,
+			Label:      label,
+			Type:       resourceType,
+			Stack:      "test-stack",
+			Properties: propsJSON,
+		},
+		Operation:  resource_update.OperationDelete,
+		StackLabel: "test-stack",
+	}
+}
+
+func TestChildPointsAt_Destroy_SingleMapping_Match(t *testing.T) {
+	producer := makeResourceUpdate(t, "AWS::EFS::FileSystem", "grafanaEfs", map[string]any{
+		"FileSystemId": "fs-abc123",
+	})
+	producer.DesiredState.Schema.Identifier = "FileSystemId"
+
+	child := makeResourceUpdate(t, "AWS::EFS::MountTarget", "mtA", map[string]any{
+		"FileSystemId": "fs-abc123",
+	})
+	child.DesiredState.Schema.Parent = "AWS::EFS::FileSystem"
+	child.DesiredState.Schema.ParentMappings = []pkgmodel.ParentMapping{
+		{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+	}
+
+	ok := childPointsAt(child, producer, resource_update.OperationDelete, nil)
+	require.True(t, ok)
+}
+
+func TestChildPointsAt_Destroy_SingleMapping_NoMatch(t *testing.T) {
+	producer := makeResourceUpdate(t, "AWS::EFS::FileSystem", "grafanaEfs", map[string]any{
+		"FileSystemId": "fs-abc123",
+	})
+	producer.DesiredState.Schema.Identifier = "FileSystemId"
+
+	child := makeResourceUpdate(t, "AWS::EFS::MountTarget", "mtX", map[string]any{
+		"FileSystemId": "fs-different", // points at a different FileSystem
+	})
+	child.DesiredState.Schema.Parent = "AWS::EFS::FileSystem"
+	child.DesiredState.Schema.ParentMappings = []pkgmodel.ParentMapping{
+		{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+	}
+
+	ok := childPointsAt(child, producer, resource_update.OperationDelete, nil)
+	require.False(t, ok)
+}
+
+// TestChildPointsAt_EmptyMappings_ReturnsFalse locks in the invariant promised
+// by the doc comment: when ParentMappings is empty, instance membership cannot
+// be proven and the function conservatively returns false.
+func TestChildPointsAt_EmptyMappings_ReturnsFalse(t *testing.T) {
+	producer := makeResourceUpdate(t, "AWS::EFS::FileSystem", "fs", map[string]any{"FileSystemId": "fs-1"})
+	child := makeResourceUpdate(t, "AWS::EFS::MountTarget", "mt", map[string]any{"FileSystemId": "fs-1"})
+	// ParentMappings is left nil/empty
+	require.False(t, childPointsAt(child, producer, resource_update.OperationDelete, nil))
+}
+
+// TestChildPointsAt_UnknownPhase_ReturnsFalse locks in the default-branch
+// behavior: any phase that is neither OperationCreate nor OperationDelete must
+// return false. OperationType is a string, so the zero value "" is a safe
+// out-of-band value distinct from all real operations.
+func TestChildPointsAt_UnknownPhase_ReturnsFalse(t *testing.T) {
+	producer := makeResourceUpdate(t, "AWS::EFS::FileSystem", "fs", map[string]any{"FileSystemId": "fs-1"})
+	child := makeResourceUpdate(t, "AWS::EFS::MountTarget", "mt", map[string]any{"FileSystemId": "fs-1"})
+	child.DesiredState.Schema.Parent = "AWS::EFS::FileSystem"
+	child.DesiredState.Schema.ParentMappings = []pkgmodel.ParentMapping{
+		{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+	}
+	var unknownPhase resource_update.OperationType // zero value, distinct from Create/Delete
+	require.False(t, childPointsAt(child, producer, unknownPhase, nil))
+}
+
+// TestChildPointsAt_Destroy_MissingChildProperty_ReturnsFalse locks in the
+// invariant that destroySideMatches returns false when the child has no value
+// under its ChildProperty key — there is nothing to compare against.
+func TestChildPointsAt_Destroy_MissingChildProperty_ReturnsFalse(t *testing.T) {
+	producer := makeResourceUpdate(t, "AWS::EFS::FileSystem", "fs", map[string]any{"FileSystemId": "fs-1"})
+	child := makeResourceUpdate(t, "AWS::EFS::MountTarget", "mt", map[string]any{}) // no FileSystemId
+	child.DesiredState.Schema.Parent = "AWS::EFS::FileSystem"
+	child.DesiredState.Schema.ParentMappings = []pkgmodel.ParentMapping{
+		{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+	}
+	require.False(t, childPointsAt(child, producer, resource_update.OperationDelete, nil))
+}

--- a/internal/metastructure/changeset/child_points_at_test.go
+++ b/internal/metastructure/changeset/child_points_at_test.go
@@ -355,3 +355,82 @@ func TestChildPointsAt_Destroy_Composite_MatchesOnlyCorrectInstance(t *testing.T
 	// Does NOT match svc2 (same ServiceName, different Cluster)
 	require.False(t, childPointsAt(ts1, svc2, resource_update.OperationDelete, nil))
 }
+
+// TestChildPointsAt_Create_Composite_ExternalSibling_StillMatches guards
+// against an over-strict baseResources lookup: when the K-side resolvable
+// for the sibling half of a composite mapping points at a resource that is
+// not in the current changeset (an unchanged Cluster that both Service and
+// TaskSet are anchored on), createSideMatches must still fall through to a
+// direct URI comparison between the child's and producer's resolvables.
+//
+// The original implementation declined as soon as the K-side URI was missing
+// from baseResources — silently breaking composite-parent matches with
+// external shared resources, which is the common case in incremental
+// reconciliation.
+func TestChildPointsAt_Create_Composite_ExternalSibling_StillMatches(t *testing.T) {
+	// Cluster is intentionally NOT registered in baseResources — it's an
+	// existing, unchanged resource that lives outside the current changeset.
+	cluster := makeResourceUpdate(t, "AWS::ECS::Cluster", "c1", nil)
+
+	svc1 := makeResourceUpdate(t, "AWS::ECS::Service", "S1", map[string]any{
+		"ServiceName": "foo",
+		"Cluster":     makeResolvable(cluster.URI(), "ClusterName"),
+	})
+	svc1.DesiredState.Schema.Identifier = "Ref"
+
+	ts1 := makeResourceUpdate(t, "AWS::ECS::TaskSet", "TS1", map[string]any{
+		"Service": makeResolvable(svc1.URI(), "ServiceName"),
+		"Cluster": makeResolvable(cluster.URI(), "ClusterName"),
+	})
+	ts1.DesiredState.Schema.Parent = "AWS::ECS::Service"
+	ts1.DesiredState.Schema.ParentMappings = []pkgmodel.ParentMapping{
+		{ParentProperty: "ServiceName", ChildProperty: "Service"},
+		{ParentProperty: "Cluster", ChildProperty: "Cluster"},
+	}
+
+	// baseResources knows about the parent (svc1) but NOT the shared Cluster.
+	baseRes := map[pkgmodel.FormaeURI]*resource_update.ResourceUpdate{
+		svc1.URI().Stripped(): svc1,
+	}
+
+	// Match still holds: the Service mapping resolves to svc1 in baseResources
+	// (parent reference), and the Cluster mapping falls through to direct URI
+	// comparison even though the Cluster is absent from baseResources.
+	require.True(t, childPointsAt(ts1, svc1, resource_update.OperationCreate, baseRes))
+}
+
+// TestChildPointsAt_Create_Composite_ExternalSibling_DiverginRefsNoMatch is
+// the negative counterpart: when the K-side and producer-side resolvables
+// for the sibling mapping point at *different* external resources, the
+// match must NOT fire. Guards against the fall-through accidentally treating
+// "neither side knows what it's pointing at" as a match.
+func TestChildPointsAt_Create_Composite_ExternalSibling_DiverginRefsNoMatch(t *testing.T) {
+	cluster1 := makeResourceUpdate(t, "AWS::ECS::Cluster", "c1", nil)
+	cluster2 := makeResourceUpdate(t, "AWS::ECS::Cluster", "c2", nil)
+
+	svc1 := makeResourceUpdate(t, "AWS::ECS::Service", "S1", map[string]any{
+		"ServiceName": "foo",
+		// Service points at cluster1.
+		"Cluster": makeResolvable(cluster1.URI(), "ClusterName"),
+	})
+	svc1.DesiredState.Schema.Identifier = "Ref"
+
+	ts1 := makeResourceUpdate(t, "AWS::ECS::TaskSet", "TS1", map[string]any{
+		"Service": makeResolvable(svc1.URI(), "ServiceName"),
+		// TaskSet points at cluster2 — divergent from the service's Cluster.
+		"Cluster": makeResolvable(cluster2.URI(), "ClusterName"),
+	})
+	ts1.DesiredState.Schema.Parent = "AWS::ECS::Service"
+	ts1.DesiredState.Schema.ParentMappings = []pkgmodel.ParentMapping{
+		{ParentProperty: "ServiceName", ChildProperty: "Service"},
+		{ParentProperty: "Cluster", ChildProperty: "Cluster"},
+	}
+
+	baseRes := map[pkgmodel.FormaeURI]*resource_update.ResourceUpdate{
+		svc1.URI().Stripped(): svc1,
+	}
+
+	// Service mapping matches (parent reference), but Cluster mapping fails:
+	// the K-side and producer-side resolvables target different cluster URIs.
+	require.False(t, childPointsAt(ts1, svc1, resource_update.OperationCreate, baseRes))
+}

--- a/internal/metastructure/changeset/child_points_at_test.go
+++ b/internal/metastructure/changeset/child_points_at_test.go
@@ -265,6 +265,59 @@ func TestChildPointsAt_Create_LiteralChildProperty_ReturnsFalse(t *testing.T) {
 	require.False(t, childPointsAt(child, producer, resource_update.OperationCreate, baseRes))
 }
 
+// TestChildPointsAt_Destroy_ResolvableChildProperty_Match locks in the
+// post-apply reality that motivated RFC-0043: the resolver leaves a child's
+// parent-reference property in the Resolvable shape
+// (`{"$ref": ..., "$value": ...}`) rather than collapsing it to a literal. The
+// destroy planner must unwrap `$value` when comparing against the producer's
+// literal identifier, otherwise runtimeDependency child edges never fire for
+// realistic resources (EFS MountTarget, etc.).
+func TestChildPointsAt_Destroy_ResolvableChildProperty_Match(t *testing.T) {
+	producer := makeResourceUpdate(t, "AWS::EFS::FileSystem", "fs", map[string]any{
+		"FileSystemId": "fs-abc123", // producer's identifier is literal post-apply
+	})
+	producer.DesiredState.Schema.Identifier = "FileSystemId"
+
+	// Child's FileSystemId is in the Resolvable shape the resolver leaves behind
+	// post-apply: {"$ref": "formae://<producer-ksuid>#/FileSystemId", "$value": "fs-abc123"}.
+	child := makeResourceUpdate(t, "AWS::EFS::MountTarget", "mt", map[string]any{
+		"FileSystemId": map[string]any{
+			"$ref":   string(pkgmodel.NewFormaeURI(producer.URI().KSUID(), "FileSystemId")),
+			"$value": "fs-abc123",
+		},
+	})
+	child.DesiredState.Schema.Parent = "AWS::EFS::FileSystem"
+	child.DesiredState.Schema.ParentMappings = []pkgmodel.ParentMapping{
+		{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+	}
+
+	require.True(t, childPointsAt(child, producer, resource_update.OperationDelete, nil))
+}
+
+// TestChildPointsAt_Destroy_ResolvableChildProperty_NoMatch is the negative
+// counterpart: a Resolvable shape whose `$value` differs from the producer's
+// literal identifier must not match. Guards against an overly-permissive unwrap
+// that ignores the comparison once it sees the Resolvable shape.
+func TestChildPointsAt_Destroy_ResolvableChildProperty_NoMatch(t *testing.T) {
+	producer := makeResourceUpdate(t, "AWS::EFS::FileSystem", "fs", map[string]any{
+		"FileSystemId": "fs-abc123",
+	})
+	producer.DesiredState.Schema.Identifier = "FileSystemId"
+
+	child := makeResourceUpdate(t, "AWS::EFS::MountTarget", "mt", map[string]any{
+		"FileSystemId": map[string]any{
+			"$ref":   "formae://other-ksuid#/FileSystemId",
+			"$value": "fs-different",
+		},
+	})
+	child.DesiredState.Schema.Parent = "AWS::EFS::FileSystem"
+	child.DesiredState.Schema.ParentMappings = []pkgmodel.ParentMapping{
+		{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+	}
+
+	require.False(t, childPointsAt(child, producer, resource_update.OperationDelete, nil))
+}
+
 // TestChildPointsAt_Destroy_Composite_MatchesOnlyCorrectInstance exercises the
 // AND-of-mappings semantics of composite parent mappings. A TaskSet under
 // ECS::Service is identified by (ServiceName, Cluster). Two services share the

--- a/internal/metastructure/changeset/child_points_at_test.go
+++ b/internal/metastructure/changeset/child_points_at_test.go
@@ -195,6 +195,76 @@ func TestChildPointsAt_Create_SingleMapping_NoMatch(t *testing.T) {
 	require.False(t, ok)
 }
 
+// TestChildPointsAt_Create_Composite_TaskSetShape exercises the create-phase
+// composite-mapping case in its canonical shape: an ECS TaskSet whose parent
+// Service is keyed by (ServiceName, Cluster). The type discriminator inside
+// createSideMatches must classify the "Service" mapping as a parent reference
+// (Resolvable target type == Schema.Parent) and the "Cluster" mapping as a
+// sibling reference (target type == AWS::ECS::Cluster), then verify both halves
+// — parent URI equality plus shared third-party URI on the Cluster side —
+// before declaring a match. Two services sharing a ServiceName but pointing at
+// different clusters demonstrate that the Cluster discriminator does its job.
+func TestChildPointsAt_Create_Composite_TaskSetShape(t *testing.T) {
+	cluster1 := makeResourceUpdate(t, "AWS::ECS::Cluster", "c1", nil)
+	cluster2 := makeResourceUpdate(t, "AWS::ECS::Cluster", "c2", nil)
+
+	svc1 := makeResourceUpdate(t, "AWS::ECS::Service", "S1", map[string]any{
+		"ServiceName": "foo",
+		"Cluster":     makeResolvable(cluster1.URI(), "ClusterName"),
+	})
+	svc1.DesiredState.Schema.Identifier = "Ref"
+
+	svc2 := makeResourceUpdate(t, "AWS::ECS::Service", "S2", map[string]any{
+		"ServiceName": "foo",
+		"Cluster":     makeResolvable(cluster2.URI(), "ClusterName"),
+	})
+	svc2.DesiredState.Schema.Identifier = "Ref"
+
+	ts1 := makeResourceUpdate(t, "AWS::ECS::TaskSet", "TS1", map[string]any{
+		"Service": makeResolvable(svc1.URI(), "ServiceName"),
+		"Cluster": makeResolvable(cluster1.URI(), "ClusterName"),
+	})
+	ts1.DesiredState.Schema.Parent = "AWS::ECS::Service"
+	ts1.DesiredState.Schema.ParentMappings = []pkgmodel.ParentMapping{
+		{ParentProperty: "ServiceName", ChildProperty: "Service"},
+		{ParentProperty: "Cluster", ChildProperty: "Cluster"},
+	}
+
+	baseRes := map[pkgmodel.FormaeURI]*resource_update.ResourceUpdate{
+		cluster1.URI().Stripped(): cluster1,
+		cluster2.URI().Stripped(): cluster2,
+		svc1.URI().Stripped():     svc1,
+		svc2.URI().Stripped():     svc2,
+	}
+
+	// Matches svc1: Service mapping resolves to svc1's URI (parent reference),
+	// Cluster mapping resolves to cluster1 on both sides (sibling reference).
+	require.True(t, childPointsAt(ts1, svc1, resource_update.OperationCreate, baseRes))
+	// Does NOT match svc2: Service mapping would point at svc1, not svc2 — the
+	// parent-reference half fails before the Cluster check is even reached.
+	require.False(t, childPointsAt(ts1, svc2, resource_update.OperationCreate, baseRes))
+}
+
+// TestChildPointsAt_Create_LiteralChildProperty_ReturnsFalse locks in the
+// extractResolvableURI early-return: when the child's parent-reference property
+// holds a literal rather than a Resolvable object, createSideMatches must
+// decline rather than treat the literal as a URI. Removing the IsObject() guard
+// in extractResolvableURI would silently regress without this test.
+func TestChildPointsAt_Create_LiteralChildProperty_ReturnsFalse(t *testing.T) {
+	producer := makeResourceUpdate(t, "AWS::EFS::FileSystem", "fs", nil)
+	child := makeResourceUpdate(t, "AWS::EFS::MountTarget", "mt", map[string]any{
+		"FileSystemId": "fs-literal-abc", // literal string, not a Resolvable
+	})
+	child.DesiredState.Schema.Parent = "AWS::EFS::FileSystem"
+	child.DesiredState.Schema.ParentMappings = []pkgmodel.ParentMapping{
+		{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+	}
+	baseRes := map[pkgmodel.FormaeURI]*resource_update.ResourceUpdate{
+		producer.URI().Stripped(): producer,
+	}
+	require.False(t, childPointsAt(child, producer, resource_update.OperationCreate, baseRes))
+}
+
 // TestChildPointsAt_Destroy_Composite_MatchesOnlyCorrectInstance exercises the
 // AND-of-mappings semantics of composite parent mappings. A TaskSet under
 // ECS::Service is identified by (ServiceName, Cluster). Two services share the

--- a/internal/metastructure/changeset/child_points_at_test.go
+++ b/internal/metastructure/changeset/child_points_at_test.go
@@ -267,8 +267,8 @@ func TestChildPointsAt_Create_LiteralChildProperty_ReturnsFalse(t *testing.T) {
 }
 
 // TestChildPointsAt_Destroy_ResolvableChildProperty_Match locks in the
-// post-apply reality that motivated RFC-0043: the resolver leaves a child's
-// parent-reference property in the Resolvable shape
+// post-apply reality that motivated the runtimeDependency edge work: the
+// resolver leaves a child's parent-reference property in the Resolvable shape
 // (`{"$ref": ..., "$value": ...}`) rather than collapsing it to a literal. The
 // destroy planner must unwrap `$value` when comparing against the producer's
 // literal identifier, otherwise runtimeDependency child edges never fire for

--- a/internal/metastructure/changeset/child_points_at_test.go
+++ b/internal/metastructure/changeset/child_points_at_test.go
@@ -246,10 +246,11 @@ func TestChildPointsAt_Create_Composite_TaskSetShape(t *testing.T) {
 }
 
 // TestChildPointsAt_Create_LiteralChildProperty_ReturnsFalse locks in the
-// extractResolvableURI early-return: when the child's parent-reference property
-// holds a literal rather than a Resolvable object, createSideMatches must
-// decline rather than treat the literal as a URI. Removing the IsObject() guard
-// in extractResolvableURI would silently regress without this test.
+// resolved-reference guard in GetPropertyReference: when the child's parent-
+// reference property holds a literal rather than a {$ref,...} object,
+// createSideMatches must decline rather than treat the literal as a URI.
+// Removing the resolved-reference shape check would silently regress without
+// this test.
 func TestChildPointsAt_Create_LiteralChildProperty_ReturnsFalse(t *testing.T) {
 	producer := makeResourceUpdate(t, "AWS::EFS::FileSystem", "fs", nil)
 	child := makeResourceUpdate(t, "AWS::EFS::MountTarget", "mt", map[string]any{

--- a/internal/metastructure/changeset/child_points_at_test.go
+++ b/internal/metastructure/changeset/child_points_at_test.go
@@ -130,6 +130,71 @@ func TestChildPointsAt_Destroy_MissingChildProperty_ReturnsFalse(t *testing.T) {
 	require.False(t, childPointsAt(child, producer, resource_update.OperationDelete, nil))
 }
 
+// makeResolvable constructs the on-the-wire Resolvable shape that
+// translatePropertiesJSON emits and the engine consumes:
+//
+//	{"$ref": "formae://<KSUID>#/<PropertyPath>", "$value": ""}
+//
+// Matches the URI format produced by pkgmodel.NewFormaeURI (`formae://ksuid#`
+// with `/<path>` appended for property fragments). Used by create-phase tests
+// that need a Resolvable value embedded in a child resource's Properties.
+func makeResolvable(uri pkgmodel.FormaeURI, propPath string) map[string]any {
+	ref := pkgmodel.NewFormaeURI(uri.KSUID(), propPath)
+	return map[string]any{
+		"$ref":   string(ref),
+		"$value": "",
+	}
+}
+
+// TestChildPointsAt_Create_SingleMapping_Match exercises the create-phase
+// happy path: the child's parent-reference property holds a Resolvable
+// pointing at the producer, and baseResources resolves the K-side URI back
+// to a resource whose Type matches Schema.Parent. Expect a match.
+func TestChildPointsAt_Create_SingleMapping_Match(t *testing.T) {
+	producer := makeResourceUpdate(t, "AWS::EFS::FileSystem", "grafanaEfs", nil)
+	producerURI := producer.URI()
+
+	child := makeResourceUpdate(t, "AWS::EFS::MountTarget", "mtA", map[string]any{
+		"FileSystemId": makeResolvable(producerURI, "FileSystemId"),
+	})
+	child.DesiredState.Schema.Parent = "AWS::EFS::FileSystem"
+	child.DesiredState.Schema.ParentMappings = []pkgmodel.ParentMapping{
+		{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+	}
+
+	baseRes := map[pkgmodel.FormaeURI]*resource_update.ResourceUpdate{
+		producerURI.Stripped(): producer,
+	}
+
+	ok := childPointsAt(child, producer, resource_update.OperationCreate, baseRes)
+	require.True(t, ok)
+}
+
+// TestChildPointsAt_Create_SingleMapping_NoMatch exercises the create-phase
+// negative case: the child's parent-reference property points at a different
+// producer of the same Schema.Parent type. baseResources knows about both,
+// but only one matches. Expect no match against the wrong producer.
+func TestChildPointsAt_Create_SingleMapping_NoMatch(t *testing.T) {
+	producer := makeResourceUpdate(t, "AWS::EFS::FileSystem", "grafanaEfs", nil)
+	other := makeResourceUpdate(t, "AWS::EFS::FileSystem", "lokiEfs", nil)
+
+	child := makeResourceUpdate(t, "AWS::EFS::MountTarget", "mtX", map[string]any{
+		"FileSystemId": makeResolvable(other.URI(), "FileSystemId"),
+	})
+	child.DesiredState.Schema.Parent = "AWS::EFS::FileSystem"
+	child.DesiredState.Schema.ParentMappings = []pkgmodel.ParentMapping{
+		{ParentProperty: "FileSystemId", ChildProperty: "FileSystemId"},
+	}
+
+	baseRes := map[pkgmodel.FormaeURI]*resource_update.ResourceUpdate{
+		producer.URI().Stripped(): producer,
+		other.URI().Stripped():    other,
+	}
+
+	ok := childPointsAt(child, producer, resource_update.OperationCreate, baseRes)
+	require.False(t, ok)
+}
+
 // TestChildPointsAt_Destroy_Composite_MatchesOnlyCorrectInstance exercises the
 // AND-of-mappings semantics of composite parent mappings. A TaskSet under
 // ECS::Service is identified by (ServiceName, Cluster). Two services share the

--- a/internal/metastructure/resource_update/resource_update_generator_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_test.go
@@ -1169,7 +1169,7 @@ func TestFindDependencyUpdates_CreateOnlyBranch(t *testing.T) {
 		{
 			// Array-indexed TargetPath ("Refs.0.Target") must be looked up
 			// under the stripped key ("Refs.Target") — same convention as
-			// changeset.fieldHintForPath / RFC-0034 AttachesTo.
+			// changeset.fieldHintForPath / the attachesTo edge hint.
 			name: "array-indexed path uses stripped hint key",
 			dependent: makeDependent(parentRefArrayJSON, map[string]pkgmodel.FieldHint{
 				"Refs.Target": {CreateOnly: true},

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -170,13 +170,26 @@ open class ListProperty {
 
 typealias FieldUpdateMethod = "Array"|"Atomic"|"EntitySet"|"Set"
 
+typealias EdgeKind =
+    "default"            // Construction-data-flow. Default for unannotated fields.
+                         // On destroy: consumer first, producer second.
+  | "attachesTo"         // Reachability. Consumer is reachable through the
+                         // producer at runtime (e.g. ECS Service via ALB Listener).
+                         // On destroy: producer first, consumer second.
+  | "runtimeDependency"  // Containment. Consumer uses the producer and its
+                         // containment children at runtime, even though those
+                         // children are not directly referenced.
+                         // On create:  producer first, then each child K, then consumer.
+                         // On destroy: consumer first, then each child K, then producer.
+
 open class FieldHint extends Annotation {
     hidden createOnly: Boolean = false
     hidden writeOnly: Boolean = false
     hidden required: Boolean = false
     hidden requiredOnCreate: Boolean = false
     hidden hasProviderDefault: Boolean = false
-    hidden attachesTo: Boolean = false
+    hidden attachesTo: Boolean = false           // DEPRECATED; use edgeKind instead
+    hidden edgeKind: EdgeKind = "default"        // NEW
     hidden indexField: String?
     hidden updateMethod: FieldUpdateMethod?
 
@@ -191,6 +204,7 @@ open class FieldHint extends Annotation {
     fixed RequiredOnCreate: Boolean = requiredOnCreate
     fixed HasProviderDefault: Boolean = hasProviderDefault
     fixed AttachesTo: Boolean = attachesTo
+    fixed EdgeKind: String = edgeKind
     fixed UpdateMethod: String = updateMethod ?? ""
     fixed IndexField: String = indexField ?? ""
 }

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -178,9 +178,8 @@ open class ListProperty {
 /// `ServiceName` is referenced by the child's `Service`).
 ///
 /// Uses plain camelCase fields (no hidden/fixed dance). The Go side binds via
-/// JSON struct tags. RFC-0043 §2 sets this as the precedent for new
-/// annotations; a separate RFC will migrate other annotations to the same
-/// shape.
+/// JSON struct tags — the precedent for new annotations; older annotations
+/// will migrate to the same shape separately.
 class ParentRef {
     /// Name of the property on the parent resource that this mapping references.
     parentProperty: String
@@ -706,7 +705,7 @@ class Fq {
 
     /// Build the Schema.ParentMappings listing from a ResourceHint.
     ///
-    /// Preference order: `parentRefs` (the RFC-0043 shape) over `listParam`
+    /// Preference order: `parentRefs` (the explicit shape) over `listParam`
     /// (legacy fallback). `parentRefs` is typed `(ParentRef|List<ParentRef>)?`
     /// so it arrives as either a single `ParentRef` or a `List<ParentRef>`; PKL
     /// rejects `Listing` literals at the type boundary so no `is Listing` arm is

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -256,6 +256,13 @@ open class Schema {
     Extractable: Boolean = true
     /// Property that dictates whether a resource can be moved across targets
     Portable: Boolean = false
+    /// Type of parent resource. Empty string when this resource has no parent.
+    /// Populated by Extractor.pkl from ResourceHint.parent.
+    Parent: String = ""
+    /// Identity-property mappings from this child to its parent. Empty when
+    /// this resource has no parent. Populated by Extractor.pkl from
+    /// ResourceHint.parentRefs, with a `listParam` fallback for legacy schemas.
+    ParentMappings: Listing<ParentRef> = new Listing {}
 
     /// Query fields by FieldHint property
     function query(prop: String): Listing<String> = this.hints.toMap().filter((_, v) -> v.getProperty(prop)).keys.toListing()
@@ -693,7 +700,49 @@ class Fq {
                 Discoverable = hint.discoverable
                 Extractable = hint.extractable
                 Portable = hint.portable
+                Parent = hint.parent ?? ""
+                ParentMappings = parentMappingsOf(hint)
             }
+
+    /// Build the Schema.ParentMappings listing from a ResourceHint.
+    ///
+    /// Preference order: `parentRefs` (the RFC-0043 shape) over `listParam`
+    /// (legacy fallback). `parentRefs` is typed `(ParentRef|List<ParentRef>)?`
+    /// so it arrives as either a single `ParentRef` or a `List<ParentRef>`; PKL
+    /// rejects `Listing` literals at the type boundary so no `is Listing` arm is
+    /// reachable here. `listParam` keeps the `is Listing` arm for symmetry with
+    /// `extractParentMappings` in Extractor.pkl. When falling back to `listParam`,
+    /// the child-side name is taken from `listParameter` (the LIST API parameter
+    /// that carries the parent's value on the child).
+    function parentMappingsOf(resourceHint): Listing<ParentRef> =
+        let (refs = resourceHint.getProperty("parentRefs"))
+        let (listParam = resourceHint.getProperty("listParam"))
+        if (refs != null)
+            if (refs is List)
+                new Listing { for (r in refs) { fromParentRef(r) } }
+            else
+                // Single ParentRef
+                new Listing { fromParentRef(refs) }
+        else if (listParam != null)
+            if (listParam is Listing)
+                new Listing { for (p in listParam) { fromListProperty(p) } }
+            else if (listParam is List)
+                new Listing { for (p in listParam) { fromListProperty(p) } }
+            else
+                // Single ListProperty
+                new Listing { fromListProperty(listParam) }
+        else
+            new Listing {}
+
+    function fromParentRef(r): ParentRef = new ParentRef {
+        parentProperty = r.parentProperty
+        childProperty = r.childProperty
+    }
+
+    function fromListProperty(p): ParentRef = new ParentRef {
+        parentProperty = p.parentProperty
+        childProperty = p.listParameter
+    }
 
     function type(resourceClass: reflect.Class): String =
       let (resourceHint = findResourceHint(resourceClass))

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -140,6 +140,10 @@ open class ResourceHint extends Annotation {
     identifier: String
     /// Type of parent resource
     parent: String?
+    /// Mapping(s) between parent identity properties and the child properties
+    /// that carry those values. Used by the changeset planner to discriminate
+    /// instance-scoped parent/child containment for runtimeDependency edges.
+    parentRefs: (ParentRef|List<ParentRef>)?
     /// Parent Property required for list operations
     listParam: (ListProperty|List<ListProperty>)?
     /// Property that dictates whether a resource is blocked from discovery
@@ -166,6 +170,22 @@ open class ListProperty {
 
     fixed ParentProperty: String = parentProperty
     fixed ListParameter: String = listParameter
+}
+
+/// Maps a parent-side identity property to the child-side property that
+/// carries that value. The two names need not match (they coincide for
+/// MountTarget→FileSystem but diverge for TaskSet→Service, where the parent's
+/// `ServiceName` is referenced by the child's `Service`).
+///
+/// Uses plain camelCase fields (no hidden/fixed dance). The Go side binds via
+/// JSON struct tags. RFC-0043 §2 sets this as the precedent for new
+/// annotations; a separate RFC will migrate other annotations to the same
+/// shape.
+class ParentRef {
+    /// Name of the property on the parent resource that this mapping references.
+    parentProperty: String
+    /// Name of the property on this child that holds the parent's value.
+    childProperty: String
 }
 
 typealias FieldUpdateMethod = "Array"|"Atomic"|"EntitySet"|"Set"

--- a/internal/schema/pkl/schema/tests/formae.pkl
+++ b/internal/schema/pkl/schema/tests/formae.pkl
@@ -595,6 +595,85 @@ facts {
     ["FieldHint EdgeKind runtimeDependency is set correctly"] {
         testEdgeKindSchema.Hints["F3"].EdgeKind == "runtimeDependency"
     }
+
+    ["ResourceHint accepts a single ParentRef"] {
+        let (hint = singleParentRefHint())
+        hint.parentRefs != null &&
+        hint.parentRefs is formae.ParentRef &&
+        hint.parentRefs.parentProperty == "FileSystemId" &&
+        hint.parentRefs.childProperty == "FileSystemId"
+    }
+
+    // `parentRefs` is typed `(ParentRef|List<ParentRef>)?`, so PKL rejects a
+    // `Listing<ParentRef>` literal at the type check (verified empirically:
+    // assigning `new Listing { ... }` errors with "Expected value of type
+    // `ParentRef|List<ParentRef>`, but got type `Listing`"). Extractor.pkl
+    // still branches on `is Listing` before `is List` for `listParam`, but
+    // for `parentRefs` only the `List` arm is reachable; Task 1.4 may omit
+    // the Listing branch.
+    ["ResourceHint accepts a List of ParentRef"] {
+        let (hint = listParentRefsHint())
+        hint.parentRefs != null &&
+        hint.parentRefs is List &&
+        hint.parentRefs.length == 2 &&
+        hint.parentRefs[0].parentProperty == "ServiceName" &&
+        hint.parentRefs[0].childProperty == "Service" &&
+        hint.parentRefs[1].parentProperty == "Cluster" &&
+        hint.parentRefs[1].childProperty == "Cluster"
+    }
+
+    ["ResourceHint without parentRefs but with listParam still works"] {
+        let (hint = listParamOnlyHint())
+        hint.parentRefs == null &&
+        hint.listParam != null &&
+        hint.listParam is formae.ListProperty
+    }
+
+    ["ResourceHint parentRefs defaults to null"] {
+        let (hint = noParentRefsHint())
+        hint.parentRefs == null
+    }
+}
+
+local function singleParentRefHint(): formae.ResourceHint = new formae.ResourceHint {
+    type = "AWS::EFS::MountTarget"
+    identifier = "MountTargetId"
+    parent = "AWS::EFS::FileSystem"
+    parentRefs = new formae.ParentRef {
+        parentProperty = "FileSystemId"
+        childProperty = "FileSystemId"
+    }
+}
+
+local function listParentRefsHint(): formae.ResourceHint = new formae.ResourceHint {
+    type = "AWS::ECS::TaskSet"
+    identifier = "TaskSetId"
+    parent = "AWS::ECS::Service"
+    parentRefs = List(
+        new formae.ParentRef {
+            parentProperty = "ServiceName"
+            childProperty = "Service"
+        },
+        new formae.ParentRef {
+            parentProperty = "Cluster"
+            childProperty = "Cluster"
+        }
+    )
+}
+
+local function listParamOnlyHint(): formae.ResourceHint = new formae.ResourceHint {
+    type = "AWS::EFS::MountTarget"
+    identifier = "MountTargetId"
+    parent = "AWS::EFS::FileSystem"
+    listParam = new formae.ListProperty {
+        parentProperty = "FileSystemId"
+        listParameter = "FileSystemId"
+    }
+}
+
+local function noParentRefsHint(): formae.ResourceHint = new formae.ResourceHint {
+    type = "AWS::S3::Bucket"
+    identifier = "BucketName"
 }
 
 local testAttachesToSchema = new formae.Schema {

--- a/internal/schema/pkl/schema/tests/formae.pkl
+++ b/internal/schema/pkl/schema/tests/formae.pkl
@@ -583,6 +583,18 @@ facts {
     ["FieldHint AttachesTo defaults to false"] {
         (new formae.FieldHint {}).AttachesTo == false
     }
+
+    ["FieldHint EdgeKind defaults to default"] {
+        (new formae.FieldHint {}).EdgeKind == "default"
+    }
+
+    ["FieldHint EdgeKind attachesTo is set correctly"] {
+        testEdgeKindSchema.Hints["F2"].EdgeKind == "attachesTo"
+    }
+
+    ["FieldHint EdgeKind runtimeDependency is set correctly"] {
+        testEdgeKindSchema.Hints["F3"].EdgeKind == "runtimeDependency"
+    }
 }
 
 local testAttachesToSchema = new formae.Schema {
@@ -590,5 +602,15 @@ local testAttachesToSchema = new formae.Schema {
     Fields = new Listing { "F1" }
     Hints = new Mapping {
         ["F1"] = new formae.FieldHint { attachesTo = true }
+    }
+}
+
+local testEdgeKindSchema = new formae.Schema {
+    Identifier = "AWS::Test::EdgeThing"
+    Fields = new Listing { "F1" "F2" "F3" }
+    Hints = new Mapping {
+        ["F1"] = new formae.FieldHint { edgeKind = "default" }
+        ["F2"] = new formae.FieldHint { edgeKind = "attachesTo" }
+        ["F3"] = new formae.FieldHint { edgeKind = "runtimeDependency" }
     }
 }

--- a/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
+++ b/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
@@ -165,6 +165,8 @@ examples {
       Discoverable = true
       Extractable = true
       Portable = false
+      Parent = ""
+      ParentMappings {}
     }
   }
   ["Test Resource - type()"] {
@@ -237,6 +239,8 @@ examples {
         Discoverable = true
         Extractable = true
         Portable = false
+        Parent = ""
+        ParentMappings {}
       }
       Properties {
         bucketName = "my-test-bucket"
@@ -317,6 +321,8 @@ examples {
         Discoverable = true
         Extractable = true
         Portable = false
+        Parent = ""
+        ParentMappings {}
       }
       Properties {
         bucketName = "my-bucket-no-tags"
@@ -425,6 +431,8 @@ examples {
         Discoverable = true
         Extractable = true
         Portable = false
+        Parent = ""
+        ParentMappings {}
       }
       Properties {
         resourceName = "my-resource"
@@ -529,6 +537,8 @@ examples {
       Discoverable = true
       Extractable = true
       Portable = false
+      Parent = ""
+      ParentMappings {}
     }
   }
   ["Fq - type"] {

--- a/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
+++ b/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
@@ -91,6 +91,7 @@ examples {
         RequiredOnCreate = false
         HasProviderDefault = false
         AttachesTo = false
+        EdgeKind = "default"
         UpdateMethod = ""
         IndexField = ""
       }
@@ -101,6 +102,7 @@ examples {
         RequiredOnCreate = false
         HasProviderDefault = false
         AttachesTo = false
+        EdgeKind = "default"
         UpdateMethod = ""
         IndexField = ""
       }
@@ -111,6 +113,7 @@ examples {
         RequiredOnCreate = false
         HasProviderDefault = false
         AttachesTo = false
+        EdgeKind = "default"
         UpdateMethod = ""
         IndexField = ""
       }
@@ -132,6 +135,7 @@ examples {
           RequiredOnCreate = false
           HasProviderDefault = false
           AttachesTo = false
+          EdgeKind = "default"
           UpdateMethod = ""
           IndexField = ""
         }
@@ -142,6 +146,7 @@ examples {
           RequiredOnCreate = false
           HasProviderDefault = false
           AttachesTo = false
+          EdgeKind = "default"
           UpdateMethod = ""
           IndexField = ""
         }
@@ -152,6 +157,7 @@ examples {
           RequiredOnCreate = false
           HasProviderDefault = false
           AttachesTo = false
+          EdgeKind = "default"
           UpdateMethod = ""
           IndexField = ""
         }
@@ -201,6 +207,7 @@ examples {
             RequiredOnCreate = false
             HasProviderDefault = false
             AttachesTo = false
+            EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
           }
@@ -211,6 +218,7 @@ examples {
             RequiredOnCreate = false
             HasProviderDefault = false
             AttachesTo = false
+            EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
           }
@@ -221,6 +229,7 @@ examples {
             RequiredOnCreate = false
             HasProviderDefault = false
             AttachesTo = false
+            EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
           }
@@ -278,6 +287,7 @@ examples {
             RequiredOnCreate = false
             HasProviderDefault = false
             AttachesTo = false
+            EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
           }
@@ -288,6 +298,7 @@ examples {
             RequiredOnCreate = false
             HasProviderDefault = false
             AttachesTo = false
+            EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
           }
@@ -298,6 +309,7 @@ examples {
             RequiredOnCreate = false
             HasProviderDefault = false
             AttachesTo = false
+            EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
           }
@@ -339,6 +351,7 @@ examples {
             RequiredOnCreate = false
             HasProviderDefault = false
             AttachesTo = false
+            EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
           }
@@ -349,6 +362,7 @@ examples {
             RequiredOnCreate = false
             HasProviderDefault = false
             AttachesTo = false
+            EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
           }
@@ -359,6 +373,7 @@ examples {
             RequiredOnCreate = false
             HasProviderDefault = false
             AttachesTo = false
+            EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
           }
@@ -369,6 +384,7 @@ examples {
             RequiredOnCreate = false
             HasProviderDefault = false
             AttachesTo = false
+            EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
           }
@@ -379,6 +395,7 @@ examples {
             RequiredOnCreate = false
             HasProviderDefault = false
             AttachesTo = false
+            EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
           }
@@ -389,6 +406,7 @@ examples {
             RequiredOnCreate = false
             HasProviderDefault = false
             AttachesTo = false
+            EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
           }
@@ -399,6 +417,7 @@ examples {
             RequiredOnCreate = false
             HasProviderDefault = false
             AttachesTo = false
+            EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
           }
@@ -436,6 +455,7 @@ examples {
         RequiredOnCreate = false
         HasProviderDefault = false
         AttachesTo = false
+        EdgeKind = "default"
         UpdateMethod = ""
         IndexField = ""
       }
@@ -446,6 +466,7 @@ examples {
         RequiredOnCreate = false
         HasProviderDefault = false
         AttachesTo = false
+        EdgeKind = "default"
         UpdateMethod = ""
         IndexField = ""
       }
@@ -456,6 +477,7 @@ examples {
         RequiredOnCreate = false
         HasProviderDefault = false
         AttachesTo = false
+        EdgeKind = "default"
         UpdateMethod = ""
         IndexField = ""
       }
@@ -477,6 +499,7 @@ examples {
           RequiredOnCreate = false
           HasProviderDefault = false
           AttachesTo = false
+          EdgeKind = "default"
           UpdateMethod = ""
           IndexField = ""
         }
@@ -487,6 +510,7 @@ examples {
           RequiredOnCreate = false
           HasProviderDefault = false
           AttachesTo = false
+          EdgeKind = "default"
           UpdateMethod = ""
           IndexField = ""
         }
@@ -497,6 +521,7 @@ examples {
           RequiredOnCreate = false
           HasProviderDefault = false
           AttachesTo = false
+          EdgeKind = "default"
           UpdateMethod = ""
           IndexField = ""
         }

--- a/internal/testplugin/fakeaws/schema/pkl/ecs/taskset.pkl
+++ b/internal/testplugin/fakeaws/schema/pkl/ecs/taskset.pkl
@@ -1,0 +1,44 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+/*
+ * FakeAWS ECS TaskSet - fixture for verifying Extractor.pkl emits
+ * Schema.ParentMappings from a composite List<ParentRef> declaration.
+ * Mirrors the AWS::ECS::TaskSet → AWS::ECS::Service relationship where
+ * the parent's `ServiceName` is referenced by the child's `Service`.
+ */
+module fakeaws.ecs.taskset
+
+import "@formae/formae.pkl"
+import "../fakeaws.pkl"
+
+const type = "FakeAWS::ECS::TaskSet"
+
+@fakeaws.ResourceHint {
+    type = module.type
+    identifier = "TaskSetId"
+    parent = "FakeAWS::ECS::Service"
+    parentRefs = List(
+        new formae.ParentRef {
+            parentProperty = "ServiceName"
+            childProperty = "Service"
+        },
+        new formae.ParentRef {
+            parentProperty = "Cluster"
+            childProperty = "Cluster"
+        }
+    )
+}
+open class TaskSet extends formae.Resource {
+    @fakeaws.FieldHint
+    service: String
+
+    @fakeaws.FieldHint
+    cluster: String
+
+    @fakeaws.FieldHint
+    taskDefinition: String?
+}

--- a/internal/testplugin/fakeaws/schema/pkl/efs/mounttarget.pkl
+++ b/internal/testplugin/fakeaws/schema/pkl/efs/mounttarget.pkl
@@ -1,0 +1,34 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+/*
+ * FakeAWS EFS MountTarget - fixture for verifying Extractor.pkl emits
+ * Schema.Parent + Schema.ParentMappings from `parent` + `parentRefs`.
+ * Mirrors the motivating runtimeDependency example from RFC-0043.
+ */
+module fakeaws.efs.mounttarget
+
+import "@formae/formae.pkl"
+import "../fakeaws.pkl"
+
+const type = "FakeAWS::EFS::MountTarget"
+
+@fakeaws.ResourceHint {
+    type = module.type
+    identifier = "MountTargetId"
+    parent = "FakeAWS::EFS::FileSystem"
+    parentRefs = new formae.ParentRef {
+        parentProperty = "FileSystemId"
+        childProperty = "FileSystemId"
+    }
+}
+open class MountTarget extends formae.Resource {
+    @fakeaws.FieldHint
+    fileSystemId: String
+
+    @fakeaws.FieldHint
+    subnetId: String
+}

--- a/internal/testplugin/fakeaws/schema/pkl/efs/mounttarget.pkl
+++ b/internal/testplugin/fakeaws/schema/pkl/efs/mounttarget.pkl
@@ -7,7 +7,7 @@
 /*
  * FakeAWS EFS MountTarget - fixture for verifying Extractor.pkl emits
  * Schema.Parent + Schema.ParentMappings from `parent` + `parentRefs`.
- * Mirrors the motivating runtimeDependency example from RFC-0043.
+ * Mirrors the motivating runtimeDependency example (EFS mount targets).
  */
 module fakeaws.efs.mounttarget
 

--- a/internal/testplugin/fakeaws/schema/pkl/legacy/legacychild.pkl
+++ b/internal/testplugin/fakeaws/schema/pkl/legacy/legacychild.pkl
@@ -1,0 +1,34 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+/*
+ * FakeAWS LegacyChild - fixture verifying Extractor.pkl's `listParam`
+ * fallback when `parentRefs` is absent. Mirrors pre-RFC-0043 schemas
+ * that only declared a `listParam` for the parent containment hint.
+ */
+module fakeaws.legacy.legacychild
+
+import "@formae/formae.pkl"
+import "../fakeaws.pkl"
+
+const type = "FakeAWS::Legacy::LegacyChild"
+
+@fakeaws.ResourceHint {
+    type = module.type
+    identifier = "ChildId"
+    parent = "FakeAWS::Legacy::LegacyParent"
+    listParam = new formae.ListProperty {
+        parentProperty = "ParentId"
+        listParameter = "ParentRef"
+    }
+}
+open class LegacyChild extends formae.Resource {
+    @fakeaws.FieldHint
+    childId: String
+
+    @fakeaws.FieldHint
+    parentRef: String
+}

--- a/internal/testplugin/fakeaws/schema/pkl/legacy/legacychild.pkl
+++ b/internal/testplugin/fakeaws/schema/pkl/legacy/legacychild.pkl
@@ -6,8 +6,8 @@
 
 /*
  * FakeAWS LegacyChild - fixture verifying Extractor.pkl's `listParam`
- * fallback when `parentRefs` is absent. Mirrors pre-RFC-0043 schemas
- * that only declared a `listParam` for the parent containment hint.
+ * fallback when `parentRefs` is absent. Mirrors older schemas that only
+ * declared a `listParam` for the parent containment hint.
  */
 module fakeaws.legacy.legacychild
 

--- a/internal/workflow_tests/local/apply_forma/runtime_dependency_destroy_test.go
+++ b/internal/workflow_tests/local/apply_forma/runtime_dependency_destroy_test.go
@@ -1,0 +1,299 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// TestRuntimeDependency_DestroyOrder verifies that the runtimeDependency
+// EdgeKind on a consumer→producer reference produces the destroy order
+// consumer → child → producer end-to-end.
+//
+// Topology:
+//   - A: producer (FakeAWS::Test::Container) — carries identifier
+//     ContainerId and an Arn property used by the containee for the
+//     default destroy edge.
+//   - B: child of A (FakeAWS::Test::Containee), Schema.Parent = A's
+//     type, ParentMappings link parent-side ContainerId → child-side
+//     ContainerId. Its ContainerId is a literal that matches A's
+//     identifier so destroySideMatches recognizes it as A's child;
+//     its ContainerArn is a $ref to A.Arn so the default destroy
+//     edge places A after B.
+//   - C: consumer (FakeAWS::Test::Consumer), references A via field
+//     "ContainerRef" ($ref to A.ContainerId) whose hint declares
+//     EdgeKind = runtimeDependency.
+//
+// Expected destroy order under runtimeDependency:
+//   - C deletes first (no incoming edges)
+//   - B.delete waits for C.delete (runtimeDependency child edge: every
+//     containment child of the referenced producer must wait for the
+//     consumer)
+//   - A.delete waits for B.delete (default destroy edge from B's
+//     ContainerArn $ref to A.Arn) and also waits for C.delete (default
+//     consumer→producer edge under runtimeDependency)
+//
+// Net order: C → B → A.
+func TestRuntimeDependency_DestroyOrder(t *testing.T) {
+	// Deterministic KSUIDs so the resources can $ref each other.
+	const (
+		containerKsuid = "2MiD2rA1SJbLMGZgTL0hCxjkjj1"
+		containeeKsuid = "2MiD2rA1SJbLMGZgTL0hCxjkjj2"
+		consumerKsuid  = "2MiD2rA1SJbLMGZgTL0hCxjkjj3"
+
+		containerType = "FakeAWS::Test::Container"
+		containeeType = "FakeAWS::Test::Containee"
+		consumerType  = "FakeAWS::Test::Consumer"
+	)
+
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		// Per-label plugin overrides keep Create/Read/Delete behavior simple
+		// and deterministic for arbitrary FakeAWS::Test::* resource types.
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          "1234",
+					NativeID:           "native-" + request.Label,
+					ResourceProperties: request.Properties,
+				}}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				// Return properties consistent with what was created so the
+				// resolver can populate $value fields when other resources
+				// $ref this one.
+				switch request.ResourceType {
+				case containerType:
+					return &resource.ReadResult{
+						ResourceType: request.ResourceType,
+						Properties:   `{"ContainerId":"container-1","Arn":"arn-container"}`,
+					}, nil
+				case containeeType:
+					return &resource.ReadResult{
+						ResourceType: request.ResourceType,
+						Properties:   `{"ContaineeId":"containee-1","ContainerId":"container-1","ContainerArn":"arn-container"}`,
+					}, nil
+				case consumerType:
+					return &resource.ReadResult{
+						ResourceType: request.ResourceType,
+						Properties:   `{"ConsumerId":"consumer-1","ContainerRef":"container-1"}`,
+					}, nil
+				}
+				return &resource.ReadResult{ResourceType: request.ResourceType, Properties: "{}"}, nil
+			},
+			Delete: func(request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+				return &resource.DeleteResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationDelete,
+					OperationStatus: resource.OperationStatusSuccess,
+					RequestID:       "delete-123",
+					NativeID:        request.NativeID,
+				}}, nil
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err, "Failed to create metastructure")
+
+		// Build the forma. The consumer ($ref to container via ContainerRef)
+		// gets the runtimeDependency hint on that field. The containee
+		// declares Schema.Parent = container type and ParentMappings so the
+		// destroy DAG recognizes it as a containment child of the container;
+		// it carries a literal ContainerId (for the destroySideMatches
+		// identity check) plus a separate ContainerArn $ref to the
+		// container so the default destroy edge places the container
+		// after the containee.
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "test"}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label:   "container",
+					Type:    containerType,
+					Stack:   "test",
+					Target:  "provider",
+					Managed: true,
+					Ksuid:   containerKsuid,
+					Schema: pkgmodel.Schema{
+						Identifier: "ContainerId",
+						Fields:     []string{"ContainerId", "Arn"},
+					},
+					Properties: json.RawMessage(`{
+						"ContainerId": "container-1",
+						"Arn": "arn-container"
+					}`),
+				},
+				{
+					Label:   "containee",
+					Type:    containeeType,
+					Stack:   "test",
+					Target:  "provider",
+					Managed: true,
+					Ksuid:   containeeKsuid,
+					Schema: pkgmodel.Schema{
+						Identifier: "ContaineeId",
+						Fields:     []string{"ContaineeId", "ContainerId", "ContainerArn"},
+						// Schema.Parent + ParentMappings make the containee a
+						// containment child of the container — the
+						// runtimeDependency rule on the consumer side will
+						// inject an edge from the consumer to *this* child.
+						Parent: containerType,
+						ParentMappings: []pkgmodel.ParentMapping{
+							{ParentProperty: "ContainerId", ChildProperty: "ContainerId"},
+						},
+					},
+					// Two independent links to the container:
+					//
+					//   ContainerId (literal) — used by destroySideMatches
+					//     to identify this resource as a containment child
+					//     of the container instance during destroy. The
+					//     current implementation reads literal values on
+					//     both sides via Resource.GetProperty, so a $ref
+					//     blob would not match the producer's literal
+					//     identifier (see test note in commit body).
+					//
+					//   ContainerArn ($ref) — drives the default destroy
+					//     edge container.delete-after-containee.delete
+					//     (B → A) by appearing in the containee's
+					//     RemainingResolvables. Without this edge the
+					//     containee and container would destroy in
+					//     parallel after the consumer.
+					Properties: json.RawMessage(fmt.Sprintf(`{
+						"ContaineeId": "containee-1",
+						"ContainerId": "container-1",
+						"ContainerArn": {"$ref":"formae://%s#/Arn","$value":"arn-container"}
+					}`, containerKsuid)),
+				},
+				{
+					Label:   "consumer",
+					Type:    consumerType,
+					Stack:   "test",
+					Target:  "provider",
+					Managed: true,
+					Ksuid:   consumerKsuid,
+					Schema: pkgmodel.Schema{
+						Identifier: "ConsumerId",
+						Fields:     []string{"ConsumerId", "ContainerRef"},
+						// Declare the runtimeDependency edge on the consumer's
+						// reference to the container — this is the rule under
+						// test.
+						Hints: map[string]pkgmodel.FieldHint{
+							"ContainerRef": {EdgeKind: pkgmodel.EdgeKindRuntimeDependency},
+						},
+					},
+					Properties: json.RawMessage(fmt.Sprintf(`{
+						"ConsumerId": "consumer-1",
+						"ContainerRef": {"$ref":"formae://%s#/ContainerId","$value":"container-1"}
+					}`, containerKsuid)),
+				},
+			},
+			Targets: []pkgmodel.Target{
+				{
+					Label:     "provider",
+					Namespace: "FakeAWS",
+					Config:    json.RawMessage(`{"region":"us-east-1"}`),
+				},
+			},
+		}
+
+		// Step 1: Apply.
+		_, err = m.ApplyForma(
+			forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
+			"test-client-id")
+		require.NoError(t, err, "ApplyForma should not error")
+
+		assert.Eventually(t, func() bool {
+			incomplete, err := m.Datastore.LoadIncompleteFormaCommands()
+			require.NoError(t, err)
+			return len(incomplete) == 0
+		}, 10*time.Second, 100*time.Millisecond, "apply should complete")
+
+		resources, err := m.Datastore.LoadResourcesByStack("test")
+		require.NoError(t, err)
+		require.Len(t, resources, 3, "should have container, containee, and consumer resources")
+
+		// Step 2: Destroy.
+		_, err = m.DestroyForma(
+			forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
+			"test-client-id")
+		require.NoError(t, err, "DestroyForma should not error")
+
+		assert.Eventually(t, func() bool {
+			cmds, err := m.Datastore.LoadFormaCommands()
+			require.NoError(t, err)
+			incomplete, err := m.Datastore.LoadIncompleteFormaCommands()
+			require.NoError(t, err)
+			return len(cmds) == 2 && len(incomplete) == 0
+		}, 10*time.Second, 100*time.Millisecond, "destroy should complete")
+
+		// Step 3: Locate the destroy command and verify resource update order.
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+
+		var destroyCmd *forma_command.FormaCommand
+		for _, cmd := range cmds {
+			if cmd.Command == pkgmodel.CommandDestroy {
+				destroyCmd = cmd
+				break
+			}
+		}
+		require.NotNil(t, destroyCmd, "should have a destroy command")
+		require.Len(t, destroyCmd.ResourceUpdates, 3, "destroy command should have 3 resource updates")
+
+		modifiedTsOfResource := func(label string) time.Time {
+			for _, ru := range destroyCmd.ResourceUpdates {
+				if ru.DesiredState.Label == label {
+					return ru.ModifiedTs
+				}
+			}
+			t.Fatalf("no ResourceUpdate for %q", label)
+			return time.Time{}
+		}
+
+		consumerTs := modifiedTsOfResource("consumer")
+		containeeTs := modifiedTsOfResource("containee")
+		containerTs := modifiedTsOfResource("container")
+
+		// Core assertions: C → B → A under runtimeDependency.
+		assert.True(t,
+			consumerTs.Before(containeeTs),
+			"consumer.delete must complete before containee.delete (runtimeDependency child edge: child waits for consumer) — consumer=%v containee=%v",
+			consumerTs, containeeTs)
+		assert.True(t,
+			containeeTs.Before(containerTs),
+			"containee.delete must complete before container.delete (default destroy edge: B→A) — containee=%v container=%v",
+			containeeTs, containerTs)
+		// Transitive: consumer also before container (runtimeDependency
+		// producer-side default edge: producer waits for consumer).
+		assert.True(t,
+			consumerTs.Before(containerTs),
+			"consumer.delete must complete before container.delete (default destroy edge from runtimeDependency) — consumer=%v container=%v",
+			consumerTs, containerTs)
+
+		for _, ru := range destroyCmd.ResourceUpdates {
+			assert.Equal(t, resource_update.ResourceUpdateStateSuccess, ru.State,
+				"ResourceUpdate for %q should be successful", ru.DesiredState.Label)
+		}
+	})
+}

--- a/pkg/model/resource.go
+++ b/pkg/model/resource.go
@@ -83,6 +83,52 @@ func (r *Resource) GetProperty(query string) (string, bool) {
 	return value.String(), true
 }
 
+// GetEffectivePropertyValue returns the scalar string value of a property,
+// transparently unwrapping the resolved-reference shape ({"$ref": "...",
+// "$value": "..."}) to its $value.
+//
+// Use this when a downstream consumer needs the producer-supplied value
+// regardless of whether the property is still wrapped in a Resolvable
+// post-apply.
+//
+// Returns false when:
+//   - the property does not exist,
+//   - the property is a resolved-reference whose $value has not been
+//     populated yet (still-pending resolution),
+//   - the property is an object that is neither a scalar nor a resolved
+//     reference (e.g. a nested sub-resource — those need direct gjson).
+func (r *Resource) GetEffectivePropertyValue(query string) (string, bool) {
+	value := r.getProperty(query)
+	if !value.Exists() || value.Type == gjson.Null {
+		return "", false
+	}
+	if ref, ok := AsResolvedReference(value); ok {
+		if !ref.Value.Exists() || ref.Value.Type == gjson.Null {
+			return "", false
+		}
+		return ref.Value.String(), true
+	}
+	if value.IsObject() {
+		// Non-resolvable object — not a scalar.
+		return "", false
+	}
+	return value.String(), true
+}
+
+// GetPropertyReference returns the $ref URI of a property when the property
+// carries the resolved-reference shape ({"$ref": "...", ...}), regardless of
+// whether $value has been populated yet.
+//
+// Returns false for literal values, non-object values, and objects without a
+// $ref key.
+func (r *Resource) GetPropertyReference(query string) (FormaeURI, bool) {
+	ref, ok := AsResolvedReference(r.getProperty(query))
+	if !ok {
+		return "", false
+	}
+	return ref.Ref, true
+}
+
 func (r *Resource) ValidateRequiredOnCreateFields() error {
 	missingFields := r.GetMissingRequiredOnCreateFields()
 

--- a/pkg/model/resource_test.go
+++ b/pkg/model/resource_test.go
@@ -165,3 +165,86 @@ func TestValidateRequiredOnCreateFieldsMissingRequiredFieldOnCreateReturnsNoErro
 	assert.Contains(t, err.Error(), "missing required fields: [InstanceType]")
 	assert.Contains(t, err.Error(), "cannot be created")
 }
+
+func TestGetEffectivePropertyValue_LiteralScalar(t *testing.T) {
+	r := &Resource{Properties: json.RawMessage(`{"FileSystemId":"fs-abc123"}`)}
+	v, ok := r.GetEffectivePropertyValue("FileSystemId")
+	assert.True(t, ok)
+	assert.Equal(t, "fs-abc123", v)
+}
+
+func TestGetEffectivePropertyValue_UnwrapsResolvedReference(t *testing.T) {
+	r := &Resource{Properties: json.RawMessage(`{
+		"FileSystemId": {"$ref": "formae://abc#/FileSystemId", "$value": "fs-abc123"}
+	}`)}
+	v, ok := r.GetEffectivePropertyValue("FileSystemId")
+	assert.True(t, ok)
+	assert.Equal(t, "fs-abc123", v, "$value should be unwrapped from resolved reference")
+}
+
+func TestGetEffectivePropertyValue_UnresolvedReferenceReturnsFalse(t *testing.T) {
+	// A $ref without $value (resolution hasn't happened yet) is not a usable
+	// scalar.
+	r := &Resource{Properties: json.RawMessage(`{
+		"FileSystemId": {"$ref": "formae://abc#/FileSystemId"}
+	}`)}
+	_, ok := r.GetEffectivePropertyValue("FileSystemId")
+	assert.False(t, ok)
+}
+
+func TestGetEffectivePropertyValue_NonScalarObjectReturnsFalse(t *testing.T) {
+	// A nested object that isn't a resolved-reference shape (no $ref) shouldn't
+	// be returned as a scalar.
+	r := &Resource{Properties: json.RawMessage(`{
+		"NetworkConfiguration": {"awsvpcConfiguration": {"subnets": ["s-1"]}}
+	}`)}
+	_, ok := r.GetEffectivePropertyValue("NetworkConfiguration")
+	assert.False(t, ok)
+}
+
+func TestGetEffectivePropertyValue_MissingPropertyReturnsFalse(t *testing.T) {
+	r := &Resource{Properties: json.RawMessage(`{}`)}
+	_, ok := r.GetEffectivePropertyValue("Anything")
+	assert.False(t, ok)
+}
+
+func TestGetEffectivePropertyValue_NullValueReturnsFalse(t *testing.T) {
+	r := &Resource{Properties: json.RawMessage(`{"FileSystemId":null}`)}
+	_, ok := r.GetEffectivePropertyValue("FileSystemId")
+	assert.False(t, ok)
+}
+
+func TestGetPropertyReference_ReturnsRefURI(t *testing.T) {
+	r := &Resource{Properties: json.RawMessage(`{
+		"FileSystemId": {"$ref": "formae://abc#/FileSystemId", "$value": "fs-abc123"}
+	}`)}
+	uri, ok := r.GetPropertyReference("FileSystemId")
+	assert.True(t, ok)
+	assert.Equal(t, FormaeURI("formae://abc#/FileSystemId"), uri)
+}
+
+func TestGetPropertyReference_ReturnsRefEvenWithoutValue(t *testing.T) {
+	// A $ref without $value is still a valid reference shape — the URI is
+	// what we want to chase regardless of whether resolution has populated
+	// $value yet.
+	r := &Resource{Properties: json.RawMessage(`{
+		"FileSystemId": {"$ref": "formae://abc#/FileSystemId"}
+	}`)}
+	uri, ok := r.GetPropertyReference("FileSystemId")
+	assert.True(t, ok)
+	assert.Equal(t, FormaeURI("formae://abc#/FileSystemId"), uri)
+}
+
+func TestGetPropertyReference_LiteralReturnsFalse(t *testing.T) {
+	r := &Resource{Properties: json.RawMessage(`{"FileSystemId":"fs-abc123"}`)}
+	_, ok := r.GetPropertyReference("FileSystemId")
+	assert.False(t, ok)
+}
+
+func TestGetPropertyReference_NonRefObjectReturnsFalse(t *testing.T) {
+	r := &Resource{Properties: json.RawMessage(`{
+		"Tags": [{"Key": "Name", "Value": "v"}]
+	}`)}
+	_, ok := r.GetPropertyReference("Tags")
+	assert.False(t, ok)
+}

--- a/pkg/model/schema.go
+++ b/pkg/model/schema.go
@@ -23,8 +23,8 @@ type Schema struct {
 // diverge for TaskSet→Service).
 //
 // Uses JSON struct tags (camelCase) to match the field names emitted by
-// `Extractor.pkl` and the corresponding PKL `ParentRef` class. RFC-0043 §2
-// sets this as the precedent for new annotations.
+// `Extractor.pkl` and the corresponding PKL `ParentRef` class — the
+// precedent for new annotations.
 type ParentMapping struct {
 	ParentProperty string `json:"parentProperty"`
 	ChildProperty  string `json:"childProperty"`

--- a/pkg/model/schema.go
+++ b/pkg/model/schema.go
@@ -4,6 +4,8 @@
 
 package model
 
+import "encoding/json"
+
 type Schema struct {
 	Identifier   string               `json:"Identifier" pkl:"Identifier"`
 	Fields       []string             `json:"Fields" pkl:"Fields"`
@@ -13,16 +15,43 @@ type Schema struct {
 	Portable     bool                 `json:"Portable" pkl:"Portable"`
 }
 
+type EdgeKind string
+
+const (
+	EdgeKindDefault           EdgeKind = "default"
+	EdgeKindAttachesTo        EdgeKind = "attachesTo"
+	EdgeKindRuntimeDependency EdgeKind = "runtimeDependency"
+)
+
 type FieldHint struct {
 	CreateOnly         bool `json:"CreateOnly" pkl:"CreateOnly"`
 	WriteOnly          bool `json:"WriteOnly" pkl:"WriteOnly"`
 	Required           bool `json:"Required" pkl:"Required"`
 	RequiredOnCreate   bool `json:"RequiredOnCreate" pkl:"RequiredOnCreate"`
 	HasProviderDefault bool `json:"HasProviderDefault" pkl:"HasProviderDefault"`
-	AttachesTo            bool `json:"AttachesTo" pkl:"AttachesTo"`
+	AttachesTo         bool     `json:"AttachesTo" pkl:"AttachesTo"` // DEPRECATED: kept for one release; engine derives EdgeKind from this when set.
+	EdgeKind           EdgeKind `json:"EdgeKind" pkl:"EdgeKind"`    // NEW
 
 	IndexField   string            `json:"IndexField" pkl:"IndexField"`
 	UpdateMethod FieldUpdateMethod `json:"UpdateMethod" pkl:"UpdateMethod"`
+}
+
+// UnmarshalJSON normalizes the deprecated AttachesTo alias into EdgeKind so
+// schemas published before EdgeKind landed continue to drive correct DAG edges.
+func (fh *FieldHint) UnmarshalJSON(data []byte) error {
+	type rawHint FieldHint
+	var raw rawHint
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*fh = FieldHint(raw)
+	if fh.EdgeKind == "" {
+		fh.EdgeKind = EdgeKindDefault
+		if fh.AttachesTo {
+			fh.EdgeKind = EdgeKindAttachesTo
+		}
+	}
+	return nil
 }
 
 type FieldUpdateMethod string

--- a/pkg/model/schema.go
+++ b/pkg/model/schema.go
@@ -7,12 +7,27 @@ package model
 import "encoding/json"
 
 type Schema struct {
-	Identifier   string               `json:"Identifier" pkl:"Identifier"`
-	Fields       []string             `json:"Fields" pkl:"Fields"`
-	Hints        map[string]FieldHint `json:"Hints" pkl:"Hints"`
-	Discoverable bool                 `json:"Discoverable" pkl:"Discoverable"`
-	Extractable  bool                 `json:"Extractable" pkl:"Extractable"`
-	Portable     bool                 `json:"Portable" pkl:"Portable"`
+	Identifier     string               `json:"Identifier" pkl:"Identifier"`
+	Fields         []string             `json:"Fields" pkl:"Fields"`
+	Hints          map[string]FieldHint `json:"Hints" pkl:"Hints"`
+	Discoverable   bool                 `json:"Discoverable" pkl:"Discoverable"`
+	Extractable    bool                 `json:"Extractable" pkl:"Extractable"`
+	Portable       bool                 `json:"Portable" pkl:"Portable"`
+	Parent         string               `json:"Parent" pkl:"Parent"`                 // NEW: from ResourceHint.parent; "" when unset.
+	ParentMappings []ParentMapping      `json:"ParentMappings" pkl:"ParentMappings"` // NEW: from ResourceHint.parentRefs[*]; nil when unset.
+}
+
+// ParentMapping pairs the parent-side property name with the child-side
+// property name for one component of a parent-child identity relationship.
+// The two names need not match (they coincide for MountTarget→FileSystem but
+// diverge for TaskSet→Service).
+//
+// Uses JSON struct tags (camelCase) to match the field names emitted by
+// `Extractor.pkl` and the corresponding PKL `ParentRef` class. RFC-0043 §2
+// sets this as the precedent for new annotations.
+type ParentMapping struct {
+	ParentProperty string `json:"parentProperty"`
+	ChildProperty  string `json:"childProperty"`
 }
 
 type EdgeKind string

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -52,3 +52,46 @@ func TestFieldHintAttachesToDefaultsFalse(t *testing.T) {
 
 	assert.False(t, decoded.AttachesTo, "AttachesTo should default false for pre-existing stored schemas")
 }
+
+func TestSchema_ParentMappings_Unmarshal(t *testing.T) {
+	var s Schema
+	raw := `{
+		"Identifier": "MountTargetId",
+		"Parent": "AWS::EFS::FileSystem",
+		"ParentMappings": [
+			{"parentProperty": "FileSystemId", "childProperty": "FileSystemId"}
+		]
+	}`
+	err := json.Unmarshal([]byte(raw), &s)
+	require.NoError(t, err)
+	require.Equal(t, "AWS::EFS::FileSystem", s.Parent)
+	require.Len(t, s.ParentMappings, 1)
+	require.Equal(t, "FileSystemId", s.ParentMappings[0].ParentProperty)
+	require.Equal(t, "FileSystemId", s.ParentMappings[0].ChildProperty)
+}
+
+func TestSchema_ParentMappings_Composite(t *testing.T) {
+	var s Schema
+	raw := `{
+		"Identifier": "TaskSetId",
+		"Parent": "AWS::ECS::Service",
+		"ParentMappings": [
+			{"parentProperty": "ServiceName", "childProperty": "Service"},
+			{"parentProperty": "Cluster", "childProperty": "Cluster"}
+		]
+	}`
+	err := json.Unmarshal([]byte(raw), &s)
+	require.NoError(t, err)
+	require.Len(t, s.ParentMappings, 2)
+	require.Equal(t, "ServiceName", s.ParentMappings[0].ParentProperty)
+	require.Equal(t, "Service", s.ParentMappings[0].ChildProperty)
+	require.Equal(t, "Cluster", s.ParentMappings[1].ParentProperty)
+	require.Equal(t, "Cluster", s.ParentMappings[1].ChildProperty)
+}
+
+func TestSchema_ParentFields_DefaultsForLegacyJSON(t *testing.T) {
+	var s Schema
+	require.NoError(t, json.Unmarshal([]byte(`{"Identifier":"X"}`), &s))
+	require.Equal(t, "", s.Parent)
+	require.Nil(t, s.ParentMappings)
+}

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -12,6 +12,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFieldHint_EdgeKind_Unmarshal_Default(t *testing.T) {
+	var fh FieldHint
+	err := json.Unmarshal([]byte(`{}`), &fh)
+	require.NoError(t, err)
+	require.Equal(t, EdgeKindDefault, fh.EdgeKind)
+}
+
+func TestFieldHint_EdgeKind_Unmarshal_Explicit(t *testing.T) {
+	var fh FieldHint
+	err := json.Unmarshal([]byte(`{"EdgeKind":"runtimeDependency"}`), &fh)
+	require.NoError(t, err)
+	require.Equal(t, EdgeKindRuntimeDependency, fh.EdgeKind)
+}
+
+func TestFieldHint_EdgeKind_FromAttachesTo_TransitionalAlias(t *testing.T) {
+	// Old-shape JSON carrying AttachesTo without EdgeKind — derive EdgeKindAttachesTo.
+	var fh FieldHint
+	err := json.Unmarshal([]byte(`{"AttachesTo":true}`), &fh)
+	require.NoError(t, err)
+	require.Equal(t, EdgeKindAttachesTo, fh.EdgeKind)
+}
+
 func TestFieldHintAttachesToJSONRoundTrip(t *testing.T) {
 	original := FieldHint{AttachesTo: true}
 

--- a/pkg/model/uri.go
+++ b/pkg/model/uri.go
@@ -238,6 +238,44 @@ func IsResolvableObject(value gjson.Result) bool {
 	return resField.Exists() && resField.Bool()
 }
 
+// ResolvedReference is the persisted/post-apply shape of a resolved
+// Resolvable: an object of the form {"$ref": "formae://...", "$value": ...}.
+// The unresolved source-time shape (carrying $res/$type/$label/$stack/$property)
+// is handled by IsResolvableObject and FindResolvablesFromProperties — see
+// those for the inverse case.
+//
+// Ref is always set when constructed via AsResolvedReference. Value may be
+// gjson.Null when the reference has not yet been resolved by the executor
+// (the post-resolver state at apply time keeps $ref but adds $value).
+type ResolvedReference struct {
+	Ref   FormaeURI
+	Value gjson.Result
+}
+
+// IsResolvedReference reports whether value is the resolved-reference shape
+// ({"$ref": "...", ...}). Mirror of IsResolvableObject for the post-apply
+// shape; the two shapes are disjoint by construction (source-time objects
+// carry $res, post-apply objects carry $ref).
+func IsResolvedReference(value gjson.Result) bool {
+	if !value.IsObject() {
+		return false
+	}
+	return value.Get("$ref").Exists()
+}
+
+// AsResolvedReference unwraps value to a ResolvedReference when it carries
+// the resolved-reference shape. Returns false for scalars, arrays,
+// non-object values, and objects without a $ref field.
+func AsResolvedReference(value gjson.Result) (ResolvedReference, bool) {
+	if !IsResolvedReference(value) {
+		return ResolvedReference{}, false
+	}
+	return ResolvedReference{
+		Ref:   FormaeURI(value.Get("$ref").String()),
+		Value: value.Get("$value"),
+	}, true
+}
+
 // ToTripletKey converts a resolvable object to a TripletKey
 func (r ResolvableObject) ToTripletKey() TripletKey {
 	return TripletKey{

--- a/pkg/plugin/descriptors/Extractor.pkl
+++ b/pkg/plugin/descriptors/Extractor.pkl
@@ -35,6 +35,8 @@ function extractDescriptors(): Listing<resourceDescriptor.ResourceDescriptor> = 
                                 }
                                 Fields = formae.fq.fields(clazz)
                                 Extractable = clazz.annotations[0].getProperty("extractable")
+                                Parent = clazz.annotations[0].getProperty("parent") ?? ""
+                                ParentMappings = formae.fq.parentMappingsOf(clazz.annotations[0])
                             }
                             ParentResourceTypesWithMappingProperties = extractParentMappings(clazz.annotations[0])
                         }

--- a/pkg/plugin/descriptors/extract_schema_test.go
+++ b/pkg/plugin/descriptors/extract_schema_test.go
@@ -59,6 +59,76 @@ func TestExtractSchema_RecursiveSubResource(t *testing.T) {
 	}
 }
 
+func TestExtractSchema_ParentMappings_SingleParentRef(t *testing.T) {
+	descriptors := extractFakeawsDescriptors(t)
+
+	d := findDescriptor(t, descriptors, "FakeAWS::EFS::MountTarget")
+	if d.Schema.Parent != "FakeAWS::EFS::FileSystem" {
+		t.Errorf("expected Parent=%q, got %q", "FakeAWS::EFS::FileSystem", d.Schema.Parent)
+	}
+	if got, want := len(d.Schema.ParentMappings), 1; got != want {
+		t.Fatalf("expected %d ParentMapping, got %d (%#v)", want, got, d.Schema.ParentMappings)
+	}
+	if d.Schema.ParentMappings[0].ParentProperty != "FileSystemId" {
+		t.Errorf("expected ParentProperty=%q, got %q", "FileSystemId", d.Schema.ParentMappings[0].ParentProperty)
+	}
+	if d.Schema.ParentMappings[0].ChildProperty != "FileSystemId" {
+		t.Errorf("expected ChildProperty=%q, got %q", "FileSystemId", d.Schema.ParentMappings[0].ChildProperty)
+	}
+}
+
+func TestExtractSchema_ParentMappings_CompositeParentRefs(t *testing.T) {
+	descriptors := extractFakeawsDescriptors(t)
+
+	d := findDescriptor(t, descriptors, "FakeAWS::ECS::TaskSet")
+	if d.Schema.Parent != "FakeAWS::ECS::Service" {
+		t.Errorf("expected Parent=%q, got %q", "FakeAWS::ECS::Service", d.Schema.Parent)
+	}
+	if got, want := len(d.Schema.ParentMappings), 2; got != want {
+		t.Fatalf("expected %d ParentMappings, got %d (%#v)", want, got, d.Schema.ParentMappings)
+	}
+	if d.Schema.ParentMappings[0].ParentProperty != "ServiceName" || d.Schema.ParentMappings[0].ChildProperty != "Service" {
+		t.Errorf("first mapping = %+v; want {ServiceName, Service}", d.Schema.ParentMappings[0])
+	}
+	if d.Schema.ParentMappings[1].ParentProperty != "Cluster" || d.Schema.ParentMappings[1].ChildProperty != "Cluster" {
+		t.Errorf("second mapping = %+v; want {Cluster, Cluster}", d.Schema.ParentMappings[1])
+	}
+}
+
+func TestExtractSchema_ParentMappings_ListParamFallback(t *testing.T) {
+	descriptors := extractFakeawsDescriptors(t)
+
+	d := findDescriptor(t, descriptors, "FakeAWS::Legacy::LegacyChild")
+	if d.Schema.Parent != "FakeAWS::Legacy::LegacyParent" {
+		t.Errorf("expected Parent=%q, got %q", "FakeAWS::Legacy::LegacyParent", d.Schema.Parent)
+	}
+	if got, want := len(d.Schema.ParentMappings), 1; got != want {
+		t.Fatalf("expected %d ParentMapping, got %d (%#v)", want, got, d.Schema.ParentMappings)
+	}
+	// listParam fallback: ParentProperty from listParam.parentProperty,
+	// ChildProperty derived from listParam.listParameter.
+	if d.Schema.ParentMappings[0].ParentProperty != "ParentId" {
+		t.Errorf("expected ParentProperty=%q, got %q", "ParentId", d.Schema.ParentMappings[0].ParentProperty)
+	}
+	if d.Schema.ParentMappings[0].ChildProperty != "ParentRef" {
+		t.Errorf("expected ChildProperty=%q (from listParameter), got %q", "ParentRef", d.Schema.ParentMappings[0].ChildProperty)
+	}
+}
+
+func TestExtractSchema_ParentMappings_AbsentWhenUnset(t *testing.T) {
+	descriptors := extractFakeawsDescriptors(t)
+
+	// A resource without `parent` or `parentRefs` must emit an empty Parent
+	// and nil/empty ParentMappings so the engine treats it as un-parented.
+	d := findDescriptor(t, descriptors, "FakeAWS::Recursive::TreeNode")
+	if d.Schema.Parent != "" {
+		t.Errorf("expected empty Parent, got %q", d.Schema.Parent)
+	}
+	if len(d.Schema.ParentMappings) != 0 {
+		t.Errorf("expected no ParentMappings, got %#v", d.Schema.ParentMappings)
+	}
+}
+
 // TestExtractSchema_UnannotatedPathsSurface verifies that descriptors.ExtractSchema
 // emits every reachable property path in Schema.Hints — annotated AND unannotated —
 // with unannotated paths defaulting to FieldHint{CreateOnly: false}. This is the

--- a/tests/e2e/config/nuke-config.yaml
+++ b/tests/e2e/config/nuke-config.yaml
@@ -144,6 +144,21 @@ presets:
         - property: DefaultVPC
           value: "true"
 
+  conformance-protect:
+    # Region isolation (regions: us-west-1/us-west-2 + global) protects
+    # region-scoped conformance resources. Global resources (IAM, S3,
+    # Route53, CloudFront) have no region, so an allowlist protects them:
+    # the nuke removes ONLY names containing "formae-e2e" (this suite's own
+    # resources). Conformance resources are named formae-sdk-test-* /
+    # plugin-sdk-test-* and are therefore preserved. New conformance
+    # resource types are protected by default (allowlist semantics).
+    filters:
+      __global__:
+        - property: Name
+          type: contains
+          value: "formae-e2e"
+          invert: true
+
 accounts:
   '942849037363':
     presets:
@@ -151,3 +166,4 @@ accounts:
       - engineers
       - organization
       - defaults
+      - conformance-protect

--- a/tests/e2e/config/nuke-config.yaml
+++ b/tests/e2e/config/nuke-config.yaml
@@ -1,7 +1,6 @@
 regions:
   - global
-  - us-east-1
-  - us-east-2
+  - us-west-1
   - us-west-2
 
 blocklist:

--- a/tests/e2e/go/fixtures/target_replace_aws_v2.pkl
+++ b/tests/e2e/go/fixtures/target_replace_aws_v2.pkl
@@ -40,7 +40,7 @@ forma {
   new formae.Target {
     label = "e2e-target-replace-target"
     config = new aws.Config {
-      region = "us-east-1"
+      region = "us-west-1"
     }
   }
 


### PR DESCRIPTION
## Summary

Introduces a typed `EdgeKind` annotation on `FieldHint` (replacing the boolean `AttachesTo`), `ParentRef`/`ParentMappings` schema additions, and instance-safe `runtimeDependency` destroy-DAG construction.

**Motivation:** an EFS MountTarget destroy race — a TaskDefinition's reference to a FileSystem did not pull the FileSystem's MountTargets into the destroy ordering, so the engine could delete the FileSystem while MountTargets still held it open, stranding both. With `edgeKind = "runtimeDependency"`, MountTargets now delete before their FileSystem.

- `EdgeKind` union (`default` / `attachesTo` / `runtimeDependency`) replaces the `AttachesTo` boolean; the engine derives `EdgeKind` from a legacy `AttachesTo` for one release.
- New `ParentRef` PKL class + `ResourceHint.parentRefs` field (plain camelCase JSON-tag binding) — the precedent for new annotations.
- `Schema.Parent` + `Schema.ParentMappings` plumbed from PKL through the extractor.
- `childPointsAt` instance check (create + destroy phases) with type-discriminated URI lookup via a base-resource index.
- `destroySideMatches` unwraps the post-apply Resolvable `$value` shape so the runtimeDependency child edge fires for the EFS MountTarget case (with regression tests).

Also bundles CI isolation so the e2e aws-nuke and the AWS plugin conformance suite can run concurrently against the shared test account: nuke restricted to its own regions (`us-west-1`/`us-west-2` + `global`) with a global allowlist filter, and the `target_replace` e2e fixture moved off the conformance regions.

A follow-up will add boot-time schema validation that flags a `runtimeDependency`-annotated field whose target type has no child type with non-empty `ParentMappings` (today such a misconfiguration silently no-ops).