### PR TITLE
fix(discovery): skip resource type on spawn failure instead of crashing

### DIFF
--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -6,6 +6,7 @@ package discovery
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -414,12 +415,23 @@ func resumeScanning(from gen.PID, state gen.Atom, data DiscoveryData, message Re
 
 		for range n {
 			nextOp := data.queuedListOperations[namespace][0]
-			err := scanTargetForResourceType(data.targets[nextOp.TargetLabel], nextOp, data, proc)
-			if err != nil {
-				proc.Log().Error("Failed to scan target for resource type %s: %v", nextOp.ResourceType, err)
-				return state, data, nil, gen.TerminateReasonPanic
-			}
 			data.queuedListOperations[namespace] = data.queuedListOperations[namespace][1:]
+			if err := scanTargetForResourceType(data.targets[nextOp.TargetLabel], nextOp, data, proc); err != nil {
+				// A failed scan of a single resource type must not crash the
+				// Discovery actor. Skip the resource type for this cycle and
+				// keep scanning the rest; it is re-queued on the next cycle. A
+				// spawn timeout is transient back-pressure (the plugin node was
+				// momentarily unresponsive), so it is logged at WRN; anything
+				// else is unexpected and logged at ERR. Either way the actor
+				// survives — mirroring ResourceUpdater and ResolveCache, which
+				// already treat a plugin spawn/operation failure as terminal for
+				// the unit of work, never fatal for the actor.
+				if errors.Is(err, gen.ErrTimeout) {
+					proc.Log().Warning("Skipping resource type %s for this discovery cycle: transient spawn back-pressure: %v", nextOp.ResourceType, err)
+				} else {
+					proc.Log().Error("Skipping resource type %s for this discovery cycle: %v", nextOp.ResourceType, err)
+				}
+			}
 		}
 	}
 	for namespace, done := range finished {
@@ -434,6 +446,15 @@ func resumeScanning(from gen.PID, state gen.Atom, data DiscoveryData, message Re
 			return state, data, nil, nil
 		}
 		delete(data.queuedListOperations, namespace)
+	}
+
+	// If every scanned operation this cycle was skipped (e.g. all spawns timed
+	// out), no Listing callback will arrive to drive completion. Finish the
+	// cycle here so the Discovering->Idle transition fires and the next
+	// scheduled discovery run is queued; otherwise Discovery would hang in
+	// StateDiscovering forever.
+	if !data.HasOutstandingWork() {
+		return StateIdle, data, nil, nil
 	}
 
 	return StateDiscovering, data, nil, nil

