### PR TITLE
fix(patch): replace Atomic list fields wholesale instead of remove+add

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.6
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.0.0-00010101000000-000000000000
 	github.com/platform-engineering-labs/formae/tests/testcontrol v0.0.0-00010101000000-000000000000
-	github.com/platform-engineering-labs/jsonpatch v0.0.0-20260509215119-2aad56a9d57b
+	github.com/platform-engineering-labs/jsonpatch v0.0.0-20260620044942-701436c7758c
 	github.com/platform-engineering-labs/orbital v0.1.41
 	github.com/posthog/posthog-go v1.6.3
 	github.com/pressly/goose/v3 v3.26.0

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/sftp v1.13.6 h1:JFZT4XbOU7l77xGSpOdW+pwIMqP044IyjXX6FGyEKFo=
 github.com/pkg/sftp v1.13.6/go.mod h1:tz1ryNURKu77RL+GuCzmoJYxQczL3wLNNpPWagdg4Qk=
-github.com/platform-engineering-labs/jsonpatch v0.0.0-20260509215119-2aad56a9d57b h1:Y3RJPd1/aZNnb3+wGu2vFnUmGkDh5u5AtCivg3h9EXE=
-github.com/platform-engineering-labs/jsonpatch v0.0.0-20260509215119-2aad56a9d57b/go.mod h1:pKZWs1WAxW55mYtE0kAtpvrIMPzaQhZoBWSKqUMndvY=
+github.com/platform-engineering-labs/jsonpatch v0.0.0-20260620044942-701436c7758c h1:J6V/LUUjSmYuV8A7cISFOqFgADUcvd9/QFkWIeYpyPI=
+github.com/platform-engineering-labs/jsonpatch v0.0.0-20260620044942-701436c7758c/go.mod h1:pKZWs1WAxW55mYtE0kAtpvrIMPzaQhZoBWSKqUMndvY=
 github.com/platform-engineering-labs/orbital v0.1.41 h1:+gbT761JoyhhdapaGGRkpGNGg8V0BKLd6+DVa/wOS2o=
 github.com/platform-engineering-labs/orbital v0.1.41/go.mod h1:wwVPqOmW5RO78dDzL/G5CN1Ioao0P/aUsOZVrPVx64s=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -2454,3 +2454,44 @@ func TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserDeclaresOne(t *test
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "characterization: with hasProviderDefault on an EntitySet, OOB-added entries are tolerated even when user declares others")
 }
+
+// TestGeneratePatch_AtomicNestedArrayProducesReplace guards the PLA-37 fix:
+// a list field marked updateMethod=Atomic via a dotted nested hint key
+// (FirewallPolicy.StatefulDefaultActions) must produce a single whole-array
+// replace, not per-element remove+add. AWS Cloud Control does not reliably
+// apply remove+add against a mutually-exclusive list, leaving both values.
+func TestGeneratePatch_AtomicNestedArrayProducesReplace(t *testing.T) {
+	document := []byte(`{
+		"FirewallPolicy": {
+			"StatefulDefaultActions": ["aws:drop_strict"],
+			"StatelessDefaultActions": ["aws:forward_to_sfe"]
+		}
+	}`)
+	patch := []byte(`{
+		"FirewallPolicy": {
+			"StatefulDefaultActions": ["aws:drop_established"],
+			"StatelessDefaultActions": ["aws:forward_to_sfe"]
+		}
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"FirewallPolicy"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"FirewallPolicy.StatefulDefaultActions": {
+				UpdateMethod: pkgmodel.FieldUpdateMethodAtomic,
+			},
+		},
+	}
+
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, createOnlyPatch)
+
+	var patches []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &patches))
+
+	require.Len(t, patches, 1)
+	assert.Equal(t, "replace", patches[0].Operation)
+	assert.Equal(t, "/FirewallPolicy/StatefulDefaultActions", patches[0].Path)
+	assert.Equal(t, []any{"aws:drop_established"}, patches[0].Value)
+}


### PR DESCRIPTION
## Summary

A list field hinted `updateMethod=Atomic` now produces a single whole-array `replace` op instead of per-element remove+add.

AWS Cloud Control does not reliably apply a remove+add pair against a mutually-exclusive list (e.g. `NetworkFirewall::FirewallPolicy.StatefulDefaultActions`): the live resource ends up with **both** the old and new value, which AWS rejects (`aws:drop_strict / aws:drop_established cannot exist together`). The patch formae generated was a correct RFC-6902 remove+add — the failure is on the CloudControl side — so the fix is to emit a single `replace`, matching how the underlying `UpdateFirewallPolicy` API and the existing object-level `Atomic` hint already behave.

The behavior change lives in jsonpatch (`handleValues` now honors `isAtomic` for array values, not just objects); this PR bumps the dependency and adds a regression test for the nested dotted-hint case.

## Changes
- Bump `jsonpatch` to include Atomic-array support.
- Add `TestGeneratePatch_AtomicNestedArrayProducesReplace` covering `FirewallPolicy.StatefulDefaultActions`.

## Related
- Paired with the AWS-plugin schema change marking the `*DefaultActions` lists `Atomic`.
