### PR TITLE
fix(patch): suppress unchanged opaque values from patch generation

### DIFF
--- a/internal/metastructure/resource_update/opaque_suppression_test.go
+++ b/internal/metastructure/resource_update/opaque_suppression_test.go
@@ -1,0 +1,256 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/jsonpatch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These are regression tests for PLA-35: a surfaced opaque value must not churn
+// (re-emit cleartext) or corrupt (re-emit its stored hash, for setOnce) on an
+// unrelated sibling edit, while a genuinely changed opaque value must still
+// produce a patch op. They drive the public factory entrypoint and assert on the
+// resulting ResourceUpdate, so they fail on the unfixed tree and are independent
+// of how the suppression is implemented.
+
+var anySHA256 = regexp.MustCompile(`[0-9a-f]{64}`)
+
+// opaqueLeaf renders a wrapped opaque property with the given strategy and value.
+func opaqueLeaf(strategy, value string) string {
+	return `{"$strategy":"` + strategy + `","$visibility":"Opaque","$value":"` + value + `"}`
+}
+
+func opaqueRes(label string, schema pkgmodel.Schema, props string) pkgmodel.Resource {
+	return pkgmodel.Resource{
+		Label:      label,
+		Type:       "AWS::SecretsManager::Secret",
+		Stack:      "default",
+		Schema:     schema,
+		Properties: json.RawMessage(props),
+	}
+}
+
+// updatePatchFor runs the production factory and returns the single mutable
+// update's patch document. Fails the test if the factory plans anything other
+// than one in-place update.
+func updatePatchFor(t *testing.T, existing, desired pkgmodel.Resource) json.RawMessage {
+	t.Helper()
+	updates := planUpdates(t, existing, desired)
+	require.Len(t, updates, 1, "expected a single in-place update, got %d", len(updates))
+	require.Equal(t, OperationUpdate, updates[0].Operation)
+	return updates[0].DesiredState.PatchDocument
+}
+
+func planUpdates(t *testing.T, existing, desired pkgmodel.Resource) []ResourceUpdate {
+	t.Helper()
+	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
+	updates, err := NewResourceUpdateForExisting(
+		resolver.ResolvableProperties{}, existing, desired,
+		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser)
+	require.NoError(t, err)
+	return updates
+}
+
+func opsByPath(t *testing.T, patchDoc json.RawMessage) map[string]jsonpatch.JsonPatchOperation {
+	t.Helper()
+	byPath := map[string]jsonpatch.JsonPatchOperation{}
+	if len(patchDoc) == 0 {
+		return byPath
+	}
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	for _, op := range ops {
+		byPath[op.Path] = op
+	}
+	return byPath
+}
+
+func writeOnlyMutableSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"secret", "name"},
+		Hints:  map[string]pkgmodel.FieldHint{"secret": {WriteOnly: true}},
+	}
+}
+
+// Headline rotation use case: a surfaced writeOnly opaque value that is UNCHANGED
+// must not re-emit when an unrelated sibling field changes (no churn, no new
+// secret version). On the unfixed tree this produces an `add /secret` op.
+func TestUpdate_WriteOnlyOpaqueUnchanged_SiblingEdit_NoValueOp(t *testing.T) {
+	schema := writeOnlyMutableSchema()
+	existing := opaqueRes("r", schema, `{"secret":`+opaqueLeaf("Update", pkgmodel.ComputeValueHash("s"))+`,"name":"old"}`)
+	desired := opaqueRes("r", schema, `{"secret":`+opaqueLeaf("Update", "s")+`,"name":"new"}`)
+
+	patchDoc := updatePatchFor(t, existing, desired)
+	byPath := opsByPath(t, patchDoc)
+
+	assert.NotContains(t, byPath, "/secret", "unchanged opaque value must not enter the patch")
+	require.Contains(t, byPath, "/name", "sibling change must still produce an op")
+	assert.NotRegexp(t, anySHA256, string(patchDoc), "no stored hash may leak into the patch")
+}
+
+// Rotation still works: a CHANGED writeOnly opaque value produces a patch op
+// carrying the new cleartext.
+func TestUpdate_WriteOnlyOpaqueChanged_CarriesCleartext(t *testing.T) {
+	schema := writeOnlyMutableSchema()
+	existing := opaqueRes("r", schema, `{"secret":`+opaqueLeaf("Update", pkgmodel.ComputeValueHash("old"))+`,"name":"x"}`)
+	desired := opaqueRes("r", schema, `{"secret":`+opaqueLeaf("Update", "new-secret")+`,"name":"x"}`)
+
+	patchDoc := updatePatchFor(t, existing, desired)
+	byPath := opsByPath(t, patchDoc)
+
+	require.Contains(t, byPath, "/secret", "changed opaque value must appear in the patch")
+	assert.Equal(t, "new-secret", byPath["/secret"].Value)
+	assert.NotRegexp(t, anySHA256, string(patchDoc))
+}
+
+// No corruption: a setOnce-frozen opaque value must not re-emit its own stored
+// hash as the new value when a sibling changes. On the unfixed tree this produces
+// `add /secret = <sha256>`.
+func TestUpdate_SetOnceOpaqueFrozen_SiblingEdit_NoValueOpNoHash(t *testing.T) {
+	schema := writeOnlyMutableSchema()
+	existing := opaqueRes("r", schema, `{"secret":`+opaqueLeaf("SetOnce", pkgmodel.ComputeValueHash("s"))+`,"name":"old"}`)
+	desired := opaqueRes("r", schema, `{"secret":`+opaqueLeaf("SetOnce", "attempted-rotation")+`,"name":"new"}`)
+
+	patchDoc := updatePatchFor(t, existing, desired)
+	byPath := opsByPath(t, patchDoc)
+
+	assert.NotContains(t, byPath, "/secret", "frozen setOnce opaque value must not enter the patch")
+	require.Contains(t, byPath, "/name")
+	assert.NotRegexp(t, anySHA256, string(patchDoc), "stored hash must never be sent as the value")
+}
+
+// The case the writeOnly-keyed approach misses: a surfaced opaque NON-writeOnly
+// value that is UNCHANGED must not churn (replace with cleartext) on a sibling
+// edit.
+func TestUpdate_NonWriteOnlyOpaqueUnchanged_SiblingEdit_NoValueOp(t *testing.T) {
+	schema := pkgmodel.Schema{Fields: []string{"secret", "name"}} // opaque but NOT writeOnly
+	existing := opaqueRes("r", schema, `{"secret":`+opaqueLeaf("Update", pkgmodel.ComputeValueHash("s"))+`,"name":"old"}`)
+	desired := opaqueRes("r", schema, `{"secret":`+opaqueLeaf("Update", "s")+`,"name":"new"}`)
+
+	patchDoc := updatePatchFor(t, existing, desired)
+	byPath := opsByPath(t, patchDoc)
+
+	assert.NotContains(t, byPath, "/secret", "unchanged non-writeOnly opaque value must not churn")
+	require.Contains(t, byPath, "/name")
+	assert.NotRegexp(t, anySHA256, string(patchDoc))
+}
+
+// PLA-35 C2: an UNCHANGED opaque createOnly value must not phantom-replace the
+// resource when a sibling changes — the factory must plan one in-place update,
+// not a destroy+create.
+func TestUpdate_OpaqueCreateOnlyUnchanged_SiblingEdit_NoReplace(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"secret", "name"},
+		Hints:  map[string]pkgmodel.FieldHint{"secret": {CreateOnly: true}},
+	}
+	existing := opaqueRes("r", schema, `{"secret":`+opaqueLeaf("Update", pkgmodel.ComputeValueHash("s"))+`,"name":"old"}`)
+	desired := opaqueRes("r", schema, `{"secret":`+opaqueLeaf("Update", "s")+`,"name":"new"}`)
+
+	updates := planUpdates(t, existing, desired)
+	require.Len(t, updates, 1, "unchanged opaque createOnly must not trigger a destroy+create")
+	assert.Equal(t, OperationUpdate, updates[0].Operation)
+	assert.Contains(t, opsByPath(t, updates[0].DesiredState.PatchDocument), "/name")
+}
+
+// PLA-35 C1 preserved: a CHANGED opaque createOnly value must still drive a
+// replacement (destroy+create), not be silently dropped.
+func TestUpdate_OpaqueCreateOnlyChanged_StillReplaces(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"secret", "name"},
+		Hints:  map[string]pkgmodel.FieldHint{"secret": {CreateOnly: true}},
+	}
+	existing := opaqueRes("r", schema, `{"secret":`+opaqueLeaf("Update", pkgmodel.ComputeValueHash("s1"))+`,"name":"x"}`)
+	desired := opaqueRes("r", schema, `{"secret":`+opaqueLeaf("Update", "s2")+`,"name":"x"}`)
+
+	updates := planUpdates(t, existing, desired)
+	require.Len(t, updates, 2, "changed opaque createOnly must plan destroy+create")
+	ops := map[OperationType]bool{}
+	for _, u := range updates {
+		ops[u.Operation] = true
+	}
+	assert.True(t, ops[OperationDelete], "replace must include a delete")
+	assert.True(t, ops[OperationCreate], "replace must include a create")
+}
+
+// Direct unit coverage of the helper's per-leaf decisions (complements the
+// behavior-level regression tests above).
+func TestSuppressUnchangedOpaqueValues_Decisions(t *testing.T) {
+	t.Run("unchanged opaque dropped from both sides", func(t *testing.T) {
+		existing := json.RawMessage(`{"secret":` + opaqueLeaf("Update", pkgmodel.ComputeValueHash("s")) + `,"name":"old"}`)
+		desired := json.RawMessage(`{"secret":` + opaqueLeaf("Update", "s") + `,"name":"new"}`)
+
+		strippedExisting, strippedDesired, err := SuppressUnchangedOpaqueValues(existing, desired)
+		require.NoError(t, err)
+		assert.NotContains(t, string(strippedDesired), "secret")
+		assert.NotContains(t, string(strippedExisting), "secret")
+		assert.Contains(t, string(strippedDesired), "name")
+	})
+
+	t.Run("changed opaque kept", func(t *testing.T) {
+		existing := json.RawMessage(`{"secret":` + opaqueLeaf("Update", pkgmodel.ComputeValueHash("old")) + `}`)
+		desired := json.RawMessage(`{"secret":` + opaqueLeaf("Update", "new") + `}`)
+
+		_, strippedDesired, err := SuppressUnchangedOpaqueValues(existing, desired)
+		require.NoError(t, err)
+		assert.Contains(t, string(strippedDesired), "secret")
+	})
+
+	t.Run("non-opaque field untouched", func(t *testing.T) {
+		existing := json.RawMessage(`{"token":{"$visibility":"Clear","$value":"a"}}`)
+		desired := json.RawMessage(`{"token":{"$visibility":"Clear","$value":"a"}}`)
+
+		_, strippedDesired, err := SuppressUnchangedOpaqueValues(existing, desired)
+		require.NoError(t, err)
+		assert.Contains(t, string(strippedDesired), "token")
+	})
+
+	t.Run("first set kept (no stored value)", func(t *testing.T) {
+		existing := json.RawMessage(`{"name":"x"}`)
+		desired := json.RawMessage(`{"secret":` + opaqueLeaf("Update", "first") + `,"name":"x"}`)
+
+		_, strippedDesired, err := SuppressUnchangedOpaqueValues(existing, desired)
+		require.NoError(t, err)
+		assert.Contains(t, string(strippedDesired), "secret")
+	})
+
+	t.Run("nested unchanged opaque dropped", func(t *testing.T) {
+		existing := json.RawMessage(`{"login":{"password":` + opaqueLeaf("Update", pkgmodel.ComputeValueHash("p")) + `}}`)
+		desired := json.RawMessage(`{"login":{"password":` + opaqueLeaf("Update", "p") + `}}`)
+
+		_, strippedDesired, err := SuppressUnchangedOpaqueValues(existing, desired)
+		require.NoError(t, err)
+		assert.NotContains(t, string(strippedDesired), "password")
+	})
+
+	t.Run("array-nested unchanged opaque dropped", func(t *testing.T) {
+		existing := json.RawMessage(`{"users":[{"password":` + opaqueLeaf("Update", pkgmodel.ComputeValueHash("p")) + `}],"name":"old"}`)
+		desired := json.RawMessage(`{"users":[{"password":` + opaqueLeaf("Update", "p") + `}],"name":"new"}`)
+
+		strippedExisting, strippedDesired, err := SuppressUnchangedOpaqueValues(existing, desired)
+		require.NoError(t, err)
+		assert.NotContains(t, string(strippedDesired), "$value", "unchanged array-nested opaque value must be dropped")
+		assert.NotContains(t, string(strippedExisting), "$value")
+		assert.Contains(t, string(strippedDesired), "name")
+	})
+
+	t.Run("array-nested changed opaque kept", func(t *testing.T) {
+		existing := json.RawMessage(`{"users":[{"password":` + opaqueLeaf("Update", pkgmodel.ComputeValueHash("p1")) + `}]}`)
+		desired := json.RawMessage(`{"users":[{"password":` + opaqueLeaf("Update", "p2") + `}]}`)
+
+		_, strippedDesired, err := SuppressUnchangedOpaqueValues(existing, desired)
+		require.NoError(t, err)
+		assert.Contains(t, string(strippedDesired), "p2", "changed array-nested opaque value must be kept")
+	})
+}

