### PR TITLE
docs(plugin): add READMEs for plugin SDK and conformance suite

### DIFF
--- a/pkg/plugin-conformance-tests/README.md
+++ b/pkg/plugin-conformance-tests/README.md
@@ -1,0 +1,177 @@
+# pkg/plugin-conformance-tests — Plugin Conformance Test Suite
+
+A provider-agnostic Go test harness that exercises a formae resource plugin
+end-to-end through the real `formae` CLI and agent: create, read, update,
+replace, destroy, extract, discover, and detect out-of-band changes. Plugin
+authors call into it from a single `_test.go` file and get a comprehensive
+CRUD-and-discovery suite for free.
+
+Module path:
+
+```
+github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests
+```
+
+## Audience
+
+Authors of formae **resource** plugins built on
+[`pkg/plugin`](../plugin) who want a standardized way to validate their plugin
+against the same lifecycle every other plugin is held to.
+
+## Quick start
+
+A complete conformance setup is two functions in one test file inside your
+plugin repo:
+
+```go
+package main
+
+import (
+    "testing"
+
+    conformance "github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests"
+)
+
+func TestPluginConformance(t *testing.T) {
+    conformance.RunCRUDTests(t)
+}
+
+func TestPluginDiscovery(t *testing.T) {
+    conformance.RunDiscoveryTests(t)
+}
+```
+
+Then run them from the plugin directory:
+
+```bash
+# Both suites
+go test -v ./...
+
+# CRUD only, on a subset of resource types
+FORMAE_TEST_TYPE=crud FORMAE_TEST_FILTER="s3-bucket,iam-group" go test -v ./...
+
+# Discovery only, in parallel
+FORMAE_TEST_TYPE=discovery FORMAE_TEST_PARALLEL=true go test -v ./...
+```
+
+The `formae plugin init` scaffold already wires this up; you only need to add
+test data.
+
+## How tests are discovered
+
+The suite looks for Pkl test fixtures in a `testdata/` directory next to the
+test (overridable via `FORMAE_TEST_TESTDATA_DIR`). For each base file it picks
+up two optional variants by suffix:
+
+| File | Role |
+| ---- | ---- |
+| `<resource>.pkl` | Required. Declares the resource to create and the expected post-create state. |
+| `<resource>-update.pkl` | Optional. Same resource with at least one mutable property changed; drives the update step. |
+| `<resource>-replace.pkl` | Optional. Same resource with a create-only field changed; drives the replace step (the suite expects `NativeID` to change). |
+
+A run-unique identifier is exposed to Pkl as the `FORMAE_TEST_RUN_ID`
+environment variable so resource names can be parameterised without
+collisions between test runs.
+
+## What the CRUD suite verifies
+
+For each test case `RunCRUDTests` walks the resource through its full
+lifecycle and asserts that:
+
+1. The plugin registers with the agent.
+2. `formae apply` creates the resource and reaches `Success`.
+3. `formae inventory` reports the resource with the properties from the base
+   Pkl file.
+4. If the resource type is extractable, `formae extract` round-trips back to
+   an equivalent Pkl declaration.
+5. A forced sync leaves the resource untouched (idempotency).
+6. If `-update.pkl` exists, patch-mode apply updates the resource without
+   changing its `NativeID`.
+7. If `-replace.pkl` exists, patch-mode apply replaces the resource (new
+   `NativeID`) and the new properties land in inventory.
+8. `formae destroy` removes the resource and inventory reflects that.
+9. After re-creating the resource and deleting it out-of-band directly through
+   the plugin, a forced sync tombstones it from inventory — confirming drift
+   detection works for this resource type.
+
+## What the discovery suite verifies
+
+For each test case `RunDiscoveryTests`:
+
+1. Creates the resource out-of-band, directly through the plugin (bypassing
+   formae apply).
+2. Registers the appropriate target with the agent.
+3. Triggers a discovery scan.
+4. Polls inventory until the resource shows up on the `$unmanaged` stack with
+   the expected type.
+
+Only resource types that declare `discoverable = true` in their Pkl schema are
+exercised.
+
+## Environment variables
+
+| Variable | Purpose |
+| -------- | ------- |
+| `FORMAE_TEST_TYPE` | `crud`, `discovery`, or `all` (default). Skips the suite that doesn't match. |
+| `FORMAE_TEST_FILTER` | Comma-separated case names or `/regex/` to restrict which test cases run. |
+| `FORMAE_TEST_PARALLEL` | Set truthy (e.g. `true`, `1`) to run cases with `t.Parallel()`. |
+| `FORMAE_TEST_TESTDATA_DIR` | Override the testdata directory. Relative paths resolve against the plugin directory. |
+| `FORMAE_TEST_EXTRA_DISCOVERY_TYPES` | Extra resource types (comma-separated) to add to the discovery scan, beyond those declared in test data. |
+| `FORMAE_BINARY` | Absolute path to a specific `formae` binary. Skips the channel-aware resolver. |
+| `FORMAE_VERSION` | Pin a specific formae version. The resolver searches stable then dev channels for an exact match. |
+| `FORMAE_TEST_RUN_ID` | Set by the harness for each run; available to Pkl fixtures for unique resource naming. |
+
+A timeout knob for the OOB-delete inventory-removal step is also exposed for
+slow backends; see the comment block above `RunCRUDTests` in
+[`runner.go`](./runner.go) for the current name and default.
+
+## Which `formae` binary gets used
+
+The harness picks the binary every test run rather than relying on whatever is
+on your `$PATH`. The resolution rules:
+
+1. If `FORMAE_BINARY` is set, that exact binary is used.
+2. Otherwise the harness reads `minFormaeVersion` from your plugin's
+   `formae-plugin.pkl` and looks for the highest matching release in the
+   **stable** orbital channel.
+3. If `FORMAE_VERSION` is set, it pins to that exact version (still searching
+   stable, then dev).
+4. If the stable channel can't satisfy `minFormaeVersion`, the harness falls
+   back to the **dev** channel. The dev tree is only initialised lazily, so
+   stable-only plugins don't pay the cost.
+5. If neither channel can satisfy the floor, the test fails with a message
+   identifying the closest available version.
+
+This means a plugin can opt in to an unreleased formae feature by bumping
+`minFormaeVersion` in its manifest, without each test author having to install
+a particular binary by hand. See [`setup.go`](./setup.go) for the resolver.
+
+## How it works under the hood
+
+`TestHarness` (see [`harness.go`](./harness.go)) does the heavy lifting:
+
+- Resolves and downloads the right `formae` binary.
+- Spins up a real `formae` agent subprocess in a temp directory.
+- Spawns an Ergo `TestPluginCoordinator` so the harness can drive the plugin
+  directly when the test step needs it (e.g. for the out-of-band delete and
+  for discovery-only resource creation).
+- Invokes `formae apply`, `formae destroy`, `formae extract`, `formae eval`,
+  `formae inventory`, and `formae sync` as subprocesses for the steps that
+  should go through the public CLI surface.
+- Polls command status against the agent's HTTP API.
+- Collects per-step results into a matrix printed by `ResultCollector` at the
+  end of the run.
+
+## See also
+
+- [`pkg/plugin`](../plugin) — the resource plugin SDK that this suite tests.
+- [`formae-plugin-template`](https://github.com/platform-engineering-labs/formae-plugin-template) —
+  the template scaffolded by `formae plugin init`. Its `conformance_test.go`
+  and `testdata/` are the canonical reference for wiring this suite into a new
+  plugin.
+- [formae documentation](https://docs.formae.io) — end-user docs and Pkl
+  primer.
+
+## License
+
+FSL-1.1-ALv2. See [LICENSES/FSL-1.1-ALv2.md](../../LICENSES/FSL-1.1-ALv2.md).

--- a/pkg/plugin/README.md
+++ b/pkg/plugin/README.md
@@ -1,0 +1,197 @@
+# pkg/plugin — Resource Plugin SDK
+
+This is the Go SDK for writing **formae** resource plugins. A resource plugin
+teaches the formae agent how to create, read, update, delete, and discover one
+or more types of cloud resources (S3 buckets, GCP projects, Azure VMs, DNS
+records, …).
+
+Module path:
+
+```
+github.com/platform-engineering-labs/formae/pkg/plugin
+```
+
+## Audience
+
+You should read this if you want to add formae support for a cloud service or
+API that doesn't have a plugin yet. If you only want to *use* an existing
+plugin, see the [formae documentation](https://docs.formae.io) instead.
+
+> **Auth plugins are a different SDK.** Authentication plugins for the formae
+> CLI/agent live in [`pkg/auth`](../auth) and use a net/rpc-based interface.
+> This package only covers **resource** plugins.
+
+## Quick start
+
+The recommended way to start a new plugin is the bundled scaffolding command,
+which clones the
+[`formae-plugin-template`](https://github.com/platform-engineering-labs/formae-plugin-template)
+repository and customises it for you:
+
+```bash
+formae plugin init
+```
+
+The generated project already wires up this SDK, the manifest, a Pkl schema
+package, and a `conformance_test.go` that uses
+[`pkg/plugin-conformance-tests`](../plugin-conformance-tests) to validate the
+plugin end-to-end.
+
+## What's in here
+
+| Path | Purpose |
+| ---- | ------- |
+| `plugin.go`, `type.go`, `version.go` | Base `Plugin` interface, plugin `Type` ("resource"), `SDKVersion` and `MinFormaeVersion` constants. |
+| `resource.go` | The `ResourcePlugin` interface that plugin authors implement, plus the optional `ObservablePlugin` and `Configurable` interfaces. |
+| `resource/` | Request and result types for the CRUD methods (`CreateRequest`, `ReadResult`, `ProgressResult`, `OperationStatus`, error codes, …). |
+| `sdk/` | The external-plugin entry point. `sdk.RunWithManifest(p, sdk.RunConfig{})` is the one call a plugin's `main` makes. |
+| `manifest.go` | `Manifest` type and parser for `formae-plugin.pkl` (name, namespace, version, license, `minFormaeVersion`). |
+| `descriptors/` | Extracts resource type descriptors and JSON schemas from the plugin's Pkl package at startup. |
+| `schema/lib/` | Pkl standard-library extensions plugin schemas can import (random, bcrypt, tfvars helpers, …). |
+| `discovery/` | Helper for the agent to locate installed plugin binaries on disk. |
+| `logger.go`, `metrics.go` | `Logger` and `MetricRegistry` interfaces injected into the request context for structured logging and OpenTelemetry metrics. |
+| `actor.go`, `application.go`, `plugin_operator.go`, `run.go`, `wrapper.go` | Ergo-actor wiring — the transport that ferries CRUD calls between the agent and the plugin process. Plugin authors don't need to touch these. |
+
+## The `ResourcePlugin` interface
+
+This is everything you implement. The SDK wraps it with manifest-derived
+identity and schema methods automatically.
+
+```go
+type ResourcePlugin interface {
+    // Configuration
+    RateLimit() pkgmodel.RateLimitConfig
+    DiscoveryFilters() []pkgmodel.MatchFilter
+    LabelConfig() pkgmodel.LabelConfig
+
+    // CRUD
+    Create(ctx context.Context, req *resource.CreateRequest) (*resource.CreateResult, error)
+    Read(ctx context.Context, req *resource.ReadRequest)     (*resource.ReadResult, error)
+    Update(ctx context.Context, req *resource.UpdateRequest) (*resource.UpdateResult, error)
+    Delete(ctx context.Context, req *resource.DeleteRequest) (*resource.DeleteResult, error)
+
+    // Async progress polling
+    Status(ctx context.Context, req *resource.StatusRequest) (*resource.StatusResult, error)
+
+    // Discovery
+    List(ctx context.Context, req *resource.ListRequest) (*resource.ListResult, error)
+}
+```
+
+See [`resource.go`](./resource.go) for the source of truth and
+[`resource/resource.go`](./resource/resource.go) for the request and result
+types.
+
+### Optional interfaces
+
+Implement these on the same struct to opt in to extra SDK features:
+
+- **`ObservablePlugin`** — receive a `Logger` and `MetricRegistry` once at
+  startup. The SDK also injects these into every `context.Context` it passes to
+  your CRUD methods, so the typical pattern is to extract them with
+  `plugin.LoggerFromContext(ctx)` / `plugin.MetricsFromContext(ctx)` inside each
+  operation.
+- **`Configurable`** — receive plugin-specific configuration as
+  `json.RawMessage`, sourced from the user's `formae.conf.pkl`. Called once
+  during startup, before the plugin announces itself to the agent.
+
+## Async operations and progress
+
+CRUD methods return a `*resource.ProgressResult` (embedded in each `*Result`
+type). Long-running cloud operations should return
+`OperationStatus.InProgress` together with the cloud-side `NativeID` and any
+provider-specific tracking info. The agent will then call `Status` on a polling
+schedule until the operation reaches `Success` or `Failure`.
+
+The SDK retries automatically for error codes classed as recoverable
+(`Throttling`, `NetworkFailure`, `ServiceInternalError`, `ServiceTimeout`,
+`NotStabilized`, `InternalFailure`, `NotFound`, `ResourceConflict`). Other
+error codes terminate the operation.
+
+## Manifest and schema
+
+Every plugin ships two extra files alongside its binary:
+
+- **`formae-plugin.pkl`** — the manifest. Declares the plugin name, namespace
+  (e.g. `AWS`, `CLOUDFLARE`), version, license, and the minimum formae version
+  the plugin requires. See [`manifest.go`](./manifest.go) for the full schema.
+- **`schema/pkl/PklProject`** — a Pkl package describing the resource types
+  the plugin supports, their fields, validation rules, create-only fields,
+  whether each type is `discoverable` / `extractable`, and parent-resource
+  mappings. The SDK extracts JSON Schemas from this package at startup via
+  [`descriptors/`](./descriptors).
+
+The scaffolding command sets both of these up; you mostly edit the Pkl files
+to describe new resource types as you add them.
+
+## Entry point
+
+A complete plugin `main` is typically a single call:
+
+```go
+package main
+
+import (
+    "github.com/platform-engineering-labs/formae/pkg/plugin/sdk"
+    "github.com/your-org/formae-plugin-foo/pkg/foo"
+)
+
+func main() {
+    sdk.RunWithManifest(&foo.Plugin{}, sdk.RunConfig{})
+}
+```
+
+`RunWithManifest` reads the manifest from the plugin's install directory,
+extracts schemas from the Pkl package, wraps your `ResourcePlugin` into the
+internal `FullResourcePlugin`, starts an Ergo node on a free local port, and
+announces the plugin to the agent. See [`sdk/run.go`](./sdk/run.go).
+
+For testing or inspection — when you want the wrapped plugin without starting
+a node — call `sdk.SetupPlugin` (or `sdk.SetupPluginFromDir` to point at a
+specific directory) instead.
+
+## Conventions and constraints
+
+A few things commonly trip up new plugin authors:
+
+- **Plugins must be stateless across operations.** The agent may restart you
+  at any time, hot-reload you, or run operations concurrently. Don't rely on
+  in-memory state surviving between calls; persist anything you need in the
+  cloud or in the resource properties you return.
+- **`NativeID` is mandatory in every `ProgressResult`.** It's how the agent
+  re-finds your resource on subsequent operations.
+- **Resource properties travel as JSON.** Properties on requests and results
+  are `json.RawMessage` (or strings); make sure they round-trip cleanly through
+  your Pkl schema.
+- **Pick the right error code.** The agent uses
+  `resource.OperationErrorCode` to decide whether to retry. Returning a generic
+  `InternalFailure` for a permanently-broken request will cause unnecessary
+  retries; using `Throttling` for a hard auth failure will mask the real
+  problem.
+- **No pointer sharing across the actor boundary.** Everything between agent
+  and plugin is serialized (MessagePack + zstd over Ergo). If you stash a
+  pointer in a request, expect to get back a fresh copy on the other side.
+
+## Stability
+
+The SDK is still evolving as more cloud providers come online and tier-1 use
+cases shake out. We try to keep `ResourcePlugin` and its request/result types
+stable, and any breaking change will be called out in the formae release
+notes. Pin `minFormaeVersion` in your `formae-plugin.pkl` to the lowest formae
+version your plugin actually requires, so end users get a clear error when
+they try to use it with an older agent.
+
+## See also
+
+- [`pkg/plugin-conformance-tests`](../plugin-conformance-tests) — provider-agnostic
+  CRUD and discovery test suite. Wire it into your plugin's `_test.go` to
+  validate the entire lifecycle through the real agent.
+- [`pkg/auth`](../auth) — the separate SDK for **auth** plugins.
+- [`formae-plugin-template`](https://github.com/platform-engineering-labs/formae-plugin-template) —
+  the template `formae plugin init` clones from.
+- [formae documentation](https://docs.formae.io) — end-user docs, installation,
+  Pkl primer, integrations.
+
+## License
+
+FSL-1.1-ALv2. See [LICENSES/FSL-1.1-ALv2.md](../../LICENSES/FSL-1.1-ALv2.md).


### PR DESCRIPTION
## Summary

Add package-level READMEs that orient plugin authors who land in `pkg/plugin` or `pkg/plugin-conformance-tests` directly (e.g. via `go doc`, GitHub's package tree, or a `formae plugin init` follow-up).

**`pkg/plugin/README.md`** documents the resource plugin SDK:

- The `ResourcePlugin` interface and the optional `ObservablePlugin` / `Configurable` interfaces.
- The async `ProgressResult` flow and the recoverable-vs-non-recoverable `OperationErrorCode` classification the agent uses to decide whether to retry.
- The expected on-disk layout (`formae-plugin.pkl` manifest + `schema/pkl/PklProject`).
- The `sdk.RunWithManifest` entry point and a minimal `main` example.
- A sub-package map (`resource/`, `sdk/`, `descriptors/`, `discovery/`, `schema/lib/`, …).
- Conventions plugin authors commonly miss: statelessness across operations, mandatory `NativeID` in every `ProgressResult`, JSON-typed properties, no pointer sharing across the actor boundary.
- A pointer at `pkg/auth` so readers know auth plugins are a separate SDK.

**`pkg/plugin-conformance-tests/README.md`** documents the conformance suite:

- The two-function quick start (`RunCRUDTests` + `RunDiscoveryTests`).
- The `testdata/*.pkl` fixture convention, including the optional `-update.pkl` and `-replace.pkl` variants.
- The full list of steps verified by the CRUD lifecycle (create, inventory, extract round-trip, idempotent sync, update, replace, destroy, OOB-delete drift detection) and by the discovery lifecycle.
- Every `FORMAE_TEST_*` environment variable and what it controls.
- The channel-aware `minFormaeVersion` binary resolver (stable → dev fallback) so users understand why the suite doesn't just use `$PATH`.

Both READMEs cross-link, point at the `formae-plugin-template` repo as the canonical starting point, and reference `docs.formae.io` for end-user material.

No code changes.