### PR TITLE
fix(docker): install standard metapackage from the stable channel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN useradd -m -s /bin/bash pel
 # which prompts for sudo when writing to the root-owned plugin store.
 RUN apt-get update &&  \
     apt-get install -y jq curl && \
-    /bin/bash -e -c "$(curl -fsSL https://hub.platform.engineering/get/setup.sh)" -- install --yes --channel ${CHANNEL} formae@${VERSION} standard && \
+    /bin/bash -e -c "$(curl -fsSL https://hub.platform.engineering/get/setup.sh)" -- install --yes --channel ${CHANNEL} formae@${VERSION} && \
+    /bin/bash -e -c "$(curl -fsSL https://hub.platform.engineering/get/setup.sh)" -- install --yes --channel stable standard && \
     apt-get remove -y jq curl && \
     apt-get autoremove -y --purge && \
     apt-get clean && \


### PR DESCRIPTION
## Summary

The container image installs the formae binary from the release channel (`dev` for `X.Y.Z-dev[.N]`, `stable` otherwise), but the `standard` metapackage and its plugins are published **only to stable** — plugins release independently of formae and have no parallel dev channel, so even dev formae containers are meant to ship stable plugins.

Commit `6a2a8642` (the `ENV HOME` fix) collapsed the documented two-step install into a single `pelmgr` invocation: `install --channel ${CHANNEL} formae@${VERSION} standard`. pelmgr applies one channel per call, so `standard` began installing from the formae release channel. On a **dev** release that channel has no `standard` candidate, so the image build fails with:

```
ERROR  No install candidates found for: standard.
```

This first surfaced on the `0.86.2-dev.1` release (the first dev release after that commit). Stable releases were unaffected, since the channel is `stable` either way — which is why it slipped through.

This restores the two separate install invocations so `standard` always resolves from stable, matching the design the surrounding comment already documents ("Pelmgr applies one channel per install call, so they have to be separate invocations"). The `ENV HOME` hoist from `6a2a8642` is retained.

cc @discount-elf — follow-up to the HOME fix in `6a2a8642`.
