### PR TITLE
feat(auto-reconciler): retry failed updates from resource_updates

### DIFF
--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -4474,32 +4474,43 @@ func (d *DatastoreAuroraDataAPI) GetStacksWithAutoReconcilePolicy() ([]datastore
 func (d *DatastoreAuroraDataAPI) GetResourcesAtLastReconcile(stackLabel string) ([]datastore.ResourceSnapshot, error) {
 	ctx := context.Background()
 
-	// Get resources from the last USER reconcile command for this stack.
-	// This gives us the "declared state" - what the user specified in their Forma file.
-	// We filter by source='user' on resource_updates to exclude auto-reconciler and sync commands,
-	// as they shouldn't change the declared state - they only enforce or detect drift.
+	// Declared state for auto-reconcile: per-resource DesiredState from the
+	// last user-source reconcile apply for this stack. Failed reconciles count
+	// (so failed updates are retried until they converge); Canceled and
+	// InProgress reconciles do not (they aren't accepted user intent).
+	// Reading from resource_updates rather than the resources table ensures
+	// resources whose update failed last time are still in the desired-state
+	// baseline — a failed Create never writes to resources, but
+	// BulkStoreResourceUpdates populates resource_updates at command-creation
+	// time for every intended update. Delete operations are excluded: a
+	// deletion the user requested is not part of the desired state going
+	// forward.
 	query := `
 		WITH last_user_reconcile_for_stack AS (
 			SELECT fc.command_id
 			FROM forma_commands fc
 			INNER JOIN resource_updates ru ON ru.command_id = fc.command_id
 			WHERE fc.config_mode = 'reconcile'
-			AND fc.state = 'Success'
+			AND fc.state IN ('Success', 'Failed')
 			AND fc.command = 'apply'
 			AND ru.source = 'user'
 			AND ru.stack_label = :stack_label
-			GROUP BY fc.command_id
+			GROUP BY fc.command_id, fc.timestamp
 			ORDER BY fc.timestamp DESC
 			LIMIT 1
 		)
-		SELECT r.ksuid, r.type, r.label, r.target,
-		       r.data->'Properties' as properties,
-		       r.data->'Schema' as schema,
-		       r.native_id
-		FROM resources r
-		WHERE r.command_id = (SELECT command_id FROM last_user_reconcile_for_stack)
-		AND r.stack = :stack_label
-		AND r.operation != 'delete'
+		SELECT ru.ksuid,
+		       ru.resource->>'Type'      as type,
+		       ru.resource->>'Label'     as label,
+		       ru.resource->>'Target'    as target,
+		       ru.resource->'Properties' as properties,
+		       ru.resource->'Schema'     as schema,
+		       ru.resource->>'NativeID'  as native_id
+		FROM resource_updates ru
+		WHERE ru.command_id = (SELECT command_id FROM last_user_reconcile_for_stack)
+		AND ru.stack_label = :stack_label
+		AND ru.source = 'user'
+		AND ru.operation != 'delete'
 	`
 
 	params := []types.SqlParameter{

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -4508,7 +4508,11 @@ func (d *DatastoreAuroraDataAPI) GetResourcesAtLastReconcile(stackLabel string) 
 		),
 		latest_per_ksuid AS (
 			SELECT ksuid, resource_json, operation,
-			       ROW_NUMBER() OVER (PARTITION BY ksuid ORDER BY timestamp DESC) as rn
+			       ROW_NUMBER() OVER (
+			           PARTITION BY ksuid
+			           ORDER BY timestamp DESC,
+			                    CASE WHEN operation = 'delete' THEN 1 ELSE 0 END
+			       ) as rn
 			FROM user_reconcile_updates
 		)
 		SELECT ksuid,

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -4475,42 +4475,51 @@ func (d *DatastoreAuroraDataAPI) GetResourcesAtLastReconcile(stackLabel string) 
 	ctx := context.Background()
 
 	// Declared state for auto-reconcile: per-resource DesiredState from the
-	// last user-source reconcile apply for this stack. Failed reconciles count
-	// (so failed updates are retried until they converge); Canceled and
-	// InProgress reconciles do not (they aren't accepted user intent).
-	// Reading from resource_updates rather than the resources table ensures
-	// resources whose update failed last time are still in the desired-state
-	// baseline — a failed Create never writes to resources, but
-	// BulkStoreResourceUpdates populates resource_updates at command-creation
-	// time for every intended update. Delete operations are excluded: a
-	// deletion the user requested is not part of the desired state going
-	// forward.
+	// most recent user-source reconcile that touched each resource. Failed
+	// reconciles count (so failed updates are retried until they converge);
+	// Canceled and InProgress reconciles do not (they aren't accepted user
+	// intent).
+	//
+	// Reading per-resource rather than per-command is the key invariant.
+	// The generator only emits resource_updates rows for resources whose
+	// state actually changes — unchanged resources produce no row. If we
+	// scoped the snapshot to a single reconcile command, a partial reconcile
+	// that changed only some resources would yield a desired-state Forma
+	// that omits the unchanged ones, and auto-reconcile would implicitly
+	// delete them as drift. Taking the most recent user-source reconcile
+	// row per ksuid keeps unchanged resources represented by the earlier
+	// reconcile that last declared them.
+	//
+	// The resource column is stored as TEXT; cast to json once in the CTE
+	// so the downstream extractions can use the JSON operators.
+	//
+	// Delete operations are excluded: a deletion the user requested is not
+	// part of the desired state going forward.
 	query := `
-		WITH last_user_reconcile_for_stack AS (
-			SELECT fc.command_id
-			FROM forma_commands fc
-			INNER JOIN resource_updates ru ON ru.command_id = fc.command_id
+		WITH user_reconcile_updates AS (
+			SELECT ru.ksuid, ru.resource::json AS resource_json, ru.operation, fc.timestamp
+			FROM resource_updates ru
+			INNER JOIN forma_commands fc ON ru.command_id = fc.command_id
 			WHERE fc.config_mode = 'reconcile'
 			AND fc.state IN ('Success', 'Failed')
 			AND fc.command = 'apply'
 			AND ru.source = 'user'
 			AND ru.stack_label = :stack_label
-			GROUP BY fc.command_id, fc.timestamp
-			ORDER BY fc.timestamp DESC
-			LIMIT 1
+		),
+		latest_per_ksuid AS (
+			SELECT ksuid, resource_json, operation,
+			       ROW_NUMBER() OVER (PARTITION BY ksuid ORDER BY timestamp DESC) as rn
+			FROM user_reconcile_updates
 		)
-		SELECT ru.ksuid,
-		       ru.resource->>'Type'      as type,
-		       ru.resource->>'Label'     as label,
-		       ru.resource->>'Target'    as target,
-		       ru.resource->'Properties' as properties,
-		       ru.resource->'Schema'     as schema,
-		       ru.resource->>'NativeID'  as native_id
-		FROM resource_updates ru
-		WHERE ru.command_id = (SELECT command_id FROM last_user_reconcile_for_stack)
-		AND ru.stack_label = :stack_label
-		AND ru.source = 'user'
-		AND ru.operation != 'delete'
+		SELECT ksuid,
+		       resource_json->>'Type'      as type,
+		       resource_json->>'Label'     as label,
+		       resource_json->>'Target'    as target,
+		       resource_json->'Properties' as properties,
+		       resource_json->'Schema'     as schema,
+		       resource_json->>'NativeID'  as native_id
+		FROM latest_per_ksuid
+		WHERE rn = 1 AND operation != 'delete'
 	`
 
 	params := []types.SqlParameter{

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -82,4 +82,15 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunFindResourcesDependingOnDeletedResourcesExcluded(t, newDS)
 
 	RunStackTransition(t, newDS)
+
+	RunGetResourcesAtLastReconcile_Empty(t, newDS)
+	RunGetResourcesAtLastReconcile_SuccessReturnsDesiredState(t, newDS)
+	RunGetResourcesAtLastReconcile_FailedReconcileIncluded(t, newDS)
+	RunGetResourcesAtLastReconcile_CanceledReconcileExcluded(t, newDS)
+	RunGetResourcesAtLastReconcile_InProgressReconcileExcluded(t, newDS)
+	RunGetResourcesAtLastReconcile_DeleteRowsExcluded(t, newDS)
+	RunGetResourcesAtLastReconcile_NonUserSourceExcluded(t, newDS)
+	RunGetResourcesAtLastReconcile_PatchModeExcluded(t, newDS)
+	RunGetResourcesAtLastReconcile_MostRecentReconcileWins(t, newDS)
+	RunGetResourcesAtLastReconcile_StackScoped(t, newDS)
 }

--- a/internal/datastore/dstest/suite_get_resources_at_last_reconcile.go
+++ b/internal/datastore/dstest/suite_get_resources_at_last_reconcile.go
@@ -228,10 +228,14 @@ func RunGetResourcesAtLastReconcile_DeleteRowsExcluded(t *testing.T, newDS func(
 			pkgmodel.FormaApplyModeReconcile,
 			-5*time.Minute,
 			[]resource_update.ResourceUpdate{
-				// Replace pair for the same resource: delete the old, create
-				// the new. Only the create side belongs in the snapshot.
+				// Replace pair: in production NewResourceUpdateForReplace
+				// emits a delete and a create for the SAME ksuid (assigned
+				// by BatchGetKSUIDsByTriplets matching the existing row).
+				// Both rows share the command's timestamp. The query must
+				// deterministically return the create side, not drop the
+				// resource because the delete row won the row-number tie.
 				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v1"}`, types.OperationDelete, resource_update.FormaCommandSourceUser),
-				resourceUpdate("stack-a", "ksuid-2", "bucket-1", `{"foo":"v2"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v2"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
 				// Implicit delete of a different resource that was removed
 				// from the forma — must also be excluded from the baseline.
 				resourceUpdate("stack-a", "ksuid-3", "bucket-removed", `{"foo":"old"}`, types.OperationDelete, resource_update.FormaCommandSourceUser),
@@ -241,9 +245,10 @@ func RunGetResourcesAtLastReconcile_DeleteRowsExcluded(t *testing.T, newDS func(
 
 		snaps, err := td.GetResourcesAtLastReconcile("stack-a")
 		assert.NoError(t, err)
-		assert.Len(t, snaps, 1, "Only the create side of the replace pair should be returned")
-		assert.Equal(t, "ksuid-2", snaps[0].KSUID)
-		assert.JSONEq(t, `{"foo":"v2"}`, string(snaps[0].Properties))
+		if assert.Len(t, snaps, 1, "Only the create side of the replace pair should be returned") {
+			assert.Equal(t, "ksuid-1", snaps[0].KSUID)
+			assert.JSONEq(t, `{"foo":"v2"}`, string(snaps[0].Properties))
+		}
 	})
 }
 

--- a/internal/datastore/dstest/suite_get_resources_at_last_reconcile.go
+++ b/internal/datastore/dstest/suite_get_resources_at_last_reconcile.go
@@ -1,0 +1,392 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package dstest
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/types"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// reconcileBuilder constructs a reconcile-mode apply forma_command with the
+// given resource updates, suitable for exercising GetResourcesAtLastReconcile.
+// startOffset is added to the current time to give the caller control over
+// ordering across multiple commands.
+func reconcileBuilder(
+	state forma_command.CommandState,
+	mode pkgmodel.FormaApplyMode,
+	startOffset time.Duration,
+	updates []resource_update.ResourceUpdate,
+) *forma_command.FormaCommand {
+	return &forma_command.FormaCommand{
+		ID:              util.NewID(),
+		Command:         pkgmodel.CommandApply,
+		Config:          config.FormaCommandConfig{Mode: mode},
+		State:           state,
+		StartTs:         util.TimeNow().Add(startOffset),
+		ModifiedTs:      util.TimeNow().Add(startOffset),
+		ResourceUpdates: updates,
+	}
+}
+
+// resourceUpdate constructs a ResourceUpdate where the DesiredState carries
+// realistic top-level fields so that GetResourcesAtLastReconcile's
+// JSON-extraction queries (Type/Label/Target/Properties/Schema/NativeID)
+// return the values the test expects.
+func resourceUpdate(
+	stack, ksuid, label, props string,
+	op types.OperationType,
+	source resource_update.FormaCommandSource,
+) resource_update.ResourceUpdate {
+	return resource_update.ResourceUpdate{
+		Operation:  op,
+		State:      resource_update.ResourceUpdateStateSuccess,
+		Source:     source,
+		StackLabel: stack,
+		DesiredState: pkgmodel.Resource{
+			Ksuid:      ksuid,
+			Label:      label,
+			Type:       "AWS::S3::Bucket",
+			Stack:      stack,
+			Target:     "default-target",
+			NativeID:   "native-" + label,
+			Properties: json.RawMessage(props),
+			Schema:     pkgmodel.Schema{Fields: []string{"foo"}},
+		},
+	}
+}
+
+// RunGetResourcesAtLastReconcile_Empty verifies the contract for a fresh
+// datastore: no rows, no error.
+func RunGetResourcesAtLastReconcile_Empty(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetResourcesAtLastReconcile_Empty", func(t *testing.T) {
+		td := newDS(t)
+		defer td.CleanUpFn() //nolint:errcheck
+
+		snaps, err := td.GetResourcesAtLastReconcile("any-stack")
+		assert.NoError(t, err)
+		assert.Empty(t, snaps)
+	})
+}
+
+// RunGetResourcesAtLastReconcile_SuccessReturnsDesiredState verifies the
+// happy path: a single successful user reconcile produces a snapshot of its
+// DesiredStates.
+func RunGetResourcesAtLastReconcile_SuccessReturnsDesiredState(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetResourcesAtLastReconcile_SuccessReturnsDesiredState", func(t *testing.T) {
+		td := newDS(t)
+		defer td.CleanUpFn() //nolint:errcheck
+
+		cmd := reconcileBuilder(
+			forma_command.CommandStateSuccess,
+			pkgmodel.FormaApplyModeReconcile,
+			-5*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+				resourceUpdate("stack-a", "ksuid-2", "bucket-2", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(cmd, cmd.ID))
+
+		snaps, err := td.GetResourcesAtLastReconcile("stack-a")
+		assert.NoError(t, err)
+		assert.Len(t, snaps, 2)
+
+		labels := map[string]bool{}
+		for _, s := range snaps {
+			labels[s.Label] = true
+			assert.Equal(t, "AWS::S3::Bucket", s.Type)
+			assert.Equal(t, "default-target", s.Target)
+			assert.Equal(t, "native-"+s.Label, s.NativeID)
+			assert.JSONEq(t, `{"foo":"v1"}`, string(s.Properties))
+		}
+		assert.True(t, labels["bucket-1"])
+		assert.True(t, labels["bucket-2"])
+	})
+}
+
+// RunGetResourcesAtLastReconcile_FailedReconcileIncluded verifies that a
+// failed user reconcile still contributes its DesiredStates to the
+// desired-state baseline, so auto-reconcile can retry the failed updates
+// on subsequent ticks.
+func RunGetResourcesAtLastReconcile_FailedReconcileIncluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetResourcesAtLastReconcile_FailedReconcileIncluded", func(t *testing.T) {
+		td := newDS(t)
+		defer td.CleanUpFn() //nolint:errcheck
+
+		cmd := reconcileBuilder(
+			forma_command.CommandStateFailed,
+			pkgmodel.FormaApplyModeReconcile,
+			-5*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+				resourceUpdate("stack-a", "ksuid-2", "bucket-2", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(cmd, cmd.ID))
+
+		snaps, err := td.GetResourcesAtLastReconcile("stack-a")
+		assert.NoError(t, err)
+		assert.Len(t, snaps, 2, "Failed user reconcile must still contribute to desired state for retry")
+	})
+}
+
+// RunGetResourcesAtLastReconcile_CanceledReconcileExcluded verifies a
+// canceled user reconcile is NOT treated as accepted user intent.
+func RunGetResourcesAtLastReconcile_CanceledReconcileExcluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetResourcesAtLastReconcile_CanceledReconcileExcluded", func(t *testing.T) {
+		td := newDS(t)
+		defer td.CleanUpFn() //nolint:errcheck
+
+		// Older success that should remain the baseline.
+		oldSuccess := reconcileBuilder(
+			forma_command.CommandStateSuccess,
+			pkgmodel.FormaApplyModeReconcile,
+			-10*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(oldSuccess, oldSuccess.ID))
+
+		// Newer canceled reconcile — must not shift the baseline.
+		canceled := reconcileBuilder(
+			forma_command.CommandStateCanceled,
+			pkgmodel.FormaApplyModeReconcile,
+			-1*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-2", "bucket-2", `{"foo":"v2"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(canceled, canceled.ID))
+
+		snaps, err := td.GetResourcesAtLastReconcile("stack-a")
+		assert.NoError(t, err)
+		assert.Len(t, snaps, 1, "Canceled reconcile should not become the baseline")
+		assert.Equal(t, "bucket-1", snaps[0].Label, "Older successful reconcile should still be the baseline")
+	})
+}
+
+// RunGetResourcesAtLastReconcile_InProgressReconcileExcluded verifies an
+// in-progress reconcile is NOT considered. Its updates may still be
+// rolling forward and shouldn't shift the baseline mid-flight.
+func RunGetResourcesAtLastReconcile_InProgressReconcileExcluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetResourcesAtLastReconcile_InProgressReconcileExcluded", func(t *testing.T) {
+		td := newDS(t)
+		defer td.CleanUpFn() //nolint:errcheck
+
+		oldSuccess := reconcileBuilder(
+			forma_command.CommandStateSuccess,
+			pkgmodel.FormaApplyModeReconcile,
+			-10*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(oldSuccess, oldSuccess.ID))
+
+		inProgress := reconcileBuilder(
+			forma_command.CommandStateInProgress,
+			pkgmodel.FormaApplyModeReconcile,
+			-1*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-2", "bucket-2", `{"foo":"v2"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(inProgress, inProgress.ID))
+
+		snaps, err := td.GetResourcesAtLastReconcile("stack-a")
+		assert.NoError(t, err)
+		assert.Len(t, snaps, 1, "InProgress reconcile should not become the baseline")
+		assert.Equal(t, "bucket-1", snaps[0].Label)
+	})
+}
+
+// RunGetResourcesAtLastReconcile_DeleteRowsExcluded verifies that
+// delete-side rows in a reconcile (implicit deletes or replace pairs) do
+// not contribute to the desired-state baseline — the user's intent for
+// deleted resources is "not exist".
+func RunGetResourcesAtLastReconcile_DeleteRowsExcluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetResourcesAtLastReconcile_DeleteRowsExcluded", func(t *testing.T) {
+		td := newDS(t)
+		defer td.CleanUpFn() //nolint:errcheck
+
+		cmd := reconcileBuilder(
+			forma_command.CommandStateSuccess,
+			pkgmodel.FormaApplyModeReconcile,
+			-5*time.Minute,
+			[]resource_update.ResourceUpdate{
+				// Replace pair for the same resource: delete the old, create
+				// the new. Only the create side belongs in the snapshot.
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v1"}`, types.OperationDelete, resource_update.FormaCommandSourceUser),
+				resourceUpdate("stack-a", "ksuid-2", "bucket-1", `{"foo":"v2"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+				// Implicit delete of a different resource that was removed
+				// from the forma — must also be excluded from the baseline.
+				resourceUpdate("stack-a", "ksuid-3", "bucket-removed", `{"foo":"old"}`, types.OperationDelete, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(cmd, cmd.ID))
+
+		snaps, err := td.GetResourcesAtLastReconcile("stack-a")
+		assert.NoError(t, err)
+		assert.Len(t, snaps, 1, "Only the create side of the replace pair should be returned")
+		assert.Equal(t, "ksuid-2", snaps[0].KSUID)
+		assert.JSONEq(t, `{"foo":"v2"}`, string(snaps[0].Properties))
+	})
+}
+
+// RunGetResourcesAtLastReconcile_NonUserSourceExcluded verifies that a
+// later auto-reconciler or sync command does not shift the baseline away
+// from the most recent user-source reconcile.
+func RunGetResourcesAtLastReconcile_NonUserSourceExcluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetResourcesAtLastReconcile_NonUserSourceExcluded", func(t *testing.T) {
+		td := newDS(t)
+		defer td.CleanUpFn() //nolint:errcheck
+
+		userReconcile := reconcileBuilder(
+			forma_command.CommandStateSuccess,
+			pkgmodel.FormaApplyModeReconcile,
+			-10*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(userReconcile, userReconcile.ID))
+
+		// A more recent auto-reconcile command — same stack, same mode, but
+		// its resource_updates are source=auto-reconcile. Must not become
+		// the baseline.
+		autoReconcile := reconcileBuilder(
+			forma_command.CommandStateSuccess,
+			pkgmodel.FormaApplyModeReconcile,
+			-1*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"reverted"}`, types.OperationUpdate, resource_update.FormaCommandSourcePolicyAutoReconcile),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(autoReconcile, autoReconcile.ID))
+
+		snaps, err := td.GetResourcesAtLastReconcile("stack-a")
+		assert.NoError(t, err)
+		assert.Len(t, snaps, 1)
+		assert.JSONEq(t, `{"foo":"v1"}`, string(snaps[0].Properties),
+			"Auto-reconcile rows must not shift the user baseline")
+	})
+}
+
+// RunGetResourcesAtLastReconcile_PatchModeExcluded verifies that a later
+// patch-mode apply does not shift the reconcile baseline. Patches are
+// intentional drift the next reconcile may overwrite.
+func RunGetResourcesAtLastReconcile_PatchModeExcluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetResourcesAtLastReconcile_PatchModeExcluded", func(t *testing.T) {
+		td := newDS(t)
+		defer td.CleanUpFn() //nolint:errcheck
+
+		reconcile := reconcileBuilder(
+			forma_command.CommandStateSuccess,
+			pkgmodel.FormaApplyModeReconcile,
+			-10*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(reconcile, reconcile.ID))
+
+		patch := reconcileBuilder(
+			forma_command.CommandStateSuccess,
+			pkgmodel.FormaApplyModePatch,
+			-1*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"patched"}`, types.OperationUpdate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(patch, patch.ID))
+
+		snaps, err := td.GetResourcesAtLastReconcile("stack-a")
+		assert.NoError(t, err)
+		assert.Len(t, snaps, 1)
+		assert.JSONEq(t, `{"foo":"v1"}`, string(snaps[0].Properties),
+			"Patch-mode applies must not become the reconcile baseline")
+	})
+}
+
+// RunGetResourcesAtLastReconcile_MostRecentReconcileWins verifies that
+// when multiple reconciles for the same stack exist, the most recent one
+// is returned, including when the most recent is Failed.
+func RunGetResourcesAtLastReconcile_MostRecentReconcileWins(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetResourcesAtLastReconcile_MostRecentReconcileWins", func(t *testing.T) {
+		td := newDS(t)
+		defer td.CleanUpFn() //nolint:errcheck
+
+		olderSuccess := reconcileBuilder(
+			forma_command.CommandStateSuccess,
+			pkgmodel.FormaApplyModeReconcile,
+			-10*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(olderSuccess, olderSuccess.ID))
+
+		// Latest reconcile is Failed but represents the user's latest
+		// intent — its DesiredState is what auto-reconcile should drive
+		// toward, not the older Success.
+		latestFailed := reconcileBuilder(
+			forma_command.CommandStateFailed,
+			pkgmodel.FormaApplyModeReconcile,
+			-1*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v2"}`, types.OperationUpdate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(latestFailed, latestFailed.ID))
+
+		snaps, err := td.GetResourcesAtLastReconcile("stack-a")
+		assert.NoError(t, err)
+		assert.Len(t, snaps, 1)
+		assert.JSONEq(t, `{"foo":"v2"}`, string(snaps[0].Properties),
+			"Latest Failed reconcile must win over older Success")
+	})
+}
+
+// RunGetResourcesAtLastReconcile_StackScoped verifies the query is
+// scoped to the requested stack and does not leak rows from other stacks.
+func RunGetResourcesAtLastReconcile_StackScoped(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetResourcesAtLastReconcile_StackScoped", func(t *testing.T) {
+		td := newDS(t)
+		defer td.CleanUpFn() //nolint:errcheck
+
+		cmd := reconcileBuilder(
+			forma_command.CommandStateSuccess,
+			pkgmodel.FormaApplyModeReconcile,
+			-5*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-a", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+				resourceUpdate("stack-b", "ksuid-2", "bucket-b", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(cmd, cmd.ID))
+
+		snapsA, err := td.GetResourcesAtLastReconcile("stack-a")
+		assert.NoError(t, err)
+		assert.Len(t, snapsA, 1)
+		assert.Equal(t, "bucket-a", snapsA[0].Label)
+
+		snapsB, err := td.GetResourcesAtLastReconcile("stack-b")
+		assert.NoError(t, err)
+		assert.Len(t, snapsB, 1)
+		assert.Equal(t, "bucket-b", snapsB[0].Label)
+	})
+}

