### PR TITLE
feat: embed resolvables inside String-typed fields (PLA-68 / RFC-28)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -117,6 +117,13 @@ jobs:
             system_plugins: aws
           - test: TestExtractAndReapply
             system_plugins: aws
+          # Embedded resolvable inside a String field (CloudFront
+          # Function.functionCode). Needs the dev-channel AWS plugin whose
+          # functionCode is widened to String|formae.Embedded (0.1.13-dev.0+);
+          # channel: dev routes the orbital install to community#dev.
+          - test: TestEmbedResolvable
+            system_plugins: aws
+            channel: dev
           - test: TestEvalDefault
             system_plugins: aws
           - test: TestEvalSchemaLocationLocal
@@ -246,8 +253,10 @@ jobs:
 
           # Install only the plugins this test needs. The agent refreshes
           # orbital's repository cache at startup, so the install candidate
-          # solver has fresh metadata to work with.
-          dist/e2e/bin/formae plugin install ${{ matrix.system_plugins }} --channel stable
+          # solver has fresh metadata to work with. matrix.channel defaults to
+          # stable; an entry sets it to dev to pull a dev-tagged plugin
+          # (--channel rewrites every repo's #fragment, e.g. community#dev).
+          dist/e2e/bin/formae plugin install ${{ matrix.system_plugins }} --channel ${{ matrix.channel || 'stable' }}
 
           # Stop the bootstrap agent so the test harness can spawn its own.
           kill -TERM "$AGENT_PID" || true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -121,9 +121,14 @@ jobs:
           # Function.functionCode). Needs the dev-channel AWS plugin whose
           # functionCode is widened to String|formae.Embedded (0.1.13-dev.0+);
           # channel: dev routes the orbital install to community#dev.
+          # formae_version pins the built binary to the plugin's minFormaeVersion
+          # floor: this branch carries the 0.87.0 schema work but git-describe
+          # still reports 0.86.2 (no 0.87.0 tag yet), so without the override the
+          # orbital solver rejects aws@dev. Drop once formae 0.87.0 is released.
           - test: TestEmbedResolvable
             system_plugins: aws
             channel: dev
+            formae_version: "0.87.0"
           - test: TestEvalDefault
             system_plugins: aws
           - test: TestEvalSchemaLocationLocal
@@ -205,7 +210,14 @@ jobs:
           # installs plugins through the same orbital tree the test agents
           # will later read from (via the SystemPluginDir scan added in
           # the multi-source plugin discovery refactor).
-          make build
+          # matrix.formae_version (when set) overrides the git-derived VERSION
+          # so the orbital solver sees a binary that satisfies a plugin's
+          # minFormaeVersion floor before that formae version is tagged. The
+          # same override is written to version.semver so setup_pkl.sh resolves
+          # the fixture's @formae schema at that (hub-published) version, which
+          # carries the new schema symbols (e.g. formae.embed).
+          make build ${{ matrix.formae_version && format('VERSION={0}', matrix.formae_version) || '' }}
+          ${{ matrix.formae_version && format('echo {0} > version.semver', matrix.formae_version) || 'true' }}
           mkdir -p dist/e2e/bin dist/e2e/.ops
           cp formae dist/e2e/bin/formae
 
@@ -296,6 +308,7 @@ jobs:
                 || format('{0}/dist/e2e/formae/plugins', github.workspace) }}
         run: >-
           make test-e2e
+          ${{ matrix.formae_version && format('VERSION={0}', matrix.formae_version) || '' }}
           E2E_RUN_FLAGS="-run ${{ matrix.test }}"
 
   cleanup:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -118,17 +118,13 @@ jobs:
           - test: TestExtractAndReapply
             system_plugins: aws
           # Embedded resolvable inside a String field (CloudFront
-          # Function.functionCode). Needs the dev-channel AWS plugin whose
-          # functionCode is widened to String|formae.Embedded (0.1.13-dev.0+);
-          # channel: dev routes the orbital install to community#dev.
-          # formae_version pins the built binary to the plugin's minFormaeVersion
-          # floor: this branch carries the 0.87.0 schema work but git-describe
-          # still reports 0.86.2 (no 0.87.0 tag yet), so without the override the
-          # orbital solver rejects aws@dev. Drop once formae 0.87.0 is released.
+          # Function.functionCode). Builds the AWS plugin from its main branch
+          # (user-install) so it carries the widened functionCode
+          # (String|formae.Embedded) without depending on a published release.
+          # TEMPORARY: move back to `system_plugins: aws` (stable channel) once
+          # an AWS plugin release ships embed support.
           - test: TestEmbedResolvable
-            system_plugins: aws
-            channel: dev
-            formae_version: "0.87.0"
+            user_plugins: aws
           - test: TestEvalDefault
             system_plugins: aws
           - test: TestEvalSchemaLocationLocal
@@ -210,14 +206,7 @@ jobs:
           # installs plugins through the same orbital tree the test agents
           # will later read from (via the SystemPluginDir scan added in
           # the multi-source plugin discovery refactor).
-          # matrix.formae_version (when set) overrides the git-derived VERSION
-          # so the orbital solver sees a binary that satisfies a plugin's
-          # minFormaeVersion floor before that formae version is tagged. The
-          # same override is written to version.semver so setup_pkl.sh resolves
-          # the fixture's @formae schema at that (hub-published) version, which
-          # carries the new schema symbols (e.g. formae.embed).
-          make build ${{ matrix.formae_version && format('VERSION={0}', matrix.formae_version) || '' }}
-          ${{ matrix.formae_version && format('echo {0} > version.semver', matrix.formae_version) || 'true' }}
+          make build
           mkdir -p dist/e2e/bin dist/e2e/.ops
           cp formae dist/e2e/bin/formae
 
@@ -265,10 +254,8 @@ jobs:
 
           # Install only the plugins this test needs. The agent refreshes
           # orbital's repository cache at startup, so the install candidate
-          # solver has fresh metadata to work with. matrix.channel defaults to
-          # stable; an entry sets it to dev to pull a dev-tagged plugin
-          # (--channel rewrites every repo's #fragment, e.g. community#dev).
-          dist/e2e/bin/formae plugin install ${{ matrix.system_plugins }} --channel ${{ matrix.channel || 'stable' }}
+          # solver has fresh metadata to work with.
+          dist/e2e/bin/formae plugin install ${{ matrix.system_plugins }} --channel stable
 
           # Stop the bootstrap agent so the test harness can spawn its own.
           kill -TERM "$AGENT_PID" || true
@@ -308,7 +295,6 @@ jobs:
                 || format('{0}/dist/e2e/formae/plugins', github.workspace) }}
         run: >-
           make test-e2e
-          ${{ matrix.formae_version && format('VERSION={0}', matrix.formae_version) || '' }}
           E2E_RUN_FLAGS="-run ${{ matrix.test }}"
 
   cleanup:

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -2179,12 +2179,28 @@ func validateNoOpaqueEmbedInJSON(raw json.RawMessage, label string) error {
 }
 
 func walkForOpaqueEmbed(val gjson.Result, label, path string) error {
+	if val.IsArray() {
+		// Recurse into each array element; mirror how the resolver's extractFromJson
+		// handles IsArray() so that embedded opaques nested in arrays are caught.
+		var childErr error
+		val.ForEach(func(key, child gjson.Result) bool {
+			childPath := key.String()
+			if path != "" {
+				childPath = path + "." + childPath
+			}
+			if err := walkForOpaqueEmbed(child, label, childPath); err != nil {
+				childErr = err
+				return false
+			}
+			return true
+		})
+		return childErr
+	}
 	if !val.IsObject() {
 		return nil
 	}
 	// Check if this object is an embed node.
-	embedFlag := val.Get("$embed")
-	if embedFlag.Type == gjson.True {
+	if val.Get("$embed").Bool() {
 		tmpl := val.Get("$template")
 		if tmpl.Type == gjson.String {
 			spans, err := pkgmodel.ScanEmbedSpans(tmpl.String())

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -2057,6 +2057,19 @@ func replaceKSUIDs(jsonStr string, ksuidToTriplet map[string]pkgmodel.TripletKey
 					}
 				}
 			}
+			// Rewrite framed envelopes inside $embed.$template spans
+			if isEmbed, _ := v["$embed"].(bool); isEmbed {
+				if tmpl, ok := v["$template"].(string); ok {
+					result := make(map[string]any, len(v))
+					for key, val := range v {
+						result[key] = replace(val)
+					}
+					result["$template"] = rewriteEmbedSpans(tmpl, func(env map[string]any) map[string]any {
+						return replace(env).(map[string]any)
+					})
+					return result
+				}
+			}
 			// Recursively process all values in the map
 			result := make(map[string]any, len(v))
 			for key, val := range v {
@@ -2086,4 +2099,32 @@ func replaceKSUIDs(jsonStr string, ksuidToTriplet map[string]pkgmodel.TripletKey
 		return jsonStr
 	}
 	return string(result)
+}
+
+// rewriteEmbedSpans scans a $embed.$template string for framed RS<base64>US spans,
+// applies fn to each decoded envelope (as a map), re-encodes, and splices back.
+// Spans are replaced in reverse offset order so earlier offsets remain valid.
+// On scan error the original template is returned unchanged.
+func rewriteEmbedSpans(tmpl string, fn func(map[string]any) map[string]any) string {
+	spans, err := pkgmodel.ScanEmbedSpans(tmpl)
+	if err != nil || len(spans) == 0 {
+		return tmpl
+	}
+
+	// Work backwards so byte offsets of earlier spans stay valid.
+	for i := len(spans) - 1; i >= 0; i-- {
+		span := spans[i]
+		var env map[string]any
+		if jsonErr := json.Unmarshal([]byte(span.EnvelopeJSON), &env); jsonErr != nil {
+			continue
+		}
+		rewritten := fn(env)
+		rewrittenJSON, marshalErr := json.Marshal(rewritten)
+		if marshalErr != nil {
+			continue
+		}
+		framed := pkgmodel.FrameEnvelope(string(rewrittenJSON))
+		tmpl = tmpl[:span.Start] + framed + tmpl[span.End:]
+	}
+	return tmpl
 }

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1860,6 +1860,13 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 		return nil, fmt.Errorf("failed to load targets: %w", err)
 	}
 
+	// Reject opaque resolvables embedded in string fields before translation.
+	// Must run pre-translation because translation drops $visibility from $res
+	// envelopes, making a post-translation check unable to see the opaque flag.
+	if err := validateNoOpaqueEmbed(forma); err != nil {
+		return nil, err
+	}
+
 	// Translate $res triplet references to $ref KSUID URIs in both resource
 	// properties and target configs. Must happen before GenerateTargetUpdates
 	// so that target config resolvables can be extracted.
@@ -2132,4 +2139,78 @@ func rewriteEmbedSpans(tmpl string, fn func(map[string]any) map[string]any) stri
 		tmpl = tmpl[:span.Start] + framed + tmpl[span.End:]
 	}
 	return tmpl
+}
+
+// validateNoOpaqueEmbed rejects any forma whose resource properties or target
+// configs contain a $embed field whose $template carries a framed span for a
+// $res envelope with $visibility == "Opaque".
+//
+// v1 limitation: once an opaque resolvable is assembled into a string the
+// structured span needed for redaction is lost, so we hard-reject it at plan
+// time rather than silently leaking secrets.
+//
+// This MUST run before translation (doTranslate) because translation replaces
+// $res envelopes with {"$ref":…} and drops $visibility.
+func validateNoOpaqueEmbed(forma *pkgmodel.Forma) error {
+	for i := range forma.Resources {
+		r := &forma.Resources[i]
+		if err := validateNoOpaqueEmbedInJSON(r.Properties, r.Label); err != nil {
+			return err
+		}
+	}
+	for i := range forma.Targets {
+		t := &forma.Targets[i]
+		if err := validateNoOpaqueEmbedInJSON(t.Config, t.Label); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateNoOpaqueEmbedInJSON walks all JSON objects in raw looking for
+// {"$embed":true, "$template":"…"} nodes, scans each template for framed
+// spans, and returns an error if any span envelope carries "$visibility":"Opaque".
+func validateNoOpaqueEmbedInJSON(raw json.RawMessage, label string) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	result := gjson.ParseBytes(raw)
+	return walkForOpaqueEmbed(result, label, "")
+}
+
+func walkForOpaqueEmbed(val gjson.Result, label, path string) error {
+	if !val.IsObject() {
+		return nil
+	}
+	// Check if this object is an embed node.
+	embedFlag := val.Get("$embed")
+	if embedFlag.Type == gjson.True {
+		tmpl := val.Get("$template")
+		if tmpl.Type == gjson.String {
+			spans, err := pkgmodel.ScanEmbedSpans(tmpl.String())
+			if err != nil {
+				return fmt.Errorf("corrupt embed template in field %q on %q: %w", path, label, err)
+			}
+			for _, span := range spans {
+				visibility := gjson.Get(span.EnvelopeJSON, "$visibility")
+				if visibility.String() == pkgmodel.VisibilityOpaque {
+					return fmt.Errorf("opaque resolvables cannot be embedded in string fields (field %q on %q); v1 limitation", path, label)
+				}
+			}
+		}
+	}
+	// Recurse into all child values.
+	var childErr error
+	val.ForEach(func(key, child gjson.Result) bool {
+		childPath := key.String()
+		if path != "" {
+			childPath = path + "." + childPath
+		}
+		if err := walkForOpaqueEmbed(child, label, childPath); err != nil {
+			childErr = err
+			return false
+		}
+		return true
+	})
+	return childErr
 }

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -2065,7 +2065,12 @@ func replaceKSUIDs(jsonStr string, ksuidToTriplet map[string]pkgmodel.TripletKey
 						result[key] = replace(val)
 					}
 					result["$template"] = rewriteEmbedSpans(tmpl, func(env map[string]any) map[string]any {
-						return replace(env).(map[string]any)
+						rewritten, ok := replace(env).(map[string]any)
+						if !ok {
+							// defensive: replace returned a non-map; leave the span unchanged
+							return env
+						}
+						return rewritten
 					})
 					return result
 				}

--- a/internal/metastructure/metastructure_test.go
+++ b/internal/metastructure/metastructure_test.go
@@ -310,3 +310,50 @@ func TestReplaceKSUIDs_RewritesEmbeddedSpan_Idempotent(t *testing.T) {
 	out2 := replaceKSUIDs(out1, ksuidToTriplet)
 	assert.Equal(t, out1, out2, "replaceKSUIDs should be idempotent")
 }
+
+func TestReplaceKSUIDs_RewritesMultipleEmbeddedSpans(t *testing.T) {
+	// Two distinct KSUIDs appear as framed $ref spans inside a single $template.
+	// Literal text separates and surrounds the spans.
+	// After replaceKSUIDs both spans must be rewritten to $res+triplet form
+	// and all surrounding/between literal text must be intact and in order.
+	ksuid1 := "aaaa1111"
+	ksuid2 := "bbbb2222"
+
+	refEnv1 := `{"$ref":"formae://` + ksuid1 + `#/arn","$value":"v1"}`
+	refEnv2 := `{"$ref":"formae://` + ksuid2 + `#/id","$value":"v2"}`
+
+	tmpl := "prefix(" + pkgmodel.FrameEnvelope(refEnv1) + ",between," + pkgmodel.FrameEnvelope(refEnv2) + ")suffix"
+
+	in, err := json.Marshal(map[string]any{
+		"code": map[string]any{"$embed": true, "$template": tmpl},
+	})
+	require.NoError(t, err)
+
+	out := replaceKSUIDs(string(in), map[string]pkgmodel.TripletKey{
+		ksuid1: {Stack: "default", Label: "bucket", Type: "AWS::S3::Bucket"},
+		ksuid2: {Stack: "default", Label: "queue", Type: "AWS::SQS::Queue"},
+	})
+
+	tmplOut := gjson.Get(out, "code.$template").String()
+	spans, err := pkgmodel.ScanEmbedSpans(tmplOut)
+	require.NoError(t, err)
+	require.Len(t, spans, 2, "expected exactly two spans in $template output")
+
+	// Both spans must have been rewritten to $res form.
+	assert.True(t, strings.Contains(spans[0].EnvelopeJSON, `"$res":true`),
+		"first span should contain $res:true, got: %s", spans[0].EnvelopeJSON)
+	assert.True(t, strings.Contains(spans[0].EnvelopeJSON, `"$label":"bucket"`),
+		"first span should contain $label:bucket, got: %s", spans[0].EnvelopeJSON)
+	assert.True(t, strings.Contains(spans[1].EnvelopeJSON, `"$res":true`),
+		"second span should contain $res:true, got: %s", spans[1].EnvelopeJSON)
+	assert.True(t, strings.Contains(spans[1].EnvelopeJSON, `"$label":"queue"`),
+		"second span should contain $label:queue, got: %s", spans[1].EnvelopeJSON)
+
+	// Surrounding and between literal text must be intact.
+	assert.True(t, strings.HasPrefix(tmplOut, "prefix("),
+		"template should start with 'prefix(', got: %s", tmplOut)
+	assert.True(t, strings.HasSuffix(tmplOut, ")suffix"),
+		"template should end with ')suffix', got: %s", tmplOut)
+	assert.True(t, strings.Contains(tmplOut, ",between,"),
+		"template should contain ',between,' between spans, got: %s", tmplOut)
+}

--- a/internal/metastructure/metastructure_test.go
+++ b/internal/metastructure/metastructure_test.go
@@ -6,13 +6,16 @@ package metastructure
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"ergo.services/ergo/gen"
 	_ "github.com/platform-engineering-labs/formae/internal/datastore/all"
