### PR TITLE
fix(planner): cascade marker for REPLACE'd provider fields

### DIFF
--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -823,7 +823,13 @@ func generateResourceUpdatesForReconcile(
 	// After processing all stacks, find dependencies for delete operations
 	allDeleteUpdates := append(resourceReplaces, implicitDeleteResources...)
 
-	dependencyDeletes, cascadeUpdates := findDependencyUpdates(allDeleteUpdates, allResourcesByStack, existingTargetMap, source, forma)
+	replacedKsuids := make(map[string]bool)
+	for _, ru := range resourceReplaces {
+		if ru.Operation == OperationDelete && ru.DesiredState.Ksuid != "" {
+			replacedKsuids[ru.DesiredState.Ksuid] = true
+		}
+	}
+	dependencyDeletes, cascadeUpdates := findDependencyUpdates(allDeleteUpdates, replacedKsuids, allResourcesByStack, existingTargetMap, source, forma)
 
 	// Convert updates to replacements if they have dependency deletes
 
@@ -1155,7 +1161,13 @@ func generateResourceUpdatesForPatch(
 
 	allUpdates := append(append(resourceCreates, resourceUpdates...), resourceReplaces...)
 
-	dependencyDeletes, cascadeUpdates := findDependencyUpdates(resourceReplaces, allResourcesByStack, existingTargetMap, source, forma)
+	replacedKsuids := make(map[string]bool)
+	for _, ru := range resourceReplaces {
+		if ru.Operation == OperationDelete && ru.DesiredState.Ksuid != "" {
+			replacedKsuids[ru.DesiredState.Ksuid] = true
+		}
+	}
+	dependencyDeletes, cascadeUpdates := findDependencyUpdates(resourceReplaces, replacedKsuids, allResourcesByStack, existingTargetMap, source, forma)
 	finalResourceUpdates := convertUpdatesToReplacementsForDependencies(allUpdates, dependencyDeletes, source)
 	finalResourceUpdates = appendCascadeUpdatesIfAbsent(finalResourceUpdates, cascadeUpdates)
 	return finalResourceUpdates, nil
@@ -1202,7 +1214,7 @@ func findResourcesThatDependOn(targetResource pkgmodel.Resource, allResources ma
 // versioned TaskDefinition (Service.taskDefinition is mutable; UpdateService
 // accepts a new TaskDefinitionArn — no tear-down needed when a new TD
 // revision is created).
-func findDependencyUpdates(allDeleteUpdates []ResourceUpdate, allResources map[string][]*pkgmodel.Resource, existingTargetMap map[string]*pkgmodel.Target, source FormaCommandSource, forma *pkgmodel.Forma) ([]ResourceUpdate, []ResourceUpdate) {
+func findDependencyUpdates(allDeleteUpdates []ResourceUpdate, replacedKsuids map[string]bool, allResources map[string][]*pkgmodel.Resource, existingTargetMap map[string]*pkgmodel.Target, source FormaCommandSource, forma *pkgmodel.Forma) ([]ResourceUpdate, []ResourceUpdate) {
 	// Collect ksuids of resources being deleted so dependents can decide
 	// whether their refs land on a deletion target. Also build a label
 	// lookup so cascade-update synthesis can name the source resource for
@@ -1290,7 +1302,7 @@ func findDependencyUpdates(allDeleteUpdates []ResourceUpdate, allResources map[s
 				// cascading field change instead of showing an empty Update.
 				// The executor's apply-time regen overwrites this with the
 				// concrete diff against the resolver-updated DesiredState.
-				if synthOps, err := synthesizeCascadeUpdatePatch(dependentRes, deletedKsuids, ksuidToLabel, formaByKsuid); err != nil {
+				if synthOps, err := synthesizeCascadeUpdatePatch(dependentRes, deletedKsuids, replacedKsuids, ksuidToLabel, formaByKsuid); err != nil {
 					slog.Warn("Failed to synthesize cascade-update patch for simulate output",
 						"resource", dependentRes.Label, "error", err)
 				} else if len(synthOps) > 0 {
@@ -1349,6 +1361,7 @@ func anyRefIsCreateOnly(dep pkgmodel.Resource, deletedKsuids map[string]bool) bo
 func synthesizeCascadeUpdatePatch(
 	dep pkgmodel.Resource,
 	deletedKsuids map[string]bool,
+	replacedKsuids map[string]bool,
 	ksuidToLabel map[string]string,
 	formaByKsuid map[string]*pkgmodel.Resource,
 ) (json.RawMessage, error) {
@@ -1366,15 +1379,31 @@ func synthesizeCascadeUpdatePatch(
 		path := jsonPointerFromDotPath(ref.TargetPath)
 
 		// Try to recover the new value from the forma's parent state.
+		// For REPLACE'd parents, the recovered value is only trustworthy
+		// for user-provided source fields. Provider-assigned fields
+		// (HasProviderDefault=true) get their value from the provider at
+		// apply time, so any value sitting in the forma now is the stale
+		// cached one — emit the marker so the renderer uses the friendly
+		// "to point at the new <source>" phrasing instead of misleading
+		// the operator with a stale concrete value.
 		if parent, ok := formaByKsuid[ksuid]; ok && parent != nil && ref.SourcePropertyName != "" && len(parent.Properties) > 0 {
-			extracted := gjson.GetBytes(parent.Properties, ref.SourcePropertyName)
-			if extracted.Exists() && !looksLikeResolvable(extracted) {
-				ops = append(ops, op{Op: "replace", Path: path, Value: extracted.Value()})
-				continue
+			sourceFieldIsProviderAssigned := false
+			if replacedKsuids[ksuid] {
+				if hint, hintOk := parent.Schema.Hints[ref.SourcePropertyName]; hintOk && hint.HasProviderDefault {
+					sourceFieldIsProviderAssigned = true
+				}
+			}
+			if !sourceFieldIsProviderAssigned {
+				extracted := gjson.GetBytes(parent.Properties, ref.SourcePropertyName)
+				if extracted.Exists() && !looksLikeResolvable(extracted) {
+					ops = append(ops, op{Op: "replace", Path: path, Value: extracted.Value()})
+					continue
+				}
 			}
 		}
 
-		// Provider-assigned: emit a marker the CLI renderer recognises.
+		// Provider-assigned source on a REPLACE'd parent (or no recoverable
+		// value at all): emit a marker the CLI renderer recognises.
 		ops = append(ops, op{
 			Op:   "replace",
 			Path: path,

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -1389,7 +1389,7 @@ func synthesizeCascadeUpdatePatch(
 		if parent, ok := formaByKsuid[ksuid]; ok && parent != nil && ref.SourcePropertyName != "" && len(parent.Properties) > 0 {
 			sourceFieldIsProviderAssigned := false
 			if replacedKsuids[ksuid] {
-				if hint, hintOk := parent.Schema.Hints[ref.SourcePropertyName]; hintOk && hint.HasProviderDefault {
+				if hint, hintOk := parent.Schema.Hints[stripArrayIndicesForHintLookup(ref.SourcePropertyName)]; hintOk && hint.HasProviderDefault {
 					sourceFieldIsProviderAssigned = true
 				}
 			}

--- a/internal/metastructure/resource_update/resource_update_generator_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_test.go
@@ -1083,7 +1083,7 @@ func TestFindDependencyUpdates_SameLabel_DifferentTypes(t *testing.T) {
 		"aws-target": {Label: "aws-target", Namespace: "AWS"},
 	}
 
-	dependencyDeletes, cascadeUpdates := findDependencyUpdates(allDeleteUpdates, allResources, targetMap, FormaCommandSourceUser, nil)
+	dependencyDeletes, cascadeUpdates := findDependencyUpdates(allDeleteUpdates, nil, allResources, targetMap, FormaCommandSourceUser, nil)
 
 	assert.Len(t, dependencyDeletes, 0, "Should not create duplicates when resources with same label but different types are already being deleted")
 	assert.Len(t, cascadeUpdates, 0, "No cascade-updates expected when no dependents reference the deletes")
@@ -1184,7 +1184,7 @@ func TestFindDependencyUpdates_CreateOnlyBranch(t *testing.T) {
 				"test-stack": {&tc.dependent},
 			}
 			dependencyDeletes, cascadeUpdates := findDependencyUpdates(
-				[]ResourceUpdate{parentDelete}, allResources, targetMap, FormaCommandSourceUser, nil,
+				[]ResourceUpdate{parentDelete}, nil, allResources, targetMap, FormaCommandSourceUser, nil,
 			)
 
 			if tc.wantCascadeDelete {
@@ -1481,6 +1481,7 @@ func TestSynthesizeCascadeUpdatePatch_UserProvidedSource(t *testing.T) {
 	patchDoc, err := synthesizeCascadeUpdatePatch(
 		dep,
 		map[string]bool{parentKsuid: true},
+		nil, // replacedKsuids — none in this test scenario
 		map[string]string{parentKsuid: "parent"},
 		formaByKsuid,
 	)
@@ -1523,6 +1524,7 @@ func TestSynthesizeCascadeUpdatePatch_ProviderAssignedSource(t *testing.T) {
 	patchDoc, err := synthesizeCascadeUpdatePatch(
 		dep,
 		map[string]bool{parentKsuid: true},
+		nil, // replacedKsuids — none in this test scenario
 		map[string]string{parentKsuid: "test-taskdef-for-service"},
 		formaByKsuid,
 	)
@@ -1551,6 +1553,7 @@ func TestSynthesizeCascadeUpdatePatch_NoMatchingRefs(t *testing.T) {
 	patchDoc, err := synthesizeCascadeUpdatePatch(
 		dep,
 		map[string]bool{"some-other-ksuid": true},
+		nil, // replacedKsuids — none in this test scenario
 		map[string]string{},
 		map[string]*pkgmodel.Resource{},
 	)
@@ -1579,6 +1582,7 @@ func TestSynthesizeCascadeUpdatePatch_ArrayIndexedPath(t *testing.T) {
 	patchDoc, err := synthesizeCascadeUpdatePatch(
 		dep,
 		map[string]bool{parentKsuid: true},
+		nil, // replacedKsuids — none in this test scenario
 		map[string]string{parentKsuid: "parent"},
 		formaByKsuid,
 	)
@@ -1586,4 +1590,169 @@ func TestSynthesizeCascadeUpdatePatch_ArrayIndexedPath(t *testing.T) {
 	require.NotEmpty(t, patchDoc)
 	assert.Contains(t, string(patchDoc), `"path":"/Refs/0/Target"`,
 		"dot-separated TargetPath with numeric segments must convert to JSON Pointer with slashes")
+}
+
+// TestSynthesizeCascadeUpdatePatch_ReplacedParentWithRecoverableValue covers
+// the REPLACE'd-parent case: the parent's delete-half has a matching
+// create-half in the same plan, AND the forma's parent state already carries
+// a concrete value for the property the dependent's Resolvable points at
+// (because the agent has merged its stale cached $value into the forma).
+// The optimization at synthesizeCascadeUpdatePatch's "recover the new value
+// from the forma's parent state" branch is unsafe for REPLACE: the recovered
+// value is the OLD revision, not the post-apply value. We expect the marker
+// to be emitted so the renderer prints the friendly phrasing.
+func TestSynthesizeCascadeUpdatePatch_ReplacedParentWithRecoverableValue(t *testing.T) {
+	parentKsuid := "taskdef-ksuid"
+	dep := pkgmodel.Resource{
+		Label: "ecs-service",
+		Type:  "AWS::ECS::Service",
+		Properties: json.RawMessage(`{
+			"ServiceName": "svc",
+			"TaskDefinition": {"$ref": "formae://` + parentKsuid + `#/TaskDefinitionArn", "$value": "arn:aws:ecs:us-east-1:0:task-definition/test:20"}
+		}`),
+	}
+	// forma's parent state DOES carry TaskDefinitionArn — simulates the
+	// production scenario where the resolver merges the cached value in.
+	formaByKsuid := map[string]*pkgmodel.Resource{
+		parentKsuid: {
+			Label:      "hub-task-def",
+			Type:       "AWS::ECS::TaskDefinition",
+			Ksuid:      parentKsuid,
+			Properties: json.RawMessage(`{"Family": "test", "TaskDefinitionArn": "arn:aws:ecs:us-east-1:0:task-definition/test:20"}`),
+			Schema: pkgmodel.Schema{
+				Hints: map[string]pkgmodel.FieldHint{
+					"TaskDefinitionArn": {HasProviderDefault: true},
+				},
+			},
+		},
+	}
+
+	patchDoc, err := synthesizeCascadeUpdatePatch(
+		dep,
+		map[string]bool{parentKsuid: true},
+		map[string]bool{parentKsuid: true}, // replacedKsuids — parent IS being REPLACE'd
+		map[string]string{parentKsuid: "hub-task-def"},
+		formaByKsuid,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, patchDoc)
+	patchStr := string(patchDoc)
+	assert.Contains(t, patchStr, `"path":"/TaskDefinition"`)
+	assert.Contains(t, patchStr, `"$cascade-resolvable":true`,
+		"REPLACE'd parents must emit the marker, not a concrete (stale) value")
+	assert.Contains(t, patchStr, `"hub-task-def"`,
+		"marker must carry the source label")
+	assert.NotContains(t, patchStr, `"value":"arn:aws:ecs:us-east-1:0:task-definition/test:20"`,
+		"stale cached value must not be emitted as the concrete 'to' target")
+}
+
+// TestFindDependencyUpdates_ReplaceParentEmitsCascadeMarker verifies the full
+// path: when a parent is being REPLACE'd and a dependent has a Resolvable
+// pointing at one of the parent's provider-assigned properties, the cascade-
+// update's PatchDocument carries the $cascade-resolvable marker (not a
+// concrete stale value pulled from the forma's parent state).
+func TestFindDependencyUpdates_ReplaceParentEmitsCascadeMarker(t *testing.T) {
+	parentKsuid := "taskdef-ksuid"
+	parentLabel := "hub-task-def"
+	depLabel := "hub-service"
+	target := pkgmodel.Target{Label: "default"}
+
+	parent := pkgmodel.Resource{
+		Ksuid:      parentKsuid,
+		Label:      parentLabel,
+		Type:       "AWS::ECS::TaskDefinition",
+		Stack:      "hub-app",
+		Target:     target.Label,
+		Properties: json.RawMessage(`{"Family": "hub", "TaskDefinitionArn": "arn:aws:ecs:us-east-1:0:task-definition/hub:20"}`),
+		Schema: pkgmodel.Schema{
+			Hints: map[string]pkgmodel.FieldHint{
+				"TaskDefinitionArn": {HasProviderDefault: true},
+			},
+		},
+	}
+	dep := pkgmodel.Resource{
+		Label:  depLabel,
+		Type:   "AWS::ECS::Service",
+		Stack:  "hub-app",
+		Target: target.Label,
+		Properties: json.RawMessage(`{
+			"ServiceName": "hub-svc",
+			"TaskDefinition": {"$ref": "formae://` + parentKsuid + `#/TaskDefinitionArn", "$value": "arn:aws:ecs:us-east-1:0:task-definition/hub:20"}
+		}`),
+	}
+
+	// resourceReplaces holds the two halves of a REPLACE on the parent.
+	resourceReplaces := []ResourceUpdate{
+		{Operation: OperationDelete, DesiredState: parent},
+		{Operation: OperationCreate, DesiredState: parent},
+	}
+
+	allResources := map[string][]*pkgmodel.Resource{
+		"hub-app": {&parent, &dep},
+	}
+	existingTargetMap := map[string]*pkgmodel.Target{target.Label: &target}
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{parent, dep}}
+
+	// Build replacedKsuids the same way the production callers do.
+	replacedKsuids := make(map[string]bool)
+	for _, ru := range resourceReplaces {
+		if ru.Operation == OperationDelete && ru.DesiredState.Ksuid != "" {
+			replacedKsuids[ru.DesiredState.Ksuid] = true
+		}
+	}
+
+	_, dependencyUpdates := findDependencyUpdates(
+		resourceReplaces,
+		replacedKsuids,
+		allResources,
+		existingTargetMap,
+		FormaCommandSourceUser,
+		forma,
+	)
+
+	require.Len(t, dependencyUpdates, 1, "exactly one cascade-update for the dependent")
+	cu := dependencyUpdates[0]
+	require.NotEmpty(t, cu.DesiredState.PatchDocument, "cascade-update must carry a synthesized patch")
+	patchStr := string(cu.DesiredState.PatchDocument)
+	assert.Contains(t, patchStr, `"$cascade-resolvable":true`,
+		"REPLACE'd parent must produce a marker, not a stale concrete value")
+	assert.NotContains(t, patchStr, `"value":"arn:aws:ecs:us-east-1:0:task-definition/hub:20"`,
+		"stale cached value must not appear as the concrete 'to' target")
+}
+
+// TestSynthesizeCascadeUpdatePatch_DeletedParentNotReplaced confirms that
+// when a parent is being deleted outright (not REPLACE'd), the recover-
+// concrete-value optimization still runs — preserving the existing behavior
+// of TestSynthesizeCascadeUpdatePatch_UserProvidedSource for the non-REPLACE
+// case explicitly.
+func TestSynthesizeCascadeUpdatePatch_DeletedParentNotReplaced(t *testing.T) {
+	parentKsuid := "parent-ksuid"
+	dep := pkgmodel.Resource{
+		Label: "consumer",
+		Properties: json.RawMessage(`{
+			"ParentRef": {"$ref": "formae://` + parentKsuid + `#/Name", "$value": "parent-v1"}
+		}`),
+	}
+	formaByKsuid := map[string]*pkgmodel.Resource{
+		parentKsuid: {
+			Label:      "parent",
+			Ksuid:      parentKsuid,
+			Properties: json.RawMessage(`{"Name": "parent-v2"}`),
+		},
+	}
+
+	patchDoc, err := synthesizeCascadeUpdatePatch(
+		dep,
+		map[string]bool{parentKsuid: true},
+		map[string]bool{}, // replacedKsuids — explicitly empty: parent is DELETE-only
+		map[string]string{parentKsuid: "parent"},
+		formaByKsuid,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, patchDoc)
+	patchStr := string(patchDoc)
+	assert.Contains(t, patchStr, `"value":"parent-v2"`,
+		"DELETE-only parents must still use the recover-concrete-value path")
+	assert.NotContains(t, patchStr, "$cascade-resolvable",
+		"no marker for DELETE-only when the forma has the value")
 }

--- a/internal/metastructure/resource_update/resource_update_generator_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_test.go
@@ -1756,3 +1756,55 @@ func TestSynthesizeCascadeUpdatePatch_DeletedParentNotReplaced(t *testing.T) {
 	assert.NotContains(t, patchStr, "$cascade-resolvable",
 		"no marker for DELETE-only when the forma has the value")
 }
+
+// TestSynthesizeCascadeUpdatePatch_ReplacedParentIndexedProviderField covers
+// the case where a dependent's Resolvable targets a provider-assigned field
+// nested inside an array on the parent (e.g. an ALB Listener referencing
+// /DefaultActions/0/TargetGroupArn). Schema hint keys are stored without
+// numeric segments, so the lookup must strip array indices before consulting
+// HasProviderDefault — otherwise REPLACE'd parents fall through to the
+// recover-concrete-value path and emit the stale cached value.
+func TestSynthesizeCascadeUpdatePatch_ReplacedParentIndexedProviderField(t *testing.T) {
+	parentKsuid := "parent-ksuid"
+	dep := pkgmodel.Resource{
+		Label: "listener",
+		Type:  "AWS::ElasticLoadBalancingV2::Listener",
+		Properties: json.RawMessage(`{
+			"Name": "listener-1",
+			"TargetGroupRef": {"$ref": "formae://` + parentKsuid + `#/DefaultActions.0.TargetGroupArn", "$value": "arn:aws:elasticloadbalancing:...:targetgroup/old/1111"}
+		}`),
+	}
+	formaByKsuid := map[string]*pkgmodel.Resource{
+		parentKsuid: {
+			Label:      "alb",
+			Ksuid:      parentKsuid,
+			Type:       "AWS::ElasticLoadBalancingV2::TargetGroup",
+			Properties: json.RawMessage(`{"DefaultActions": [{"TargetGroupArn": "arn:aws:elasticloadbalancing:...:targetgroup/old/1111"}]}`),
+			Schema: pkgmodel.Schema{
+				Hints: map[string]pkgmodel.FieldHint{
+					// Schema hints are keyed without array indices.
+					"DefaultActions.TargetGroupArn": {HasProviderDefault: true},
+				},
+			},
+		},
+	}
+
+	patchDoc, err := synthesizeCascadeUpdatePatch(
+		dep,
+		map[string]bool{parentKsuid: true},
+		map[string]bool{parentKsuid: true}, // parent is REPLACE'd
+		map[string]string{parentKsuid: "alb"},
+		formaByKsuid,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, patchDoc)
+	patchStr := string(patchDoc)
+	assert.Contains(t, patchStr, `"$cascade-resolvable":true`,
+		"indexed provider-assigned source on REPLACE'd parent must still emit the marker after array-index stripping")
+	assert.Contains(t, patchStr, `"alb"`, "marker must carry the source label")
+	assert.Contains(t, patchStr, `"arn:aws:elasticloadbalancing:...:targetgroup/old/1111"`,
+		"marker must carry the current $value so the user sees what is being replaced")
+	// The stale value must appear only inside the cascade marker, not as a bare replace target.
+	assert.NotContains(t, patchStr, `"value":"arn:`,
+		"stale cached value must not be emitted as a bare concrete replace value outside the cascade marker")
+}


### PR DESCRIPTION
## Summary

- Targeted fix in `synthesizeCascadeUpdatePatch`: when a parent is being REPLACE'd in the same plan AND the referenced source field is provider-assigned (`HasProviderDefault: true`), suppress the recover-concrete-value branch and fall through to the existing `$cascade-resolvable` marker emission. The CLI renderer then produces the friendly "to point at the new <source>" phrasing instead of a stale concrete value.
- User-provided fields on REPLACE'd parents (e.g. `Name` set by the operator in PKL) continue to use the recover branch — their post-apply value is knowable from the forma.
- Source bug: hub-app v0.1.23 simulate showed `change property "TaskDefinition" from "...:25" to "...:20"` (stale cached value), suggesting a downgrade. Runtime apply was always correct; only the display was misleading.
- Runtime apply behavior is unaffected — the executor regenerates the patch at apply time as before.