--- a/internal/datastore/mssql/mssql_policies.go
+++ b/internal/datastore/mssql/mssql_policies.go
@@ -748,7 +748,11 @@ func (d *DatastoreMSSQL) GetResourcesAtLastReconcile(stackLabel string) ([]datas
 		),
 		latest_per_ksuid AS (
 			SELECT ksuid, resource, operation,
-			       ROW_NUMBER() OVER (PARTITION BY ksuid ORDER BY timestamp DESC) as rn
+			       ROW_NUMBER() OVER (
+			           PARTITION BY ksuid
+			           ORDER BY timestamp DESC,
+			                    CASE WHEN operation = 'delete' THEN 1 ELSE 0 END
+			       ) as rn
 			FROM user_reconcile_updates
 		)
 		SELECT ksuid,

--- a/internal/datastore/mssql/mssql_policies.go
+++ b/internal/datastore/mssql/mssql_policies.go
@@ -717,29 +717,42 @@ func (d *DatastoreMSSQL) GetResourcesAtLastReconcile(stackLabel string) ([]datas
 	ctx, span := mssqlTracer.Start(context.Background(), "GetResourcesAtLastReconcile")
 	defer span.End()
 
-	// Declared state: resources from the last user-initiated reconcile apply.
-	// Filter source='user' so auto-reconcile/sync don't shift the baseline.
+	// Declared state for auto-reconcile: per-resource DesiredState from the
+	// last user-source reconcile apply for this stack. Failed reconciles count
+	// (so failed updates are retried until they converge); Canceled and
+	// InProgress reconciles do not (they aren't accepted user intent).
+	// Reading from resource_updates rather than the resources table ensures
+	// resources whose update failed last time are still in the desired-state
+	// baseline — a failed Create never writes to resources, but
+	// BulkStoreResourceUpdates populates resource_updates at command-creation
+	// time for every intended update. Delete operations are excluded: a
+	// deletion the user requested is not part of the desired state going
+	// forward.
 	query := `
 		WITH last_user_reconcile_for_stack AS (
 			SELECT TOP (1) fc.command_id, fc.timestamp
 			FROM forma_commands fc
 			INNER JOIN resource_updates ru ON ru.command_id = fc.command_id
 			WHERE fc.config_mode = 'reconcile'
-			AND fc.state = 'Success'
+			AND fc.state IN ('Success', 'Failed')
 			AND fc.command = 'apply'
 			AND ru.source = 'user'
 			AND ru.stack_label = @p1
 			GROUP BY fc.command_id, fc.timestamp
 			ORDER BY fc.timestamp DESC
 		)
-		SELECT r.ksuid, r.type, r.label, r.target,
-		       JSON_QUERY(r.data, '$.Properties') as properties,
-		       JSON_QUERY(r.data, '$.Schema') as [schema],
-		       r.native_id
-		FROM resources r
-		WHERE r.command_id = (SELECT command_id FROM last_user_reconcile_for_stack)
-		AND r.stack = @p2
-		AND r.operation != 'delete'`
+		SELECT ru.ksuid,
+		       JSON_VALUE(ru.resource, '$.Type')         as type,
+		       JSON_VALUE(ru.resource, '$.Label')        as label,
+		       JSON_VALUE(ru.resource, '$.Target')       as target,
+		       JSON_QUERY(ru.resource, '$.Properties')   as properties,
+		       JSON_QUERY(ru.resource, '$.Schema')       as [schema],
+		       JSON_VALUE(ru.resource, '$.NativeID')     as native_id
+		FROM resource_updates ru
+		WHERE ru.command_id = (SELECT command_id FROM last_user_reconcile_for_stack)
+		AND ru.stack_label = @p2
+		AND ru.source = 'user'
+		AND ru.operation != 'delete'`
 
 	rows, err := d.conn.QueryContext(ctx, query, stackLabel, stackLabel)
 	if err != nil {

--- a/internal/datastore/mssql/mssql_policies.go
+++ b/internal/datastore/mssql/mssql_policies.go
@@ -718,43 +718,50 @@ func (d *DatastoreMSSQL) GetResourcesAtLastReconcile(stackLabel string) ([]datas
 	defer span.End()
 
 	// Declared state for auto-reconcile: per-resource DesiredState from the
-	// last user-source reconcile apply for this stack. Failed reconciles count
-	// (so failed updates are retried until they converge); Canceled and
-	// InProgress reconciles do not (they aren't accepted user intent).
-	// Reading from resource_updates rather than the resources table ensures
-	// resources whose update failed last time are still in the desired-state
-	// baseline — a failed Create never writes to resources, but
-	// BulkStoreResourceUpdates populates resource_updates at command-creation
-	// time for every intended update. Delete operations are excluded: a
-	// deletion the user requested is not part of the desired state going
-	// forward.
+	// most recent user-source reconcile that touched each resource. Failed
+	// reconciles count (so failed updates are retried until they converge);
+	// Canceled and InProgress reconciles do not (they aren't accepted user
+	// intent).
+	//
+	// Reading per-resource rather than per-command is the key invariant.
+	// The generator only emits resource_updates rows for resources whose
+	// state actually changes — unchanged resources produce no row. If we
+	// scoped the snapshot to a single reconcile command, a partial reconcile
+	// that changed only some resources would yield a desired-state Forma
+	// that omits the unchanged ones, and auto-reconcile would implicitly
+	// delete them as drift. Taking the most recent user-source reconcile
+	// row per ksuid keeps unchanged resources represented by the earlier
+	// reconcile that last declared them.
+	//
+	// Delete operations are excluded: a deletion the user requested is not
+	// part of the desired state going forward.
 	query := `
-		WITH last_user_reconcile_for_stack AS (
-			SELECT TOP (1) fc.command_id, fc.timestamp
-			FROM forma_commands fc
-			INNER JOIN resource_updates ru ON ru.command_id = fc.command_id
+		WITH user_reconcile_updates AS (
+			SELECT ru.ksuid, ru.resource, ru.operation, fc.timestamp
+			FROM resource_updates ru
+			INNER JOIN forma_commands fc ON ru.command_id = fc.command_id
 			WHERE fc.config_mode = 'reconcile'
 			AND fc.state IN ('Success', 'Failed')
 			AND fc.command = 'apply'
 			AND ru.source = 'user'
 			AND ru.stack_label = @p1
-			GROUP BY fc.command_id, fc.timestamp
-			ORDER BY fc.timestamp DESC
+		),
+		latest_per_ksuid AS (
+			SELECT ksuid, resource, operation,
+			       ROW_NUMBER() OVER (PARTITION BY ksuid ORDER BY timestamp DESC) as rn
+			FROM user_reconcile_updates
 		)
-		SELECT ru.ksuid,
-		       JSON_VALUE(ru.resource, '$.Type')         as type,
-		       JSON_VALUE(ru.resource, '$.Label')        as label,
-		       JSON_VALUE(ru.resource, '$.Target')       as target,
-		       JSON_QUERY(ru.resource, '$.Properties')   as properties,
-		       JSON_QUERY(ru.resource, '$.Schema')       as [schema],
-		       JSON_VALUE(ru.resource, '$.NativeID')     as native_id
-		FROM resource_updates ru
-		WHERE ru.command_id = (SELECT command_id FROM last_user_reconcile_for_stack)
-		AND ru.stack_label = @p2
-		AND ru.source = 'user'
-		AND ru.operation != 'delete'`
+		SELECT ksuid,
+		       JSON_VALUE(resource, '$.Type')         as type,
+		       JSON_VALUE(resource, '$.Label')        as label,
+		       JSON_VALUE(resource, '$.Target')       as target,
+		       JSON_QUERY(resource, '$.Properties')   as properties,
+		       JSON_QUERY(resource, '$.Schema')       as [schema],
+		       JSON_VALUE(resource, '$.NativeID')     as native_id
+		FROM latest_per_ksuid
+		WHERE rn = 1 AND operation != 'delete'`
 
-	rows, err := d.conn.QueryContext(ctx, query, stackLabel, stackLabel)
+	rows, err := d.conn.QueryContext(ctx, query, stackLabel)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -2526,7 +2526,11 @@ func (d DatastorePostgres) GetResourcesAtLastReconcile(stackLabel string) ([]dat
 		),
 		latest_per_ksuid AS (
 			SELECT ksuid, resource_json, operation,
-			       ROW_NUMBER() OVER (PARTITION BY ksuid ORDER BY timestamp DESC) as rn
+			       ROW_NUMBER() OVER (
+			           PARTITION BY ksuid
+			           ORDER BY timestamp DESC,
+			                    CASE WHEN operation = 'delete' THEN 1 ELSE 0 END
+			       ) as rn
 			FROM user_reconcile_updates
 		)
 		SELECT ksuid,

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -2492,32 +2492,43 @@ func (d DatastorePostgres) GetResourcesAtLastReconcile(stackLabel string) ([]dat
 	ctx, span := tracer.Start(context.Background(), "GetResourcesAtLastReconcile")
 	defer span.End()
 
-	// Get resources from the last USER reconcile command for this stack.
-	// This gives us the "declared state" - what the user specified in their Forma file.
-	// We filter by source='user' on resource_updates to exclude auto-reconciler and sync commands,
-	// as they shouldn't change the declared state - they only enforce or detect drift.
+	// Declared state for auto-reconcile: per-resource DesiredState from the
+	// last user-source reconcile apply for this stack. Failed reconciles count
+	// (so failed updates are retried until they converge); Canceled and
+	// InProgress reconciles do not (they aren't accepted user intent).
+	// Reading from resource_updates rather than the resources table ensures
+	// resources whose update failed last time are still in the desired-state
+	// baseline — a failed Create never writes to resources, but
+	// BulkStoreResourceUpdates populates resource_updates at command-creation
+	// time for every intended update. Delete operations are excluded: a
+	// deletion the user requested is not part of the desired state going
+	// forward.
 	query := `
 		WITH last_user_reconcile_for_stack AS (
 			SELECT fc.command_id
 			FROM forma_commands fc
 			INNER JOIN resource_updates ru ON ru.command_id = fc.command_id
 			WHERE fc.config_mode = 'reconcile'
-			AND fc.state = 'Success'
+			AND fc.state IN ('Success', 'Failed')
 			AND fc.command = 'apply'
 			AND ru.source = 'user'
 			AND ru.stack_label = $1
-			GROUP BY fc.command_id
+			GROUP BY fc.command_id, fc.timestamp
 			ORDER BY fc.timestamp DESC
 			LIMIT 1
 		)
-		SELECT r.ksuid, r.type, r.label, r.target,
-		       r.data->'Properties' as properties,
-		       r.data->'Schema' as schema,
-		       r.native_id
-		FROM resources r
-		WHERE r.command_id = (SELECT command_id FROM last_user_reconcile_for_stack)
-		AND r.stack = $2
-		AND r.operation != 'delete'
+		SELECT ru.ksuid,
+		       ru.resource->>'Type'      as type,
+		       ru.resource->>'Label'     as label,
+		       ru.resource->>'Target'    as target,
+		       ru.resource->'Properties' as properties,
+		       ru.resource->'Schema'     as schema,
+		       ru.resource->>'NativeID'  as native_id
+		FROM resource_updates ru
+		WHERE ru.command_id = (SELECT command_id FROM last_user_reconcile_for_stack)
+		AND ru.stack_label = $2
+		AND ru.source = 'user'
+		AND ru.operation != 'delete'
 	`
 
 	rows, err := d.pool.Query(ctx, query, stackLabel, stackLabel)

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -2493,45 +2493,54 @@ func (d DatastorePostgres) GetResourcesAtLastReconcile(stackLabel string) ([]dat
 	defer span.End()
 
 	// Declared state for auto-reconcile: per-resource DesiredState from the
-	// last user-source reconcile apply for this stack. Failed reconciles count
-	// (so failed updates are retried until they converge); Canceled and
-	// InProgress reconciles do not (they aren't accepted user intent).
-	// Reading from resource_updates rather than the resources table ensures
-	// resources whose update failed last time are still in the desired-state
-	// baseline — a failed Create never writes to resources, but
-	// BulkStoreResourceUpdates populates resource_updates at command-creation
-	// time for every intended update. Delete operations are excluded: a
-	// deletion the user requested is not part of the desired state going
-	// forward.
+	// most recent user-source reconcile that touched each resource. Failed
+	// reconciles count (so failed updates are retried until they converge);
+	// Canceled and InProgress reconciles do not (they aren't accepted user
+	// intent).
+	//
+	// Reading per-resource rather than per-command is the key invariant.
+	// The generator only emits resource_updates rows for resources whose
+	// state actually changes — unchanged resources produce no row. If we
+	// scoped the snapshot to a single reconcile command, a partial reconcile
+	// that changed only some resources would yield a desired-state Forma
+	// that omits the unchanged ones, and auto-reconcile would implicitly
+	// delete them as drift. Taking the most recent user-source reconcile
+	// row per ksuid keeps unchanged resources represented by the earlier
+	// reconcile that last declared them.
+	//
+	// The resource column is stored as TEXT; cast to json once in the CTE
+	// so the downstream extractions can use the JSON operators.
+	//
+	// Delete operations are excluded: a deletion the user requested is not
+	// part of the desired state going forward.
 	query := `
-		WITH last_user_reconcile_for_stack AS (
-			SELECT fc.command_id
-			FROM forma_commands fc
-			INNER JOIN resource_updates ru ON ru.command_id = fc.command_id
+		WITH user_reconcile_updates AS (
+			SELECT ru.ksuid, ru.resource::json AS resource_json, ru.operation, fc.timestamp
+			FROM resource_updates ru
+			INNER JOIN forma_commands fc ON ru.command_id = fc.command_id
 			WHERE fc.config_mode = 'reconcile'
 			AND fc.state IN ('Success', 'Failed')
 			AND fc.command = 'apply'
 			AND ru.source = 'user'
 			AND ru.stack_label = $1
-			GROUP BY fc.command_id, fc.timestamp
-			ORDER BY fc.timestamp DESC
-			LIMIT 1
+		),
+		latest_per_ksuid AS (
+			SELECT ksuid, resource_json, operation,
+			       ROW_NUMBER() OVER (PARTITION BY ksuid ORDER BY timestamp DESC) as rn
+			FROM user_reconcile_updates
 		)
-		SELECT ru.ksuid,
-		       ru.resource->>'Type'      as type,
-		       ru.resource->>'Label'     as label,
-		       ru.resource->>'Target'    as target,
-		       ru.resource->'Properties' as properties,
-		       ru.resource->'Schema'     as schema,
-		       ru.resource->>'NativeID'  as native_id
-		FROM resource_updates ru
-		WHERE ru.command_id = (SELECT command_id FROM last_user_reconcile_for_stack)
-		AND ru.stack_label = $2
-		AND ru.source = 'user'
-		AND ru.operation != 'delete'
+		SELECT ksuid,
+		       resource_json->>'Type'      as type,
+		       resource_json->>'Label'     as label,
+		       resource_json->>'Target'    as target,
+		       resource_json->'Properties' as properties,
+		       resource_json->'Schema'     as schema,
+		       resource_json->>'NativeID'  as native_id
+		FROM latest_per_ksuid
+		WHERE rn = 1 AND operation != 'delete'
 	`
 
-	rows, err := d.pool.Query(ctx, query, stackLabel, stackLabel)
+	rows, err := d.pool.Query(ctx, query, stackLabel)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -2399,17 +2399,24 @@ func (d DatastoreSQLite) GetResourcesAtLastReconcile(stackLabel string) ([]datas
 	_, span := sqliteTracer.Start(context.Background(), "GetResourcesAtLastReconcile")
 	defer span.End()
 
-	// Get resources from the last USER reconcile command for this stack.
-	// This gives us the "declared state" - what the user specified in their Forma file.
-	// We filter by source='user' on resource_updates to exclude auto-reconciler and sync commands,
-	// as they shouldn't change the declared state - they only enforce or detect drift.
+	// Declared state for auto-reconcile: per-resource DesiredState from the
+	// last user-source reconcile apply for this stack. Failed reconciles count
+	// (so failed updates are retried until they converge); Canceled and
+	// InProgress reconciles do not (they aren't accepted user intent).
+	// Reading from resource_updates rather than the resources table ensures
+	// resources whose update failed last time are still in the desired-state
+	// baseline — a failed Create never writes to resources, but
+	// BulkStoreResourceUpdates populates resource_updates at command-creation
+	// time for every intended update. Delete operations are excluded: a
+	// deletion the user requested is not part of the desired state going
+	// forward.
 	query := `
 		WITH last_user_reconcile_for_stack AS (
 			SELECT fc.command_id
 			FROM forma_commands fc
 			INNER JOIN resource_updates ru ON ru.command_id = fc.command_id
 			WHERE fc.config_mode = 'reconcile'
-			AND fc.state = 'Success'
+			AND fc.state IN ('Success', 'Failed')
 			AND fc.command = 'apply'
 			AND ru.source = 'user'
 			AND ru.stack_label = ?
@@ -2417,14 +2424,18 @@ func (d DatastoreSQLite) GetResourcesAtLastReconcile(stackLabel string) ([]datas
 			ORDER BY fc.timestamp DESC
 			LIMIT 1
 		)
-		SELECT r.ksuid, r.type, r.label, r.target,
-		       json_extract(r.data, '$.Properties') as properties,
-		       json_extract(r.data, '$.Schema') as schema,
-		       r.native_id
-		FROM resources r
-		WHERE r.command_id = (SELECT command_id FROM last_user_reconcile_for_stack)
-		AND r.stack = ?
-		AND r.operation != 'delete'
+		SELECT ru.ksuid,
+		       json_extract(ru.resource, '$.Type')       as type,
+		       json_extract(ru.resource, '$.Label')      as label,
+		       json_extract(ru.resource, '$.Target')     as target,
+		       json_extract(ru.resource, '$.Properties') as properties,
+		       json_extract(ru.resource, '$.Schema')     as schema,
+		       json_extract(ru.resource, '$.NativeID')   as native_id
+		FROM resource_updates ru
+		WHERE ru.command_id = (SELECT command_id FROM last_user_reconcile_for_stack)
+		AND ru.stack_label = ?
+		AND ru.source = 'user'
+		AND ru.operation != 'delete'
 	`
 
 	rows, err := d.conn.Query(query, stackLabel, stackLabel)

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -2430,7 +2430,11 @@ func (d DatastoreSQLite) GetResourcesAtLastReconcile(stackLabel string) ([]datas
 		),
 		latest_per_ksuid AS (
 			SELECT ksuid, resource, operation,
-			       ROW_NUMBER() OVER (PARTITION BY ksuid ORDER BY timestamp DESC) as rn
+			       ROW_NUMBER() OVER (
+			           PARTITION BY ksuid
+			           ORDER BY timestamp DESC,
+			                    CASE WHEN operation = 'delete' THEN 1 ELSE 0 END
+			       ) as rn
 			FROM user_reconcile_updates
 		)
 		SELECT ksuid,

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -2400,45 +2400,51 @@ func (d DatastoreSQLite) GetResourcesAtLastReconcile(stackLabel string) ([]datas
 	defer span.End()
 
 	// Declared state for auto-reconcile: per-resource DesiredState from the
-	// last user-source reconcile apply for this stack. Failed reconciles count
-	// (so failed updates are retried until they converge); Canceled and
-	// InProgress reconciles do not (they aren't accepted user intent).
-	// Reading from resource_updates rather than the resources table ensures
-	// resources whose update failed last time are still in the desired-state
-	// baseline — a failed Create never writes to resources, but
-	// BulkStoreResourceUpdates populates resource_updates at command-creation
-	// time for every intended update. Delete operations are excluded: a
-	// deletion the user requested is not part of the desired state going
-	// forward.
+	// most recent user-source reconcile that touched each resource. Failed
+	// reconciles count (so failed updates are retried until they converge);
+	// Canceled and InProgress reconciles do not (they aren't accepted user
+	// intent).
+	//
+	// Reading per-resource rather than per-command is the key invariant.
+	// The generator only emits resource_updates rows for resources whose
+	// state actually changes — unchanged resources produce no row. If we
+	// scoped the snapshot to a single reconcile command, a partial reconcile
+	// that changed only some resources would yield a desired-state Forma
+	// that omits the unchanged ones, and auto-reconcile would implicitly
+	// delete them as drift. Taking the most recent user-source reconcile
+	// row per ksuid keeps unchanged resources represented by the earlier
+	// reconcile that last declared them.
+	//
+	// Delete operations are excluded: a deletion the user requested is not
+	// part of the desired state going forward.
 	query := `
-		WITH last_user_reconcile_for_stack AS (
-			SELECT fc.command_id
-			FROM forma_commands fc
-			INNER JOIN resource_updates ru ON ru.command_id = fc.command_id
+		WITH user_reconcile_updates AS (
+			SELECT ru.ksuid, ru.resource, ru.operation, fc.timestamp
+			FROM resource_updates ru
+			INNER JOIN forma_commands fc ON ru.command_id = fc.command_id
 			WHERE fc.config_mode = 'reconcile'
 			AND fc.state IN ('Success', 'Failed')
 			AND fc.command = 'apply'
 			AND ru.source = 'user'
 			AND ru.stack_label = ?
-			GROUP BY fc.command_id
-			ORDER BY fc.timestamp DESC
-			LIMIT 1
+		),
+		latest_per_ksuid AS (
+			SELECT ksuid, resource, operation,
+			       ROW_NUMBER() OVER (PARTITION BY ksuid ORDER BY timestamp DESC) as rn
+			FROM user_reconcile_updates
 		)
-		SELECT ru.ksuid,
-		       json_extract(ru.resource, '$.Type')       as type,
-		       json_extract(ru.resource, '$.Label')      as label,
-		       json_extract(ru.resource, '$.Target')     as target,
-		       json_extract(ru.resource, '$.Properties') as properties,
-		       json_extract(ru.resource, '$.Schema')     as schema,
-		       json_extract(ru.resource, '$.NativeID')   as native_id
-		FROM resource_updates ru
-		WHERE ru.command_id = (SELECT command_id FROM last_user_reconcile_for_stack)
-		AND ru.stack_label = ?
-		AND ru.source = 'user'
-		AND ru.operation != 'delete'
+		SELECT ksuid,
+		       json_extract(resource, '$.Type')       as type,
+		       json_extract(resource, '$.Label')      as label,
+		       json_extract(resource, '$.Target')     as target,
+		       json_extract(resource, '$.Properties') as properties,
+		       json_extract(resource, '$.Schema')     as schema,
+		       json_extract(resource, '$.NativeID')   as native_id
+		FROM latest_per_ksuid
+		WHERE rn = 1 AND operation != 'delete'
 	`
 
-	rows, err := d.conn.Query(query, stackLabel, stackLabel)
+	rows, err := d.conn.Query(query, stackLabel)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workflow_tests/local/auto_reconciler_test.go
+++ b/internal/workflow_tests/local/auto_reconciler_test.go
@@ -546,3 +546,135 @@ func TestAutoReconciler_RetriesFailureAndRevertsOOBDriftSimultaneously(t *testin
 			"after clearing B's failure: all 3 resources converge to v2")
 	})
 }
+
+// TestAutoReconciler_RevertsInterveningPatch verifies that a patch-mode
+// apply between two reconcile cycles does not shift the auto-reconcile
+// baseline — auto-reconcile drives the resource back to the state declared
+// by the last reconcile, undoing the patch.
+//
+// This is the patch-side counterpart to TestAutoReconciler_ReconcileAfterSyncChange
+// (which exercises the same property for sync-detected OOB drift): the
+// auto-reconcile baseline is the user's last reconcile-mode apply, and
+// intervening sync or patch operations are treated as drift that the next
+// reconcile cycle overwrites.
+func TestAutoReconciler_RevertsInterveningPatch(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		var mu sync.Mutex
+		observedProps := map[string]string{}
+		getPropsByNativeID := func(nativeID string) string {
+			mu.Lock()
+			defer mu.Unlock()
+			return observedProps[nativeID]
+		}
+		setPropsByNativeID := func(nativeID, props string) {
+			mu.Lock()
+			defer mu.Unlock()
+			observedProps[nativeID] = props
+		}
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				nativeID := "native-" + request.Label
+				setPropsByNativeID(nativeID, string(request.Properties))
+				return &resource.CreateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationCreate,
+						OperationStatus: resource.OperationStatusSuccess,
+						NativeID:        nativeID,
+					},
+				}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{
+					ResourceType: request.ResourceType,
+					Properties:   getPropsByNativeID(request.NativeID),
+				}, nil
+			},
+			Update: func(request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				setPropsByNativeID(request.NativeID, string(request.DesiredProperties))
+				return &resource.UpdateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationUpdate,
+						OperationStatus: resource.OperationStatusSuccess,
+						NativeID:        request.NativeID,
+					},
+				}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		// Sync stays off here so the reverted property doesn't get echoed
+		// back from the plugin between reconcile cycles — we want a clean
+		// signal that the auto-reconciler is the one driving the property
+		// back to its declared value.
+		cfg.Agent.Synchronization.Enabled = false
+		m, cleanup, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer cleanup()
+		require.NoError(t, err)
+
+		schema := pkgmodel.Schema{Fields: []string{"foo"}}
+		v1 := json.RawMessage(`{"foo":"v1"}`)
+		vPatched := json.RawMessage(`{"foo":"patched"}`)
+		stack := pkgmodel.Stack{
+			Label: "patch-undo-stack",
+			Policies: []json.RawMessage{
+				json.RawMessage(`{"Type":"auto-reconcile","IntervalSeconds":2}`),
+			},
+		}
+		targets := []pkgmodel.Target{{Label: "test-target"}}
+		resourceTemplate := func(props json.RawMessage) pkgmodel.Resource {
+			return pkgmodel.Resource{
+				Label: "patched-resource", Type: "FakeAWS::Resource",
+				Properties: props, Schema: schema,
+				Stack: "patch-undo-stack", Target: "test-target",
+			}
+		}
+
+		// Phase 1: initial reconcile at v1.
+		f1 := &pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{stack},
+			Resources: []pkgmodel.Resource{resourceTemplate(v1)},
+			Targets:   targets,
+		}
+		m.ApplyForma(f1, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+
+		r := require.New(t)
+		r.Eventually(func() bool {
+			resources, err := m.Datastore.LoadResourcesByStack("patch-undo-stack")
+			if err != nil || len(resources) != 1 {
+				return false
+			}
+			return string(resources[0].Properties) == `{"foo":"v1"}`
+		}, 15*time.Second, 200*time.Millisecond, "initial reconcile should land the resource at v1")
+
+		// Phase 2: patch the resource to a new value. This succeeds and
+		// updates the resources table, but is mode=patch so it must not
+		// become the auto-reconcile baseline.
+		fPatch := &pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{stack},
+			Resources: []pkgmodel.Resource{resourceTemplate(vPatched)},
+			Targets:   targets,
+		}
+		m.ApplyForma(fPatch, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch}, "test-client")
+
+		r.Eventually(func() bool {
+			resources, err := m.Datastore.LoadResourcesByStack("patch-undo-stack")
+			if err != nil || len(resources) != 1 {
+				return false
+			}
+			return string(resources[0].Properties) == `{"foo":"patched"}`
+		}, 15*time.Second, 200*time.Millisecond, "patch should land the resource at patched")
+
+		// Phase 3: auto-reconcile should pick the initial reconcile as the
+		// baseline (the patch's config_mode='patch' excludes it from the
+		// candidate pool) and drive the resource back to v1.
+		r.Eventually(func() bool {
+			resources, err := m.Datastore.LoadResourcesByStack("patch-undo-stack")
+			if err != nil || len(resources) != 1 {
+				return false
+			}
+			return string(resources[0].Properties) == `{"foo":"v1"}`
+		}, 30*time.Second, 500*time.Millisecond,
+			"auto-reconcile should revert the intervening patch back to the reconcile baseline (v1)")
+	})
+}