--- a/internal/metastructure/resource_update/resource_comparison.go
+++ b/internal/metastructure/resource_update/resource_comparison.go
@@ -41,6 +41,100 @@ func EnforceSetOnceAndCompareResourceForUpdate(existing, new *pkgmodel.Resource)
 	return !equal, filteredRawProps, nil
 }
 
+// SuppressUnchangedOpaqueValues removes opaque leaf properties whose desired
+// value is unchanged from what is stored, from BOTH the existing (document) and
+// desired (patch) property sets that feed patch generation.
+//
+// A surfaced opaque field is force-re-added by patch generation when it is
+// writeOnly (the provider never returns it on Read, so it is absent from the
+// document and jsonpatch emits an "add"), and re-diffed against its stored hash
+// when it is not. Either way, an unrelated sibling edit re-emits the opaque
+// field: as cleartext (churn — a needless new value/version) or, for a
+// setOnce-frozen value, as its own stored hash (corruption). Dropping the
+// unchanged opaque leaf from both sides makes it invisible to the diff, so no
+// op is produced. Genuinely changed opaque values are left in place, so a real
+// rotation still produces a patch op.
+//
+// "Unchanged" is decided exactly as the update gate decides whole-resource
+// change: hash the desired (wrapped) properties with PersistValueTransformer and
+// compare the resulting opaque $value to the stored $value. Keyed on
+// $visibility == Opaque, so it covers opaque fields whether or not they are also
+// writeOnly or createOnly, and never touches non-opaque fields. Inputs are the
+// wrapped {$strategy,$visibility,$value} forms, so call this before
+// ConvertToPluginFormat unwraps them. Inputs are not mutated; stripped copies
+// are returned.
+func SuppressUnchangedOpaqueValues(existing, desired json.RawMessage) (json.RawMessage, json.RawMessage, error) {
+	if len(existing) == 0 || len(desired) == 0 {
+		return existing, desired, nil
+	}
+
+	// Hash the desired opaque values the same way the gate and persistence do,
+	// so the comparison cannot drift from the gate's decision.
+	transformer := transformations.NewPersistValueTransformer()
+	hashed, err := transformer.ApplyToResource(&pkgmodel.Resource{Properties: desired})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to hash desired properties for opaque comparison: %w", err)
+	}
+
+	hashedResult := gjson.ParseBytes(hashed.Properties)
+	existingResult := gjson.ParseBytes(existing)
+	desiredResult := gjson.ParseBytes(desired)
+
+	// Collect dotted paths of opaque leaves anywhere in the desired props,
+	// recursing through both objects and arrays (PersistValueTransformer and
+	// filterSetOnceProps hash/freeze opaque values nested under arrays too, so
+	// they are equally subject to the churn this guards against).
+	var opaquePaths []string
+	var walk func(prefix string, node gjson.Result)
+	walk = func(prefix string, node gjson.Result) {
+		switch {
+		case node.IsObject():
+			if node.Get("$visibility").String() == "Opaque" {
+				opaquePaths = append(opaquePaths, prefix)
+				return
+			}
+			node.ForEach(func(key, val gjson.Result) bool {
+				walk(buildPath(prefix, key.String()), val)
+				return true
+			})
+		case node.IsArray():
+			node.ForEach(func(idx, val gjson.Result) bool {
+				walk(buildPath(prefix, idx.String()), val)
+				return true
+			})
+		}
+	}
+	desiredResult.ForEach(func(key, val gjson.Result) bool {
+		walk(key.String(), val)
+		return true
+	})
+
+	strippedExisting := string(existing)
+	strippedDesired := string(desired)
+	for _, path := range opaquePaths {
+		storedVal := existingResult.Get(path + ".$value")
+		if !storedVal.Exists() {
+			continue // first set: keep so the create op is emitted
+		}
+		if hashedResult.Get(path+".$value").String() != storedVal.String() {
+			continue // changed: keep so the rotation emits an op
+		}
+		// Unchanged: drop from both sides so no add/replace/remove is produced.
+		strippedDesired, err = sjson.Delete(strippedDesired, path)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to drop unchanged opaque path %q from desired: %w", path, err)
+		}
+		if existingResult.Get(path).Exists() {
+			strippedExisting, err = sjson.Delete(strippedExisting, path)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to drop unchanged opaque path %q from existing: %w", path, err)
+			}
+		}
+	}
+
+	return json.RawMessage(strippedExisting), json.RawMessage(strippedDesired), nil
+}
+
 // filterSetOnceProps recursively removes SetOnce properties with existing values
 func filterSetOnceProps(existing, new json.RawMessage, label string) (json.RawMessage, error) {
 	if len(existing) == 0 || len(new) == 0 {

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -59,12 +59,23 @@ func NewResourceUpdateForExisting(
 	var createOnlyPatch json.RawMessage
 
 	if hasChanges {
-		existingPluginProps, err := resolver.ConvertToPluginFormat(existingResource.Properties)
+		// Drop opaque values that are unchanged from what is stored so a sibling
+		// edit does not churn (re-emit cleartext) or corrupt (re-emit the stored
+		// hash, for setOnce) the opaque field. Genuinely changed opaque values
+		// stay, so rotation still produces a patch op. filteredProps is left
+		// untouched for DesiredState.Properties below — only the patch inputs are
+		// stripped.
+		existingForPatch, desiredForPatch, err := SuppressUnchangedOpaqueValues(existingResource.Properties, filteredProps)
+		if err != nil {
+			return nil, fmt.Errorf("failed to suppress unchanged opaque values for resource %s: %w", existingResource.Label, err)
+		}
+
+		existingPluginProps, err := resolver.ConvertToPluginFormat(existingForPatch)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert existing properties to plugin format: %w", err)
 		}
 
-		newPluginProps, err := resolver.ConvertToPluginFormat(filteredProps)
+		newPluginProps, err := resolver.ConvertToPluginFormat(desiredForPatch)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert new properties to plugin format: %w", err)
 		}


### PR DESCRIPTION
## Summary

Surfaced `opaque` values (`formae.value(x).opaque`) re-emit on unrelated **sibling** edits:

- **churn** — a plain opaque value is re-sent as cleartext, minting a needless new value/version on every unrelated change;
- **corruption** — a `setOnce`-frozen opaque value is re-sent as its **own stored SHA-256 hash**, overwriting the secret with its hash.

Root cause: once a sibling field forces patch generation, `generatePatch` diffs the **stored hash** of the opaque field against the **desired cleartext**. They never match, so an op is always emitted — even when the value is unchanged. The upstream gate (`EnforceSetOnceAndCompareResourceForUpdate`) compares hash-vs-hash correctly, but only gates whole-resource `hasChanges`.

## Fix

`SuppressUnchangedOpaqueValues` drops opaque leaves whose desired value is unchanged from what is stored, from **both** the existing (document) and desired (patch) inputs to `GeneratePatch`, so the diff produces no op for them. It is:

- decided **upstream**, where the `{$strategy,$visibility,$value}` envelope still exists (before `ConvertToPluginFormat` unwraps it);
- **keyed on `$visibility == Opaque`** — so it covers opaque fields whether or not they are also `writeOnly`/`createOnly`, and never touches non-opaque fields;
- **reuses `PersistValueTransformer`** (the same hashing the gate and persistence use), so the decision cannot drift from the gate's;
- applied **before** the createOnly/mutable split, with no new `GeneratePatch` parameter.

Genuinely changed values are kept, so rotation still produces a patch op. Recurses objects and arrays.

This supersedes the approach in #521, which keyed exclusion on `writeOnly` (missing surfaced *non-writeOnly* opaque churn), added a `GeneratePatch` parameter, and introduced a second `gjson`+`ComputeValueHash` comparison parallel to the gate's.

Tracking: PLA-35.

## Tests

Regression tests drive the public factory entrypoint (`NewResourceUpdateForExisting`) and assert on the produced patch, independent of the implementation. They were verified to **fail without the fix** (reproducing `add /secret=<cleartext>`, `add /secret=<sha256>`, `replace /secret`, and a destroy+create phantom-replace) and pass with it. Plus unit coverage of the helper's per-leaf decisions, including object- and array-nested opaque values.

## Known limitations / follow-ups

1. If a value is rotated to a string that is *itself* the 64-char lowercase-hex SHA-256 of the previous value, it is treated as unchanged. This stems from `isAlreadyHashed`'s shape-based detection, which the update gate and persistence layer already rely on; it is not introduced here. A real fix requires a typed persisted marker instead of shape-sniffing — tracked separately.
2. The overbroad `intersectFields(WriteOnly, CreateOnly)` strip is left in place; removing it (so a legitimately *changed* writeOnly+createOnly value isn't dropped) risks regressing non-opaque writeOnly+createOnly fields and is deferred.
3. Dotted-literal-key path handling is left consistent with `filterSetOnceProps` (both use unescaped gjson/sjson paths).