-	"github.com/platform-engineering-labs/formae/pkg/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestReplaceKSUIDs_NestedRefInArrays(t *testing.T) {
@@ -24,7 +27,7 @@ func TestReplaceKSUIDs_NestedRefInArrays(t *testing.T) {
 	tests := []struct {
 		name           string
 		inputJSON      string
-		ksuidToTriplet map[string]model.TripletKey
+		ksuidToTriplet map[string]pkgmodel.TripletKey
 		wantContains   []string
 		wantNotContain []string
 	}{
@@ -36,7 +39,7 @@ func TestReplaceKSUIDs_NestedRefInArrays(t *testing.T) {
 					"$value": "https://example.com/network"
 				}
 			}`,
-			ksuidToTriplet: map[string]model.TripletKey{
+			ksuidToTriplet: map[string]pkgmodel.TripletKey{
 				"abc123": {Stack: "my-stack", Label: "my-network", Type: "GCP::Compute::Network"},
 			},
 			wantContains:   []string{`"$res":true`, `"$label":"my-network"`, `"$stack":"my-stack"`, `"$type":"GCP::Compute::Network"`, `"$property":"selfLink"`},
@@ -55,7 +58,7 @@ func TestReplaceKSUIDs_NestedRefInArrays(t *testing.T) {
 					}
 				]
 			}`,
-			ksuidToTriplet: map[string]model.TripletKey{
+			ksuidToTriplet: map[string]pkgmodel.TripletKey{
 				"disk123": {Stack: "my-stack", Label: "my-disk", Type: "GCP::Compute::Disk"},
 			},
 			wantContains:   []string{`"$res":true`, `"$label":"my-disk"`, `"$stack":"my-stack"`, `"$type":"GCP::Compute::Disk"`, `"$property":"selfLink"`},
@@ -78,7 +81,7 @@ func TestReplaceKSUIDs_NestedRefInArrays(t *testing.T) {
 					}
 				]
 			}`,
-			ksuidToTriplet: map[string]model.TripletKey{
+			ksuidToTriplet: map[string]pkgmodel.TripletKey{
 				"net123":    {Stack: "my-stack", Label: "my-network", Type: "GCP::Compute::Network"},
 				"subnet123": {Stack: "my-stack", Label: "my-subnet", Type: "GCP::Compute::Subnetwork"},
 			},
@@ -101,7 +104,7 @@ func TestReplaceKSUIDs_NestedRefInArrays(t *testing.T) {
 					}
 				]
 			}`,
