### PR TITLE
fix(patch): keep unchanged + setOnce-frozen writeOnly values out of patch

### DIFF
--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -27,8 +27,11 @@ var defaultIgnoredFields = []jsonpatch.Path{}
 //     these immutable properties changed: …") and are never sent to plugins.
 //
 // The two slices are disjoint. Either can be nil.
-func GeneratePatch(document []byte, patch []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, error) {
-	return generatePatch(document, patch, properties, schema, mode)
+//
+// excludeWriteOnly lists dotted paths the caller found unchanged or setOnce-frozen;
+// they are stripped from desired so no op is emitted. Callers with none pass nothing.
+func GeneratePatch(document []byte, patch []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode, excludeWriteOnly ...string) (json.RawMessage, json.RawMessage, error) {
+	return generatePatch(document, patch, properties, schema, mode, excludeWriteOnly...)
 }
 
 func collectionSemanticsFromFieldHints(hints map[string]pkgmodel.FieldHint) jsonpatch.Collections {
@@ -63,7 +66,7 @@ func entitySetProviderDefaultsFromHints(hints map[string]pkgmodel.FieldHint) map
 	return result
 }
 
-func generatePatch(document []byte, patch []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, error) {
+func generatePatch(document []byte, patch []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode, excludeWriteOnly ...string) (json.RawMessage, json.RawMessage, error) {
 	flattenedDocument, flattenedPatch, err := flattenAndResolveRefs(document, patch, properties)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to flatten and resolve refs: %w", err)
@@ -90,6 +93,16 @@ func generatePatch(document []byte, patch []byte, properties resolver.Resolvable
 		flattenedPatch, err = removeWriteOnlyFields(flattenedPatch, writeOnlyCreateOnly)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to strip writeOnly+createOnly fields from desired state: %w", err)
+		}
+	}
+
+	// Also drop unchanged/setOnce-frozen writeOnly paths from desired. createPatchDocument
+	// strips writeOnly from the document, so otherwise they re-emit as an "add"; removing
+	// from both sides emits no op. Changed paths stay and re-add their cleartext.
+	if len(excludeWriteOnly) > 0 {
+		flattenedPatch, err = removeWriteOnlyFields(flattenedPatch, excludeWriteOnly)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to strip excluded writeOnly fields from desired state: %w", err)
 		}
 	}
 

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -2495,3 +2495,70 @@ func TestGeneratePatch_AtomicNestedArrayProducesReplace(t *testing.T) {
 	assert.Equal(t, "/FirewallPolicy/StatefulDefaultActions", patches[0].Path)
 	assert.Equal(t, []any{"aws:drop_established"}, patches[0].Value)
 }
+
+func TestGeneratePatch_WriteOnlyNonOpaqueAndNestedPath_NoOverStripping(t *testing.T) {
+	// Password is a writeOnly leaf nested under LoginProfile (dotted hint key),
+	// plus a top-level non-opaque writeOnly token. Read never returns either;
+	// both must be re-added with their cleartext values and nothing else.
+	// Passing an empty exclude list must not over-strip.
+	document := []byte(`{"LoginProfile":{"PasswordResetRequired":false},"UserName":"u"}`)
+	patch := []byte(`{
+		"LoginProfile":{"Password":"p@ss","PasswordResetRequired":false},
+		"UserName":"u",
+		"ApiToken":"tok-123"
+	}`)
+	schema := pkgmodel.Schema{
+		Fields: []string{"LoginProfile", "UserName", "ApiToken"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"LoginProfile.Password": {WriteOnly: true}, // nested/dotted
+			"ApiToken":              {WriteOnly: true}, // top-level non-opaque
+		},
+	}
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch,
+		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	require.NoError(t, err)
+	assert.Empty(t, createOnlyPatch)
+
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	byPath := map[string]jsonpatch.JsonPatchOperation{}
+	for _, op := range ops {
+		byPath[op.Path] = op
+	}
+	require.Contains(t, byPath, "/LoginProfile/Password")
+	assert.Equal(t, "p@ss", byPath["/LoginProfile/Password"].Value)
+	require.Contains(t, byPath, "/ApiToken")
+	assert.Equal(t, "tok-123", byPath["/ApiToken"].Value)
+	// no over-stripping: PasswordResetRequired (unchanged) and UserName must NOT appear
+	assert.NotContains(t, byPath, "/LoginProfile/PasswordResetRequired")
+	assert.NotContains(t, byPath, "/UserName")
+}
+
+func TestGeneratePatch_ExcludeList_DropsWriteOnlyOpFromDesired(t *testing.T) {
+	// The exclude list (variadic) drops a writeOnly field path from the desired
+	// side so jsonpatch emits no op for it, while leaving non-excluded writeOnly
+	// fields intact.
+	document := []byte(`{"UserName":"u"}`)
+	patch := []byte(`{"UserName":"u","SecretString":"shhh","ApiToken":"tok"}`)
+	schema := pkgmodel.Schema{
+		Fields: []string{"UserName", "SecretString", "ApiToken"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"SecretString": {WriteOnly: true},
+			"ApiToken":     {WriteOnly: true},
+		},
+	}
+
+	patchDoc, _, err := generatePatch(document, patch,
+		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch, "SecretString")
+	require.NoError(t, err)
+
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	byPath := map[string]jsonpatch.JsonPatchOperation{}
+	for _, op := range ops {
+		byPath[op.Path] = op
+	}
+	assert.NotContains(t, byPath, "/SecretString", "excluded writeOnly path must produce no op")
+	require.Contains(t, byPath, "/ApiToken", "non-excluded writeOnly path must still be emitted")
+	assert.Equal(t, "tok", byPath["/ApiToken"].Value)
+}

--- a/internal/metastructure/resource_update/resource_comparison.go
+++ b/internal/metastructure/resource_update/resource_comparison.go
@@ -41,6 +41,90 @@ func EnforceSetOnceAndCompareResourceForUpdate(existing, new *pkgmodel.Resource)
 	return !equal, filteredRawProps, nil
 }
 
