### PR TITLE
fix(auto-reconciler): include destroy commands in baseline query

### DIFF
--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -4490,19 +4490,31 @@ func (d *DatastoreAuroraDataAPI) GetResourcesAtLastReconcile(stackLabel string) 
 	// row per ksuid keeps unchanged resources represented by the earlier
 	// reconcile that last declared them.
 	//
+	// Destroy commands also contribute to the baseline. A destroy is the
+	// user's latest declaration that the named resources should not exist —
+	// its resource_updates rows have operation='delete' and become the
+	// latest-per-ksuid touch for any destroyed resource. The outer filter
+	// (operation != 'delete') then drops them from the snapshot, yielding
+	// the correct empty desired baseline for fully-destroyed stacks (or
+	// the correctly trimmed baseline for partial destroys). Destroys land
+	// in forma_commands with command='destroy' and config_mode='patch', so
+	// the OR branch admits them without further filtering on config_mode.
+	//
 	// The resource column is stored as TEXT; cast to json once in the CTE
 	// so the downstream extractions can use the JSON operators.
 	//
-	// Delete operations are excluded: a deletion the user requested is not
-	// part of the desired state going forward.
+	// Delete operations are excluded from the outer SELECT: a deletion the
+	// user requested is not part of the desired state going forward.
 	query := `
 		WITH user_reconcile_updates AS (
 			SELECT ru.ksuid, ru.resource::json AS resource_json, ru.operation, fc.timestamp
 			FROM resource_updates ru
 			INNER JOIN forma_commands fc ON ru.command_id = fc.command_id
-			WHERE fc.config_mode = 'reconcile'
+			WHERE (
+				(fc.command = 'apply' AND fc.config_mode = 'reconcile')
+				OR fc.command = 'destroy'
+			)
 			AND fc.state IN ('Success', 'Failed')
-			AND fc.command = 'apply'
 			AND ru.source = 'user'
 			AND ru.stack_label = :stack_label
 		),

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -93,4 +93,7 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunGetResourcesAtLastReconcile_PatchModeExcluded(t, newDS)
 	RunGetResourcesAtLastReconcile_MostRecentReconcileWins(t, newDS)
 	RunGetResourcesAtLastReconcile_StackScoped(t, newDS)
+	RunGetResourcesAtLastReconcile_DestroyAfterApplyEmptiesBaseline(t, newDS)
+	RunGetResourcesAtLastReconcile_FailedDestroyIncluded(t, newDS)
+	RunGetResourcesAtLastReconcile_PartialDestroyLeavesUntouchedInBaseline(t, newDS)
 }

--- a/internal/datastore/dstest/suite_get_resources_at_last_reconcile.go
+++ b/internal/datastore/dstest/suite_get_resources_at_last_reconcile.go
@@ -41,6 +41,27 @@ func reconcileBuilder(
 	}
 }
 
+// destroyBuilder constructs a destroy-command forma_command with the given
+// delete-operation resource updates. Destroy commands are persisted with
+// command='destroy' and config_mode='patch' (the default when
+// FormaCommandConfig.Mode is empty, as set by the API server's DestroyForma
+// path).
+func destroyBuilder(
+	state forma_command.CommandState,
+	startOffset time.Duration,
+	updates []resource_update.ResourceUpdate,
+) *forma_command.FormaCommand {
+	return &forma_command.FormaCommand{
+		ID:              util.NewID(),
+		Command:         pkgmodel.CommandDestroy,
+		Config:          config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch},
+		State:           state,
+		StartTs:         util.TimeNow().Add(startOffset),
+		ModifiedTs:      util.TimeNow().Add(startOffset),
+		ResourceUpdates: updates,
+	}
+}
+
 // resourceUpdate constructs a ResourceUpdate where the DesiredState carries
 // realistic top-level fields so that GetResourcesAtLastReconcile's
 // JSON-extraction queries (Type/Label/Target/Properties/Schema/NativeID)
@@ -393,5 +414,127 @@ func RunGetResourcesAtLastReconcile_StackScoped(t *testing.T, newDS func(t *test
 		assert.NoError(t, err)
 		assert.Len(t, snapsB, 1)
 		assert.Equal(t, "bucket-b", snapsB[0].Label)
+	})
+}
+
+// RunGetResourcesAtLastReconcile_DestroyAfterApplyEmptiesBaseline verifies
+// that a successful destroy of a stack supersedes the prior apply: the
+// baseline becomes empty even though the apply's create rows are still
+// present in resource_updates.
+//
+// Without the destroy-included filter, the apply's create rows would be the
+// only candidates and the resource would remain in the baseline forever —
+// driving auto-reconcile to resurrect it.
+func RunGetResourcesAtLastReconcile_DestroyAfterApplyEmptiesBaseline(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetResourcesAtLastReconcile_DestroyAfterApplyEmptiesBaseline", func(t *testing.T) {
+		td := newDS(t)
+		defer td.CleanUpFn() //nolint:errcheck
+
+		// Older successful apply.
+		apply := reconcileBuilder(
+			forma_command.CommandStateSuccess,
+			pkgmodel.FormaApplyModeReconcile,
+			-10*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(apply, apply.ID))
+
+		// Later successful destroy of the same resource.
+		destroy := destroyBuilder(
+			forma_command.CommandStateSuccess,
+			-1*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v1"}`, types.OperationDelete, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(destroy, destroy.ID))
+
+		snaps, err := td.GetResourcesAtLastReconcile("stack-a")
+		assert.NoError(t, err)
+		assert.Empty(t, snaps, "destroy must supersede the prior apply — baseline should be empty")
+	})
+}
+
+// RunGetResourcesAtLastReconcile_FailedDestroyIncluded verifies that a
+// failed destroy still contributes its delete rows to the latest-per-ksuid
+// computation. The user's intent is "delete these"; the auto-reconciler
+// must treat them as desired-state-empty even if the delete didn't succeed.
+//
+// Combined with the outer operation != 'delete' filter, a failed destroy
+// yields an empty baseline for destroyed resources (correct: don't resurrect
+// them; the user wanted them gone). A subsequent retry by the user (or by
+// auto-reconcile itself, once it can do destroys) completes the work.
+func RunGetResourcesAtLastReconcile_FailedDestroyIncluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetResourcesAtLastReconcile_FailedDestroyIncluded", func(t *testing.T) {
+		td := newDS(t)
+		defer td.CleanUpFn() //nolint:errcheck
+
+		apply := reconcileBuilder(
+			forma_command.CommandStateSuccess,
+			pkgmodel.FormaApplyModeReconcile,
+			-10*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(apply, apply.ID))
+
+		// Failed destroy — user intent still recorded.
+		destroy := destroyBuilder(
+			forma_command.CommandStateFailed,
+			-1*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "bucket-1", `{"foo":"v1"}`, types.OperationDelete, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(destroy, destroy.ID))
+
+		snaps, err := td.GetResourcesAtLastReconcile("stack-a")
+		assert.NoError(t, err)
+		assert.Empty(t, snaps, "failed destroy still records the user's intent — baseline should be empty")
+	})
+}
+
+// RunGetResourcesAtLastReconcile_PartialDestroyLeavesUntouchedInBaseline
+// verifies that destroying one resource while another is left alone yields
+// a baseline containing only the un-destroyed resource. The latest-per-ksuid
+// logic picks the apply's create row for the surviving resource (its only
+// touch) and the destroy's delete row for the removed one (which the outer
+// filter drops).
+func RunGetResourcesAtLastReconcile_PartialDestroyLeavesUntouchedInBaseline(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetResourcesAtLastReconcile_PartialDestroyLeavesUntouchedInBaseline", func(t *testing.T) {
+		td := newDS(t)
+		defer td.CleanUpFn() //nolint:errcheck
+
+		// Apply creates two resources.
+		apply := reconcileBuilder(
+			forma_command.CommandStateSuccess,
+			pkgmodel.FormaApplyModeReconcile,
+			-10*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-1", "keeper", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+				resourceUpdate("stack-a", "ksuid-2", "doomed", `{"foo":"v1"}`, types.OperationCreate, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(apply, apply.ID))
+
+		// Destroy targets only the second resource.
+		destroy := destroyBuilder(
+			forma_command.CommandStateSuccess,
+			-1*time.Minute,
+			[]resource_update.ResourceUpdate{
+				resourceUpdate("stack-a", "ksuid-2", "doomed", `{"foo":"v1"}`, types.OperationDelete, resource_update.FormaCommandSourceUser),
+			},
+		)
+		assert.NoError(t, td.StoreFormaCommand(destroy, destroy.ID))
+
+		snaps, err := td.GetResourcesAtLastReconcile("stack-a")
+		assert.NoError(t, err)
+		if assert.Len(t, snaps, 1, "only the untouched resource should remain in the baseline") {
+			assert.Equal(t, "ksuid-1", snaps[0].KSUID)
+			assert.Equal(t, "keeper", snaps[0].Label)
+		}
 	})
 }

