### PR TITLE
feat(planner): gate cascade-replace on the dependent's referring CreateOnly

### DIFF
--- a/internal/cli/renderer/patches.go
+++ b/internal/cli/renderer/patches.go
@@ -40,6 +40,15 @@ type PropertyChange struct {
 	IsRef            bool
 	IsOpaque         bool
 	ExistsInPrevious bool
+
+	// IsCascadeResolvable signals an RFC-0042 cascade-update synthetic op
+	// where the new value isn't knowable at plan time (e.g. provider-
+	// assigned identifiers like TaskDefinitionArn). The renderer prints a
+	// friendly "to point at the new <source-label> (current: <value>)"
+	// line instead of trying to format a missing value.
+	IsCascadeResolvable bool
+	CascadeSourceLabel  string
+	CascadeCurrentValue string
 }
 
 // FormatPatchDocument formats JSON Patch operations for cli display
@@ -198,6 +207,20 @@ func extractPropertyChange(patch patchOperation, props map[string]any, previousP
 		Operation: patch.Op,
 	}
 
+	// RFC-0042 cascade-resolvable marker: the value is an object carrying
+	// `$cascade-resolvable: true` and metadata about the source. The new
+	// concrete value isn't known at plan time (provider-assigned), so we
+	// short-circuit normal value formatting and capture the source info
+	// for friendly rendering.
+	if valueMap, ok := patch.Value.(map[string]any); ok {
+		if isCascade, _ := valueMap["$cascade-resolvable"].(bool); isCascade {
+			change.IsCascadeResolvable = true
+			change.CascadeSourceLabel, _ = valueMap["$source-label"].(string)
+			change.CascadeCurrentValue, _ = valueMap["$current-value"].(string)
+			return change, nil
+		}
+	}
+
 	// Set IsOpaque after we have the path
 	propsBytes, _ := json.Marshal(props)
 	change.IsOpaque = isOpaqueProperty(change.Path, previousProperties) || isOpaqueProperty(change.Path, json.RawMessage(propsBytes))