+// WriteOnlyPathsToExclude returns the writeOnly paths to drop from the patch:
+// setOnce-frozen (a value already exists) or unchanged (hash of desired == stored
+// hash). Reads the wrapped {$strategy,$visibility,$value} form, so call it before
+// ConvertToPluginFormat unwraps the values.
+func WriteOnlyPathsToExclude(existing, desired json.RawMessage, writeOnlyPaths []string) []string {
+	if len(writeOnlyPaths) == 0 {
+		return nil
+	}
+
+	existingResult := gjson.ParseBytes(existing)
+	desiredResult := gjson.ParseBytes(desired)
+
+	var exclude []string
+	for _, path := range writeOnlyPaths {
+		existingNode := existingResult.Get(path)
+		desiredNode := desiredResult.Get(path)
+
+		storedVal, storedExists := leafValue(existingNode)
+		if !storedExists {
+			continue // not yet stored: first set, keep it
+		}
+
+		// setOnce with a stored value is frozen; never re-send. Strategy comes from
+		// desired, falling back to existing (filterSetOnceProps keeps the marker).
+		strategy := nodeStrategy(desiredNode)
+		if strategy == "" {
+			strategy = nodeStrategy(existingNode)
+		}
+		if strategy == pkgmodel.StrategySetOnce {
+			exclude = append(exclude, path)
+			continue
+		}
+
+		// unchanged: hash of desired cleartext == stored value (Opaque stores the hash)
+		desiredVal, desiredHasVal := leafValue(desiredNode)
+		if !desiredHasVal {
+			exclude = append(exclude, path)
+			continue
+		}
+		if pkgmodel.ComputeValueHash(valueToString(desiredVal)) == valueToString(storedVal) {
+			exclude = append(exclude, path)
+		}
+	}
+
+	return exclude
+}
+
+// leafValue returns the comparable leaf value for a property node and whether a
+// value is present. A wrapped Value object ({"$value": ...}) yields its $value;
+// a plain scalar yields itself.
+func leafValue(node gjson.Result) (gjson.Result, bool) {
+	if !node.Exists() {
+		return gjson.Result{}, false
+	}
+	if node.IsObject() {
+		v := node.Get("$value")
+		if !v.Exists() || v.Value() == nil {
+			return gjson.Result{}, false
+		}
+		return v, true
+	}
+	if node.Value() == nil {
+		return gjson.Result{}, false
+	}
+	return node, true
+}
+
+// nodeStrategy returns the $strategy of a wrapped Value node, or "" otherwise.
+func nodeStrategy(node gjson.Result) string {
+	if node.Exists() && node.IsObject() {
+		return node.Get("$strategy").String()
+	}
+	return ""
+}
+
+// valueToString renders a gjson leaf the same way Value.GetStringValue does, so
+// the hash comparison matches what PersistValueTransformer stored.
+func valueToString(v gjson.Result) string {
+	if v.Type == gjson.String {
+		return v.Str
+	}
+	return v.String()
+}
+
 // filterSetOnceProps recursively removes SetOnce properties with existing values
 func filterSetOnceProps(existing, new json.RawMessage, label string) (json.RawMessage, error) {
 	if len(existing) == 0 || len(new) == 0 {

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -124,12 +124,16 @@ func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value strin
 	ru.DesiredState.Properties = properties
 
 	if ru.Operation == OperationUpdate && len(ru.DesiredState.Schema.Fields) > 0 {
+		// Recompute the same writeOnly exclusion the factory applied, so this
+		// regeneration does not re-introduce an unchanged or setOnce-frozen value.
+		excludeWriteOnly := WriteOnlyPathsToExclude(ru.PriorState.Properties, ru.DesiredState.Properties, ru.DesiredState.Schema.WriteOnly())
 		patchDoc, _, derr := patch.GeneratePatch(
 			ru.PriorState.Properties,
 			ru.DesiredState.Properties,
 			resolver.NewResolvableProperties(),
 			ru.DesiredState.Schema,
 			pkgmodel.FormaApplyModePatch,
+			excludeWriteOnly...,
 		)
 		if derr != nil {
 			return fmt.Errorf("failed to re-derive patch document after resolving %s: %w", formaeUri, derr)

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -59,6 +59,10 @@ func NewResourceUpdateForExisting(
 	var createOnlyPatch json.RawMessage
 
 	if hasChanges {
+		// Compute writeOnly exclusions before ConvertToPluginFormat unwraps the
+		// wrapped values (the check needs $strategy and the stored hash).
+		excludeWriteOnly := WriteOnlyPathsToExclude(existingResource.Properties, filteredProps, newResource.Schema.WriteOnly())
+
 		existingPluginProps, err := resolver.ConvertToPluginFormat(existingResource.Properties)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert existing properties to plugin format: %w", err)
@@ -75,6 +79,7 @@ func NewResourceUpdateForExisting(
 			resolvableProperties,
 			newResource.Schema,
 			mode,
+			excludeWriteOnly...,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create patch document for resource %s: %w", existingResource.Label, err)

--- a/internal/metastructure/resource_update/resource_update_readonly_test.go
+++ b/internal/metastructure/resource_update/resource_update_readonly_test.go
@@ -1,0 +1,45 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/stretchr/testify/require"
+)
+
+// A surfaced writeOnly field is echoed back by some providers as a bare cleartext
+// string in the Read result. It must not be persisted into Properties or
+// ReadOnlyProperties; the managed (hashed) value in desired Properties is kept.
+func TestUpdateProperties_DropsWriteOnlyFromReadBack(t *testing.T) {
+	ru := &ResourceUpdate{
+		DesiredState: pkgmodel.Resource{
+			Properties: json.RawMessage(`{"Name":"n","SecretString":{"$value":"deadbeefhash","$visibility":"Opaque"}}`),
+			Schema: pkgmodel.Schema{
+				Fields: []string{"Name", "SecretString"},
+				Hints: map[string]pkgmodel.FieldHint{
+					"SecretString": {WriteOnly: true},
+				},
+			},
+		},
+	}
+
+	// Provider Read returns the writeOnly value as bare cleartext, plus a real read-only field.
+	readBack := `{"Name":"n","SecretString":"super-secret-cleartext","Arn":"arn:aws:secretsmanager:::secret:x"}`
+	require.NoError(t, ru.updateResourceProperties(readBack))
+
+	props := string(ru.DesiredState.Properties)
+	ro := string(ru.DesiredState.ReadOnlyProperties)
+
+	require.NotContains(t, ro, "super-secret-cleartext", "cleartext must not land in ReadOnlyProperties")
+	require.NotContains(t, ro, "SecretString", "writeOnly field must not appear in ReadOnlyProperties")
+	require.NotContains(t, props, "super-secret-cleartext", "provider read-back cleartext must not overwrite the managed value")
+	require.Contains(t, props, "deadbeefhash", "managed hashed value is preserved")
+	require.Contains(t, ro, "Arn", "genuine read-only fields are still captured")
+}

--- a/internal/metastructure/resource_update/resource_update_writeonly_opaque_test.go
+++ b/internal/metastructure/resource_update/resource_update_writeonly_opaque_test.go
@@ -1,0 +1,188 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update_test
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/patch"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/jsonpatch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var sha256Hex = regexp.MustCompile(`[0-9a-f]{64}`)
+
+// writeOnlyOpaqueSchema builds a schema with a single writeOnly field plus a
+// sibling, mirroring an AWS::SecretsManager::Secret shape.
+func writeOnlyOpaqueSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"secret", "name"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"secret": {WriteOnly: true},
+		},
+	}
+}
+
+// opsByPath unmarshals a patch document and indexes the ops by RFC-6902 path.
+func opsByPath(t *testing.T, patchDoc json.RawMessage) map[string]jsonpatch.JsonPatchOperation {
+	t.Helper()
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	byPath := map[string]jsonpatch.JsonPatchOperation{}
+	for _, op := range ops {
+		byPath[op.Path] = op
+	}
+	return byPath
+}
+
+// genPatchFor runs the same factory-side pipeline that NewResourceUpdateForExisting
+// uses: setOnce filter, compute the writeOnly exclude list from the WRAPPED props,
+// convert both sides to plugin format, then GeneratePatch with the exclude list.
+func genPatchFor(t *testing.T, existing, newRes *pkgmodel.Resource) json.RawMessage {
+	t.Helper()
+	_, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes)
+	require.NoError(t, err)
+
+	exclude := resource_update.WriteOnlyPathsToExclude(existing.Properties, filteredProps, newRes.Schema.WriteOnly())
+
+	existingPP, err := resolver.ConvertToPluginFormat(existing.Properties)
+	require.NoError(t, err)
+	newPP, err := resolver.ConvertToPluginFormat(filteredProps)
+	require.NoError(t, err)
+
+	patchDoc, createOnlyPatch, err := patch.GeneratePatch(existingPP, newPP,
+		resolver.NewResolvableProperties(), newRes.Schema, pkgmodel.FormaApplyModePatch, exclude...)
+	require.NoError(t, err)
+	assert.Empty(t, createOnlyPatch)
+	return patchDoc
+}
+
+// (a) setOnce + opaque value frozen, sibling changes -> no op on value path, no sha256 anywhere.
+func TestGeneratePatch_SetOnceOpaqueFrozen_SiblingChange_NoValueOpNoHash(t *testing.T) {
+	existing := &pkgmodel.Resource{
+		Label:  "r",
+		Schema: writeOnlyOpaqueSchema(),
+		Properties: json.RawMessage(`{
+			"secret": {"$strategy": "SetOnce", "$visibility": "Opaque", "$value": "old-secret"},
+			"name": "old"
+		}`),
+	}
+	newRes := &pkgmodel.Resource{
+		Label:  "r",
+		Schema: writeOnlyOpaqueSchema(),
+		Properties: json.RawMessage(`{
+			"secret": {"$strategy": "SetOnce", "$visibility": "Opaque", "$value": "rotated-secret"},
+			"name": "new"
+		}`),
+	}
+
+	patchDoc := genPatchFor(t, existing, newRes)
+	byPath := opsByPath(t, patchDoc)
+
+	assert.NotContains(t, byPath, "/secret", "frozen setOnce opaque value must not enter the patch")
+	require.Contains(t, byPath, "/name", "sibling change must still produce an op")
+	assert.NotRegexp(t, sha256Hex, string(patchDoc), "no sha256 hash may appear anywhere in the patch")
+}
+
+// (b) Update-strategy + opaque value CHANGED -> patch carries the value path with CLEARTEXT new value.
+func TestGeneratePatch_UpdateOpaqueChanged_CarriesCleartext(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"secret"},
+		Hints:  map[string]pkgmodel.FieldHint{"secret": {WriteOnly: true}},
+	}
+	// Stored Opaque value is the hash of the old cleartext (persist-time form).
+	storedHash := pkgmodel.ComputeValueHash("old")
+	existing := &pkgmodel.Resource{
+		Label:      "r",
+		Schema:     schema,
+		Properties: json.RawMessage(`{"secret": {"$strategy": "Update", "$visibility": "Opaque", "$value": "` + storedHash + `"}}`),
+	}
+	newRes := &pkgmodel.Resource{
+		Label:      "r",
+		Schema:     schema,
+		Properties: json.RawMessage(`{"secret": {"$strategy": "Update", "$visibility": "Opaque", "$value": "new-cleartext"}}`),
+	}
+
+	patchDoc := genPatchFor(t, existing, newRes)
+	byPath := opsByPath(t, patchDoc)
+
+	require.Contains(t, byPath, "/secret", "changed Update opaque value must appear on /secret")
+	assert.Equal(t, "new-cleartext", byPath["/secret"].Value)
+	assert.NotRegexp(t, sha256Hex, string(patchDoc))
+}
+
+// (c) Update-strategy + opaque UNCHANGED, sibling change -> no op on value path.
+func TestGeneratePatch_UpdateOpaqueUnchanged_SiblingChange_NoValueOp(t *testing.T) {
+	// The stored Opaque value is the SHA-256 hash of the cleartext (written by
+	// PersistValueTransformer at persist time). The desired side carries the
+	// matching cleartext "same", so it is unchanged.
+	storedHash := pkgmodel.ComputeValueHash("same")
+	existing := &pkgmodel.Resource{
+		Label:  "r",
+		Schema: writeOnlyOpaqueSchema(),
+		Properties: json.RawMessage(`{
+			"secret": {"$strategy": "Update", "$visibility": "Opaque", "$value": "` + storedHash + `"},
+			"name": "old"
+		}`),
+	}
+	newRes := &pkgmodel.Resource{
+		Label:  "r",
+		Schema: writeOnlyOpaqueSchema(),
+		Properties: json.RawMessage(`{
+			"secret": {"$strategy": "Update", "$visibility": "Opaque", "$value": "same"},
+			"name": "new"
+		}`),
+	}
+
+	patchDoc := genPatchFor(t, existing, newRes)
+	byPath := opsByPath(t, patchDoc)
+
+	assert.NotContains(t, byPath, "/secret", "unchanged opaque value must not enter the patch")
+	require.Contains(t, byPath, "/name", "sibling change must still produce an op")
+	assert.NotRegexp(t, sha256Hex, string(patchDoc))
+}
+
+// (d) First set (value absent from existing) -> patch carries cleartext value.
+func TestGeneratePatch_OpaqueFirstSet_CarriesCleartext(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"secret"},
+		Hints:  map[string]pkgmodel.FieldHint{"secret": {WriteOnly: true}},
+	}
+	existing := &pkgmodel.Resource{
+		Label:      "r",
+		Schema:     schema,
+		Properties: json.RawMessage(`{}`),
+	}
+	newRes := &pkgmodel.Resource{
+		Label:      "r",
+		Schema:     schema,
+		Properties: json.RawMessage(`{"secret": {"$strategy": "Update", "$visibility": "Opaque", "$value": "first-cleartext"}}`),
+	}
+
+	patchDoc := genPatchFor(t, existing, newRes)
+	byPath := opsByPath(t, patchDoc)
+
+	require.Contains(t, byPath, "/secret", "first set of opaque value must appear on /secret")
+	assert.Equal(t, "first-cleartext", byPath["/secret"].Value)
+	assert.NotRegexp(t, sha256Hex, string(patchDoc))
+}
+
+// WriteOnlyPathsToExclude unit coverage: a non-opaque writeOnly field that
+// changed must NOT be excluded (no over-stripping of non-opaque writeOnly).
+func TestWriteOnlyPathsToExclude_NonOpaqueChanged_NotExcluded(t *testing.T) {
+	existing := json.RawMessage(`{"token": {"$visibility": "Clear", "$value": "old"}}`)
+	desired := json.RawMessage(`{"token": {"$visibility": "Clear", "$value": "new"}}`)
+
+	exclude := resource_update.WriteOnlyPathsToExclude(existing, desired, []string{"token"})
+	assert.NotContains(t, exclude, "token", "changed non-opaque writeOnly field must not be excluded")
+}