--- a/internal/metastructure/discovery/spawn_timeout_test.go
+++ b/internal/metastructure/discovery/spawn_timeout_test.go
@@ -1,0 +1,163 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package discovery
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/changeset"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+)
+
+// stubLog is a gen.Log that swallows all log output.
+type stubLog struct {
+	gen.Log
+}
+
+func (stubLog) Trace(string, ...any)   {}
+func (stubLog) Debug(string, ...any)   {}
+func (stubLog) Info(string, ...any)    {}
+func (stubLog) Warning(string, ...any) {}
+func (stubLog) Error(string, ...any)   {}
+func (stubLog) Panic(string, ...any)   {}
+
+// stubNode is a gen.Node that only knows its name.
+type stubNode struct {
+	gen.Node
+}
+
+func (stubNode) Name() gen.Atom { return gen.Atom("test-node") }
+
+// stubProcess is a hand-rolled gen.Process test double that stands in for the
+// RateLimiter and PluginCoordinator collaborators that the discovery scan loop
+// calls. It records every PluginOperator spawn requested and delegates the spawn
+// outcome to a configurable responder, so individual tests can make a given
+// spawn time out or fail.
+type stubProcess struct {
+	gen.Process
+
+	// spawn decides the outcome of the nth (1-based) PluginOperator spawn.
+	// nil means every spawn succeeds.
+	spawn func(n int, req messages.SpawnPluginOperator) (any, error)
+
+	spawnRequests []messages.SpawnPluginOperator
+}
+
+func (p *stubProcess) Log() gen.Log   { return stubLog{} }
+func (p *stubProcess) Node() gen.Node { return stubNode{} }
+func (p *stubProcess) PID() gen.PID   { return gen.PID{Node: "test-node", ID: 1} }
+
+func (p *stubProcess) Send(_ any, _ any) error { return nil }
+
+func (p *stubProcess) SendAfter(_ any, _ any, _ time.Duration) (gen.CancelFunc, error) {
+	return func() bool { return true }, nil
+}
+
+func (p *stubProcess) Call(_ any, message any) (any, error) {
+	switch m := message.(type) {
+	case changeset.RequestTokens:
+		// Grant every token requested so the whole queue is scanned in one pass.
+		return changeset.TokensGranted{N: m.N}, nil
+	case messages.SpawnPluginOperator:
+		p.spawnRequests = append(p.spawnRequests, m)
+		if p.spawn != nil {
+			return p.spawn(len(p.spawnRequests), m)
+		}
+		return messages.SpawnPluginOperatorResult{}, nil
+	default:
+		return nil, fmt.Errorf("stubProcess: unexpected Call message %T", message)
+	}
+}
+
+// newScanData builds a DiscoveryData with the given resource types queued for a
+// single discoverable target, ready to be driven through resumeScanning.
+func newScanData(resourceTypes ...string) DiscoveryData {
+	const namespace = "FakeAWS"
+	const targetLabel = "us-east-1"
+
+	data := DiscoveryData{
+		targets: map[string]pkgmodel.Target{
+			targetLabel: {Label: targetLabel, Namespace: namespace, Discoverable: true},
+		},
+		resourceDescriptors:       map[string]plugin.ResourceDescriptor{},
+		queuedListOperations:      map[string][]ListOperation{},
+		outstandingListOperations: map[string]ListOperation{},
+		outstandingSyncCommands:   map[string]ListOperation{},
+		summary:                   map[string]int{},
+	}
+
+	for _, rt := range resourceTypes {
+		data.resourceDescriptors[rt] = plugin.ResourceDescriptor{Type: rt, Discoverable: true}
+		data.queuedListOperations[namespace] = append(data.queuedListOperations[namespace], ListOperation{
+			ResourceType: rt,
+			TargetLabel:  targetLabel,
+		})
+	}
+
+	return data
+}
+
+// A spawn timeout for one resource type is transient back-pressure: discovery
+// must skip that resource type for the cycle and keep scanning the rest, not
+// crash the actor.
+func TestResumeScanning_SpawnTimeoutSkipsResourceTypeAndContinues(t *testing.T) {
+	data := newScanData("FakeAWS::S3::Bucket", "FakeAWS::EC2::VPC", "FakeAWS::EC2::Instance")
+	proc := &stubProcess{spawn: func(n int, _ messages.SpawnPluginOperator) (any, error) {
+		if n == 2 { // the second resource type times out
+			return nil, gen.ErrTimeout
+		}
+		return messages.SpawnPluginOperatorResult{}, nil
+	}}
+
+	_, _, _, err := resumeScanning(gen.PID{}, StateDiscovering, data, ResumeScanning{}, proc)
+
+	require.NotEqual(t, gen.TerminateReasonPanic, err, "spawn timeout must not crash the Discovery actor")
+	assert.NoError(t, err)
+	assert.Len(t, proc.spawnRequests, 3, "all three resource types should be attempted; the loop must continue past the timed-out one")
+}
+
+// When every spawn in a cycle times out, there is no outstanding listing to
+// drive completion via a Listing callback. Discovery must still finish the cycle
+// (return to Idle) so the next scheduled run is queued — otherwise it hangs in
+// StateDiscovering forever.
+func TestResumeScanning_AllSpawnsTimeOutStillCompletesCycle(t *testing.T) {
+	data := newScanData("FakeAWS::S3::Bucket", "FakeAWS::EC2::VPC", "FakeAWS::EC2::Instance")
+	proc := &stubProcess{spawn: func(int, messages.SpawnPluginOperator) (any, error) {
+		return nil, gen.ErrTimeout // every spawn times out
+	}}
+
+	nextState, _, _, err := resumeScanning(gen.PID{}, StateDiscovering, data, ResumeScanning{}, proc)
+
+	require.NotEqual(t, gen.TerminateReasonPanic, err, "consecutive spawn timeouts must not crash the Discovery actor")
+	assert.NoError(t, err)
+	assert.Len(t, proc.spawnRequests, 3, "all resource types should be attempted despite every spawn timing out")
+	assert.Equal(t, StateIdle, nextState, "a fully-skipped cycle must return to Idle so the next discovery run is scheduled")
+}
+
+// A non-timeout spawn failure for one resource type is likewise skipped, not
+// fatal: the actor logs it and keeps scanning.
+func TestResumeScanning_NonTimeoutSpawnErrorSkipsResourceTypeAndContinues(t *testing.T) {
+	data := newScanData("FakeAWS::S3::Bucket", "FakeAWS::EC2::VPC", "FakeAWS::EC2::Instance")
+	proc := &stubProcess{spawn: func(n int, _ messages.SpawnPluginOperator) (any, error) {
+		if n == 2 {
+			return messages.SpawnPluginOperatorResult{Error: "plugin not found: FakeAWS"}, nil
+		}
+		return messages.SpawnPluginOperatorResult{}, nil
+	}}
+
+	_, _, _, err := resumeScanning(gen.PID{}, StateDiscovering, data, ResumeScanning{}, proc)
+
+	require.NotEqual(t, gen.TerminateReasonPanic, err, "a non-timeout scan error must not crash the Discovery actor")
+	assert.NoError(t, err)
+	assert.Len(t, proc.spawnRequests, 3, "the loop must continue past the failed resource type")
+}


### PR DESCRIPTION
## Summary

A failed `PluginOperator` spawn during a discovery scan returned `gen.TerminateReasonPanic`, crashing the `Discovery` actor. The common trigger is a spawn-register timeout — transient back-pressure when the plugin node is momentarily unresponsive — which is recoverable: the resource type is simply retried on the next discovery cycle.

This makes a per-resource-type scan failure non-fatal, consistent with `ResourceUpdater` and `ResolveCache`, which already treat a plugin spawn/operation failure as terminal for the unit of work rather than fatal for the actor:

- A spawn timeout (`gen.ErrTimeout`) is logged at WRN as transient back-pressure; any other scan error is logged at ERR. In both cases the resource type is skipped for the current cycle and scanning continues with the remaining types.
- When every scanned operation in a cycle is skipped (e.g. all spawns time out), the cycle now completes (returns to `Idle`) so the next scheduled discovery run is queued. Otherwise no `Listing` callback arrives to drive the transition and Discovery hangs in `Discovering`.

Unit tests drive `resumeScanning` with a stubbed coordinator: one resource type times out (the rest are still scanned, no panic), all spawns time out (the cycle still completes at `Idle`), and a non-timeout spawn error (skipped, no panic).