-			ksuidToTriplet: map[string]model.TripletKey{
+			ksuidToTriplet: map[string]pkgmodel.TripletKey{
 				"deep123": {Stack: "deep-stack", Label: "deep-label", Type: "Deep::Type"},
 			},
 			wantContains:   []string{`"$res":true`, `"$label":"deep-label"`, `"$stack":"deep-stack"`},
@@ -123,7 +126,7 @@ func TestReplaceKSUIDs_NestedRefInArrays(t *testing.T) {
 					}
 				]
 			}`,
-			ksuidToTriplet: map[string]model.TripletKey{
+			ksuidToTriplet: map[string]pkgmodel.TripletKey{
 				"top123": {Stack: "stack1", Label: "label1", Type: "Type1"},
 				"arr123": {Stack: "stack2", Label: "label2", Type: "Type2"},
 			},
@@ -239,9 +242,9 @@ func TestExtractKSUIDs_NestedRefInArrays(t *testing.T) {
 }
 
 func TestMetastructure_NetworkingEnabled(t *testing.T) {
-	cfg := &model.Config{
-		Agent: model.AgentConfig{
-			Server: model.ServerConfig{
+	cfg := &pkgmodel.Config{
+		Agent: pkgmodel.AgentConfig{
+			Server: pkgmodel.ServerConfig{
 				Nodename: "test-agent",
 				Hostname: "localhost",
 				Secret:   "secret",
@@ -262,4 +265,48 @@ func TestMetastructure_NetworkingEnabled(t *testing.T) {
 	// Verify cookie is set from config
 	assert.Equal(t, "secret", m.options.Network.Cookie,
 		"Network cookie should match config secret")
+}
+
+func TestReplaceKSUIDs_RewritesEmbeddedSpan(t *testing.T) {
+	ksuid := "abc123"
+	refEnv := `{"$ref":"formae://` + ksuid + `#/id","$value":"v1"}`
+	tmpl := "cf.kvs('" + pkgmodel.FrameEnvelope(refEnv) + "')"
+
+	in, err := json.Marshal(map[string]any{
+		"functionCode": map[string]any{"$embed": true, "$template": tmpl},
+	})
+	require.NoError(t, err)
+
+	out := replaceKSUIDs(string(in), map[string]pkgmodel.TripletKey{
+		ksuid: {Stack: "default", Label: "kvs", Type: "AWS::CloudFront::KeyValueStore"},
+	})
+
+	tmplOut := gjson.Get(out, "functionCode.$template").String()
+	spans, err := pkgmodel.ScanEmbedSpans(tmplOut)
+	require.NoError(t, err)
+	require.Len(t, spans, 1, "expected exactly one span in $template output")
+
+	assert.True(t, strings.Contains(spans[0].EnvelopeJSON, `"$res":true`),
+		"span should contain $res:true, got: %s", spans[0].EnvelopeJSON)
+	assert.True(t, strings.Contains(spans[0].EnvelopeJSON, `"$label":"kvs"`),
+		"span should contain $label:kvs, got: %s", spans[0].EnvelopeJSON)
+}
+
+func TestReplaceKSUIDs_RewritesEmbeddedSpan_Idempotent(t *testing.T) {
+	ksuid := "abc123"
+	refEnv := `{"$ref":"formae://` + ksuid + `#/id","$value":"v1"}`
+	tmpl := "cf.kvs('" + pkgmodel.FrameEnvelope(refEnv) + "')"
+
+	in, err := json.Marshal(map[string]any{
+		"functionCode": map[string]any{"$embed": true, "$template": tmpl},
+	})
+	require.NoError(t, err)
+
+	ksuidToTriplet := map[string]pkgmodel.TripletKey{
+		ksuid: {Stack: "default", Label: "kvs", Type: "AWS::CloudFront::KeyValueStore"},
+	}
+
+	out1 := replaceKSUIDs(string(in), ksuidToTriplet)
+	out2 := replaceKSUIDs(out1, ksuidToTriplet)
+	assert.Equal(t, out1, out2, "replaceKSUIDs should be idempotent")
 }

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -889,6 +889,7 @@ func flattenRefs(m map[string]any) {
 							if assembled, err := assembleEmbedTemplate(tmplStr); err == nil {
 								m[k] = assembled
 							}
+							// on scan error: leave node as-is; flattenRefs has no error path (corrupt templates are rejected at plan time)
 							continue
 						}
 					}

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -852,11 +852,48 @@ func resolveRefs(current, mod map[string]any, resolvableProperties resolver.Reso
 	return nil
 }
 
+// assembleEmbedTemplate replaces each framed span in tmpl with the $value
+// from its envelope JSON. Spans without a $value are replaced with "".
+func assembleEmbedTemplate(tmpl string) (string, error) {
+	spans, err := pkgmodel.ScanEmbedSpans(tmpl)
+	if err != nil {
+		return "", err
+	}
+	// Replace spans in reverse order so earlier offsets stay valid.
+	result := tmpl
+	for i := len(spans) - 1; i >= 0; i-- {
+		span := spans[i]
+		replacement := ""
+		var envelope map[string]any
+		if json.Unmarshal([]byte(span.EnvelopeJSON), &envelope) == nil {
+			if val, ok := envelope["$value"]; ok {
+				if s, ok := val.(string); ok {
+					replacement = s
+				}
+			}
+		}
+		result = result[:span.Start] + replacement + result[span.End:]
+	}
+	return result, nil
+}
+
 // flattenRefs recursively flattens $ref / $value pairs
 func flattenRefs(m map[string]any) {
 	for k, v := range m {
 		switch vv := v.(type) {
 		case map[string]any:
+			if embedVal, hasEmbed := vv["$embed"]; hasEmbed {
+				if embedBool, ok := embedVal.(bool); ok && embedBool {
+					if tmpl, hasTmpl := vv["$template"]; hasTmpl {
+						if tmplStr, ok := tmpl.(string); ok {
+							if assembled, err := assembleEmbedTemplate(tmplStr); err == nil {
+								m[k] = assembled
+							}
+							continue
+						}
+					}
+				}
+			}
 			if _, hasRef := vv["$ref"]; hasRef {
 				if val, hasVal := vv["$value"]; hasVal {
 					m[k] = val

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -2495,3 +2495,15 @@ func TestGeneratePatch_AtomicNestedArrayProducesReplace(t *testing.T) {
 	assert.Equal(t, "/FirewallPolicy/StatefulDefaultActions", patches[0].Path)
 	assert.Equal(t, []any{"aws:drop_established"}, patches[0].Value)
 }
+
+func TestFlattenRefs_AssemblesEmbed(t *testing.T) {
+	ksuid := "abc"
+	span := pkgmodel.FrameEnvelope(`{"$ref":"formae://` + ksuid + `#/id","$value":"KV-7H9X"}`)
+	m := map[string]any{
+		"functionCode": map[string]any{"$embed": true, "$template": "cf.kvs('" + span + "')"},
+	}
+	flattenRefs(m)
+	if got := m["functionCode"]; got != "cf.kvs('KV-7H9X')" {
+		t.Errorf("flattenRefs embed: got %v want assembled string", got)
+	}
+}

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -362,8 +362,119 @@ func (pr *propertyResolver) resolveReferences(properties json.RawMessage) (json.
 	return result, nil
 }
 
+// assembleEmbedTemplate iterates over every framed span in tmpl, calling
+// valueForEnvelope(envelopeJSON) to obtain the replacement string for that span.
+// It returns the assembled string (every span replaced) and whether ALL spans
+// had a value. Processing is done in reverse byte order so earlier offsets remain
+// valid after later splices.
+func assembleEmbedTemplate(tmpl string, valueForEnvelope func(envJSON string) (string, bool)) (string, bool) {
+	spans, err := pkgmodel.ScanEmbedSpans(tmpl)
+	if err != nil || len(spans) == 0 {
+		return tmpl, len(spans) == 0 && err == nil
+	}
+
+	allResolved := true
+	// Work in reverse order so earlier offsets are unaffected by later splices.
+	result := tmpl
+	for i := len(spans) - 1; i >= 0; i-- {
+		sp := spans[i]
+		val, ok := valueForEnvelope(sp.EnvelopeJSON)
+		if !ok {
+			allResolved = false
+			continue
+		}
+		result = result[:sp.Start] + val + result[sp.End:]
+	}
+	return result, allResolved
+}
+
+// resolveEmbedRef writes the resolved $value for ref inside the matching span
+// envelope(s) within the $embed field's $template. The $embed field remains
+// structured (still {$embed, $template}); only the span envelopes are updated.
+func (pr *propertyResolver) resolveEmbedRef(properties json.RawMessage, ref pkgmodel.Ref) (json.RawMessage, error) {
+	fieldPath := ref.EmbedFieldPath
+	parsed := gjson.Parse(string(properties))
+	embedObj := parsed.Get(fieldPath)
+	if !embedObj.Exists() {
+		slog.Debug("embed: field not found", "path", fieldPath)
+		return properties, nil
+	}
+
+	tmpl := embedObj.Get("$template").String()
+	if tmpl == "" {
+		return properties, nil
+	}
+
+	valueToSet := pr.extractResolvedValue(ref)
+	valueStr, ok := valueToSet.(string)
+	if !ok || valueStr == "" {
+		if valueToSet != nil {
+			valueStr = fmt.Sprintf("%v", valueToSet)
+			ok = true
+		}
+	}
+	if !ok {
+		return properties, nil
+	}
+
+	// For each span whose envelope URI matches this ref's PropertyURI, encode the
+	// envelope with $value added, then splice back (reverse order).
+	spans, err := pkgmodel.ScanEmbedSpans(tmpl)
+	if err != nil {
+		return properties, fmt.Errorf("embed: scan spans for %s: %w", fieldPath, err)
+	}
+
+	updatedTmpl := tmpl
+	for i := len(spans) - 1; i >= 0; i-- {
+		sp := spans[i]
+		env := gjson.Parse(sp.EnvelopeJSON)
+		if env.Get("$ref").String() != ref.PropertyURI {
+			continue
+		}
+		// Build updated envelope with $value.
+		envMap := make(map[string]any)
+		env.ForEach(func(k, v gjson.Result) bool {
+			envMap[k.String()] = v.Value()
+			return true
+		})
+		envMap["$value"] = valueStr
+		envJSON, err := json.Marshal(envMap)
+		if err != nil {
+			return properties, fmt.Errorf("embed: marshal updated envelope: %w", err)
+		}
+		framed := pkgmodel.FrameEnvelope(string(envJSON))
+		updatedTmpl = updatedTmpl[:sp.Start] + framed + updatedTmpl[sp.End:]
+	}
+
+	if updatedTmpl == tmpl {
+		// No span matched — nothing to update.
+		return properties, nil
+	}
+
+	// Write the updated $embed object back (preserving $embed:true and updated $template).
+	embedMap := map[string]any{
+		"$embed":    true,
+		"$template": updatedTmpl,
+	}
+	embedJSON, err := json.Marshal(embedMap)
+	if err != nil {
+		return properties, fmt.Errorf("embed: marshal updated embed object: %w", err)
+	}
+	updatedJSON, err := sjson.SetRaw(string(properties), fieldPath, string(embedJSON))
+	if err != nil {
+		return properties, fmt.Errorf("embed: set embed field %s: %w", fieldPath, err)
+	}
+	return json.RawMessage(updatedJSON), nil
+}
+
 // resolveReference resolves a single reference in the properties
 func (pr *propertyResolver) resolveReference(properties json.RawMessage, ref pkgmodel.Ref) (json.RawMessage, error) {
+	// Embedded refs live inside a $embed field's $template; update the span envelope
+	// in place rather than replacing the whole field with a scalar.
+	if ref.Embedded {
+		return pr.resolveEmbedRef(properties, ref)
+	}
+
 	parsed := gjson.Parse(string(properties))
 	targetObj := parsed.Get(ref.TargetPath)
 	if !targetObj.Exists() {
@@ -475,8 +586,34 @@ func (pr *propertyResolver) toPluginFormat(originalProperties json.RawMessage) (
 	outputJsonString := string(originalProperties)
 	var err error
 
+	// Track embed field paths that have been assembled so we process each once.
+	assembledEmbedFields := make(map[string]bool)
+
 	for _, refs := range pr.refs {
 		for _, ref := range refs {
+			if ref.Embedded {
+				// Embed fields are assembled from the $template, not from a single ref value.
+				// Process each embed field path exactly once.
+				if assembledEmbedFields[ref.EmbedFieldPath] {
+					continue
+				}
+				assembledEmbedFields[ref.EmbedFieldPath] = true
+
+				assembled, ok := pr.assembleEmbedField(outputJsonString, ref.EmbedFieldPath)
+				if !ok {
+					// Not all spans resolved; leave the field structured.
+					continue
+				}
+				outputJsonString, err = sjson.Set(outputJsonString, ref.EmbedFieldPath, assembled)
+				if err != nil {
+					slog.Error("ToPluginFormat: failed to set assembled embed field",
+						"path", ref.EmbedFieldPath,
+						"error", err)
+					return nil, err
+				}
+				continue
+			}
+
 			if ref.ResolvedValue.Value == nil {
 				continue
 			}
@@ -513,6 +650,31 @@ func (pr *propertyResolver) toPluginFormat(originalProperties json.RawMessage) (
 	}
 
 	return json.RawMessage(outputJsonString), nil
+}
+
+// assembleEmbedField reads the $embed field at fieldPath from the JSON string,
+// scans its $template for framed spans, and assembles the plain string if every
+// span carries a $value. Returns the assembled string and true when all spans are
+// resolved; returns "", false otherwise (including parse errors).
+func (pr *propertyResolver) assembleEmbedField(jsonStr string, fieldPath string) (string, bool) {
+	embedObj := gjson.Get(jsonStr, fieldPath)
+	if !embedObj.Exists() {
+		return "", false
+	}
+	tmpl := embedObj.Get("$template").String()
+	if tmpl == "" {
+		return "", false
+	}
+
+	assembled, allResolved := assembleEmbedTemplate(tmpl, func(envJSON string) (string, bool) {
+		env := gjson.Parse(envJSON)
+		val := env.Get("$value")
+		if !val.Exists() {
+			return "", false
+		}
+		return val.String(), true
+	})
+	return assembled, allResolved
 }
 
 func (pr *propertyResolver) getResolvableURIs() []pkgmodel.FormaeURI {

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -125,6 +125,7 @@ const (
 	typeReference propertyType = iota // Object with $ref (with or without $value)
 	typeValue                         // Object with only $value (no $ref)
 	typePlain                         // Regular property (no $ref or $value)
+	typeEmbed                         // Object with $embed: true — template with framed spans
 )
 
 func (pp *propertyParser) Parse(result gjson.Result) propertyType {
@@ -137,6 +138,10 @@ func (pp *propertyParser) Parse(result gjson.Result) propertyType {
 			pp.Value = result.Get("$value").Value()
 		}
 		return typeReference
+	}
+
+	if result.Get("$embed").Exists() {
+		return typeEmbed
 	}
 
 	if pp.HasValue {
@@ -258,6 +263,29 @@ func (pr *propertyResolver) extractFromJson(result gjson.Result, currentPath str
 		case typeValue:
 			value := parser.CreateValue(result)
 			pr.values[currentPath] = *value
+			return
+		case typeEmbed:
+			tmpl := result.Get("$template").String()
+			spans, err := pkgmodel.ScanEmbedSpans(tmpl)
+			if err != nil {
+				slog.Warn("embed: failed to scan spans in $template, skipping extraction",
+					"path", currentPath,
+					"error", err)
+				return
+			}
+			for _, sp := range spans {
+				env := gjson.Parse(sp.EnvelopeJSON)
+				spanParser := &propertyParser{}
+				spanParser.Parse(env)
+				if !spanParser.HasRef {
+					continue
+				}
+				ref := spanParser.CreateRef(currentPath, env)
+				ref.Embedded = true
+				ref.EmbedFieldPath = currentPath
+				uri := pkgmodel.FormaeURI(ref.PropertyURI)
+				pr.refs[uri] = append(pr.refs[uri], ref)
+			}
 			return
 		case typePlain:
 			result.ForEach(func(key, val gjson.Result) bool {

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -140,7 +140,7 @@ func (pp *propertyParser) Parse(result gjson.Result) propertyType {
 		return typeReference
 	}
 
-	if result.Get("$embed").Exists() {
+	if result.Get("$embed").Bool() {
 		return typeEmbed
 	}
 

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -266,6 +266,10 @@ func (pr *propertyResolver) extractFromJson(result gjson.Result, currentPath str
 			return
 		case typeEmbed:
 			tmpl := result.Get("$template").String()
+			if tmpl == "" {
+				slog.Debug("embed: $template absent or empty, skipping extraction", "path", currentPath)
+				return
+			}
 			spans, err := pkgmodel.ScanEmbedSpans(tmpl)
 			if err != nil {
 				slog.Warn("embed: failed to scan spans in $template, skipping extraction",
@@ -278,6 +282,7 @@ func (pr *propertyResolver) extractFromJson(result gjson.Result, currentPath str
 				spanParser := &propertyParser{}
 				spanParser.Parse(env)
 				if !spanParser.HasRef {
+					slog.Debug("embed: span has no $ref, skipping", "path", currentPath)
 					continue
 				}
 				ref := spanParser.CreateRef(currentPath, env)

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -373,19 +373,23 @@ func assembleEmbedTemplate(tmpl string, valueForEnvelope func(envJSON string) (s
 		return tmpl, len(spans) == 0 && err == nil
 	}
 
-	allResolved := true
-	// Work in reverse order so earlier offsets are unaffected by later splices.
+	// Verify all spans are resolved before doing any work; short-circuit on the
+	// first unresolved span so no partial string is produced.
+	vals := make([]string, len(spans))
+	for i, sp := range spans {
+		val, ok := valueForEnvelope(sp.EnvelopeJSON)
+		if !ok {
+			return "", false
+		}
+		vals[i] = val
+	}
+	// All spans resolved — splice in reverse order so earlier offsets stay valid.
 	result := tmpl
 	for i := len(spans) - 1; i >= 0; i-- {
 		sp := spans[i]
-		val, ok := valueForEnvelope(sp.EnvelopeJSON)
-		if !ok {
-			allResolved = false
-			continue
-		}
-		result = result[:sp.Start] + val + result[sp.End:]
+		result = result[:sp.Start] + vals[i] + result[sp.End:]
 	}
-	return result, allResolved
+	return result, true
 }
 
 // resolveEmbedRef writes the resolved $value for ref inside the matching span

--- a/internal/metastructure/resolver/resolver_test.go
+++ b/internal/metastructure/resolver/resolver_test.go
@@ -1559,6 +1559,21 @@ func TestEmbed_DuplicateIdenticalSpans(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, gjson.GetBytes(resolved, "code.$embed").Bool())
 
+	// After resolve, BOTH span envelopes in the $template must carry $value="VAL-42".
+	// A regression that only updated one span would leave the other without $value.
+	resolvedTmpl := gjson.GetBytes(resolved, "code.$template").String()
+	resolvedSpans, scanErr := pkgmodel.ScanEmbedSpans(resolvedTmpl)
+	require.NoError(t, scanErr)
+	require.Len(t, resolvedSpans, 2, "expected two span sites in resolved $template")
+	resolvedCount := 0
+	for _, sp := range resolvedSpans {
+		if gjson.Get(sp.EnvelopeJSON, "$value").String() == "VAL-42" {
+			resolvedCount++
+		}
+	}
+	assert.Equal(t, 2, resolvedCount,
+		"expected $value='VAL-42' to appear in both span envelopes of the resolved $template")
+
 	plugin, err := resolver.toPluginFormat(resolved)
 	require.NoError(t, err)
 	assert.Equal(t, "cf.fn('VAL-42', 'VAL-42')", gjson.GetBytes(plugin, "code").String())

--- a/internal/metastructure/resolver/resolver_test.go
+++ b/internal/metastructure/resolver/resolver_test.go
@@ -1429,6 +1429,29 @@ func TestExtractResolvableRefs_EmbedField(t *testing.T) {
 	if refs[0].TargetPath != "functionCode" {
 		t.Errorf("TargetPath: got %q want functionCode", refs[0].TargetPath)
 	}
+
+	// Assert the Embedded flag and EmbedFieldPath are set on the internal Ref —
+	// these are the primary output of Task 3 and must survive refactoring.
+	pr := newPropertyResolverFromResource(res)
+	var embedRef pkgmodel.Ref
+	found := false
+	for _, bucket := range pr.refs {
+		for _, r := range bucket {
+			if r.Embedded {
+				embedRef = r
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no Ref with Embedded==true found in propertyResolver.refs")
+	}
+	if !embedRef.Embedded {
+		t.Errorf("Ref.Embedded: got false, want true")
+	}
+	if embedRef.EmbedFieldPath != "functionCode" {
+		t.Errorf("Ref.EmbedFieldPath: got %q, want functionCode", embedRef.EmbedFieldPath)
+	}
 }
 
 // newTestRef creates a test reference with a real KSUID for the given property

--- a/internal/metastructure/resolver/resolver_test.go
+++ b/internal/metastructure/resolver/resolver_test.go
@@ -1409,6 +1409,28 @@ func TestConvertToPluginFormat_TargetConfig(t *testing.T) {
 	})
 }
 
+func TestExtractResolvableRefs_EmbedField(t *testing.T) {
+	// Build a $embed field whose $template contains one framed span.
+	// The span envelope is a post-translation $ref (KSUID-based) so
+	// ExtractResolvableRefs can construct the URI exactly as for whole-value refs.
+	kvsKsuid := util.NewID()
+	envJSON := fmt.Sprintf(`{"$ref":"formae://%s#/id"}`, kvsKsuid)
+	tmpl := "cf.kvs('" + pkgmodel.FrameEnvelope(envJSON) + "')"
+	props, _ := json.Marshal(map[string]any{
+		"functionCode": map[string]any{"$embed": true, "$template": tmpl},
+	})
+	res := pkgmodel.Resource{Properties: props}
+
+	refs := ExtractResolvableRefs(res)
+
+	if len(refs) != 1 {
+		t.Fatalf("want 1 embedded ref, got %d", len(refs))
+	}
+	if refs[0].TargetPath != "functionCode" {
+		t.Errorf("TargetPath: got %q want functionCode", refs[0].TargetPath)
+	}
+}
+
 // newTestRef creates a test reference with a real KSUID for the given property
 func newTestRef(property string) string {
 	ksuid := util.NewID()

--- a/internal/metastructure/resolver/resolver_test.go
+++ b/internal/metastructure/resolver/resolver_test.go
@@ -1484,3 +1484,82 @@ func TestExtractPropertyValue_EscapedDotInKey(t *testing.T) {
 	require.True(t, result.Exists())
 	assert.Equal(t, "example.com", result.String())
 }
+
+// embedProps is a helper that builds a JSON props object with a single $embed field.
+// It uses json.Marshal so the control characters in the template are properly
+// encoded as / (valid JSON escapes) rather than \x1e/\x1f (Go-only).
+func embedProps(fieldName, tmpl string) json.RawMessage {
+	tmplJSON, err := json.Marshal(tmpl)
+	if err != nil {
+		panic(fmt.Sprintf("embedProps: json.Marshal failed: %v", err))
+	}
+	fieldJSON, err := json.Marshal(fieldName)
+	if err != nil {
+		panic(fmt.Sprintf("embedProps: json.Marshal fieldName failed: %v", err))
+	}
+	return json.RawMessage(`{` + string(fieldJSON) + `:{"$embed":true,"$template":` + string(tmplJSON) + `}}`)
+}
+
+func TestEmbed_ResolveThenPluginFormat(t *testing.T) {
+	ksuid := "abc123"
+	refEnv := `{"$ref":"formae://` + ksuid + `#/id"}`
+	tmpl := "cf.kvs('" + pkgmodel.FrameEnvelope(refEnv) + "')"
+	props := embedProps("functionCode", tmpl)
+
+	resolver := newPropertyResolver(props)
+	require.NoError(t, resolver.setRefValue(pkgmodel.FormaeURI("formae://"+ksuid+"#/id"), "KV-7H9X"))
+
+	// Persisted form: still a $embed envelope, span now carries the value.
+	resolved, err := resolver.resolveReferences(props)
+	require.NoError(t, err)
+	assert.True(t, gjson.GetBytes(resolved, "functionCode.$embed").Bool())
+
+	// Plugin form: assembled plain string.
+	plugin, err := resolver.toPluginFormat(resolved)
+	require.NoError(t, err)
+	assert.Equal(t, "cf.kvs('KV-7H9X')", gjson.GetBytes(plugin, "functionCode").String())
+}
+
+func TestEmbed_MultiResolvable(t *testing.T) {
+	ksuid1 := util.NewID()
+	ksuid2 := util.NewID()
+	refEnv1 := fmt.Sprintf(`{"$ref":"formae://%s#/id"}`, ksuid1)
+	refEnv2 := fmt.Sprintf(`{"$ref":"formae://%s#/name"}`, ksuid2)
+	// Two distinct spans in one template.
+	tmpl := "cf.kvs('" + pkgmodel.FrameEnvelope(refEnv1) + "', '" + pkgmodel.FrameEnvelope(refEnv2) + "')"
+	props := embedProps("functionCode", tmpl)
+
+	resolver := newPropertyResolver(props)
+	require.NoError(t, resolver.setRefValue(pkgmodel.FormaeURI("formae://"+ksuid1+"#/id"), "KV-7H9X"))
+	require.NoError(t, resolver.setRefValue(pkgmodel.FormaeURI("formae://"+ksuid2+"#/name"), "my-store"))
+
+	resolved, err := resolver.resolveReferences(props)
+	require.NoError(t, err)
+	// Still structured after resolution.
+	assert.True(t, gjson.GetBytes(resolved, "functionCode.$embed").Bool())
+
+	// Assembled plain string in plugin format.
+	plugin, err := resolver.toPluginFormat(resolved)
+	require.NoError(t, err)
+	assert.Equal(t, "cf.kvs('KV-7H9X', 'my-store')", gjson.GetBytes(plugin, "functionCode").String())
+}
+
+func TestEmbed_DuplicateIdenticalSpans(t *testing.T) {
+	// Same envelope (same URI) appearing twice: both spans get the same resolved value.
+	ksuid := util.NewID()
+	refEnv := fmt.Sprintf(`{"$ref":"formae://%s#/id"}`, ksuid)
+	span := pkgmodel.FrameEnvelope(refEnv)
+	tmpl := "cf.fn('" + span + "', '" + span + "')"
+	props := embedProps("code", tmpl)
+
+	resolver := newPropertyResolver(props)
+	require.NoError(t, resolver.setRefValue(pkgmodel.FormaeURI("formae://"+ksuid+"#/id"), "VAL-42"))
+
+	resolved, err := resolver.resolveReferences(props)
+	require.NoError(t, err)
+	assert.True(t, gjson.GetBytes(resolved, "code.$embed").Bool())
+
+	plugin, err := resolver.toPluginFormat(resolved)
+	require.NoError(t, err)
+	assert.Equal(t, "cf.fn('VAL-42', 'VAL-42')", gjson.GetBytes(plugin, "code").String())
+}

--- a/internal/metastructure/resource_update/merge_embed_test.go
+++ b/internal/metastructure/resource_update/merge_embed_test.go
@@ -42,6 +42,7 @@ func TestMerge_PreservesEmbedEnvelope_PluginReturnsObject(t *testing.T) {
 	plugin := json.RawMessage(`{"functionCode":{"$embed":false,"$template":"stale"}}`)
 	out, err := mergeRefsPreservingUserRefs(user, plugin, pkgmodel.Schema{})
 	require.NoError(t, err)
+	assert.True(t, gjson.GetBytes(out, "functionCode").IsObject())
 	assert.True(t, gjson.GetBytes(out, "functionCode.$embed").Bool(),
 		"merge must keep user's $embed:true even when plugin returns an object at the same path")
 	assert.Equal(t, "cf.kvs('X')", gjson.GetBytes(out, "functionCode.$template").String(),

--- a/internal/metastructure/resource_update/merge_embed_test.go
+++ b/internal/metastructure/resource_update/merge_embed_test.go
@@ -22,6 +22,28 @@ func TestMerge_PreservesEmbedEnvelope(t *testing.T) {
 	plugin := json.RawMessage(`{"functionCode":"cf.kvs('KV-7H9X')"}`) // assembled scalar from cloud
 	out, err := mergeRefsPreservingUserRefs(user, plugin, pkgmodel.Schema{})
 	require.NoError(t, err)
+	// The merged result must be an object (the user's envelope), not the plugin scalar
+	assert.True(t, gjson.GetBytes(out, "functionCode").IsObject(),
+		"merge must keep the $embed object envelope, not collapse to the plugin scalar")
 	assert.True(t, gjson.GetBytes(out, "functionCode.$embed").Bool(),
-		"merge must keep the $embed envelope, not the plugin scalar")
+		"merge must keep $embed:true from user envelope")
+	assert.Equal(t, "cf.kvs('X')", gjson.GetBytes(out, "functionCode.$template").String(),
+		"merge must keep user's $template expression")
+}
+
+// TestMerge_PreservesEmbedEnvelope_PluginReturnsObject is the regression case that
+// FAILS without the explicit $embed guard in mergeObject. When the plugin returns an
+// OBJECT at functionCode (rather than a scalar), the recursive merge would normally
+// descend into it and overwrite the user's $embed:true with the plugin's $embed:false.
+func TestMerge_PreservesEmbedEnvelope_PluginReturnsObject(t *testing.T) {
+	user := json.RawMessage(`{"functionCode":{"$embed":true,"$template":"cf.kvs('X')"}}`)
+	// Plugin returns an object at functionCode — without an explicit guard, the recursive
+	// merge would descend into this object and clobber the user's $embed:true.
+	plugin := json.RawMessage(`{"functionCode":{"$embed":false,"$template":"stale"}}`)
+	out, err := mergeRefsPreservingUserRefs(user, plugin, pkgmodel.Schema{})
+	require.NoError(t, err)
+	assert.True(t, gjson.GetBytes(out, "functionCode.$embed").Bool(),
+		"merge must keep user's $embed:true even when plugin returns an object at the same path")
+	assert.Equal(t, "cf.kvs('X')", gjson.GetBytes(out, "functionCode.$template").String(),
+		"merge must keep user's $template, not the plugin's stale value")
 }

--- a/internal/metastructure/resource_update/merge_embed_test.go
+++ b/internal/metastructure/resource_update/merge_embed_test.go
@@ -1,0 +1,27 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func TestMerge_PreservesEmbedEnvelope(t *testing.T) {
+	user := json.RawMessage(`{"functionCode":{"$embed":true,"$template":"cf.kvs('X')"}}`)
+	plugin := json.RawMessage(`{"functionCode":"cf.kvs('KV-7H9X')"}`) // assembled scalar from cloud
+	out, err := mergeRefsPreservingUserRefs(user, plugin, pkgmodel.Schema{})
+	require.NoError(t, err)
+	assert.True(t, gjson.GetBytes(out, "functionCode.$embed").Bool(),
+		"merge must keep the $embed envelope, not the plugin scalar")
+}

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -498,7 +498,7 @@ func (m *propertyMerger) mergeObject(path string, userVal, pluginVal gjson.Resul
 	// Check if this is a $embed object — preserve the user's envelope wholesale.
 	// The plugin value is always the assembled result of the template; we never
 	// let the plugin overwrite the user's $embed declaration.
-	if userVal.Get("$embed").Exists() {
+	if userVal.Get("$embed").Bool() {
 		cleanPath := m.cleanPath(path)
 		*m.result, _ = sjson.SetRaw(*m.result, cleanPath, userVal.Raw)
 		return

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -495,7 +495,16 @@ func (m *propertyMerger) mergeObject(path string, userVal, pluginVal gjson.Resul
 		return
 	}
 
-	// Not a $ref object - recursively merge each field
+	// Check if this is a $embed object — preserve the user's envelope wholesale.
+	// The plugin value is always the assembled result of the template; we never
+	// let the plugin overwrite the user's $embed declaration.
+	if userVal.Get("$embed").Exists() {
+		cleanPath := m.cleanPath(path)
+		*m.result, _ = sjson.SetRaw(*m.result, cleanPath, userVal.Raw)
+		return
+	}
+
+	// Not a $ref or $embed object - recursively merge each field
 	userVal.ForEach(func(key, val gjson.Result) bool {
 		childPath := m.buildChildPath(path, key.String())
 		pluginChildVal := pluginVal.Get(key.String())

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -2081,5 +2081,134 @@ func translatePropertiesJSON(properties json.RawMessage, tripletToKsuid map[pkgm
 		}
 	}
 
+	// Second pass: translate $res envelopes framed inside $embed.$template strings.
+	// FindResolvablesFromProperties does not scan string contents, so embedded spans
+	// are invisible to the flat-list pass above. We walk the tree explicitly here.
+	result, err = translateEmbedSpans(result, tripletToKsuid, ds, externalLabels)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	return json.RawMessage(result), externalLabels, nil
+}
+
+// translateEmbedSpans walks the JSON tree for objects with $embed==true and
+// rewrites any framed RS<base64>US $res envelopes in $template to $ref+KSUID form.
+func translateEmbedSpans(jsonStr string, tripletToKsuid map[pkgmodel.TripletKey]string, ds ResourceDataLookup, externalLabels map[string]string) (string, error) {
+	return translateEmbedSpansAtPath("", gjson.Parse(jsonStr), jsonStr, tripletToKsuid, ds, externalLabels)
+}
+
+func translateEmbedSpansAtPath(basePath string, value gjson.Result, jsonStr string, tripletToKsuid map[pkgmodel.TripletKey]string, ds ResourceDataLookup, externalLabels map[string]string) (string, error) {
+	var err error
+	if value.IsObject() {
+		if value.Get("$embed").Bool() {
+			tmplResult := value.Get("$template")
+			if tmplResult.Exists() && tmplResult.Type == gjson.String {
+				tmpl := tmplResult.String()
+				tmpl, err = translateEmbedSpansInTemplate(tmpl, tripletToKsuid, ds, externalLabels)
+				if err != nil {
+					return jsonStr, err
+				}
+				templatePath := basePath
+				if templatePath == "" {
+					templatePath = "$template"
+				} else {
+					templatePath = templatePath + ".$template"
+				}
+				jsonStr, err = sjson.Set(jsonStr, templatePath, tmpl)
+				if err != nil {
+					return jsonStr, fmt.Errorf("failed to update $embed.$template at path %s: %w", templatePath, err)
+				}
+			}
+			return jsonStr, nil
+		}
+		// Recurse into child fields
+		var walkErr error
+		value.ForEach(func(key, val gjson.Result) bool {
+			var childPath string
+			if basePath == "" {
+				childPath = key.String()
+			} else {
+				childPath = basePath + "." + key.String()
+			}
+			jsonStr, walkErr = translateEmbedSpansAtPath(childPath, val, jsonStr, tripletToKsuid, ds, externalLabels)
+			return walkErr == nil
+		})
+		if walkErr != nil {
+			return jsonStr, walkErr
+		}
+	} else if value.IsArray() {
+		var walkErr error
+		value.ForEach(func(key, val gjson.Result) bool {
+			var childPath string
+			if basePath == "" {
+				childPath = key.String()
+			} else {
+				childPath = basePath + "." + key.String()
+			}
+			jsonStr, walkErr = translateEmbedSpansAtPath(childPath, val, jsonStr, tripletToKsuid, ds, externalLabels)
+			return walkErr == nil
+		})
+		if walkErr != nil {
+			return jsonStr, walkErr
+		}
+	}
+	return jsonStr, nil
+}
+
+// translateEmbedSpansInTemplate rewrites every framed $res envelope in a $template
+// string to its $ref+KSUID equivalent using the same lookup logic as the flat pass.
+func translateEmbedSpansInTemplate(tmpl string, tripletToKsuid map[pkgmodel.TripletKey]string, ds ResourceDataLookup, externalLabels map[string]string) (string, error) {
+	spans, err := pkgmodel.ScanEmbedSpans(tmpl)
+	if err != nil || len(spans) == 0 {
+		return tmpl, err
+	}
+
+	// Process in reverse offset order so earlier offsets stay valid.
+	for i := len(spans) - 1; i >= 0; i-- {
+		span := spans[i]
+		parsed := gjson.Parse(span.EnvelopeJSON)
+		if !pkgmodel.IsResolvableObject(parsed) {
+			// Not a $res envelope — leave span unchanged.
+			continue
+		}
+		resolvable := pkgmodel.ResolvableObject{
+			Label:    parsed.Get("$label").String(),
+			Type:     parsed.Get("$type").String(),
+			Stack:    parsed.Get("$stack").String(),
+			Property: parsed.Get("$property").String(),
+		}
+
+		var formaeURI pkgmodel.FormaeURI
+		ksuid, ok := tripletToKsuid[resolvable.ToTripletKey()]
+		if ok {
+			formaeURI = resolvable.ToFormaeURI(ksuid)
+		} else {
+			if resolvable.Label == "" || resolvable.Type == "" || resolvable.Stack == "" {
+				return tmpl, fmt.Errorf("embed span has incomplete triplet (label=%q type=%q stack=%q)", resolvable.Label, resolvable.Type, resolvable.Stack)
+			}
+			ksuid, err = ds.GetKSUIDByTriplet(resolvable.Stack, resolvable.Label, resolvable.Type)
+			if err != nil || ksuid == "" {
+				ksuid, err = ds.GetKSUIDByTriplet(constants.UnmanagedStack, resolvable.Label, resolvable.Type)
+				if err != nil || ksuid == "" {
+					return tmpl, fmt.Errorf("embed span references unknown resource (label=%q type=%q stack=%q)", resolvable.Label, resolvable.Type, resolvable.Stack)
+				}
+			}
+			formaeURI = resolvable.ToFormaeURI(ksuid)
+		}
+
+		refEnv := map[string]string{"$ref": string(formaeURI)}
+		refJSON, marshalErr := json.Marshal(refEnv)
+		if marshalErr != nil {
+			return tmpl, fmt.Errorf("embed span: failed to marshal $ref envelope: %w", marshalErr)
+		}
+
+		framed := pkgmodel.FrameEnvelope(string(refJSON))
+		tmpl = tmpl[:span.Start] + framed + tmpl[span.End:]
+
+		if resolvable.Label != "" && externalLabels != nil {
+			externalLabels[formaeURI.KSUID()] = resolvable.Label
+		}
+	}
+	return tmpl, nil
 }

--- a/internal/metastructure/resource_update/translate_embed_test.go
+++ b/internal/metastructure/resource_update/translate_embed_test.go
@@ -1,0 +1,115 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func TestTranslatePropertiesJSON_RewritesEmbeddedSpan(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	triplet := pkgmodel.TripletKey{Stack: "default", Label: "kvs", Type: "AWS::CloudFront::KeyValueStore"}
+	ksuid := "testembed123"
+
+	// Seed mock datastore so GetKSUIDByTriplet finds it
+	_, err := ds.StoreResource(&pkgmodel.Resource{
+		Ksuid: ksuid,
+		Label: triplet.Label,
+		Type:  triplet.Type,
+		Stack: triplet.Stack,
+	}, "cmd-1")
+	require.NoError(t, err)
+
+	// Build a $res envelope that lives inside a $embed.$template
+	resEnvJSON, _ := json.Marshal(map[string]any{
+		"$res":      true,
+		"$label":    triplet.Label,
+		"$type":     triplet.Type,
+		"$stack":    triplet.Stack,
+		"$property": "id",
+	})
+	tmpl := "cf.kvs('" + pkgmodel.FrameEnvelope(string(resEnvJSON)) + "')"
+
+	properties, err := json.Marshal(map[string]any{
+		"functionCode": map[string]any{
+			"$embed":    true,
+			"$template": tmpl,
+		},
+	})
+	require.NoError(t, err)
+
+	// tripletToKsuid map includes our triplet
+	tripletToKsuid := map[pkgmodel.TripletKey]string{triplet: ksuid}
+
+	result, _, err := translatePropertiesJSON(json.RawMessage(properties), tripletToKsuid, ds)
+	require.NoError(t, err)
+
+	// The $template in the result should have a $ref span (not a $res span)
+	tmplOut := gjson.Get(string(result), "functionCode.$template").String()
+	spans, scanErr := pkgmodel.ScanEmbedSpans(tmplOut)
+	require.NoError(t, scanErr)
+	require.Len(t, spans, 1, "expected exactly one span in translated $template")
+
+	assert.True(t, strings.Contains(spans[0].EnvelopeJSON, `"$ref"`),
+		"span should contain $ref, got: %s", spans[0].EnvelopeJSON)
+	assert.True(t, strings.Contains(spans[0].EnvelopeJSON, ksuid),
+		"span should contain KSUID, got: %s", spans[0].EnvelopeJSON)
+	assert.False(t, strings.Contains(spans[0].EnvelopeJSON, `"$res"`),
+		"span should not contain $res after forward translation, got: %s", spans[0].EnvelopeJSON)
+}
+
+func TestTranslatePropertiesJSON_RewritesEmbeddedSpan_Idempotent(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	triplet := pkgmodel.TripletKey{Stack: "default", Label: "kvs", Type: "AWS::CloudFront::KeyValueStore"}
+	ksuid := "testembed456"
+
+	_, err := ds.StoreResource(&pkgmodel.Resource{
+		Ksuid: ksuid,
+		Label: triplet.Label,
+		Type:  triplet.Type,
+		Stack: triplet.Stack,
+	}, "cmd-2")
+	require.NoError(t, err)
+
+	resEnvJSON, _ := json.Marshal(map[string]any{
+		"$res":      true,
+		"$label":    triplet.Label,
+		"$type":     triplet.Type,
+		"$stack":    triplet.Stack,
+		"$property": "id",
+	})
+	tmpl := "cf.kvs('" + pkgmodel.FrameEnvelope(string(resEnvJSON)) + "')"
+
+	properties, err := json.Marshal(map[string]any{
+		"functionCode": map[string]any{
+			"$embed":    true,
+			"$template": tmpl,
+		},
+	})
+	require.NoError(t, err)
+
+	tripletToKsuid := map[pkgmodel.TripletKey]string{triplet: ksuid}
+
+	result1, _, err := translatePropertiesJSON(json.RawMessage(properties), tripletToKsuid, ds)
+	require.NoError(t, err)
+
+	// Applying a second time (now $ref spans, not $res spans) should be idempotent
+	result2, _, err := translatePropertiesJSON(result1, tripletToKsuid, ds)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(result1), string(result2), "translatePropertiesJSON should be idempotent for embed spans")
+}

--- a/internal/schema/pkl/generator/examples/json/embed_field.json
+++ b/internal/schema/pkl/generator/examples/json/embed_field.json
@@ -1,0 +1,39 @@
+{
+  "Targets": [
+    {
+      "Label": "testprovider-target",
+      "Namespace": "TestProvider",
+      "Config": { "Type": "TestProvider", "Region": "us-east-1" }
+    }
+  ],
+  "Stacks": [
+    { "Label": "compute-stack", "Description": "Embedded-resolvable extract test" }
+  ],
+  "Resources": [
+    {
+      "Label": "web-server",
+      "Type": "TestProvider::Compute::Server",
+      "Stack": "compute-stack",
+      "Target": "testprovider-target",
+      "Properties": {
+        "ServerType": "t3.medium",
+        "ImageId": "ami-12345678",
+        "UserData": {
+          "$embed": true,
+          "$templateParts": [
+            "echo prefix-",
+            {
+              "$res": true,
+              "$label": "web-server",
+              "$type": "TestProvider::Compute::Server",
+              "$stack": "compute-stack",
+              "$property": "ServerId",
+              "$value": "srv-abc123"
+            },
+            "-suffix"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/internal/schema/pkl/generator/examples/json/embed_field.json
+++ b/internal/schema/pkl/generator/examples/json/embed_field.json
@@ -11,6 +11,13 @@
   ],
   "Resources": [
     {
+      "Label": "my-vpc",
+      "Type": "TestProvider::EC2::VPC",
+      "Stack": "compute-stack",
+      "Target": "testprovider-target",
+      "Properties": { "CidrBlock": "10.0.0.0/16" }
+    },
+    {
       "Label": "web-server",
       "Type": "TestProvider::Compute::Server",
       "Stack": "compute-stack",
@@ -21,16 +28,16 @@
         "UserData": {
           "$embed": true,
           "$templateParts": [
-            "echo prefix-",
+            "echo vpc=",
             {
               "$res": true,
-              "$label": "web-server",
-              "$type": "TestProvider::Compute::Server",
+              "$label": "my-vpc",
+              "$type": "TestProvider::EC2::VPC",
               "$stack": "compute-stack",
-              "$property": "ServerId",
-              "$value": "srv-abc123"
+              "$property": "VpcId",
+              "$value": "vpc-abc123"
             },
-            "-suffix"
+            " done"
           ]
         }
       }

--- a/internal/schema/pkl/generator/gen.pkl
+++ b/internal/schema/pkl/generator/gen.pkl
@@ -390,8 +390,14 @@ local function applyDynamicOrMapping(type: reflect.Class, value: Dynamic|Mapping
             FakeStrategy = strategy
         }
     else if (valueAsMap.containsKey("$embed") && valueAsMap.containsKey("$templateParts"))
+        // $templateParts arrives as a Listing when parsed from JSON (the real
+        // extract flow), but may be a List/Dynamic in other construction paths.
+        let (rawParts = valueAsMap["$templateParts"])
         new FakeEmbed {
-            FakeParts = (valueAsMap["$templateParts"] as Dynamic).toList()
+            FakeParts =
+                if (rawParts is Listing) rawParts.toList()
+                else if (rawParts is List) rawParts
+                else (rawParts as Dynamic).toList()
         }
     else
         // Get the reverse mapping for this class
@@ -649,13 +655,14 @@ local function renderEmbedRefPart(resMap: Map<String, Any>, indent: String): Str
       property
   )
   let (resInfo = resolvables.MapResolvableResourceUri().getOrNull(refType))
-  let (refExpr =
-    if (resInfo == null || s == "$unmanaged")
-      resMap.getOrNull("$value") as String? ?? "null"
-    else
-      "\(resInfo.importName).\(resInfo.clazz.simpleName) { stack = \"\(s)\" //resolvable\n\(indent)  label = \"\(l)\"\n\(indent)}.\(renderResolvableProperty(mappedProperty))"
-  )
-  "\\(" + refExpr + ")"
+  if (resInfo == null || s == "$unmanaged")
+    // No resolvable mapping (or unmanaged source): there is no reference
+    // expression to interpolate, so bake the resolved value as literal text.
+    escapeString(resMap.getOrNull("$value") as String? ?? "")
+  else
+    // Single-line interpolation so the enclosing single-line embed string stays
+    // valid: \(<Module>.<Resolvable> { stack = ".."; label = ".." }.<prop>)
+    "\\(\(resInfo.importName).\(resInfo.clazz.simpleName) { stack = \"\(s)\"; label = \"\(l)\" }.\(renderResolvableProperty(mappedProperty)))"
 
 local function formatValueWithTypes(value: Any, indent: String): String =
   if (value is Dynamic)
@@ -715,7 +722,8 @@ local function formatValueWithTypes(value: Any, indent: String): String =
           let (parts = value.getOrNull("FakeParts") as List)
           let (innerContent = parts.foldIndexed("", (idx: Int, acc: String, part: Any) ->
             if (part is String)
-              acc + part
+              // Literal template segment — escape for a single-line PKL string.
+              acc + escapeString(part)
             else if (part is Map)
               acc + renderEmbedRefPart(part as Map<String, Any>, indent)
             else if (part is Dynamic)
@@ -724,7 +732,9 @@ local function formatValueWithTypes(value: Any, indent: String): String =
             else
               acc
           ))
-          "formae.embed(\"\"\"\(innerContent)\"\"\")"
+          // Single-line string: valid regardless of newlines in the literal text
+          // (escaped to \n above) and free of multi-line-indentation pitfalls.
+          "formae.embed(\"\(innerContent)\")"
         else
           typeDeclaration + " {\n" +
           formatNestedContentWithTypes(value, indent + "  ") +

--- a/internal/schema/pkl/generator/gen.pkl
+++ b/internal/schema/pkl/generator/gen.pkl
@@ -259,6 +259,13 @@ class FakeResolvable extends formae.Resolvable {
   FakeProperty: String
 }
 
+/// Carrier for a pre-processed $embed field.
+/// FakeParts is a List whose elements are alternately String (literal segment)
+/// and Map (decoded $res envelope — same shape FakeResolvable already handles).
+class FakeEmbed {
+  FakeParts: List
+}
+
 function applyPropertyWithMapping(valueAsMap: Map, prop: reflect.Property, reverseMapping: Mapping<String, String>) =
     // First try the direct property name
     if (valueAsMap.containsKey(prop.name))
@@ -382,6 +389,10 @@ local function applyDynamicOrMapping(type: reflect.Class, value: Dynamic|Mapping
             FakeVisibility = visibility
             FakeStrategy = strategy
         }
+    else if (valueAsMap.containsKey("$embed") && valueAsMap.containsKey("$templateParts"))
+        new FakeEmbed {
+            FakeParts = (valueAsMap["$templateParts"] as Dynamic).toList()
+        }
     else
         // Get the reverse mapping for this class
         let (reverseMapping =
@@ -502,6 +513,11 @@ local function parseValueEnhanced(value: Any): Any =
   else if (value is Typed)
     let (m = value.toMap())
     let (typeName = getTypeName(value))
+    // FakeEmbed: preserve parts as-is (each part is either a String literal
+    // or a Dynamic/$res map — formatValueWithTypes handles the rendering).
+    if (typeName == "FakeEmbed")
+      Map("__type__", "FakeEmbed", "FakeParts", (value as FakeEmbed).FakeParts)
+    else
     let (importInfo = getImportInfoForType(value.getClass(), typeName, value))
     let (defaultMap =
       if (typeName == "FakeResolvable")
@@ -659,6 +675,52 @@ local function formatValueWithTypes(value: Any, indent: String): String =
           let (withVisibility = if (visibility == "Opaque") base + ".opaque" else base)
           let (withStrategy = if (strategy == "SetOnce") withVisibility + ".setOnce" else withVisibility)
             withStrategy
+        else if (typeName == "FakeEmbed")
+          // Render as formae.embed("""...\(<resolvable-ref>)...""").
+          // FakeParts is a List alternating String literals and $res maps.
+          // Each $res map is rendered using the existing FakeResolvable path
+          // (via applyDynamicOrMapping) and wrapped in \(...).
+          let (parts = value.getOrNull("FakeParts") as List)
+          let (innerContent = parts.foldIndexed("", (idx: Int, acc: String, part: Any) ->
+            if (part is String)
+              acc + part
+            else if (part is Map)
+              // Render the $res map as a FakeResolvable using applyDynamicOrMapping,
+              // then format it and wrap in PKL string interpolation \(...).
+              let (resMap = part as Map<String, Any>)
+              let (s = resMap.getOrNull("$stack") as String?)
+              let (l = resMap.getOrNull("$label") as String?)
+              let (refType = resMap.getOrNull("$type") as String?)
+              let (property = resMap.getOrNull("$property") as String?)
+              let (resolvableMapping = getResolvablePropertyMapping(refType))
+              let (mappedProperty =
+                if (property == null)
+                  null
+                else if (resolvableMapping.containsKey(property))
+                  resolvableMapping[property]
+                else if (property.contains("."))
+                  let (segments = splitGjsonPath(property))
+                  let (base = segments[0])
+                  let (rest = segments.drop(1))
+                  let (mappedBase = if (resolvableMapping.containsKey(base)) resolvableMapping[base] else base)
+                  mappedBase + rest.fold("", (a, seg) -> a + "." + seg)
+                else
+                  property
+              )
+              // Build the inline resolvable reference expression
+              let (resInfo = resolvables.MapResolvableResourceUri().getOrNull(refType))
+              let (refExpr =
+                if (resInfo == null || s == "$unmanaged")
+                  // Unresolvable — emit the raw value or a placeholder
+                  resMap.getOrNull("$value") as String? ?? "null"
+                else
+                  "\(resInfo.importName).\(resInfo.clazz.simpleName) { stack = \"\(s)\" //resolvable\n\(indent)  label = \"\(l)\"\n\(indent)}.\(renderResolvableProperty(mappedProperty))"
+              )
+              acc + "\\(" + refExpr + ")"
+            else
+              acc
+          ))
+          "formae.embed(\"\"\"\(innerContent)\"\"\")"
         else
           typeDeclaration + " {\n" +
           formatNestedContentWithTypes(value, indent + "  ") +

--- a/internal/schema/pkl/generator/gen.pkl
+++ b/internal/schema/pkl/generator/gen.pkl
@@ -634,6 +634,20 @@ local function escapeString(str: String): String =
     .replaceAll("\r", "\\r")     // Escape carriage returns
     .replaceAll("\t", "\\t")     // Escape tabs
 
+// toCamelCase mirrors pklGenerator.toCamelCase (cannot import it — pklGenerator
+// imports this module). Used to reference the generated stack local by name.
+local function embedToCamelCase(input: String): String =
+  if (input == "$unmanaged")
+    "myStack"
+  else
+    let (parts = input.split("-"))
+    if (parts.length == 1)
+      input
+    else
+      parts.first + parts.drop(1).map((part) ->
+        if (part.isEmpty) "" else part.substring(0, 1).toUpperCase() + part.substring(1, part.length)
+      ).join("")
+
 local function renderEmbedRefPart(resMap: Map<String, Any>, indent: String): String =
   let (s = resMap.getOrNull("$stack") as String?)
   let (l = resMap.getOrNull("$label") as String?)
@@ -661,8 +675,14 @@ local function renderEmbedRefPart(resMap: Map<String, Any>, indent: String): Str
     escapeString(resMap.getOrNull("$value") as String? ?? "")
   else
     // Single-line interpolation so the enclosing single-line embed string stays
-    // valid: \(<Module>.<Resolvable> { stack = ".."; label = ".." }.<prop>)
-    "\\(\(resInfo.importName).\(resInfo.clazz.simpleName) { stack = \"\(s)\"; label = \"\(l)\" }.\(renderResolvableProperty(mappedProperty)))"
+    // valid. The class must be parenthesized — `(X) { .. }` — because an amends
+    // expression in expression context (inside \(…)) requires it. The stack is
+    // emitted already in its localized String form (<stackLocal>.res.label) so
+    // the post-processing localization (which would otherwise rewrite a bare
+    // `stack = ".."` to a StackResolvable, mismatching Resolvable.stack: String?)
+    // leaves it alone; this is the same value the //resolvable marker yields on
+    // the whole-value path.
+    "\\((\(resInfo.importName).\(resInfo.clazz.simpleName)) { stack = \(embedToCamelCase(s ?? "")).res.label; label = \"\(l)\" }.\(renderResolvableProperty(mappedProperty)))"
 
 local function formatValueWithTypes(value: Any, indent: String): String =
   if (value is Dynamic)

--- a/internal/schema/pkl/generator/gen.pkl
+++ b/internal/schema/pkl/generator/gen.pkl
@@ -628,8 +628,40 @@ local function escapeString(str: String): String =
     .replaceAll("\r", "\\r")     // Escape carriage returns
     .replaceAll("\t", "\\t")     // Escape tabs
 
+local function renderEmbedRefPart(resMap: Map<String, Any>, indent: String): String =
+  let (s = resMap.getOrNull("$stack") as String?)
+  let (l = resMap.getOrNull("$label") as String?)
+  let (refType = resMap.getOrNull("$type") as String?)
+  let (property = resMap.getOrNull("$property") as String?)
+  let (resolvableMapping = getResolvablePropertyMapping(refType))
+  let (mappedProperty =
+    if (property == null)
+      null
+    else if (resolvableMapping.containsKey(property))
+      resolvableMapping[property]
+    else if (property.contains("."))
+      let (segments = splitGjsonPath(property))
+      let (base = segments[0])
+      let (rest = segments.drop(1))
+      let (mappedBase = if (resolvableMapping.containsKey(base)) resolvableMapping[base] else base)
+      mappedBase + rest.fold("", (a, seg) -> a + "." + seg)
+    else
+      property
+  )
+  let (resInfo = resolvables.MapResolvableResourceUri().getOrNull(refType))
+  let (refExpr =
+    if (resInfo == null || s == "$unmanaged")
+      resMap.getOrNull("$value") as String? ?? "null"
+    else
+      "\(resInfo.importName).\(resInfo.clazz.simpleName) { stack = \"\(s)\" //resolvable\n\(indent)  label = \"\(l)\"\n\(indent)}.\(renderResolvableProperty(mappedProperty))"
+  )
+  "\\(" + refExpr + ")"
+
 local function formatValueWithTypes(value: Any, indent: String): String =
-  if (value is Map)
+  if (value is Dynamic)
+    // JSON-deserialized objects arrive as Dynamic; normalize to Map and recurse.
+    formatValueWithTypes(value.toMap(), indent)
+  else if (value is Map)
     // Check if this map represents a typed object (has a special type key)
     if (value.containsKey("__type__"))
       let (typeName = value["__type__"])
@@ -685,38 +717,10 @@ local function formatValueWithTypes(value: Any, indent: String): String =
             if (part is String)
               acc + part
             else if (part is Map)
-              // Render the $res map as a FakeResolvable using applyDynamicOrMapping,
-              // then format it and wrap in PKL string interpolation \(...).
-              let (resMap = part as Map<String, Any>)
-              let (s = resMap.getOrNull("$stack") as String?)
-              let (l = resMap.getOrNull("$label") as String?)
-              let (refType = resMap.getOrNull("$type") as String?)
-              let (property = resMap.getOrNull("$property") as String?)
-              let (resolvableMapping = getResolvablePropertyMapping(refType))
-              let (mappedProperty =
-                if (property == null)
-                  null
-                else if (resolvableMapping.containsKey(property))
-                  resolvableMapping[property]
-                else if (property.contains("."))
-                  let (segments = splitGjsonPath(property))
-                  let (base = segments[0])
-                  let (rest = segments.drop(1))
-                  let (mappedBase = if (resolvableMapping.containsKey(base)) resolvableMapping[base] else base)
-                  mappedBase + rest.fold("", (a, seg) -> a + "." + seg)
-                else
-                  property
-              )
-              // Build the inline resolvable reference expression
-              let (resInfo = resolvables.MapResolvableResourceUri().getOrNull(refType))
-              let (refExpr =
-                if (resInfo == null || s == "$unmanaged")
-                  // Unresolvable — emit the raw value or a placeholder
-                  resMap.getOrNull("$value") as String? ?? "null"
-                else
-                  "\(resInfo.importName).\(resInfo.clazz.simpleName) { stack = \"\(s)\" //resolvable\n\(indent)  label = \"\(l)\"\n\(indent)}.\(renderResolvableProperty(mappedProperty))"
-              )
-              acc + "\\(" + refExpr + ")"
+              acc + renderEmbedRefPart(part as Map<String, Any>, indent)
+            else if (part is Dynamic)
+              // JSON-deserialized $res envelope objects arrive as Dynamic, not Map.
+              acc + renderEmbedRefPart(part.toMap(), indent)
             else
               acc
           ))

--- a/internal/schema/pkl/generator/tests/gen.pkl
+++ b/internal/schema/pkl/generator/tests/gen.pkl
@@ -304,6 +304,46 @@ facts {
         gen.getPackageName(deploymentconfig.DeploymentConfig) == "testprovider"
     }
 
+    // --- FakeEmbed rendering tests ---
+
+    ["FakeEmbed: genMapToPklStringWithTypes renders formae.embed"] {
+        // A resource map containing a FakeEmbed value in one of its fields.
+        // We construct the map that parseValueEnhanced would produce for a FakeEmbed
+        // and verify that genMapToPklStringWithTypes emits formae.embed(""".
+        // The FakeParts list alternates String literals and $res maps.
+        let (resMap = Map(
+            "$res", true,
+            "$label", "kvs",
+            "$type", "TestProvider::EC2::VPC",
+            "$stack", "default",
+            "$property", "VpcId"
+        ))
+        let (fakeEmbedMap = Map(
+            "__type__", "FakeEmbed",
+            "FakeParts", List("cf.kvs('", resMap, "')")
+        ))
+        let (resourceMap = Map("functionCode", fakeEmbedMap))
+        let (rendered = gen.genMapToPklStringWithTypes("TestResource", resourceMap, "test"))
+        rendered.contains("formae.embed(\"\"\"")
+    }
+
+    ["FakeEmbed: rendered output contains PKL interpolation marker"] {
+        let (resMap = Map(
+            "$res", true,
+            "$label", "kvs",
+            "$type", "TestProvider::EC2::VPC",
+            "$stack", "default",
+            "$property", "VpcId"
+        ))
+        let (fakeEmbedMap = Map(
+            "__type__", "FakeEmbed",
+            "FakeParts", List("prefix", resMap, "suffix")
+        ))
+        let (resourceMap = Map("code", fakeEmbedMap))
+        let (rendered = gen.genMapToPklStringWithTypes("TestResource", resourceMap, "test"))
+        rendered.contains("\\(")
+    }
+
     ["duplicate Typed values produce single import after dedup"] {
         // Two SubResource instances in the same resource should not
         // produce duplicate __import_statement__ entries after dedup.

--- a/internal/schema/pkl/generator/tests/gen.pkl
+++ b/internal/schema/pkl/generator/tests/gen.pkl
@@ -325,7 +325,9 @@ facts {
         })
         let (resourceMap = Map("functionCode", fakeEmbedMap))
         let (rendered = gen.genMapToPklStringWithTypes("TestResource", resourceMap, "test"))
-        rendered.contains("formae.embed(\"\"\"")
+        // Single-line form. The old multi-line """ rendering produced invalid PKL
+        // (content on the same line as """) and broke extract re-eval — see PLA-68.
+        rendered.contains("formae.embed(\"") && !rendered.contains("formae.embed(\"\"\"")
     }
 
     ["FakeEmbed: rendered output contains PKL interpolation marker"] {

--- a/internal/schema/pkl/generator/tests/gen.pkl
+++ b/internal/schema/pkl/generator/tests/gen.pkl
@@ -311,34 +311,36 @@ facts {
         // We construct the map that parseValueEnhanced would produce for a FakeEmbed
         // and verify that genMapToPklStringWithTypes emits formae.embed(""".
         // The FakeParts list alternates String literals and $res maps.
-        let (resMap = Map(
-            "$res", true,
-            "$label", "kvs",
-            "$type", "TestProvider::EC2::VPC",
-            "$stack", "default",
-            "$property", "VpcId"
-        ))
-        let (fakeEmbedMap = Map(
-            "__type__", "FakeEmbed",
-            "FakeParts", List("cf.kvs('", resMap, "')")
-        ))
+        // Use Dynamic (not Map) to match JSON-deserialized production type.
+        let (resMap = new Dynamic {
+            ["$res"] = true
+            ["$label"] = "kvs"
+            ["$type"] = "TestProvider::EC2::VPC"
+            ["$stack"] = "default"
+            ["$property"] = "VpcId"
+        })
+        let (fakeEmbedMap = new Dynamic {
+            ["__type__"] = "FakeEmbed"
+            ["FakeParts"] = List("cf.kvs('", resMap, "')")
+        })
         let (resourceMap = Map("functionCode", fakeEmbedMap))
         let (rendered = gen.genMapToPklStringWithTypes("TestResource", resourceMap, "test"))
         rendered.contains("formae.embed(\"\"\"")
     }
 
     ["FakeEmbed: rendered output contains PKL interpolation marker"] {
-        let (resMap = Map(
-            "$res", true,
-            "$label", "kvs",
-            "$type", "TestProvider::EC2::VPC",
-            "$stack", "default",
-            "$property", "VpcId"
-        ))
-        let (fakeEmbedMap = Map(
-            "__type__", "FakeEmbed",
-            "FakeParts", List("prefix", resMap, "suffix")
-        ))
+        // Use Dynamic (not Map) to match JSON-deserialized production type.
+        let (resMap = new Dynamic {
+            ["$res"] = true
+            ["$label"] = "kvs"
+            ["$type"] = "TestProvider::EC2::VPC"
+            ["$stack"] = "default"
+            ["$property"] = "VpcId"
+        })
+        let (fakeEmbedMap = new Dynamic {
+            ["__type__"] = "FakeEmbed"
+            ["FakeParts"] = List("prefix", resMap, "suffix")
+        })
         let (resourceMap = Map("code", fakeEmbedMap))
         let (rendered = gen.genMapToPklStringWithTypes("TestResource", resourceMap, "test"))
         rendered.contains("\\(")

--- a/internal/schema/pkl/generator/tests/schema/compute/server.pkl
+++ b/internal/schema/pkl/generator/tests/schema/compute/server.pkl
@@ -24,6 +24,11 @@ open class Server extends formae.Resource {
     @testprovider.FieldHint
     imageId: String
 
+    // String|formae.Embedded field — exercises extract-to-PKL regeneration of an
+    // embedded resolvable (formae.embed("…\(ref)…")). See PLA-68.
+    @testprovider.FieldHint
+    userData: (String|formae.Embedded)?
+
     @testprovider.FieldHint
     networkConfig: networkconfig.NetworkConfig?
 

--- a/internal/schema/pkl/pkl_serialize.go
+++ b/internal/schema/pkl/pkl_serialize.go
@@ -24,7 +24,12 @@ import (
 
 // serializeWithPKL is a generic helper function that can serialize any data structure
 func (p PKL) serializeWithPKL(data *model.Forma, options *schema.SerializeOptions) (string, error) {
-	input, err := json.Marshal(data)
+	preprocessed, err := preprocessFormaEmbeds(data)
+	if err != nil {
+		return "", fmt.Errorf("error pre-processing embed fields: %w", err)
+	}
+
+	input, err := json.Marshal(preprocessed)
 	if err != nil {
 		return "", fmt.Errorf("error marshalling JSON: %w", err)
 	}
@@ -456,4 +461,127 @@ func (p PKL) generatePklFileWithProps(generatorDir, generatorName, outputName st
 	}
 
 	return nil
+}
+
+// preprocessFormaEmbeds returns a shallow copy of forma with every resource's
+// Properties pre-processed: any {"$embed":true,"$template":"..."} object whose
+// template contains framed RS+base64+US spans is replaced with
+// {"$embed":true,"$templateParts":[...]} where the parts array interleaves
+// literal string segments (as JSON strings) with decoded $res envelope maps
+// (as JSON objects). This avoids the PKL generator having to parse base64 or
+// binary control characters inside PKL string literals.
+func preprocessFormaEmbeds(f *model.Forma) (*model.Forma, error) {
+	if f == nil {
+		return nil, nil
+	}
+	out := *f // shallow copy
+	out.Resources = make([]model.Resource, len(f.Resources))
+	for i, r := range f.Resources {
+		nr := r
+		if len(r.Properties) > 0 {
+			processed, err := preprocessEmbedInJSON(r.Properties)
+			if err != nil {
+				return nil, fmt.Errorf("resource %q: %w", r.Label, err)
+			}
+			nr.Properties = processed
+		}
+		out.Resources[i] = nr
+	}
+	return &out, nil
+}
+
+// preprocessEmbedInJSON walks arbitrary JSON and rewrites every
+// {"$embed":true,"$template":"..."} object, replacing "$template" with
+// "$templateParts" — a JSON array of alternating literal strings and $res maps.
+func preprocessEmbedInJSON(raw json.RawMessage) (json.RawMessage, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return raw, nil // not parseable — leave unchanged
+	}
+	out, err := rewriteEmbedValue(v)
+	if err != nil {
+		return nil, err
+	}
+	result, err := json.Marshal(out)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// rewriteEmbedValue recurses into arbitrary JSON values and rewrites embed objects.
+func rewriteEmbedValue(v any) (any, error) {
+	switch val := v.(type) {
+	case map[string]any:
+		// Check for an embed node: {"$embed": true, "$template": "..."}
+		if embedFlag, ok := val["$embed"].(bool); ok && embedFlag {
+			if tmpl, ok := val["$template"].(string); ok {
+				parts, err := splitEmbedTemplate(tmpl)
+				if err != nil {
+					// Template is malformed — leave the node unchanged so
+					// downstream can surface the error rather than silently
+					// dropping embed fields.
+					return val, nil
+				}
+				result := map[string]any{
+					"$embed":         true,
+					"$templateParts": parts,
+				}
+				return result, nil
+			}
+		}
+		// Recurse into all keys
+		out := make(map[string]any, len(val))
+		for k, child := range val {
+			rewritten, err := rewriteEmbedValue(child)
+			if err != nil {
+				return nil, err
+			}
+			out[k] = rewritten
+		}
+		return out, nil
+	case []any:
+		out := make([]any, len(val))
+		for i, item := range val {
+			rewritten, err := rewriteEmbedValue(item)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = rewritten
+		}
+		return out, nil
+	default:
+		return v, nil
+	}
+}
+
+// splitEmbedTemplate scans a $embed.$template string for framed RS+base64+US
+// spans and returns an ordered slice of parts. Each part is either a plain
+// string (a literal segment between/around spans) or a map[string]any (the
+// decoded $res envelope for a span). Empty literal strings between adjacent
+// spans are included so that the PKL renderer can join them faithfully.
+func splitEmbedTemplate(tmpl string) ([]any, error) {
+	spans, err := model.ScanEmbedSpans(tmpl)
+	if err != nil {
+		return nil, err
+	}
+
+	var parts []any
+	cursor := 0
+	for _, span := range spans {
+		// Literal segment before this span
+		literal := tmpl[cursor:span.Start]
+		parts = append(parts, literal)
+
+		// Decode the envelope JSON to a map
+		var env map[string]any
+		if jsonErr := json.Unmarshal([]byte(span.EnvelopeJSON), &env); jsonErr != nil {
+			return nil, fmt.Errorf("embed: span envelope is not valid JSON: %w", jsonErr)
+		}
+		parts = append(parts, env)
+		cursor = span.End
+	}
+	// Trailing literal after the last span
+	parts = append(parts, tmpl[cursor:])
+	return parts, nil
 }

--- a/internal/schema/pkl/pkl_serialize.go
+++ b/internal/schema/pkl/pkl_serialize.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -518,9 +519,7 @@ func rewriteEmbedValue(v any) (any, error) {
 			if tmpl, ok := val["$template"].(string); ok {
 				parts, err := splitEmbedTemplate(tmpl)
 				if err != nil {
-					// Template is malformed — leave the node unchanged so
-					// downstream can surface the error rather than silently
-					// dropping embed fields.
+					slog.Warn("embed: malformed $embed template, passing through unchanged", "error", err)
 					return val, nil
 				}
 				result := map[string]any{

--- a/internal/schema/pkl/pkl_serialize_test.go
+++ b/internal/schema/pkl/pkl_serialize_test.go
@@ -18,6 +18,111 @@ import (
 	"github.com/platform-engineering-labs/formae/pkg/model"
 )
 
+// --- preprocessFormaEmbeds tests ---
+
+// TestPreprocessFormaEmbeds_SingleSpan verifies that a resource property
+// containing a $embed field whose $template has one framed span is split into
+// the correct $templateParts: [literal-before, $res-map, literal-after].
+func TestPreprocessFormaEmbeds_SingleSpan(t *testing.T) {
+	resEnv := `{"$res":true,"$label":"kvs","$type":"AWS::CloudFront::KeyValueStore","$stack":"default","$property":"id"}`
+	framed := model.FrameEnvelope(resEnv)
+	template := "cf.kvs('" + framed + "')"
+
+	embedObj := map[string]any{
+		"$embed":     true,
+		"$template":  template,
+	}
+	propsBytes, err := json.Marshal(map[string]any{"functionCode": embedObj})
+	require.NoError(t, err)
+
+	forma := &model.Forma{
+		Resources: []model.Resource{
+			{
+				Label:      "my-fn",
+				Type:       "AWS::Lambda::Function",
+				Stack:      "default",
+				Properties: propsBytes,
+			},
+		},
+	}
+
+	result, err := preprocessFormaEmbeds(forma)
+	require.NoError(t, err)
+
+	// Unmarshal the processed properties
+	var props map[string]any
+	require.NoError(t, json.Unmarshal(result.Resources[0].Properties, &props))
+
+	fc, ok := props["functionCode"].(map[string]any)
+	require.True(t, ok, "functionCode must be a map")
+
+	assert.Equal(t, true, fc["$embed"], "$embed must remain true")
+	assert.Nil(t, fc["$template"], "$template must be replaced by $templateParts")
+
+	parts, ok := fc["$templateParts"].([]any)
+	require.True(t, ok, "$templateParts must be a list")
+	require.Len(t, parts, 3, "expected [literal, $res-map, literal]")
+
+	// Part 0: literal before the span
+	assert.Equal(t, "cf.kvs('", parts[0], "first part must be the literal prefix")
+
+	// Part 1: the $res envelope map
+	resMap, ok := parts[1].(map[string]any)
+	require.True(t, ok, "second part must be a map (the $res envelope)")
+	assert.Equal(t, true, resMap["$res"], "$res must be true")
+	assert.Equal(t, "kvs", resMap["$label"])
+	assert.Equal(t, "default", resMap["$stack"])
+	assert.Equal(t, "id", resMap["$property"])
+
+	// Part 2: literal after the span
+	assert.Equal(t, "')", parts[2], "third part must be the literal suffix")
+}
+
+// TestPreprocessFormaEmbeds_NilFormaIsNoop verifies nil input is handled safely.
+func TestPreprocessFormaEmbeds_NilFormaIsNoop(t *testing.T) {
+	result, err := preprocessFormaEmbeds(nil)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+// TestPreprocessFormaEmbeds_NoEmbedFieldsUnchanged verifies that resources
+// without $embed fields are passed through without modification.
+func TestPreprocessFormaEmbeds_NoEmbedFieldsUnchanged(t *testing.T) {
+	propsBytes := json.RawMessage(`{"bucketName":"my-bucket"}`)
+	forma := &model.Forma{
+		Resources: []model.Resource{
+			{Label: "b", Type: "AWS::S3::Bucket", Stack: "default", Properties: propsBytes},
+		},
+	}
+	result, err := preprocessFormaEmbeds(forma)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"bucketName":"my-bucket"}`, string(result.Resources[0].Properties))
+}
+
+// TestSplitEmbedTemplate_TwoSpans verifies that two spans produce five parts:
+// [literal, $res, literal, $res, literal].
+func TestSplitEmbedTemplate_TwoSpans(t *testing.T) {
+	a := model.FrameEnvelope(`{"$res":true,"$label":"a","$stack":"s","$property":"p"}`)
+	b := model.FrameEnvelope(`{"$res":true,"$label":"b","$stack":"s","$property":"q"}`)
+	tmpl := "prefix" + a + "middle" + b + "suffix"
+
+	parts, err := splitEmbedTemplate(tmpl)
+	require.NoError(t, err)
+	require.Len(t, parts, 5)
+
+	assert.Equal(t, "prefix", parts[0])
+	mapA, ok := parts[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "a", mapA["$label"])
+
+	assert.Equal(t, "middle", parts[2])
+	mapB, ok := parts[3].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "b", mapB["$label"])
+
+	assert.Equal(t, "suffix", parts[4])
+}
+
 func TestResolveIncludes_PreResolvedDepsTakePrecedence(t *testing.T) {
 	forma := &model.Forma{Resources: []model.Resource{{Type: "AWS::S3::Bucket"}}}
 	options := &schema.SerializeOptions{

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -7,6 +7,7 @@
 module Formae
 
 import "pkl:reflect"
+import "pkl:json"
 
 open class Description {
     hidden text: String
@@ -320,6 +321,21 @@ open class Resolvable {
 
     $res: Boolean = true
     $visibility: String = visibility
+
+    // Rendered when this Resolvable is interpolated inside a string via \(…).
+    // Emits the full $res envelope, base64-encoded, framed by RS (U+001E) … US (U+001F),
+    // so the agent can locate and parse it back out of arbitrary string content.
+    // Whole-value rendering (assigning the Resolvable directly) is unaffected.
+    function toString(): String =
+        let (env = new Dynamic {
+                ["$res"] = true
+                ["$label"] = label
+                ["$type"] = type
+                ["$stack"] = stack
+                ["$property"] = property
+                ["$visibility"] = visibility
+            })
+        "\u{1e}" + new JsonRenderer { indent = "" }.renderValue(env).base64 + "\u{1f}"
 }
 
 /// Resolvable that resolves to a Mapping. Supports key-based access via at().
@@ -488,6 +504,17 @@ function mode(): String = read?("prop:$mode") ?? "replace"
 function value(val: String) = new Value {
     value = val
 }
+
+/// A String-typed field value carrying one or more embedded resolvables,
+/// produced by `embed(...)`. Renders to an `{$embed, $template}` envelope that
+/// the agent substitutes at resolve time, shipping a plain String to the plugin.
+open class Embedded {
+    hidden template: String
+    $embed: Boolean = true
+    $template: String = template
+}
+
+function embed(s: String): Embedded = new Embedded { template = s }
 
 // Fq Formae query functions can be used globally
 class Fq {

--- a/internal/schema/pkl/schema/tests/formae.pkl
+++ b/internal/schema/pkl/schema/tests/formae.pkl
@@ -633,6 +633,28 @@ facts {
         let (hint = noParentRefsHint())
         hint.parentRefs == null
     }
+
+    local embedResolvable = new formae.Resolvable {
+        label = "kvs"; type = "AWS::CloudFront::KeyValueStore"; stack = "default"; property = "id"
+    }
+    local embedded = formae.embed("cf.kvs('\(embedResolvable)')")
+
+    ["embed() sets $embed = true"] {
+        embedded.$embed == true
+    }
+    ["embed() template wraps the resolvable in RS<base64>US"] {
+        // RS then base64 chars then US, inside the literal
+        embedded.$template.matches(Regex("cf\\.kvs\\('\\u001e[A-Za-z0-9+/=]+\\u001f'\\)"))
+    }
+    ["framed base64 decodes to the $res envelope"] {
+        let (b64 = embedded.$template.split("\u{1e}")[1].split("\u{1f}")[0])
+        let (json = b64.base64Decoded)
+        json.contains(#""$res":true"#) && json.contains(#""$label":"kvs""#)
+        && json.contains(#""$property":"id""#)
+    }
+    ["whole-value rendering is unchanged (still the envelope object)"] {
+        embedResolvable.$res == true && embedResolvable.$label == "kvs"
+    }
 }
 
 local function singleParentRefHint(): formae.ResourceHint = new formae.ResourceHint {

--- a/internal/workflow_tests/local/apply_forma/embed_resolvable_test.go
+++ b/internal/workflow_tests/local/apply_forma/embed_resolvable_test.go
@@ -8,16 +8,22 @@ package workflow_tests_local
 
 import (
 	"encoding/json"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
 func TestMetastructure_RejectsOpaqueEmbed(t *testing.T) {
@@ -140,5 +146,485 @@ func TestMetastructure_RejectsOpaqueEmbed_InArray(t *testing.T) {
 		resources, dsErr := m.Datastore.LoadAllResources()
 		require.NoError(t, dsErr)
 		assert.Empty(t, resources, "no resource row should be persisted on opaque-embed-in-array rejection")
+	})
+}
+
+// TestEmbed_ResolvesToPluginInOneApply verifies that when a host and a consumer
+// (whose functionCode uses $embed referencing the host's Id) are applied together
+// in one FormaCommand:
+//   - the system creates the host before the consumer (ordering requirement), and
+//   - the consumer's plugin Create receives the assembled plain string (not the
+//     structured envelope).
+func TestEmbed_ResolvesToPluginInOneApply(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const hostID = "resolved-host-id-1234"
+
+		var mu sync.Mutex
+		var createOrder []string
+		var consumerReceivedProperties json.RawMessage
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				mu.Lock()
+				createOrder = append(createOrder, req.Label)
+				if req.Label == "embed-consumer" {
+					consumerReceivedProperties = append(json.RawMessage{}, req.Properties...)
+				}
+				mu.Unlock()
+
+				nativeID := req.Label + "-native"
+				props := req.Properties
+				if req.Label == "embed-host" {
+					props = json.RawMessage(`{"Id":"` + hostID + `","name":"host1"}`)
+				}
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          req.Label,
+					NativeID:           nativeID,
+					ResourceProperties: props,
+				}}, nil
+			},
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				if req.NativeID == "embed-host-native" {
+					return &resource.ReadResult{
+						ResourceType: req.ResourceType,
+						Properties:   `{"Id":"` + hostID + `","name":"host1"}`,
+					}, nil
+				}
+				return &resource.ReadResult{
+					ResourceType: req.ResourceType,
+					Properties:   `{"functionCode":"cf.kvs('` + hostID + `')","name":"consumer1"}`,
+				}, nil
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		_, err = m.Datastore.CreateTarget(&pkgmodel.Target{
+			Label:  "test-target",
+			Config: json.RawMessage(`{}`),
+		})
+		require.NoError(t, err)
+
+		hostKsuid := util.NewID()
+
+		// Build the $res envelope referencing the host's Id, then frame it for embed.
+		resEnvJSON, err := json.Marshal(map[string]any{
+			"$res":      true,
+			"$label":    "embed-host",
+			"$type":     "FakeAWS::S3::Host",
+			"$stack":    "embed-stack",
+			"$property": "Id",
+		})
+		require.NoError(t, err)
+		framedSpan := pkgmodel.FrameEnvelope(string(resEnvJSON))
+
+		embedField := map[string]any{
+			"$embed":    true,
+			"$template": "cf.kvs('" + framedSpan + "')",
+		}
+		embedFieldJSON, err := json.Marshal(embedField)
+		require.NoError(t, err)
+
+		consumerPropsJSON, err := json.Marshal(map[string]any{
+			"name":         "consumer1",
+			"functionCode": json.RawMessage(embedFieldJSON),
+		})
+		require.NoError(t, err)
+
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "embed-stack"}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label:  "embed-host",
+					Type:   "FakeAWS::S3::Host",
+					Stack:  "embed-stack",
+					Target: "test-target",
+					Ksuid:  hostKsuid,
+					Schema: pkgmodel.Schema{
+						Identifier: "name",
+						Fields:     []string{"name", "Id"},
+					},
+					Properties:         json.RawMessage(`{"name":"host1"}`),
+					ReadOnlyProperties: json.RawMessage(`{"Id":"` + hostID + `"}`),
+				},
+				{
+					Label:      "embed-consumer",
+					Type:       "FakeAWS::S3::Bucket",
+					Stack:      "embed-stack",
+					Target:     "test-target",
+					Properties: json.RawMessage(consumerPropsJSON),
+					Schema: pkgmodel.Schema{
+						Identifier: "name",
+						Fields:     []string{"name", "functionCode"},
+					},
+				},
+			},
+			Targets: []pkgmodel.Target{{Label: "test-target", Config: json.RawMessage(`{}`)}},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test")
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			fas, err := m.Datastore.LoadFormaCommands()
+			if err != nil || len(fas) != 1 {
+				return false
+			}
+			for _, ru := range fas[0].ResourceUpdates {
+				if ru.State != resource_update.ResourceUpdateStateSuccess {
+					return false
+				}
+			}
+			return len(fas[0].ResourceUpdates) == 2
+		}, 5*time.Second, 100*time.Millisecond, "both resources should be created successfully")
+
+		// Assert ordering: host must be created before consumer.
+		mu.Lock()
+		order := append([]string{}, createOrder...)
+		received := append(json.RawMessage{}, consumerReceivedProperties...)
+		mu.Unlock()
+
+		require.Len(t, order, 2, "exactly two Create calls expected")
+		assert.Equal(t, "embed-host", order[0], "host must be created before consumer")
+		assert.Equal(t, "embed-consumer", order[1], "consumer must be created after host")
+
+		// Assert the consumer received the assembled plain string, not a $embed envelope.
+		require.NotEmpty(t, received, "consumer Create must have been called")
+		fcResult := gjson.GetBytes(received, "functionCode")
+		require.True(t, fcResult.Exists(), "functionCode must be present in plugin Create request")
+		assert.Equal(t, "cf.kvs('"+hostID+"')", fcResult.String(),
+			"plugin Create must receive the assembled plain string with the resolved host Id")
+		assert.False(t, gjson.GetBytes(received, "functionCode.$embed").Bool(),
+			"plugin Create must NOT receive a $embed envelope")
+	})
+}
+
+// TestEmbed_PersistedStateStaysStructured verifies that after a successful apply
+// the consumer resource row in the datastore retains the structured $embed envelope
+// (not the assembled plain string). This is the persist-structured invariant: the
+// agent always stores intent, never the flattened plugin view.
+func TestEmbed_PersistedStateStaysStructured(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const hostID = "structured-host-id-5678"
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				var props json.RawMessage
+				if req.Label == "embed-host" {
+					props = json.RawMessage(`{"Id":"` + hostID + `","name":"host1"}`)
+				} else {
+					props = req.Properties
+				}
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          req.Label,
+					NativeID:           req.Label + "-native",
+					ResourceProperties: props,
+				}}, nil
+			},
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				if req.NativeID == "embed-host-native" {
+					return &resource.ReadResult{
+						ResourceType: req.ResourceType,
+						Properties:   `{"Id":"` + hostID + `","name":"host1"}`,
+					}, nil
+				}
+				// Consumer: return the assembled plain string (as the cloud would).
+				return &resource.ReadResult{
+					ResourceType: req.ResourceType,
+					Properties:   `{"functionCode":"cf.kvs('` + hostID + `')","name":"consumer1"}`,
+				}, nil
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		_, err = m.Datastore.CreateTarget(&pkgmodel.Target{
+			Label:  "test-target",
+			Config: json.RawMessage(`{}`),
+		})
+		require.NoError(t, err)
+
+		hostKsuid := util.NewID()
+
+		resEnvJSON, err := json.Marshal(map[string]any{
+			"$res":      true,
+			"$label":    "embed-host",
+			"$type":     "FakeAWS::S3::Host",
+			"$stack":    "embed-stack",
+			"$property": "Id",
+		})
+		require.NoError(t, err)
+		framedSpan := pkgmodel.FrameEnvelope(string(resEnvJSON))
+
+		embedFieldJSON, err := json.Marshal(map[string]any{
+			"$embed":    true,
+			"$template": "cf.kvs('" + framedSpan + "')",
+		})
+		require.NoError(t, err)
+
+		consumerPropsJSON, err := json.Marshal(map[string]any{
+			"name":         "consumer1",
+			"functionCode": json.RawMessage(embedFieldJSON),
+		})
+		require.NoError(t, err)
+
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "embed-stack"}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label:  "embed-host",
+					Type:   "FakeAWS::S3::Host",
+					Stack:  "embed-stack",
+					Target: "test-target",
+					Ksuid:  hostKsuid,
+					Schema: pkgmodel.Schema{
+						Identifier: "name",
+						Fields:     []string{"name", "Id"},
+					},
+					Properties:         json.RawMessage(`{"name":"host1"}`),
+					ReadOnlyProperties: json.RawMessage(`{"Id":"` + hostID + `"}`),
+				},
+				{
+					Label:      "embed-consumer",
+					Type:       "FakeAWS::S3::Bucket",
+					Stack:      "embed-stack",
+					Target:     "test-target",
+					Properties: json.RawMessage(consumerPropsJSON),
+					Schema: pkgmodel.Schema{
+						Identifier: "name",
+						Fields:     []string{"name", "functionCode"},
+					},
+				},
+			},
+			Targets: []pkgmodel.Target{{Label: "test-target", Config: json.RawMessage(`{}`)}},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test")
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			fas, err := m.Datastore.LoadFormaCommands()
+			if err != nil || len(fas) != 1 {
+				return false
+			}
+			for _, ru := range fas[0].ResourceUpdates {
+				if ru.State != resource_update.ResourceUpdateStateSuccess {
+					return false
+				}
+			}
+			return len(fas[0].ResourceUpdates) == 2
+		}, 5*time.Second, 100*time.Millisecond, "both resources should be created successfully")
+
+		// Load the consumer resource from the datastore.
+		resources, err := m.Datastore.LoadResourcesByStack("embed-stack")
+		require.NoError(t, err)
+
+		var consumer *pkgmodel.Resource
+		for _, r := range resources {
+			if r.Label == "embed-consumer" {
+				consumer = r
+				break
+			}
+		}
+		require.NotNil(t, consumer, "embed-consumer resource must be persisted")
+
+		// The stored functionCode must retain the $embed envelope — NOT the assembled string.
+		fcResult := gjson.GetBytes(consumer.Properties, "functionCode")
+		require.True(t, fcResult.Exists(), "functionCode must be present in stored resource")
+		assert.True(t, fcResult.Get("$embed").Bool(),
+			"stored functionCode must be the structured $embed envelope, not the assembled plain string")
+		assert.NotEmpty(t, fcResult.Get("$template").String(),
+			"stored functionCode must retain the $template field")
+		assert.NotEqual(t, "cf.kvs('"+hostID+"')", fcResult.String(),
+			"stored functionCode must NOT be the assembled plain string")
+	})
+}
+
+// TestEmbed_SyncPreservesEnvelope verifies that after a sync (where the plugin's
+// Read returns the assembled plain string as the cloud would), the stored desired
+// state of the consumer still carries the $embed envelope. This is the
+// merge-preservation invariant: the agent never lets a sync Read overwrite
+// user-provided resolvable structures.
+func TestEmbed_SyncPreservesEnvelope(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const hostID = "sync-host-id-9012"
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				var props json.RawMessage
+				if req.Label == "embed-host" {
+					props = json.RawMessage(`{"Id":"` + hostID + `","name":"host1"}`)
+				} else {
+					props = req.Properties
+				}
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          req.Label,
+					NativeID:           req.Label + "-native",
+					ResourceProperties: props,
+				}}, nil
+			},
+			// Read always returns the assembled plain string — simulating what the cloud
+			// returns for a lambda functionCode.
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				if req.NativeID == "embed-host-native" {
+					return &resource.ReadResult{
+						ResourceType: req.ResourceType,
+						Properties:   `{"Id":"` + hostID + `","name":"host1"}`,
+					}, nil
+				}
+				// Consumer: return the assembled plain string (cloud-native view).
+				return &resource.ReadResult{
+					ResourceType: req.ResourceType,
+					Properties:   `{"functionCode":"cf.kvs('` + hostID + `')","name":"consumer1"}`,
+				}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false // manual sync control
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		_, err = m.Datastore.CreateTarget(&pkgmodel.Target{
+			Label:  "test-target",
+			Config: json.RawMessage(`{}`),
+		})
+		require.NoError(t, err)
+
+		hostKsuid := util.NewID()
+
+		resEnvJSON, err := json.Marshal(map[string]any{
+			"$res":      true,
+			"$label":    "embed-host",
+			"$type":     "FakeAWS::S3::Host",
+			"$stack":    "embed-stack",
+			"$property": "Id",
+		})
+		require.NoError(t, err)
+		framedSpan := pkgmodel.FrameEnvelope(string(resEnvJSON))
+
+		embedFieldJSON, err := json.Marshal(map[string]any{
+			"$embed":    true,
+			"$template": "cf.kvs('" + framedSpan + "')",
+		})
+		require.NoError(t, err)
+
+		consumerPropsJSON, err := json.Marshal(map[string]any{
+			"name":         "consumer1",
+			"functionCode": json.RawMessage(embedFieldJSON),
+		})
+		require.NoError(t, err)
+
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "embed-stack"}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label:  "embed-host",
+					Type:   "FakeAWS::S3::Host",
+					Stack:  "embed-stack",
+					Target: "test-target",
+					Ksuid:  hostKsuid,
+					Schema: pkgmodel.Schema{
+						Identifier: "name",
+						Fields:     []string{"name", "Id"},
+					},
+					Properties:         json.RawMessage(`{"name":"host1"}`),
+					ReadOnlyProperties: json.RawMessage(`{"Id":"` + hostID + `"}`),
+				},
+				{
+					Label:      "embed-consumer",
+					Type:       "FakeAWS::S3::Bucket",
+					Stack:      "embed-stack",
+					Target:     "test-target",
+					Properties: json.RawMessage(consumerPropsJSON),
+					Schema: pkgmodel.Schema{
+						Identifier: "name",
+						Fields:     []string{"name", "functionCode"},
+					},
+				},
+			},
+			Targets: []pkgmodel.Target{{Label: "test-target", Config: json.RawMessage(`{}`)}},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test")
+		require.NoError(t, err)
+
+		// Wait for the apply to complete.
+		require.Eventually(t, func() bool {
+			fas, err := m.Datastore.LoadFormaCommands()
+			if err != nil || len(fas) != 1 {
+				return false
+			}
+			for _, ru := range fas[0].ResourceUpdates {
+				if ru.State != resource_update.ResourceUpdateStateSuccess {
+					return false
+				}
+			}
+			return len(fas[0].ResourceUpdates) == 2
+		}, 5*time.Second, 100*time.Millisecond, "apply must complete before triggering sync")
+
+		// Trigger a manual sync. The Read override returns the assembled plain string
+		// for the consumer — simulating what the cloud returns for a lambda's code.
+		err = m.ForceSync()
+		require.NoError(t, err)
+
+		// Wait for the sync command to complete.
+		require.Eventually(t, func() bool {
+			fas, err := m.Datastore.LoadFormaCommands()
+			if err != nil {
+				return false
+			}
+			for _, fc := range fas {
+				if fc.Command == pkgmodel.CommandSync {
+					for _, ru := range fc.ResourceUpdates {
+						if ru.State != resource_update.ResourceUpdateStateSuccess &&
+							ru.State != resource_update.ResourceUpdateStateFailed {
+							return false
+						}
+					}
+					return len(fc.ResourceUpdates) > 0
+				}
+			}
+			return false
+		}, 5*time.Second, 100*time.Millisecond, "sync must complete")
+
+		// After sync, load the consumer from the datastore and verify the $embed is preserved.
+		resources, err := m.Datastore.LoadResourcesByStack("embed-stack")
+		require.NoError(t, err)
+
+		var consumer *pkgmodel.Resource
+		for _, r := range resources {
+			if r.Label == "embed-consumer" {
+				consumer = r
+				break
+			}
+		}
+		require.NotNil(t, consumer, "embed-consumer resource must still be in datastore after sync")
+
+		fcResult := gjson.GetBytes(consumer.Properties, "functionCode")
+		require.True(t, fcResult.Exists(), "functionCode must be present in stored resource after sync")
+		assert.True(t, fcResult.Get("$embed").Bool(),
+			"sync must preserve the $embed envelope: stored functionCode must still be structured")
+		assert.NotEmpty(t, fcResult.Get("$template").String(),
+			"$template must be preserved after sync")
+		assert.NotEqual(t, "cf.kvs('"+hostID+"')", fcResult.String(),
+			"stored functionCode must NOT be the assembled plain string after sync")
 	})
 }

