### PR TITLE
fix(resolve): surface failing ref + property on terminal resolve miss

### DIFF
--- a/internal/metastructure/changeset/resolve_cache.go
+++ b/internal/metastructure/changeset/resolve_cache.go
@@ -87,6 +87,21 @@ func (r *ResolveCache) HandleMessage(from gen.PID, message any) error {
 	return nil
 }
 
+// resolveMissReason builds a human-readable explanation for a terminal
+// resolve miss — a referenced property that is absent from the source
+// resource even after a successful Read. It names the reference and the
+// missing property so the operator can act without log spelunking, and
+// additionally identifies the source resource by triplet when it is known.
+func resolveMissReason(resourceURI pkgmodel.FormaeURI, source *pkgmodel.Resource) string {
+	property := resourceURI.PropertyPath()
+	if source != nil && source.Label != "" {
+		return fmt.Sprintf("could not resolve reference %q: source resource %q has no property %q",
+			string(resourceURI), source.Stack+"/"+source.Type+"/"+source.Label, property)
+	}
+	return fmt.Sprintf("could not resolve reference %q: source resource has no property %q",
+		string(resourceURI), property)
+}
+
 // startResolve handles a new ResolveValue request: checks the cache, loads from
 // the persister if needed, and kicks off the first read attempt.
 func (r *ResolveCache) startResolve(from gen.PID, resourceURI pkgmodel.FormaeURI) {
@@ -96,7 +111,7 @@ func (r *ResolveCache) startResolve(from gen.PID, resourceURI pkgmodel.FormaeURI
 		value := json.Get(resourceURI.PropertyPath())
 		if !value.Exists() {
 			r.Log().Error("Unable to resolve property in cached properties property=%s resourceURI=%v", resourceURI.PropertyPath(), resourceURI)
-			_ = r.Send(from, messages.FailedToResolveValue(messages.ResolveValue{ResourceURI: resourceURI}))
+			_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI, Reason: resolveMissReason(resourceURI, nil)})
 			return
 		}
 		_ = r.Send(from, messages.ValueResolved{ResourceURI: resourceURI, Value: value.String()})
@@ -112,13 +127,13 @@ func (r *ResolveCache) startResolve(from gen.PID, resourceURI pkgmodel.FormaeURI
 		})
 	if err != nil {
 		r.Log().Error("Failed to load resource from resource persister resourceURI=%v: %v", resourceURI, err)
-		_ = r.Send(from, messages.FailedToResolveValue(messages.ResolveValue{ResourceURI: resourceURI}))
+		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI})
 		return
 	}
 	loadResourceResult, ok := stackerResult.(messages.LoadResourceResult)
 	if !ok {
 		r.Log().Error("Unexpected result type from resource persister resultType=%v", reflect.TypeOf(stackerResult))
-		_ = r.Send(from, messages.FailedToResolveValue(messages.ResolveValue{ResourceURI: resourceURI}))
+		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI})
 		return
 	}
 
@@ -150,7 +165,7 @@ func (r *ResolveCache) continueResolve(retry resolveRetry) {
 	progress, err := r.readViaPlugin(retry)
 	if err != nil {
 		r.Log().Error("Failed to read resource via plugin resourceURI=%v: %v", resourceURI, err)
-		_ = r.Send(from, messages.FailedToResolveValue(messages.ResolveValue{ResourceURI: resourceURI}))
+		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI})
 		return
 	}
 
@@ -162,13 +177,13 @@ func (r *ResolveCache) continueResolve(retry resolveRetry) {
 			retry.Attempt++
 			if _, err := r.SendAfter(r.PID(), retry, r.retryDelay); err != nil {
 				r.Log().Error("Failed to schedule resolve retry: %v", err)
-				_ = r.Send(from, messages.FailedToResolveValue(messages.ResolveValue{ResourceURI: resourceURI}))
+				_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI})
 			}
 			return
 		}
 		r.Log().Error("ResolveCache: exhausted retries errorCode=%s resourceURI=%v attempts=%d",
 			progress.ErrorCode, resourceURI, retry.Attempt)