--- a/internal/workflow_tests/local/auto_reconciler_test.go
+++ b/internal/workflow_tests/local/auto_reconciler_test.go
@@ -678,3 +678,166 @@ func TestAutoReconciler_RevertsInterveningPatch(t *testing.T) {
 			"auto-reconcile should revert the intervening patch back to the reconcile baseline (v1)")
 	})
 }
+
+// TestAutoReconciler_PreservesUnchangedResourcesAfterPartialFailure exercises
+// the case where a reconcile generates updates only for the subset of
+// resources whose declared state actually changed. If one of those updates
+// fails, auto-reconcile must still treat the unchanged resources as part of
+// the desired baseline — otherwise it would observe them in the resources
+// table but not in the latest reconcile's diff-only snapshot and implicitly
+// delete them.
+//
+// Scenario: initial reconcile creates three resources at v1, then a second
+// reconcile changes only resource-a to v2 (B and C unchanged, so no
+// resource_updates rows are emitted for them). A's update fails. Auto-
+// reconcile must keep B and C present and retry A.
+func TestAutoReconciler_PreservesUnchangedResourcesAfterPartialFailure(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		var failAUpdate atomic.Bool
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				return &resource.CreateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationCreate,
+						OperationStatus: resource.OperationStatusSuccess,
+						NativeID:        "native-" + request.Label,
+					},
+				}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{
+					ResourceType: request.ResourceType,
+					Properties:   `{"foo":"v1"}`,
+				}, nil
+			},
+			Update: func(request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				if request.Label == "resource-a" && failAUpdate.Load() {
+					return &resource.UpdateResult{
+						ProgressResult: &resource.ProgressResult{
+							Operation:       resource.OperationUpdate,
+							OperationStatus: resource.OperationStatusFailure,
+							ErrorCode:       resource.OperationErrorCodeUnforeseenError,
+							StatusMessage:   "simulated outage",
+							NativeID:        request.NativeID,
+						},
+					}, nil
+				}
+				return &resource.UpdateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationUpdate,
+						OperationStatus: resource.OperationStatusSuccess,
+						NativeID:        request.NativeID,
+					},
+				}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, cleanup, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer cleanup()
+		require.NoError(t, err)
+
+		schema := pkgmodel.Schema{Fields: []string{"foo"}}
+		v1 := json.RawMessage(`{"foo":"v1"}`)
+		v2 := json.RawMessage(`{"foo":"v2"}`)
+		stack := pkgmodel.Stack{
+			Label: "partial-failure-stack",
+			Policies: []json.RawMessage{
+				json.RawMessage(`{"Type":"auto-reconcile","IntervalSeconds":2}`),
+			},
+		}
+		targets := []pkgmodel.Target{{Label: "test-target"}}
+		mk := func(label string, props json.RawMessage) pkgmodel.Resource {
+			return pkgmodel.Resource{
+				Label: label, Type: "FakeAWS::Resource",
+				Properties: props, Schema: schema,
+				Stack: "partial-failure-stack", Target: "test-target",
+			}
+		}
+
+		// Phase 1: initial reconcile creates all three resources at v1.
+		f1 := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{stack},
+			Resources: []pkgmodel.Resource{
+				mk("resource-a", v1), mk("resource-b", v1), mk("resource-c", v1),
+			},
+			Targets: targets,
+		}
+		m.ApplyForma(f1, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+
+		r := require.New(t)
+		r.Eventually(func() bool {
+			resources, err := m.Datastore.LoadResourcesByStack("partial-failure-stack")
+			return err == nil && len(resources) == 3
+		}, 15*time.Second, 200*time.Millisecond, "initial reconcile should create 3 resources")
+
+		// Phase 2: arm A's update failure, then reconcile with only A
+		// changed. B and C carry their existing v1 properties — the
+		// generator emits no resource_updates rows for them.
+		failAUpdate.Store(true)
+		f2 := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{stack},
+			Resources: []pkgmodel.Resource{
+				mk("resource-a", v2), mk("resource-b", v1), mk("resource-c", v1),
+			},
+			Targets: targets,
+		}
+		m.ApplyForma(f2, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+
+		// Wait for the second reconcile to settle: A still at v1 (its
+		// update failed), B and C still at v1 (untouched). All three
+		// remain in the stack.
+		r.Eventually(func() bool {
+			resources, err := m.Datastore.LoadResourcesByStack("partial-failure-stack")
+			if err != nil || len(resources) != 3 {
+				return false
+			}
+			byLabel := map[string]string{}
+			for _, res := range resources {
+				byLabel[res.Label] = string(res.Properties)
+			}
+			return byLabel["resource-a"] == `{"foo":"v1"}` &&
+				byLabel["resource-b"] == `{"foo":"v1"}` &&
+				byLabel["resource-c"] == `{"foo":"v1"}`
+		}, 15*time.Second, 200*time.Millisecond,
+			"after failed second reconcile: A unchanged (update failed), B and C unchanged (no diff)")
+
+		// Phase 3: auto-reconcile must keep B and C present across
+		// several ticks while it retries A. The auto-reconciler should
+		// see B and C as part of the desired baseline even though the
+		// failed reconcile produced no resource_updates rows for them.
+		// Wait long enough for at least ~5 auto-reconcile ticks (each
+		// 2s) to fire — gives ample time for an incorrect baseline to
+		// delete them.
+		time.Sleep(12 * time.Second)
+		resources, err := m.Datastore.LoadResourcesByStack("partial-failure-stack")
+		r.NoError(err)
+		labels := map[string]bool{}
+		for _, res := range resources {
+			labels[res.Label] = true
+		}
+		r.True(labels["resource-b"], "B must remain present — failed reconcile didn't change it")
+		r.True(labels["resource-c"], "C must remain present — failed reconcile didn't change it")
+		r.True(labels["resource-a"], "A must remain present — its update failed, not deleted")
+
+		// Phase 4: clear A's failure; auto-reconcile should converge A
+		// to v2 without disturbing B or C.
+		failAUpdate.Store(false)
+		r.Eventually(func() bool {
+			resources, err := m.Datastore.LoadResourcesByStack("partial-failure-stack")
+			if err != nil || len(resources) != 3 {
+				return false
+			}
+			byLabel := map[string]string{}
+			for _, res := range resources {
+				byLabel[res.Label] = string(res.Properties)
+			}
+			return byLabel["resource-a"] == `{"foo":"v2"}` &&
+				byLabel["resource-b"] == `{"foo":"v1"}` &&
+				byLabel["resource-c"] == `{"foo":"v1"}`
+		}, 30*time.Second, 500*time.Millisecond,
+			"after clearing A's failure: A=v2 (converged), B and C still at v1")
+	})
+}

