### PR TITLE
fix(changeset): give ResolveCache plugin reads the full PluginOperationCallTimeout

### DIFF
--- a/internal/metastructure/changeset/resolve_cache.go
+++ b/internal/metastructure/changeset/resolve_cache.go
@@ -19,6 +19,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
@@ -221,7 +222,11 @@ func (r *ResolveCache) readViaPlugin(retry resolveRetry) (*plugin.TrackedProgres
 		return nil, fmt.Errorf("failed to spawn plugin operator: %s", spawnRes.Error)
 	}
 
-	progressResult, err := r.Call(
+	// Use the same call budget as ResourceUpdater.doPluginOperation. The default
+	// Ergo Call timeout (5s) is too short for live AWS API reads, which routinely
+	// run longer than that — especially CloudControl GetResource immediately
+	// after a Create, when SDK credential resolution and the read itself stack up.
+	progressResult, err := r.CallWithTimeout(
 		spawnRes.PID,
 		plugin.ReadResource{
 			Namespace:         retry.loadResult.Resource.Namespace(),
@@ -231,7 +236,8 @@ func (r *ResolveCache) readViaPlugin(retry resolveRetry) (*plugin.TrackedProgres
 			Resource:          retry.loadResult.Resource,
 			NativeID:          retry.loadResult.Resource.NativeID,
 			TargetConfig:      retry.config,
-		})
+		},
+		resource_update.PluginOperationCallTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read resource: %w", err)
 	}