-		_ = r.Send(from, messages.FailedToResolveValue(messages.ResolveValue{ResourceURI: resourceURI}))
+		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI})
 		return
 	}
 
@@ -176,7 +191,7 @@ func (r *ResolveCache) continueResolve(retry resolveRetry) {
 	if progress.OperationStatus == resource.OperationStatusFailure {
 		r.Log().Error("ResolveCache: non-recoverable error reading resource errorCode=%s resourceURI=%v",
 			progress.ErrorCode, resourceURI)
-		_ = r.Send(from, messages.FailedToResolveValue(messages.ResolveValue{ResourceURI: resourceURI}))
+		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI})
 		return
 	}
 
@@ -189,7 +204,7 @@ func (r *ResolveCache) continueResolve(retry resolveRetry) {
 	value := enhancedParsed.Get(resourceURI.PropertyPath())
 	if !value.Exists() {
 		r.Log().Error("Unable to resolve property in cached properties property=%s resourceURI=%v", resourceURI.PropertyPath(), resourceURI)
-		_ = r.Send(from, messages.FailedToResolveValue(messages.ResolveValue{ResourceURI: resourceURI}))
+		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI, Reason: resolveMissReason(resourceURI, &retry.loadResult.Resource)})
 		return
 	}
 

--- a/internal/metastructure/messages/resolve_cache.go
+++ b/internal/metastructure/messages/resolve_cache.go
@@ -17,4 +17,9 @@ type ValueResolved struct {
 
 type FailedToResolveValue struct {
 	ResourceURI model.FormaeURI
+	// Reason is a human-readable explanation of why the value could not be
+	// resolved (e.g. which property was missing on which source resource).
+	// It is surfaced to the operator as the failed resource update's
+	// ErrorMessage.
+	Reason string
 }

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -84,6 +84,12 @@ type ResourceUpdate struct {
 	// immutable properties forced the replace. Never sent to resource
 	// plugins — the replace executes as a plain destroy + create.
 	CreateOnlyPatch json.RawMessage `json:"CreateOnlyPatch,omitempty"`
+	// FailureReason carries a human-readable explanation for a failure that
+	// is not recorded as plugin progress — notably a terminal resolve miss,
+	// where the resource fails before any plugin operation runs and would
+	// otherwise surface an empty ErrorMessage. MostRecentFailureMessage falls
+	// back to this when no progress-based failure message is available.
+	FailureReason string `json:"FailureReason,omitempty"`
 }
 
 func (ru *ResourceUpdate) URI() pkgmodel.FormaeURI {
@@ -260,9 +266,15 @@ func (ru *ResourceUpdate) MostRecentFailureMessage() string {
 	}
 
 	// Account for recoverable errors
-	return ru.FilterProgressMessage(func(p plugin.TrackedProgress) bool {
+	if msg := ru.FilterProgressMessage(func(p plugin.TrackedProgress) bool {
 		return p.OperationStatus == resource.OperationStatusFailure && p.StatusMessage != ""
-	})
+	}); msg != "" {
+		return msg
+	}
+
+	// Fall back to a failure that was not recorded as plugin progress (e.g. a
+	// terminal resolve miss, which fails before any plugin operation runs).
+	return ru.FailureReason
 }
 
 func (ru *ResourceUpdate) MostRecentStatusMessage() string {

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -918,7 +918,11 @@ func resolveCacheMissingInAction(from gen.PID, state gen.Atom, data ResourceUpda
 }
 
 func resourceFailedToResolve(from gen.PID, state gen.Atom, data ResourceUpdateData, message messages.FailedToResolveValue, proc gen.Process) (gen.Atom, ResourceUpdateData, []statemachine.Action, error) {
-	proc.Log().Error("Failed to resolve resource property resourceUri=%v", message.ResourceURI)
+	proc.Log().Error("Failed to resolve resource property resourceUri=%v reason=%s", message.ResourceURI, message.Reason)
+	// The resolve failure precedes any plugin operation, so no progress is
+	// recorded. Carry the reason explicitly so it surfaces as the failed
+	// resource update's ErrorMessage instead of an empty string.
+	data.resourceUpdate.FailureReason = message.Reason
 	data.resourceUpdate.MarkAsFailed()
 	return StateFinishedWithError, data, nil, nil
 }

--- a/internal/metastructure/resource_update/resource_updater_test.go
+++ b/internal/metastructure/resource_update/resource_updater_test.go
@@ -15,6 +15,8 @@ import (
 	"ergo.services/ergo/gen"
 	"ergo.services/ergo/testing/unit"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -146,7 +148,7 @@ func TestResolveValue_NonUpdateLeavesPatchDocumentUntouched(t *testing.T) {
 	for _, op := range []OperationType{OperationCreate, OperationDelete, OperationReplace} {
 		t.Run(string(op), func(t *testing.T) {
 			ru := &ResourceUpdate{
-				Operation: op,
+				Operation:  op,
 				PriorState: pkgmodel.Resource{Properties: props},
 				DesiredState: pkgmodel.Resource{
 					Properties: append(json.RawMessage(nil), props...),
@@ -165,4 +167,43 @@ func TestResolveValue_NonUpdateLeavesPatchDocumentUntouched(t *testing.T) {
 				"non-Update operations must not re-derive PatchDocument")
 		})
 	}
+}
+
+// TestMostRecentFailureMessage_FallsBackToFailureReason covers the
+// terminal-resolve-miss path: the resource fails before any plugin operation
+// runs, so there is no progress-based failure message. Without a fallback the
+// operator sees an empty ErrorMessage. MostRecentFailureMessage must surface
+// the recorded FailureReason instead.
+func TestMostRecentFailureMessage_FallsBackToFailureReason(t *testing.T) {
+	ru := &ResourceUpdate{
+		State:         ResourceUpdateStateFailed,
+		FailureReason: `could not resolve reference "formae://abc#/Arn": source resource has no property "Arn"`,
+		// No ProgressResult — the failure precedes any plugin call.
+	}
+
+	assert.Equal(t, ru.FailureReason, ru.MostRecentFailureMessage(),
+		"a terminal resolve miss has no plugin progress, so the FailureReason must surface as the failure message")
+}
+
+// TestMostRecentFailureMessage_PrefersProgressMessage ensures the FailureReason
+// is only a fallback: a genuine plugin failure message still takes precedence
+// so we never mask a richer provider error with a generic resolve reason.
+func TestMostRecentFailureMessage_PrefersProgressMessage(t *testing.T) {
+	const pluginErr = "AccessDenied: not authorized to perform iam:CreateRole"
+	ru := &ResourceUpdate{
+		State:         ResourceUpdateStateFailed,
+		FailureReason: "some resolve reason that must not win",
+		ProgressResult: []plugin.TrackedProgress{
+			{
+				ProgressResult: resource.ProgressResult{
+					Operation:       resource.OperationCreate,
+					OperationStatus: resource.OperationStatusFailure,
+					StatusMessage:   pluginErr,
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, pluginErr, ru.MostRecentFailureMessage(),
+		"a plugin failure message must take precedence over the resolve FailureReason fallback")
 }

--- a/internal/workflow_tests/local/apply_forma/readonly_output_resolvable_test.go
+++ b/internal/workflow_tests/local/apply_forma/readonly_output_resolvable_test.go
@@ -1,0 +1,150 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// TestMetastructure_ReconcileResolvesReadOnlyOutputReference verifies that a
+// dependent resolving a reference to another resource's read-only output
+// resolves correctly under a reconcile apply. Read-only/computed outputs (an
+// IAM Role's Arn, a Secret's Id) are segregated into ReadOnlyProperties rather
+// than Properties, so resolution must consult both. Here the source resource's
+// Arn lives only in ReadOnlyProperties and a newly-added dependent references
+// it via `.res.arn`; the reference must resolve to the concrete Arn value.
+//
+// The sibling TestMetastructure_ApplyFormaWithRes covers the same shape in
+// patch mode; this exercises the reconcile path with a new dependent against a
+// pre-existing source.
+func TestMetastructure_ReconcileResolvesReadOnlyOutputReference(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const hostArn = "arn:fake:host/host1"
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          "1234",
+					NativeID:           "5678",
+					ResourceProperties: json.RawMessage(`{"name":"bucket1"}`),
+				}}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{
+					ResourceType: "FakeAWS::S3::Host",
+					Properties:   `{"name":"host1","Arn":"` + hostArn + `"}`,
+				}, nil
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		m.Datastore.CreateTarget(&pkgmodel.Target{
+			Label:  "test-target",
+			Config: json.RawMessage(`{}`),
+		})
+
+		// Existing source resource whose Arn lives only in ReadOnlyProperties.
+		hostKsuid := util.NewID()
+		host := pkgmodel.Resource{
+			Label:              "snarf-host",
+			Type:               "FakeAWS::S3::Host",
+			Properties:         json.RawMessage(`{"name": "host1"}`),
+			ReadOnlyProperties: json.RawMessage(`{"Arn": "` + hostArn + `"}`),
+			Stack:              "test-stack",
+			Target:             "test-target",
+			Ksuid:              hostKsuid,
+			Schema: pkgmodel.Schema{
+				Identifier: "name",
+				Hints:      map[string]pkgmodel.FieldHint{"name": {CreateOnly: true}},
+				Fields:     []string{"name"},
+			},
+		}
+		_, err = m.Datastore.BulkStoreResources([]pkgmodel.Resource{host}, "host-setup-command")
+		require.NoError(t, err)
+
+		// New dependent referencing the source's read-only Arn output via $res.
+		bucket := pkgmodel.Resource{
+			Label: "test-bucket",
+			Type:  "FakeAWS::S3::Bucket",
+			Properties: json.RawMessage(`{
+				"name": "bucket1",
+				"host-arn": {
+					"$res": true,
+					"$label": "snarf-host",
+					"$type": "FakeAWS::S3::Host",
+					"$stack": "test-stack",
+					"$property": "Arn"
+				}
+			}`),
+			Stack:  "test-stack",
+			Target: "test-target",
+			Schema: pkgmodel.Schema{
+				Identifier: "name",
+				Hints:      map[string]pkgmodel.FieldHint{"name": {CreateOnly: true}},
+				Fields:     []string{"name", "host-arn"},
+			},
+		}
+
+		// Reconcile mode describes the full stack, so the (unchanged) source is
+		// included alongside the new dependent.
+		forma := &pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: "test-stack"}},
+			Resources: []pkgmodel.Resource{host, bucket},
+			Targets:   []pkgmodel.Target{{Label: "test-target", Config: json.RawMessage(`{}`)}},
+		}
+
+		m.ApplyForma(forma, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test")
+
+		var bucketUpdate resource_update.ResourceUpdate
+		require.Eventually(t, func() bool {
+			fas, err := m.Datastore.LoadFormaCommands()
+			require.NoError(t, err)
+			if len(fas) != 1 {
+				return false
+			}
+			for _, ru := range fas[0].ResourceUpdates {
+				if ru.DesiredState.Label == "test-bucket" {
+					bucketUpdate = ru
+					return ru.State == resource_update.ResourceUpdateStateSuccess ||
+						ru.State == resource_update.ResourceUpdateStateFailed
+				}
+			}
+			return false
+		}, 5*time.Second, 100*time.Millisecond)
+
+		require.Equal(t, resource_update.ResourceUpdateStateSuccess, bucketUpdate.State,
+			"dependent referencing a read-only output must resolve, not fail: %q",
+			bucketUpdate.MostRecentFailureMessage())
+
+		var props map[string]any
+		require.NoError(t, json.Unmarshal(bucketUpdate.DesiredState.Properties, &props))
+		hostArnRef, ok := props["host-arn"].(map[string]any)
+		require.True(t, ok, "host-arn ref should be present")
+		assert.Equal(t, hostArn, hostArnRef["$value"],
+			"a read-only output reference must resolve to the source's Arn")
+	})
+}

--- a/internal/workflow_tests/local/resolve_cache_test.go
+++ b/internal/workflow_tests/local/resolve_cache_test.go
@@ -155,3 +155,137 @@ func TestResolveCache(t *testing.T) {
 		assert.Equal(t, 1, callsToReadOperation)
 	})
 }
