### PR TITLE
fix(metastructure): resolve bare-stack embed references by (label, type) (PLA-68)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -284,6 +284,10 @@ jobs:
         env:
           AWS_PROFILE: e2e-test
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          # Unique per run+attempt so fixtures can name globally-scoped cloud
+          # resources (e.g. CloudFront KeyValueStore/Function, which aws-nuke
+          # does not clean) without colliding across reruns or concurrent jobs.
+          FORMAE_TEST_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
           # Point setup_pkl.sh at whichever tree has plugins. system_plugins
           # land in dist/e2e/formae/plugins (orbital's SystemPluginDir);
           # user_plugins land in /home/runner/.pel/formae/plugins (make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,11 @@ jobs:
         run: echo "/opt/pel/bin" >> $GITHUB_PATH
 
       - name: Configure AWS Credentials
+        # Fail fast instead of hanging: a stalled STS AssumeRoleWithWebIdentity
+        # has been seen retrying for 40+ min on a flaky runner (no timeout), so
+        # cap it — a healthy creds exchange takes seconds, and a fast failure is
+        # re-runnable rather than holding the job to the 6h job ceiling.
+        timeout-minutes: 5
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-west-2

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -2156,6 +2156,24 @@ func translateEmbedSpansAtPath(basePath string, value gjson.Result, jsonStr stri
 	return jsonStr, nil
 }
 
