### PR TITLE
feat(pkl): auto-resolve PklProject deps via shared pklrun evaluator

### DIFF
--- a/internal/schema/pkl/pkl.go
+++ b/internal/schema/pkl/pkl.go
@@ -24,6 +24,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/schema"
 	pklmodel "github.com/platform-engineering-labs/formae/internal/schema/pkl/model"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/pklrun"
 )
 
 const ProjectFile = "PklProject"
@@ -949,43 +950,17 @@ func parseLogLevel(level string) slog.Level {
 	}
 }
 
-// newSafeProjectEvaluator creates a project-aware PKL evaluator without the race
-// condition in pkl-go's NewProjectEvaluator. That function internally creates two
-// evaluators on the same manager and defer-closes the first one. If the pkl subprocess
-// sends a late message for the closed evaluator, the manager's listen loop exits
-// entirely (calls return instead of continue), killing all message processing.
-// See: https://github.com/apple/pkl-go/blob/v0.12.0/pkl/evaluator_exec.go#L57-L84
-//
-// This function keeps both evaluators alive until the returned cleanup function is
-// called, which closes the entire manager.
+// newSafeProjectEvaluator builds a project-aware PKL evaluator for the project
+// at projectBaseURL, delegating to pklrun. pklrun auto-runs `pkl project resolve`
+// when PklProject.deps.json is missing (so `formae apply` works on an unresolved
+// project) and owns the race-condition workaround around pkl-go's evaluator
+// manager. The bundled, sibling-of-formae pkl binary is preferred over PATH so
+// schemas relying on newer stdlib features resolve correctly.
 func newSafeProjectEvaluator(ctx context.Context, projectBaseURL *url.URL, opts ...func(*pklgo.EvaluatorOptions)) (pklgo.Evaluator, func(), error) {
-	var manager pklgo.EvaluatorManager
-	if cmd := bundledPklCommand(); cmd != nil {
-		manager = pklgo.NewEvaluatorManagerWithCommand(cmd)
-	} else {
-		manager = pklgo.NewEvaluatorManager()
-	}
-
-	projectEvaluator, err := manager.NewEvaluator(ctx, opts...)
-	if err != nil {
-		_ = manager.Close()
-		return nil, nil, fmt.Errorf("failed to create project evaluator: %w", err)
-	}
-
-	projectPath := projectBaseURL.JoinPath("PklProject")
-	project, err := pklgo.LoadProjectFromEvaluator(ctx, projectEvaluator, &pklgo.ModuleSource{Uri: projectPath})
-	if err != nil {
-		_ = manager.Close()
-		return nil, nil, fmt.Errorf("failed to load project: %w", err)
-	}
-
-	newOpts := []func(*pklgo.EvaluatorOptions){pklgo.WithProject(project)}
-	newOpts = append(newOpts, opts...)
-	evaluator, err := manager.NewEvaluator(ctx, newOpts...)
-	if err != nil {
-		_ = manager.Close()
-		return nil, nil, fmt.Errorf("failed to create evaluator: %w", err)
-	}
-
-	return evaluator, func() { _ = manager.Close() }, nil
+	return pklrun.NewProjectEvaluator(
+		ctx,
+		projectBaseURL.Path,
+		pklrun.WithPklCommand(bundledPklCommand()),
+		pklrun.WithEvaluatorOptions(opts...),
+	)
 }