+
+// TestResolveCache_MissingPropertyReportsReason covers the terminal
+// resolve-miss diagnosability gap (PLA-25): when a referenced property is
+// absent from the source resource after a successful Read, the ResolveCache
+// must report *why* it failed — naming the reference and the missing
+// property — rather than sending an empty failure that surfaces as a blank
+// ErrorMessage. It exercises both terminal-miss branches: the post-read miss
+// (cache miss → read → property absent) and the subsequent cache-hit miss.
+func TestResolveCache_MissingPropertyReportsReason(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		overrides := &plugin.ResourcePluginOverrides{
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{
+					ResourceType: "FakeAWS::S3::Bucket",
+					Properties:   `{"name":"bucket1"}`,
+				}, nil
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		if err != nil {
+			t.Fatalf("Failed to create metastructure: %v", err)
+			return
+		}
+
+		received := make(chan any, 1)
+		_, err = testutil.StartTestHelperActor(m.Node, received)
+		assert.NoError(t, err)
+
+		target := pkgmodel.Target{
+			Label:     "test-target",
+			Namespace: "test-namespace",
+			Config:    json.RawMessage(`{}`),
+		}
+
+		targetUpdate := target_update.TargetUpdate{
+			Target:    target,
+			Operation: target_update.TargetOperationCreate,
+			State:     target_update.TargetUpdateStateNotStarted,
+		}
+
+		_, err = testutil.Call(m.Node, "ResourcePersister", target_update.PersistTargetUpdates{
+			TargetUpdates: []target_update.TargetUpdate{targetUpdate},
+			CommandID:     "test-command-1",
+		})
+		assert.NoError(t, err)
+
+		resourceUpdate := &resource_update.ResourceUpdate{
+			DesiredState: pkgmodel.Resource{
+				Label:      "resource-1",
+				Type:       "FakeAWS::S3::Bucket",
+				Properties: json.RawMessage(`{"name":"bucket1"}`),
+				Stack:      "test-stack",
+				Target:     "test-target",
+				NativeID:   "test-native-id-1",
+				Ksuid:      util.NewID(),
+			},
+			ResourceTarget: target,
+			State:          resource_update.ResourceUpdateStateSuccess,
+			Version:        "test-persist-hash-1",
+			ProgressResult: []plugin.TrackedProgress{
+				{
+					ProgressResult: resource.ProgressResult{
+						Operation:          resource.OperationCreate,
+						OperationStatus:    resource.OperationStatusSuccess,
+						RequestID:          "test-request-id-1",
+						NativeID:           "test-native-id-1",
+						ResourceProperties: json.RawMessage(`{"name":"bucket1"}`),
+					},
+					ResourceType: "FakeAWS::S3::Bucket",
+					StartTs:      util.TimeNow(),
+					ModifiedTs:   util.TimeNow(),
+					Attempts:     1,
+				},
+			},
+			RemainingResolvables: []pkgmodel.FormaeURI{},
+			StackLabel:           "test-stack",
+			GroupID:              "test-group-id-1",
+		}
+
+		hash, err := testutil.Call(m.Node, "ResourcePersister", resource_update.PersistResourceUpdate{
+			PluginOperation: resource.OperationCreate,
+			ResourceUpdate:  *resourceUpdate,
+		})
+		assert.NoError(t, err)
+		assert.NotEmpty(t, hash)
+
+		_, err = testutil.Call(m.Node, "ChangesetSupervisor", changeset.EnsureResolveCache{
+			CommandID: "test-command-1",
+		})
+		assert.NoError(t, err)
+
+		// "arn" is not a property of the read result — this resolves terminally.
+		missingURI := pkgmodel.NewFormaeURI(resourceUpdate.DesiredState.Ksuid, "arn")
+
+		// First attempt: cache miss -> read -> property absent (post-read miss).
+		testutil.Send(m.Node,
+			actornames.ResolveCache("test-command-1"),
+			messages.ResolveValue{ResourceURI: missingURI})
+
+		testutil.ExpectMessageWithPredicate(t, received, 5*time.Second, func(msg any) bool {
+			failed, ok := msg.(messages.FailedToResolveValue)
+			if !ok {
+				t.Fatalf("Expected FailedToResolveValue message, got %T", msg)
+			}
+			assert.NotEmpty(t, failed.Reason,
+				"a terminal resolve miss must carry a Reason so the operator sees the cause")
+			assert.Contains(t, failed.Reason, "arn",
+				"Reason must name the property that could not be resolved")
+			assert.Contains(t, failed.Reason, "resource-1",
+				"Reason must name the source resource the property is missing from")
+			return true
+		})
+
+		// Second attempt for the same property: the resource is now cached, so
+		// this exercises the cache-hit miss branch, which must also report a Reason.
+		testutil.Send(m.Node,
+			actornames.ResolveCache("test-command-1"),
+			messages.ResolveValue{ResourceURI: missingURI})
+
+		testutil.ExpectMessageWithPredicate(t, received, 5*time.Second, func(msg any) bool {
+			failed, ok := msg.(messages.FailedToResolveValue)
+			if !ok {
+				t.Fatalf("Expected FailedToResolveValue message, got %T", msg)
+			}
+			assert.NotEmpty(t, failed.Reason,
+				"a cache-hit terminal miss must also carry a Reason")
+			assert.Contains(t, failed.Reason, "arn",
+				"Reason must name the property that could not be resolved")
+			return true
+		})
+	})
+}