--- a/internal/workflow_tests/local/apply_forma/embed_resolvable_test.go
+++ b/internal/workflow_tests/local/apply_forma/embed_resolvable_test.go
@@ -1,0 +1,80 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+)
+
+func TestMetastructure_RejectsOpaqueEmbed(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		// No plugin overrides needed — the rejection happens before any plugin call.
+		m, def, err := test_helpers.NewTestMetastructure(t, &plugin.ResourcePluginOverrides{})
+		defer def()
+		require.NoError(t, err)
+
+		// Build a $res envelope with $visibility:"Opaque", then frame it in a
+		// $template so it looks like an embedded opaque resolvable.
+		opaqueEnvelope := `{"$res":true,"$label":"some-host","$type":"FakeAWS::S3::Host","$stack":"test-stack","$property":"SecretKey","$visibility":"Opaque"}`
+		framedSpan := pkgmodel.FrameEnvelope(opaqueEnvelope)
+
+		embedField := map[string]any{
+			"$embed":     true,
+			"$template":  "prefix-" + framedSpan + "-suffix",
+		}
+		embedFieldJSON, err := json.Marshal(embedField)
+		require.NoError(t, err)
+
+		propsJSON, err := json.Marshal(map[string]any{
+			"Name":         "consumer-resource",
+			"functionCode": json.RawMessage(embedFieldJSON),
+		})
+		require.NoError(t, err)
+
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+			Resources: []pkgmodel.Resource{{
+				Label:      "consumer",
+				Type:       "FakeAWS::S3::Bucket",
+				Stack:      "test-stack",
+				Target:     "test-target",
+				Properties: json.RawMessage(propsJSON),
+			}},
+			Targets: []pkgmodel.Target{{
+				Label:     "test-target",
+				Namespace: "test-namespace",
+			}},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test-client-id")
+
+		require.Error(t, err, "apply should be rejected when an opaque resolvable is embedded in a string field")
+		assert.Contains(t, err.Error(), "opaque")
+		assert.Contains(t, err.Error(), "embed")
+
+		// No FormaCommand or resource row should have been persisted.
+		fas, dsErr := m.Datastore.LoadFormaCommands()
+		require.NoError(t, dsErr)
+		assert.Empty(t, fas, "no FormaCommand should be persisted on opaque-embed rejection")
+
+		resources, dsErr := m.Datastore.LoadAllResources()
+		require.NoError(t, dsErr)
+		assert.Empty(t, resources, "no resource row should be persisted on opaque-embed rejection")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/embed_resolvable_test.go
+++ b/internal/workflow_tests/local/apply_forma/embed_resolvable_test.go
@@ -78,3 +78,67 @@ func TestMetastructure_RejectsOpaqueEmbed(t *testing.T) {
 		assert.Empty(t, resources, "no resource row should be persisted on opaque-embed rejection")
 	})
 }