--- a/internal/schema/pkl/pkl.go
+++ b/internal/schema/pkl/pkl.go
@@ -8,13 +8,11 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -47,45 +45,14 @@ func init() {
 // bundledPklCommand returns the sibling pkl binary next to the formae executable,
 // or nil to let pkl-go fall back to PATH. Using PATH risks picking up a pkl
 // version that doesn't support stdlib features our schemas rely on (e.g.
-// `pkl.reflect.Property.allAnnotations` needs 0.31+).
+// `pkl.reflect.Property.allAnnotations` needs 0.31+). The detection logic lives
+// in pklrun so every pkl invocation (eval and `project resolve`) shares it.
 func bundledPklCommand() []string {
 	exe, err := os.Executable()
 	if err != nil {
 		return nil
 	}
-	// Resolve symlinks so /usr/local/bin/formae -> /opt/pel/bin/formae finds
-	// /opt/pel/bin/pkl rather than looking in /usr/local/bin.
-	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
-		exe = resolved
-	}
-	bundled := filepath.Join(filepath.Dir(exe), "pkl")
-	if info, err := os.Stat(bundled); err == nil && !info.IsDir() {
-		return []string{bundled}
-	}
-	return nil
-}
-
-// runPklProjectResolve invokes `pkl project resolve <dir>` using the
-// sibling-of-formae binary when present, falling back to PATH. Combined
-// stdout/stderr is included in the returned error so failures (missing
-// binary, malformed PklProject, network issues fetching remote deps) are
-// surfaced at the call site instead of silently dropped.
-func runPklProjectResolve(dir string) error {
-	args := []string{"project", "resolve", dir}
-	var cmd *exec.Cmd
-	if pklCmd := bundledPklCommand(); pklCmd != nil {
-		cmd = exec.Command(pklCmd[0], append(append([]string{}, pklCmd[1:]...), args...)...)
-	} else {
-		cmd = exec.Command("pkl", args...)
-	}
-	if errors.Is(cmd.Err, exec.ErrDot) {
-		cmd.Err = nil
-	}
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("pkl project resolve failed in %s: %w\nOutput: %s", dir, err, string(output))
-	}
-	return nil
+	return pklrun.BundledPklCommand(exe)
 }
 
 func (p PKL) Name() string {
@@ -646,7 +613,7 @@ func (p PKL) ProjectInit(path string, include []string, schemaLocation schema.Sc
 	}
 
 	if hasRemotePackages {
-		if err := runPklProjectResolve(path); err != nil {
+		if err := pklrun.ProjectResolve(path, pklrun.WithPklCommand(bundledPklCommand())); err != nil {
 			return err
 		}
 	}

--- a/internal/schema/pkl/pkl_serialize.go
+++ b/internal/schema/pkl/pkl_serialize.go
@@ -19,6 +19,7 @@ import (
 	formae "github.com/platform-engineering-labs/formae"
 	"github.com/platform-engineering-labs/formae/internal/schema"
 	"github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/pklrun"
 )
 
 // serializeWithPKL is a generic helper function that can serialize any data structure
@@ -105,7 +106,7 @@ func (p PKL) serializeWithPKL(data *model.Forma, options *schema.SerializeOption
 		if err := os.Remove(depsJSON); err != nil && !os.IsNotExist(err) {
 			return "", fmt.Errorf("failed to clear stale deps.json: %w", err)
 		}
-		if err := runPklProjectResolve(generatorDir); err != nil {
+		if err := pklrun.ProjectResolve(generatorDir, pklrun.WithPklCommand(bundledPklCommand())); err != nil {
 			return "", fmt.Errorf("re-resolve after dep swap: %w", err)
 		}
 	}

--- a/internal/schema/pkl/pkl_test.go
+++ b/internal/schema/pkl/pkl_test.go
@@ -33,6 +33,27 @@ func TestPkl_Evaluate(t *testing.T) {
 	assert.Equal(t, "A", gjson.Get(jsonString, "Resources.1.Properties.Type").String())
 }
 
+// TestPkl_Evaluate_AutoResolvesUnresolvedProject reproduces the reported failure:
+// applying a forma whose directory has a PklProject but no resolved
+// PklProject.deps.json used to fail with a NoSuchFileException and force a manual
+// `pkl project resolve`. Evaluate now auto-resolves via pklrun. The deps file is
+// gitignored and regenerated, so removing it needs no cleanup.
+func TestPkl_Evaluate_AutoResolvesUnresolvedProject(t *testing.T) {
+	depsPath := "./testdata/forma/PklProject.deps.json"
+	if err := os.Remove(depsPath); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("removing deps.json to simulate unresolved project: %v", err)
+	}
+
+	props := map[string]string{"name": "bacon.platform.engineering"}
+	p := PKL{}
+	_, err := p.Evaluate("./testdata/forma/test.pkl", model.CommandApply, model.FormaApplyModeReconcile, props)
+	require.NoError(t, err, "Evaluate must auto-run `pkl project resolve` when PklProject.deps.json is missing")
+
+	if _, statErr := os.Stat(depsPath); statErr != nil {
+		t.Fatalf("auto-resolve should have recreated PklProject.deps.json: %v", statErr)
+	}
+}
+
 func TestPkl_EvaluateCommandAndMode(t *testing.T) {
 	props := map[string]string{"name": "bacon.platform.engineering"}
 

--- a/pkg/plugin/descriptors/extract_schema.go
+++ b/pkg/plugin/descriptors/extract_schema.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -165,16 +164,10 @@ func generatePklProject(ctx context.Context, workDir string, dependencies []Depe
 	return nil
 }
 
-// resolvePklProject runs pkl project resolve to fetch dependencies
+// resolvePklProject runs pkl project resolve to fetch dependencies, creating
+// PklProject.deps.json with resolved versions.
 func resolvePklProject(workDir string) error {
-	// Use pkl CLI to resolve dependencies
-	// This creates PklProject.deps.json with resolved versions
-	cmd := newPklCommand("project", "resolve", workDir)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("pkl project resolve failed: %w\nOutput: %s", err, string(output))
-	}
-	return nil
+	return pklrun.ProjectResolve(workDir)
 }
 
 // generateImports generates imports.pkl from PklProject dependencies using ImportsGenerator.pkl
@@ -238,11 +231,6 @@ func runExtractor(ctx context.Context, workDir string) ([]plugin.ResourceTypeDes
 	}
 
 	return pklResult.Descriptors, nil
-}
-
-// newPklCommand creates a new exec.Cmd for running pkl CLI commands
-func newPklCommand(args ...string) *exec.Cmd {
-	return exec.Command("pkl", args...)
 }
 
 // formaeDepPattern matches the `["formae"] { ... }` or `["formae"] = import(...)`

--- a/pkg/plugin/descriptors/extract_schema.go
+++ b/pkg/plugin/descriptors/extract_schema.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/apple/pkl-go/pkl"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/pklrun"
 )
 
 //go:embed *.pkl
