### PR TITLE
fix(generator): stop double-escaping quotes in extract output

### DIFF
--- a/internal/schema/pkl/generator/gen.pkl
+++ b/internal/schema/pkl/generator/gen.pkl
@@ -36,7 +36,11 @@ hidden classHandlers: Mapping<Class, (List<reflect.Type>, Any) -> Any|Generation
     else Unexpected("Int", value.getClass().simpleName)
 
   [String] = (_, value) ->
-    if (value is String) value.replaceAll("\"", "\\\"")
+    // Return the raw string unchanged. Escaping for PKL string literals is a
+    // serialization concern handled by escapeString during rendering. Escaping
+    // here too would double-escape quotes (" -> \" -> \\\") and break the
+    // extract -> apply roundtrip with phantom drift.
+    if (value is String) value
     else if (value is Int || value is Number) value.toString()
     else Unexpected("String", value.getClass().simpleName)
 

--- a/internal/schema/pkl/generator/tests/gen.pkl
+++ b/internal/schema/pkl/generator/tests/gen.pkl
@@ -367,6 +367,19 @@ facts {
         rendered.contains("name = \"a\\\"b\"")
     }
 
+    ["EdgeFunction code body roundtrips with single escaping"] {
+        // Real-world repro: a Supabase EdgeFunction inline body containing
+        // double-quotes. Extract must escape each quote exactly once so the
+        // generated forma parses back to the original source (no phantom drift).
+        let (body = "Deno.serve(() => new Response(\"Hello from formae!\"))")
+        let (applied = gen.apply(SimpleFoo, new Dynamic { x = 1; name = body; label = "fn" }))
+        let (rendered = gen.genMapToPklStringWithTypes("SimpleFoo", gen.genPklToMap(applied.toDynamic()), "test"))
+        // type conversion preserves the body verbatim ...
+        applied.name == body &&
+        // ... and serialization renders it single-escaped.
+        rendered.contains("name = \"Deno.serve(() => new Response(\\\"Hello from formae!\\\"))\"")
+    }
+
     ["duplicate Typed values produce single import after dedup"] {
         // Two SubResource instances in the same resource should not
         // produce duplicate __import_statement__ entries after dedup.

--- a/internal/schema/pkl/generator/tests/gen.pkl
+++ b/internal/schema/pkl/generator/tests/gen.pkl
@@ -348,6 +348,25 @@ facts {
         rendered.contains("\\(")
     }
 
+    // --- String escaping (roundtrip) tests ---
+
+    ["String type conversion preserves quotes (escaping is a serialization concern)"] {
+        // Type conversion must NOT escape quotes; escaping belongs only to the
+        // serialization stage (escapeString). If it escapes here too, the value
+        // gets double-escaped: " -> \" -> \\\" and the extract->apply roundtrip
+        // sees phantom drift.
+        gen.apply(SimpleFoo, new Dynamic { x = 1; name = "a\"b"; label = "q" }).name == "a\"b"
+    }
+
+    ["String serialization escapes quotes exactly once (no double-escape)"] {
+        let (applied = gen.apply(SimpleFoo, new Dynamic { x = 1; name = "a\"b"; label = "q" }))
+        let (pklMap = gen.genPklToMap(applied.toDynamic()))
+        let (rendered = gen.genMapToPklStringWithTypes("SimpleFoo", pklMap, "test"))
+        // Correct output contains: name = "a\"b" (single backslash before the quote).
+        // The double-escape bug would render a\\\"b, which does not contain a\"b.
+        rendered.contains("name = \"a\\\"b\"")
+    }
+
     ["duplicate Typed values produce single import after dedup"] {
         // Two SubResource instances in the same resource should not
         // produce duplicate __import_statement__ entries after dedup.


### PR DESCRIPTION
## Problem

Extracting a resource then applying it reported phantom drift on any `String` property containing a `"`. Repro: ingest a Supabase `EdgeFunction` with an inline `body`, extract to a forma, `apply` → endless `update` on `body`:

```
change property "body"
  from "Deno.serve(() => new Response("Hello from formae!"))"
  to   "Deno.serve(() => new Response(\"Hello from formae!\"))"
```

## Root cause

`internal/schema/pkl/generator/gen.pkl` escaped string values **twice**:

1. `[String]` classHandler (type conversion): `"` → `\"`
2. `escapeString` (serialization): `\"` → `\\\"`

A stored `"` was emitted as `\\\"`, which PKL parses back to `\"` (backslash + quote) ≠ original `"`. Roundtrip never converges. Affects all String properties, not just code bodies.

## Fix

Escaping is a serialization concern. The `[String]` handler now returns the raw value; `escapeString` stays the single escaping point.

## Tests

Two `pkl:test` facts added to `tests/gen.pkl` (written failing first, pass after fix):
- type conversion preserves quotes
- serialization escapes exactly once (no double-escape)

`pkl test gen.pkl` → 29/29 pass. pklGenerator.pkl + jsonhelper.pkl unaffected. (Pre-existing generator.pkl expected-fixture path mismatch is unrelated.)