--- a/internal/workflow_tests/local/auto_reconciler_test.go
+++ b/internal/workflow_tests/local/auto_reconciler_test.go
@@ -8,6 +8,8 @@ package workflow_tests_local
 
 import (
 	"encoding/json"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -213,5 +215,334 @@ func TestForceReconcile_RejectedWithoutPolicy(t *testing.T) {
 		var policyErr apimodel.ReconcilePolicyRequiredError
 		r.ErrorAs(err, &policyErr, "Error should be ReconcilePolicyRequiredError")
 		r.Equal("no-policy-stack", policyErr.StackLabel)
+	})
+}
+
+// TestAutoReconciler_RetriesFailedUpdate documents whether the auto-reconciler
+// can re-attempt a resource update that failed on the previous reconcile.
+//
+// Scenario: an apply with three resources is issued against a stack with an
+// auto-reconcile policy. One resource's Create fails transiently. Once the
+// transient failure clears, the auto-reconciler should eventually issue a
+// follow-up reconcile that brings the failed resource into the desired state
+// — i.e. the fleet should converge over multiple auto-reconcile ticks, even
+// across intermittent failures.
+//
+// Today, the resources persisted by the previous reconcile are the only basis
+// for the next desired-state forma (via GetResourcesAtLastReconcile), so a
+// resource whose Create failed never appears in any subsequent reconcile and
+// the system cannot self-heal.
+func TestAutoReconciler_RetriesFailedUpdate(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		var failBCreate atomic.Bool
+		failBCreate.Store(true)
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				if request.Label == "resource-b" && failBCreate.Load() {
+					// Use a non-recoverable error code so the PluginOperator's
+					// built-in retries don't paper over the failure — the
+					// update should end up in Failed state, matching the
+					// "transient outage that exceeded local retries" scenario.
+					return &resource.CreateResult{
+						ProgressResult: &resource.ProgressResult{
+							Operation:       resource.OperationCreate,
+							OperationStatus: resource.OperationStatusFailure,
+							ErrorCode:       resource.OperationErrorCodeUnforeseenError,
+							StatusMessage:   "simulated outage (non-recoverable)",
+							NativeID:        "native-" + request.Label,
+						},
+					}, nil
+				}
+				return &resource.CreateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationCreate,
+						OperationStatus: resource.OperationStatusSuccess,
+						NativeID:        "native-" + request.Label,
+					},
+				}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{
+					ResourceType: request.ResourceType,
+					Properties:   `{"foo":"original"}`,
+				}, nil
+			},
+			Update: func(request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				return &resource.UpdateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationUpdate,
+						OperationStatus: resource.OperationStatusSuccess,
+						NativeID:        request.NativeID,
+					},
+				}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		// Disable sync so the only path that can recover the failed resource
+		// is auto-reconcile — keeps this test focused on convergence.
+		cfg.Agent.Synchronization.Enabled = false
+		m, cleanup, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer cleanup()
+		require.NoError(t, err)
+
+		resourceProps := json.RawMessage(`{"foo":"original"}`)
+		schema := pkgmodel.Schema{Fields: []string{"foo"}}
+
+		f := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{
+				{
+					Label: "convergence-stack",
+					Policies: []json.RawMessage{
+						json.RawMessage(`{"Type":"auto-reconcile","IntervalSeconds":2}`),
+					},
+				},
+			},
+			Resources: []pkgmodel.Resource{
+				{Label: "resource-a", Type: "FakeAWS::Resource", Properties: resourceProps, Schema: schema, Stack: "convergence-stack", Target: "test-target"},
+				{Label: "resource-b", Type: "FakeAWS::Resource", Properties: resourceProps, Schema: schema, Stack: "convergence-stack", Target: "test-target"},
+				{Label: "resource-c", Type: "FakeAWS::Resource", Properties: resourceProps, Schema: schema, Stack: "convergence-stack", Target: "test-target"},
+			},
+			Targets: []pkgmodel.Target{{Label: "test-target"}},
+		}
+
+		m.ApplyForma(f, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test-client")
+
+		r := require.New(t)
+
+		// Wait for the initial apply to reach a final state. Only A and C
+		// should have been persisted; B's Create failed.
+		r.Eventually(
+			func() bool {
+				resources, err := m.Datastore.LoadResourcesByStack("convergence-stack")
+				if err != nil {
+					return false
+				}
+				labels := map[string]bool{}
+				for _, res := range resources {
+					labels[res.Label] = true
+				}
+				return labels["resource-a"] && labels["resource-c"] && !labels["resource-b"]
+			},
+			15*time.Second,
+			200*time.Millisecond,
+			"initial apply: A and C should be persisted, B should not (Create failed)",
+		)
+
+		// Clear the transient failure so the next attempt at B succeeds.
+		failBCreate.Store(false)
+
+		// The auto-reconciler should fire (interval=2s) and produce a follow-up
+		// reconcile that includes resource-b. Eventually all three resources
+		// should be present.
+		r.Eventually(
+			func() bool {
+				resources, err := m.Datastore.LoadResourcesByStack("convergence-stack")
+				if err != nil {
+					return false
+				}
+				labels := map[string]bool{}
+				for _, res := range resources {
+					labels[res.Label] = true
+				}
+				return labels["resource-a"] && labels["resource-b"] && labels["resource-c"]
+			},
+			30*time.Second,
+			500*time.Millisecond,
+			"auto-reconciler should retry failed update and converge to all 3 resources present",
+		)
+	})
+}
+
+// TestAutoReconciler_RetriesFailureAndRevertsOOBDriftSimultaneously covers
+// the fleet-convergence scenario this work is motivated by: one node is
+// offline during a fleet-wide update (its update fails), and meanwhile a
+// healthy node has its config drifted out-of-band. Auto-reconcile must
+// revert the OOB drift on the healthy node in the same cycle that retries
+// the offline node — the offline node's repeated failure must not block
+// drift correction on the others.
+func TestAutoReconciler_RetriesFailureAndRevertsOOBDriftSimultaneously(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		var failBUpdate atomic.Bool
+
+		// observedProps simulates the plugin-side ("cloud") view of each
+		// resource's properties, keyed by NativeID (the field Read sees).
+		// Read returns whatever is stored here; successful Updates mutate
+		// it; we mutate it directly to simulate out-of-band drift.
+		var mu sync.Mutex
+		observedProps := map[string]string{}
+		nativeIDFor := func(label string) string { return "native-" + label }
+		getPropsByNativeID := func(nativeID string) string {
+			mu.Lock()
+			defer mu.Unlock()
+			return observedProps[nativeID]
+		}
+		setPropsByNativeID := func(nativeID, props string) {
+			mu.Lock()
+			defer mu.Unlock()
+			observedProps[nativeID] = props
+		}
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				nativeID := nativeIDFor(request.Label)
+				setPropsByNativeID(nativeID, string(request.Properties))
+				return &resource.CreateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationCreate,
+						OperationStatus: resource.OperationStatusSuccess,
+						NativeID:        nativeID,
+					},
+				}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{
+					ResourceType: request.ResourceType,
+					Properties:   getPropsByNativeID(request.NativeID),
+				}, nil
+			},
+			Update: func(request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				if request.Label == "resource-b" && failBUpdate.Load() {
+					return &resource.UpdateResult{
+						ProgressResult: &resource.ProgressResult{
+							Operation:       resource.OperationUpdate,
+							OperationStatus: resource.OperationStatusFailure,
+							ErrorCode:       resource.OperationErrorCodeUnforeseenError,
+							StatusMessage:   "simulated outage (node offline)",
+							NativeID:        request.NativeID,
+						},
+					}, nil
+				}
+				setPropsByNativeID(request.NativeID, string(request.DesiredProperties))
+				return &resource.UpdateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationUpdate,
+						OperationStatus: resource.OperationStatusSuccess,
+						NativeID:        request.NativeID,
+					},
+				}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		// Enable sync so OOB drift propagates from the plugin-side view
+		// into the resources table — the auto-reconciler reads from the
+		// resources table for the existing state side of its diff.
+		cfg.Agent.Synchronization.Enabled = true
+		cfg.Agent.Synchronization.Interval = 1 * time.Second
+		m, cleanup, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer cleanup()
+		require.NoError(t, err)
+
+		schema := pkgmodel.Schema{Fields: []string{"foo"}}
+		v1 := json.RawMessage(`{"foo":"v1"}`)
+		v2 := json.RawMessage(`{"foo":"v2"}`)
+		stack := pkgmodel.Stack{
+			Label: "convergence-stack",
+			Policies: []json.RawMessage{
+				json.RawMessage(`{"Type":"auto-reconcile","IntervalSeconds":2}`),
+			},
+		}
+		targets := []pkgmodel.Target{{Label: "test-target"}}
+
+		// Phase 1: initial apply at v1 — all three succeed.
+		f1 := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{stack},
+			Resources: []pkgmodel.Resource{
+				{Label: "resource-a", Type: "FakeAWS::Resource", Properties: v1, Schema: schema, Stack: "convergence-stack", Target: "test-target"},
+				{Label: "resource-b", Type: "FakeAWS::Resource", Properties: v1, Schema: schema, Stack: "convergence-stack", Target: "test-target"},
+				{Label: "resource-c", Type: "FakeAWS::Resource", Properties: v1, Schema: schema, Stack: "convergence-stack", Target: "test-target"},
+			},
+			Targets: targets,
+		}
+		m.ApplyForma(f1, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+
+		r := require.New(t)
+		r.Eventually(func() bool {
+			resources, err := m.Datastore.LoadResourcesByStack("convergence-stack")
+			return err == nil && len(resources) == 3
+		}, 15*time.Second, 200*time.Millisecond, "initial apply: all 3 resources should be created")
+
+		// Phase 2: arm B's update failure, then apply v2 to all three.
+		failBUpdate.Store(true)
+		f2 := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{stack},
+			Resources: []pkgmodel.Resource{
+				{Label: "resource-a", Type: "FakeAWS::Resource", Properties: v2, Schema: schema, Stack: "convergence-stack", Target: "test-target"},
+				{Label: "resource-b", Type: "FakeAWS::Resource", Properties: v2, Schema: schema, Stack: "convergence-stack", Target: "test-target"},
+				{Label: "resource-c", Type: "FakeAWS::Resource", Properties: v2, Schema: schema, Stack: "convergence-stack", Target: "test-target"},
+			},
+			Targets: targets,
+		}
+		m.ApplyForma(f2, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+
+		// Wait for the second reconcile to settle: A and C at v2, B still at v1.
+		r.Eventually(func() bool {
+			resources, err := m.Datastore.LoadResourcesByStack("convergence-stack")
+			if err != nil {
+				return false
+			}
+			byLabel := map[string]string{}
+			for _, res := range resources {
+				byLabel[res.Label] = string(res.Properties)
+			}
+			return byLabel["resource-a"] == `{"foo":"v2"}` &&
+				byLabel["resource-b"] == `{"foo":"v1"}` &&
+				byLabel["resource-c"] == `{"foo":"v2"}`
+		}, 15*time.Second, 200*time.Millisecond, "after second reconcile: A=v2, B=v1 (failed), C=v2")
+
+		// Phase 3: simulate OOB drift on A — change observed properties.
+		// Sync (1s interval) will detect this and update the resources table.
+		setPropsByNativeID(nativeIDFor("resource-a"), `{"foo":"v_oob"}`)
+		r.Eventually(func() bool {
+			resources, err := m.Datastore.LoadResourcesByStack("convergence-stack")
+			if err != nil {
+				return false
+			}
+			for _, res := range resources {
+				if res.Label == "resource-a" && string(res.Properties) == `{"foo":"v_oob"}` {
+					return true
+				}
+			}
+			return false
+		}, 10*time.Second, 200*time.Millisecond, "sync should ingest OOB drift on A into the resources table")
+
+		// Phase 4: auto-reconcile should revert A's drift while B's update
+		// still fails. We assert by waiting for A's stored properties to
+		// flip back to v2, while B stays at v1.
+		r.Eventually(func() bool {
+			resources, err := m.Datastore.LoadResourcesByStack("convergence-stack")
+			if err != nil {
+				return false
+			}
+			byLabel := map[string]string{}
+			for _, res := range resources {
+				byLabel[res.Label] = string(res.Properties)
+			}
+			return byLabel["resource-a"] == `{"foo":"v2"}` &&
+				byLabel["resource-b"] == `{"foo":"v1"}` &&
+				byLabel["resource-c"] == `{"foo":"v2"}`
+		}, 30*time.Second, 500*time.Millisecond,
+			"auto-reconcile should revert OOB drift on A while B's update continues to fail")
+
+		// Phase 5: clear B's failure; auto-reconcile should drive B to v2
+		// on its next tick without disturbing A or C.
+		failBUpdate.Store(false)
+		r.Eventually(func() bool {
+			resources, err := m.Datastore.LoadResourcesByStack("convergence-stack")
+			if err != nil || len(resources) != 3 {
+				return false
+			}
+			for _, res := range resources {
+				if string(res.Properties) != `{"foo":"v2"}` {
+					return false
+				}
+			}
+			return true
+		}, 30*time.Second, 500*time.Millisecond,
+			"after clearing B's failure: all 3 resources converge to v2")
 	})
 }


