### PR TITLE
fix(changeset): stop sync Read failures from self-cascading

### DIFF
--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -498,7 +498,10 @@ func handleUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, even
 		var failedTargets []forma_persister.TargetUpdateRef
 		for _, failedUpdate := range cascadingFailures {
 			// Skip the original failure — its updater actor already persisted it.
-			if failedUpdate.NodeURI() == event.nodeURI {
+			// Compare by identity: NodeURI() is the bare resource URI while
+			// event.nodeURI is the operation-qualified DAG key, so they never
+			// match and the original would otherwise be re-marked as a cascade.
+			if failedUpdate == node.Update {
 				continue
 			}
 			switch u := failedUpdate.(type) {

--- a/internal/workflow_tests/local/changeset_executor_test.go
+++ b/internal/workflow_tests/local/changeset_executor_test.go
@@ -316,6 +316,77 @@ func TestChangesetExecutor_CascadeFailure(t *testing.T) {
 	})
 }
 
+// TestChangesetExecutor_SyncReadFailureDoesNotCascade verifies that a failed
+// Read inside a sync command does not trigger cascade-failure handling. A sync's
+// resources are Read operations with no inter-dependencies, so there is nothing
+// for a failure to cascade *to* — the only candidate is the failed Read itself.
+//
+// Reproduces the prod incident where a single-resource sync whose Read failed
+// produced a self-cascade: the executor reported the failed Read as a cascading
+// failure and pushed it to FormaCommandPersister.MarkResourcesAsFailed, which
+// (for an empty sync command already evicted from cache and deleted from the DB)
+// panicked the persister with "forma command not found".
+func TestChangesetExecutor_SyncReadFailureDoesNotCascade(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		logCapture := test_helpers.SetupTestLogger()
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				return nil, fmt.Errorf("simulated read failure")
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		assert.NoError(t, err)
+
+		messages := make(chan any, 10)
+		_, err = testutil.StartTestHelperActor(m.Node, messages)
+		assert.NoError(t, err)
+
+		commandID := "test-command-sync-read-failure"
+
+		// A single read resource update originating from the Synchronizer.
+		readUpdate := newTestUpdateResourceUpdate("sync-vpc", "native-will-fail", "FakeAWS::EC2::VPC")
+		readUpdate.Operation = resource_update.OperationRead
+		readUpdate.Source = resource_update.FormaCommandSourceSynchronize
+
+		testutil.Call(m.Node, "FormaCommandPersister", forma_persister.StoreNewFormaCommand{
+			Command: forma_command.FormaCommand{
+				ID:      commandID,
+				Command: pkgmodel.CommandSync,
+				State:   forma_command.CommandStateNotStarted,
+				ResourceUpdates: []resource_update.ResourceUpdate{
+					readUpdate,
+				},
+			},
+		})
+
+		cs, err := changeset.NewChangeset(
+			[]resource_update.ResourceUpdate{readUpdate}, nil, commandID, pkgmodel.CommandSync)
+		assert.NoError(t, err)
+
+		_, err = testutil.Call(m.Node, "ChangesetSupervisor", changeset.EnsureChangesetExecutor{
+			CommandID: commandID,
+		})
+		assert.NoError(t, err)
+
+		testutil.Send(m.Node, actornames.ChangesetExecutor(commandID), changeset.Start{
+			Changeset:        cs,
+			NotifyOnComplete: true,
+		})
+
+		testutil.ExpectMessageWithPredicate(t, messages, 15*time.Second, func(msg changeset.ChangesetCompleted) bool {
+			return msg.CommandID == commandID
+		})
+
+		// The failed Read must not be treated as a cascading failure: a sync has
+		// no dependency edges, so the executor must never engage the cascade path.
+		assert.False(t, logCapture.ContainsAll("Cascading failures detected"),
+			"a failed Read in a sync command must not trigger cascade-failure handling")
+	})
+}
+
 func TestChangesetExecutor_HashesAllResourcesOnCompletion(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		overrides := &plugin.ResourcePluginOverrides{


### PR DESCRIPTION
## Summary

A failed Read inside a background **sync** command could take down the `FormaCommandPersister`, leaving the agent unable to accept any apply/destroy/sync command until a redeploy.

A sync's changeset has no dependency edges (Reads never depend on Reads), so a failure has nothing to cascade *to*. But the ChangesetExecutor's cascade-failure handler still engaged: its guard meant to skip the originally-failed update compared `Update.NodeURI()` (the bare resource URI) against the operation-qualified DAG key in `event.nodeURI`. Those never match, so the original failure was re-marked as a cascade and pushed to `FormaCommandPersister.MarkResourcesAsFailed` — a single failed Read "cascading" against itself.

For an empty sync command (deleted from the DB on completion), that bulk-update's load returned "not found" and terminated the persister.

This fixes the skip to compare by identity against the original node's update, so the originally-failed update is correctly excluded from cascade persistence for every command type. Genuine apply cascades (failure propagating to dependents) are unaffected.

Adds a workflow test that drives a sync command with a failing Read and asserts the cascade path is never engaged.