--- a/internal/workflow_tests/local/apply_forma/opaque_secret_value_test.go
+++ b/internal/workflow_tests/local/apply_forma/opaque_secret_value_test.go
@@ -1,0 +1,188 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+// Regression suite for opaque + writeOnly secret values (AWS SecretsManager
+// SecretString, Azure KeyVault Secret value). Distilled from the characterization
+// tests Jeroen Soeters authored on branch opaque-writeonly-characterization-tests;
+// those mapped the behavior matrix, these pin the fixed behavior.
+//
+// The value field is now SURFACED (not hidden), so it appears in Schema.WriteOnly()
+// and the suppression logic applies. End to end, through the metastructure:
+//   - rotate:   a changed value reaches the plugin as cleartext
+//   - no churn: an unchanged value yields no /SecretString op on a sibling edit
+//   - setOnce:  a frozen value is never re-sent, and never as its stored hash (no corruption)
+//   - create:   the first value reaches the plugin as cleartext
+
+import (
+	"encoding/json"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/stretchr/testify/require"
+)
+
+var sha256Re = regexp.MustCompile(`[0-9a-f]{64}`)
+
+// opaque builds the wrapped value envelope a user writes as formae.value(v).opaque[.setOnce].
+func opaque(v, strategy string) string {
+	return `{"$value":"` + v + `","$visibility":"Opaque","$strategy":"` + strategy + `"}`
+}
+
+// surfacedSecretSchema is the post-fix shape: SecretString is a surfaced, writeOnly field.
+func surfacedSecretSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Description", "SecretString"},
+		Hints:      map[string]pkgmodel.FieldHint{"SecretString": {WriteOnly: true}},
+	}
+}
+
+func secretForma(nativeID, props string) *pkgmodel.Forma {
+	r := pkgmodel.Resource{
+		Label:      "the-secret",
+		Type:       "FakeAWS::SecretsManager::Secret",
+		Stack:      "secrets-stack",
+		Target:     "secrets-target",
+		Schema:     surfacedSecretSchema(),
+		Properties: json.RawMessage(props),
+		Managed:    true,
+	}
+	if nativeID != "" {
+		r.NativeID = nativeID
+	}
+	return &pkgmodel.Forma{
+		Stacks:    []pkgmodel.Stack{{Label: "secrets-stack"}},
+		Resources: []pkgmodel.Resource{r},
+		Targets:   []pkgmodel.Target{{Label: "secrets-target", Namespace: "secrets-namespace", Config: json.RawMessage(`{}`)}},
+	}
+}
+
+// secretRun is the evidence captured from the plugin: the Properties Create saw,
+// and the PatchDocument of every Update.
+type secretRun struct {
+	createProps   string
+	updatePatches []string
+}
+
+// applySecret creates with createProps, then (when reapplyProps != "") re-applies it.
+// The provider Read returns Name + readDesc (never the writeOnly secret), so the
+// only diff the re-apply sees is whatever createProps and reapplyProps differ on.
+func applySecret(t *testing.T, createProps, reapplyProps, readDesc string) secretRun {
+	t.Helper()
+	var run secretRun
+	var mu sync.Mutex
+
+	overrides := &plugin.ResourcePluginOverrides{
+		Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+			mu.Lock()
+			run.createProps = string(req.Properties)
+			mu.Unlock()
+			return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+				Operation: resource.OperationCreate, OperationStatus: resource.OperationStatusSuccess,
+				NativeID: "secret-native-id", ResourceProperties: json.RawMessage(`{"Name":"my-secret"}`),
+			}}, nil
+		},
+		Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+			mu.Lock()
+			if req.PatchDocument != nil {
+				run.updatePatches = append(run.updatePatches, *req.PatchDocument)
+			}
+			mu.Unlock()
+			return &resource.UpdateResult{ProgressResult: &resource.ProgressResult{
+				Operation: resource.OperationUpdate, OperationStatus: resource.OperationStatusSuccess,
+				NativeID: req.NativeID, ResourceProperties: json.RawMessage(`{"Name":"my-secret"}`),
+			}}, nil
+		},
+		Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+			return &resource.ReadResult{ResourceType: req.ResourceType,
+				Properties: `{"Name":"my-secret","Description":"` + readDesc + `"}`}, nil
+		},
+	}
+
+	m, done, err := test_helpers.NewTestMetastructure(t, overrides)
+	require.NoError(t, err)
+	defer done()
+
+	reconcile := &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}
+	_, err = m.ApplyForma(secretForma("", createProps), reconcile, "client")
+	require.NoError(t, err)
+	waitForCommands(t, m, 1)
+
+	if reapplyProps != "" {
+		_, err = m.ApplyForma(secretForma("secret-native-id", reapplyProps), reconcile, "client")
+		require.NoError(t, err)
+		waitForCommands(t, m, 2)
+		time.Sleep(500 * time.Millisecond)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	return run
+}
+
+func props(desc, secret string) string {
+	return `{"Name":"my-secret","Description":"` + desc + `","SecretString":` + secret + `}`
+}
+
+func joinPatches(r secretRun) string {
+	out := ""
+	for _, p := range r.updatePatches {
+		out += p
+	}
+	return out
+}
+
+// Create sends the first value to the plugin as cleartext (never a hash).
+func TestOpaqueSecret_Create_SendsCleartext(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		r := applySecret(t, props("A", opaque("value-V", "Update")), "", "A")
+		require.Contains(t, r.createProps, "value-V", "Create must receive the cleartext value")
+		require.NotRegexp(t, sha256Re, r.createProps, "Create must not receive a hash")
+	})
+}
+
+// A changed value rotates: the plugin gets a /SecretString op carrying the new cleartext.
+func TestOpaqueSecret_Update_Rotates(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		r := applySecret(t, props("A", opaque("value-V", "Update")), props("A", opaque("value-V2", "Update")), "A")
+		patch := joinPatches(r)
+		require.Contains(t, patch, "/SecretString", "a real change must reach the plugin")
+		require.Contains(t, patch, "value-V2", "the new value must be sent as cleartext")
+		require.NotRegexp(t, sha256Re, patch, "the patch must never carry a hash")
+	})
+}
+
+// An unchanged value does not churn: a sibling edit produces no /SecretString op.
+func TestOpaqueSecret_Update_NoChurnOnSiblingEdit(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		r := applySecret(t, props("A", opaque("value-V", "Update")), props("B", opaque("value-V", "Update")), "A")
+		patch := joinPatches(r)
+		require.Contains(t, patch, "/Description", "the sibling change must reach the plugin")
+		require.NotContains(t, patch, "/SecretString", "an unchanged value must not be re-sent")
+		require.NotRegexp(t, sha256Re, patch, "no hash anywhere")
+	})
+}
+
+// setOnce freezes the value and never corrupts it: a sibling edit (with a changed
+// value in the forma) sends the sibling op but no /SecretString, and no hash.
+func TestOpaqueSecret_SetOnce_FrozenNoCorruption(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		r := applySecret(t, props("A", opaque("value-V", "SetOnce")), props("B", opaque("value-V2", "SetOnce")), "A")
+		patch := joinPatches(r)
+		require.Contains(t, patch, "/Description", "the sibling change must reach the plugin")
+		require.NotContains(t, patch, "/SecretString", "a setOnce value must never be re-sent")
+		require.NotRegexp(t, sha256Re, patch, "the value must never be sent as its stored hash")
+	})
+}


### PR DESCRIPTION
**Issue:** Secrets churned on each apply which made rotation indistinguishable at patch layer
- writeOnly opaque values were re-sent on reconcile
- a writeOnly field is stripped from the read/actual side, so the diff always re-added it

**Fix:** A writeOnly opaque value enters the patch only when it genuinely changed and isn't frozen from setOnce designation
- unchanged -> no op (no churn)
- .opaque.setOnce -> frozen after first set
- .opaque changed -> rotates (cleartext flows through)

A new function `WriteOnlyPathsToExclude` reads the wrapped res (i.e. `{$strategy,$visibility,$value}`) _before_ ConvertToPluginFormat unwraps it, thus gating both unchanged and setOnce values from reaching the patch. This has been threaded into into patch generation at the resolve value re-gen

---

Unblocks the Azure Key Vault secret (platform-engineering-labs/formae-plugin-azure#67).