+// uniqueKsuidByLabelAndType resolves a (label, type) pair to a KSUID when exactly
+// one resource in the forma matches it regardless of stack. It mirrors forma.pkl's
+// getResource(label, type) lookup and is used to default the stack of a bare embed
+// reference whose $stack was omitted at PKL render time. It returns false when the
+// match is absent or ambiguous, so the caller can surface the incomplete-triplet
+// error and the user disambiguates with an explicit stack.
+func uniqueKsuidByLabelAndType(tripletToKsuid map[pkgmodel.TripletKey]string, label, resourceType string) (string, bool) {
+	var ksuid string
+	count := 0
+	for tk, ks := range tripletToKsuid {
+		if tk.Label == label && tk.Type == resourceType {
+			ksuid = ks
+			count++
+		}
+	}
+	return ksuid, count == 1
+}
+
 // translateEmbedSpansInTemplate rewrites every framed $res envelope in a $template
 // string to its $ref+KSUID equivalent using the same lookup logic as the flat pass.
 func translateEmbedSpansInTemplate(tmpl string, tripletToKsuid map[pkgmodel.TripletKey]string, ds ResourceDataLookup, externalLabels map[string]string) (string, error) {
@@ -2181,6 +2199,18 @@ func translateEmbedSpansInTemplate(tmpl string, tripletToKsuid map[pkgmodel.Trip
 
 		var formaeURI pkgmodel.FormaeURI
 		ksuid, ok := tripletToKsuid[resolvable.ToTripletKey()]
+		if !ok && resolvable.Stack == "" && resolvable.Label != "" && resolvable.Type != "" {
+			// A bare embed reference omits $stack: Resolvable.toString() renders
+			// the envelope at interpolation time, before forma.pkl applies
+			// single-stack defaulting, and the JSON renderer drops the null
+			// $stack key. The whole-value path is fixed up by forma.pkl's
+			// [formae.Resolvable] converter via getResource(label, type); mirror
+			// that here by resolving on (label, type) when it is unambiguous
+			// across the forma.
+			if k, found := uniqueKsuidByLabelAndType(tripletToKsuid, resolvable.Label, resolvable.Type); found {
+				ksuid, ok = k, true
+			}
+		}
 		if ok {
 			formaeURI = resolvable.ToFormaeURI(ksuid)
 		} else {

--- a/internal/metastructure/resource_update/translate_embed_test.go
+++ b/internal/metastructure/resource_update/translate_embed_test.go
@@ -113,3 +113,86 @@ func TestTranslatePropertiesJSON_RewritesEmbeddedSpan_Idempotent(t *testing.T) {
 
 	assert.Equal(t, string(result1), string(result2), "translatePropertiesJSON should be idempotent for embed spans")
 }
+
+// TestTranslatePropertiesJSON_EmbeddedSpan_BareStack verifies that an embed span
+// whose $stack was omitted resolves via (label, type). A bare resource (no
+// explicit stack) renders its embed envelope before forma.pkl's single-stack
+// defaulting runs, so the null $stack key is dropped — yet the resource is keyed
+// in tripletToKsuid under its defaulted stack. This mirrors how the whole-value
+// [formae.Resolvable] converter resolves via getResource(label, type).
+func TestTranslatePropertiesJSON_EmbeddedSpan_BareStack(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	// Resource is keyed under its DEFAULTED stack, not "".
+	triplet := pkgmodel.TripletKey{Stack: "default", Label: "kvs", Type: "AWS::CloudFront::KeyValueStore"}
+	ksuid := "testembedbare"
+
+	_, err := ds.StoreResource(&pkgmodel.Resource{
+		Ksuid: ksuid,
+		Label: triplet.Label,
+		Type:  triplet.Type,
+		Stack: triplet.Stack,
+	}, "cmd-bare")
+	require.NoError(t, err)
+
+	// Envelope WITHOUT $stack — what the JSON renderer emits for a bare ref.
+	resEnvJSON, _ := json.Marshal(map[string]any{
+		"$res":      true,
+		"$label":    triplet.Label,
+		"$type":     triplet.Type,
+		"$property": "id",
+	})
+	tmpl := "cf.kvs('" + pkgmodel.FrameEnvelope(string(resEnvJSON)) + "')"
+
+	properties, err := json.Marshal(map[string]any{
+		"functionCode": map[string]any{
+			"$embed":    true,
+			"$template": tmpl,
+		},
+	})
+	require.NoError(t, err)
+
+	tripletToKsuid := map[pkgmodel.TripletKey]string{triplet: ksuid}
+
+	result, _, err := translatePropertiesJSON(json.RawMessage(properties), tripletToKsuid, ds)
+	require.NoError(t, err, "bare-stack embed span should resolve via (label, type)")
+
+	tmplOut := gjson.Get(string(result), "functionCode.$template").String()
+	spans, scanErr := pkgmodel.ScanEmbedSpans(tmplOut)
+	require.NoError(t, scanErr)
+	require.Len(t, spans, 1)
+	assert.Contains(t, spans[0].EnvelopeJSON, `"$ref"`)
+	assert.Contains(t, spans[0].EnvelopeJSON, ksuid)
+}
+
+// TestTranslatePropertiesJSON_EmbeddedSpan_BareStackAmbiguous verifies that a
+// bare embed reference whose (label, type) matches more than one resource across
+// stacks is rejected, so the user disambiguates with an explicit stack.
+func TestTranslatePropertiesJSON_EmbeddedSpan_BareStackAmbiguous(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	a := pkgmodel.TripletKey{Stack: "stack-a", Label: "kvs", Type: "AWS::CloudFront::KeyValueStore"}
+	b := pkgmodel.TripletKey{Stack: "stack-b", Label: "kvs", Type: "AWS::CloudFront::KeyValueStore"}
+
+	resEnvJSON, _ := json.Marshal(map[string]any{
+		"$res":      true,
+		"$label":    "kvs",
+		"$type":     "AWS::CloudFront::KeyValueStore",
+		"$property": "id",
+	})
+	tmpl := "cf.kvs('" + pkgmodel.FrameEnvelope(string(resEnvJSON)) + "')"
+
+	properties, err := json.Marshal(map[string]any{
+		"functionCode": map[string]any{
+			"$embed":    true,
+			"$template": tmpl,
+		},
+	})
+	require.NoError(t, err)
+
+	tripletToKsuid := map[pkgmodel.TripletKey]string{a: "ksuidA", b: "ksuidB"}
+
+	_, _, err = translatePropertiesJSON(json.RawMessage(properties), tripletToKsuid, ds)
+	require.Error(t, err, "ambiguous bare-stack embed should error")
+	assert.Contains(t, err.Error(), "incomplete triplet")
+}

--- a/tests/e2e/go/embed_resolvable_test.go
+++ b/tests/e2e/go/embed_resolvable_test.go
@@ -47,8 +47,11 @@ func TestEmbedResolvable(t *testing.T) {
 	RequireResource(t, resources, "e2e-embed-kvs")
 	RequireResource(t, resources, "e2e-embed-fn")
 
-	// Step 2: Extract — the regenerated PKL must carry the embed as
-	// formae.embed("…\(kvStore.res.id)…"), with no raw envelope leaking.
+	// Step 2: Extract — the regenerated PKL must carry the embed as a
+	// formae.embed("…\(<resolvable>.id)…") interpolation, not a raw envelope or
+	// a baked literal. Extract reconstructs the reference in full resolvable
+	// form (the original `.res` shorthand isn't recoverable), e.g.
+	// `\((keyvaluestore.KeyValueStoreResolvable) { … label = "e2e-embed-kvs" }.id)`.
 	// --schema-location local: the AWS plugin is user-installed (built from
 	// source), so the extracted PKL must reference the on-disk plugin schema
 	// for the reapply below to resolve.
@@ -59,7 +62,7 @@ func TestEmbedResolvable(t *testing.T) {
 		t.Fatalf("failed to read extracted PKL: %v", err)
 	}
 	src := string(body)
-	for _, want := range []string{"formae.embed(", ".res.id", `\(`} {
+	for _, want := range []string{"formae.embed(", `\(`, "e2e-embed-kvs", ".id)"} {
 		if !strings.Contains(src, want) {
 			t.Fatalf("extracted PKL missing %q; got:\n%s", want, src)
 		}

--- a/tests/e2e/go/fixtures/embed_resolvable_aws.pkl
+++ b/tests/e2e/go/fixtures/embed_resolvable_aws.pkl
@@ -21,9 +21,14 @@ import "@aws/cloudfront/keyvaluestore.pkl" as kvsmod
 
 local stackName = "e2e-embed-resolvable-aws"
 
+// Unique suffix for globally-scoped CloudFront resource names — aws-nuke does
+// not clean KeyValueStore/Function, so reused static names collide across reruns
+// and concurrent jobs. Labels and the stack stay static for test assertions.
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+
 local kvStore = new kvsmod.KeyValueStore {
   label = "e2e-embed-kvs"
-  name = "formae-e2e-embed-kvs"
+  name = "formae-e2e-embed-kvs-\(testRunID)"
   comment = "e2e embedded-resolvable test KVS"
 }
 
@@ -44,7 +49,7 @@ forma {
 
   new cffn.Function {
     label = "e2e-embed-fn"
-    name = "formae-e2e-embed-fn"
+    name = "formae-e2e-embed-fn-\(testRunID)"
     autoPublish = true
     // The embedded resolvable: the KVS short Id is substituted into the JS
     // literal at resolve time, so this ships as a plain String to CloudFront.


### PR DESCRIPTION
## Problem

An embedded resolvable to a resource declared **without an explicit `stack`** (the
common bare-resource style) failed at apply with:

```
500 - embed span has incomplete triplet (label="…" type="…" stack="")
```

A whole-value resolvable to the *same* bare resource (e.g. `kvStore.res.arn`)
resolved fine — only the embed span (`formae.embed("…\(kvStore.res.id)…")`) broke.

## Root cause

Single-stack defaulting (`forma.pkl`: `when (res.stack == null) { stack = defaultStack }`)
and whole-value `.res` stack fill-in (the `[formae.Resolvable]` renderer converter,
`getResource(label,type).stack.label`) both run in **PKL output rendering**.
`Resolvable.toString()` — which materializes the embed envelope — runs earlier, at
**string-interpolation time**, before those converters. The null `$stack` key is then
dropped by the JSON renderer, so the embed envelope reaches the agent with no stack,
while the resource itself is keyed in `tripletToKsuid` under its *defaulted* stack.
The lookup misses and the incomplete-triplet guard fires.

## Fix

In `translateEmbedSpansInTemplate`, when an embed span omits the stack, resolve it by
`(label, type)` when that is unambiguous across the forma — mirroring the whole-value
converter's `getResource(label, type)`. Ambiguous or absent matches still error, so the
user disambiguates with an explicit stack. Bare-resource embeds now behave exactly like
whole-value resolvables; no `StackResolvable` workaround needed.

## Tests

- `TestTranslatePropertiesJSON_EmbeddedSpan_BareStack` — bare span (no `$stack`) resolves via `(label, type)`.
- `TestTranslatePropertiesJSON_EmbeddedSpan_BareStackAmbiguous` — same `(label, type)` in two stacks still errors.

Found by the PLA-68 AWS e2e (`TestEmbedResolvable`), whose fixture uses bare resources;
this unblocks it.