+
+func TestMetastructure_RejectsOpaqueEmbed_InArray(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		// Rejection must happen even when the $embed node is nested inside an array
+		// of objects (the validator previously only walked object values, so an
+		// opaque embed inside an array would slip through — security leak).
+		m, def, err := test_helpers.NewTestMetastructure(t, &plugin.ResourcePluginOverrides{})
+		defer def()
+		require.NoError(t, err)
+
+		// Build a $res envelope with $visibility:"Opaque", framed for embed.
+		opaqueEnvelope := `{"$res":true,"$label":"some-host","$type":"FakeAWS::S3::Host","$stack":"test-stack","$property":"SecretKey","$visibility":"Opaque"}`
+		framedSpan := pkgmodel.FrameEnvelope(opaqueEnvelope)
+
+		embedField := map[string]any{
+			"$embed":    true,
+			"$template": "prefix-" + framedSpan + "-suffix",
+		}
+
+		// Place the embed node inside an array of objects — one innocent entry and
+		// one that carries the opaque embed. The validator must descend into the
+		// array to find it.
+		propsJSON, err := json.Marshal(map[string]any{
+			"Name": "consumer-resource",
+			"statements": []any{
+				map[string]any{"action": "s3:GetObject"},
+				map[string]any{"document": embedField},
+			},
+		})
+		require.NoError(t, err)
+
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+			Resources: []pkgmodel.Resource{{
+				Label:      "consumer",
+				Type:       "FakeAWS::S3::Bucket",
+				Stack:      "test-stack",
+				Target:     "test-target",
+				Properties: json.RawMessage(propsJSON),
+			}},
+			Targets: []pkgmodel.Target{{
+				Label:     "test-target",
+				Namespace: "test-namespace",
+			}},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test-client-id")
+
+		require.Error(t, err, "apply should be rejected when an opaque resolvable is embedded inside an array element")
+		assert.Contains(t, err.Error(), "opaque")
+		assert.Contains(t, err.Error(), "embed")
+
+		// No FormaCommand or resource row should have been persisted.
+		fas, dsErr := m.Datastore.LoadFormaCommands()
+		require.NoError(t, dsErr)
+		assert.Empty(t, fas, "no FormaCommand should be persisted on opaque-embed-in-array rejection")
+
+		resources, dsErr := m.Datastore.LoadAllResources()
+		require.NoError(t, dsErr)
+		assert.Empty(t, resources, "no resource row should be persisted on opaque-embed-in-array rejection")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/embed_resolvable_test.go
+++ b/internal/workflow_tests/local/apply_forma/embed_resolvable_test.go
@@ -585,7 +585,7 @@ func TestEmbed_SyncPreservesEnvelope(t *testing.T) {
 		err = m.ForceSync()
 		require.NoError(t, err)
 
-		// Wait for the sync command to complete.
+		// Wait for the sync command to complete successfully.
 		require.Eventually(t, func() bool {
 			fas, err := m.Datastore.LoadFormaCommands()
 			if err != nil {
@@ -594,8 +594,7 @@ func TestEmbed_SyncPreservesEnvelope(t *testing.T) {
 			for _, fc := range fas {
 				if fc.Command == pkgmodel.CommandSync {
 					for _, ru := range fc.ResourceUpdates {
-						if ru.State != resource_update.ResourceUpdateStateSuccess &&
-							ru.State != resource_update.ResourceUpdateStateFailed {
+						if ru.State != resource_update.ResourceUpdateStateSuccess {
 							return false
 						}
 					}
@@ -603,7 +602,7 @@ func TestEmbed_SyncPreservesEnvelope(t *testing.T) {
 				}
 			}
 			return false
-		}, 5*time.Second, 100*time.Millisecond, "sync must complete")
+		}, 5*time.Second, 100*time.Millisecond, "sync must complete successfully")
 
 		// After sync, load the consumer from the datastore and verify the $embed is preserved.
 		resources, err := m.Datastore.LoadResourcesByStack("embed-stack")

--- a/pkg/model/embed.go
+++ b/pkg/model/embed.go
@@ -1,0 +1,95 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package model
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+const (
+	EmbedSentinelStart = '\x1e' // U+001E RECORD SEPARATOR
+	EmbedSentinelEnd   = '\x1f' // U+001F UNIT SEPARATOR
+)
+
+// EmbedSpan is a single RS<base64>US span located in a $template string.
+// Start/End are byte offsets such that template[Start:End] is the whole framed
+// span (including both sentinels).
+type EmbedSpan struct {
+	Start        int
+	End          int
+	EnvelopeJSON string
+}
+
+// FrameEnvelope wraps an envelope JSON string as RS + base64(json) + US.
+func FrameEnvelope(envelopeJSON string) string {
+	return string(EmbedSentinelStart) +
+		base64.StdEncoding.EncodeToString([]byte(envelopeJSON)) +
+		string(EmbedSentinelEnd)
+}
+
+// ScanEmbedSpans finds every well-formed RS<base64>US span. It returns an error
+// if, after removing well-formed spans, any stray RS/US byte remains (a literal
+// that itself carried a control char — a corruption we refuse to ship).
+func ScanEmbedSpans(template string) ([]EmbedSpan, error) {
+	var spans []EmbedSpan
+	i := 0
+	for {
+		start := strings.IndexByte(template[i:], EmbedSentinelStart)
+		if start < 0 {
+			break
+		}
+		start += i
+		end := strings.IndexByte(template[start+1:], EmbedSentinelEnd)
+		if end < 0 {
+			return nil, fmt.Errorf("embed: opening sentinel without closing sentinel at offset %d", start)
+		}
+		end += start + 1
+		b64 := template[start+1 : end]
+		decoded, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			return nil, fmt.Errorf("embed: span at offset %d is not valid base64: %w", start, err)
+		}
+		spans = append(spans, EmbedSpan{Start: start, End: end + 1, EnvelopeJSON: string(decoded)})
+		i = end + 1
+	}
+	// Stray-sentinel guard: no RS/US may remain outside the spans we matched.
+	if HasStrayEmbedSentinel(template) {
+		return nil, fmt.Errorf("embed: stray RS/US byte in template literal (not part of a framed span)")
+	}
+	return spans, nil
+}
+
+// HasStrayEmbedSentinel reports whether removing every well-formed RS<base64>US
+// span still leaves an RS or US byte behind.
+func HasStrayEmbedSentinel(template string) bool {
+	var b strings.Builder
+	i := 0
+	for {
+		start := strings.IndexByte(template[i:], EmbedSentinelStart)
+		if start < 0 {
+			b.WriteString(template[i:])
+			break
+		}
+		start += i
+		end := strings.IndexByte(template[start+1:], EmbedSentinelEnd)
+		if end < 0 {
+			b.WriteString(template[i:])
+			break
+		}
+		end += start + 1
+		if _, err := base64.StdEncoding.DecodeString(template[start+1 : end]); err != nil {
+			// Not a real span; treat the RS as stray by writing up to and incl it.
+			b.WriteString(template[i : start+1])
+			i = start + 1
+			continue
+		}
+		b.WriteString(template[i:start]) // keep text before the span, drop the span
+		i = end + 1
+	}
+	s := b.String()
+	return strings.IndexByte(s, EmbedSentinelStart) >= 0 || strings.IndexByte(s, EmbedSentinelEnd) >= 0
+}

--- a/pkg/model/embed_test.go
+++ b/pkg/model/embed_test.go
@@ -1,3 +1,7 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
 //go:build unit
 
 package model

--- a/pkg/model/embed_test.go
+++ b/pkg/model/embed_test.go
@@ -1,0 +1,50 @@
+//go:build unit
+
+package model
+
+import (
+	"testing"
+)
+
+func TestFrameEnvelope_RoundTrips(t *testing.T) {
+	env := `{"$res":true,"$label":"kvs","$type":"AWS::CloudFront::KeyValueStore","$stack":"default","$property":"id","$visibility":"Clear"}`
+	tmpl := "cf.kvs('" + FrameEnvelope(env) + "')"
+
+	spans, err := ScanEmbedSpans(tmpl)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("want 1 span, got %d", len(spans))
+	}
+	if spans[0].EnvelopeJSON != env {
+		t.Errorf("decoded envelope mismatch:\n got %q\nwant %q", spans[0].EnvelopeJSON, env)
+	}
+	if tmpl[spans[0].Start] != EmbedSentinelStart || tmpl[spans[0].End-1] != EmbedSentinelEnd {
+		t.Errorf("span offsets not on sentinels")
+	}
+}
+
+func TestScanEmbedSpans_TwoSpans(t *testing.T) {
+	a := FrameEnvelope(`{"$res":true,"$label":"a"}`)
+	b := FrameEnvelope(`{"$res":true,"$label":"b"}`)
+	spans, err := ScanEmbedSpans("x" + a + "y" + b + "z")
+	if err != nil || len(spans) != 2 {
+		t.Fatalf("want 2 spans no err, got %d / %v", len(spans), err)
+	}
+}
+
+func TestScanEmbedSpans_StraySentinelRejected(t *testing.T) {
+	// A lone RS in user text, not part of a well-formed span.
+	_, err := ScanEmbedSpans("legit\x1etext-no-close")
+	if err == nil {
+		t.Fatal("want error on stray sentinel, got nil")
+	}
+}
+
+func TestScanEmbedSpans_NoSpans(t *testing.T) {
+	spans, err := ScanEmbedSpans("const x = 1;")
+	if err != nil || len(spans) != 0 {
+		t.Fatalf("want 0 spans no err, got %d / %v", len(spans), err)
+	}
+}

--- a/pkg/model/ref.go
+++ b/pkg/model/ref.go
@@ -16,6 +16,13 @@ type Ref struct {
 	// Path in consuming resource. e.g. "NetworkConfig.VpcId"
 	TargetPath string
 
+	// Embedded marks a ref that lives inside a $embed field's $template string
+	// (a framed span) rather than as a whole-value $ref object.
+	Embedded bool
+	// EmbedFieldPath is the dot-path of the enclosing $embed field (== TargetPath
+	// for embedded refs); used at resolution to assemble the $template in place.
+	EmbedFieldPath string
+
 	// Resolved data
 	ResolvedValue Value
 }

--- a/pkg/plugin-conformance-tests/runner.go
+++ b/pkg/plugin-conformance-tests/runner.go
@@ -335,6 +335,64 @@ func isResolvable(value any) bool {
 	return ok && resBool
 }
 
+// isEmbed reports whether value is a {$embed: true, $template: "..."} field
+// (an embedded resolvable inside a String-typed field — PLA-68).
+func isEmbed(value any) bool {
+	m, ok := value.(map[string]any)
+	if !ok {
+		return false
+	}
+	embed, ok := m["$embed"].(bool)
+	return ok && embed
+}
+
+// normalizeEmbedTemplate canonicalizes a $embed $template for comparison: each
+// framed span's envelope is stripped of $value/$visibility/$strategy and
+// re-encoded with sorted keys. An authored template (pre-resolution, no $value,
+// PKL insertion-order keys) and a stored template (resolved $value, Go
+// sorted-key) then compare equal when they reference the same resolvable.
+// Literal segments are preserved verbatim. Mirrors normalizeResolvables.
+func normalizeEmbedTemplate(tmpl string) string {
+	spans, err := pkgmodel.ScanEmbedSpans(tmpl)
+	if err != nil {
+		return tmpl
+	}
+	out := tmpl
+	for i := len(spans) - 1; i >= 0; i-- {
+		var env map[string]any
+		if err := json.Unmarshal([]byte(spans[i].EnvelopeJSON), &env); err != nil {
+			continue
+		}
+		delete(env, "$value")
+		delete(env, "$visibility")
+		delete(env, "$strategy")
+		canonical, err := json.Marshal(env) // map keys marshal in sorted order
+		if err != nil {
+			continue
+		}
+		out = out[:spans[i].Start] + pkgmodel.FrameEnvelope(string(canonical)) + out[spans[i].End:]
+	}
+	return out
+}
+
+// compareEmbed compares two $embed fields by normalizing their $template spans.
+func compareEmbed(r testReporter, name string, expected, actual any) bool {
+	expMap, ok1 := expected.(map[string]any)
+	actMap, ok2 := actual.(map[string]any)
+	if !ok1 || !ok2 {
+		r.Errorf("Embed field %s: expected and actual must both be $embed objects", name)
+		return false
+	}
+	expTmpl, _ := expMap["$template"].(string)
+	actTmpl, _ := actMap["$template"].(string)
+	if normalizeEmbedTemplate(expTmpl) != normalizeEmbedTemplate(actTmpl) {
+		r.Errorf("Embed field %s.$template should match expected (normalized): expected %q, got %q",
+			name, expTmpl, actTmpl)
+		return false
+	}
+	return true
+}
+
 // normalizeEscaping removes common backslash escape sequences from a string
 // to allow comparison of values that may have been escaped differently during
 // JSON/PKL round-trips (e.g. `"` vs `\"`).
@@ -890,6 +948,12 @@ func compareMap(r testReporter, name string, expected, actual map[string]any, co
 			ok = false
 			continue
 		}
+		if isEmbed(expectedValue) {
+			if !compareEmbed(r, name+"."+key, expectedValue, actualValue) {
+				ok = false
+			}
+			continue
+		}
 		if isResolvable(expectedValue) {
 			if !compareResolvable(r, name+"."+key, expectedValue, actualValue, context) {
 				ok = false
@@ -980,6 +1044,17 @@ func compareProperties(r testReporter, expectedProperties map[string]any, actual
 			}
 			r.Errorf("Property %s should exist in actual resource (%s)", key, context)
 			hasErrors = true
+			continue
+		}
+
+		// Validate embedded-resolvable fields ($embed) by normalizing their
+		// $template spans — the stored form carries the resolved $value and
+		// sorted keys, the authored form does not (PLA-68).
+		if isEmbed(expectedValue) {
+			r.Logf("Validating embedded-resolvable property %s (resolved at runtime)", key)
+			if !compareEmbed(r, key, expectedValue, actualValue) {
+				hasErrors = true
+			}
 			continue
 		}
 

--- a/pkg/plugin-conformance-tests/runner_test.go
+++ b/pkg/plugin-conformance-tests/runner_test.go
@@ -7,6 +7,8 @@ package conformance
 import (
 	"os"
 	"testing"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
 func TestFilterTestCases(t *testing.T) {
@@ -471,6 +473,54 @@ func TestCompareProperties_NestedResolvable(t *testing.T) {
 		t.Errorf("compareProperties should pass when SubResource contains a nested Resolvable with resolved $value")
 	}
 }
+
+// Reproduces the PLA-68 conformance Verify failure: a $embed field's stored
+// $template carries the resolved $value and Go sorted-key envelope encoding,
+// while the authored expected $template has neither. They must compare equal.
+func TestCompareProperties_Embed(t *testing.T) {
+	// Expected (from Pkl eval): $res span, insertion-order keys, no $value.
+	expectedSpan := pkgmodel.FrameEnvelope(
+		`{"$res":true,"$label":"kvs","$type":"AWS::CloudFront::KeyValueStore","$stack":"s","$property":"Id","$visibility":"Clear"}`)
+	expectedProperties := map[string]any{
+		"FunctionCode": map[string]any{
+			"$embed":    true,
+			"$template": "const kvsId = '" + expectedSpan + "';",
+		},
+	}
+
+	// Actual (from inventory after resolution): same span with sorted keys + $value.
+	actualSpan := pkgmodel.FrameEnvelope(
+		`{"$label":"kvs","$property":"Id","$res":true,"$stack":"s","$type":"AWS::CloudFront::KeyValueStore","$value":"21775858-76bb"}`)
+	actualResource := map[string]any{
+		"Properties": map[string]any{
+			"FunctionCode": map[string]any{
+				"$embed":    true,
+				"$template": "const kvsId = '" + actualSpan + "';",
+			},
+		},
+	}
+
+	if !compareProperties(t, expectedProperties, actualResource, "after create", map[string]providerDefault{}) {
+		t.Errorf("compareProperties should pass for an embedded resolvable whose stored $template carries the resolved $value and sorted-key encoding")
+	}
+}
+
+// A literal segment difference in a $embed $template MUST be detected (negative).
+func TestCompareEmbed_DifferentLiteralFails(t *testing.T) {
+	span := pkgmodel.FrameEnvelope(`{"$res":true,"$label":"kvs","$type":"T","$stack":"s","$property":"Id"}`)
+	expected := map[string]any{"$embed": true, "$template": "A-" + span + "-B"}
+	actual := map[string]any{"$embed": true, "$template": "A-" + span + "-DIFFERENT"}
+	rec := &recordingReporter{}
+	if compareEmbed(rec, "FunctionCode", expected, actual) {
+		t.Errorf("compareEmbed should fail when the literal template text differs")
+	}
+}
+
+// recordingReporter captures errors without failing the test (for negative cases).
+type recordingReporter struct{ errors int }
+
+func (r *recordingReporter) Errorf(string, ...any) { r.errors++ }
+func (r *recordingReporter) Logf(string, ...any)   {}
 
 func TestCompareMap(t *testing.T) {
 	t.Run("nested resolvable passes", func(t *testing.T) {

--- a/tests/e2e/go/embed_resolvable_test.go
+++ b/tests/e2e/go/embed_resolvable_test.go
@@ -49,8 +49,11 @@ func TestEmbedResolvable(t *testing.T) {
 
 	// Step 2: Extract — the regenerated PKL must carry the embed as
 	// formae.embed("…\(kvStore.res.id)…"), with no raw envelope leaking.
+	// --schema-location local: the AWS plugin is user-installed (built from
+	// source), so the extracted PKL must reference the on-disk plugin schema
+	// for the reapply below to resolve.
 	extracted := filepath.Join(t.TempDir(), "extracted.pkl")
-	cli.ExtractToFile(t, stackQuery, extracted)
+	cli.ExtractToFile(t, stackQuery, extracted, "--schema-location", "local")
 	body, err := os.ReadFile(extracted)
 	if err != nil {
 		t.Fatalf("failed to read extracted PKL: %v", err)
@@ -83,7 +86,7 @@ func TestEmbedResolvable(t *testing.T) {
 	// embed survived a read-back from the cloud (envelope kept structured).
 	cli.ForceSync(t)
 	reextracted := filepath.Join(t.TempDir(), "extracted2.pkl")
-	cli.ExtractToFile(t, stackQuery, reextracted)
+	cli.ExtractToFile(t, stackQuery, reextracted, "--schema-location", "local")
 	body2, err := os.ReadFile(reextracted)
 	if err != nil {
 		t.Fatalf("failed to read re-extracted PKL: %v", err)

--- a/tests/e2e/go/embed_resolvable_test.go
+++ b/tests/e2e/go/embed_resolvable_test.go
@@ -1,0 +1,101 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build e2e
+
+package e2e_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestEmbedResolvable exercises an embedded resolvable inside a String-typed
+// field (CloudFront Function.functionCode) end-to-end against real AWS:
+//
+//  1. single-apply resolution — the KeyValueStore's post-create short Id is
+//     substituted into the JS literal and shipped to CloudFront as a String;
+//  2. extract regenerates the field as formae.embed("…\(…)…"), not a raw
+//     $embed envelope nor a baked-in literal;
+//  3. editing the literal text around the ref and reapplying lands an update;
+//  4. a forced sync preserves the structured embed (re-extract still emits it).
+//
+// Requires the dev-channel AWS plugin (functionCode widened to
+// String|formae.Embedded) — the e2e workflow installs aws@dev for this entry.
+func TestEmbedResolvable(t *testing.T) {
+	bin := FormaeBinary(t)
+	agent := StartAgent(t, bin)
+	cli := NewFormaeCLI(bin, agent.ConfigPath(), agent.Port())
+
+	fixture := filepath.Join(fixturesDir(t), "embed_resolvable_aws.pkl")
+	const stackQuery = "stack:e2e-embed-resolvable-aws"
+	commandTimeout := 5 * time.Minute
+
+	// Step 1: Apply — KVS + Function are created in dependency order; the KVS
+	// short Id is resolved and embedded into functionCode at apply time.
+	cmdID := cli.Apply(t, "reconcile", fixture)
+	RequireCommandSuccess(t, cli.WaitForCommand(t, cmdID, commandTimeout))
+
+	resources := cli.Inventory(t, "--query", stackQuery)
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resources after apply, got %d", len(resources))
+	}
+	RequireResource(t, resources, "e2e-embed-kvs")
+	RequireResource(t, resources, "e2e-embed-fn")
+
+	// Step 2: Extract — the regenerated PKL must carry the embed as
+	// formae.embed("…\(kvStore.res.id)…"), with no raw envelope leaking.
+	extracted := filepath.Join(t.TempDir(), "extracted.pkl")
+	cli.ExtractToFile(t, stackQuery, extracted)
+	body, err := os.ReadFile(extracted)
+	if err != nil {
+		t.Fatalf("failed to read extracted PKL: %v", err)
+	}
+	src := string(body)
+	for _, want := range []string{"formae.embed(", ".res.id", `\(`} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("extracted PKL missing %q; got:\n%s", want, src)
+		}
+	}
+	for _, bad := range []string{"$embed", "$template"} {
+		if strings.Contains(src, bad) {
+			t.Fatalf("extracted PKL leaked raw embed envelope (%q); got:\n%s", bad, src)
+		}
+	}
+
+	// Step 3: Edit literal text around the ref and reapply — the update lands
+	// without the embedded resolvable getting in the way.
+	edited := strings.Replace(src, "async function handler", "async function handlerV2", 1)
+	if edited == src {
+		t.Fatalf("expected to edit the function literal; marker not found in:\n%s", src)
+	}
+	if err := os.WriteFile(extracted, []byte(edited), 0o644); err != nil {
+		t.Fatalf("failed to write edited PKL: %v", err)
+	}
+	editID := cli.Apply(t, "reconcile", extracted)
+	RequireCommandSuccess(t, cli.WaitForCommand(t, editID, commandTimeout))
+
+	// Step 4: Sync preservation — ForceSync, then re-extract and confirm the
+	// embed survived a read-back from the cloud (envelope kept structured).
+	cli.ForceSync(t)
+	reextracted := filepath.Join(t.TempDir(), "extracted2.pkl")
+	cli.ExtractToFile(t, stackQuery, reextracted)
+	body2, err := os.ReadFile(reextracted)
+	if err != nil {
+		t.Fatalf("failed to read re-extracted PKL: %v", err)
+	}
+	if !strings.Contains(string(body2), "formae.embed(") {
+		t.Fatalf("embed not preserved after sync; got:\n%s", string(body2))
+	}
+
+	// Step 5: Destroy via the extracted PKL; the stack must be empty.
+	destroyID := cli.Destroy(t, extracted)
+	RequireCommandSuccess(t, cli.WaitForCommand(t, destroyID, commandTimeout))
+	if remaining := cli.Inventory(t, "--query", stackQuery); len(remaining) != 0 {
+		t.Errorf("expected 0 resources after destroy, got %d", len(remaining))
+	}
+}

--- a/tests/e2e/go/fixtures/embed_resolvable_aws.pkl
+++ b/tests/e2e/go/fixtures/embed_resolvable_aws.pkl
@@ -1,0 +1,69 @@
+/*
+ * © 2026 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+// E2E fixture for PLA-68: an embedded resolvable inside a String-typed field.
+// The Function's functionCode is a cf-js-2.0 literal that references the
+// KeyValueStore's CloudFront-generated short Id, embedded into the source via
+// formae.embed(...). Applying this in one pass resolves the Id and ships a
+// plain String to CloudFront; pre-PLA-68 this required a two-apply manual
+// substitution.
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/cloudfront/cffunction.pkl" as cffn
+import "@aws/cloudfront/keyvaluestore.pkl" as kvsmod
+
+local stackName = "e2e-embed-resolvable-aws"
+
+local kvStore = new kvsmod.KeyValueStore {
+  label = "e2e-embed-kvs"
+  name = "formae-e2e-embed-kvs"
+  comment = "e2e embedded-resolvable test KVS"
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "E2E embedded-resolvable test (CloudFront Function functionCode)"
+  }
+
+  new formae.Target {
+    label = "e2e-aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  kvStore
+
+  new cffn.Function {
+    label = "e2e-embed-fn"
+    name = "formae-e2e-embed-fn"
+    autoPublish = true
+    // The embedded resolvable: the KVS short Id is substituted into the JS
+    // literal at resolve time, so this ships as a plain String to CloudFront.
+    functionCode = formae.embed("""
+      import cf from 'cloudfront';
+      const kvsId = '\(kvStore.res.id)';
+      async function handler(event) {
+        const kvs = cf.kvs(kvsId);
+        return event.request;
+      }
+      """)
+    functionConfig = new cffn.FunctionConfig {
+      runtime = "cloudfront-js-2.0"
+      comment = "e2e embedded-resolvable Function"
+      keyValueStoreAssociations = new Listing {
+        new cffn.KeyValueStoreAssociation {
+          keyValueStoreARN = kvStore.res.arn
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implements **PLA-68 / RFC-28** — embedding cross-resource resolvables inside
String-typed fields, so a late-bound value (e.g. a CloudFront KeyValueStore's
post-create `Id`) can be interpolated directly into a String literal such as a
Function's JS source, resolved in a single apply.

## Authoring

```pkl
functionCode = formae.embed("""
  const kvsId = '\(kvStore.res.id)';
  ...
  """)
```

`Resolvable.toString()` renders each embedded ref to a base64-framed span
(`RS + base64($res-envelope-JSON) + US`); `formae.embed(s)` wraps the result as
`{ $embed = true; $template = s }`. The field type widens from `String` to
`String|formae.Embedded`.

## Agent machinery

The framed envelope reuses the existing translate → extract → DAG → resolve
pipeline rather than a parallel path:

- **Extraction** pulls embedded refs out of `$template` into `RemainingResolvables`.
- **Translation** rewrites framed spans triplet↔ksuid in place.
- **Resolution** resolves each span and assembles a plain String only at the
  plugin boundary (`toPluginFormat`); persisted state keeps the field
  structured.
- **Progress/sync merge** preserves the `$embed` envelope across read-backs.
- **Patch** flattens `$embed` to the assembled string before diff generation.
- **Opaque-in-embed** refs are rejected at plan time (before translation drops
  `$visibility`), including inside arrays.
- **Extract-to-PKL** regenerates `formae.embed("…\(ref)…")` — single-line form,
  parenthesized amends for mapped resolvables, stack emitted already-localized.

## What's included

Schema (`formae.pkl`), the Go framed-span codec (`pkg/model/embed.go`),
resolver / translate / resource_update / patch / metastructure changes, the
extract generator (`gen.pkl`), in-node workflow tests, and an AWS e2e test
(`TestEmbedResolvable`, apply→extract→reapply→sync, gated on the dev-channel
AWS plugin via a new `channel` matrix knob).

## Validation

- `make test-unit` + `make test-pkl` green.
- **Validated end-to-end on real AWS** via `debug-conformance` (formae built
  from this branch, schema 0.87.0, `aws@0.1.13-dev.0`): the full CRUD lifecycle
  — Create / Verify / Extract / Sync / Update / Replace / Destroy — is green for
  an embedded `KeyValueStore.Id` in `functionCode`.
- `aws@0.1.13-dev.0` (functionCode widened) is published; this PR's e2e run
  exercises the whole stack against AWS.

## Release sequencing

Discovery of embeds is out of scope by design (an embed only originates in user
code — nothing to reconstruct from a baked-in literal). A **stable** AWS plugin
`0.1.13` must wait until this lands in a released formae and the plugin's
`minFormaeVersion` points at that release; `0.87.0` currently carries the schema
type, not a released agent.