@@ -179,10 +179,10 @@ func resolvePklProject(workDir string) error {
 
 // generateImports generates imports.pkl from PklProject dependencies using ImportsGenerator.pkl
 func generateImports(ctx context.Context, workDir string) error {
-	evaluator, cleanup, err := newSafeProjectEvaluator(
+	evaluator, cleanup, err := pklrun.NewProjectEvaluator(
 		ctx,
-		&url.URL{Scheme: "file", Path: workDir},
-		pkl.PreconfiguredOptions,
+		workDir,
+		pklrun.WithEvaluatorOptions(pkl.PreconfiguredOptions),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create evaluator: %w", err)
@@ -206,13 +206,15 @@ func generateImports(ctx context.Context, workDir string) error {
 
 // runExtractor runs the Extractor.pkl to extract ResourceDescriptors
 func runExtractor(ctx context.Context, workDir string) ([]plugin.ResourceTypeDescriptor, error) {
-	evaluator, cleanup, err := newSafeProjectEvaluator(
+	evaluator, cleanup, err := pklrun.NewProjectEvaluator(
 		ctx,
-		&url.URL{Scheme: "file", Path: workDir},
-		pkl.PreconfiguredOptions,
-		func(opts *pkl.EvaluatorOptions) {
-			opts.OutputFormat = "json"
-		},
+		workDir,
+		pklrun.WithEvaluatorOptions(
+			pkl.PreconfiguredOptions,
+			func(opts *pkl.EvaluatorOptions) {
+				opts.OutputFormat = "json"
+			},
+		),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create project evaluator: %w", err)
@@ -236,42 +238,6 @@ func runExtractor(ctx context.Context, workDir string) ([]plugin.ResourceTypeDes
 	}
 
 	return pklResult.Descriptors, nil
-}
-
-// newSafeProjectEvaluator creates a project-aware PKL evaluator without the race
-// condition in pkl-go's NewProjectEvaluator. That function internally creates two
-// evaluators on the same manager and defer-closes the first one. If the pkl subprocess
-// sends a late message for the closed evaluator, the manager's listen loop exits
-// entirely (calls return instead of continue), killing all message processing.
-// See: https://github.com/apple/pkl-go/blob/v0.12.0/pkl/evaluator_exec.go#L57-L84
-//
-// This function keeps both evaluators alive until the returned cleanup function is
-// called, which closes the entire manager.
-func newSafeProjectEvaluator(ctx context.Context, projectBaseURL *url.URL, opts ...func(*pkl.EvaluatorOptions)) (pkl.Evaluator, func(), error) {
-	manager := pkl.NewEvaluatorManager()
-
-	projectEvaluator, err := manager.NewEvaluator(ctx, opts...)
-	if err != nil {
-		manager.Close()
-		return nil, nil, fmt.Errorf("failed to create project evaluator: %w", err)
-	}
-
-	projectPath := projectBaseURL.JoinPath("PklProject")
-	project, err := pkl.LoadProjectFromEvaluator(ctx, projectEvaluator, &pkl.ModuleSource{Uri: projectPath})
-	if err != nil {
-		manager.Close()
-		return nil, nil, fmt.Errorf("failed to load project: %w", err)
-	}
-
-	newOpts := []func(*pkl.EvaluatorOptions){pkl.WithProject(project)}
-	newOpts = append(newOpts, opts...)
-	evaluator, err := manager.NewEvaluator(ctx, newOpts...)
-	if err != nil {
-		manager.Close()
-		return nil, nil, fmt.Errorf("failed to create evaluator: %w", err)
-	}
-
-	return evaluator, func() { manager.Close() }, nil
 }
 
 // newPklCommand creates a new exec.Cmd for running pkl CLI commands

--- a/pkg/plugin/pklrun/pklrun.go
+++ b/pkg/plugin/pklrun/pklrun.go
@@ -1,0 +1,174 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+// Package pklrun is formae's evaluator engine on top of apple/pkl-go. It owns
+// how formae runs pkl: which binary to invoke, loading a PklProject, and —
+// crucially — running `pkl project resolve` automatically when a project's
+// PklProject.deps.json is missing, so callers never have to resolve by hand.
+//
+// It is the single home for the project-aware evaluator that was previously
+// copy-pasted across internal/schema/pkl, pkg/plugin/descriptors, and
+// pkg/plugin/testutil. The package lives under pkg/plugin because that is the
+// only module importable by both the root formae module and the plugin
+// packages (the root module depends on pkg/plugin, never the reverse).
+package pklrun
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/apple/pkl-go/pkl"
+)
+
+const (
+	projectFile = "PklProject"
+	depsFile    = "PklProject.deps.json"
+)
+
+// config holds the resolved options for NewProjectEvaluator.
+type config struct {
+	pklCmd   []string                      // nil/empty → resolve "pkl" via PATH
+	evalOpts []func(*pkl.EvaluatorOptions) // forwarded to the pkl evaluator
+}
+
+// Option configures NewProjectEvaluator.
+type Option func(*config)
+
+// WithPklCommand overrides the pkl binary used for both `project resolve` and
+// evaluation. The root formae module passes its bundled, sibling-of-formae
+// binary (see BundledPklCommand); a nil or empty command falls back to PATH.
+func WithPklCommand(cmd []string) Option {
+	return func(c *config) { c.pklCmd = cmd }
+}
+
+// WithEvaluatorOptions appends pkl-go evaluator options (e.g.
+// pkl.PreconfiguredOptions, output format, resource readers).
+func WithEvaluatorOptions(o ...func(*pkl.EvaluatorOptions)) Option {
+	return func(c *config) { c.evalOpts = append(c.evalOpts, o...) }
+}
+
+// NewProjectEvaluator builds a project-aware pkl evaluator for projectDir.
+//
+// If projectDir/PklProject.deps.json is missing, it first runs
+// `pkl project resolve <projectDir>` to generate it — this removes the manual
+// step that otherwise surfaces as a NoSuchFileException when loading the
+// project. The returned cleanup function closes the underlying evaluator
+// manager and must be called by the caller.
+func NewProjectEvaluator(ctx context.Context, projectDir string, opts ...Option) (pkl.Evaluator, func(), error) {
+	cfg := &config{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	if err := ensureProjectResolved(projectDir, cfg.pklCmd); err != nil {
+		return nil, nil, err
+	}
+
+	return newSafeProjectEvaluator(ctx, projectDir, cfg.pklCmd, cfg.evalOpts...)
+}
+
+// ensureProjectResolved runs `pkl project resolve` when projectDir has a
+// PklProject but no resolved PklProject.deps.json. When the deps file already
+// exists it is a no-op, so resolution happens at most once per project dir.
+func ensureProjectResolved(projectDir string, pklCmd []string) error {
+	deps := filepath.Join(projectDir, depsFile)
+	switch _, err := os.Stat(deps); {
+	case err == nil:
+		return nil // already resolved
+	case os.IsNotExist(err):
+		return runPklProjectResolve(projectDir, pklCmd)
+	default:
+		return fmt.Errorf("failed to stat %s: %w", deps, err)
+	}
+}
+
+// runPklProjectResolve invokes `pkl project resolve <dir>`. Combined
+// stdout/stderr is included in the returned error so failures (missing binary,
+// malformed PklProject, network issues fetching remote deps) surface at the
+// call site instead of being silently dropped.
+func runPklProjectResolve(dir string, pklCmd []string) error {
+	bin, pre := pklBinary(pklCmd)
+	cmd := exec.Command(bin, append(append([]string{}, pre...), "project", "resolve", dir)...)
+	if errors.Is(cmd.Err, exec.ErrDot) {
+		cmd.Err = nil
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("pkl project resolve failed in %s: %w\nOutput: %s", dir, err, string(output))
+	}
+	return nil
+}
+
+// pklBinary splits a pkl command override into its binary and leading args,
+// defaulting to "pkl" on PATH when no override is given.
+func pklBinary(pklCmd []string) (string, []string) {
+	if len(pklCmd) > 0 {
+		return pklCmd[0], pklCmd[1:]
+	}
+	return "pkl", nil
+}
+
+// newSafeProjectEvaluator creates a project-aware PKL evaluator without the race
+// condition in pkl-go's NewProjectEvaluator. That function internally creates two
+// evaluators on the same manager and defer-closes the first one. If the pkl subprocess
+// sends a late message for the closed evaluator, the manager's listen loop exits
+// entirely (calls return instead of continue), killing all message processing.
+// See: https://github.com/apple/pkl-go/blob/v0.12.0/pkl/evaluator_exec.go#L57-L84
+//
+// This function keeps both evaluators alive until the returned cleanup function is
+// called, which closes the entire manager.
+func newSafeProjectEvaluator(ctx context.Context, projectDir string, pklCmd []string, opts ...func(*pkl.EvaluatorOptions)) (pkl.Evaluator, func(), error) {
+	var manager pkl.EvaluatorManager
+	if len(pklCmd) > 0 {
+		manager = pkl.NewEvaluatorManagerWithCommand(pklCmd)
+	} else {
+		manager = pkl.NewEvaluatorManager()
+	}
+
+	projectEvaluator, err := manager.NewEvaluator(ctx, opts...)
+	if err != nil {
+		_ = manager.Close()
+		return nil, nil, fmt.Errorf("failed to create project evaluator: %w", err)
+	}
+
+	projectPath := (&url.URL{Scheme: "file", Path: projectDir}).JoinPath(projectFile)
+	project, err := pkl.LoadProjectFromEvaluator(ctx, projectEvaluator, &pkl.ModuleSource{Uri: projectPath})
+	if err != nil {
+		_ = manager.Close()
+		return nil, nil, fmt.Errorf("failed to load project: %w", err)
+	}
+
+	newOpts := append([]func(*pkl.EvaluatorOptions){pkl.WithProject(project)}, opts...)
+	evaluator, err := manager.NewEvaluator(ctx, newOpts...)
+	if err != nil {
+		_ = manager.Close()
+		return nil, nil, fmt.Errorf("failed to create evaluator: %w", err)
+	}
+
+	return evaluator, func() { _ = manager.Close() }, nil
+}
+
+// BundledPklCommand returns the sibling pkl binary next to exePath, or nil to
+// let callers fall back to PATH. Using PATH risks picking up a pkl version that
+// doesn't support stdlib features formae schemas rely on (e.g.
+// pkl.reflect.Property.allAnnotations needs 0.31+). Symlinks are resolved so
+// /usr/local/bin/formae -> /opt/pel/bin/formae finds /opt/pel/bin/pkl.
+func BundledPklCommand(exePath string) []string {
+	if exePath == "" {
+		return nil
+	}
+	if resolved, err := filepath.EvalSymlinks(exePath); err == nil {
+		exePath = resolved
+	}
+	bundled := filepath.Join(filepath.Dir(exePath), "pkl")
+	if info, err := os.Stat(bundled); err == nil && !info.IsDir() {
+		return []string{bundled}
+	}
+	return nil
+}

--- a/pkg/plugin/pklrun/pklrun.go
+++ b/pkg/plugin/pklrun/pklrun.go
@@ -73,6 +73,20 @@ func NewProjectEvaluator(ctx context.Context, projectDir string, opts ...Option)
 	return newSafeProjectEvaluator(ctx, projectDir, cfg.pklCmd, cfg.evalOpts...)
 }
 
+// ProjectResolve unconditionally runs `pkl project resolve <projectDir>`,
+// regenerating PklProject.deps.json. Use it after writing or changing a
+// PklProject (e.g. ProjectInit, schema generators); for the lazy
+// resolve-only-if-missing behavior used when loading a project for evaluation,
+// prefer NewProjectEvaluator. WithPklCommand selects the binary; evaluator
+// options are ignored.
+func ProjectResolve(projectDir string, opts ...Option) error {
+	cfg := &config{}
+	for _, o := range opts {
+		o(cfg)
+	}
+	return runPklProjectResolve(projectDir, cfg.pklCmd)
+}
+
 // ensureProjectResolved runs `pkl project resolve` when projectDir has a
 // PklProject but no resolved PklProject.deps.json. When the deps file already
 // exists it is a no-op, so resolution happens at most once per project dir.

--- a/pkg/plugin/pklrun/pklrun.go
+++ b/pkg/plugin/pklrun/pklrun.go
@@ -87,19 +87,37 @@ func ProjectResolve(projectDir string, opts ...Option) error {
 	return runPklProjectResolve(projectDir, cfg.pklCmd)
 }
 
-// ensureProjectResolved runs `pkl project resolve` when projectDir has a
-// PklProject but no resolved PklProject.deps.json. When the deps file already
-// exists it is a no-op, so resolution happens at most once per project dir.
+// ensureProjectResolved runs `pkl project resolve` when the project's resolved
+// dependency set is missing or out of date:
+//
+//   - PklProject.deps.json absent            → resolve (never resolved before)
+//   - PklProject newer than its deps.json    → resolve (deps edited after the
+//     last resolve; the cached set is stale)
+//   - otherwise                              → no-op (trust the resolved set)
+//
+// The mtime check closes the gap where editing dependencies without deleting
+// deps.json would silently evaluate against the old resolved set.
 func ensureProjectResolved(projectDir string, pklCmd []string) error {
 	deps := filepath.Join(projectDir, depsFile)
-	switch _, err := os.Stat(deps); {
-	case err == nil:
-		return nil // already resolved
+	depsInfo, err := os.Stat(deps)
+	switch {
 	case os.IsNotExist(err):
 		return runPklProjectResolve(projectDir, pklCmd)
-	default:
+	case err != nil:
 		return fmt.Errorf("failed to stat %s: %w", deps, err)
 	}
+
+	// deps.json exists — re-resolve if the PklProject has been touched since.
+	projInfo, err := os.Stat(filepath.Join(projectDir, projectFile))
+	if err != nil {
+		// No (readable) PklProject to compare against; trust the existing
+		// deps.json rather than guessing.
+		return nil
+	}
+	if projInfo.ModTime().After(depsInfo.ModTime()) {
+		return runPklProjectResolve(projectDir, pklCmd)
+	}
+	return nil
 }
 
 // runPklProjectResolve invokes `pkl project resolve <dir>`. Combined

--- a/pkg/plugin/pklrun/pklrun_test.go
+++ b/pkg/plugin/pklrun/pklrun_test.go
@@ -1,0 +1,167 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package pklrun
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Env keys driving the fake pkl binary (see TestHelperProcess). They are passed
+// to the child via the parent's environment (t.Setenv), so no shell is involved
+// and the test is OS-independent.
+const (
+	envHelper  = "PKLRUN_HELPER_PROCESS" // "1" activates the fake-pkl behavior
+	envCounter = "PKLRUN_HELPER_COUNTER" // file to append one byte per invocation
+	envExit    = "PKLRUN_HELPER_EXIT"    // exit code (default 0)
+	envStderr  = "PKLRUN_HELPER_STDERR"  // text to emit on stderr
+)
+
+// fakePklCommand returns a WithPklCommand value that re-invokes this test binary
+// as a stand-in for the pkl CLI. Behavior is controlled by the env vars above,
+// which the child process inherits — no shell script, works on any OS.
+func fakePklCommand() []string {
+	return []string{os.Args[0], "-test.run=TestHelperProcess", "--"}
+}
+
+// useFakePkl configures the fake pkl for one test via the inherited environment.
+func useFakePkl(t *testing.T, counterPath string, exitCode int, stderr string) {
+	t.Helper()
+	t.Setenv(envHelper, "1")
+	t.Setenv(envCounter, counterPath)
+	t.Setenv(envExit, strconv.Itoa(exitCode))
+	t.Setenv(envStderr, stderr)
+}
+
+// TestHelperProcess is not a real test: it is the fake `pkl` executable that
+// fakePklCommand re-invokes. It is inert during a normal test run and only acts
+// when PKLRUN_HELPER_PROCESS=1, then exits the process. On `project resolve
+// <dir>` with a zero exit code it creates <dir>/PklProject.deps.json, mirroring
+// what real `pkl project resolve` produces.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv(envHelper) != "1" {
+		return
+	}
+
+	if counter := os.Getenv(envCounter); counter != "" {
+		if f, err := os.OpenFile(counter, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644); err == nil {
+			_, _ = f.WriteString("x")
+			_ = f.Close()
+		}
+	}
+
+	code := 0
+	if e := os.Getenv(envExit); e != "" {
+		code, _ = strconv.Atoi(e)
+	}
+
+	// Args after "--": the pkl subcommand, e.g. "project resolve <dir>".
+	args := os.Args
+	for i, a := range args {
+		if a == "--" {
+			args = args[i+1:]
+			break
+		}
+	}
+	if code == 0 && len(args) >= 3 && args[0] == "project" && args[1] == "resolve" {
+		_ = os.WriteFile(filepath.Join(args[2], depsFile), []byte("{}"), 0o644)
+	}
+
+	if s := os.Getenv(envStderr); s != "" {
+		fmt.Fprintln(os.Stderr, s)
+	}
+	os.Exit(code)
+}
+
+func invocations(t *testing.T, counterPath string) int {
+	t.Helper()
+	data, err := os.ReadFile(counterPath)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	return strings.Count(string(data), "x")
+}
+
+func TestEnsureProjectResolved_MissingDeps_Resolves(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, projectFile), []byte("amends \"pkl:Project\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	counter := filepath.Join(t.TempDir(), "calls")
+	useFakePkl(t, counter, 0, "")
+
+	if err := ensureProjectResolved(dir, fakePklCommand()); err != nil {
+		t.Fatalf("ensureProjectResolved: %v", err)
+	}
+
+	if n := invocations(t, counter); n != 1 {
+		t.Fatalf("expected 1 resolve invocation, got %d", n)
+	}
+	if _, err := os.Stat(filepath.Join(dir, depsFile)); err != nil {
+		t.Fatalf("expected %s to be created: %v", depsFile, err)
+	}
+}
+
+func TestEnsureProjectResolved_PresentDeps_Skips(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, depsFile), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	counter := filepath.Join(t.TempDir(), "calls")
+	useFakePkl(t, counter, 0, "")
+
+	if err := ensureProjectResolved(dir, fakePklCommand()); err != nil {
+		t.Fatalf("ensureProjectResolved: %v", err)
+	}
+
+	if n := invocations(t, counter); n != 0 {
+		t.Fatalf("expected 0 resolve invocations when %s present, got %d", depsFile, n)
+	}
+}
+
+func TestEnsureProjectResolved_ResolveFailure_SurfacesOutput(t *testing.T) {
+	dir := t.TempDir()
+	counter := filepath.Join(t.TempDir(), "calls")
+	useFakePkl(t, counter, 1, "boom-malformed-project")
+
+	err := ensureProjectResolved(dir, fakePklCommand())
+	if err == nil {
+		t.Fatal("expected error on resolve failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "boom-malformed-project") {
+		t.Fatalf("expected combined output in error, got: %v", err)
+	}
+}
+
+func TestBundledPklCommand(t *testing.T) {
+	// No sibling pkl → nil.
+	emptyDir := t.TempDir()
+	if got := BundledPklCommand(filepath.Join(emptyDir, "formae")); got != nil {
+		t.Fatalf("expected nil when no sibling pkl, got %v", got)
+	}
+
+	// Sibling pkl present → [<dir>/pkl].
+	dir := t.TempDir()
+	pklPath := filepath.Join(dir, "pkl")
+	if err := os.WriteFile(pklPath, []byte(""), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got := BundledPklCommand(filepath.Join(dir, "formae"))
+	if len(got) != 1 || got[0] != pklPath {
+		t.Fatalf("expected [%s], got %v", pklPath, got)
+	}
+
+	// Empty exe path → nil.
+	if got := BundledPklCommand(""); got != nil {
+		t.Fatalf("expected nil for empty exe path, got %v", got)
+	}
+}

--- a/pkg/plugin/pklrun/pklrun_test.go
+++ b/pkg/plugin/pklrun/pklrun_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // Env keys driving the fake pkl binary (see TestHelperProcess). They are passed
@@ -111,11 +112,32 @@ func TestEnsureProjectResolved_MissingDeps_Resolves(t *testing.T) {
 	}
 }
 
-func TestEnsureProjectResolved_PresentDeps_Skips(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, depsFile), []byte("{}"), 0o644); err != nil {
+// writeProjectWithDeps writes a PklProject and its deps.json into dir, then
+// stamps them so the PklProject's mtime is projAge before the deps.json's. A
+// negative projAge makes the project older (fresh deps); a positive one makes it
+// newer (stale deps).
+func writeProjectWithDeps(t *testing.T, dir string, projAge time.Duration) {
+	t.Helper()
+	proj := filepath.Join(dir, projectFile)
+	deps := filepath.Join(dir, depsFile)
+	if err := os.WriteFile(proj, []byte("amends \"pkl:Project\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(deps, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(deps, base, base); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(proj, base.Add(projAge), base.Add(projAge)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureProjectResolved_FreshDeps_Skips(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectWithDeps(t, dir, -time.Minute) // PklProject older than deps.json
 	counter := filepath.Join(t.TempDir(), "calls")
 	useFakePkl(t, counter, 0, "")
 
@@ -124,7 +146,22 @@ func TestEnsureProjectResolved_PresentDeps_Skips(t *testing.T) {
 	}
 
 	if n := invocations(t, counter); n != 0 {
-		t.Fatalf("expected 0 resolve invocations when %s present, got %d", depsFile, n)
+		t.Fatalf("expected 0 resolve invocations when deps.json is fresh, got %d", n)
+	}
+}
+
+func TestEnsureProjectResolved_StaleDeps_Resolves(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectWithDeps(t, dir, time.Minute) // PklProject newer than deps.json
+	counter := filepath.Join(t.TempDir(), "calls")
+	useFakePkl(t, counter, 0, "")
+
+	if err := ensureProjectResolved(dir, fakePklCommand()); err != nil {
+		t.Fatalf("ensureProjectResolved: %v", err)
+	}
+
+	if n := invocations(t, counter); n != 1 {
+		t.Fatalf("expected 1 resolve invocation when PklProject is newer than deps.json, got %d", n)
 	}
 }
 

--- a/pkg/plugin/testutil/docs.go
+++ b/pkg/plugin/testutil/docs.go
@@ -8,13 +8,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/apple/pkl-go/pkl"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/pklrun"
 )
 
 // DocsResult contains the documentation for a schema.
@@ -100,10 +100,10 @@ func GenerateDocsWithNamespace(schemaDir, namespace string) (*DocsResult, error)
 
 // runDocs runs Docs.pkl and parses the result.
 func runDocs(ctx context.Context, workDir string) (*DocsResult, error) {
-	evaluator, cleanup, err := newSafeProjectEvaluator(
+	evaluator, cleanup, err := pklrun.NewProjectEvaluator(
 		ctx,
-		&url.URL{Scheme: "file", Path: workDir},
-		pkl.PreconfiguredOptions,
+		workDir,
+		pklrun.WithEvaluatorOptions(pkl.PreconfiguredOptions),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create evaluator: %w", err)

--- a/pkg/plugin/testutil/verify.go
+++ b/pkg/plugin/testutil/verify.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -193,12 +192,7 @@ func generatePklProject(ctx context.Context, workDir, namespace, schemaPath stri
 
 // resolvePklProject runs pkl project resolve to fetch dependencies.
 func resolvePklProject(workDir string) error {
-	cmd := exec.Command("pkl", "project", "resolve", workDir)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("pkl project resolve failed: %s", string(output))
-	}
-	return nil
+	return pklrun.ProjectResolve(workDir)
 }
 
 // generateImports generates imports.pkl from PklProject dependencies.

--- a/pkg/plugin/testutil/verify.go
+++ b/pkg/plugin/testutil/verify.go
@@ -10,7 +10,6 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/apple/pkl-go/pkl"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/pklrun"
 )
 
 //go:embed pkl/*.pkl
@@ -203,10 +203,10 @@ func resolvePklProject(workDir string) error {
 
 // generateImports generates imports.pkl from PklProject dependencies.
 func generateImports(ctx context.Context, workDir string) error {
-	evaluator, cleanup, err := newSafeProjectEvaluator(
+	evaluator, cleanup, err := pklrun.NewProjectEvaluator(
 		ctx,
-		&url.URL{Scheme: "file", Path: workDir},
-		pkl.PreconfiguredOptions,
+		workDir,
+		pklrun.WithEvaluatorOptions(pkl.PreconfiguredOptions),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create evaluator: %w", err)
@@ -229,10 +229,10 @@ func generateImports(ctx context.Context, workDir string) error {
 
 // runVerification runs Verify.pkl and parses the result.
 func runVerification(ctx context.Context, workDir string) (*VerifyResult, error) {
-	evaluator, cleanup, err := newSafeProjectEvaluator(
+	evaluator, cleanup, err := pklrun.NewProjectEvaluator(
 		ctx,
-		&url.URL{Scheme: "file", Path: workDir},
-		pkl.PreconfiguredOptions,
+		workDir,
+		pklrun.WithEvaluatorOptions(pkl.PreconfiguredOptions),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create evaluator: %w", err)
@@ -298,38 +298,3 @@ func (r *VerifyResult) FormatReport(namespace string) string {
 	return sb.String()
 }
 
-// newSafeProjectEvaluator creates a project-aware PKL evaluator without the race
-// condition in pkl-go's NewProjectEvaluator. That function internally creates two
-// evaluators on the same manager and defer-closes the first one. If the pkl subprocess
-// sends a late message for the closed evaluator, the manager's listen loop exits
-// entirely (calls return instead of continue), killing all message processing.
-// See: https://github.com/apple/pkl-go/blob/v0.12.0/pkl/evaluator_exec.go#L57-L84
-//
-// This function keeps both evaluators alive until the returned cleanup function is
-// called, which closes the entire manager.
-func newSafeProjectEvaluator(ctx context.Context, projectBaseURL *url.URL, opts ...func(*pkl.EvaluatorOptions)) (pkl.Evaluator, func(), error) {
-	manager := pkl.NewEvaluatorManager()
-
-	projectEvaluator, err := manager.NewEvaluator(ctx, opts...)
-	if err != nil {
-		manager.Close()
-		return nil, nil, fmt.Errorf("failed to create project evaluator: %w", err)
-	}
-
-	projectPath := projectBaseURL.JoinPath("PklProject")
-	project, err := pkl.LoadProjectFromEvaluator(ctx, projectEvaluator, &pkl.ModuleSource{Uri: projectPath})
-	if err != nil {
-		manager.Close()
-		return nil, nil, fmt.Errorf("failed to load project: %w", err)
-	}
-
-	newOpts := []func(*pkl.EvaluatorOptions){pkl.WithProject(project)}
-	newOpts = append(newOpts, opts...)
-	evaluator, err := manager.NewEvaluator(ctx, newOpts...)
-	if err != nil {
-		manager.Close()
-		return nil, nil, fmt.Errorf("failed to create evaluator: %w", err)
-	}
-
-	return evaluator, func() { manager.Close() }, nil
-}


### PR DESCRIPTION
## Problem

Running `formae apply` (or `eval`) against a `.pkl` forma whose directory has an **unresolved** `PklProject` fails and forces the user to run `pkl project resolve` by hand first:

```
❯ formae apply --mode reconcile .../testdata/ec2-vpc.pkl
Error: –– Pkl Error ––
Encountered an error when attempting to load `PklProject.deps.json` at
`file:///.../testdata/PklProject.deps.json`.
NoSuchFileException: /.../testdata/PklProject.deps.json
7 | amends "@formae/forma.pkl"
Try running `pkl project resolve` within the project directory ...
```

`PklProject.deps.json` is gitignored (regenerated by `pkl project resolve`), so a fresh checkout / fresh testdata dir always hits this.

## Root cause

`PKL.Evaluate` walks up to find a `PklProject`, then builds a project-aware evaluator that calls pkl-go `LoadProjectFromEvaluator`, which **requires** `PklProject.deps.json`. When the project was never resolved, pkl throws `NoSuchFileException`.

The project-evaluator helper (`newSafeProjectEvaluator`) was also **copy-pasted in three places across two Go modules**, so the gap — and any fix — had to be repeated.

## Change

Introduce **`pkg/plugin/pklrun`**, formae's evaluator engine on top of `apple/pkl-go`. `NewProjectEvaluator`:

- **Auto-runs `pkl project resolve <dir>` when `PklProject.deps.json` is missing** (only when missing — no extra latency once resolved).
- Owns bundled-binary detection (`BundledPklCommand`, sibling-of-formae `pkl`) via an optional `WithPklCommand`; defaults to PATH.
- Keeps the existing pkl-go evaluator-manager race-condition workaround.

The three `newSafeProjectEvaluator` copies are collapsed onto it:

- `internal/schema/pkl/pkl.go` → thin shim (signature unchanged; the 9 project-mode call sites are untouched), passing the bundled pkl command.
- `pkg/plugin/descriptors/extract_schema.go`, `pkg/plugin/testutil/{verify,docs}.go` → call `pklrun` directly; duplicate defs and now-dead `net/url` imports removed.

### Why `pkg/plugin`

Module graph: the root `formae` module **depends on** `pkg/plugin` (the leaf), which cannot import `internal/`. `pkg/plugin` is therefore the only module importable by both the root `internal/schema/pkl` package and the plugin packages — so the shared helper must live there.

## Verification

| Check | Result |
|-------|--------|
| `pklrun` unit (auto-resolve logic via command spy) | 4 pass |
| root `internal/schema/pkl` unit / integration | 7 / 23 pass |
| `pkg/plugin` descriptors + testutil unit / integration | 20 / 16 pass |
| `go vet` + `go build`, both modules | clean |

New integration test `TestPkl_Evaluate_AutoResolvesUnresolvedProject` reproduces the original failure: it removes `PklProject.deps.json`, evaluates a real forma, and asserts success + that the deps file is recreated.

Net **−130/+57** lines in the touched existing files (duplication removed), plus the new package.

## Out of scope

- Always-resolve / staleness detection (resolving on every eval to catch `PklProject` edits).
- Concurrent-resolve locking (`pkl project resolve` is idempotent).
- Routing the plain, non-project evaluator sites through `pklrun` (they *create* the `PklProject` — nothing to resolve yet).
