### PR TITLE
fix(discovery): re-arm periodic tick lost to a one-shot cycle

### DIFF
--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -94,7 +94,15 @@ type DiscoveryData struct {
 	ds                            datastore.Datastore
 	serverCfg                     *pkgmodel.ServerConfig
 	discoveryCfg                  *pkgmodel.DiscoveryConfig
-	isScheduledDiscovery          bool
+	// tickPending tracks whether a periodic Discover{} SendAfter is currently in
+	// flight. A successor tick is scheduled on cycle completion iff no timer is
+	// pending, so exactly one periodic timer exists at all times: a tick dropped
+	// while a cycle is running clears the flag and is replaced when that cycle
+	// completes, while a one-shot (Once=true) completing under a pending timer
+	// schedules nothing. Tracking the run's provenance instead (the previous
+	// design) wedged discovery permanently when a one-shot cycle outlived and
+	// swallowed the only pending tick.
+	tickPending                   bool
 	targets                       map[string]pkgmodel.Target
 	resourceHierarchy             map[string]*hierarchyNode
 	resourceDescriptors           map[string]plugin.ResourceDescriptor
@@ -179,6 +187,8 @@ func (d *Discovery) Init(args ...any) (statemachine.StateMachineSpec[DiscoveryDa
 		pluginInfoCache:               make(map[string]*messages.PluginInfoResponse),
 		typesWithChildrenQueued:       make(map[string]struct{}),
 		nativeIDsByCommand:            make(map[string][]string),
+		// The initial tick is armed below when discovery is enabled.
+		tickPending: discoveryCfg.Enabled,
 	}
 
 	spec := statemachine.NewStateMachineSpec(StateIdle,
@@ -212,12 +222,13 @@ func (d *Discovery) Init(args ...any) (statemachine.StateMachineSpec[DiscoveryDa
 func onStateChange(oldState gen.Atom, newState gen.Atom, data DiscoveryData, proc gen.Process) (gen.Atom, DiscoveryData, error) {
 	if oldState == StateDiscovering && newState == StateIdle {
 		proc.Log().Debug("Discovery finished (duration=%s). The following resources have been discovered:\n%s", time.Since(data.timeStarted), renderSummary(data.summary))
-		if data.isScheduledDiscovery {
+		if !data.tickPending && data.discoveryCfg.Enabled {
 			_, err := proc.SendAfter(proc.PID(), Discover{}, data.discoveryCfg.Interval)
 			if err != nil {
 				proc.Log().Error("Failed to schedule next discovery run: %v", err)
 				return newState, data, gen.TerminateReasonPanic
 			}
+			data.tickPending = true
 		}
 	}
 	return newState, data, nil
@@ -278,13 +289,20 @@ func getPluginInfo(proc gen.Process, namespace string) (*messages.PluginInfoResp
 }
 
 func discover(from gen.PID, state gen.Atom, data DiscoveryData, message Discover, proc gen.Process) (gen.Atom, DiscoveryData, []statemachine.Action, error) {
+	// A periodic tick has landed, so its timer is no longer in flight. Recorded
+	// before the already-running guard: a tick dropped into a running cycle is
+	// consumed, and clearing the flag here is what makes that cycle schedule a
+	// replacement when it completes.
+	if !message.Once {
+		data.tickPending = false
+	}
+
 	// Check if a discovery cycle is already running
 	if state == StateDiscovering {
 		proc.Log().Debug("Discovery already running, consider configuring a longer interval")
 		return state, data, nil, nil
 	}
 
-	data.isScheduledDiscovery = !message.Once
 	data.timeStarted = time.Now()
 	data.summary = make(map[string]int)
 
@@ -305,12 +323,13 @@ func discover(from gen.PID, state gen.Atom, data DiscoveryData, message Discover
 	if len(data.targets) == 0 {
 		proc.Log().Debug("No discoverable targets found, completing discovery")
 
-		if data.isScheduledDiscovery {
+		if !data.tickPending && data.discoveryCfg.Enabled {
 			_, err := proc.SendAfter(proc.PID(), Discover{}, data.discoveryCfg.Interval)
 			if err != nil {
 				proc.Log().Error("Failed to schedule next discovery run: %v", err)
 				return StateIdle, data, nil, gen.TerminateReasonPanic
 			}
+			data.tickPending = true
 			proc.Log().Debug("Scheduled next discovery run interval=%s", data.discoveryCfg.Interval)
 		}
 
@@ -364,12 +383,13 @@ func discover(from gen.PID, state gen.Atom, data DiscoveryData, message Discover
 	// to allow future Discover messages to be processed
 	if !data.HasOutstandingWork() {
 		proc.Log().Debug("No targets could be processed (plugins not available), completing discovery")
-		if data.isScheduledDiscovery {
+		if !data.tickPending && data.discoveryCfg.Enabled {
 			_, err := proc.SendAfter(proc.PID(), Discover{}, data.discoveryCfg.Interval)
 			if err != nil {
 				proc.Log().Error("Failed to schedule next discovery run: %v", err)
 				return StateIdle, data, nil, gen.TerminateReasonPanic
 			}
+			data.tickPending = true
 			proc.Log().Debug("Scheduled next discovery run interval=%s", data.discoveryCfg.Interval)
 		}
 		return StateIdle, data, nil, nil

--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -94,15 +94,6 @@ type DiscoveryData struct {
 	ds                            datastore.Datastore
 	serverCfg                     *pkgmodel.ServerConfig
 	discoveryCfg                  *pkgmodel.DiscoveryConfig
-	// tickPending tracks whether a periodic Discover{} SendAfter is currently in
-	// flight. A successor tick is scheduled on cycle completion iff no timer is
-	// pending, so exactly one periodic timer exists at all times: a tick dropped
-	// while a cycle is running clears the flag and is replaced when that cycle
-	// completes, while a one-shot (Once=true) completing under a pending timer
-	// schedules nothing. Tracking the run's provenance instead (the previous
-	// design) wedged discovery permanently when a one-shot cycle outlived and
-	// swallowed the only pending tick.
-	tickPending                   bool
 	targets                       map[string]pkgmodel.Target
 	resourceHierarchy             map[string]*hierarchyNode
 	resourceDescriptors           map[string]plugin.ResourceDescriptor
@@ -128,6 +119,15 @@ type DiscoveryData struct {
 	hasPendingResumeScan bool
 	// Cached plugin info per namespace, refreshed at start of each discovery cycle
 	pluginInfoCache map[string]*messages.PluginInfoResponse
+	// tickPending tracks whether a periodic Discover{} SendAfter is currently in
+	// flight. A successor tick is scheduled on cycle completion iff no timer is
+	// pending, so exactly one periodic timer exists at all times: a tick dropped
+	// while a cycle is running clears the flag and is replaced when that cycle
+	// completes, while a one-shot (Once=true) completing under a pending timer
+	// schedules nothing. Tracking the run's provenance instead (the previous
+	// design) wedged discovery permanently when a one-shot cycle outlived and
+	// swallowed the only pending tick.
+	tickPending bool
 }
 
 func (d *DiscoveryData) SetTargets(targets []*pkgmodel.Target) {

--- a/internal/metastructure/discovery/periodic_rearm_test.go
+++ b/internal/metastructure/discovery/periodic_rearm_test.go
@@ -1,0 +1,139 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package discovery
+
+import (
+	"testing"
+	"time"
+
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+)
+
+// stubDiscoveryDatastore is a datastore.Datastore test double that only serves
+// the discoverable-targets lookup discover() performs at the start of a cycle.
+type stubDiscoveryDatastore struct {
+	datastore.Datastore
+
+	targets []*pkgmodel.Target
+}
+
+func (s *stubDiscoveryDatastore) LoadDiscoverableTargets() ([]*pkgmodel.Target, error) {
+	return s.targets, nil
+}
+
+// newDiscoverData builds a DiscoveryData wired to one discoverable target whose
+// plugin reports a single discoverable resource type, ready to be driven through
+// the discover() and onStateChange() handlers directly.
+func newDiscoverData(proc *stubProcess) DiscoveryData {
+	const namespace = "FakeAWS"
+
+	proc.pluginInfo = &messages.PluginInfoResponse{
+		Found:     true,
+		Namespace: namespace,
+		SupportedResources: []plugin.ResourceDescriptor{
+			{Type: "FakeAWS::EC2::InternetGateway", Discoverable: true},
+		},
+	}
+
+	return DiscoveryData{
+		ds: &stubDiscoveryDatastore{targets: []*pkgmodel.Target{
+			{Label: "us-east-1", Namespace: namespace, Discoverable: true},
+		}},
+		discoveryCfg:                  &pkgmodel.DiscoveryConfig{Enabled: true, Interval: 20 * time.Second},
+		serverCfg:                     &pkgmodel.ServerConfig{},
+		targets:                       map[string]pkgmodel.Target{},
+		resourceHierarchy:             map[string]*hierarchyNode{},
+		resourceDescriptors:           map[string]plugin.ResourceDescriptor{},
+		queuedListOperations:          map[string][]ListOperation{},
+		outstandingListOperations:     map[string]ListOperation{},
+		outstandingSyncCommands:       map[string]ListOperation{},
+		recentlyDiscoveredResourceIDs: map[string]struct{}{},
+		summary:                       map[string]int{},
+		pluginInfoCache:               map[string]*messages.PluginInfoResponse{},
+		typesWithChildrenQueued:       map[string]struct{}{},
+		nativeIDsByCommand:            map[string][]string{},
+	}
+}
+
+// Regression test for the discovery wedge: a one-shot Discover{Once:true}
+// (fired by target persistence during an apply) enters Discovering and is held
+// there while the apply runs. The pending periodic tick fires mid-cycle, hits
+// the already-running guard, and is dropped. When the one-shot cycle finally
+// completes, a replacement periodic tick MUST be scheduled — otherwise the
+// periodic chain is dead until agent restart and out-of-band resources are
+// never discovered.
+func TestOneShotCycleThatSwallowsPeriodicTickReschedulesOnCompletion(t *testing.T) {
+	proc := &stubProcess{}
+	data := newDiscoverData(proc)
+
+	// A one-shot discovery starts while Idle (target persisted during apply).
+	state, data, _, err := discover(gen.PID{}, StateIdle, data, Discover{Once: true}, proc)
+	require.NoError(t, err)
+	require.Equal(t, StateDiscovering, state, "one-shot must start a cycle")
+	require.Equal(t, 0, proc.scheduledDiscoverCount(), "a one-shot run must not arm the periodic ticker by itself")
+
+	// The pending periodic tick fires mid-cycle and is dropped by the
+	// already-running guard. This consumes the only periodic timer in flight.
+	state, data, _, err = discover(gen.PID{}, state, data, Discover{}, proc)
+	require.NoError(t, err)
+	require.Equal(t, StateDiscovering, state, "tick during a running cycle must be dropped, not start a second cycle")
+
+	// The parked one-shot cycle completes (apply finished, queue drained).
+	_, _, err = onStateChange(StateDiscovering, StateIdle, data, proc)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, proc.scheduledDiscoverCount(),
+		"the dropped periodic tick must be replaced when the cycle completes; otherwise periodic discovery is dead until restart")
+}
+
+// A fast one-shot that completes while the periodic timer is still pending must
+// NOT schedule an additional tick — otherwise every force_discover or
+// target-persist trigger would spawn an extra periodic chain and multiply the
+// scan frequency.
+func TestOneShotCompletionWithPendingTickDoesNotDoubleSchedule(t *testing.T) {
+	proc := &stubProcess{}
+	data := newDiscoverData(proc)
+
+	// A periodic cycle runs and completes: it schedules the next tick (baton out).
+	state, data, _, err := discover(gen.PID{}, StateIdle, data, Discover{}, proc)
+	require.NoError(t, err)
+	require.Equal(t, StateDiscovering, state)
+	_, data, err = onStateChange(StateDiscovering, StateIdle, data, proc)
+	require.NoError(t, err)
+	require.Equal(t, 1, proc.scheduledDiscoverCount(), "a periodic cycle must schedule its successor on completion")
+
+	// A one-shot starts and completes while that tick is still pending.
+	state, data, _, err = discover(gen.PID{}, StateIdle, data, Discover{Once: true}, proc)
+	require.NoError(t, err)
+	require.Equal(t, StateDiscovering, state)
+	_, _, err = onStateChange(StateDiscovering, StateIdle, data, proc)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, proc.scheduledDiscoverCount(),
+		"a one-shot completing while a periodic tick is pending must not schedule a second timer")
+}
+
+// The plain periodic loop: each cycle schedules exactly one successor on
+// completion.
+func TestPeriodicCycleSchedulesExactlyOneSuccessor(t *testing.T) {
+	proc := &stubProcess{}
+	data := newDiscoverData(proc)
+
+	state, data, _, err := discover(gen.PID{}, StateIdle, data, Discover{}, proc)
+	require.NoError(t, err)
+	require.Equal(t, StateDiscovering, state)
+
+	_, _, err = onStateChange(StateDiscovering, StateIdle, data, proc)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, proc.scheduledDiscoverCount())
+}

--- a/internal/metastructure/discovery/spawn_timeout_test.go
+++ b/internal/metastructure/discovery/spawn_timeout_test.go
@@ -51,6 +51,14 @@ type stubProcess struct {
 	spawn func(n int, req messages.SpawnPluginOperator) (any, error)
 
 	spawnRequests []messages.SpawnPluginOperator
+
+	// pluginInfo, when set, answers GetPluginInfo calls so discover() can be
+	// driven end-to-end without a PluginCoordinator.
+	pluginInfo *messages.PluginInfoResponse
+
+	// sendAfterMsgs records every message scheduled via SendAfter, so tests can
+	// assert on the periodic Discover re-arm behavior.
+	sendAfterMsgs []any
 }
 
 func (p *stubProcess) Log() gen.Log   { return stubLog{} }
@@ -59,8 +67,21 @@ func (p *stubProcess) PID() gen.PID   { return gen.PID{Node: "test-node", ID: 1}
 
 func (p *stubProcess) Send(_ any, _ any) error { return nil }
 
-func (p *stubProcess) SendAfter(_ any, _ any, _ time.Duration) (gen.CancelFunc, error) {
+func (p *stubProcess) SendAfter(_ any, message any, _ time.Duration) (gen.CancelFunc, error) {
+	p.sendAfterMsgs = append(p.sendAfterMsgs, message)
 	return func() bool { return true }, nil
+}
+
+// scheduledDiscoverCount returns how many periodic Discover messages have been
+// scheduled via SendAfter.
+func (p *stubProcess) scheduledDiscoverCount() int {
+	n := 0
+	for _, m := range p.sendAfterMsgs {
+		if _, ok := m.(Discover); ok {
+			n++
+		}
+	}
+	return n
 }
 
 func (p *stubProcess) Call(_ any, message any) (any, error) {
@@ -68,6 +89,11 @@ func (p *stubProcess) Call(_ any, message any) (any, error) {
 	case changeset.RequestTokens:
 		// Grant every token requested so the whole queue is scanned in one pass.
 		return changeset.TokensGranted{N: m.N}, nil
+	case messages.GetPluginInfo:
+		if p.pluginInfo != nil {
+			return *p.pluginInfo, nil
+		}
+		return nil, fmt.Errorf("stubProcess: no pluginInfo configured")
 	case messages.SpawnPluginOperator:
 		p.spawnRequests = append(p.spawnRequests, m)
 		if p.spawn != nil {


### PR DESCRIPTION
## Summary

Fixes the 0.86.0-reported bug where periodic discovery permanently stops after `formae apply` creates a new discoverable target (e.g. the lifeline example), so out-of-band resources — like a manually created internet gateway — are never discovered until the agent restarts.

## Root cause

The periodic loop is a single timer chain: each cycle schedules its successor **on completion**, gated by `isScheduledDiscovery` ("was this run periodic?"). Sequence that kills it (reproduced live, v0.86.0, 20s interval, lifeline apply ~70s):

1. Apply persists a new discoverable target → `resource_persister` fires `Discover{Once:true}`.
2. The one-shot sets `isScheduledDiscovery=false` and enters `Discovering`; the apply's discovery pause parks it there for the whole apply.
3. The pending periodic tick fires mid-apply → already-running guard drops it. The only timer in flight is now gone.
4. The parked cycle completes → reschedule is skipped (flag is false). No timer exists, none is ever created. Dead until restart (`Init` is the only other arm site).

Log evidence: `Discovery already running` at the dropped tick, then `Discovery finished (duration=1m10s)` with no subsequent `Starting resource discovery`. Reachable since 0.75.2 (#61 one-shot-on-target-persist + #83 pause-during-apply) whenever an apply that creates a target outlives the discovery interval; 0.86.0 made it visible by fixing the louder discovery-death modes (spawn-stall hangs, 38d3ac79).

## Fix

Replace the run-provenance flag with `tickPending` — tracking the **timer**, not the run:

- a landing periodic tick clears `tickPending` (recorded *before* the busy guard, so a dropped tick is accounted for);
- every cycle completion (and the no-targets / no-work early exits) schedules a successor **iff** no timer is pending.

Invariant: exactly one periodic timer in flight at all times.

- the wedge heals: the cycle that swallowed the tick schedules the replacement when it completes
- no double chains: a fast one-shot completing under a pending tick schedules nothing (`force_discover` spam can't multiply scan frequency)
- cadence unchanged: still fixed-delay (gap between cycles ≥ interval) — no increase in cloud List/Describe volume

## Tests

- `TestOneShotCycleThatSwallowsPeriodicTickReschedulesOnCompletion` — the wedge; red before this change (0 timers scheduled), green after
- `TestOneShotCompletionWithPendingTickDoesNotDoubleSchedule` — guards against extra timer chains
- `TestPeriodicCycleSchedulesExactlyOneSuccessor` — plain loop behavior
- existing discovery/changeset/resource_persister suites pass

## Live verification (pre-fix repro)

agent start → apply lifeline (reconcile) → `aws ec2 create-internet-gateway` out-of-band → 3+ intervals: never discovered; log shows discovery dead after the apply. Same scenario on a patched build should discover the IGW within one interval — happy to run that on this branch before merge.