--- a/internal/datastore/mssql/mssql_policies.go
+++ b/internal/datastore/mssql/mssql_policies.go
@@ -733,16 +733,28 @@ func (d *DatastoreMSSQL) GetResourcesAtLastReconcile(stackLabel string) ([]datas
 	// row per ksuid keeps unchanged resources represented by the earlier
 	// reconcile that last declared them.
 	//
-	// Delete operations are excluded: a deletion the user requested is not
-	// part of the desired state going forward.
+	// Destroy commands also contribute to the baseline. A destroy is the
+	// user's latest declaration that the named resources should not exist —
+	// its resource_updates rows have operation='delete' and become the
+	// latest-per-ksuid touch for any destroyed resource. The outer filter
+	// (operation != 'delete') then drops them from the snapshot, yielding
+	// the correct empty desired baseline for fully-destroyed stacks (or
+	// the correctly trimmed baseline for partial destroys). Destroys land
+	// in forma_commands with command='destroy' and config_mode='patch', so
+	// the OR branch admits them without further filtering on config_mode.
+	//
+	// Delete operations are excluded from the outer SELECT: a deletion the
+	// user requested is not part of the desired state going forward.
 	query := `
 		WITH user_reconcile_updates AS (
 			SELECT ru.ksuid, ru.resource, ru.operation, fc.timestamp
 			FROM resource_updates ru
 			INNER JOIN forma_commands fc ON ru.command_id = fc.command_id
-			WHERE fc.config_mode = 'reconcile'
+			WHERE (
+				(fc.command = 'apply' AND fc.config_mode = 'reconcile')
+				OR fc.command = 'destroy'
+			)
 			AND fc.state IN ('Success', 'Failed')
-			AND fc.command = 'apply'
 			AND ru.source = 'user'
 			AND ru.stack_label = @p1
 		),

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -2508,19 +2508,31 @@ func (d DatastorePostgres) GetResourcesAtLastReconcile(stackLabel string) ([]dat
 	// row per ksuid keeps unchanged resources represented by the earlier
 	// reconcile that last declared them.
 	//
+	// Destroy commands also contribute to the baseline. A destroy is the
+	// user's latest declaration that the named resources should not exist —
+	// its resource_updates rows have operation='delete' and become the
+	// latest-per-ksuid touch for any destroyed resource. The outer filter
+	// (operation != 'delete') then drops them from the snapshot, yielding
+	// the correct empty desired baseline for fully-destroyed stacks (or
+	// the correctly trimmed baseline for partial destroys). Destroys land
+	// in forma_commands with command='destroy' and config_mode='patch', so
+	// the OR branch admits them without further filtering on config_mode.
+	//
 	// The resource column is stored as TEXT; cast to json once in the CTE
 	// so the downstream extractions can use the JSON operators.
 	//
-	// Delete operations are excluded: a deletion the user requested is not
-	// part of the desired state going forward.
+	// Delete operations are excluded from the outer SELECT: a deletion the
+	// user requested is not part of the desired state going forward.
 	query := `
 		WITH user_reconcile_updates AS (
 			SELECT ru.ksuid, ru.resource::json AS resource_json, ru.operation, fc.timestamp
 			FROM resource_updates ru
 			INNER JOIN forma_commands fc ON ru.command_id = fc.command_id
-			WHERE fc.config_mode = 'reconcile'
+			WHERE (
+				(fc.command = 'apply' AND fc.config_mode = 'reconcile')
+				OR fc.command = 'destroy'
+			)
 			AND fc.state IN ('Success', 'Failed')
-			AND fc.command = 'apply'
 			AND ru.source = 'user'
 			AND ru.stack_label = $1
 		),

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -2415,16 +2415,33 @@ func (d DatastoreSQLite) GetResourcesAtLastReconcile(stackLabel string) ([]datas
 	// row per ksuid keeps unchanged resources represented by the earlier
 	// reconcile that last declared them.
 	//
-	// Delete operations are excluded: a deletion the user requested is not
-	// part of the desired state going forward.
+	// Destroy commands also contribute to the baseline. A destroy is the
+	// user's latest declaration that the named resources should not exist —
+	// its resource_updates rows have operation='delete' and become the
+	// latest-per-ksuid touch for any destroyed resource. The outer filter
+	// (operation != 'delete') then drops them from the snapshot, yielding
+	// the correct empty desired baseline for fully-destroyed stacks (or
+	// the correctly trimmed baseline for partial destroys). Without this
+	// branch, a destroy is invisible to the baseline and auto-reconcile
+	// resurrects the destroyed resources on its next beat.
+	//
+	// Destroys land in forma_commands with command='destroy' and
+	// config_mode='patch' (the API server's DestroyForma path sends only
+	// Simulate; FormaCommandFromForma defaults empty Mode to Patch), so
+	// the OR branch admits them without further filtering on config_mode.
+	//
+	// Delete operations are excluded from the outer SELECT: a deletion the
+	// user requested is not part of the desired state going forward.
 	query := `
 		WITH user_reconcile_updates AS (
 			SELECT ru.ksuid, ru.resource, ru.operation, fc.timestamp
 			FROM resource_updates ru
 			INNER JOIN forma_commands fc ON ru.command_id = fc.command_id
-			WHERE fc.config_mode = 'reconcile'
+			WHERE (
+				(fc.command = 'apply' AND fc.config_mode = 'reconcile')
+				OR fc.command = 'destroy'
+			)
 			AND fc.state IN ('Success', 'Failed')
-			AND fc.command = 'apply'
 			AND ru.source = 'user'
 			AND ru.stack_label = ?
 		),

--- a/internal/metastructure/auto_reconciler.go
+++ b/internal/metastructure/auto_reconciler.go
@@ -274,7 +274,19 @@ func prepareReconcile(ds datastore.Datastore, stackLabel string, clientID string
 	}
 
 	if len(snapshots) == 0 {
-		return nil, fmt.Errorf("no resources to reconcile")
+		// Empty baseline = nothing to enforce. Two cases produce this:
+		//   1. The user destroyed the stack (latest user-source row per
+		//      ksuid is a delete; outer filter drops it; snapshot empty).
+		//   2. No user-source reconcile-mode command has ever touched
+		//      the stack (the auto-reconcile policy was attached but
+		//      no apply ran yet).
+		// Both cases are no-ops for the auto-reconciler, not errors.
+		// Returning (nil, nil) lets startReconcile fall through its
+		// "no drift, nothing to reconcile" branch and reschedule the
+		// next tick quietly. Otherwise (returning an error) we'd log
+		// a failed reconcile attempt on every beat after a successful
+		// destroy.
+		return nil, nil
 	}
 
 	// Convert snapshots to Resource objects.

--- a/internal/workflow_tests/local/auto_reconciler_test.go
+++ b/internal/workflow_tests/local/auto_reconciler_test.go
@@ -841,3 +841,124 @@ func TestAutoReconciler_PreservesUnchangedResourcesAfterPartialFailure(t *testin
 			"after clearing A's failure: A=v2 (converged), B and C still at v1")
 	})
 }
+
+// TestAutoReconciler_DestroyedResourcesStayDestroyed verifies that when a
+// stack with an AutoReconcilePolicy is destroyed, the auto-reconciler does
+// not resurrect the destroyed resources on its next beat.
+//
+// The destroy must be visible to GetResourcesAtLastReconcile so the
+// auto-reconciler's baseline reflects "this stack is empty" rather than the
+// pre-destroy apply. Otherwise the next beat diffs the apply's resources
+// against the now-empty actual state and creates them again.
+//
+// The test counts both Create and Delete plugin calls, and queries
+// GetResourcesAtLastReconcile directly after the destroy completes — both
+// to prove the destroy actually went through the plugin Delete path AND
+// that the SQL baseline computation reflects an empty stack.
+func TestAutoReconciler_DestroyedResourcesStayDestroyed(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		var createCount atomic.Int32
+		var deleteCount atomic.Int32
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				createCount.Add(1)
+				return &resource.CreateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationCreate,
+						OperationStatus: resource.OperationStatusSuccess,
+						NativeID:        "native-" + request.Label,
+					},
+				}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{
+					ResourceType: request.ResourceType,
+					Properties:   `{"foo":"v1"}`,
+				}, nil
+			},
+			Delete: func(request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+				deleteCount.Add(1)
+				return &resource.DeleteResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationDelete,
+						OperationStatus: resource.OperationStatusSuccess,
+						NativeID:        request.NativeID,
+					},
+				}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		// Disable sync — the destroy + auto-reconcile interaction is the
+		// only thing under test; sync would muddy timing.
+		cfg.Agent.Synchronization.Enabled = false
+		m, cleanup, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer cleanup()
+		require.NoError(t, err)
+
+		schema := pkgmodel.Schema{Fields: []string{"foo"}}
+		v1 := json.RawMessage(`{"foo":"v1"}`)
+		stack := pkgmodel.Stack{
+			Label: "destroy-stack",
+			Policies: []json.RawMessage{
+				json.RawMessage(`{"Type":"auto-reconcile","IntervalSeconds":2}`),
+			},
+		}
+		targets := []pkgmodel.Target{{Label: "test-target"}}
+
+		// Phase 1: apply a stack with auto-reconcile + one resource.
+		f := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{stack},
+			Resources: []pkgmodel.Resource{
+				{Label: "doomed", Type: "FakeAWS::Resource", Properties: v1, Schema: schema, Stack: "destroy-stack", Target: "test-target"},
+			},
+			Targets: targets,
+		}
+		m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+
+		r := require.New(t)
+		r.Eventually(func() bool {
+			resources, err := m.Datastore.LoadResourcesByStack("destroy-stack")
+			return err == nil && len(resources) == 1
+		}, 15*time.Second, 200*time.Millisecond, "initial apply should create the resource")
+
+		// Sanity: exactly one Create from the initial apply, no Deletes yet.
+		r.Equal(int32(1), createCount.Load(), "exactly one Create from initial apply")
+		r.Equal(int32(0), deleteCount.Load(), "no Deletes before destroy")
+
+		// Reset Create counter so we can detect any resurrection-driven
+		// Create. The Delete counter accumulates the destroy's call below.
+		createCount.Store(0)
+
+		// Phase 2: destroy the stack.
+		m.DestroyForma(f, &config.FormaCommandConfig{}, "test-client")
+		r.Eventually(func() bool {
+			resources, err := m.Datastore.LoadResourcesByStack("destroy-stack")
+			return err == nil && len(resources) == 0
+		}, 15*time.Second, 200*time.Millisecond, "destroy should remove the resource")
+
+		// Prove the destroy actually went through the plugin: exactly one
+		// Delete call. (Without this assertion, a "destroy" that bypasses
+		// the plugin and just clears inventory would also produce zero
+		// resurrection-Creates and the test would pass falsely.)
+		r.Equal(int32(1), deleteCount.Load(), "destroy must call the plugin Delete exactly once")
+
+		// Prove the SQL baseline correctly reflects an empty stack post-destroy.
+		snaps, err := m.Datastore.GetResourcesAtLastReconcile("destroy-stack")
+		r.NoError(err)
+		r.Empty(snaps, "GetResourcesAtLastReconcile should return empty after destroy — destroy must be visible to the baseline query")
+
+		// Phase 3: wait through several auto-reconcile beats (interval=2s).
+		// No additional Create should happen — the destroy must "stick".
+		time.Sleep(8 * time.Second)
+		r.Equal(int32(0), createCount.Load(),
+			"auto-reconcile must not resurrect destroyed resources (got %d unexpected Creates)",
+			createCount.Load())
+
+		// Sanity: still gone.
+		resources, err := m.Datastore.LoadResourcesByStack("destroy-stack")
+		r.NoError(err)
+		r.Empty(resources, "stack should remain empty after auto-reconcile beats")
+	})
+}


### PR DESCRIPTION
## Summary

A stack with an `AutoReconcilePolicy` could not be reliably destroyed: the next auto-reconcile beat would resurrect the just-destroyed resources. This PR widens the baseline query so destroy commands are recognised as user-source desired-state changes, and treats an empty post-destroy baseline as a clean no-op rather than an error.

Hit live during the vLLM fleet demo: destroying a `vllm-fleet` stack with a 30s `AutoReconcilePolicy` re-loaded the LoRA adapters within one reconcile interval.

## Why this was broken

`GetResourcesAtLastReconcile` filtered baseline candidates to `command = 'apply' AND config_mode = 'reconcile'`. Destroys land with `command = 'destroy'` and `config_mode = 'patch'` — the API server sends `FormaCommandConfig{Simulate: simulate}` only (no `Mode`), and `FormaCommandFromForma` defaults empty `Mode` to `Patch`. The baseline never saw the destroy. The pre-destroy apply stayed "desired" against now-empty actual state, the diff produced creates, and auto-reconcile recreated everything on the next beat.

## What changed

**SQL filter widened** across all four datastore backends (`internal/datastore/{sqlite,postgres,aurora,mssql}/...`):

```sql
WHERE (
    (fc.command = 'apply' AND fc.config_mode = 'reconcile')
    OR fc.command = 'destroy'
)
AND fc.state IN ('Success', 'Failed')
AND ru.source = 'user'
AND ru.stack_label = <param>
```

The per-resource latest-touch logic composes correctly:

- Destroyed resources: latest user-source row is the delete from the destroy command. The outer `WHERE rn = 1 AND operation != 'delete'` filter drops them. Baseline omits the destroyed resources → no resurrection.
- Untouched resources during a partial destroy: their latest row is still the apply's create. They remain in the baseline.
- Failed destroys: user intent is still recorded (`state IN ('Success', 'Failed')` admits them), so the baseline correctly treats the resources as gone even if the delete failed.

**`prepareReconcile` empty-baseline treated as no-op** (`internal/metastructure/auto_reconciler.go`). Previously the function returned `fmt.Errorf("no resources to reconcile")` on an empty snapshot, which would have logged a failed reconcile attempt on every interval after a full destroy. The empty branch now returns `(nil, nil)` — `startReconcile` already handles a nil result as "no drift, reschedule normally", so the auto-reconciler ticks quietly without errors.

No code outside the datastore SQL and the auto-reconciler. Destroy mode stays `'patch'`. Per-resource latest-touch invariant from the prior auto-reconcile work unchanged.

## Coverage

- **`TestAutoReconciler_DestroyedResourcesStayDestroyed`** (`internal/workflow_tests/local/auto_reconciler_test.go`) — end-to-end: apply a resource on a 2s auto-reconcile stack, destroy it, assert the destroy actually went through the plugin Delete path (counts Delete calls, asserts exactly one), assert `GetResourcesAtLastReconcile` returns empty after destroy, wait through ~4 beats, assert no Create is issued and the stack stays empty.
- **Three new `dstest` cases** wired into the cross-backend suite (`RunAll`):
  - `DestroyAfterApplyEmptiesBaseline` — happy path.
  - `FailedDestroyIncluded` — user intent recorded even when the underlying delete failed.
  - `PartialDestroyLeavesUntouchedInBaseline` — destroying one resource doesn't drop the rest of the stack from the baseline.

## Risk

Narrow. The change is local to four SQL functions plus one early-return branch in the auto-reconciler. All existing auto-reconcile tests continue to pass — verified locally against SQLite; Postgres and MSSQL exercised in CI via the dstest suite; Aurora rides on the same Postgres engine as the in-CI Postgres job.