### PR TITLE
fix(target): suppress false Target updates on reconcile

### DIFF
--- a/internal/metastructure/target_update/target_update_generator.go
+++ b/internal/metastructure/target_update/target_update_generator.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/tidwall/gjson"
-
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	"github.com/platform-engineering-labs/formae/pkg/api/model"
@@ -230,14 +228,14 @@ func (tp *TargetUpdateGenerator) resolvedConfigs(existingConfig, newConfig json.
 			return existingConfig, newConfig, false, nil
 		}
 
-		value := gjson.GetBytes(resource.Properties, propertyPath)
-		if !value.Exists() {
+		strVal, ok := resource.GetProperty(propertyPath)
+		if !ok {
 			slog.Debug("Referenced property not found in resource, treating as config change",
 				"uri", uri, "propertyPath", propertyPath)
 			return existingConfig, newConfig, false, nil
 		}
 
-		resolvedConfig, err = resolver.ResolvePropertyReferences(uri, resolvedConfig, value.String())
+		resolvedConfig, err = resolver.ResolvePropertyReferences(uri, resolvedConfig, strVal)
 		if err != nil {
 			return existingConfig, newConfig, false, nil
 		}

--- a/internal/metastructure/target_update/target_update_generator_test.go
+++ b/internal/metastructure/target_update/target_update_generator_test.go
@@ -1176,3 +1176,56 @@ func TestGenerateTargetUpdates_RefWithCachedValue_UnresolvableRef(t *testing.T) 
 	require.Len(t, updates, 1, "dangling $ref with stale cached $value must surface as an update, not be silently absorbed")
 	assert.Equal(t, TargetOperationUpdate, updates[0].Operation)
 }
+
+// Mirrors a real K8s target Config shape: $refs are nested under Auth, alongside
+// plain scalar fields. Existing Config has $ref+$value pairs (resolved at apply);
+// desired Config has $ref only. Same resolved values, same shape → no update.
+func TestGenerateTargetUpdates_RefWithCachedValue_NestedAuth_NoChange(t *testing.T) {
+	mockDS := &mockTargetDatastore{
+		targets: map[string]*pkgmodel.Target{
+			"k8s-target-aws": {
+				Label:     "k8s-target-aws",
+				Namespace: "K8S",
+				Config: json.RawMessage(`{
+					"Type":"K8S",
+					"Auth":{
+						"Type":"EKS",
+						"Endpoint":{"$ref":"formae://cluster1#/Endpoint","$value":"https://abc.eks.amazonaws.com"},
+						"CertificateAuthority":{"$ref":"formae://cluster1#/CertificateAuthorityData","$value":"LS0tLS1CRUdJTg=="},
+						"ClusterName":{"$ref":"formae://cluster1#/Name","$value":"k8s-fullstack"}
+					},
+					"ApiVersion":"v1.34"
+				}`),
+			},
+		},
+		resources: map[string]*pkgmodel.Resource{
+			"cluster1": {
+				Ksuid:              "cluster1",
+				Properties:         json.RawMessage(`{"Name":"k8s-fullstack"}`),
+				ReadOnlyProperties: json.RawMessage(`{"Endpoint":"https://abc.eks.amazonaws.com","CertificateAuthorityData":"LS0tLS1CRUdJTg=="}`),
+			},
+		},
+	}
+	generator := NewTargetUpdateGenerator(mockDS)
+
+	targets := []pkgmodel.Target{
+		{
+			Label:     "k8s-target-aws",
+			Namespace: "K8S",
+			Config: json.RawMessage(`{
+				"Type":"K8S",
+				"Auth":{
+					"Type":"EKS",
+					"Endpoint":{"$ref":"formae://cluster1#/Endpoint"},
+					"CertificateAuthority":{"$ref":"formae://cluster1#/CertificateAuthorityData"},
+					"ClusterName":{"$ref":"formae://cluster1#/Name"}
+				},
+				"ApiVersion":"v1.34"
+			}`),
+		},
+	}
+
+	updates, err := generator.GenerateTargetUpdates(targets, pkgmodel.CommandApply, false)
+	require.NoError(t, err)
+	assert.Empty(t, updates, "nested $ref+$value vs $ref-only with same resolved values must not produce an update")
+}


### PR DESCRIPTION
**Problem:** Target Config `$ref`s pointing at fields stored in ReadOnlyProperties failed to resolve during Target diff because only Properties were checked

**Fix:** switch the lookup to resource.GetProperty, which walks both