### PR DESCRIPTION
## Summary

Auto-reconcile now sources its desired-state baseline from `resource_updates` (per-resource `DesiredState` captured at command-creation time) rather than from the `resources` table (success-only).

A stack with an auto-reconcile policy now converges to the user's declared state even when individual resource updates fail. A transient outage on one node — or any other reason a single resource update fails mid-reconcile — no longer leaves the fleet stuck, and a partial-failure user reconcile (`state=Failed`) becomes the new baseline for retries instead of being ignored in favour of an older successful reconcile.

## Why this was wrong before

`GetResourcesAtLastReconcile` previously read from the `resources` table filtered by `command_id`, with `fc.state = 'Success'` on the command. Two consequences:

1. The `resources` table is only written for successful plugin operations. A failed Create produced no row, so the resource was invisible to every subsequent auto-reconcile tick — first-time failures could never converge.
2. A partial-failure user reconcile (`state=Failed`) was excluded entirely. In the worst case this meant auto-reconcile actively reverted the resources whose updates *had* succeeded back to the older successful reconcile's state, while never retrying the resource whose update failed.

## What changed

The new `GetResourcesAtLastReconcile` query reads `DesiredState` from `resource_updates` with:

- `fc.state IN ('Success', 'Failed')` — failed reconciles contribute the user's latest intent; canceled and in-progress reconciles do not.
- `ru.source = 'user'` — auto-reconcile and sync commands never shift the baseline.
- `ru.operation != 'delete'` — delete intents (implicit or replace pairs) are excluded from the desired baseline.
- `ORDER BY fc.timestamp DESC LIMIT 1` — latest user intent wins.

