### PR TITLE
refactor(discovery,sync): use GenericTimeout for periodic re-arm

### DIFF
--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -75,9 +75,7 @@ func NewDiscovery() gen.ProcessBehavior {
 
 // Messages processed by Discovery
 
-type Discover struct {
-	Once bool
-}
+type Discover struct{}
 
 type ResumeScanning struct{}
 
@@ -88,7 +86,26 @@ const (
 	// InitialDelay is the delay before the first discovery run after startup
 	// to allow the plugins to register.
 	InitialDelay = 10 * time.Second
+
+	// discoveryTickName is the GenericTimeout name used for the periodic
+	// re-arm. Setting a new timer with this name auto-cancels any prior one,
+	// so exactly one periodic tick is in flight at any time.
+	discoveryTickName = gen.Atom("discovery-tick")
 )
+
+// rescheduleAction returns the action that schedules the next periodic
+// discovery. Auto-cancel-on-replace semantics of the named GenericTimeout
+// guarantee a single periodic chain.
+func rescheduleAction(data DiscoveryData) []statemachine.Action {
+	if !data.discoveryCfg.Enabled {
+		return nil
+	}
+	return []statemachine.Action{statemachine.GenericTimeout{
+		Name:     discoveryTickName,
+		Duration: data.discoveryCfg.Interval,
+		Message:  Discover{},
+	}}
+}
 
 type DiscoveryData struct {
 	ds                            datastore.Datastore
@@ -119,15 +136,6 @@ type DiscoveryData struct {
 	hasPendingResumeScan bool
 	// Cached plugin info per namespace, refreshed at start of each discovery cycle
 	pluginInfoCache map[string]*messages.PluginInfoResponse
-	// tickPending tracks whether a periodic Discover{} SendAfter is currently in
-	// flight. A successor tick is scheduled on cycle completion iff no timer is
-	// pending, so exactly one periodic timer exists at all times: a tick dropped
-	// while a cycle is running clears the flag and is replaced when that cycle
-	// completes, while a one-shot (Once=true) completing under a pending timer
-	// schedules nothing. Tracking the run's provenance instead (the previous
-	// design) wedged discovery permanently when a one-shot cycle outlived and
-	// swallowed the only pending tick.
-	tickPending bool
 }
 
 func (d *DiscoveryData) SetTargets(targets []*pkgmodel.Target) {
@@ -187,8 +195,6 @@ func (d *Discovery) Init(args ...any) (statemachine.StateMachineSpec[DiscoveryDa
 		pluginInfoCache:               make(map[string]*messages.PluginInfoResponse),
 		typesWithChildrenQueued:       make(map[string]struct{}),
 		nativeIDsByCommand:            make(map[string][]string),
-		// The initial tick is armed below when discovery is enabled.
-		tickPending: discoveryCfg.Enabled,
 	}
 
 	spec := statemachine.NewStateMachineSpec(StateIdle,
@@ -222,14 +228,6 @@ func (d *Discovery) Init(args ...any) (statemachine.StateMachineSpec[DiscoveryDa
 func onStateChange(oldState gen.Atom, newState gen.Atom, data DiscoveryData, proc gen.Process) (gen.Atom, DiscoveryData, error) {
 	if oldState == StateDiscovering && newState == StateIdle {
 		proc.Log().Debug("Discovery finished (duration=%s). The following resources have been discovered:\n%s", time.Since(data.timeStarted), renderSummary(data.summary))
-		if !data.tickPending && data.discoveryCfg.Enabled {
-			_, err := proc.SendAfter(proc.PID(), Discover{}, data.discoveryCfg.Interval)
-			if err != nil {
-				proc.Log().Error("Failed to schedule next discovery run: %v", err)
-				return newState, data, gen.TerminateReasonPanic
-			}
-			data.tickPending = true
-		}
 	}
 	return newState, data, nil
 }
@@ -289,14 +287,6 @@ func getPluginInfo(proc gen.Process, namespace string) (*messages.PluginInfoResp
 }
 
 func discover(from gen.PID, state gen.Atom, data DiscoveryData, message Discover, proc gen.Process) (gen.Atom, DiscoveryData, []statemachine.Action, error) {
-	// A periodic tick has landed, so its timer is no longer in flight. Recorded
-	// before the already-running guard: a tick dropped into a running cycle is
-	// consumed, and clearing the flag here is what makes that cycle schedule a
-	// replacement when it completes.
-	if !message.Once {
-		data.tickPending = false
-	}
-
 	// Check if a discovery cycle is already running
 	if state == StateDiscovering {
 		proc.Log().Debug("Discovery already running, consider configuring a longer interval")
@@ -322,18 +312,7 @@ func discover(from gen.PID, state gen.Atom, data DiscoveryData, message Discover
 	// If there are no discoverable targets, complete discovery immediately
 	if len(data.targets) == 0 {
 		proc.Log().Debug("No discoverable targets found, completing discovery")
-
-		if !data.tickPending && data.discoveryCfg.Enabled {
-			_, err := proc.SendAfter(proc.PID(), Discover{}, data.discoveryCfg.Interval)
-			if err != nil {
-				proc.Log().Error("Failed to schedule next discovery run: %v", err)
-				return StateIdle, data, nil, gen.TerminateReasonPanic
-			}
-			data.tickPending = true
-			proc.Log().Debug("Scheduled next discovery run interval=%s", data.discoveryCfg.Interval)
-		}
-
-		return StateIdle, data, nil, nil
+		return StateIdle, data, rescheduleAction(data), nil
 	}
 
 	for _, target := range data.targets {
@@ -383,16 +362,7 @@ func discover(from gen.PID, state gen.Atom, data DiscoveryData, message Discover
 	// to allow future Discover messages to be processed
 	if !data.HasOutstandingWork() {
 		proc.Log().Debug("No targets could be processed (plugins not available), completing discovery")
-		if !data.tickPending && data.discoveryCfg.Enabled {
-			_, err := proc.SendAfter(proc.PID(), Discover{}, data.discoveryCfg.Interval)
-			if err != nil {
-				proc.Log().Error("Failed to schedule next discovery run: %v", err)
-				return StateIdle, data, nil, gen.TerminateReasonPanic
-			}
-			data.tickPending = true
-			proc.Log().Debug("Scheduled next discovery run interval=%s", data.discoveryCfg.Interval)
-		}
-		return StateIdle, data, nil, nil
+		return StateIdle, data, rescheduleAction(data), nil
 	}
 
 	// Send ResumeScanning only after confirming work was queued and we're transitioning to StateDiscovering.
@@ -474,7 +444,7 @@ func resumeScanning(from gen.PID, state gen.Atom, data DiscoveryData, message Re
 	// scheduled discovery run is queued; otherwise Discovery would hang in
 	// StateDiscovering forever.
 	if !data.HasOutstandingWork() {
-		return StateIdle, data, nil, nil
+		return StateIdle, data, rescheduleAction(data), nil
 	}
 
 	return StateDiscovering, data, nil, nil
@@ -557,7 +527,7 @@ func processListing(from gen.PID, state gen.Atom, data DiscoveryData, message pl
 	if message.Error != "" {
 		proc.Log().Error("Failed to list resources for %s in target %s: %s", message.ResourceType, message.TargetLabel, message.Error)
 		if !data.HasOutstandingWork() {
-			return StateIdle, data, nil, nil
+			return StateIdle, data, rescheduleAction(data), nil
 		}
 		return state, data, nil, nil
 	}
@@ -583,12 +553,12 @@ func processListing(from gen.PID, state gen.Atom, data DiscoveryData, message pl
 		if err := discoverChildrenOnce(op, data, proc); err != nil {
 			proc.Log().Error("Failed to discover children for %s in target %s: %v", message.ResourceType, message.TargetLabel, err)
 			if !data.HasOutstandingWork() {
-				return StateIdle, data, nil, nil
+				return StateIdle, data, rescheduleAction(data), nil
 			}
 			return state, data, nil, nil
 		}
 		if !data.HasOutstandingWork() {
-			return StateIdle, data, nil, nil
+			return StateIdle, data, rescheduleAction(data), nil
 		}
 		return state, data, nil, nil
 	}
@@ -598,7 +568,7 @@ func processListing(from gen.PID, state gen.Atom, data DiscoveryData, message pl
 	if !ok {
 		proc.Log().Error("Target not found for label %s", message.TargetLabel)
 		if !data.HasOutstandingWork() {
-			return StateIdle, data, nil, nil
+			return StateIdle, data, rescheduleAction(data), nil
 		}
 		return state, data, nil, nil
 	}
@@ -608,7 +578,7 @@ func processListing(from gen.PID, state gen.Atom, data DiscoveryData, message pl
 	if err != nil {
 		proc.Log().Error("Failed to synchronize resources for %s in target %s: %v", message.ResourceType, message.TargetLabel, err)
 		if !data.HasOutstandingWork() {
-			return StateIdle, data, nil, nil
+			return StateIdle, data, rescheduleAction(data), nil
 		}
 	}
 
@@ -847,7 +817,7 @@ func syncCompleted(from gen.PID, state gen.Atom, data DiscoveryData, message cha
 		proc.Log().Error("Discovery failed to synchronize discovered resources resourceType=%s listParams=%s commandID=%s", op.ResourceType, op.ListParams, message.CommandID)
 		delete(data.nativeIDsByCommand, message.CommandID)
 		if !data.HasOutstandingWork() {
-			return StateIdle, data, nil, nil
+			return StateIdle, data, rescheduleAction(data), nil
 		}
 	}
 
@@ -865,7 +835,7 @@ func syncCompleted(from gen.PID, state gen.Atom, data DiscoveryData, message cha
 		if err != nil {
 			proc.Log().Error("Failed to load parent resources for child discovery type=%s target=%s: %v", op.ResourceType, op.TargetLabel, err)
 			if !data.HasOutstandingWork() {
-				return StateIdle, data, nil, nil
+				return StateIdle, data, rescheduleAction(data), nil
 			}
 			return state, data, nil, nil
 		}
@@ -885,13 +855,13 @@ func syncCompleted(from gen.PID, state gen.Atom, data DiscoveryData, message cha
 		if err := discoverChildren(syncedParents, op, data, proc); err != nil {
 			proc.Log().Error("Failed to discover children for %s in target %s: %v", op.ResourceType, op.TargetLabel, err)
 			if !data.HasOutstandingWork() {
-				return StateIdle, data, nil, nil
+				return StateIdle, data, rescheduleAction(data), nil
 			}
 			return state, data, nil, nil
 		}
 	}
 	if !data.HasOutstandingWork() {
-		return StateIdle, data, nil, nil
+		return StateIdle, data, rescheduleAction(data), nil
 	}
 
 	return state, data, nil, nil

--- a/internal/metastructure/discovery/periodic_rearm_test.go
+++ b/internal/metastructure/discovery/periodic_rearm_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"ergo.services/actor/statemachine"
 	"ergo.services/ergo/gen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,7 @@ func (s *stubDiscoveryDatastore) LoadDiscoverableTargets() ([]*pkgmodel.Target, 
 
 // newDiscoverData builds a DiscoveryData wired to one discoverable target whose
 // plugin reports a single discoverable resource type, ready to be driven through
-// the discover() and onStateChange() handlers directly.
+// the discover() handler directly.
 func newDiscoverData(proc *stubProcess) DiscoveryData {
 	const namespace = "FakeAWS"
 
@@ -64,76 +65,53 @@ func newDiscoverData(proc *stubProcess) DiscoveryData {
 	}
 }
 
-// Regression test for the discovery wedge: a one-shot Discover{Once:true}
-// (fired by target persistence during an apply) enters Discovering and is held
-// there while the apply runs. The pending periodic tick fires mid-cycle, hits
-// the already-running guard, and is dropped. When the one-shot cycle finally
-// completes, a replacement periodic tick MUST be scheduled — otherwise the
-// periodic chain is dead until agent restart and out-of-band resources are
-// never discovered.
-func TestOneShotCycleThatSwallowsPeriodicTickReschedulesOnCompletion(t *testing.T) {
+// A Discover arriving while a discovery cycle is running (e.g. force_discover
+// or a target persisted mid-cycle) must not break the periodic chain. The
+// busy guard drops the message without producing actions, and a subsequent
+// cycle completion still returns a GenericTimeout to schedule the next tick.
+//
+// The named-timer design makes the wedge that 0.86.0 hit (a cycle swallowing
+// the only pending periodic tick) structurally impossible: every transition
+// to Idle returns a fresh GenericTimeout, and the framework auto-cancels any
+// prior tick with the same name. There is no flag whose stale value could
+// suppress the next schedule.
+func TestDiscoverDuringRunningCycleDoesNotKillPeriodicChain(t *testing.T) {
 	proc := &stubProcess{}
 	data := newDiscoverData(proc)
 
-	// A one-shot discovery starts while Idle (target persisted during apply).
-	state, data, _, err := discover(gen.PID{}, StateIdle, data, Discover{Once: true}, proc)
+	// A Discover lands during a running cycle. Busy guard drops it without
+	// producing actions.
+	state, _, actions, err := discover(gen.PID{}, StateDiscovering, data, Discover{}, proc)
 	require.NoError(t, err)
-	require.Equal(t, StateDiscovering, state, "one-shot must start a cycle")
-	require.Equal(t, 0, proc.scheduledDiscoverCount(), "a one-shot run must not arm the periodic ticker by itself")
+	require.Equal(t, StateDiscovering, state, "Discover during a running cycle must be dropped, not start a second cycle")
+	require.Empty(t, actions, "a dropped message must not produce actions")
 
-	// The pending periodic tick fires mid-cycle and is dropped by the
-	// already-running guard. This consumes the only periodic timer in flight.
-	state, data, _, err = discover(gen.PID{}, state, data, Discover{}, proc)
+	// A subsequent cycle completes — here exercised via the no-targets early
+	// exit, which is the simplest path through discover() that returns to
+	// Idle with a rescheduleAction. The full completion paths in
+	// processListing/syncCompleted use the same helper.
+	data.ds = &stubDiscoveryDatastore{targets: nil}
+	nextState, _, actions, err := discover(gen.PID{}, StateIdle, data, Discover{}, proc)
 	require.NoError(t, err)
-	require.Equal(t, StateDiscovering, state, "tick during a running cycle must be dropped, not start a second cycle")
+	require.Equal(t, StateIdle, nextState)
 
-	// The parked one-shot cycle completes (apply finished, queue drained).
-	_, _, err = onStateChange(StateDiscovering, StateIdle, data, proc)
-	require.NoError(t, err)
-
-	assert.Equal(t, 1, proc.scheduledDiscoverCount(),
-		"the dropped periodic tick must be replaced when the cycle completes; otherwise periodic discovery is dead until restart")
+	require.Len(t, actions, 1, "cycle completion must schedule the next periodic tick")
+	timeout, ok := actions[0].(statemachine.GenericTimeout)
+	require.True(t, ok, "scheduled action must be a GenericTimeout (named timer so a fresh schedule cancels any prior one)")
+	assert.Equal(t, discoveryTickName, timeout.Name)
+	assert.Equal(t, data.discoveryCfg.Interval, timeout.Duration)
+	assert.Equal(t, Discover{}, timeout.Message)
 }
 
-// A fast one-shot that completes while the periodic timer is still pending must
-// NOT schedule an additional tick — otherwise every force_discover or
-// target-persist trigger would spawn an extra periodic chain and multiply the
-// scan frequency.
-func TestOneShotCompletionWithPendingTickDoesNotDoubleSchedule(t *testing.T) {
+// When discovery is disabled, no periodic chain should exist; cycle
+// completion must not schedule a tick.
+func TestDiscoveryDisabledDoesNotScheduleTick(t *testing.T) {
 	proc := &stubProcess{}
 	data := newDiscoverData(proc)
+	data.discoveryCfg = &pkgmodel.DiscoveryConfig{Enabled: false, Interval: 20 * time.Second}
+	data.ds = &stubDiscoveryDatastore{targets: nil}
 
-	// A periodic cycle runs and completes: it schedules the next tick (baton out).
-	state, data, _, err := discover(gen.PID{}, StateIdle, data, Discover{}, proc)
+	_, _, actions, err := discover(gen.PID{}, StateIdle, data, Discover{}, proc)
 	require.NoError(t, err)
-	require.Equal(t, StateDiscovering, state)
-	_, data, err = onStateChange(StateDiscovering, StateIdle, data, proc)
-	require.NoError(t, err)
-	require.Equal(t, 1, proc.scheduledDiscoverCount(), "a periodic cycle must schedule its successor on completion")
-
-	// A one-shot starts and completes while that tick is still pending.
-	state, data, _, err = discover(gen.PID{}, StateIdle, data, Discover{Once: true}, proc)
-	require.NoError(t, err)
-	require.Equal(t, StateDiscovering, state)
-	_, _, err = onStateChange(StateDiscovering, StateIdle, data, proc)
-	require.NoError(t, err)
-
-	assert.Equal(t, 1, proc.scheduledDiscoverCount(),
-		"a one-shot completing while a periodic tick is pending must not schedule a second timer")
-}
-
-// The plain periodic loop: each cycle schedules exactly one successor on
-// completion.
-func TestPeriodicCycleSchedulesExactlyOneSuccessor(t *testing.T) {
-	proc := &stubProcess{}
-	data := newDiscoverData(proc)
-
-	state, data, _, err := discover(gen.PID{}, StateIdle, data, Discover{}, proc)
-	require.NoError(t, err)
-	require.Equal(t, StateDiscovering, state)
-
-	_, _, err = onStateChange(StateDiscovering, StateIdle, data, proc)
-	require.NoError(t, err)
-
-	assert.Equal(t, 1, proc.scheduledDiscoverCount())
+	assert.Empty(t, actions, "disabled discovery must not schedule any timer")
 }

--- a/internal/metastructure/discovery/spawn_timeout_test.go
+++ b/internal/metastructure/discovery/spawn_timeout_test.go
@@ -55,10 +55,6 @@ type stubProcess struct {
 	// pluginInfo, when set, answers GetPluginInfo calls so discover() can be
 	// driven end-to-end without a PluginCoordinator.
 	pluginInfo *messages.PluginInfoResponse
-
-	// sendAfterMsgs records every message scheduled via SendAfter, so tests can
-	// assert on the periodic Discover re-arm behavior.
-	sendAfterMsgs []any
 }
 
 func (p *stubProcess) Log() gen.Log   { return stubLog{} }
@@ -66,23 +62,6 @@ func (p *stubProcess) Node() gen.Node { return stubNode{} }
 func (p *stubProcess) PID() gen.PID   { return gen.PID{Node: "test-node", ID: 1} }
 
 func (p *stubProcess) Send(_ any, _ any) error { return nil }
-
-func (p *stubProcess) SendAfter(_ any, message any, _ time.Duration) (gen.CancelFunc, error) {
-	p.sendAfterMsgs = append(p.sendAfterMsgs, message)
-	return func() bool { return true }, nil
-}
-
-// scheduledDiscoverCount returns how many periodic Discover messages have been
-// scheduled via SendAfter.
-func (p *stubProcess) scheduledDiscoverCount() int {
-	n := 0
-	for _, m := range p.sendAfterMsgs {
-		if _, ok := m.(Discover); ok {
-			n++
-		}
-	}
-	return n
-}
 
 func (p *stubProcess) Call(_ any, message any) (any, error) {
 	switch m := message.(type) {
@@ -112,6 +91,7 @@ func newScanData(resourceTypes ...string) DiscoveryData {
 	const targetLabel = "us-east-1"
 
 	data := DiscoveryData{
+		discoveryCfg: &pkgmodel.DiscoveryConfig{Enabled: true, Interval: 20 * time.Second},
 		targets: map[string]pkgmodel.Target{
 			targetLabel: {Label: targetLabel, Namespace: namespace, Discoverable: true},
 		},

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1209,7 +1209,7 @@ func (m *Metastructure) ListDrift(stack string) (*apimodel.ModifiedStack, error)
 }
 
 func (m *Metastructure) ForceSync() error {
-	if err := m.Node.Send(gen.Atom("Synchronizer"), Synchronize{Once: true}); err != nil {
+	if err := m.Node.Send(gen.Atom("Synchronizer"), Synchronize{}); err != nil {
 		slog.Error(fmt.Sprintf("Failed to send message to Synchronizer: %v", err))
 		return err
 	}
@@ -1218,7 +1218,7 @@ func (m *Metastructure) ForceSync() error {
 }
 
 func (m *Metastructure) ForceDiscovery() error {
-	if err := m.Node.Send(gen.Atom("Discovery"), discovery.Discover{Once: true}); err != nil {
+	if err := m.Node.Send(gen.Atom("Discovery"), discovery.Discover{}); err != nil {
 		slog.Error(fmt.Sprintf("Failed to send message to Discovery: %v", err))
 		return err
 	}

--- a/internal/metastructure/resource_persister/resource_persister.go
+++ b/internal/metastructure/resource_persister/resource_persister.go
@@ -532,7 +532,7 @@ func (rp *ResourcePersister) persistTargetUpdate(update *target_update.TargetUpd
 			Name: actornames.Discovery,
 			Node: rp.Node().Name(),
 		}
-		if err := rp.Send(discoveryPID, discovery.Discover{Once: true}); err != nil {
+		if err := rp.Send(discoveryPID, discovery.Discover{}); err != nil {
 			rp.Log().Error("Failed to trigger discovery for newly discoverable target label=%s: %v",
 				update.Target.Label, err)
 		} else {

--- a/internal/metastructure/synchronizer.go
+++ b/internal/metastructure/synchronizer.go
@@ -69,9 +69,8 @@ type SynchronizerData struct {
 	datastore datastore.Datastore
 	cfg       pkgmodel.SynchronizationConfig
 
-	isScheduledSync bool
-	timeStarted     time.Time
-	commandID       string
+	timeStarted time.Time
+	commandID   string
 
 	// excludedResources tracks resources that are currently being updated by
 	// non-sync operations (e.g., user apply/destroy commands). These resources
@@ -81,8 +80,22 @@ type SynchronizerData struct {
 
 // Messages processed by Synchronizer
 
-type Synchronize struct {
-	Once bool
+type Synchronize struct{}
+
+const syncTickName = gen.Atom("sync-tick")
+
+// rescheduleAction returns the action that schedules the next periodic
+// synchronization. Setting a GenericTimeout with the same name auto-cancels
+// any prior pending timer, so exactly one tick is in flight at any time.
+func rescheduleAction(data SynchronizerData) []statemachine.Action {
+	if !data.cfg.Enabled {
+		return nil
+	}
+	return []statemachine.Action{statemachine.GenericTimeout{
+		Name:     syncTickName,
+		Duration: data.cfg.Interval,
+		Message:  Synchronize{},
+	}}
 }
 
 func (s *Synchronizer) Init(args ...any) (statemachine.StateMachineSpec[SynchronizerData], error) {
@@ -138,21 +151,17 @@ func (s *Synchronizer) Init(args ...any) (statemachine.StateMachineSpec[Synchron
 func onStateChange(oldState gen.Atom, newState gen.Atom, data SynchronizerData, proc gen.Process) (gen.Atom, SynchronizerData, error) {
 	if oldState == StateSynchronizing && newState == StateIdle {
 		proc.Log().Debug("Synchronization finished duration=%s", time.Since(data.timeStarted))
-		if err := scheduleNextSync(data, proc); err != nil {
-			return newState, data, gen.TerminateReasonPanic
-		}
 	}
 	return newState, data, nil
 }
 
 func synchronize(from gen.PID, state gen.Atom, data SynchronizerData, message Synchronize, proc gen.Process) (gen.Atom, SynchronizerData, []statemachine.Action, error) {
-	data.isScheduledSync = !message.Once
-	data.timeStarted = time.Now()
-
 	if state == StateSynchronizing {
 		proc.Log().Debug("Synchronizer already running, consider configuring a longer interval")
 		return state, data, nil, nil
 	}
+
+	data.timeStarted = time.Now()
 	proc.Log().Debug("Starting resource synchronization timestamp=%v", data.timeStarted)
 
 	return synchronizeAllResources(state, data, proc)
@@ -273,10 +282,7 @@ func synchronizeAllResources(state gen.Atom, data SynchronizerData, proc gen.Pro
 
 	if len(allResourceUpdates) == 0 {
 		proc.Log().Debug("Synchronizer: no resources found to synchronize")
-		if err = scheduleNextSync(data, proc); err != nil {
-			return state, data, nil, gen.TerminateReasonPanic
-		}
-		return StateIdle, data, nil, nil
+		return StateIdle, data, rescheduleAction(data), nil
 	}
 
 	var resourcesToSynchronize []pkgmodel.Resource
@@ -339,7 +345,7 @@ func changesetCompleted(from gen.PID, state gen.Atom, data SynchronizerData, mes
 		return state, data, nil, nil
 	}
 
-	return StateIdle, data, nil, nil
+	return StateIdle, data, rescheduleAction(data), nil
 }
 
 func registerInProgressResource(from gen.PID, state gen.Atom, data SynchronizerData, message messages.RegisterInProgressResource, proc gen.Process) (gen.Atom, SynchronizerData, []statemachine.Action, error) {
@@ -352,15 +358,4 @@ func unregisterInProgressResource(from gen.PID, state gen.Atom, data Synchronize
 	delete(data.excludedResources, message.ResourceURI)
 	proc.Log().Debug("Resource unregistered from in-progress, can be synced resourceURI=%s", message.ResourceURI)
 	return state, data, nil, nil
-}
-
-func scheduleNextSync(data SynchronizerData, proc gen.Process) error {
-	if data.isScheduledSync {
-		_, err := proc.SendAfter(proc.PID(), Synchronize{}, data.cfg.Interval)
-		if err != nil {
-			return fmt.Errorf("failed to schedule next resource synchronization %w", err)
-		}
-	}
-
-	return nil
 }

--- a/internal/metastructure/synchronizer_test.go
+++ b/internal/metastructure/synchronizer_test.go
@@ -1,0 +1,87 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package metastructure
+
+import (
+	"testing"
+	"time"
+
+	"ergo.services/actor/statemachine"
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/changeset"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// stubSyncLog is a gen.Log that swallows all log output.
+type stubSyncLog struct {
+	gen.Log
+}
+
+func (stubSyncLog) Trace(string, ...any)   {}
+func (stubSyncLog) Debug(string, ...any)   {}
+func (stubSyncLog) Info(string, ...any)    {}
+func (stubSyncLog) Warning(string, ...any) {}
+func (stubSyncLog) Error(string, ...any)   {}
+func (stubSyncLog) Panic(string, ...any)   {}
+
+// stubSyncProcess is a hand-rolled gen.Process double for synchronizer tests.
+// The synchronize() busy-guard path and changesetCompleted() don't reach into
+// the datastore or any collaborators, so an inert process is enough to drive
+// them directly through their handlers.
+type stubSyncProcess struct {
+	gen.Process
+}
+
+func (p *stubSyncProcess) Log() gen.Log { return stubSyncLog{} }
+func (p *stubSyncProcess) PID() gen.PID { return gen.PID{Node: "test-node", ID: 1} }
+
+// A second Synchronize arriving while a periodic synchronization cycle is
+// running (e.g. a ForceSync triggered by the CLI) must not kill the periodic
+// chain. The intervening message is dropped by the busy guard, and when the
+// running cycle completes, the next periodic tick is still scheduled.
+// Otherwise synchronization would be dead until agent restart and
+// out-of-band changes would never be detected.
+func TestForceSyncDuringPeriodicCycleDoesNotKillPeriodicChain(t *testing.T) {
+	proc := &stubSyncProcess{}
+	data := SynchronizerData{
+		cfg:       pkgmodel.SynchronizationConfig{Enabled: true, Interval: 5 * time.Minute},
+		commandID: "cycle-1",
+	}
+
+	// While a periodic cycle is running, a second Synchronize arrives.
+	state, data, actions, err := synchronize(gen.PID{}, StateSynchronizing, data, Synchronize{}, proc)
+	require.NoError(t, err)
+	require.Equal(t, StateSynchronizing, state, "intervening Synchronize must be dropped by the busy guard, not start a second cycle")
+	require.Empty(t, actions, "a dropped message must not produce actions")
+
+	// The running cycle completes.
+	nextState, _, actions, err := changesetCompleted(gen.PID{}, StateSynchronizing, data, changeset.ChangesetCompleted{CommandID: data.commandID}, proc)
+	require.NoError(t, err)
+	require.Equal(t, StateIdle, nextState)
+
+	require.Len(t, actions, 1, "cycle completion must schedule the next periodic tick")
+	timeout, ok := actions[0].(statemachine.GenericTimeout)
+	require.True(t, ok, "scheduled action must be a GenericTimeout (named timer so a fresh schedule cancels any prior one)")
+	assert.Equal(t, syncTickName, timeout.Name)
+	assert.Equal(t, data.cfg.Interval, timeout.Duration)
+	assert.Equal(t, Synchronize{}, timeout.Message)
+}
+
+// When synchronization is disabled, no periodic chain should exist; cycle
+// completion must not schedule a tick.
+func TestSynchronizationDisabledDoesNotScheduleTick(t *testing.T) {
+	proc := &stubSyncProcess{}
+	data := SynchronizerData{
+		cfg:       pkgmodel.SynchronizationConfig{Enabled: false, Interval: 5 * time.Minute},
+		commandID: "cycle-1",
+	}
+
+	_, _, actions, err := changesetCompleted(gen.PID{}, StateSynchronizing, data, changeset.ChangesetCompleted{CommandID: data.commandID}, proc)
+	require.NoError(t, err)
+	assert.Empty(t, actions, "disabled synchronization must not schedule any timer")
+}


### PR DESCRIPTION
## Summary

Replace hand-rolled timer-state bookkeeping in the discovery and synchronizer actors with `statemachine.GenericTimeout`. A named `GenericTimeout` auto-cancels any prior timer with the same name, so the "exactly one periodic timer in flight" invariant is enforced by the framework instead of by a boolean flag the handlers have to maintain.

This collapses the `Once`-vs-periodic distinction:

- Every `Discover{}` / `Synchronize{}` is treated the same. Force-discovery, target-persist, and force-sync triggers just send the bare message.
- Every transition to `Idle` returns a `rescheduleAction` (a `GenericTimeout` with the discovery-tick / sync-tick name).
- There is no flag whose stale value could suppress the next schedule.

Deleted: `Discover.Once`, `Synchronize.Once`, `tickPending`, `isScheduledSync`, `scheduleNextSync`, and the reschedule branches in `onStateChange`.

## Why

Two reasons:

1. **Simpler.** The `tickPending` flag exists to maintain an invariant the `statemachine` package already enforces via named-timer cancel-on-replace. Removing it eliminates a category of bug (forgetting to update the flag on a code path) and ~80 net lines.

2. **Fixes a latent wedge in the synchronizer.** Under the old design, `data.isScheduledSync = !message.Once` ran before the busy guard. A `ForceSync` arriving while a periodic cycle was running would clobber the flag to `false`; when the running cycle completed, `scheduleNextSync` would skip and the periodic chain would die until agent restart. Same shape as the discovery wedge fixed in #514, just user-triggered (CLI `ForceSync`) instead of apply-triggered (target persist). Lower frequency, real bug, fixed by the same refactor.

## Tests

Tests now assert on the action returned by the handler rather than recording `SendAfter` calls. Two tests per package:

- `TestForceSyncDuringPeriodicCycleDoesNotKillPeriodicChain` / `TestDiscoverDuringRunningCycleDoesNotKillPeriodicChain` — wedge regression: a message dropped mid-cycle does not prevent the next reschedule.
- `TestSynchronizationDisabledDoesNotScheduleTick` / `TestDiscoveryDisabledDoesNotScheduleTick` — disabled-config guard.

The three tests added in #514 (`TestOneShotCycle…`, `TestOneShotCompletion…`, `TestPeriodicCycleSchedulesExactlyOneSuccessor`) are replaced — under the named-timer design their scenarios are structurally impossible (no `Once` flag, no double-schedule possible) so the names no longer describe behavior worth locking in.