### PR TITLE
ci(e2e): pin status-check context to the test name

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -72,6 +72,10 @@ jobs:
           done
 
   e2e:
+    # Pin the check-context name to the test only, so adding plugin dimensions
+    # to the matrix below does not rename the GitHub status check. The ruleset's
+    # required checks match contexts as "e2e (<test>)".
+    name: e2e (${{ matrix.test }}${{ matrix.user_plugins && ' [user-install]' || '' }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [pre-cleanup]


### PR DESCRIPTION
## Summary

- The `e2e` job in `e2e-tests.yml` had no explicit `name`, so GitHub derived each matrix job's status-check **context** from all matrix values.
- Adding plugin dimensions (`system_plugins`/`user_plugins`) to the matrix silently renamed the contexts from `e2e (<test>)` to `e2e (<test>, <plugins>)`.
- Those no longer match the branch ruleset's required checks, so the required `e2e (<test>)` contexts sit as **"Expected — Waiting for status to be reported"** indefinitely. On PRs from authors without admin bypass this blocks merges even though the full e2e suite passes.
- Fix: pin the job `name` to `e2e (${{ matrix.test }})` so plugin dimensions no longer affect the context name. The user-install variant of `TestExtractSchemaLocationLocal` gets a `[user-install]` suffix to keep contexts unique.