@@ -245,6 +268,18 @@ func extractPropertyChange(patch patchOperation, props map[string]any, previousP
 // formatPropertyChange formats a PropertyChange for display
 func formatPropertyChange(change PropertyChange) string {
 	displayPath := stripArrayIndices(change.Path)
+
+	if change.IsCascadeResolvable {
+		// RFC-0042 cascade-update where the new value is provider-assigned
+		// (e.g. TaskDefinitionArn). Render the friendly form rather than
+		// trying to show `from X to Y` with a missing Y.
+		if change.CascadeCurrentValue != "" {
+			return display.Gold(fmt.Sprintf(`change property "%s" to point at the new %s (current: "%s")`,
+				displayPath, change.CascadeSourceLabel, change.CascadeCurrentValue))
+		}
+		return display.Gold(fmt.Sprintf(`change property "%s" to point at the new %s`,
+			displayPath, change.CascadeSourceLabel))
+	}
 
 	switch change.Operation {
 	case "add":

--- a/internal/cli/renderer/patches.go
+++ b/internal/cli/renderer/patches.go
@@ -41,11 +41,11 @@ type PropertyChange struct {
 	IsOpaque         bool
 	ExistsInPrevious bool
 
-	// IsCascadeResolvable signals an RFC-0042 cascade-update synthetic op
-	// where the new value isn't knowable at plan time (e.g. provider-
-	// assigned identifiers like TaskDefinitionArn). The renderer prints a
-	// friendly "to point at the new <source-label> (current: <value>)"
-	// line instead of trying to format a missing value.
+	// IsCascadeResolvable signals a cascade-update synthetic op where the
+	// new value isn't knowable at plan time (e.g. provider-assigned
+	// identifiers like AWS ARNs). The renderer prints a friendly
+	// "to point at the new <source-label> (current: <value>)" line
+	// instead of trying to format a missing value.
 	IsCascadeResolvable bool
 	CascadeSourceLabel  string
 	CascadeCurrentValue string
@@ -207,7 +207,7 @@ func extractPropertyChange(patch patchOperation, props map[string]any, previousP
 		Operation: patch.Op,
 	}
 
-	// RFC-0042 cascade-resolvable marker: the value is an object carrying
+	// Cascade-resolvable marker: the value is an object carrying
 	// `$cascade-resolvable: true` and metadata about the source. The new
 	// concrete value isn't known at plan time (provider-assigned), so we
 	// short-circuit normal value formatting and capture the source info
@@ -270,9 +270,9 @@ func formatPropertyChange(change PropertyChange) string {
 	displayPath := stripArrayIndices(change.Path)
 
 	if change.IsCascadeResolvable {
-		// RFC-0042 cascade-update where the new value is provider-assigned
-		// (e.g. TaskDefinitionArn). Render the friendly form rather than
-		// trying to show `from X to Y` with a missing Y.
+		// Cascade-update where the new value is provider-assigned (e.g.
+		// an AWS ARN). Render the friendly form rather than trying to
+		// show `from X to Y` with a missing Y.
 		if change.CascadeCurrentValue != "" {
 			return display.Gold(fmt.Sprintf(`change property "%s" to point at the new %s (current: "%s")`,
 				displayPath, change.CascadeSourceLabel, change.CascadeCurrentValue))

--- a/internal/cli/renderer/patches_test.go
+++ b/internal/cli/renderer/patches_test.go
@@ -643,13 +643,13 @@ func TestFormatPatchDocument_EmptyPatchWithUnmanagedOldStack_ShowsManagementMess
 	})
 }
 
-// TestFormatPatchDocument_CascadeResolvableMarker covers RFC-0042's
-// simulate-time UX: the planner synthesizes a `$cascade-resolvable` marker
-// op when a cascade-update's resolvable target is provider-assigned (e.g.
-// ECS Service.TaskDefinition → AWS-assigned TaskDefinitionArn). The
-// renderer must surface "to point at the new <source> (current: <value>)"
-// rather than attempt the usual `from X to Y` formatting that would print
-// the marker JSON.
+// TestFormatPatchDocument_CascadeResolvableMarker covers simulate-time
+// UX for cascade-updates: the planner synthesizes a `$cascade-resolvable`
+// marker op when a cascade-update's resolvable target is provider-
+// assigned (e.g. ECS Service.TaskDefinition → AWS-assigned
+// TaskDefinitionArn). The renderer must surface "to point at the new
+// <source> (current: <value>)" rather than attempt the usual `from X to Y`
+// formatting that would print the marker JSON.
 func TestFormatPatchDocument_CascadeResolvableMarker(t *testing.T) {
 	node := gtree.NewRoot("")
 	patchDoc := json.RawMessage(`[
@@ -677,7 +677,7 @@ func TestFormatPatchDocument_CascadeResolvableMarker(t *testing.T) {
 	}
 
 	assert.Contains(t, combined, `change property "TaskDefinition" to point at the new test-taskdef-for-service`,
-		"renderer must use the friendly RFC-0042 phrasing, not raw JSON")
+		"renderer must use the friendly cascade-update phrasing, not raw JSON")
 	assert.Contains(t, combined, `(current: "arn:aws:ecs:us-east-1:0:task-definition/test:1")`,
 		"renderer must surface the current value so the user can compare")
 	assert.NotContains(t, combined, "$cascade-resolvable",

--- a/internal/cli/renderer/patches_test.go
+++ b/internal/cli/renderer/patches_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ddddddO/gtree"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractTagChange(t *testing.T) {
@@ -640,6 +641,49 @@ func TestFormatPatchDocument_EmptyPatchWithUnmanagedOldStack_ShowsManagementMess
 		// Should only have root node, no management message
 		assert.Len(t, nodes, 1)
 	})
+}
+
+// TestFormatPatchDocument_CascadeResolvableMarker covers RFC-0042's
+// simulate-time UX: the planner synthesizes a `$cascade-resolvable` marker
+// op when a cascade-update's resolvable target is provider-assigned (e.g.
+// ECS Service.TaskDefinition → AWS-assigned TaskDefinitionArn). The
+// renderer must surface "to point at the new <source> (current: <value>)"
+// rather than attempt the usual `from X to Y` formatting that would print
+// the marker JSON.
+func TestFormatPatchDocument_CascadeResolvableMarker(t *testing.T) {
+	node := gtree.NewRoot("")
+	patchDoc := json.RawMessage(`[
+		{
+			"op": "replace",
+			"path": "/TaskDefinition",
+			"value": {
+				"$cascade-resolvable": true,
+				"$source-label": "test-taskdef-for-service",
+				"$current-value": "arn:aws:ecs:us-east-1:0:task-definition/test:1"
+			}
+		}
+	]`)
+	properties := json.RawMessage(`{"TaskDefinition": {"$ref": "formae://x#/TaskDefinitionArn", "$value": "arn:aws:ecs:us-east-1:0:task-definition/test:1"}}`)
+
+	FormatPatchDocument(node, patchDoc, properties, json.RawMessage("{}"), map[string]string{}, "")
+
+	nodes, err := collectNodes(gtree.WalkIterFromRoot(node))
+	require.NoError(t, err)
+	require.NotEmpty(t, nodes)
+
+	var combined string
+	for _, n := range nodes {
+		combined += n.Name() + "\n"
+	}
+
+	assert.Contains(t, combined, `change property "TaskDefinition" to point at the new test-taskdef-for-service`,
+		"renderer must use the friendly RFC-0042 phrasing, not raw JSON")
+	assert.Contains(t, combined, `(current: "arn:aws:ecs:us-east-1:0:task-definition/test:1")`,
+		"renderer must surface the current value so the user can compare")
+	assert.NotContains(t, combined, "$cascade-resolvable",
+		"marker JSON must never leak into user-facing output")
+	assert.NotContains(t, combined, "$source-label",
+		"marker metadata fields must never leak into user-facing output")
 }
 
 func collectNodes(it iter.Seq2[*gtree.WalkerNode, error]) ([]*gtree.WalkerNode, error) {

--- a/internal/datastore/migrations_postgres/00013_resource_updates_cascade_columns.sql
+++ b/internal/datastore/migrations_postgres/00013_resource_updates_cascade_columns.sql
@@ -1,0 +1,16 @@
+-- © 2025 Platform Engineering Labs Inc.
+--
+-- SPDX-License-Identifier: FSL-1.1-ALv2
+
+-- +goose Up
+-- The planner sets IsCascade / CascadeSource on ResourceUpdates produced
+-- by cascade-delete and cascade-update branches; persist them so the CLI
+-- can render the "(cascade) because it depends on X" breadcrumb after
+-- the command is loaded back from the database (e.g. after an agent
+-- restart, or via `formae status <command-id>`).
+ALTER TABLE resource_updates ADD COLUMN IF NOT EXISTS is_cascade BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE resource_updates ADD COLUMN IF NOT EXISTS cascade_source TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE resource_updates DROP COLUMN IF EXISTS is_cascade;
+ALTER TABLE resource_updates DROP COLUMN IF EXISTS cascade_source;

--- a/internal/datastore/migrations_sqlite/00013_resource_updates_cascade_columns.sql
+++ b/internal/datastore/migrations_sqlite/00013_resource_updates_cascade_columns.sql
@@ -1,0 +1,17 @@
+-- © 2025 Platform Engineering Labs Inc.
+--
+-- SPDX-License-Identifier: FSL-1.1-ALv2
+
+-- +goose Up
+-- The planner sets IsCascade / CascadeSource on ResourceUpdates produced
+-- by cascade-delete and cascade-update branches; persist them so the CLI
+-- can render the "(cascade) because it depends on X" breadcrumb after
+-- the command is loaded back from the database (e.g. after an agent
+-- restart, or via `formae status <command-id>`).
+ALTER TABLE resource_updates ADD COLUMN is_cascade INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE resource_updates ADD COLUMN cascade_source TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+-- SQLite doesn't support DROP COLUMN before 3.35.0; leaving the columns
+-- in place on rollback is safe (the application ignores extra columns).
+SELECT 1;

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -258,7 +258,8 @@ SELECT
 	ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 	ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
 	ru.progress_result, ru.most_recent_progress,
-	ru.remaining_resolvables, ru.reference_labels, ru.previous_properties
+	ru.remaining_resolvables, ru.reference_labels, ru.previous_properties,
+	ru.is_cascade, ru.cascade_source
 FROM forma_commands fc
 LEFT JOIN resource_updates ru ON fc.command_id = ru.command_id`
 
@@ -288,6 +289,8 @@ func scanJoinedRowPostgres(rows pgx.Rows) (*forma_command.FormaCommand, *resourc
 	var resourceJSON, resourceTargetJSON, existingResourceJSON, existingTargetJSON []byte
 	var progressResultJSON, mostRecentProgressJSON []byte
 	var remainingResolvablesJSON, referenceLabelsJSON, previousPropertiesJSON []byte
+	var ruIsCascade *bool
+	var ruCascadeSource *string
 
 	err := rows.Scan(
 		// FormaCommand columns
@@ -300,6 +303,7 @@ func scanJoinedRowPostgres(rows pgx.Rows) (*forma_command.FormaCommand, *resourc
 		&resourceJSON, &resourceTargetJSON, &existingResourceJSON, &existingTargetJSON,
 		&progressResultJSON, &mostRecentProgressJSON,
 		&remainingResolvablesJSON, &referenceLabelsJSON, &previousPropertiesJSON,
+		&ruIsCascade, &ruCascadeSource,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -429,6 +433,13 @@ func scanJoinedRowPostgres(rows pgx.Rows) (*forma_command.FormaCommand, *resourc
 	}
 
 	ru.PreviousProperties = previousPropertiesJSON
+
+	if ruIsCascade != nil {
+		ru.IsCascade = *ruIsCascade
+	}
+	if ruCascadeSource != nil {
+		ru.CascadeSource = *ruCascadeSource
+	}
 
 	return &cmd, &ru, nil
 }
@@ -615,7 +626,8 @@ func (d DatastorePostgres) QueryFormaCommands(query *datastore.StatusQuery) ([]*
 			ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 			ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
 			ru.progress_result, ru.most_recent_progress,
-			ru.remaining_resolvables, ru.reference_labels, ru.previous_properties
+			ru.remaining_resolvables, ru.reference_labels, ru.previous_properties,
+	ru.is_cascade, ru.cascade_source
 		FROM forma_commands fc
 		LEFT JOIN resource_updates ru ON fc.command_id = ru.command_id
 		WHERE fc.command_id IN (%s)
@@ -3349,8 +3361,9 @@ func (d DatastorePostgres) BulkStoreResourceUpdates(commandID string, updates []
 				retries, remaining, version, stack_label, group_id, source,
 				resource, resource_target, existing_resource, existing_target,
 				progress_result, most_recent_progress,
-				remaining_resolvables, reference_labels, previous_properties
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+				remaining_resolvables, reference_labels, previous_properties,
+				is_cascade, cascade_source
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
 			ON CONFLICT (command_id, ksuid, operation) DO UPDATE SET
 				state = EXCLUDED.state,
 				start_ts = EXCLUDED.start_ts,
@@ -3369,7 +3382,9 @@ func (d DatastorePostgres) BulkStoreResourceUpdates(commandID string, updates []
 				most_recent_progress = EXCLUDED.most_recent_progress,
 				remaining_resolvables = EXCLUDED.remaining_resolvables,
 				reference_labels = EXCLUDED.reference_labels,
-				previous_properties = EXCLUDED.previous_properties
+				previous_properties = EXCLUDED.previous_properties,
+				is_cascade = EXCLUDED.is_cascade,
+				cascade_source = EXCLUDED.cascade_source
 		`,
 			commandID,
 			ru.DesiredState.Ksuid,
@@ -3392,6 +3407,8 @@ func (d DatastorePostgres) BulkStoreResourceUpdates(commandID string, updates []
 			remainingResolvablesJSON,
 			referenceLabelsJSON,
 			ru.PreviousProperties,
+			ru.IsCascade,
+			ru.CascadeSource,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to insert resource update: %w", err)
@@ -3416,7 +3433,8 @@ func (d DatastorePostgres) LoadResourceUpdates(commandID string) ([]resource_upd
 			retries, remaining, version, stack_label, group_id, source,
 			resource, resource_target, existing_resource, existing_target,
 			progress_result, most_recent_progress,
-			remaining_resolvables, reference_labels, previous_properties
+			remaining_resolvables, reference_labels, previous_properties,
+			is_cascade, cascade_source
 		FROM resource_updates
 		WHERE command_id = $1
 		ORDER BY ksuid ASC
@@ -3437,6 +3455,8 @@ func (d DatastorePostgres) LoadResourceUpdates(commandID string) ([]resource_upd
 		var resourceJSON, resourceTargetJSON, existingResourceJSON, existingTargetJSON []byte
 		var progressResultJSON, mostRecentProgressJSON []byte
 		var remainingResolvablesJSON, referenceLabelsJSON, previousPropertiesJSON []byte
+		var ruIsCascade *bool
+		var ruCascadeSource *string
 
 		err := rows.Scan(
 			&ksuid,
@@ -3459,6 +3479,8 @@ func (d DatastorePostgres) LoadResourceUpdates(commandID string) ([]resource_upd
 			&remainingResolvablesJSON,
 			&referenceLabelsJSON,
 			&previousPropertiesJSON,
+			&ruIsCascade,
+			&ruCascadeSource,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan resource update: %w", err)
@@ -3519,6 +3541,13 @@ func (d DatastorePostgres) LoadResourceUpdates(commandID string) ([]resource_upd
 		}
 
 		ru.PreviousProperties = previousPropertiesJSON
+
+		if ruIsCascade != nil {
+			ru.IsCascade = *ruIsCascade
+		}
+		if ruCascadeSource != nil {
+			ru.CascadeSource = *ruCascadeSource
+		}
 
 		updates = append(updates, ru)
 	}

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -212,7 +212,8 @@ SELECT
 	ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 	ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
 	ru.progress_result, ru.most_recent_progress,
-	ru.remaining_resolvables, ru.reference_labels, ru.previous_properties
+	ru.remaining_resolvables, ru.reference_labels, ru.previous_properties,
+	ru.is_cascade, ru.cascade_source
 FROM forma_commands fc
 LEFT JOIN resource_updates ru ON fc.command_id = ru.command_id`
 
@@ -242,6 +243,8 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 	var resourceJSON, resourceTargetJSON, existingResourceJSON, existingTargetJSON []byte
 	var progressResultJSON, mostRecentProgressJSON []byte
 	var remainingResolvablesJSON, referenceLabelsJSON, previousPropertiesJSON []byte
+	var ruIsCascade sql.NullInt64
+	var ruCascadeSource sql.NullString
 
 	err := rows.Scan(
 		// FormaCommand columns
@@ -254,6 +257,7 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 		&resourceJSON, &resourceTargetJSON, &existingResourceJSON, &existingTargetJSON,
 		&progressResultJSON, &mostRecentProgressJSON,
 		&remainingResolvablesJSON, &referenceLabelsJSON, &previousPropertiesJSON,
+		&ruIsCascade, &ruCascadeSource,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -397,6 +401,13 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 
 	ru.PreviousProperties = previousPropertiesJSON
 
+	if ruIsCascade.Valid {
+		ru.IsCascade = ruIsCascade.Int64 != 0
+	}
+	if ruCascadeSource.Valid {
+		ru.CascadeSource = ruCascadeSource.String
+	}
+
 	return &cmd, &ru, nil
 }
 
@@ -522,7 +533,8 @@ func (d DatastoreSQLite) GetMostRecentFormaCommandByClientID(clientID string) (*
 			ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 			ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
 			ru.progress_result, ru.most_recent_progress,
-			ru.remaining_resolvables, ru.reference_labels, ru.previous_properties
+			ru.remaining_resolvables, ru.reference_labels, ru.previous_properties,
+	ru.is_cascade, ru.cascade_source
 		FROM forma_commands fc
 		LEFT JOIN resource_updates ru ON fc.command_id = ru.command_id
 		WHERE fc.command_id = (
@@ -689,7 +701,8 @@ func (d DatastoreSQLite) QueryFormaCommands(query *datastore.StatusQuery) ([]*fo
 			ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 			ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
 			ru.progress_result, ru.most_recent_progress,
-			ru.remaining_resolvables, ru.reference_labels, ru.previous_properties
+			ru.remaining_resolvables, ru.reference_labels, ru.previous_properties,
+	ru.is_cascade, ru.cascade_source
 		FROM forma_commands fc
 		LEFT JOIN resource_updates ru ON fc.command_id = ru.command_id
 		WHERE fc.command_id IN (%s)
@@ -3420,8 +3433,9 @@ func (d DatastoreSQLite) BulkStoreResourceUpdates(commandID string, updates []re
 			retries, remaining, version, stack_label, group_id, source,
 			resource, resource_target, existing_resource, existing_target,
 			progress_result, most_recent_progress,
-			remaining_resolvables, reference_labels, previous_properties
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			remaining_resolvables, reference_labels, previous_properties,
+			is_cascade, cascade_source
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement: %w", err)
@@ -3501,6 +3515,8 @@ func (d DatastoreSQLite) BulkStoreResourceUpdates(commandID string, updates []re
 			remainingResolvablesJSON,
 			referenceLabelsJSON,
 			ru.PreviousProperties,
+			ru.IsCascade,
+			ru.CascadeSource,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to insert resource update: %w", err)

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -46,12 +46,37 @@ func ExtractResolvableURIs(resource pkgmodel.Resource) []pkgmodel.FormaeURI {
 	return resolver.getResolvableURIs()
 }
 
+// stringifyValue best-effort stringifies a resolvable's cached $value
+// payload (any) into a display string. Returns "" when the value is nil.
+// Maps strings to themselves, scalars via fmt, and everything else via
+// JSON marshalling so renderers can show concrete user-facing strings.
+func stringifyValue(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	switch v := v.(type) {
+	case bool, int, int32, int64, uint, uint32, uint64, float32, float64:
+		return fmt.Sprintf("%v", v)
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+}
+
 // ResolvableRef pairs a resolvable's target resource URI with the field-path
 // at which the reference appears in the consuming resource. Consumers that
 // need to look up per-field schema hints use this instead of ExtractResolvableURIs.
 type ResolvableRef struct {
-	URI        pkgmodel.FormaeURI // resource being referenced
-	TargetPath string             // dot-separated path within the consuming resource
+	URI                pkgmodel.FormaeURI // resource being referenced (no fragment)
+	TargetPath         string             // dot-separated path within the consuming resource
+	SourcePropertyName string             // property name on the referenced resource (e.g. "TaskDefinitionArn")
+	CurrentValue       string             // the cached $value at the consuming TargetPath, or "" if absent
 }
 
 // ExtractResolvableRefs returns every resolvable in the resource along with
@@ -64,7 +89,12 @@ func ExtractResolvableRefs(resource pkgmodel.Resource) []ResolvableRef {
 		for _, ref := range refs {
 			// Construct URI without fragment (just scheme://ksuid)
 			uri := pkgmodel.FormaeURI(fmt.Sprintf("formae://%s", ref.ResourceURI.KSUID()))
-			out = append(out, ResolvableRef{URI: uri, TargetPath: ref.TargetPath})
+			out = append(out, ResolvableRef{
+				URI:                uri,
+				TargetPath:         ref.TargetPath,
+				SourcePropertyName: ref.SourcePropertyName,
+				CurrentValue:       stringifyValue(ref.ResolvedValue.Value),
+			})
 		}
 	}
 	return out

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/platform-engineering-labs/formae/internal/metastructure/patch"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/types"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
@@ -97,6 +98,17 @@ func (ru *ResourceUpdate) ListResolvables() []pkgmodel.FormaeURI {
 	return ru.RemainingResolvables
 }
 
+// ResolveValue substitutes a freshly-read property value into the
+// DesiredState's $ref/$value structures and keeps the derived
+// PatchDocument in sync. PatchDocument is a derived view of (PriorState,
+// DesiredState, Schema) — whenever the executor mutates the state the
+// patch is derived from, the patch must be re-derived so the eventual
+// plugin call sees a diff that matches reality. ResolveValue is the only
+// apply-time mutator of DesiredState.Properties, so it owns the regen.
+//
+// Only Updates need a fresh patch — Create/Delete/Replace carry full
+// desired/prior state to the provider rather than a diff. Patch regen is
+// also a no-op when no Schema is available (sync/discovery paths).
 func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value string) error {
 	properties, err := resolver.ResolvePropertyReferences(formaeUri, ru.DesiredState.Properties, value)
 	if err != nil {
@@ -104,6 +116,21 @@ func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value strin
 		return fmt.Errorf("failed to resolve dynamic properties: %w", err)
 	}
 	ru.DesiredState.Properties = properties
+
+	if ru.Operation == OperationUpdate && len(ru.DesiredState.Schema.Fields) > 0 {
+		patchDoc, _, derr := patch.GeneratePatch(
+			ru.PriorState.Properties,
+			ru.DesiredState.Properties,
+			resolver.NewResolvableProperties(),
+			ru.DesiredState.Schema,
+			pkgmodel.FormaApplyModePatch,
+		)
+		if derr != nil {
+			return fmt.Errorf("failed to re-derive patch document after resolving %s: %w", formaeUri, derr)
+		}
+		ru.DesiredState.PatchDocument = patchDoc
+	}
+
 	return nil
 }
 

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"strings"
 
 	"github.com/tidwall/sjson"
 
@@ -821,7 +822,7 @@ func generateResourceUpdatesForReconcile(
 	// After processing all stacks, find dependencies for delete operations
 	allDeleteUpdates := append(resourceReplaces, implicitDeleteResources...)
 
-	dependencyDeletes := findDependencyUpdates(allDeleteUpdates, allResourcesByStack, existingTargetMap, source)
+	dependencyDeletes, cascadeUpdates := findDependencyUpdates(allDeleteUpdates, allResourcesByStack, existingTargetMap, source)
 
 	// Convert updates to replacements if they have dependency deletes
 
@@ -838,7 +839,36 @@ func generateResourceUpdatesForReconcile(
 	allResourceUpdates = append(allResourceUpdates, convertedDependencyDeletes...)
 
 	finalResourceUpdates := convertUpdatesToReplacementsForDependencies(allResourceUpdates, dependencyDeletes, source)
+
+	// RFC-0042: append cascade-updates produced by findDependencyUpdates'
+	// non-CreateOnly branch AFTER the convert* steps so they're not
+	// re-promoted to Replace. Skip any cascade-update whose resource is
+	// already represented by a user-driven update/create or by an existing
+	// delete (those paths already cover the dependent).
+	finalResourceUpdates = appendCascadeUpdatesIfAbsent(finalResourceUpdates, cascadeUpdates)
 	return finalResourceUpdates, nil
+}
+
+// appendCascadeUpdatesIfAbsent adds each cascade-update to out only when its
+// resource isn't already represented in out by another operation. Prevents
+// double-emission when the user's forma also touches the dependent.
+func appendCascadeUpdatesIfAbsent(out []ResourceUpdate, cascadeUpdates []ResourceUpdate) []ResourceUpdate {
+	if len(cascadeUpdates) == 0 {
+		return out
+	}
+	present := make(map[pkgmodel.FormaeURI]bool, len(out))
+	for _, ru := range out {
+		present[ru.DesiredState.URI().Stripped()] = true
+	}
+	for _, cu := range cascadeUpdates {
+		key := cu.DesiredState.URI().Stripped()
+		if present[key] {
+			continue
+		}
+		out = append(out, cu)
+		present[key] = true
+	}
+	return out
 }
 
 func findUnmanagedResource(resource pkgmodel.Resource, allResources map[string][]*pkgmodel.Resource) (pkgmodel.Resource, bool) {
@@ -1057,8 +1087,9 @@ func generateResourceUpdatesForPatch(
 
 	allUpdates := append(append(resourceCreates, resourceUpdates...), resourceReplaces...)
 
-	dependencyDeletes := findDependencyUpdates(resourceReplaces, allResourcesByStack, existingTargetMap, source)
+	dependencyDeletes, cascadeUpdates := findDependencyUpdates(resourceReplaces, allResourcesByStack, existingTargetMap, source)
 	finalResourceUpdates := convertUpdatesToReplacementsForDependencies(allUpdates, dependencyDeletes, source)
+	finalResourceUpdates = appendCascadeUpdatesIfAbsent(finalResourceUpdates, cascadeUpdates)
 	return finalResourceUpdates, nil
 }
 
@@ -1090,57 +1121,166 @@ func findResourcesThatDependOn(targetResource pkgmodel.Resource, allResources ma
 	return dependentResources, nil
 }
 
-// findDependencyDeletes finds resources that need to be deleted because they depend on resources being deleted
-func findDependencyUpdates(allDeleteUpdates []ResourceUpdate, allResources map[string][]*pkgmodel.Resource, existingTargetMap map[string]*pkgmodel.Target, source FormaCommandSource) []ResourceUpdate {
+// findDependencyUpdates finds resources affected by deletes/replaces and
+// classifies each per RFC-0042: if any of a dependent's references to a
+// resource being deleted lands on a CreateOnly field, the dependent must be
+// cascade-deleted (the same call site converts the delete to a Replace if
+// the dependent is in the forma). If all such references land on mutable
+// fields, the dependent is cascade-updated instead — the resolvable
+// re-resolves at execution time and pushes the new value via Update rather
+// than tearing the dependent down.
+//
+// The cascade-update path is RFC-0042's bug fix for the ECS Service +
+// TaskDefinition revision-bump case and equivalents: parents whose changes
+// force replacement, consumed by resources whose referring field is mutable
+// (UpdateService accepts a new TaskDefinitionArn, no tear-down needed).
+func findDependencyUpdates(allDeleteUpdates []ResourceUpdate, allResources map[string][]*pkgmodel.Resource, existingTargetMap map[string]*pkgmodel.Target, source FormaCommandSource) ([]ResourceUpdate, []ResourceUpdate) {
+	// Collect ksuids of resources being deleted so dependents can decide
+	// whether their refs land on a deletion target.
+	deletedKsuids := make(map[string]bool)
+	for _, du := range allDeleteUpdates {
+		if du.Operation == OperationDelete {
+			deletedKsuids[du.DesiredState.Ksuid] = true
+		}
+	}
+
 	var dependencyDeletes []ResourceUpdate
+	var dependencyUpdates []ResourceUpdate
 
 	for _, deleteUpdate := range allDeleteUpdates {
-		if deleteUpdate.Operation == OperationDelete {
-			// Find all resources that depend on this resource being deleted
-			dependentResources, err := findResourcesThatDependOn(deleteUpdate.DesiredState, allResources)
-			if err != nil {
-				slog.Warn("Failed to find dependent resources",
-					"resource", deleteUpdate.DesiredState.Label,
-					"error", err)
+		if deleteUpdate.Operation != OperationDelete {
+			continue
+		}
+		// Find all resources that depend on this resource being deleted
+		dependentResources, err := findResourcesThatDependOn(deleteUpdate.DesiredState, allResources)
+		if err != nil {
+			slog.Warn("Failed to find dependent resources",
+				"resource", deleteUpdate.DesiredState.Label,
+				"error", err)
+			continue
+		}
+
+		for _, dependentRes := range dependentResources {
+			if dependentRes.Stack == constants.UnmanagedStack {
+				continue
+			}
+			// Check if this dependent resource is not already being deleted
+			alreadyBeingDeleted := false
+			for _, existingDelete := range allDeleteUpdates {
+				if existingDelete.DesiredState.Label == dependentRes.Label &&
+					existingDelete.DesiredState.Stack == dependentRes.Stack &&
+					existingDelete.DesiredState.Type == dependentRes.Type {
+					alreadyBeingDeleted = true
+					break
+				}
+			}
+			if alreadyBeingDeleted {
 				continue
 			}
 
-			// Create delete operations for dependent resources
-			for _, dependentRes := range dependentResources {
-				// Check if this dependent resource is not already being deleted
-				alreadyBeingDeleted := false
-				for _, existingDelete := range allDeleteUpdates {
-					if existingDelete.DesiredState.Label == dependentRes.Label &&
-						existingDelete.DesiredState.Stack == dependentRes.Stack &&
-						existingDelete.DesiredState.Type == dependentRes.Type {
-						alreadyBeingDeleted = true
-						break
-					}
-				}
+			target, ok := existingTargetMap[dependentRes.Target]
+			if !ok || target == nil {
+				slog.Warn("Target not found for cascade",
+					"target", dependentRes.Target, "resource", dependentRes.Label)
+				continue
+			}
 
-				if !alreadyBeingDeleted && dependentRes.Stack != constants.UnmanagedStack {
-					// Create a dependency delete operation
-					dependencyDelete, err := NewResourceUpdateForDestroy(
-						dependentRes,
-						*existingTargetMap[dependentRes.Target],
-						source,
-					)
-					if err != nil {
-						slog.Error("Failed to create dependency delete for resource",
-							"resource", dependentRes.Label,
-							"error", err)
-						continue
-					}
-					dependencyDeletes = append(dependencyDeletes, dependencyDelete)
-					slog.Debug("Adding dependency delete",
-						"dependent", dependentRes.Label,
-						"dependsOn", deleteUpdate.DesiredState.Label)
+			// RFC-0042 branch: cascade-delete only when at least one ref from
+			// dependentRes to a deletion target lands on a CreateOnly field.
+			// Otherwise emit a cascade-update so the resolvable re-resolves
+			// against the new parent without tearing the dependent down.
+			if anyRefIsCreateOnly(dependentRes, deletedKsuids) {
+				dependencyDelete, err := NewResourceUpdateForDestroy(dependentRes, *target, source)
+				if err != nil {
+					slog.Error("Failed to create dependency delete for resource",
+						"resource", dependentRes.Label,
+						"error", err)
+					continue
 				}
+				dependencyDeletes = append(dependencyDeletes, dependencyDelete)
+				slog.Debug("Adding dependency delete",
+					"dependent", dependentRes.Label,
+					"dependsOn", deleteUpdate.DesiredState.Label)
+			} else {
+				dependencyUpdates = append(dependencyUpdates, newCascadeUpdate(dependentRes, *target, source, deleteUpdate.DesiredState.Label))
+				slog.Debug("Adding cascade update (RFC-0042)",
+					"dependent", dependentRes.Label,
+					"dependsOn", deleteUpdate.DesiredState.Label)
 			}
 		}
 	}
 
-	return dependencyDeletes
+	return dependencyDeletes, dependencyUpdates
+}
+
+// anyRefIsCreateOnly reports whether any of dep's resolvable references
+// points at a resource in deletedKsuids via a CreateOnly field on dep's
+// schema. A single CreateOnly ref to a deletion target forces cascade-replace
+// for the whole dependent (per RFC-0042 §2a, mixed-refs case).
+func anyRefIsCreateOnly(dep pkgmodel.Resource, deletedKsuids map[string]bool) bool {
+	for _, ref := range resolver.ExtractResolvableRefs(dep) {
+		ksuid := strings.TrimPrefix(string(ref.URI), "formae://")
+		if !deletedKsuids[ksuid] {
+			continue
+		}
+		hint := dep.Schema.Hints[stripArrayIndicesForHintLookup(ref.TargetPath)]
+		if hint.CreateOnly {
+			return true
+		}
+	}
+	return false
+}
+
+// newCascadeUpdate constructs an Update on dep for the RFC-0042 cascade-
+// update path. DesiredState carries dep's stored properties, including any
+// resolvable URIs; the executor re-reads the (now replaced) parent at apply
+// time and resolves $value fresh, so the new parent value flows to dep
+// through Update rather than a destroy+create.
+func newCascadeUpdate(dep pkgmodel.Resource, target pkgmodel.Target, source FormaCommandSource, cascadeSourceLabel string) ResourceUpdate {
+	return ResourceUpdate{
+		PriorState:           dep,
+		DesiredState:         dep,
+		ExistingTarget:       target,
+		ResourceTarget:       target,
+		Operation:            OperationUpdate,
+		State:                ResourceUpdateStateNotStarted,
+		Source:               source,
+		StackLabel:           dep.Stack,
+		RemainingResolvables: resolver.ExtractResolvableURIs(dep),
+		IsCascade:            true,
+		CascadeSource:        cascadeSourceLabel,
+	}
+}
+
+// stripArrayIndicesForHintLookup mirrors changeset.stripArrayIndices: dotted
+// path with numeric segments removed, suitable for Schema.Hints key lookup.
+// Duplicated rather than imported because changeset depends on
+// resource_update.
+func stripArrayIndicesForHintLookup(path string) string {
+	if path == "" {
+		return path
+	}
+	parts := strings.Split(path, ".")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if isAllDigits(part) && len(parts) > 1 {
+			continue
+		}
+		out = append(out, part)
+	}
+	return strings.Join(out, ".")
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func convertUpdatesToReplacementsForDependencies(allResourceUpdates []ResourceUpdate, dependencyDeletes []ResourceUpdate, source FormaCommandSource) []ResourceUpdate {

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"strings"
 
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
 	"github.com/platform-engineering-labs/formae/internal/constants"
@@ -822,7 +823,7 @@ func generateResourceUpdatesForReconcile(
 	// After processing all stacks, find dependencies for delete operations
 	allDeleteUpdates := append(resourceReplaces, implicitDeleteResources...)
 
-	dependencyDeletes, cascadeUpdates := findDependencyUpdates(allDeleteUpdates, allResourcesByStack, existingTargetMap, source)
+	dependencyDeletes, cascadeUpdates := findDependencyUpdates(allDeleteUpdates, allResourcesByStack, existingTargetMap, source, forma)
 
 	// Convert updates to replacements if they have dependency deletes
 
@@ -878,6 +879,17 @@ func appendCascadeUpdatesIfAbsent(out []ResourceUpdate, cascadeUpdates []Resourc
 				if out[idx].CascadeSource == "" {
 					out[idx].CascadeSource = cu.CascadeSource
 				}
+				// Merge the cascade-update's synthesized ops into the
+				// existing user-driven patch so simulate output covers
+				// both the user's direct changes AND the cascading
+				// resolvable-driven changes in one document.
+				merged, err := mergeJSONPatchDocuments(out[idx].DesiredState.PatchDocument, cu.DesiredState.PatchDocument)
+				if err != nil {
+					slog.Warn("Failed to merge cascade-update patch into existing user Update",
+						"resource", out[idx].DesiredState.Label, "error", err)
+				} else {
+					out[idx].DesiredState.PatchDocument = merged
+				}
 			}
 			continue
 		}
@@ -885,6 +897,46 @@ func appendCascadeUpdatesIfAbsent(out []ResourceUpdate, cascadeUpdates []Resourc
 		indexByURI[key] = len(out) - 1
 	}
 	return out
+}
+
+// mergeJSONPatchDocuments concatenates two JSON-Patch documents (each a JSON
+// array of ops) into a single document. Used to fuse a user-driven Update's
+// patch with the planner's cascade-update synthesized ops. Skips ops in the
+// addition whose `path` already appears in the base (user wins on conflict).
+func mergeJSONPatchDocuments(base, addition json.RawMessage) (json.RawMessage, error) {
+	var baseOps, addOps []json.RawMessage
+	if len(base) > 0 {
+		if err := json.Unmarshal(base, &baseOps); err != nil {
+			return nil, fmt.Errorf("failed to parse base patch document: %w", err)
+		}
+	}
+	if len(addition) > 0 {
+		if err := json.Unmarshal(addition, &addOps); err != nil {
+			return nil, fmt.Errorf("failed to parse addition patch document: %w", err)
+		}
+	}
+	if len(addOps) == 0 {
+		if len(baseOps) == 0 {
+			return nil, nil
+		}
+		return base, nil
+	}
+	// Build a set of paths already covered by the base so duplicate ops
+	// don't override the user's intent.
+	covered := make(map[string]bool, len(baseOps))
+	for _, op := range baseOps {
+		if p := gjson.GetBytes(op, "path").String(); p != "" {
+			covered[p] = true
+		}
+	}
+	merged := append(baseOps[:0:0], baseOps...)
+	for _, op := range addOps {
+		if p := gjson.GetBytes(op, "path").String(); p != "" && covered[p] {
+			continue
+		}
+		merged = append(merged, op)
+	}
+	return json.Marshal(merged)
 }
 
 func findUnmanagedResource(resource pkgmodel.Resource, allResources map[string][]*pkgmodel.Resource) (pkgmodel.Resource, bool) {
@@ -1103,7 +1155,7 @@ func generateResourceUpdatesForPatch(
 
 	allUpdates := append(append(resourceCreates, resourceUpdates...), resourceReplaces...)
 
-	dependencyDeletes, cascadeUpdates := findDependencyUpdates(resourceReplaces, allResourcesByStack, existingTargetMap, source)
+	dependencyDeletes, cascadeUpdates := findDependencyUpdates(resourceReplaces, allResourcesByStack, existingTargetMap, source, forma)
 	finalResourceUpdates := convertUpdatesToReplacementsForDependencies(allUpdates, dependencyDeletes, source)
 	finalResourceUpdates = appendCascadeUpdatesIfAbsent(finalResourceUpdates, cascadeUpdates)
 	return finalResourceUpdates, nil
@@ -1150,13 +1202,27 @@ func findResourcesThatDependOn(targetResource pkgmodel.Resource, allResources ma
 // TaskDefinition revision-bump case and equivalents: parents whose changes
 // force replacement, consumed by resources whose referring field is mutable
 // (UpdateService accepts a new TaskDefinitionArn, no tear-down needed).
-func findDependencyUpdates(allDeleteUpdates []ResourceUpdate, allResources map[string][]*pkgmodel.Resource, existingTargetMap map[string]*pkgmodel.Target, source FormaCommandSource) ([]ResourceUpdate, []ResourceUpdate) {
+func findDependencyUpdates(allDeleteUpdates []ResourceUpdate, allResources map[string][]*pkgmodel.Resource, existingTargetMap map[string]*pkgmodel.Target, source FormaCommandSource, forma *pkgmodel.Forma) ([]ResourceUpdate, []ResourceUpdate) {
 	// Collect ksuids of resources being deleted so dependents can decide
-	// whether their refs land on a deletion target.
+	// whether their refs land on a deletion target. Also build a label
+	// lookup so cascade-update synthesis can name the source resource for
+	// the user, and a forma-by-ksuid index so the synthesizer can recover
+	// the parent's new property values where the user supplied them.
 	deletedKsuids := make(map[string]bool)
+	ksuidToLabel := make(map[string]string)
 	for _, du := range allDeleteUpdates {
 		if du.Operation == OperationDelete {
 			deletedKsuids[du.DesiredState.Ksuid] = true
+			ksuidToLabel[du.DesiredState.Ksuid] = du.DesiredState.Label
+		}
+	}
+	formaByKsuid := make(map[string]*pkgmodel.Resource)
+	if forma != nil {
+		for i := range forma.Resources {
+			r := &forma.Resources[i]
+			if r.Ksuid != "" {
+				formaByKsuid[r.Ksuid] = r
+			}
 		}
 	}
 
@@ -1218,7 +1284,18 @@ func findDependencyUpdates(allDeleteUpdates []ResourceUpdate, allResources map[s
 					"dependent", dependentRes.Label,
 					"dependsOn", deleteUpdate.DesiredState.Label)
 			} else {
-				dependencyUpdates = append(dependencyUpdates, newCascadeUpdate(dependentRes, *target, source, deleteUpdate.DesiredState.Label))
+				cu := newCascadeUpdate(dependentRes, *target, source, deleteUpdate.DesiredState.Label)
+				// Synthesize a plan-time patch so simulate output names the
+				// cascading field change instead of showing an empty Update.
+				// The executor's apply-time regen overwrites this with the
+				// concrete diff against the resolver-updated DesiredState.
+				if synthOps, err := synthesizeCascadeUpdatePatch(dependentRes, deletedKsuids, ksuidToLabel, formaByKsuid); err != nil {
+					slog.Warn("Failed to synthesize cascade-update patch for simulate output",
+						"resource", dependentRes.Label, "error", err)
+				} else if len(synthOps) > 0 {
+					cu.DesiredState.PatchDocument = synthOps
+				}
+				dependencyUpdates = append(dependencyUpdates, cu)
 				slog.Debug("Adding cascade update (RFC-0042)",
 					"dependent", dependentRes.Label,
 					"dependsOn", deleteUpdate.DesiredState.Label)
@@ -1245,6 +1322,92 @@ func anyRefIsCreateOnly(dep pkgmodel.Resource, deletedKsuids map[string]bool) bo
 		}
 	}
 	return false
+}
+
+// synthesizeCascadeUpdatePatch builds a JSON-Patch document describing the
+// resolvable-driven changes a cascade-update will introduce at apply time.
+// Used by the planner so simulate/preview output names every cascading
+// change, not just the user's direct property edits.
+//
+// For each resolvable in dep that points at a resource in deletedKsuids:
+//
+//   - If the parent's forma resource carries a concrete (non-resolvable)
+//     value for the resolvable's source property — i.e. a user-set field
+//     like Name — emit a normal `replace` op with that new value. The
+//     standard renderer then prints `from "old" to "new"`.
+//
+//   - If the source property is provider-assigned (not present in the
+//     forma at plan time — e.g. TaskDefinitionArn assigned by AWS at
+//     Create), emit a `replace` op whose value is a `$cascade-resolvable`
+//     marker object. The CLI renderer translates this into "to point at
+//     the new <source-label> (current: <value>)". The executor's apply-
+//     time regen overwrites this with the concrete diff, so the marker
+//     never reaches a provider.
+//
+// Returns (nil, nil) when dep has no refs to deletion targets.
+func synthesizeCascadeUpdatePatch(
+	dep pkgmodel.Resource,
+	deletedKsuids map[string]bool,
+	ksuidToLabel map[string]string,
+	formaByKsuid map[string]*pkgmodel.Resource,
+) (json.RawMessage, error) {
+	type op struct {
+		Op    string `json:"op"`
+		Path  string `json:"path"`
+		Value any    `json:"value"`
+	}
+	var ops []op
+	for _, ref := range resolver.ExtractResolvableRefs(dep) {
+		ksuid := strings.TrimPrefix(string(ref.URI), "formae://")
+		if !deletedKsuids[ksuid] {
+			continue
+		}
+		path := jsonPointerFromDotPath(ref.TargetPath)
+
+		// Try to recover the new value from the forma's parent state.
+		if parent, ok := formaByKsuid[ksuid]; ok && parent != nil && ref.SourcePropertyName != "" && len(parent.Properties) > 0 {
+			extracted := gjson.GetBytes(parent.Properties, ref.SourcePropertyName)
+			if extracted.Exists() && !looksLikeResolvable(extracted) {
+				ops = append(ops, op{Op: "replace", Path: path, Value: extracted.Value()})
+				continue
+			}
+		}
+
+		// Provider-assigned: emit a marker the CLI renderer recognises.
+		ops = append(ops, op{
+			Op:   "replace",
+			Path: path,
+			Value: map[string]any{
+				"$cascade-resolvable": true,
+				"$source-label":       ksuidToLabel[ksuid],
+				"$current-value":      ref.CurrentValue,
+			},
+		})
+	}
+	if len(ops) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(ops)
+}
+
+// looksLikeResolvable reports whether a gjson Result is itself a $ref/$value
+// wrapper — used to skip parent fields that are themselves resolvables
+// (cross-stack chains), since we can't substitute a concrete value for them.
+func looksLikeResolvable(r gjson.Result) bool {
+	if !r.IsObject() {
+		return false
+	}
+	return r.Get("$ref").Exists() || r.Get("$value").Exists()
+}
+
+// jsonPointerFromDotPath converts the resolver's dot-separated TargetPath
+// (e.g. "Refs.0.Target") into a JSON Pointer (e.g. "/Refs/0/Target") that
+// JSON-Patch consumers expect.
+func jsonPointerFromDotPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	return "/" + strings.ReplaceAll(p, ".", "/")
 }
 
 // newCascadeUpdate constructs an Update on dep for the RFC-0042 cascade-

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -849,24 +849,40 @@ func generateResourceUpdatesForReconcile(
 	return finalResourceUpdates, nil
 }
 
-// appendCascadeUpdatesIfAbsent adds each cascade-update to out only when its
-// resource isn't already represented in out by another operation. Prevents
-// double-emission when the user's forma also touches the dependent.
+// appendCascadeUpdatesIfAbsent merges cascade-updates into out. When the
+// dependent has no user-driven op for the same resource, the cascade-update
+// is appended as-is. When the dependent already has a user-driven Update,
+// the cascade-update is dropped but the existing Update is marked
+// IsCascade=true so the executor regenerates its PatchDocument at apply
+// time — the user's plan-time patch only reflects user changes, but the
+// resolvable's new value from the parent's replacement only becomes
+// available after the resolver runs, and the provider's Update needs both
+// in a single patch.
+//
+// If the existing op is a Create/Delete/Replace (not Update), the cascade-
+// update is dropped without altering the existing op: those operations are
+// "complete" and don't need patch augmentation.
 func appendCascadeUpdatesIfAbsent(out []ResourceUpdate, cascadeUpdates []ResourceUpdate) []ResourceUpdate {
 	if len(cascadeUpdates) == 0 {
 		return out
 	}
-	present := make(map[pkgmodel.FormaeURI]bool, len(out))
-	for _, ru := range out {
-		present[ru.DesiredState.URI().Stripped()] = true
+	indexByURI := make(map[pkgmodel.FormaeURI]int, len(out))
+	for i, ru := range out {
+		indexByURI[ru.DesiredState.URI().Stripped()] = i
 	}
 	for _, cu := range cascadeUpdates {
 		key := cu.DesiredState.URI().Stripped()
-		if present[key] {
+		if idx, exists := indexByURI[key]; exists {
+			if out[idx].Operation == OperationUpdate {
+				out[idx].IsCascade = true
+				if out[idx].CascadeSource == "" {
+					out[idx].CascadeSource = cu.CascadeSource
+				}
+			}
 			continue
 		}
 		out = append(out, cu)
-		present[key] = true
+		indexByURI[key] = len(out) - 1
 	}
 	return out
 }

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -841,10 +841,10 @@ func generateResourceUpdatesForReconcile(
 
 	finalResourceUpdates := convertUpdatesToReplacementsForDependencies(allResourceUpdates, dependencyDeletes, source)
 
-	// RFC-0042: append cascade-updates produced by findDependencyUpdates'
-	// non-CreateOnly branch AFTER the convert* steps so they're not
-	// re-promoted to Replace. Skip any cascade-update whose resource is
-	// already represented by a user-driven update/create or by an existing
+	// Append cascade-updates from findDependencyUpdates' non-CreateOnly
+	// branch AFTER the convert* steps so they're not re-promoted to
+	// Replace. Skip any cascade-update whose resource is already
+	// represented by a user-driven update/create or by an existing
 	// delete (those paths already cover the dependent).
 	finalResourceUpdates = appendCascadeUpdatesIfAbsent(finalResourceUpdates, cascadeUpdates)
 	return finalResourceUpdates, nil
@@ -1190,18 +1190,18 @@ func findResourcesThatDependOn(targetResource pkgmodel.Resource, allResources ma
 }
 
 // findDependencyUpdates finds resources affected by deletes/replaces and
-// classifies each per RFC-0042: if any of a dependent's references to a
-// resource being deleted lands on a CreateOnly field, the dependent must be
-// cascade-deleted (the same call site converts the delete to a Replace if
-// the dependent is in the forma). If all such references land on mutable
-// fields, the dependent is cascade-updated instead — the resolvable
-// re-resolves at execution time and pushes the new value via Update rather
-// than tearing the dependent down.
+// classifies each by the dependent's referring FieldHint: if any of a
+// dependent's references to a resource being deleted lands on a CreateOnly
+// field, the dependent must be cascade-deleted (the same call site
+// converts the delete to a Replace if the dependent is in the forma). If
+// all such references land on mutable fields, the dependent is cascade-
+// updated instead — the resolvable re-resolves at execution time and the
+// new value flows through Update rather than tearing the dependent down.
 //
-// The cascade-update path is RFC-0042's bug fix for the ECS Service +
-// TaskDefinition revision-bump case and equivalents: parents whose changes
-// force replacement, consumed by resources whose referring field is mutable
-// (UpdateService accepts a new TaskDefinitionArn, no tear-down needed).
+// The cascade-update path covers cases like ECS Service consuming a
+// versioned TaskDefinition (Service.taskDefinition is mutable; UpdateService
+// accepts a new TaskDefinitionArn — no tear-down needed when a new TD
+// revision is created).
 func findDependencyUpdates(allDeleteUpdates []ResourceUpdate, allResources map[string][]*pkgmodel.Resource, existingTargetMap map[string]*pkgmodel.Target, source FormaCommandSource, forma *pkgmodel.Forma) ([]ResourceUpdate, []ResourceUpdate) {
 	// Collect ksuids of resources being deleted so dependents can decide
 	// whether their refs land on a deletion target. Also build a label
@@ -1267,10 +1267,11 @@ func findDependencyUpdates(allDeleteUpdates []ResourceUpdate, allResources map[s
 				continue
 			}
 
-			// RFC-0042 branch: cascade-delete only when at least one ref from
-			// dependentRes to a deletion target lands on a CreateOnly field.
-			// Otherwise emit a cascade-update so the resolvable re-resolves
-			// against the new parent without tearing the dependent down.
+			// Cascade decision: cascade-delete only when at least one ref
+			// from dependentRes to a deletion target lands on a CreateOnly
+			// field. Otherwise emit a cascade-update so the resolvable
+			// re-resolves against the new parent without tearing the
+			// dependent down.
 			if anyRefIsCreateOnly(dependentRes, deletedKsuids) {
 				dependencyDelete, err := NewResourceUpdateForDestroy(dependentRes, *target, source)
 				if err != nil {
@@ -1296,7 +1297,7 @@ func findDependencyUpdates(allDeleteUpdates []ResourceUpdate, allResources map[s
 					cu.DesiredState.PatchDocument = synthOps
 				}
 				dependencyUpdates = append(dependencyUpdates, cu)
-				slog.Debug("Adding cascade update (RFC-0042)",
+				slog.Debug("Adding cascade update",
 					"dependent", dependentRes.Label,
 					"dependsOn", deleteUpdate.DesiredState.Label)
 			}
@@ -1309,7 +1310,7 @@ func findDependencyUpdates(allDeleteUpdates []ResourceUpdate, allResources map[s
 // anyRefIsCreateOnly reports whether any of dep's resolvable references
 // points at a resource in deletedKsuids via a CreateOnly field on dep's
 // schema. A single CreateOnly ref to a deletion target forces cascade-replace
-// for the whole dependent (per RFC-0042 §2a, mixed-refs case).
+// for the whole dependent (mixed-refs case).
 func anyRefIsCreateOnly(dep pkgmodel.Resource, deletedKsuids map[string]bool) bool {
 	for _, ref := range resolver.ExtractResolvableRefs(dep) {
 		ksuid := strings.TrimPrefix(string(ref.URI), "formae://")
@@ -1410,11 +1411,11 @@ func jsonPointerFromDotPath(p string) string {
 	return "/" + strings.ReplaceAll(p, ".", "/")
 }
 
-// newCascadeUpdate constructs an Update on dep for the RFC-0042 cascade-
-// update path. DesiredState carries dep's stored properties, including any
-// resolvable URIs; the executor re-reads the (now replaced) parent at apply
-// time and resolves $value fresh, so the new parent value flows to dep
-// through Update rather than a destroy+create.
+// newCascadeUpdate constructs an Update on dep for the cascade-update
+// path. DesiredState carries dep's stored properties, including any
+// resolvable URIs; the executor re-reads the (now replaced) parent at
+// apply time and resolves $value fresh, so the new parent value flows to
+// dep through Update rather than a destroy+create.
 func newCascadeUpdate(dep pkgmodel.Resource, target pkgmodel.Target, source FormaCommandSource, cascadeSourceLabel string) ResourceUpdate {
 	return ResourceUpdate{
 		PriorState:           dep,

--- a/internal/metastructure/resource_update/resource_update_generator_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_test.go
@@ -1089,11 +1089,11 @@ func TestFindDependencyUpdates_SameLabel_DifferentTypes(t *testing.T) {
 	assert.Len(t, cascadeUpdates, 0, "No cascade-updates expected when no dependents reference the deletes")
 }
 
-// TestFindDependencyUpdates_CreateOnlyBranch exercises RFC-0042 §2: the
-// cascade decision branches on the dependent's referring FieldHint.CreateOnly.
-// CreateOnly=true → cascade-delete (today's behavior, dependent gets torn
-// down). CreateOnly=false → cascade-update (the resolvable re-resolves at
-// apply time; the provider's Update absorbs the new parent value).
+// TestFindDependencyUpdates_CreateOnlyBranch exercises the cascade
+// decision: branches on the dependent's referring FieldHint.CreateOnly.
+// CreateOnly=true → cascade-delete (dependent gets torn down).
+// CreateOnly=false → cascade-update (the resolvable re-resolves at apply
+// time; the provider's Update absorbs the new parent value).
 func TestFindDependencyUpdates_CreateOnlyBranch(t *testing.T) {
 	parentKsuid := util.NewID()
 	dependentKsuid := util.NewID()
@@ -1378,7 +1378,7 @@ func TestTranslateFormaeReferencesToKsuid_TargetConfig(t *testing.T) {
 	assert.Equal(t, "us-east-1", config["region"])
 }
 
-// TestAppendCascadeUpdatesIfAbsent_MarksExistingUpdate covers RFC-0042's
+// TestAppendCascadeUpdatesIfAbsent_MarksExistingUpdate covers the cascade-update
 // merge-vs-dedup semantics. The conformance test's ecs-service-update
 // fixture changes BOTH the Service's deploymentConfiguration (mutable Service
 // field — user-driven Update) AND the TaskDef's container image (CreateOnly
@@ -1560,7 +1560,7 @@ func TestSynthesizeCascadeUpdatePatch_NoMatchingRefs(t *testing.T) {
 
 // TestSynthesizeCascadeUpdatePatch_ArrayIndexedPath exercises the path
 // translation from the resolver's dot-separated form (e.g. "Refs.0.Target")
-// into JSON Pointer (e.g. "/Refs/0/Target"). RFC-0042 §2a's array-indexed
+// into JSON Pointer (e.g. "/Refs/0/Target"). The array-indexed
 // case applies equally to the rendered patch.
 func TestSynthesizeCascadeUpdatePatch_ArrayIndexedPath(t *testing.T) {
 	parentKsuid := "parent-ksuid"

--- a/internal/metastructure/resource_update/resource_update_generator_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_test.go
@@ -1083,7 +1083,7 @@ func TestFindDependencyUpdates_SameLabel_DifferentTypes(t *testing.T) {
 		"aws-target": {Label: "aws-target", Namespace: "AWS"},
 	}
 
-	dependencyDeletes, cascadeUpdates := findDependencyUpdates(allDeleteUpdates, allResources, targetMap, FormaCommandSourceUser)
+	dependencyDeletes, cascadeUpdates := findDependencyUpdates(allDeleteUpdates, allResources, targetMap, FormaCommandSourceUser, nil)
 
 	assert.Len(t, dependencyDeletes, 0, "Should not create duplicates when resources with same label but different types are already being deleted")
 	assert.Len(t, cascadeUpdates, 0, "No cascade-updates expected when no dependents reference the deletes")
@@ -1184,7 +1184,7 @@ func TestFindDependencyUpdates_CreateOnlyBranch(t *testing.T) {
 				"test-stack": {&tc.dependent},
 			}
 			dependencyDeletes, cascadeUpdates := findDependencyUpdates(
-				[]ResourceUpdate{parentDelete}, allResources, targetMap, FormaCommandSourceUser,
+				[]ResourceUpdate{parentDelete}, allResources, targetMap, FormaCommandSourceUser, nil,
 			)
 
 			if tc.wantCascadeDelete {
@@ -1452,4 +1452,138 @@ func TestAppendCascadeUpdatesIfAbsent_MarksExistingUpdate(t *testing.T) {
 		assert.Equal(t, OperationCreate, out[0].Operation)
 		assert.False(t, out[0].IsCascade, "Create/Delete should not be repurposed")
 	})
+}
+
+// TestSynthesizeCascadeUpdatePatch_UserProvidedSource exercises the case
+// where the parent's target property is a user-set field whose new value
+// lives in the forma at plan time (e.g. a versioned-parent's Name). The
+// synthesized patch op should be a normal `replace` carrying the concrete
+// new value, ready for the renderer to display `from "old" to "new"`.
+func TestSynthesizeCascadeUpdatePatch_UserProvidedSource(t *testing.T) {
+	parentKsuid := "parent-ksuid"
+	dep := pkgmodel.Resource{
+		Label: "consumer",
+		Type:  "FakeAWS::Versioned::Consumer",
+		Properties: json.RawMessage(`{
+			"Name": "consumer-1",
+			"ParentRef": {"$ref": "formae://` + parentKsuid + `#/Name", "$value": "parent-v1"}
+		}`),
+	}
+	formaByKsuid := map[string]*pkgmodel.Resource{
+		parentKsuid: {
+			Label:      "parent",
+			Type:       "FakeAWS::Versioned::Parent",
+			Ksuid:      parentKsuid,
+			Properties: json.RawMessage(`{"Name": "parent-v2"}`),
+		},
+	}
+
+	patchDoc, err := synthesizeCascadeUpdatePatch(
+		dep,
+		map[string]bool{parentKsuid: true},
+		map[string]string{parentKsuid: "parent"},
+		formaByKsuid,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, patchDoc)
+	patchStr := string(patchDoc)
+	assert.Contains(t, patchStr, `"path":"/ParentRef"`, "patch must target the consumer's referring field")
+	assert.Contains(t, patchStr, `"value":"parent-v2"`, "patch must carry the forma's new value for the user-set source field")
+	assert.NotContains(t, patchStr, "$cascade-resolvable",
+		"user-provided source values should produce normal ops, no marker needed")
+}
+
+// TestSynthesizeCascadeUpdatePatch_ProviderAssignedSource exercises the case
+// where the parent's target property is provider-assigned (e.g. TaskDef's
+// TaskDefinitionArn — only known after AWS Create). The synthesized op
+// should carry a `$cascade-resolvable` marker so the CLI renderer prints
+// the friendly "to point at the new <source> (current: ...)" wording
+// instead of attempting `from X to Y` with a placeholder.
+func TestSynthesizeCascadeUpdatePatch_ProviderAssignedSource(t *testing.T) {
+	parentKsuid := "taskdef-ksuid"
+	dep := pkgmodel.Resource{
+		Label: "ecs-service",
+		Type:  "AWS::ECS::Service",
+		Properties: json.RawMessage(`{
+			"ServiceName": "svc",
+			"TaskDefinition": {"$ref": "formae://` + parentKsuid + `#/TaskDefinitionArn", "$value": "arn:aws:ecs:us-east-1:0:task-definition/test:1"}
+		}`),
+	}
+	// forma's parent has the user-set fields (family, containerDefinitions,
+	// etc.) but NOT TaskDefinitionArn — that's assigned by AWS at Create.
+	formaByKsuid := map[string]*pkgmodel.Resource{
+		parentKsuid: {
+			Label:      "test-taskdef-for-service",
+			Type:       "AWS::ECS::TaskDefinition",
+			Ksuid:      parentKsuid,
+			Properties: json.RawMessage(`{"Family": "test", "ContainerDefinitions": [{"Image": "nginx:1.27"}]}`),
+		},
+	}
+
+	patchDoc, err := synthesizeCascadeUpdatePatch(
+		dep,
+		map[string]bool{parentKsuid: true},
+		map[string]string{parentKsuid: "test-taskdef-for-service"},
+		formaByKsuid,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, patchDoc)
+	patchStr := string(patchDoc)
+	assert.Contains(t, patchStr, `"path":"/TaskDefinition"`)
+	assert.Contains(t, patchStr, `"$cascade-resolvable":true`,
+		"provider-assigned sources must emit the marker so the renderer falls back to the friendly phrasing")
+	assert.Contains(t, patchStr, `"test-taskdef-for-service"`,
+		"marker must carry the source label so the renderer can name the parent")
+	assert.Contains(t, patchStr, "task-definition/test:1",
+		"marker must carry the current $value so the user sees what's being replaced")
+}
+
+// TestSynthesizeCascadeUpdatePatch_NoMatchingRefs returns empty when the
+// dependent has no resolvables pointing at the to-be-deleted set. This is
+// the common path for refs pointing at unaffected parents.
+func TestSynthesizeCascadeUpdatePatch_NoMatchingRefs(t *testing.T) {
+	dep := pkgmodel.Resource{
+		Label: "consumer",
+		Properties: json.RawMessage(`{
+			"OtherRef": {"$ref": "formae://unrelated-ksuid#/Foo", "$value": "x"}
+		}`),
+	}
+	patchDoc, err := synthesizeCascadeUpdatePatch(
+		dep,
+		map[string]bool{"some-other-ksuid": true},
+		map[string]string{},
+		map[string]*pkgmodel.Resource{},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, patchDoc, "no refs to deletion targets → no synthesized ops")
+}
+
+// TestSynthesizeCascadeUpdatePatch_ArrayIndexedPath exercises the path
+// translation from the resolver's dot-separated form (e.g. "Refs.0.Target")
+// into JSON Pointer (e.g. "/Refs/0/Target"). RFC-0042 §2a's array-indexed
+// case applies equally to the rendered patch.
+func TestSynthesizeCascadeUpdatePatch_ArrayIndexedPath(t *testing.T) {
+	parentKsuid := "parent-ksuid"
+	dep := pkgmodel.Resource{
+		Label: "consumer",
+		Properties: json.RawMessage(`{
+			"Refs": [{"Target": {"$ref": "formae://` + parentKsuid + `#/Name", "$value": "v1"}}]
+		}`),
+	}
+	formaByKsuid := map[string]*pkgmodel.Resource{
+		parentKsuid: {
+			Ksuid:      parentKsuid,
+			Properties: json.RawMessage(`{"Name": "v2"}`),
+		},
+	}
+	patchDoc, err := synthesizeCascadeUpdatePatch(
+		dep,
+		map[string]bool{parentKsuid: true},
+		map[string]string{parentKsuid: "parent"},
+		formaByKsuid,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, patchDoc)
+	assert.Contains(t, string(patchDoc), `"path":"/Refs/0/Target"`,
+		"dot-separated TargetPath with numeric segments must convert to JSON Pointer with slashes")
 }

--- a/internal/metastructure/resource_update/resource_update_generator_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_test.go
@@ -1377,3 +1377,79 @@ func TestTranslateFormaeReferencesToKsuid_TargetConfig(t *testing.T) {
 	// Plain values should be unchanged
 	assert.Equal(t, "us-east-1", config["region"])
 }
+
+// TestAppendCascadeUpdatesIfAbsent_MarksExistingUpdate covers RFC-0042's
+// merge-vs-dedup semantics. The conformance test's ecs-service-update
+// fixture changes BOTH the Service's deploymentConfiguration (mutable Service
+// field — user-driven Update) AND the TaskDef's container image (CreateOnly
+// — TaskDef Replace, cascades to Service). The planner emits both a user-
+// driven Update for the Service and a cascade-update from
+// findDependencyUpdates. They target the same URI. Dropping the cascade-
+// update without preserving its information would lose the IsCascade flag,
+// and the executor wouldn't regenerate the patch with the new resolvable
+// value — sending the user's plan-time patch (deploymentConfiguration only)
+// to the provider, which then has no idea TaskDefinitionArn should change.
+//
+// The fix: when the dependent already has a user-driven Update,
+// appendCascadeUpdatesIfAbsent must mark that Update IsCascade=true so the
+// executor knows to regenerate.
+func TestAppendCascadeUpdatesIfAbsent_MarksExistingUpdate(t *testing.T) {
+	dependentURI := pkgmodel.NewFormaeURI("dependent-ksuid", "")
+	sourceLabel := "parent"
+
+	t.Run("existing user-driven Update gets IsCascade=true", func(t *testing.T) {
+		existing := ResourceUpdate{
+			DesiredState: pkgmodel.Resource{Label: "dependent", Type: "T", Stack: "s", Ksuid: dependentURI.KSUID()},
+			Operation:    OperationUpdate,
+			IsCascade:    false,
+		}
+		cascade := ResourceUpdate{
+			DesiredState: pkgmodel.Resource{Label: "dependent", Type: "T", Stack: "s", Ksuid: dependentURI.KSUID()},
+			Operation:    OperationUpdate,
+			IsCascade:    true,
+			CascadeSource: sourceLabel,
+		}
+
+		out := appendCascadeUpdatesIfAbsent([]ResourceUpdate{existing}, []ResourceUpdate{cascade})
+
+		require.Len(t, out, 1, "must dedup — exactly one op for the dependent")
+		assert.Equal(t, OperationUpdate, out[0].Operation)
+		assert.True(t, out[0].IsCascade,
+			"existing Update must be marked IsCascade so the executor regenerates the patch")
+		assert.Equal(t, sourceLabel, out[0].CascadeSource,
+			"existing Update should inherit the cascade source label for diagnostics")
+	})
+
+	t.Run("no duplicate — cascade-update appended as-is", func(t *testing.T) {
+		cascade := ResourceUpdate{
+			DesiredState: pkgmodel.Resource{Label: "dependent", Type: "T", Stack: "s", Ksuid: dependentURI.KSUID()},
+			Operation:    OperationUpdate,
+			IsCascade:    true,
+		}
+		out := appendCascadeUpdatesIfAbsent(nil, []ResourceUpdate{cascade})
+		require.Len(t, out, 1)
+		assert.True(t, out[0].IsCascade)
+	})
+
+	t.Run("existing Create/Delete is not modified", func(t *testing.T) {
+		// If something else already owns the dependent's slot — e.g. a
+		// Replace decomposed into Delete+Create — the cascade-update is
+		// dropped without touching the existing op. Those "complete"
+		// operations carry their own desired state and don't need patch
+		// augmentation.
+		existing := ResourceUpdate{
+			DesiredState: pkgmodel.Resource{Label: "dependent", Type: "T", Stack: "s", Ksuid: dependentURI.KSUID()},
+			Operation:    OperationCreate,
+			IsCascade:    false,
+		}
+		cascade := ResourceUpdate{
+			DesiredState: pkgmodel.Resource{Label: "dependent", Type: "T", Stack: "s", Ksuid: dependentURI.KSUID()},
+			Operation:    OperationUpdate,
+			IsCascade:    true,
+		}
+		out := appendCascadeUpdatesIfAbsent([]ResourceUpdate{existing}, []ResourceUpdate{cascade})
+		require.Len(t, out, 1)
+		assert.Equal(t, OperationCreate, out[0].Operation)
+		assert.False(t, out[0].IsCascade, "Create/Delete should not be repurposed")
+	})
+}

--- a/internal/metastructure/resource_update/resource_update_generator_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_test.go
@@ -1083,9 +1083,126 @@ func TestFindDependencyUpdates_SameLabel_DifferentTypes(t *testing.T) {
 		"aws-target": {Label: "aws-target", Namespace: "AWS"},
 	}
 
-	dependencyDeletes := findDependencyUpdates(allDeleteUpdates, allResources, targetMap, FormaCommandSourceUser)
+	dependencyDeletes, cascadeUpdates := findDependencyUpdates(allDeleteUpdates, allResources, targetMap, FormaCommandSourceUser)
 
 	assert.Len(t, dependencyDeletes, 0, "Should not create duplicates when resources with same label but different types are already being deleted")
+	assert.Len(t, cascadeUpdates, 0, "No cascade-updates expected when no dependents reference the deletes")
+}
+
+// TestFindDependencyUpdates_CreateOnlyBranch exercises RFC-0042 §2: the
+// cascade decision branches on the dependent's referring FieldHint.CreateOnly.
+// CreateOnly=true → cascade-delete (today's behavior, dependent gets torn
+// down). CreateOnly=false → cascade-update (the resolvable re-resolves at
+// apply time; the provider's Update absorbs the new parent value).
+func TestFindDependencyUpdates_CreateOnlyBranch(t *testing.T) {
+	parentKsuid := util.NewID()
+	dependentKsuid := util.NewID()
+
+	parentDelete := ResourceUpdate{
+		DesiredState: pkgmodel.Resource{
+			Label: "parent",
+			Type:  "AWS::Versioned::Parent",
+			Stack: "test-stack",
+			Ksuid: parentKsuid,
+		},
+		Operation: OperationDelete,
+	}
+	targetMap := map[string]*pkgmodel.Target{
+		"test-target": {Label: "test-target", Namespace: "AWS"},
+	}
+
+	// makeDependent returns a dependent resource referencing the parent via
+	// the given property at the given path with the given CreateOnly hint.
+	makeDependent := func(propsJSON string, hints map[string]pkgmodel.FieldHint) pkgmodel.Resource {
+		return pkgmodel.Resource{
+			Label:      "dependent",
+			Type:       "AWS::Versioned::Consumer",
+			Stack:      "test-stack",
+			Target:     "test-target",
+			Ksuid:      dependentKsuid,
+			Properties: json.RawMessage(propsJSON),
+			Schema: pkgmodel.Schema{
+				Identifier: "Name",
+				Hints:      hints,
+			},
+		}
+	}
+
+	parentRefJSON := fmt.Sprintf(`{"ParentRef":{"$ref":"formae://%s#/Name","$value":"parent-v1"}}`, parentKsuid)
+	parentRefArrayJSON := fmt.Sprintf(`{"Refs":[{"Target":{"$ref":"formae://%s#/Name","$value":"parent-v1"}}]}`, parentKsuid)
+	otherKsuid := util.NewID()
+	mixedRefsJSON := fmt.Sprintf(
+		`{"ImmutableRef":{"$ref":"formae://%s#/Name","$value":"parent-v1"},"MutableRef":{"$ref":"formae://%s#/Other","$value":"x"}}`,
+		parentKsuid, otherKsuid,
+	)
+
+	cases := []struct {
+		name              string
+		dependent         pkgmodel.Resource
+		wantCascadeDelete bool // true => dependencyDeletes has 1, cascadeUpdates 0
+	}{
+		{
+			name: "createOnly=true emits cascade-delete",
+			dependent: makeDependent(parentRefJSON, map[string]pkgmodel.FieldHint{
+				"ParentRef": {CreateOnly: true},
+			}),
+			wantCascadeDelete: true,
+		},
+		{
+			name: "createOnly=false emits cascade-update",
+			dependent: makeDependent(parentRefJSON, map[string]pkgmodel.FieldHint{
+				"ParentRef": {CreateOnly: false},
+			}),
+			wantCascadeDelete: false,
+		},
+		{
+			// Per the plan's mixed-refs case: a single CreateOnly ref to a
+			// deletion target forces cascade-replace for the whole dependent
+			// even when another ref to the same target is mutable.
+			name: "mixed refs — any CreateOnly forces cascade-delete",
+			dependent: makeDependent(mixedRefsJSON, map[string]pkgmodel.FieldHint{
+				"ImmutableRef": {CreateOnly: true},
+				"MutableRef":   {CreateOnly: false},
+			}),
+			wantCascadeDelete: true,
+		},
+		{
+			// Array-indexed TargetPath ("Refs.0.Target") must be looked up
+			// under the stripped key ("Refs.Target") — same convention as
+			// changeset.fieldHintForPath / RFC-0034 AttachesTo.
+			name: "array-indexed path uses stripped hint key",
+			dependent: makeDependent(parentRefArrayJSON, map[string]pkgmodel.FieldHint{
+				"Refs.Target": {CreateOnly: true},
+			}),
+			wantCascadeDelete: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			allResources := map[string][]*pkgmodel.Resource{
+				"test-stack": {&tc.dependent},
+			}
+			dependencyDeletes, cascadeUpdates := findDependencyUpdates(
+				[]ResourceUpdate{parentDelete}, allResources, targetMap, FormaCommandSourceUser,
+			)
+
+			if tc.wantCascadeDelete {
+				require.Len(t, dependencyDeletes, 1, "expected a cascade-delete for the dependent")
+				assert.Equal(t, OperationDelete, dependencyDeletes[0].Operation)
+				assert.Equal(t, "dependent", dependencyDeletes[0].DesiredState.Label)
+				assert.Len(t, cascadeUpdates, 0, "no cascade-updates expected when CreateOnly forces delete")
+			} else {
+				require.Len(t, cascadeUpdates, 1, "expected a cascade-update for the dependent")
+				assert.Equal(t, OperationUpdate, cascadeUpdates[0].Operation)
+				assert.Equal(t, "dependent", cascadeUpdates[0].DesiredState.Label)
+				assert.True(t, cascadeUpdates[0].IsCascade, "cascade-update should be marked IsCascade")
+				assert.Equal(t, "parent", cascadeUpdates[0].CascadeSource,
+					"cascade-update should record the source label for debugging")
+				assert.Len(t, dependencyDeletes, 0, "no cascade-deletes expected when all refs are mutable")
+			}
+		})
+	}
 }
 
 func TestGenerateResourceUpdatesForApply_SameLabelDifferentTypes_ReplaceNotGenerated(t *testing.T) {

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -553,7 +553,12 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 	// the plugin call here, the executor has resolved each remaining
 	// resolvable into DesiredState.Properties, so a fresh patch.GeneratePatch
 	// against PriorState.Properties yields the actual provider-side diff.
+	proc.Log().Info("cascade-update regen check IsCascade=%v hasEmptyPatch=%v uri=%v",
+		data.resourceUpdate.IsCascade, hasEmptyPatch, data.resourceUpdate.DesiredState.URI())
 	if data.resourceUpdate.IsCascade && hasEmptyPatch {
+		proc.Log().Info("cascade-update regen INPUT prior=%s desired=%s",
+			string(data.resourceUpdate.PriorState.Properties),
+			string(data.resourceUpdate.DesiredState.Properties))
 		patchDoc, _, err := patch.GeneratePatch(
 			data.resourceUpdate.PriorState.Properties,
 			data.resourceUpdate.DesiredState.Properties,
@@ -566,6 +571,7 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 			data.resourceUpdate.MarkAsFailed()
 			return StateFinishedWithError, data, nil, nil
 		}
+		proc.Log().Info("cascade-update regen OUTPUT patch=%s", string(patchDoc))
 		data.resourceUpdate.DesiredState.PatchDocument = patchDoc
 	}
 

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -504,32 +504,6 @@ func create(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 	return handleProgressUpdate(gen.PID{}, state, data, *result, proc)
 }
 
-// regenerateCascadePatch recomputes the JSON-Patch body for an RFC-0042
-// cascade-update at apply time. The planner emits cascade-updates with an
-// empty PatchDocument because the new resolved value is unknown at plan
-// time (e.g. AWS-assigned identifiers like TaskDefinitionArn:N). After
-// the executor's resolver has substituted post-Create $value entries into
-// the dependent's DesiredState.Properties, the diff against PriorState is
-// concrete; this helper produces the patch the plugin needs.
-//
-// Reuses patch.GeneratePatch — the same machinery NewResourceUpdateForExisting
-// uses — but is invoked here because the planner's prior == desired check
-// inside NewResourceUpdateForExisting would have short-circuited the
-// cascade-update (the user didn't change the dependent, only the parent).
-func regenerateCascadePatch(prior, desired json.RawMessage, schema pkgmodel.Schema) (json.RawMessage, error) {
-	patchDoc, _, err := patch.GeneratePatch(
-		prior,
-		desired,
-		resolver.NewResolvableProperties(),
-		schema,
-		pkgmodel.FormaApplyModePatch,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to regenerate cascade-update patch: %w", err)
-	}
-	return patchDoc, nil
-}
-
 func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom, ResourceUpdateData, []statemachine.Action, error) {
 	// When bringing a resource under management without property changes, skip the plugin
 	// Update call since there are no actual changes to make in the cloud. Instead, create
@@ -573,27 +547,9 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 		return handleProgressUpdate(proc.PID(), state, data, syntheticResult, proc)
 	}
 
-	// RFC-0042: regenerate the PatchDocument at apply time for any Update
-	// that's flagged as cascading. The plan-time patch (if any) only
-	// reflects the user's direct property changes, but a cascade dependent
-	// also needs the new resolved value of a resolvable whose parent is
-	// being replaced — and that value only lands in DesiredState.Properties
-	// once the executor's resolver has run. The regenerated patch is the
-	// concrete diff against PriorState and is a superset of any plan-time
-	// patch, so it's always safe to overwrite.
-	if data.resourceUpdate.IsCascade {
-		patchDoc, err := regenerateCascadePatch(
-			data.resourceUpdate.PriorState.Properties,
-			data.resourceUpdate.DesiredState.Properties,
-			data.resourceUpdate.DesiredState.Schema,
-		)
-		if err != nil {
-			proc.Log().Error("failed to regenerate patch for cascade-update: %v", err)
-			data.resourceUpdate.MarkAsFailed()
-			return StateFinishedWithError, data, nil, nil
-		}
-		data.resourceUpdate.DesiredState.PatchDocument = patchDoc
-	}
+	// PatchDocument is kept in sync by ResourceUpdate.ResolveValue as the
+	// executor's resolver substitutes fresh $value entries into
+	// DesiredState.Properties; nothing patch-related needs doing here.
 
 	// Convert properties to plugin format (extracts $value from opaque structures)
 	convertedResource, err := convertResourceForPlugin(data.resourceUpdate.DesiredState)

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -547,6 +547,28 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 		return handleProgressUpdate(proc.PID(), state, data, syntheticResult, proc)
 	}
 
+	// RFC-0042: planner-emitted cascade-updates carry an empty PatchDocument
+	// because the new resolved value isn't known at plan time (e.g. AWS-
+	// assigned identifiers like TaskDefinitionArn:N). By the time we reach
+	// the plugin call here, the executor has resolved each remaining
+	// resolvable into DesiredState.Properties, so a fresh patch.GeneratePatch
+	// against PriorState.Properties yields the actual provider-side diff.
+	if data.resourceUpdate.IsCascade && hasEmptyPatch {
+		patchDoc, _, err := patch.GeneratePatch(
+			data.resourceUpdate.PriorState.Properties,
+			data.resourceUpdate.DesiredState.Properties,
+			resolver.NewResolvableProperties(),
+			data.resourceUpdate.DesiredState.Schema,
+			pkgmodel.FormaApplyModePatch,
+		)
+		if err != nil {
+			proc.Log().Error("failed to regenerate patch for cascade-update: %v", err)
+			data.resourceUpdate.MarkAsFailed()
+			return StateFinishedWithError, data, nil, nil
+		}
+		data.resourceUpdate.DesiredState.PatchDocument = patchDoc
+	}
+
 	// Convert properties to plugin format (extracts $value from opaque structures)
 	convertedResource, err := convertResourceForPlugin(data.resourceUpdate.DesiredState)
 	if err != nil {

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -547,10 +547,6 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 		return handleProgressUpdate(proc.PID(), state, data, syntheticResult, proc)
 	}
 
-	// PatchDocument is kept in sync by ResourceUpdate.ResolveValue as the
-	// executor's resolver substitutes fresh $value entries into
-	// DesiredState.Properties; nothing patch-related needs doing here.
-
 	// Convert properties to plugin format (extracts $value from opaque structures)
 	convertedResource, err := convertResourceForPlugin(data.resourceUpdate.DesiredState)
 	if err != nil {

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -504,6 +504,32 @@ func create(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 	return handleProgressUpdate(gen.PID{}, state, data, *result, proc)
 }
 
+// regenerateCascadePatch recomputes the JSON-Patch body for an RFC-0042
+// cascade-update at apply time. The planner emits cascade-updates with an
+// empty PatchDocument because the new resolved value is unknown at plan
+// time (e.g. AWS-assigned identifiers like TaskDefinitionArn:N). After
+// the executor's resolver has substituted post-Create $value entries into
+// the dependent's DesiredState.Properties, the diff against PriorState is
+// concrete; this helper produces the patch the plugin needs.
+//
+// Reuses patch.GeneratePatch — the same machinery NewResourceUpdateForExisting
+// uses — but is invoked here because the planner's prior == desired check
+// inside NewResourceUpdateForExisting would have short-circuited the
+// cascade-update (the user didn't change the dependent, only the parent).
+func regenerateCascadePatch(prior, desired json.RawMessage, schema pkgmodel.Schema) (json.RawMessage, error) {
+	patchDoc, _, err := patch.GeneratePatch(
+		prior,
+		desired,
+		resolver.NewResolvableProperties(),
+		schema,
+		pkgmodel.FormaApplyModePatch,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to regenerate cascade-update patch: %w", err)
+	}
+	return patchDoc, nil
+}
+
 func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom, ResourceUpdateData, []statemachine.Action, error) {
 	// When bringing a resource under management without property changes, skip the plugin
 	// Update call since there are no actual changes to make in the cloud. Instead, create
@@ -547,31 +573,25 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 		return handleProgressUpdate(proc.PID(), state, data, syntheticResult, proc)
 	}
 
-	// RFC-0042: planner-emitted cascade-updates carry an empty PatchDocument
-	// because the new resolved value isn't known at plan time (e.g. AWS-
-	// assigned identifiers like TaskDefinitionArn:N). By the time we reach
-	// the plugin call here, the executor has resolved each remaining
-	// resolvable into DesiredState.Properties, so a fresh patch.GeneratePatch
-	// against PriorState.Properties yields the actual provider-side diff.
-	proc.Log().Info("cascade-update regen check IsCascade=%v hasEmptyPatch=%v uri=%v",
-		data.resourceUpdate.IsCascade, hasEmptyPatch, data.resourceUpdate.DesiredState.URI())
-	if data.resourceUpdate.IsCascade && hasEmptyPatch {
-		proc.Log().Info("cascade-update regen INPUT prior=%s desired=%s",
-			string(data.resourceUpdate.PriorState.Properties),
-			string(data.resourceUpdate.DesiredState.Properties))
-		patchDoc, _, err := patch.GeneratePatch(
+	// RFC-0042: regenerate the PatchDocument at apply time for any Update
+	// that's flagged as cascading. The plan-time patch (if any) only
+	// reflects the user's direct property changes, but a cascade dependent
+	// also needs the new resolved value of a resolvable whose parent is
+	// being replaced — and that value only lands in DesiredState.Properties
+	// once the executor's resolver has run. The regenerated patch is the
+	// concrete diff against PriorState and is a superset of any plan-time
+	// patch, so it's always safe to overwrite.
+	if data.resourceUpdate.IsCascade {
+		patchDoc, err := regenerateCascadePatch(
 			data.resourceUpdate.PriorState.Properties,
 			data.resourceUpdate.DesiredState.Properties,
-			resolver.NewResolvableProperties(),
 			data.resourceUpdate.DesiredState.Schema,
-			pkgmodel.FormaApplyModePatch,
 		)
 		if err != nil {
 			proc.Log().Error("failed to regenerate patch for cascade-update: %v", err)
 			data.resourceUpdate.MarkAsFailed()
 			return StateFinishedWithError, data, nil, nil
 		}
-		proc.Log().Info("cascade-update regen OUTPUT patch=%s", string(patchDoc))
 		data.resourceUpdate.DesiredState.PatchDocument = patchDoc
 	}
 

--- a/internal/metastructure/resource_update/resource_updater_test.go
+++ b/internal/metastructure/resource_update/resource_updater_test.go
@@ -40,23 +40,19 @@ func TestResourceUpdater_Initialization(t *testing.T) {
 	assert.False(t, updater.IsTerminated(), "Resource updater should not be terminated after spawning")
 }
 
-// TestRegenerateCascadePatch_ResolvableValueChanged mirrors the RFC-0042
-// cascade-update scenario: the dependent's PriorState carries a $ref+$value
-// pointing at a parent property (e.g. ECS Service.TaskDefinition →
-// TaskDef.TaskDefinitionArn), and the executor's resolver has substituted
-// the post-Create value into DesiredState's $value. The regen helper must
-// flatten both sides and produce a JSON-Patch that replaces the resolvable's
-// target path with the new value — that's the patch the AWS plugin sends to
-// CloudControl UpdateResource.
-func TestRegenerateCascadePatch_ResolvableValueChanged(t *testing.T) {
+// TestResolveValue_KeepsPatchDocumentInSync covers the ResolveValue
+// contract: PatchDocument is derived from (PriorState, DesiredState,
+// Schema), so whenever ResolveValue mutates DesiredState.Properties it
+// must re-derive the patch. Mirrors the cascade-update scenario where a
+// parent (e.g. ECS TaskDefinition) is being replaced and the dependent's
+// $value tracks the parent's new identifier — the eventual plugin Update
+// must see a patch reflecting that change.
+func TestResolveValue_KeepsPatchDocumentInSync(t *testing.T) {
 	parentKsuid := "3E3wKW8YqVCQEyfKjsGpbsoE8bl"
+	parentURI := pkgmodel.FormaeURI("formae://" + parentKsuid + "#/TaskDefinitionArn")
 
 	priorProps := json.RawMessage(`{
 		"ServiceName": "formae-sdk-test-svc",
-		"Cluster": {
-			"$ref": "formae://cluster-ksuid#/Arn",
-			"$value": "arn:aws:ecs:us-east-1:0:cluster/test"
-		},
 		"TaskDefinition": {
 			"$ref": "formae://` + parentKsuid + `#/TaskDefinitionArn",
 			"$value": "arn:aws:ecs:us-east-1:0:task-definition/test:1"
@@ -64,71 +60,109 @@ func TestRegenerateCascadePatch_ResolvableValueChanged(t *testing.T) {
 		"DesiredCount": 0
 	}`)
 
-	// DesiredState mirrors PriorState except the cascading ref's $value has
-	// been bumped by the executor's resolver after the parent's Create
-	// completed (TaskDef revision 2 of the same family).
-	desiredProps := json.RawMessage(`{
-		"ServiceName": "formae-sdk-test-svc",
-		"Cluster": {
-			"$ref": "formae://cluster-ksuid#/Arn",
-			"$value": "arn:aws:ecs:us-east-1:0:cluster/test"
-		},
-		"TaskDefinition": {
-			"$ref": "formae://` + parentKsuid + `#/TaskDefinitionArn",
-			"$value": "arn:aws:ecs:us-east-1:0:task-definition/test:2"
-		},
-		"DesiredCount": 0
-	}`)
-
 	schema := pkgmodel.Schema{
 		Identifier: "ServiceName",
-		Fields:     []string{"ServiceName", "Cluster", "TaskDefinition", "DesiredCount"},
+		Fields:     []string{"ServiceName", "TaskDefinition", "DesiredCount"},
 		Hints: map[string]pkgmodel.FieldHint{
 			"ServiceName":    {CreateOnly: true},
-			"Cluster":        {CreateOnly: true},
 			"TaskDefinition": {CreateOnly: false},
 			"DesiredCount":   {CreateOnly: false},
 		},
 	}
 
-	patchDoc, err := regenerateCascadePatch(priorProps, desiredProps, schema)
-	require.NoError(t, err, "regenerateCascadePatch should succeed")
-	require.NotEmpty(t, patchDoc, "regenerated patch must not be empty — that's the whole point of the helper")
-	patchStr := string(patchDoc)
-	assert.NotEqual(t, "[]", patchStr, "regenerated patch must contain at least one op")
-	assert.Contains(t, patchStr, "TaskDefinition", "patch must target the TaskDefinition path")
-	assert.Contains(t, patchStr, "task-definition/test:2", "patch must carry the post-resolution $value (revision 2)")
-	assert.NotContains(t, patchStr, "task-definition/test:1", "patch must NOT carry the old $value (revision 1)")
-	// Unchanged fields must not appear in the patch.
-	assert.False(t, strings.Contains(patchStr, "DesiredCount") || strings.Contains(patchStr, "Cluster"),
-		"patch should only mention the changed resolvable, not stable fields: %s", patchStr)
+	ru := &ResourceUpdate{
+		Operation: OperationUpdate,
+		PriorState: pkgmodel.Resource{
+			Label:      "svc",
+			Properties: priorProps,
+			Schema:     schema,
+		},
+		DesiredState: pkgmodel.Resource{
+			Label: "svc",
+			// DesiredState starts byte-identical to prior — typical for a
+			// cascade-update emitted by the planner where the user didn't
+			// directly modify the dependent.
+			Properties: append(json.RawMessage(nil), priorProps...),
+			Schema:     schema,
+		},
+	}
+
+	err := ru.ResolveValue(parentURI, "arn:aws:ecs:us-east-1:0:task-definition/test:2")
+	require.NoError(t, err)
+	require.NotEmpty(t, ru.DesiredState.PatchDocument, "ResolveValue must populate PatchDocument when DesiredState changes")
+	patchStr := string(ru.DesiredState.PatchDocument)
+	assert.Contains(t, patchStr, "TaskDefinition", "patch must target the path whose $value changed")
+	assert.Contains(t, patchStr, "task-definition/test:2", "patch must carry the post-resolution $value")
+	assert.NotContains(t, patchStr, "task-definition/test:1", "patch must not carry the pre-resolution $value")
+	assert.False(t, strings.Contains(patchStr, "DesiredCount"),
+		"patch should only diff the changed field, not stable ones: %s", patchStr)
 }
 
-// TestRegenerateCascadePatch_NoChange covers a degenerate input where prior
-// and desired are byte-identical (e.g. the resolver didn't surface a new
-// $value because the parent's relevant property didn't actually change after
-// all). The helper must succeed and return an empty patch — the executor's
-// upstream check then short-circuits the plugin call instead of sending
-// noise.
-func TestRegenerateCascadePatch_NoChange(t *testing.T) {
+// TestResolveValue_NoChangeProducesEmptyPatch confirms that resolving a
+// $ref to the same $value it already has yields an empty/no-op patch —
+// no spurious provider calls.
+func TestResolveValue_NoChangeProducesEmptyPatch(t *testing.T) {
+	parentKsuid := "parent-ksuid"
+	parentURI := pkgmodel.FormaeURI("formae://" + parentKsuid + "#/Arn")
 	props := json.RawMessage(`{
 		"ServiceName": "svc",
-		"TaskDefinition": {
-			"$ref": "formae://parent-ksuid#/TaskDefinitionArn",
-			"$value": "arn:aws:ecs:us-east-1:0:task-definition/test:1"
-		}
+		"ParentRef": {"$ref": "formae://` + parentKsuid + `#/Arn", "$value": "v1"}
 	}`)
 	schema := pkgmodel.Schema{
 		Identifier: "ServiceName",
-		Fields:     []string{"ServiceName", "TaskDefinition"},
+		Fields:     []string{"ServiceName", "ParentRef"},
 		Hints: map[string]pkgmodel.FieldHint{
-			"ServiceName":    {CreateOnly: true},
-			"TaskDefinition": {CreateOnly: false},
+			"ServiceName": {CreateOnly: true},
+			"ParentRef":   {CreateOnly: false},
 		},
 	}
-	patchDoc, err := regenerateCascadePatch(props, props, schema)
+	ru := &ResourceUpdate{
+		Operation: OperationUpdate,
+		PriorState: pkgmodel.Resource{
+			Properties: props,
+			Schema:     schema,
+		},
+		DesiredState: pkgmodel.Resource{
+			Properties: append(json.RawMessage(nil), props...),
+			Schema:     schema,
+		},
+	}
+	err := ru.ResolveValue(parentURI, "v1")
 	require.NoError(t, err)
-	if len(patchDoc) > 0 {
-		assert.Equal(t, "[]", string(patchDoc), "no diff should produce empty patch ops, got %s", string(patchDoc))
+	if len(ru.DesiredState.PatchDocument) > 0 {
+		assert.Equal(t, "[]", string(ru.DesiredState.PatchDocument),
+			"no $value change should produce no patch ops, got %s", string(ru.DesiredState.PatchDocument))
+	}
+}
+
+// TestResolveValue_NonUpdateLeavesPatchDocumentUntouched ensures the
+// patch-regen branch only fires for Updates. Creates and Deletes carry
+// full state to the provider rather than a diff, so they don't need —
+// and shouldn't pay for — a regenerated PatchDocument when resolvables
+// are substituted along the way.
+func TestResolveValue_NonUpdateLeavesPatchDocumentUntouched(t *testing.T) {
+	parentURI := pkgmodel.FormaeURI("formae://parent-ksuid#/Arn")
+	props := json.RawMessage(`{"Ref": {"$ref": "formae://parent-ksuid#/Arn", "$value": "v1"}}`)
+	for _, op := range []OperationType{OperationCreate, OperationDelete, OperationReplace} {
+		t.Run(string(op), func(t *testing.T) {
+			ru := &ResourceUpdate{
+				Operation: op,
+				PriorState: pkgmodel.Resource{Properties: props},
+				DesiredState: pkgmodel.Resource{
+					Properties: append(json.RawMessage(nil), props...),
+					// Schema with Fields so the regen WOULD fire if the
+					// Operation guard weren't in place.
+					Schema: pkgmodel.Schema{
+						Fields: []string{"Ref"},
+						Hints:  map[string]pkgmodel.FieldHint{"Ref": {CreateOnly: false}},
+					},
+					PatchDocument: json.RawMessage(`["pre-existing-untouched"]`),
+				},
+			}
+			err := ru.ResolveValue(parentURI, "v2")
+			require.NoError(t, err)
+			assert.Equal(t, `["pre-existing-untouched"]`, string(ru.DesiredState.PatchDocument),
+				"non-Update operations must not re-derive PatchDocument")
+		})
 	}
 }

--- a/internal/metastructure/resource_update/resource_updater_test.go
+++ b/internal/metastructure/resource_update/resource_updater_test.go
@@ -7,6 +7,8 @@
 package resource_update
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	"ergo.services/ergo/testing/unit"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResourceUpdater_Initialization(t *testing.T) {
@@ -35,4 +38,97 @@ func TestResourceUpdater_Initialization(t *testing.T) {
 	assert.NoError(t, err, "Failed to spawn resource updater")
 	assert.NotNil(t, updater, "Resource updater should not be nil")
 	assert.False(t, updater.IsTerminated(), "Resource updater should not be terminated after spawning")
+}
+
+// TestRegenerateCascadePatch_ResolvableValueChanged mirrors the RFC-0042
+// cascade-update scenario: the dependent's PriorState carries a $ref+$value
+// pointing at a parent property (e.g. ECS Service.TaskDefinition →
+// TaskDef.TaskDefinitionArn), and the executor's resolver has substituted
+// the post-Create value into DesiredState's $value. The regen helper must
+// flatten both sides and produce a JSON-Patch that replaces the resolvable's
+// target path with the new value — that's the patch the AWS plugin sends to
+// CloudControl UpdateResource.
+func TestRegenerateCascadePatch_ResolvableValueChanged(t *testing.T) {
+	parentKsuid := "3E3wKW8YqVCQEyfKjsGpbsoE8bl"
+
+	priorProps := json.RawMessage(`{
+		"ServiceName": "formae-sdk-test-svc",
+		"Cluster": {
+			"$ref": "formae://cluster-ksuid#/Arn",
+			"$value": "arn:aws:ecs:us-east-1:0:cluster/test"
+		},
+		"TaskDefinition": {
+			"$ref": "formae://` + parentKsuid + `#/TaskDefinitionArn",
+			"$value": "arn:aws:ecs:us-east-1:0:task-definition/test:1"
+		},
+		"DesiredCount": 0
+	}`)
+
+	// DesiredState mirrors PriorState except the cascading ref's $value has
+	// been bumped by the executor's resolver after the parent's Create
+	// completed (TaskDef revision 2 of the same family).
+	desiredProps := json.RawMessage(`{
+		"ServiceName": "formae-sdk-test-svc",
+		"Cluster": {
+			"$ref": "formae://cluster-ksuid#/Arn",
+			"$value": "arn:aws:ecs:us-east-1:0:cluster/test"
+		},
+		"TaskDefinition": {
+			"$ref": "formae://` + parentKsuid + `#/TaskDefinitionArn",
+			"$value": "arn:aws:ecs:us-east-1:0:task-definition/test:2"
+		},
+		"DesiredCount": 0
+	}`)
+
+	schema := pkgmodel.Schema{
+		Identifier: "ServiceName",
+		Fields:     []string{"ServiceName", "Cluster", "TaskDefinition", "DesiredCount"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"ServiceName":    {CreateOnly: true},
+			"Cluster":        {CreateOnly: true},
+			"TaskDefinition": {CreateOnly: false},
+			"DesiredCount":   {CreateOnly: false},
+		},
+	}
+
+	patchDoc, err := regenerateCascadePatch(priorProps, desiredProps, schema)
+	require.NoError(t, err, "regenerateCascadePatch should succeed")
+	require.NotEmpty(t, patchDoc, "regenerated patch must not be empty — that's the whole point of the helper")
+	patchStr := string(patchDoc)
+	assert.NotEqual(t, "[]", patchStr, "regenerated patch must contain at least one op")
+	assert.Contains(t, patchStr, "TaskDefinition", "patch must target the TaskDefinition path")
+	assert.Contains(t, patchStr, "task-definition/test:2", "patch must carry the post-resolution $value (revision 2)")
+	assert.NotContains(t, patchStr, "task-definition/test:1", "patch must NOT carry the old $value (revision 1)")
+	// Unchanged fields must not appear in the patch.
+	assert.False(t, strings.Contains(patchStr, "DesiredCount") || strings.Contains(patchStr, "Cluster"),
+		"patch should only mention the changed resolvable, not stable fields: %s", patchStr)
+}
+
+// TestRegenerateCascadePatch_NoChange covers a degenerate input where prior
+// and desired are byte-identical (e.g. the resolver didn't surface a new
+// $value because the parent's relevant property didn't actually change after
+// all). The helper must succeed and return an empty patch — the executor's
+// upstream check then short-circuits the plugin call instead of sending
+// noise.
+func TestRegenerateCascadePatch_NoChange(t *testing.T) {
+	props := json.RawMessage(`{
+		"ServiceName": "svc",
+		"TaskDefinition": {
+			"$ref": "formae://parent-ksuid#/TaskDefinitionArn",
+			"$value": "arn:aws:ecs:us-east-1:0:task-definition/test:1"
+		}
+	}`)
+	schema := pkgmodel.Schema{
+		Identifier: "ServiceName",
+		Fields:     []string{"ServiceName", "TaskDefinition"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"ServiceName":    {CreateOnly: true},
+			"TaskDefinition": {CreateOnly: false},
+		},
+	}
+	patchDoc, err := regenerateCascadePatch(props, props, schema)
+	require.NoError(t, err)
+	if len(patchDoc) > 0 {
+		assert.Equal(t, "[]", string(patchDoc), "no diff should produce empty patch ops, got %s", string(patchDoc))
+	}
 }

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -462,8 +462,8 @@ class Fq {
 
     function hints(resourceClass: reflect.Class): Mapping<String, FieldHint> =
         let(resourceHint = findResourceHint(resourceClass))
-        let(directHints = resourceClass.properties.filter((_, v) -> v.allAnnotations.filterIsInstance(FieldHint).length > 0).map((k, v) ->
-            let(fieldHint = v.allAnnotations.filterIsInstance(FieldHint).firstOrNull)
+        let(directHints = resourceClass.properties.filter((_, v) -> !v.modifiers.contains("hidden")).map((k, v) ->
+            let(fieldHint = v.allAnnotations.filterIsInstance(FieldHint).firstOrNull ?? new FieldHint {})
             let(key = if(fieldHint.outputField != null) fieldHint.outputField else resourceHint.outputKeyTransformation.apply(k))
             let(baseHint = (fieldHint) {
                 required = !(v.type is reflect.NullableType)
@@ -496,8 +496,8 @@ class Fq {
         let(nextVisited = visited.add(className))
         let(subResourceHint = findSubResourceHint(subResourceClass))
         let(outputKeyTransformation = if (subResourceHint != null) subResourceHint.outputKeyTransformation else (it) -> it)
-        let(directHints = subResourceClass.properties.filter((_, v) -> v.allAnnotations.filterIsInstance(FieldHint).length > 0).map((k, v) ->
-            let(fieldHint = v.allAnnotations.filterIsInstance(FieldHint).firstOrNull)
+        let(directHints = subResourceClass.properties.filter((_, v) -> !v.modifiers.contains("hidden")).map((k, v) ->
+            let(fieldHint = v.allAnnotations.filterIsInstance(FieldHint).firstOrNull ?? new FieldHint {})
             let(key = if(fieldHint.outputField != null) fieldHint.outputField else outputKeyTransformation.apply(k))
             let(baseHint = (fieldHint) {
                 required = !(v.type is reflect.NullableType)

--- a/internal/testplugin/fakeaws/fake_aws.go
+++ b/internal/testplugin/fakeaws/fake_aws.go
@@ -80,6 +80,18 @@ func (s *FakeAWS) SupportedResources() []plugin.ResourceDescriptor {
 			Type:         "FakeAWS::EC2::Instance",
 			Discoverable: true,
 		},
+		// Versioned::Parent + Versioned::Consumer model the RFC-0042 case:
+		// a parent whose CreateOnly field forces Replace, and a consumer
+		// referencing it via a non-createOnly field. Used to verify that the
+		// planner does NOT cascade-replace the consumer in that situation.
+		{
+			Type:         "FakeAWS::Versioned::Parent",
+			Discoverable: false,
+		},
+		{
+			Type:         "FakeAWS::Versioned::Consumer",
+			Discoverable: false,
+		},
 	}
 }
 
@@ -108,6 +120,23 @@ func (s *FakeAWS) SchemaForResourceType(resourceType string) (model.Schema, erro
 				"VpcId"},
 			Hints: map[string]model.FieldHint{
 				"VpcId": {AttachesTo: true},
+			},
+		}, nil
+	case "FakeAWS::Versioned::Parent":
+		return model.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "Value"},
+			Hints: map[string]model.FieldHint{
+				"Name": {CreateOnly: true},
+			},
+		}, nil
+	case "FakeAWS::Versioned::Consumer":
+		return model.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "ParentRef"},
+			Hints: map[string]model.FieldHint{
+				"Name":      {CreateOnly: true},
+				"ParentRef": {CreateOnly: false},
 			},
 		}, nil
 	default:

--- a/internal/testplugin/fakeaws/fake_aws.go
+++ b/internal/testplugin/fakeaws/fake_aws.go
@@ -80,10 +80,11 @@ func (s *FakeAWS) SupportedResources() []plugin.ResourceDescriptor {
 			Type:         "FakeAWS::EC2::Instance",
 			Discoverable: true,
 		},
-		// Versioned::Parent + Versioned::Consumer model the RFC-0042 case:
-		// a parent whose CreateOnly field forces Replace, and a consumer
-		// referencing it via a non-createOnly field. Used to verify that the
-		// planner does NOT cascade-replace the consumer in that situation.
+		// Versioned::Parent + Versioned::Consumer model the cascade-update
+		// case: a parent whose CreateOnly field forces Replace, and a
+		// consumer referencing it via a non-CreateOnly field. Used to
+		// verify that the planner does NOT cascade-replace the consumer
+		// in that situation.
 		{
 			Type:         "FakeAWS::Versioned::Parent",
 			Discoverable: false,

--- a/internal/testplugin/fakeaws/schema/pkl/mixed/versioned.pkl
+++ b/internal/testplugin/fakeaws/schema/pkl/mixed/versioned.pkl
@@ -1,0 +1,65 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+/*
+ * FakeAWS Versioned - mixed annotated / unannotated FieldHint fixture
+ * for verifying that descriptors.ExtractSchema emits every property path
+ * (RFC-0042). Properties without an explicit FieldHint must surface in
+ * Schema.Hints with a default FieldHint (createOnly = false); annotated
+ * paths must preserve their values.
+ *
+ * Coverage matrix (paths after Capitalize):
+ *
+ *   VersionedId           — annotated, createOnly = false (default)
+ *   MutableTag            — UNANNOTATED top-level scalar
+ *   ImmutableId           — annotated, createOnly = true
+ *   Block.Description     — UNANNOTATED SubResource leaf
+ *   Block.KnownLeaf       — annotated SubResource leaf
+ *   Block.Inner.Label     — UNANNOTATED deeply nested leaf
+ *   Block.Inner.Tag       — annotated deeply nested leaf, createOnly = true
+ */
+module fakeaws.mixed.versioned
+
+import "@formae/formae.pkl"
+import "../fakeaws.pkl"
+
+const type = "FakeAWS::Mixed::Versioned"
+
+@fakeaws.SubResourceHint
+open class InnerBlock extends formae.SubResource {
+    label: String?
+
+    @fakeaws.FieldHint { createOnly = true }
+    tag: String?
+}
+
+@fakeaws.SubResourceHint
+open class OuterBlock extends formae.SubResource {
+    description: String?
+
+    @fakeaws.FieldHint
+    knownLeaf: String?
+
+    @fakeaws.FieldHint
+    inner: InnerBlock?
+}
+
+@fakeaws.ResourceHint {
+    type = module.type
+    identifier = "VersionedId"
+}
+open class Versioned extends formae.Resource {
+    @fakeaws.FieldHint
+    versionedId: String
+
+    mutableTag: String?
+
+    @fakeaws.FieldHint { createOnly = true }
+    immutableId: String
+
+    @fakeaws.FieldHint
+    block: OuterBlock?
+}

--- a/internal/testplugin/fakeaws/schema/pkl/mixed/versioned.pkl
+++ b/internal/testplugin/fakeaws/schema/pkl/mixed/versioned.pkl
@@ -6,10 +6,10 @@
 
 /*
  * FakeAWS Versioned - mixed annotated / unannotated FieldHint fixture
- * for verifying that descriptors.ExtractSchema emits every property path
- * (RFC-0042). Properties without an explicit FieldHint must surface in
- * Schema.Hints with a default FieldHint (createOnly = false); annotated
- * paths must preserve their values.
+ * for verifying that descriptors.ExtractSchema emits every property path.
+ * Properties without an explicit FieldHint must surface in Schema.Hints
+ * with a default FieldHint (createOnly = false); annotated paths must
+ * preserve their values.
  *
  * Coverage matrix (paths after Capitalize):
  *

--- a/internal/workflow_tests/local/apply_forma/cascade_replace_test.go
+++ b/internal/workflow_tests/local/apply_forma/cascade_replace_test.go
@@ -267,12 +267,14 @@ func TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated(t *testing
 
 		v2cmd := fas[0]
 		var realParentOps, realConsumerOps []resource_update.OperationType
-		for _, ru := range v2cmd.ResourceUpdates {
+		var realConsumerRU *resource_update.ResourceUpdate
+		for i, ru := range v2cmd.ResourceUpdates {
 			switch ru.DesiredState.Label {
 			case "parent":
 				realParentOps = append(realParentOps, ru.Operation)
 			case "consumer":
 				realConsumerOps = append(realConsumerOps, ru.Operation)
+				realConsumerRU = &v2cmd.ResourceUpdates[i]
 			}
 		}
 		assert.Len(t, realParentOps, 2, "real-apply: parent should be Replaced (delete + create)")
@@ -280,6 +282,17 @@ func TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated(t *testing
 		assert.Contains(t, realParentOps, resource_update.OperationCreate)
 		require.Len(t, realConsumerOps, 1, "real-apply: consumer should be Updated, not Replaced")
 		assert.Equal(t, resource_update.OperationUpdate, realConsumerOps[0])
+
+		// IsCascade / CascadeSource must round-trip through SQLite so
+		// post-restart `formae status` can still render the "(cascade)
+		// because it depends on X" breadcrumb. Pre-fix BulkStoreResourceUpdates
+		// dropped these columns and reloading them as the zero value
+		// silently lost the breadcrumb.
+		require.NotNil(t, realConsumerRU)
+		assert.True(t, realConsumerRU.IsCascade,
+			"persisted ResourceUpdate must round-trip IsCascade=true so post-restart status still renders the cascade marker")
+		assert.Equal(t, "parent", realConsumerRU.CascadeSource,
+			"persisted ResourceUpdate must round-trip CascadeSource so 'because it depends on X' survives a reload")
 
 		// The end-to-end proof: the executor's resolver substituted
 		// parent-v2 into DesiredState, ResolveValue re-derived the patch,

--- a/internal/workflow_tests/local/apply_forma/cascade_replace_test.go
+++ b/internal/workflow_tests/local/apply_forma/cascade_replace_test.go
@@ -1,0 +1,196 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated covers
+// RFC-0042 §2: when a parent is replaced (a CreateOnly field on the parent
+// changed) and a dependent references it via a *non*-CreateOnly field, the
+// planner must emit a single Update on the dependent — not a cascade
+// delete+create. Today the planner cascade-replaces the dependent regardless
+// of the referring field's mutability, forcing a tear-down (the ECS Service
+// outage on every TaskDefinition revision bump).
+//
+// Fixture: FakeAWS::Versioned::Parent has a CreateOnly Name field; changing
+// it forces Replace. FakeAWS::Versioned::Consumer.ParentRef resolves to the
+// Parent and is *not* CreateOnly.
+func TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		// The resolve cache performs a plugin Read whenever a $ref needs
+		// fresh resolution. The default fakeaws Read returns "{}", which
+		// fails to surface the parent's Name. Provide canonical responses
+		// per resource type so the resolver succeeds.
+		overrides := &plugin.ResourcePluginOverrides{
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				switch request.ResourceType {
+				case "FakeAWS::Versioned::Parent":
+					return &resource.ReadResult{
+						ResourceType: request.ResourceType,
+						Properties:   `{"Name":"parent-v1","Value":"hello"}`,
+					}, nil
+				case "FakeAWS::Versioned::Consumer":
+					return &resource.ReadResult{
+						ResourceType: request.ResourceType,
+						Properties:   `{"Name":"consumer-1","ParentRef":"parent-v1"}`,
+					}, nil
+				}
+				return nil, nil
+			},
+		}
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		parentSchema := pkgmodel.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "Value"},
+			Hints: map[string]pkgmodel.FieldHint{
+				"Name": {CreateOnly: true},
+			},
+		}
+		consumerSchema := pkgmodel.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "ParentRef"},
+			Hints: map[string]pkgmodel.FieldHint{
+				"Name":      {CreateOnly: true},
+				"ParentRef": {CreateOnly: false},
+			},
+		}
+
+		v1Forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label:      "parent",
+					Type:       "FakeAWS::Versioned::Parent",
+					Properties: json.RawMessage(`{"Name":"parent-v1","Value":"hello"}`),
+					Stack:      "test-stack",
+					Target:     "test-target",
+					Managed:    true,
+					Schema:     parentSchema,
+				},
+				{
+					Label: "consumer",
+					Type:  "FakeAWS::Versioned::Consumer",
+					Properties: json.RawMessage(`{
+						"Name": "consumer-1",
+						"ParentRef": {
+							"$res": true,
+							"$label": "parent",
+							"$type": "FakeAWS::Versioned::Parent",
+							"$stack": "test-stack",
+							"$property": "Name"
+						}
+					}`),
+					Stack:   "test-stack",
+					Target:  "test-target",
+					Managed: true,
+					Schema:  consumerSchema,
+				},
+			},
+			Targets: []pkgmodel.Target{{Label: "test-target"}},
+		}
+
+		_, err = m.ApplyForma(v1Forma, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test")
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			fas, err := m.Datastore.LoadFormaCommands()
+			if err != nil || len(fas) == 0 {
+				return false
+			}
+			return fas[0].State == forma_command.CommandStateSuccess
+		}, 10*time.Second, 100*time.Millisecond, "v1 apply should succeed")
+
+		// v2: change Parent's CreateOnly field, forcing Replace. The Consumer
+		// is unchanged in the forma — only the parent's identity is shifting,
+		// and the resolvable URI (by ksuid) is stable across the parent's
+		// Replace.
+		v2Forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label:      "parent",
+					Type:       "FakeAWS::Versioned::Parent",
+					Properties: json.RawMessage(`{"Name":"parent-v2","Value":"hello"}`),
+					Stack:      "test-stack",
+					Target:     "test-target",
+					Managed:    true,
+					Schema:     parentSchema,
+				},
+				{
+					Label: "consumer",
+					Type:  "FakeAWS::Versioned::Consumer",
+					Properties: json.RawMessage(`{
+						"Name": "consumer-1",
+						"ParentRef": {
+							"$res": true,
+							"$label": "parent",
+							"$type": "FakeAWS::Versioned::Parent",
+							"$stack": "test-stack",
+							"$property": "Name"
+						}
+					}`),
+					Stack:   "test-stack",
+					Target:  "test-target",
+					Managed: true,
+					Schema:  consumerSchema,
+				},
+			},
+			Targets: []pkgmodel.Target{{Label: "test-target"}},
+		}
+
+		// Simulate v2 — we only care about what the planner emits, not what
+		// the executor does with it. Simulate skips execution and returns the
+		// resolved plan directly.
+		resp, err := m.ApplyForma(v2Forma, &config.FormaCommandConfig{
+			Mode:     pkgmodel.FormaApplyModeReconcile,
+			Simulate: true,
+		}, "test")
+		require.NoError(t, err)
+		require.True(t, resp.Simulation.ChangesRequired,
+			"v2 should produce changes — parent's CreateOnly field is shifting")
+
+		var parentOps, consumerOps []string
+		for _, ru := range resp.Simulation.Command.ResourceUpdates {
+			switch ru.ResourceLabel {
+			case "parent":
+				parentOps = append(parentOps, ru.Operation)
+			case "consumer":
+				consumerOps = append(consumerOps, ru.Operation)
+			}
+		}
+
+		assert.Len(t, parentOps, 2, "parent should be Replaced (delete + create)")
+		assert.Contains(t, parentOps, apimodel.OperationDelete, "parent should have a Delete op")
+		assert.Contains(t, parentOps, apimodel.OperationCreate, "parent should have a Create op")
+
+		require.Len(t, consumerOps, 1,
+			"RFC-0042: consumer with non-CreateOnly ref should NOT cascade-replace when parent is replaced")
+		assert.Equal(t, apimodel.OperationUpdate, consumerOps[0],
+			"RFC-0042: consumer with non-CreateOnly ref should be Updated, not Replaced")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/cascade_replace_test.go
+++ b/internal/workflow_tests/local/apply_forma/cascade_replace_test.go
@@ -25,12 +25,14 @@ import (
 )
 
 // TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated covers
-// RFC-0042 §2: when a parent is replaced (a CreateOnly field on the parent
-// changed) and a dependent references it via a *non*-CreateOnly field, the
-// planner must emit a single Update on the dependent — not a cascade
-// delete+create. Today the planner cascade-replaces the dependent regardless
-// of the referring field's mutability, forcing a tear-down (the ECS Service
-// outage on every TaskDefinition revision bump).
+// the cascade-update path: when a parent is replaced (a CreateOnly field
+// on the parent changed) and a dependent references it via a
+// *non*-CreateOnly field, the planner must emit a single Update on the
+// dependent — not a cascade delete+create. The motivating case is an ECS
+// Service consuming a versioned TaskDefinition: tearing the Service down
+// on every TaskDef revision bump (~2-4 min outage per image deploy) was
+// the previous behavior; this test pins the rolling-update behavior in
+// place.
 //
 // Fixture: FakeAWS::Versioned::Parent has a CreateOnly Name field; changing
 // it forces Replace. FakeAWS::Versioned::Consumer.ParentRef resolves to the
@@ -191,9 +193,9 @@ func TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated(t *testing
 		assert.Contains(t, parentOps, apimodel.OperationCreate, "parent should have a Create op")
 
 		require.Len(t, consumerOps, 1,
-			"RFC-0042: consumer with non-CreateOnly ref should NOT cascade-replace when parent is replaced")
+			"consumer with non-CreateOnly ref should NOT cascade-replace when parent is replaced")
 		assert.Equal(t, apimodel.OperationUpdate, consumerOps[0],
-			"RFC-0042: consumer with non-CreateOnly ref should be Updated, not Replaced")
+			"consumer with non-CreateOnly ref should be Updated, not Replaced")
 
 		// Verify the simulate output surfaces the cascading change. The
 		// parent's Name is a user-provided field, so the new value lives in

--- a/internal/workflow_tests/local/apply_forma/cascade_replace_test.go
+++ b/internal/workflow_tests/local/apply_forma/cascade_replace_test.go
@@ -8,6 +8,8 @@ package workflow_tests_local
 
 import (
 	"encoding/json"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,6 +18,7 @@ import (
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
 	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
 	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
@@ -25,39 +28,78 @@ import (
 )
 
 // TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated covers
-// the cascade-update path: when a parent is replaced (a CreateOnly field
-// on the parent changed) and a dependent references it via a
-// *non*-CreateOnly field, the planner must emit a single Update on the
-// dependent — not a cascade delete+create. The motivating case is an ECS
-// Service consuming a versioned TaskDefinition: tearing the Service down
-// on every TaskDef revision bump (~2-4 min outage per image deploy) was
-// the previous behavior; this test pins the rolling-update behavior in
-// place.
+// the cascade-update path end-to-end: when a parent is replaced (a
+// CreateOnly field on the parent changed) and a dependent references it
+// via a *non*-CreateOnly field, the planner emits a single Update on the
+// dependent — not a cascade delete+create — and the executor regenerates
+// the dependent's PatchDocument so the provider's Update actually carries
+// the new resolved value.
 //
-// Fixture: FakeAWS::Versioned::Parent has a CreateOnly Name field; changing
-// it forces Replace. FakeAWS::Versioned::Consumer.ParentRef resolves to the
-// Parent and is *not* CreateOnly.
+// Motivating real-world case: an ECS Service consuming a versioned
+// TaskDefinition. Tearing the Service down on every TaskDef revision
+// bump (~2-4 min outage per image deploy) was the previous behavior;
+// this test pins the rolling-update behavior in place locally so we
+// don't have to rely solely on the AWS-side conformance run.
+//
+// Two phases share the same v1 setup:
+//   - Simulate v2 to confirm the planner emits cascade-update with
+//     IsCascade=true and a synthesized PatchDocument the CLI can preview.
+//   - Real-apply v2 to confirm the executor runs the resolver, regenerates
+//     the patch with the post-replace parent value, and hands that patch
+//     to the provider's Update.
+//
+// Fixture: FakeAWS::Versioned::Parent has a CreateOnly Name field;
+// changing it forces Replace. FakeAWS::Versioned::Consumer.ParentRef
+// resolves to the Parent and is *not* CreateOnly.
 func TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
-		// The resolve cache performs a plugin Read whenever a $ref needs
-		// fresh resolution. The default fakeaws Read returns "{}", which
-		// fails to surface the parent's Name. Provide canonical responses
-		// per resource type so the resolver succeeds.
+		// Stateful Read so the resolve cache returns parent-v1 during v1
+		// and parent-v2 once we flip the flag for v2. Without this the
+		// executor's resolver would substitute the old value into
+		// DesiredState at v2 apply time, the patch regen would produce
+		// no diff, and the test would silently pass the wrong thing.
+		var parentName atomic.Value
+		parentName.Store("parent-v1")
+
+		// Captures the PatchDocument the plugin actually receives for the
+		// consumer's Update — the end-to-end signal that the regenerated
+		// patch made it all the way through.
+		var consumerUpdatePatch atomic.Value
+
 		overrides := &plugin.ResourcePluginOverrides{
-			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
-				switch request.ResourceType {
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				switch req.ResourceType {
 				case "FakeAWS::Versioned::Parent":
+					name := parentName.Load().(string)
 					return &resource.ReadResult{
-						ResourceType: request.ResourceType,
-						Properties:   `{"Name":"parent-v1","Value":"hello"}`,
+						ResourceType: req.ResourceType,
+						Properties:   fmt.Sprintf(`{"Name":"%s","Value":"hello"}`, name),
 					}, nil
 				case "FakeAWS::Versioned::Consumer":
+					// The drift-detection Read at the start of an Update
+					// compares the plugin's properties to the stored ones
+					// (with $ref/$value stripped). Return the pre-update
+					// cloud state — the consumer's ParentRef still tracks
+					// parent-v1 because Update hasn't fired yet.
 					return &resource.ReadResult{
-						ResourceType: request.ResourceType,
+						ResourceType: req.ResourceType,
 						Properties:   `{"Name":"consumer-1","ParentRef":"parent-v1"}`,
 					}, nil
 				}
 				return nil, nil
+			},
+			Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				if req.ResourceType == "FakeAWS::Versioned::Consumer" && req.PatchDocument != nil {
+					consumerUpdatePatch.Store(*req.PatchDocument)
+				}
+				return &resource.UpdateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationUpdate,
+						OperationStatus: resource.OperationStatusSuccess,
+						RequestID:       "update-req-1",
+						NativeID:        req.NativeID,
+					},
+				}, nil
 			},
 		}
 		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
@@ -120,17 +162,20 @@ func TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated(t *testing
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			fas, err := m.Datastore.LoadFormaCommands()
-			if err != nil || len(fas) == 0 {
+			fas, _ := m.Datastore.LoadFormaCommands()
+			if len(fas) == 0 {
 				return false
 			}
-			return fas[0].State == forma_command.CommandStateSuccess
-		}, 10*time.Second, 100*time.Millisecond, "v1 apply should succeed")
+			return fas[0].State == forma_command.CommandStateSuccess || fas[0].State == forma_command.CommandStateFailed
+		}, 10*time.Second, 100*time.Millisecond, "v1 should reach terminal state")
+		fas, _ := m.Datastore.LoadFormaCommands()
+		require.Equal(t, forma_command.CommandStateSuccess, fas[0].State, "v1 apply should succeed")
 
-		// v2: change Parent's CreateOnly field, forcing Replace. The Consumer
-		// is unchanged in the forma — only the parent's identity is shifting,
-		// and the resolvable URI (by ksuid) is stable across the parent's
-		// Replace.
+		// v2: bump parent.Name (CreateOnly, forces Replace) and flip the
+		// stateful Read so the executor's resolver picks up the new
+		// identity when the consumer re-resolves at apply time.
+		parentName.Store("parent-v2")
+
 		v2Forma := &pkgmodel.Forma{
 			Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
 			Resources: []pkgmodel.Resource{
@@ -165,50 +210,90 @@ func TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated(t *testing
 			Targets: []pkgmodel.Target{{Label: "test-target"}},
 		}
 
-		// Simulate v2 — we only care about what the planner emits, not what
-		// the executor does with it. Simulate skips execution and returns the
-		// resolved plan directly.
-		resp, err := m.ApplyForma(v2Forma, &config.FormaCommandConfig{
+		// --- Phase 1: simulate v2, assert on the planner's API-level output.
+		// Simulate doesn't persist a FormaCommand, so the IsCascade flag
+		// (which BulkStoreResourceUpdates currently drops on the floor)
+		// survives in the response.
+		simResp, err := m.ApplyForma(v2Forma, &config.FormaCommandConfig{
 			Mode:     pkgmodel.FormaApplyModeReconcile,
 			Simulate: true,
 		}, "test")
 		require.NoError(t, err)
-		require.True(t, resp.Simulation.ChangesRequired,
-			"v2 should produce changes — parent's CreateOnly field is shifting")
+		require.True(t, simResp.Simulation.ChangesRequired, "v2 should produce changes")
 
-		var parentOps, consumerOps []string
-		var consumerUpdate *apimodel.ResourceUpdate
-		for i, ru := range resp.Simulation.Command.ResourceUpdates {
+		var simParentOps, simConsumerOps []string
+		var simConsumerUpdate *apimodel.ResourceUpdate
+		for i, ru := range simResp.Simulation.Command.ResourceUpdates {
 			switch ru.ResourceLabel {
 			case "parent":
-				parentOps = append(parentOps, ru.Operation)
+				simParentOps = append(simParentOps, ru.Operation)
 			case "consumer":
-				consumerOps = append(consumerOps, ru.Operation)
-				consumerUpdate = &resp.Simulation.Command.ResourceUpdates[i]
+				simConsumerOps = append(simConsumerOps, ru.Operation)
+				simConsumerUpdate = &simResp.Simulation.Command.ResourceUpdates[i]
 			}
 		}
-
-		assert.Len(t, parentOps, 2, "parent should be Replaced (delete + create)")
-		assert.Contains(t, parentOps, apimodel.OperationDelete, "parent should have a Delete op")
-		assert.Contains(t, parentOps, apimodel.OperationCreate, "parent should have a Create op")
-
-		require.Len(t, consumerOps, 1,
-			"consumer with non-CreateOnly ref should NOT cascade-replace when parent is replaced")
-		assert.Equal(t, apimodel.OperationUpdate, consumerOps[0],
-			"consumer with non-CreateOnly ref should be Updated, not Replaced")
-
-		// Verify the simulate output surfaces the cascading change. The
-		// parent's Name is a user-provided field, so the new value lives in
-		// the v2 forma and the synthesized patch should carry a concrete
-		// `replace` op on /ParentRef with "parent-v2".
-		require.NotNil(t, consumerUpdate)
-		require.NotEmpty(t, consumerUpdate.PatchDocument,
-			"cascade-update must carry a synthesized patch so simulate output names the cascading field change")
-		patchStr := string(consumerUpdate.PatchDocument)
+		assert.Len(t, simParentOps, 2, "simulate: parent should be Replaced (delete + create)")
+		assert.Contains(t, simParentOps, apimodel.OperationDelete)
+		assert.Contains(t, simParentOps, apimodel.OperationCreate)
+		require.Len(t, simConsumerOps, 1, "simulate: consumer with non-CreateOnly ref should NOT cascade-replace")
+		assert.Equal(t, apimodel.OperationUpdate, simConsumerOps[0])
+		require.NotNil(t, simConsumerUpdate)
+		assert.True(t, simConsumerUpdate.IsCascade,
+			"simulate response must surface the IsCascade flag so the CLI can render '(cascade)'")
+		patchStr := string(simConsumerUpdate.PatchDocument)
 		assert.Contains(t, patchStr, `"path":"/ParentRef"`,
 			"synthesized patch must target the dependent's referring field")
 		assert.Contains(t, patchStr, `"parent-v2"`,
 			"user-provided source field: synthesized patch should carry the concrete new value from the forma")
-		assert.True(t, consumerUpdate.IsCascade, "cascade-update must propagate the IsCascade flag to the API model")
+
+		// --- Phase 2: real-apply v2. The simulate above didn't persist;
+		// this run drives the executor through resolving → updating, the
+		// resolver substitutes parent-v2 via the stateful Read, ResolveValue
+		// re-derives the patch, and the provider's Update receives it.
+		_, err = m.ApplyForma(v2Forma, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test")
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			fas, _ := m.Datastore.LoadFormaCommands()
+			if len(fas) < 2 {
+				return false
+			}
+			return fas[0].State == forma_command.CommandStateSuccess || fas[0].State == forma_command.CommandStateFailed
+		}, 30*time.Second, 100*time.Millisecond, "v2 should reach terminal state")
+		fas, _ = m.Datastore.LoadFormaCommands()
+		require.Equal(t, forma_command.CommandStateSuccess, fas[0].State, "v2 apply should succeed end-to-end")
+
+		v2cmd := fas[0]
+		var realParentOps, realConsumerOps []resource_update.OperationType
+		for _, ru := range v2cmd.ResourceUpdates {
+			switch ru.DesiredState.Label {
+			case "parent":
+				realParentOps = append(realParentOps, ru.Operation)
+			case "consumer":
+				realConsumerOps = append(realConsumerOps, ru.Operation)
+			}
+		}
+		assert.Len(t, realParentOps, 2, "real-apply: parent should be Replaced (delete + create)")
+		assert.Contains(t, realParentOps, resource_update.OperationDelete)
+		assert.Contains(t, realParentOps, resource_update.OperationCreate)
+		require.Len(t, realConsumerOps, 1, "real-apply: consumer should be Updated, not Replaced")
+		assert.Equal(t, resource_update.OperationUpdate, realConsumerOps[0])
+
+		// The end-to-end proof: the executor's resolver substituted
+		// parent-v2 into DesiredState, ResolveValue re-derived the patch,
+		// and that patch made it all the way to the provider's Update
+		// call. Without the apply-time regen this would either be empty
+		// (silently no-opping the Update) or carry the stale parent-v1
+		// value.
+		rawPatch, ok := consumerUpdatePatch.Load().(string)
+		require.True(t, ok, "plugin Update was never called for the consumer")
+		assert.Contains(t, rawPatch, "/ParentRef",
+			"the patch the provider receives must target the resolvable's path")
+		assert.Contains(t, rawPatch, "parent-v2",
+			"the patch the provider receives must carry the post-resolution value, not the stale plan-time one")
+		assert.NotContains(t, rawPatch, "parent-v1",
+			"the patch the provider receives must NOT carry the pre-resolution value")
 	})
 }

--- a/internal/workflow_tests/local/apply_forma/cascade_replace_test.go
+++ b/internal/workflow_tests/local/apply_forma/cascade_replace_test.go
@@ -175,12 +175,14 @@ func TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated(t *testing
 			"v2 should produce changes — parent's CreateOnly field is shifting")
 
 		var parentOps, consumerOps []string
-		for _, ru := range resp.Simulation.Command.ResourceUpdates {
+		var consumerUpdate *apimodel.ResourceUpdate
+		for i, ru := range resp.Simulation.Command.ResourceUpdates {
 			switch ru.ResourceLabel {
 			case "parent":
 				parentOps = append(parentOps, ru.Operation)
 			case "consumer":
 				consumerOps = append(consumerOps, ru.Operation)
+				consumerUpdate = &resp.Simulation.Command.ResourceUpdates[i]
 			}
 		}
 
@@ -192,5 +194,19 @@ func TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated(t *testing
 			"RFC-0042: consumer with non-CreateOnly ref should NOT cascade-replace when parent is replaced")
 		assert.Equal(t, apimodel.OperationUpdate, consumerOps[0],
 			"RFC-0042: consumer with non-CreateOnly ref should be Updated, not Replaced")
+
+		// Verify the simulate output surfaces the cascading change. The
+		// parent's Name is a user-provided field, so the new value lives in
+		// the v2 forma and the synthesized patch should carry a concrete
+		// `replace` op on /ParentRef with "parent-v2".
+		require.NotNil(t, consumerUpdate)
+		require.NotEmpty(t, consumerUpdate.PatchDocument,
+			"cascade-update must carry a synthesized patch so simulate output names the cascading field change")
+		patchStr := string(consumerUpdate.PatchDocument)
+		assert.Contains(t, patchStr, `"path":"/ParentRef"`,
+			"synthesized patch must target the dependent's referring field")
+		assert.Contains(t, patchStr, `"parent-v2"`,
+			"user-provided source field: synthesized patch should carry the concrete new value from the forma")
+		assert.True(t, consumerUpdate.IsCascade, "cascade-update must propagate the IsCascade flag to the API model")
 	})
 }

--- a/pkg/plugin/descriptors/extract_schema_test.go
+++ b/pkg/plugin/descriptors/extract_schema_test.go
@@ -62,9 +62,9 @@ func TestExtractSchema_RecursiveSubResource(t *testing.T) {
 // TestExtractSchema_UnannotatedPathsSurface verifies that descriptors.ExtractSchema
 // emits every reachable property path in Schema.Hints — annotated AND unannotated —
 // with unannotated paths defaulting to FieldHint{CreateOnly: false}. This is the
-// schema contract underpinning RFC-0042 (cascade-replace gating on createOnly):
-// the planner must see every reference target's createOnly value, even when the
-// PKL author did not write an explicit @FieldHint.
+// schema contract that lets the planner gate cascade-replace on createOnly: it
+// must see every reference target's createOnly value, even when the PKL author
+// did not write an explicit @FieldHint.
 //
 // Annotated values (createOnly=true on IAM::Role.RoleName-style fields) must be
 // preserved exactly; unannotated paths must show up with createOnly=false at

--- a/pkg/plugin/descriptors/extract_schema_test.go
+++ b/pkg/plugin/descriptors/extract_schema_test.go
@@ -9,6 +9,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
 )
 
 func projectRoot() string {
@@ -16,7 +19,8 @@ func projectRoot() string {
 	return filepath.Join(filepath.Dir(filename), "..", "..", "..")
 }
 
-func TestExtractSchema_RecursiveSubResource(t *testing.T) {
+func extractFakeawsDescriptors(t *testing.T) []plugin.ResourceTypeDescriptor {
+	t.Helper()
 	ctx := context.Background()
 
 	formaeSchemaProject := filepath.Join(projectRoot(), "internal", "schema", "pkl", "schema", "PklProject")
@@ -27,25 +31,89 @@ func TestExtractSchema_RecursiveSubResource(t *testing.T) {
 		{Name: "fakeaws", Value: fakeawsProject},
 	})
 	if err != nil {
-		t.Fatalf("ExtractSchema failed (possible stack overflow on recursive sub-resource types): %v", err)
+		t.Fatalf("ExtractSchema failed: %v", err)
 	}
+	return descriptors
+}
 
-	// Verify the recursive TreeNode resource was extracted
-	var found bool
-	for _, d := range descriptors {
-		if d.Type == "FakeAWS::Recursive::TreeNode" {
-			found = true
-			// Verify hints were extracted for the recursive sub-resource fields
-			if d.Schema.Hints == nil {
-				t.Fatal("TreeNode schema hints should not be nil")
-			}
-			if _, ok := d.Schema.Hints["Root.Name"]; !ok {
-				t.Error("expected hint for Root.Name (nested sub-resource field)")
-			}
-			break
+func findDescriptor(t *testing.T, ds []plugin.ResourceTypeDescriptor, typeName string) plugin.ResourceTypeDescriptor {
+	t.Helper()
+	for _, d := range ds {
+		if d.Type == typeName {
+			return d
 		}
 	}
-	if !found {
-		t.Fatal("FakeAWS::Recursive::TreeNode not found in extracted descriptors")
+	t.Fatalf("descriptor %q not found in extracted descriptors", typeName)
+	return plugin.ResourceTypeDescriptor{}
+}
+
+func TestExtractSchema_RecursiveSubResource(t *testing.T) {
+	descriptors := extractFakeawsDescriptors(t)
+
+	d := findDescriptor(t, descriptors, "FakeAWS::Recursive::TreeNode")
+	if d.Schema.Hints == nil {
+		t.Fatal("TreeNode schema hints should not be nil")
 	}
+	if _, ok := d.Schema.Hints["Root.Name"]; !ok {
+		t.Error("expected hint for Root.Name (nested sub-resource field)")
+	}
+}
+
+// TestExtractSchema_UnannotatedPathsSurface verifies that descriptors.ExtractSchema
+// emits every reachable property path in Schema.Hints — annotated AND unannotated —
+// with unannotated paths defaulting to FieldHint{CreateOnly: false}. This is the
+// schema contract underpinning RFC-0042 (cascade-replace gating on createOnly):
+// the planner must see every reference target's createOnly value, even when the
+// PKL author did not write an explicit @FieldHint.
+//
+// Annotated values (createOnly=true on IAM::Role.RoleName-style fields) must be
+// preserved exactly; unannotated paths must show up with createOnly=false at
+// every nesting depth (top-level, SubResource leaf, deeply nested SubResource).
+func TestExtractSchema_UnannotatedPathsSurface(t *testing.T) {
+	descriptors := extractFakeawsDescriptors(t)
+
+	d := findDescriptor(t, descriptors, "FakeAWS::Mixed::Versioned")
+	if d.Schema.Hints == nil {
+		t.Fatal("Versioned schema hints should not be nil")
+	}
+
+	cases := []struct {
+		path       string
+		wantExists bool
+		wantCO     bool
+		note       string
+	}{
+		{path: "VersionedId", wantExists: true, wantCO: false, note: "annotated leaf, empty body"},
+		{path: "MutableTag", wantExists: true, wantCO: false, note: "UNANNOTATED top-level scalar"},
+		{path: "ImmutableId", wantExists: true, wantCO: true, note: "annotated createOnly=true"},
+		{path: "Block.Description", wantExists: true, wantCO: false, note: "UNANNOTATED SubResource leaf"},
+		{path: "Block.KnownLeaf", wantExists: true, wantCO: false, note: "annotated SubResource leaf"},
+		{path: "Block.Inner.Label", wantExists: true, wantCO: false, note: "UNANNOTATED deeply nested leaf"},
+		{path: "Block.Inner.Tag", wantExists: true, wantCO: true, note: "annotated deeply nested createOnly=true"},
+	}
+
+	for _, tc := range cases {
+		h, ok := d.Schema.Hints[tc.path]
+		if !ok {
+			if tc.wantExists {
+				t.Errorf("path %q missing from Hints (%s); have keys: %v", tc.path, tc.note, hintKeys(d.Schema.Hints))
+			}
+			continue
+		}
+		if !tc.wantExists {
+			t.Errorf("path %q unexpectedly present (%s): %+v", tc.path, tc.note, h)
+			continue
+		}
+		if h.CreateOnly != tc.wantCO {
+			t.Errorf("path %q (%s): got CreateOnly=%v, want %v", tc.path, tc.note, h.CreateOnly, tc.wantCO)
+		}
+	}
+}
+
+func hintKeys(m map[string]model.FieldHint) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }


### PR DESCRIPTION
## Summary

When the planner detects a parent being replaced, today it cascade-replaces every dependent regardless of how they reference the parent. That's the right call when the dependent's referring field is CreateOnly (the dependent can't survive a parent identity change), but it's wrong when the field is mutable — the dependent could absorb the new value with a provider-native Update.

The canonical case this fixes: an ECS Service consuming a TaskDefinition via the mutable `taskDefinition` field is currently torn down on every TaskDef revision bump (~2–4 minute outage per image deploy). Post-this-change, the Service does a rolling deploy.

### Two coupled changes

- **`descriptors.ExtractSchema` emits every property path** — `Schema.Hints` now includes annotated *and* unannotated paths, with `createOnly = false` as the default for paths without an explicit hint. Matches the `formae.pkl` declared default and gives the planner a complete schema surface to consult.
- **Planner cascade decision branches on `FieldHint.CreateOnly`** — `findDependencyUpdates` now returns both cascade-deletes and cascade-updates. CreateOnly=true on the dependent's referring field keeps today's tear-down behavior; CreateOnly=false emits a cascade-update so the resolvable re-resolves at apply time and the provider's Update absorbs the new parent value. Mixed-refs case: any single CreateOnly ref to a deletion target forces cascade-replace for the whole dependent. Array-indexed `TargetPath` looks up the hint under the stripped key (consistent with the existing `AttachesTo` lookup).

### Simulate output

A cascade-update where the user *also* changed the dependent directly (e.g. Service.deploymentConfiguration AND TaskDef.containerDefinitions.image) used to display only the user's direct patch in `--simulate`, hiding the cascading TaskDefinition change. The planner now synthesizes plan-time patch ops for each resolvable that points at a being-replaced parent: concrete `replace` ops with the new value when it's user-set in the forma, and a `$cascade-resolvable` marker op when the source property is provider-assigned (AWS ARNs and the like). The CLI renderer turns the marker into:

```
change property "TaskDefinition" to point at the new test-taskdef-for-service (current: "arn:aws:ecs:us-east-1:0:task-definition/test:1")
```

### PatchDocument as a derived property

At apply time, the executor's resolver substitutes fresh `$value` entries into `DesiredState.Properties` via `ResourceUpdate.ResolveValue`. Since `PatchDocument` is derived from `(PriorState, DesiredState, Schema)`, `ResolveValue` is the one place that owns keeping it in sync — when it mutates the state the patch is derived from, it also re-derives the patch. The executor's `update()` carries no cascade-specific logic; the regen path collapses into "whenever I change the state, I re-derive the view."

### Pairing

Pairs with formae-plugin-aws PR https://github.com/platform-engineering-labs/formae-plugin-aws/pull/78 which lands the AWS schema under-mark fixes (60 annotations across 13 services) the audit surfaced. Both PRs need formae `0.86.0` to be tagged before either can ship to users — the planner change is breaking for plugins that under-mark CreateOnly fields, so the rollout vehicle is the standard metapackage pinning audited plugin versions.