### PR DESCRIPTION
## Summary

When a resolvable reference fails to resolve **terminally** — the referenced property is absent from the source resource even after a successful Read — the dependent resource was marked `Failed` with an **empty** `ErrorMessage`, before any cloud API call. The operator got nothing to act on, and the cause was only visible by log spelunking.

Root cause: the terminal-miss branch in `ResolveCache` marked the resource failed but recorded no message, and `MostRecentFailureMessage` only scans plugin progress — of which this path produces none, since the failure precedes any plugin operation.

## What changed

- Added a `Reason` field to `FailedToResolveValue`; `ResolveCache` now populates it at both terminal-miss branches (post-read and cache-hit) with a message naming the reference, the missing property, and — when known — the source resource by `stack/type/label`.
- Added `FailureReason` to `ResourceUpdate`; the resolve-failure handler stores the reason there.
- `MostRecentFailureMessage` falls back to `FailureReason` when no progress-based failure message exists, so a terminal resolve miss now surfaces a descriptive `ErrorMessage`. Genuine provider failure messages still take precedence.

## Tests

- `TestResolveCache_MissingPropertyReportsReason` — both terminal-miss branches carry a Reason naming the property and source.
- `TestMostRecentFailureMessage_FallsBackToFailureReason` — the reason surfaces as the failure message.
- `TestMostRecentFailureMessage_PrefersProgressMessage` — guards that plugin errors still win over the fallback.