### PR TITLE
feat(rebind): foundation for RFC-0041 aliases

### DIFF
--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -101,6 +101,15 @@ func NewDatastoreAuroraDataAPI(ctx context.Context, cfg *pkgmodel.DatastoreConfi
 	return d, nil
 }
 
+// WithTx runs fn with the datastore as the transaction value. Aurora-side
+// BEGIN/COMMIT semantics will be plumbed when the first real Tx method
+// lands in a follow-up PR (RFC-0041 PR 2); this PR ships the marker
+// interface only.
+func (d *DatastoreAuroraDataAPI) WithTx(ctx context.Context, fn func(datastore.Tx) error) error {
+	_ = ctx
+	return fn(d)
+}
+
 func (d *DatastoreAuroraDataAPI) runMigrations() error {
 	ctx := context.Background()
 

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -5,6 +5,7 @@
 package datastore
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -15,6 +16,14 @@ import (
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
 )
+
+// Tx represents a datastore transaction context handed to callers of
+// WithTx. The marker carries no methods in this PR; subsequent RFC-0041
+// PRs (resource and stack rebind) will extend it with the specific
+// write operations the rebinder needs. Keeping the interface marker-only
+// for now means every Datastore implementation can satisfy it trivially
+// without committing to a full transactional API up front.
+type Tx interface{}
 
 const (
 	CommandsTable                  string              = "forma_commands"
@@ -111,6 +120,13 @@ type ResourceSnapshot struct {
 // It handles storage and retrieval of FormaCommands (requested changes),
 // Resources (actual cloud state), Stacks, and Targets.
 type Datastore interface {
+	// Transactional operations
+
+	// WithTx runs fn inside a single datastore transaction. If fn returns
+	// an error, the transaction is rolled back. Used by the rebind phase
+	// (RFC-0041) to atomically apply identity-column rewrites.
+	WithTx(ctx context.Context, fn func(Tx) error) error
+
 	// FormaCommand operations - these represent requested changes to infrastructure
 
 	// StoreFormaCommand persists a new FormaCommand with its ResourceUpdates

--- a/internal/datastore/mock_datastore_test.go
+++ b/internal/datastore/mock_datastore_test.go
@@ -5,6 +5,7 @@
 package datastore
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -20,6 +21,10 @@ import (
 // Only the name field is used; all interface methods are stubs.
 type mockDatastore struct {
 	name string
+}
+
+func (m *mockDatastore) WithTx(_ context.Context, fn func(Tx) error) error {
+	return fn(m)
 }
 
 func (m *mockDatastore) StoreFormaCommand(_ *forma_command.FormaCommand, _ string) error {

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -178,6 +178,15 @@ func NewDatastorePostgres(ctx context.Context, cfg *pkgmodel.DatastoreConfig, ag
 	return d, nil
 }
 
+// WithTx runs fn with the datastore as the transaction value. Postgres-side
+// BEGIN/COMMIT semantics will be plumbed when the first real Tx method
+// lands in a follow-up PR (RFC-0041 PR 2); this PR ships the marker
+// interface only.
+func (d DatastorePostgres) WithTx(ctx context.Context, fn func(datastore.Tx) error) error {
+	_ = ctx
+	return fn(d)
+}
+
 func (d DatastorePostgres) StoreFormaCommand(fa *forma_command.FormaCommand, commandID string) error {
 	ctx, span := tracer.Start(context.Background(), "StoreFormaCommand")
 	defer span.End()

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -116,6 +116,15 @@ func NewDatastoreSQLite(ctx context.Context, cfg *pkgmodel.DatastoreConfig, agen
 	return d, nil
 }
 
+// WithTx runs fn with the datastore as the transaction value. SQLite-side
+// BEGIN/COMMIT semantics will be plumbed when the first real Tx method
+// lands in a follow-up PR (RFC-0041 PR 2); this PR ships the marker
+// interface only.
+func (d DatastoreSQLite) WithTx(ctx context.Context, fn func(datastore.Tx) error) error {
+	_ = ctx
+	return fn(d)
+}
+
 func (d DatastoreSQLite) ClearCommandsTable() error {
 	_, err := d.conn.Exec(fmt.Sprintf("DELETE FROM %s", datastore.CommandsTable))
 	if err != nil {

--- a/internal/metastructure/extract_resources_test.go
+++ b/internal/metastructure/extract_resources_test.go
@@ -5,6 +5,7 @@
 package metastructure
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -28,6 +29,10 @@ type mockExtractDatastore struct {
 	targets   map[string]*pkgmodel.Target
 	stacks    map[string]*pkgmodel.Stack
 	policies  map[string]pkgmodel.Policy
+}
+
+func (m *mockExtractDatastore) WithTx(_ context.Context, fn func(datastore.Tx) error) error {
+	return fn(m)
 }
 
 func (m *mockExtractDatastore) QueryResources(_ *datastore.ResourceQuery) ([]*pkgmodel.Resource, error) {

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -33,6 +33,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/policy_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/querier"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/rebind"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/stack_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
@@ -277,6 +278,17 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 	// persisted and visible to subsequent queries.
 	if !config.Simulate {
 		if err := m.checkForConflictingCommands(stackLabelsFromForma(forma)); err != nil {
+			return nil, err
+		}
+	}
+
+	// RFC-0041: run the rebind phase ahead of update generation so the
+	// downstream diff observes any renamed identities. PR 1 ships this
+	// as a no-op when no aliases are declared; later PRs add real rename
+	// behaviour without touching the wiring.
+	if !config.Simulate {
+		rebinder := rebind.NewRebinder(m.Datastore)
+		if err := rebinder.Run(context.Background(), *forma, clientID); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/metastructure/rebind/plan.go
+++ b/internal/metastructure/rebind/plan.go
@@ -11,26 +11,34 @@ package rebind
 
 // RebindPlan is the output of the validation step. Execution applies the
 // identity-column rewrites it contains to the metastructure.
+//
+// Each kind of write has its own concrete type so the executor cannot
+// accidentally mix scopes. In particular, ResourceRebind only carries
+// a new label: moving a resource between stacks or targets via a
+// per-resource alias is out of scope for this RFC. Cross-stack moves
+// are only possible through a StackRebind + its cascade.
 type RebindPlan struct {
-	Stacks    []StackRebind
-	Resources []ResourceRebind
-	// Targets is intentionally absent in this PR. Target rename is
-	// deferred to a follow-up RFC (RFC-0041 §Scope of this RFC).
+	Stacks        []StackRebind
+	Resources     []ResourceRebind
+	StackCascades []ResourceStackCascade
+	// Targets and TargetCascades are intentionally absent. Target rename
+	// is deferred to a follow-up RFC (RFC-0041 §Scope of this RFC).
 }
 
-// ResourceRebind is one identity-column rewrite of a managed resource.
-// The row is identified by Ksuid (stable); identity columns get the
-// new values.
+// ResourceRebind is a resource label rename. Only `label` is mutable
+// here; moving a resource across stacks or targets is out of scope
+// for this RFC.
 type ResourceRebind struct {
-	Ksuid     string
-	NewLabel  string
-	NewStack  string
-	NewTarget string
-	// Source records what produced this entry: "alias" for a direct
-	// alias hit on the resource declaration, "stack-cascade" for a
-	// cascade triggered by a renamed stack. (Target-cascade is not
-	// used in this PR; reserved for the follow-up RFC.)
-	Source string
+	Ksuid    string // stable identity, unchanged
+	NewLabel string
+}
+
+// ResourceStackCascade is the per-child write produced by a stack
+// rename. It only touches resources.stack; the resource label and
+// target stay put.
+type ResourceStackCascade struct {
+	Ksuid    string // resource being cascaded
+	NewStack string // new parent stack label
 }
 
 // StackRebind is one identity-column rewrite of a stack.
@@ -41,5 +49,6 @@ type StackRebind struct {
 
 // IsEmpty reports whether the plan has nothing to do.
 func (p *RebindPlan) IsEmpty() bool {
-	return p == nil || (len(p.Stacks) == 0 && len(p.Resources) == 0)
+	return p == nil ||
+		(len(p.Stacks) == 0 && len(p.Resources) == 0 && len(p.StackCascades) == 0)
 }

--- a/internal/metastructure/rebind/plan.go
+++ b/internal/metastructure/rebind/plan.go
@@ -1,0 +1,45 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+// Package rebind implements the rename rebind phase described in RFC-0041.
+//
+// The phase is split into a read-only validation step that produces a
+// RebindPlan and an execution step that applies the plan inside a single
+// datastore transaction. This package owns both halves.
+package rebind
+
+// RebindPlan is the output of the validation step. Execution applies the
+// identity-column rewrites it contains to the metastructure.
+type RebindPlan struct {
+	Stacks    []StackRebind
+	Resources []ResourceRebind
+	// Targets is intentionally absent in this PR. Target rename is
+	// deferred to a follow-up RFC (RFC-0041 §Scope of this RFC).
+}
+
+// ResourceRebind is one identity-column rewrite of a managed resource.
+// The row is identified by Ksuid (stable); identity columns get the
+// new values.
+type ResourceRebind struct {
+	Ksuid     string
+	NewLabel  string
+	NewStack  string
+	NewTarget string
+	// Source records what produced this entry: "alias" for a direct
+	// alias hit on the resource declaration, "stack-cascade" for a
+	// cascade triggered by a renamed stack. (Target-cascade is not
+	// used in this PR; reserved for the follow-up RFC.)
+	Source string
+}
+
+// StackRebind is one identity-column rewrite of a stack.
+type StackRebind struct {
+	ID       string // stable Stack.ID, unchanged
+	NewLabel string
+}
+
+// IsEmpty reports whether the plan has nothing to do.
+func (p *RebindPlan) IsEmpty() bool {
+	return p == nil || (len(p.Stacks) == 0 && len(p.Resources) == 0)
+}

--- a/internal/metastructure/rebind/rebind.go
+++ b/internal/metastructure/rebind/rebind.go
@@ -1,0 +1,63 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package rebind
+
+import (
+	"context"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// Rebinder runs the alias rebind phase of an apply (see RFC-0041).
+//
+// PR 1 wires the skeleton into the apply pipeline as a no-op when no
+// aliases are declared. Resource and stack rename logic land in
+// follow-up PRs (RFC-0041 §Implementation plan).
+type Rebinder struct {
+	ds datastore.Datastore
+}
+
+// NewRebinder constructs a Rebinder backed by the given datastore.
+func NewRebinder(ds datastore.Datastore) *Rebinder {
+	return &Rebinder{ds: ds}
+}
+
+// Run validates the forma's aliases, then executes the resulting plan.
+// Callers must hold the apply-level commandMu lock to ensure validation
+// and execution observe a consistent metastructure snapshot.
+func (r *Rebinder) Run(ctx context.Context, forma pkgmodel.Forma, commandID string) error {
+	plan, err := r.Validate(ctx, forma)
+	if err != nil {
+		return err
+	}
+	if plan.IsEmpty() {
+		return nil
+	}
+	return r.Execute(ctx, plan, commandID)
+}
+
+// Validate walks the forma, consults declared aliases, and returns a
+// RebindPlan or an error describing the first conflict.
+//
+// PR 1: always returns an empty plan. Real validation logic lands in
+// PR 2 (resource rename) and PR 7 (stack rename).
+func (r *Rebinder) Validate(ctx context.Context, forma pkgmodel.Forma) (*RebindPlan, error) {
+	_ = ctx
+	_ = forma
+	return &RebindPlan{}, nil
+}
+
+// Execute applies the plan inside a single datastore transaction.
+//
+// PR 1: empty body; only invoked when the plan is non-empty, which is
+// impossible while Validate is a no-op. Reserved for PR 2.
+func (r *Rebinder) Execute(ctx context.Context, plan *RebindPlan, commandID string) error {
+	_ = commandID
+	return r.ds.WithTx(ctx, func(_ datastore.Tx) error {
+		_ = plan
+		return nil
+	})
+}

--- a/internal/metastructure/rebind/rebind_test.go
+++ b/internal/metastructure/rebind/rebind_test.go
@@ -1,0 +1,65 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package rebind
+
+import (
+	"context"
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func TestRebinder_Run_NoAliases_IsNoOp(t *testing.T) {
+	ds := &stubDatastore{}
+	r := NewRebinder(ds)
+
+	forma := pkgmodel.Forma{
+		Stacks:    []pkgmodel.Stack{{Label: "prod"}},
+		Targets:   []pkgmodel.Target{{Label: "aws-prod"}},
+		Resources: []pkgmodel.Resource{{Label: "web-server", Stack: "prod", Target: "aws-prod"}},
+	}
+
+	if err := r.Run(context.Background(), forma, "cmd-1"); err != nil {
+		t.Fatalf("Run with no aliases should be a no-op, got error: %v", err)
+	}
+
+	if ds.withTxCalls != 0 {
+		t.Fatalf("expected WithTx to NOT be called when plan is empty, got %d calls", ds.withTxCalls)
+	}
+}
+
+func TestRebinder_Validate_NoAliases_ReturnsEmptyPlan(t *testing.T) {
+	ds := &stubDatastore{}
+	r := NewRebinder(ds)
+
+	forma := pkgmodel.Forma{
+		Stacks:    []pkgmodel.Stack{{Label: "prod"}},
+		Resources: []pkgmodel.Resource{{Label: "web-server", Stack: "prod"}},
+	}
+
+	plan, err := r.Validate(context.Background(), forma)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !plan.IsEmpty() {
+		t.Fatalf("expected empty plan, got %+v", plan)
+	}
+}
+
+// stubDatastore embeds the Datastore interface to satisfy the compiler;
+// only WithTx is overridden because that is the only method exercised
+// by the rebinder under test. Any other interface method invocation
+// would panic on the nil embedded interface, which is the desired test
+// behaviour ("you broke encapsulation").
+type stubDatastore struct {
+	datastore.Datastore
+	withTxCalls int
+}
+
+func (s *stubDatastore) WithTx(_ context.Context, fn func(datastore.Tx) error) error {
+	s.withTxCalls++
+	return fn(s)
+}

--- a/internal/schema/pkl/generator/tests/gen.pkl-expected.pcf
+++ b/internal/schema/pkl/generator/tests/gen.pkl-expected.pcf
@@ -5,6 +5,7 @@ examples {
       group = null
       target = null
       stack = null
+      alias = null
       managed = true
       x = 42
       name = "test"
@@ -16,6 +17,7 @@ examples {
       group = null
       target = null
       stack = null
+      alias = null
       managed = true
       items {
         "item1"
@@ -27,10 +29,10 @@ examples {
     }
   }
   ["Convert to map with types - simple"] {
-    Map("label", "simple", "group", null, "target", null, "stack", null, "managed", true, "x", 42, "name", "test")
+    Map("label", "simple", "group", null, "target", null, "stack", null, "alias", null, "managed", true, "x", 42, "name", "test")
   }
   ["Convert to map with types - complex"] {
-    Map("label", "my-bucket", "group", null, "target", null, "stack", null, "managed", true, "type", "FakePlugin::Service::TestResource", "size", null, "tags", List(), "bucketName", "my-test-bucket")
+    Map("label", "my-bucket", "group", null, "target", null, "stack", null, "alias", null, "managed", true, "type", "FakePlugin::Service::TestResource", "size", null, "tags", List(), "bucketName", "my-test-bucket")
   }
   ["Generate import statements"] {
     List("@aws/s3.pkl")

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -19,11 +19,22 @@ open class Description {
     fixed Confirm: Boolean = confirm
 }
 
+/// Marks a previous identity of a Resource, Stack, or Target.
+/// Used by formae to rebind an existing managed row to a new
+/// identity without destroy/recreate. See RFC-0041.
+open class Alias {
+    hidden label: String(length > 0)
+
+    // Output
+    fixed Label: String = label
+}
+
 open class Resource {
     label: String
     group: String?
     target: TargetResolvable?
     stack: StackResolvable?
+    alias: Alias?
     fixed managed: Boolean = true
 
     local self = this
@@ -38,6 +49,7 @@ open class Resource {
         Group = self.group
         Target = self.target
         Stack = self.stack
+        Alias = self.alias
         Managed = self.managed
 
         Type = self.type()
@@ -55,6 +67,7 @@ open class Stack {
     hidden label: String(length > 0)
     hidden description: String
     hidden policies: Listing<Policy|PolicyResolvable>?
+    hidden alias: Alias?
 
     local parent = this
     hidden res: StackResolvable = new {
@@ -64,6 +77,7 @@ open class Stack {
     // Output
     fixed Label: String = label
     fixed Description: String = description
+    fixed Alias: Alias? = alias
     fixed Policies: Listing<Dynamic>? = policies?.toList()?.map((p) ->
         if (p is PolicyResolvable)
             new Dynamic { `$ref` = "policy://\(p.label)" }
@@ -232,6 +246,7 @@ open class Target {
     hidden namespace: String = config.type.toUpperCase()
     hidden config: Any?
     hidden discoverable: Boolean = true
+    hidden alias: Alias?
 
     local self = this
     hidden res: TargetResolvable = new {
@@ -242,6 +257,7 @@ open class Target {
     fixed Label: String = label
     fixed Namespace: String = namespace
     fixed Config: Any? = config
+    fixed Alias: Alias? = alias
     fixed ConfigSchema: ConfigSchema? =
         if (config != null)
             let (hints = module.fq.configHints(reflect.Class(config.getClass())))

--- a/pkg/api/model/types.go
+++ b/pkg/api/model/types.go
@@ -95,6 +95,7 @@ const (
 	OperationDelete  = "delete"
 	OperationRead    = "read"
 	OperationReplace = "replace" // delete + create
+	OperationRebind  = "rebind"  // RFC-0041 identity-column rewrite (no plugin call)
 )
 
 const (

--- a/pkg/model/alias.go
+++ b/pkg/model/alias.go
@@ -1,0 +1,12 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package model
+
+// Alias marks a previous identity of a Resource, Stack, or Target.
+// Used by the rebind phase to find an existing managed row by its old
+// label and rewrite its identity columns to the new label. See RFC-0041.
+type Alias struct {
+	Label string `json:"Label" pkl:"Label"`
+}

--- a/pkg/model/alias_test.go
+++ b/pkg/model/alias_test.go
@@ -1,0 +1,96 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package model
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestAlias_JSONRoundTrip(t *testing.T) {
+	original := Alias{Label: "old-name"}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded Alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.Label != "old-name" {
+		t.Fatalf("expected Label=old-name, got %q", decoded.Label)
+	}
+}
+
+func TestResource_AliasField(t *testing.T) {
+	jsonInput := []byte(`{
+        "Label": "app-server",
+        "Stack": "prod",
+        "Target": "aws-prod",
+        "Type": "EC2.Instance",
+        "Schema": {"Fields": []},
+        "Properties": {},
+        "Alias": {"Label": "web-server"}
+    }`)
+
+	var r Resource
+	if err := json.Unmarshal(jsonInput, &r); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if r.Alias == nil {
+		t.Fatalf("expected Alias to be populated")
+	}
+	if r.Alias.Label != "web-server" {
+		t.Fatalf("expected Alias.Label=web-server, got %q", r.Alias.Label)
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Contains(data, []byte(`"Alias":{"Label":"web-server"}`)) {
+		t.Fatalf("Alias not present in marshalled JSON: %s", data)
+	}
+}
+
+func TestStack_AliasField(t *testing.T) {
+	jsonInput := []byte(`{
+        "Label": "production",
+        "Description": "prod env",
+        "Alias": {"Label": "prod"}
+    }`)
+
+	var s Stack
+	if err := json.Unmarshal(jsonInput, &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if s.Alias == nil || s.Alias.Label != "prod" {
+		t.Fatalf("expected Alias.Label=prod, got %+v", s.Alias)
+	}
+}
+
+func TestTarget_AliasField(t *testing.T) {
+	jsonInput := []byte(`{
+        "Label": "aws-prod-eu",
+        "Namespace": "AWS",
+        "Discoverable": true,
+        "Alias": {"Label": "aws-prod"}
+    }`)
+
+	var tt Target
+	if err := json.Unmarshal(jsonInput, &tt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if tt.Alias == nil || tt.Alias.Label != "aws-prod" {
+		t.Fatalf("expected Alias.Label=aws-prod, got %+v", tt.Alias)
+	}
+}

--- a/pkg/model/resource.go
+++ b/pkg/model/resource.go
@@ -32,6 +32,7 @@ type Resource struct {
 	NativeID           string          `json:"NativeID,omitempty"`
 	Managed            bool            `json:"Managed,omitempty"` // Whether the resource is managed by Formae or not
 	Ksuid              string          `json:"Ksuid,omitempty"`
+	Alias              *Alias          `json:"Alias,omitempty"` // RFC-0041 rename alias (previous identity)
 }
 
 // TupleKey returns the lookup key for this resource in the format: type/stack/label

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -18,6 +18,7 @@ type Stack struct {
 	Description string            `json:"Description"`
 	Policies    []json.RawMessage `json:"Policies,omitempty"` // Inline policies from PKL
 	CreatedAt   time.Time         `json:"CreatedAt,omitempty"`
+	Alias       *Alias            `json:"Alias,omitempty"` // RFC-0041 rename alias (previous identity)
 }
 
 // IsPolicyReference checks if a raw policy JSON is a reference ($ref) rather than inline

--- a/pkg/model/target.go
+++ b/pkg/model/target.go
@@ -30,6 +30,7 @@ type Target struct {
 	ConfigSchema ConfigSchema    `json:"ConfigSchema,omitzero" pkl:"ConfigSchema,omitempty"`
 	Discoverable bool            `json:"Discoverable" pkl:"Discoverable"`
 	Version      int             `json:"Version,omitempty"`
+	Alias        *Alias          `json:"Alias,omitempty" pkl:"Alias,omitempty"` // RFC-0041 rename alias (previous identity)
 }
 
 func NewTargetFromString(target string) Target {


### PR DESCRIPTION
## Summary

Lands the foundation for RFC-0041 (resource / stack rename via aliases). No behaviour change for existing formae — formae that do not declare `alias` see no DB writes from this code.

- **PKL:** new `Alias` class with required `label`; optional `alias: Alias?` on `Resource`, `Stack`, `Target`.
- **Go:** matching `Alias` struct (`pkg/model/alias.go`) mirrored as `Alias *Alias` on `Resource`, `Stack`, `Target`.
- **Datastore:** new `Tx` marker interface and `WithTx(ctx, fn) error` method on `Datastore`. All impls (Aurora, Postgres, SQLite, mocks) pass-through; the marker carries no methods yet so later PRs can extend it without churn.
- **API:** new `OperationRebind = "rebind"` constant.
- **Engine:** new `internal/metastructure/rebind` package with `Rebinder.Run / Validate / Execute`. All no-op. `Run` is wired into the apply path ahead of `FormaCommandFromForma`; subsequent PRs add real rename behaviour without touching the wiring.

## Why

Subsequent PRs in the rename-aliases stack add real rename logic on top of this skeleton. Landing the surface up-front lets each follow-up PR stay small and focused.

## Why `WithTx`

Rebind is **multi-row, atomic**. A single rename like `stack: prod → production` writes one new `stacks` row plus N new `resources` rows (cascade-update of `resources.stack`). If the cascade partially fails the metastructure is torn — stack renamed, children still pointing at the old label, downstream apply phase creates bogus resources. `WithTx` wraps the whole rebind in one DB transaction:

- All writes succeed → commit; renamed view is what the downstream apply phase sees.
- Any write fails → rollback; metastructure unchanged; no plugin called; author retries from clean state.

The `Tx` interface is intentionally empty in this PR. PR 2 (resource rebind) adds the real methods (`StoreResource`, `CreateStack`, …) to `Tx`. Doing the `Datastore`-interface widening once now means PR 2 is purely additive on `Tx`. All five implementations currently call `fn(d)` pass-through; real BEGIN/COMMIT plumbing is scoped to PR 2 where it is first exercised by a non-empty `RebindPlan`.

## Test plan

- [x] `go test ./pkg/model/...` — 25 passed.
- [x] `go test ./internal/metastructure/rebind/...` — 2 passed (no-op Run + Validate).
- [x] `go test ./internal/datastore/... ./internal/metastructure/...` — green; pre-existing Postgres collation flake unrelated.
- [x] `make test-generator-pkl` — 27/27 PKL tests pass after fixture refresh.