`prepareReconcile` and `generateResourceUpdatesForReconcile` are unchanged. The generator's existing recompute path handles re-resolution of `$ref` placeholders and dependency-graph computation against current state, so the snapshot from `resource_updates` is treated identically to a fresh user-submitted forma.

Applied identically across the SQLite, Postgres, Aurora Data API, and MSSQL backends.

## Coverage

- **`dstest` cross-backend conformance** — 10 new tests in `suite_get_resources_at_last_reconcile.go`, wired into `RunAll` so they exercise every backend in CI: empty datastore, success/failed inclusion, canceled/in-progress exclusion, delete-row exclusion, non-user-source exclusion, patch-mode exclusion, most-recent-wins, stack-scoping.
- **`TestAutoReconciler_RetriesFailedUpdate`** — first-time failure convergence (3 resources, one create fails transiently, auto-reconcile retries once the failure clears).
- **`TestAutoReconciler_RetriesFailureAndRevertsOOBDriftSimultaneously`** — fleet-update scenario: a successful first reconcile, then a second reconcile where one node is offline and its update fails, then an OOB drift on a healthy node. Asserts that auto-reconcile reverts the OOB drift in the same cycle that retries the offline node, and the fleet fully converges once the offline node comes back.

## Risk

The change is SQL-only in four datastores. The calling code path is unchanged, so all existing behavior around resolvables, cascade-deletes, target replace, alias/rename, discovery, and force-reconcile is unaffected — verified by the existing `TestAutoReconciler_ReconcileAfterSyncChange` (drift reversion via sync) continuing to pass.