--- a/internal/metastructure/changeset/resolve_cache.go
+++ b/internal/metastructure/changeset/resolve_cache.go
@@ -56,19 +56,17 @@ func NewResolveCache() gen.ProcessBehavior {
 func (r *ResolveCache) Init(args ...any) error {
 	r.cache = make(map[pkgmodel.FormaeURI]gjson.Result)
 
-	// Read retry config from node environment (set by metastructure).
+	// Read retry config from node environment (set by metastructure). Apply
+	// shared defaults so ResourceUpdater can size its outer watchdog from the
+	// same values without re-encoding them.
+	var retryCfg pkgmodel.RetryConfig
 	if cfg, ok := r.Env("RetryConfig"); ok {
-		if retryCfg, ok := cfg.(pkgmodel.RetryConfig); ok {
-			r.maxRetries = retryCfg.MaxRetries
-			r.retryDelay = retryCfg.RetryDelay
+		if rc, ok := cfg.(pkgmodel.RetryConfig); ok {
+			retryCfg = rc
 		}
 	}
-	if r.maxRetries == 0 {
-		r.maxRetries = 3
-	}
-	if r.retryDelay == 0 {
-		r.retryDelay = 2 * time.Second
-	}
+	r.maxRetries = retryCfg.MaxRetriesOrDefault()
+	r.retryDelay = retryCfg.RetryDelayOrDefault()
 
 	r.Log().Debug("ResolveCache actor initialized maxRetries=%d retryDelay=%s", r.maxRetries, r.retryDelay)
 

--- a/internal/metastructure/changeset/resolve_cache.go
+++ b/internal/metastructure/changeset/resolve_cache.go
@@ -56,17 +56,16 @@ func NewResolveCache() gen.ProcessBehavior {
 func (r *ResolveCache) Init(args ...any) error {
 	r.cache = make(map[pkgmodel.FormaeURI]gjson.Result)
 
-	// Read retry config from node environment (set by metastructure). Apply
-	// shared defaults so ResourceUpdater can size its outer watchdog from the
-	// same values without re-encoding them.
-	var retryCfg pkgmodel.RetryConfig
-	if cfg, ok := r.Env("RetryConfig"); ok {
-		if rc, ok := cfg.(pkgmodel.RetryConfig); ok {
-			retryCfg = rc
-		}
+	cfg, ok := r.Env("RetryConfig")
+	if !ok {
+		return fmt.Errorf("resolveCache: missing 'RetryConfig' environment variable")
 	}
-	r.maxRetries = retryCfg.MaxRetriesOrDefault()
-	r.retryDelay = retryCfg.RetryDelayOrDefault()
+	retryCfg, ok := cfg.(pkgmodel.RetryConfig)
+	if !ok {
+		return fmt.Errorf("resolveCache: 'RetryConfig' environment variable has wrong type %T", cfg)
+	}
+	r.maxRetries = retryCfg.MaxRetries
+	r.retryDelay = retryCfg.RetryDelay
 
 	r.Log().Debug("ResolveCache actor initialized maxRetries=%d retryDelay=%s", r.maxRetries, r.retryDelay)
 

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -455,12 +455,10 @@ func resolve(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Ato
 	// MaxRetries times with RetryDelay spacing for recoverable errors. Derive
 	// the envelope from the same RetryConfig that ResolveCache itself reads, so
 	// the two cannot drift if the policy is tuned.
-	maxRetries := data.retryConfig.MaxRetriesOrDefault()
-	retryDelay := data.retryConfig.RetryDelayOrDefault()
 	perAttempt := time.Duration(PluginOperationCallTimeout) * time.Second
 	const resolveCacheMargin = 30 * time.Second
-	resolveCacheTimeout := time.Duration(maxRetries)*perAttempt +
-		time.Duration(maxRetries-1)*retryDelay +
+	resolveCacheTimeout := time.Duration(data.retryConfig.MaxRetries)*perAttempt +
+		time.Duration(data.retryConfig.MaxRetries-1)*data.retryConfig.RetryDelay +
 		resolveCacheMargin
 	timeout := statemachine.StateTimeout{
 		Duration: resolveCacheTimeout,

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -7,6 +7,7 @@ package resource_update
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"ergo.services/actor/statemachine"
 	"ergo.services/ergo/gen"
@@ -449,8 +450,17 @@ func resolve(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Ato
 		return StateResolving, data, nil, fmt.Errorf("failed to send ResolveValue message to resolve cache: %w", err)
 	}
 
+	// Size the envelope to the actual ResolveCache budget per property, not the
+	// progress-poll interval. ResolveCache's plugin Call uses PluginOperationCallTimeout
+	// per attempt, and may internally retry up to maxRetries times with retryDelay
+	// spacing for recoverable errors. 4x gives comfortable headroom over the
+	// worst-case ~3 attempts.
+	resolveCacheTimeout := time.Duration(PluginOperationCallTimeout*4) * time.Second
+	if heartbeatTimeout := data.retryConfig.StatusCheckInterval * 10; heartbeatTimeout > resolveCacheTimeout {
+		resolveCacheTimeout = heartbeatTimeout
+	}
 	timeout := statemachine.StateTimeout{
-		Duration: data.retryConfig.StatusCheckInterval * 10,
+		Duration: resolveCacheTimeout,
 		Message:  ResolveCacheMissingInAction{},
 	}
 

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -450,15 +450,18 @@ func resolve(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Ato
 		return StateResolving, data, nil, fmt.Errorf("failed to send ResolveValue message to resolve cache: %w", err)
 	}
 
-	// Size the envelope to the actual ResolveCache budget per property, not the
-	// progress-poll interval. ResolveCache's plugin Call uses PluginOperationCallTimeout
-	// per attempt, and may internally retry up to maxRetries times with retryDelay
-	// spacing for recoverable errors. 4x gives comfortable headroom over the
-	// worst-case ~3 attempts.
-	resolveCacheTimeout := time.Duration(PluginOperationCallTimeout*4) * time.Second
-	if heartbeatTimeout := data.retryConfig.StatusCheckInterval * 10; heartbeatTimeout > resolveCacheTimeout {
-		resolveCacheTimeout = heartbeatTimeout
-	}
+	// The watchdog must outlive ResolveCache's worst-case wall time per property:
+	// each plugin Call takes up to PluginOperationCallTimeout, retried up to
+	// MaxRetries times with RetryDelay spacing for recoverable errors. Derive
+	// the envelope from the same RetryConfig that ResolveCache itself reads, so
+	// the two cannot drift if the policy is tuned.
+	maxRetries := data.retryConfig.MaxRetriesOrDefault()
+	retryDelay := data.retryConfig.RetryDelayOrDefault()
+	perAttempt := time.Duration(PluginOperationCallTimeout) * time.Second
+	const resolveCacheMargin = 30 * time.Second
+	resolveCacheTimeout := time.Duration(maxRetries)*perAttempt +
+		time.Duration(maxRetries-1)*retryDelay +
+		resolveCacheMargin
 	timeout := statemachine.StateTimeout{
 		Duration: resolveCacheTimeout,
 		Message:  ResolveCacheMissingInAction{},

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -149,28 +149,6 @@ type RetryConfig struct {
 	RetryDelay          time.Duration
 }
 
-// Defaults for RetryConfig fields when a config carries zero/unset values.
-// Co-located here so ResolveCache (which applies them) and ResourceUpdater
-// (which sizes its resolving-state watchdog from them) cannot drift.
-const (
-	DefaultMaxRetries = 3
-	DefaultRetryDelay = 2 * time.Second
-)
-
-func (rc RetryConfig) MaxRetriesOrDefault() int {
-	if rc.MaxRetries <= 0 {
-		return DefaultMaxRetries
-	}
-	return rc.MaxRetries
-}
-
-func (rc RetryConfig) RetryDelayOrDefault() time.Duration {
-	if rc.RetryDelay <= 0 {
-		return DefaultRetryDelay
-	}
-	return rc.RetryDelay
-}
-
 type SynchronizationConfig struct {
 	Enabled  bool
 	Interval time.Duration

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -149,6 +149,28 @@ type RetryConfig struct {
 	RetryDelay          time.Duration
 }
 
+// Defaults for RetryConfig fields when a config carries zero/unset values.
+// Co-located here so ResolveCache (which applies them) and ResourceUpdater
+// (which sizes its resolving-state watchdog from them) cannot drift.
+const (
+	DefaultMaxRetries = 3
+	DefaultRetryDelay = 2 * time.Second
+)
+
+func (rc RetryConfig) MaxRetriesOrDefault() int {
+	if rc.MaxRetries <= 0 {
+		return DefaultMaxRetries
+	}
+	return rc.MaxRetries
+}
+
+func (rc RetryConfig) RetryDelayOrDefault() time.Duration {
+	if rc.RetryDelay <= 0 {
+		return DefaultRetryDelay
+	}
+	return rc.RetryDelay
+}
+
 type SynchronizationConfig struct {
 	Enabled  bool
 	Interval time.Duration


### PR DESCRIPTION
## Summary
- `ResolveCache.readViaPlugin` was calling the PluginOperator with plain `r.Call`, which falls back to Ergo's 5s `DefaultRequestTimeout`. Live AWS reads — CloudControl `GetResource` immediately after a Create, where SDK credential resolution and the read itself stack up — routinely take longer than that, so the Call times out and the resolve fails without retry (the existing retry path only triggers on recoverable progress errors, not on Call-level timeouts).
- Switch to `CallWithTimeout(PluginOperationCallTimeout)` so the resolver gets the same 60s budget per attempt that `ResourceUpdater.doPluginOperation` already uses for Create/Update/Delete.
- Bump the `ResourceUpdater` `ResolveCacheMissingInAction` state timeout to be sized against `PluginOperationCallTimeout` (4× = 240s) rather than `StatusCheckInterval * 10`. The old formula gave 200s in production — just over a worst-case 3 attempts × 60s + 2 × 2s retry spacing, tight — and 50s in conformance configs that use a 5s poll interval (smaller than a single attempt). `max(4 × PluginOperationCallTimeout, StatusCheckInterval × 10)` keeps configs with deliberately long poll intervals unchanged.

## How it surfaced

`efs-mounttarget` in the formae-plugin-aws conformance matrix (only on main pushes — PRs don't run conformance):

```
DBG Cache miss for resource URI uri=formae://.../SubnetId [...changeset.ResolveCache]
DBG Remote spawned PluginOperator for namespace AWS on node '...aws-plugin@localhost' [...PluginCoordinator]
ERR Failed to read resource via plugin resourceURI=formae://.../SubnetId: failed to read resource: timed out [...changeset.ResolveCache]
```

Exactly 5s between spawn and timeout — Ergo's `DefaultRequestTimeout`. Sibling Create operations in the same run took ~20s each and succeeded because they go through `doPluginOperation`'s `CallWithTimeout(60s)`.