### PR TITLE
plugin/sdk: raise MinFormaeVersion to 0.86.0

### DIFF
--- a/pkg/plugin/version.go
+++ b/pkg/plugin/version.go
@@ -7,7 +7,7 @@ package plugin
 // MinFormaeVersion is the minimum formae agent version compatible with this SDK.
 // Plugins built against this SDK should check this at startup to ensure
 // the agent they're running under is compatible.
-const MinFormaeVersion = "0.84.0"
+const MinFormaeVersion = "0.86.0"
 
 // SDKVersion is the version of this SDK package.
 // It is embedded in plugin manifests and used for compatibility checks.

--- a/pkg/plugin/version_test.go
+++ b/pkg/plugin/version_test.go
@@ -17,7 +17,7 @@ import (
 func TestMinFormaeVersion_IsValidSemver(t *testing.T) {
 	v, err := semver.NewVersion(MinFormaeVersion)
 	require.NoError(t, err, "MinFormaeVersion should be a valid semver string")
-	assert.Equal(t, "0.84.0", v.String())
+	assert.Equal(t, "0.86.0", v.String())
 }
 
 func TestSDKVersion_IsValidSemver(t *testing.T) {


### PR DESCRIPTION
## What

Bump the plugin SDK's compatibility floor:

```
pkg/plugin/version.go:  const MinFormaeVersion = "0.84.0"  →  "0.86.0"
```

(plus the matching `version_test.go` assertion).

## Why — driven by the K8s plugin 0.1.4 release

`MinFormaeVersion` is the **source of truth** for the `minFormaeVersion` field plugins publish in their manifest. The K8s plugin's `make build` reads this constant out of the SDK (via `go list -m … MinFormaeVersion`) and writes it into `formae-plugin.pkl` on every build.

The K8s plugin 0.1.4 release (K8s 1.36 support + `MutatingAdmissionPolicy`, see [formae-plugin-kubernetes#26](https://github.com/platform-engineering-labs/formae-plugin-kubernetes/pull/26)) requires **formae ≥ 0.86.0** — its schema dep resolves against `formae@0.86.0` on the hub, and it was committed with `minFormaeVersion = "0.86.0"`.

But the SDK constant was still `0.84.0`, so `make build` **silently downgraded** the plugin's committed `0.86.0` back to `0.84.0` on every local build/install — letting a manifest claim compatibility with an agent that doesn't have the features the plugin needs. Raising the SDK floor to `0.86.0` makes the auto-derived manifest value correct and prevents the downgrade.

## Scope

Only the SDK floor constant + its unit-test assertion. Other `0.84.0` occurrences in `pkg/plugin/**` are unrelated test fixtures (discovery test plugin data, `formae@0.84.0` schema-URI tests) and are intentionally untouched.

## Verification

- `go build ./...` and `go test -count=1 .` in `pkg/plugin` pass.
- `pkg/plugin/testutil` PKL failure seen locally is a fresh-worktree artifact (missing generated `version.semver` at repo root), not related to this change.

## Follow-up

After this releases, bump the formae SDK dep in formae-plugin-kubernetes; `make build` will then auto-write `minFormaeVersion = "0.86.0"` with no Makefile change.