### PR TITLE
feat(metastructure): canonicalize serialized-JSON String fields in the update diff

### DIFF
--- a/internal/metastructure/canonicalize/canonicalize.go
+++ b/internal/metastructure/canonicalize/canonicalize.go
@@ -1,0 +1,131 @@
+// Package canonicalize provides format-keyed canonicalizers for serialized
+// structured String fields (JSON first), so core can compare a field's content
+// rather than its byte serialization. See PLA-196.
+package canonicalize
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Canonicalizer maps a raw serialized value to a stable canonical form.
+type Canonicalizer func(raw string) (string, error)
+
+var canonicalizers = map[string]Canonicalizer{
+	"json": canonicalizeJSON,
+}
+
+// IsRegistered reports whether a canonicalizer exists for format.
+func IsRegistered(format string) bool {
+	_, ok := canonicalizers[format]
+	return ok
+}
+
+// Canonicalize returns the canonical form of raw under the named format. It
+// returns an error for an unregistered format or for input that cannot be
+// safely canonicalized (invalid JSON, duplicate object keys). Callers treat any
+// error as "leave the value as-is and compare raw".
+func Canonicalize(format, raw string) (string, error) {
+	c, ok := canonicalizers[format]
+	if !ok {
+		return "", fmt.Errorf("canonicalize: no canonicalizer registered for format %q", format)
+	}
+	return c(raw)
+}
+
+// canonicalizeJSON parses raw as a single JSON document and re-serializes it to
+// a stable form: object keys sorted (json.Marshal sorts map keys), whitespace
+// compacted, HTML escaping applied (Go default — symmetric on both sides),
+// array order preserved, and numeric literals preserved via UseNumber (no
+// float64 round-trip). Duplicate object keys are rejected.
+func canonicalizeJSON(raw string) (string, error) {
+	if err := rejectDuplicateKeys(raw); err != nil {
+		return "", err
+	}
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return "", fmt.Errorf("canonicalize json: %w", err)
+	}
+	if dec.More() {
+		return "", fmt.Errorf("canonicalize json: unexpected trailing content")
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize json: %w", err)
+	}
+	return string(out), nil
+}
+
+// rejectDuplicateKeys errors if any object in raw has a duplicate key. It walks
+// tokens with an explicit nesting stack: '{' pushes an object frame (a fresh
+// seen-set + an expect-key toggle); inside an object, key and value tokens
+// alternate, so the toggle tells a key apart from a string value; a container in
+// value position flips the parent back to expect-key as it is consumed.
+func rejectDuplicateKeys(raw string) error {
+	type frame struct {
+		inObject  bool
+		expectKey bool
+		seen      map[string]struct{}
+	}
+	var stack []*frame
+
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.UseNumber()
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("canonicalize json: %w", err)
+		}
+
+		top := func() *frame {
+			if len(stack) == 0 {
+				return nil
+			}
+			return stack[len(stack)-1]
+		}
+
+		if d, ok := tok.(json.Delim); ok {
+			switch d {
+			case '{', '[':
+				// A container in value position consumes the parent's value slot.
+				if t := top(); t != nil && t.inObject && !t.expectKey {
+					t.expectKey = true
+				}
+				if d == '{' {
+					stack = append(stack, &frame{inObject: true, expectKey: true, seen: map[string]struct{}{}})
+				} else {
+					stack = append(stack, &frame{inObject: false})
+				}
+			case '}', ']':
+				if len(stack) > 0 {
+					stack = stack[:len(stack)-1]
+				}
+			}
+			continue
+		}
+
+		t := top()
+		if t == nil || !t.inObject {
+			continue // top-level scalar, or an array element
+		}
+		if t.expectKey {
+			key, _ := tok.(string)
+			if _, dup := t.seen[key]; dup {
+				return fmt.Errorf("canonicalize json: duplicate key %q", key)
+			}
+			t.seen[key] = struct{}{}
+			t.expectKey = false
+		} else {
+			// Just consumed a scalar value → next token is a key.
+			t.expectKey = true
+		}
+	}
+	return nil
+}

--- a/internal/metastructure/canonicalize/canonicalize.go
+++ b/internal/metastructure/canonicalize/canonicalize.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/platform-engineering-labs/formae/pkg/model"
 )
 
 // Canonicalizer maps a raw serialized value to a stable canonical form.
@@ -33,6 +35,19 @@ func Canonicalize(format, raw string) (string, error) {
 		return "", fmt.Errorf("canonicalize: no canonicalizer registered for format %q", format)
 	}
 	return c(raw)
+}
+
+// ValidateSchemaFormats returns an error if any field in s declares a
+// FieldHint.Format with no registered canonicalizer. Called at plugin
+// registration so an unsupported/typo'd format fails fast rather than silently
+// not canonicalizing at reconcile time.
+func ValidateSchemaFormats(resourceType string, s model.Schema) error {
+	for field, h := range s.Hints {
+		if h.Format != "" && !IsRegistered(h.Format) {
+			return fmt.Errorf("resource %s field %s declares unknown canonicalization format %q", resourceType, field, h.Format)
+		}
+	}
+	return nil
 }
 
 // canonicalizeJSON parses raw as a single JSON document and re-serializes it to

--- a/internal/metastructure/canonicalize/canonicalize.go
+++ b/internal/metastructure/canonicalize/canonicalize.go
@@ -1,3 +1,7 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
 // Package canonicalize provides format-keyed canonicalizers for serialized
 // structured String fields (JSON first), so core can compare a field's content
 // rather than its byte serialization. See PLA-196.

--- a/internal/metastructure/canonicalize/canonicalize_test.go
+++ b/internal/metastructure/canonicalize/canonicalize_test.go
@@ -1,6 +1,10 @@
 package canonicalize
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/pkg/model"
+)
 
 func TestCanonicalizeJSON_EqualUnderReorderWhitespaceEscape(t *testing.T) {
 	cases := []struct{ name, a, b string }{
@@ -110,5 +114,20 @@ func TestIsRegistered(t *testing.T) {
 	}
 	if IsRegistered("js") {
 		t.Fatal("js must not be registered")
+	}
+}
+
+func TestValidateSchemaFormats(t *testing.T) {
+	ok := model.Schema{Hints: map[string]model.FieldHint{"configJson": {Format: "json"}}}
+	if err := ValidateSchemaFormats("X", ok); err != nil {
+		t.Fatalf("registered format must validate: %v", err)
+	}
+	bad := model.Schema{Hints: map[string]model.FieldHint{"code": {Format: "js"}}}
+	if err := ValidateSchemaFormats("X", bad); err == nil {
+		t.Fatal("unregistered format must fail validation")
+	}
+	none := model.Schema{Hints: map[string]model.FieldHint{"name": {CreateOnly: true}}}
+	if err := ValidateSchemaFormats("X", none); err != nil {
+		t.Fatalf("no Format hints must validate: %v", err)
 	}
 }

--- a/internal/metastructure/canonicalize/canonicalize_test.go
+++ b/internal/metastructure/canonicalize/canonicalize_test.go
@@ -1,0 +1,114 @@
+package canonicalize
+
+import "testing"
+
+func TestCanonicalizeJSON_EqualUnderReorderWhitespaceEscape(t *testing.T) {
+	cases := []struct{ name, a, b string }{
+		{"key order", `{"b":1,"a":2}`, `{"a":2,"b":1}`},
+		{"whitespace", `{"a":  1}`, `{"a":1}`},
+		{"pretty vs compact", "{\n  \"a\": 1\n}", `{"a":1}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ca, err := Canonicalize("json", c.a)
+			if err != nil {
+				t.Fatalf("a: %v", err)
+			}
+			cb, err := Canonicalize("json", c.b)
+			if err != nil {
+				t.Fatalf("b: %v", err)
+			}
+			if ca != cb {
+				t.Fatalf("expected equal canonical forms, got %q vs %q", ca, cb)
+			}
+		})
+	}
+}
+
+func TestCanonicalizeJSON_HTMLEscapeSymmetry(t *testing.T) {
+	// A value containing & ; both sides canonicalize to the same escaped form.
+	a := `{"title":"Throughput & outcomes"}`
+	b := "{\n  \"title\": \"Throughput & outcomes\"\n}"
+	ca, _ := Canonicalize("json", a)
+	cb, _ := Canonicalize("json", b)
+	if ca != cb {
+		t.Fatalf("expected equal, got %q vs %q", ca, cb)
+	}
+}
+
+func TestCanonicalizeJSON_DistinguishesContentChange(t *testing.T) {
+	ca, _ := Canonicalize("json", `{"a":1}`)
+	cb, _ := Canonicalize("json", `{"a":2}`)
+	if ca == cb {
+		t.Fatal("expected different canonical forms for different content")
+	}
+}
+
+func TestCanonicalizeJSON_ArrayOrderSignificant(t *testing.T) {
+	ca, _ := Canonicalize("json", `{"p":[1,2]}`)
+	cb, _ := Canonicalize("json", `{"p":[2,1]}`)
+	if ca == cb {
+		t.Fatal("array order must be significant")
+	}
+}
+
+func TestCanonicalizeJSON_BigIntFidelity(t *testing.T) {
+	// Two distinct large ints must never alias (would collapse under float64).
+	ca, _ := Canonicalize("json", `{"id":9007199254740993}`)
+	cb, _ := Canonicalize("json", `{"id":9007199254740992}`)
+	if ca == cb {
+		t.Fatal("distinct large ints must not alias")
+	}
+	// And the literal is preserved.
+	if got, _ := Canonicalize("json", `{"id":9007199254740993}`); got != `{"id":9007199254740993}` {
+		t.Fatalf("big int not preserved: %q", got)
+	}
+}
+
+func TestCanonicalizeJSON_NumericFormatIsADiff(t *testing.T) {
+	ca, _ := Canonicalize("json", `{"a":1}`)
+	cb, _ := Canonicalize("json", `{"a":1.0}`)
+	if ca == cb {
+		t.Fatal("1 and 1.0 must compare as a diff under UseNumber")
+	}
+}
+
+func TestCanonicalizeJSON_RejectsDuplicateKeys(t *testing.T) {
+	for _, raw := range []string{
+		`{"a":1,"a":2}`,           // top-level
+		`{"o":{"a":1,"a":2}}`,     // nested object
+		`{"arr":[{"a":1,"a":2}]}`, // object inside array
+	} {
+		if _, err := Canonicalize("json", raw); err == nil {
+			t.Fatalf("expected duplicate-key error for %q", raw)
+		}
+	}
+}
+
+func TestCanonicalizeJSON_AllowsRepeatedStringValuesThatLookLikeKeys(t *testing.T) {
+	// "a" appears as a value, not a duplicate key — must NOT error.
+	if _, err := Canonicalize("json", `{"x":"a","y":"a"}`); err != nil {
+		t.Fatalf("string values must not be mistaken for keys: %v", err)
+	}
+}
+
+func TestCanonicalize_InvalidJSONErrors(t *testing.T) {
+	if _, err := Canonicalize("json", `{not json`); err == nil {
+		t.Fatal("expected error on invalid JSON")
+	}
+}
+
+func TestCanonicalize_UnregisteredFormatErrors(t *testing.T) {
+	if _, err := Canonicalize("yaml", `{}`); err == nil {
+		t.Fatal("expected error for unregistered format")
+	}
+}
+
+func TestIsRegistered(t *testing.T) {
+	if !IsRegistered("json") {
+		t.Fatal("json must be registered")
+	}
+	if IsRegistered("js") {
+		t.Fatal("js must not be registered")
+	}
+}

--- a/internal/metastructure/canonicalize/canonicalize_test.go
+++ b/internal/metastructure/canonicalize/canonicalize_test.go
@@ -1,3 +1,7 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
 package canonicalize
 
 import (

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -664,6 +664,12 @@ func dropCanonicallyEqualHintedOps(ops []jsonpatch.JsonPatchOperation, document,
 		field := cleanPath(op.Path)
 		format, hinted := formats[field]
 		if hinted && isTopLevelPath(op.Path) {
+			// The hint key is used as a gjson path (dot = nesting). v1 targets
+			// top-level fields whose names contain no gjson-special chars
+			// (`.`/`*`/`?`); the grafana `configJson` consumer satisfies this. A
+			// top-level field literally named with a `.` would not be matched
+			// (canonicalization silently skipped — safe-direction, never drops a
+			// real change).
 			oldVal := gjson.GetBytes(document, field)
 			newVal := gjson.GetBytes(patch, field)
 			if oldVal.Type == gjson.String && newVal.Type == gjson.String {

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/platform-engineering-labs/formae/internal/metastructure/canonicalize"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/jsonpatch"
+	"github.com/tidwall/gjson"
 )
 
 var defaultIgnoredFields = []jsonpatch.Path{}
@@ -111,6 +113,11 @@ func generatePatch(document []byte, patch []byte, properties resolver.Resolvable
 	// EntitySet array elements may not match their actual counterparts and
 	// produce "array items are not unique" errors.
 	patchOps = stripEmptyCollectionsFromOps(patchOps)
+
+	// Drop serialization-only ops on Format-hinted fields before the createOnly
+	// split, so a cosmetic diff on a (possibly createOnly) hinted field neither
+	// reaches the plugin nor triggers a replacement (PLA-196).
+	patchOps = dropCanonicallyEqualHintedOps(patchOps, flattenedDocument, flattenedPatch, schema)
 
 	if len(patchOps) == 0 {
 		return nil, nil, nil
@@ -633,6 +640,43 @@ func filterSpuriousEmptyAdds(patchOps []jsonpatch.JsonPatchOperation) []jsonpatc
 		filtered = append(filtered, op)
 	}
 	return filtered
+}
+
+// isTopLevelPath reports whether a JSON Pointer addresses a single top-level
+// field (e.g. "/configJson"), not a nested or array-index path.
+func isTopLevelPath(p string) bool {
+	trimmed := strings.TrimPrefix(p, "/")
+	return trimmed != "" && !strings.Contains(trimmed, "/")
+}
+
+// dropCanonicallyEqualHintedOps removes patch ops targeting a top-level
+// Format-hinted field whose old/new values are canonically equal (a
+// serialization-only diff). On any canonicalizer error, a non-string value, or a
+// nested/array path, the op is KEPT — suppression can only ever drop a cosmetic
+// op, never a real change (PLA-196).
+func dropCanonicallyEqualHintedOps(ops []jsonpatch.JsonPatchOperation, document, patch []byte, schema pkgmodel.Schema) []jsonpatch.JsonPatchOperation {
+	formats := schema.FormatHints()
+	if len(formats) == 0 {
+		return ops
+	}
+	kept := make([]jsonpatch.JsonPatchOperation, 0, len(ops))
+	for _, op := range ops {
+		field := cleanPath(op.Path)
+		format, hinted := formats[field]
+		if hinted && isTopLevelPath(op.Path) {
+			oldVal := gjson.GetBytes(document, field)
+			newVal := gjson.GetBytes(patch, field)
+			if oldVal.Type == gjson.String && newVal.Type == gjson.String {
+				oc, oerr := canonicalize.Canonicalize(format, oldVal.String())
+				nc, nerr := canonicalize.Canonicalize(format, newVal.String())
+				if oerr == nil && nerr == nil && oc == nc {
+					continue // serialization-only diff → drop
+				}
+			}
+		}
+		kept = append(kept, op)
+	}
+	return kept
 }
 
 // stripEmptyCollectionsFromOps recursively removes empty arrays and maps from

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -7,6 +7,7 @@ package patch
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
@@ -2715,5 +2716,84 @@ func TestFlattenRefs_AssemblesEmbed(t *testing.T) {
 	flattenRefs(m)
 	if got := m["functionCode"]; got != "cf.kvs('KV-7H9X')" {
 		t.Errorf("flattenRefs embed: got %v want assembled string", got)
+	}
+}
+
+func TestGeneratePatch_BundledUpdate_DropsSerializationOnlyHintedOp(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"folderUid", "configJson"},
+		Hints:  map[string]pkgmodel.FieldHint{"configJson": {Format: "json"}},
+	}
+	document := []byte(`{"folderUid":"a","configJson":"{\"x\":1,\"y\":2}"}`)
+	patch := []byte(`{"folderUid":"b","configJson":"{\n  \"y\": 2,\n  \"x\": 1\n}"}`)
+
+	mutable, _, err := GeneratePatch(document, patch, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(mutable)
+	if !strings.Contains(s, "folderUid") {
+		t.Fatalf("expected the real folderUid op, got %s", s)
+	}
+	if strings.Contains(s, "configJson") {
+		t.Fatalf("serialization-only configJson op must be dropped, got %s", s)
+	}
+}
+
+func TestGeneratePatch_GenuineHintedChange_KeepsOp(t *testing.T) {
+	schema := pkgmodel.Schema{Fields: []string{"configJson"}, Hints: map[string]pkgmodel.FieldHint{"configJson": {Format: "json"}}}
+	document := []byte(`{"configJson":"{\"x\":1}"}`)
+	patch := []byte(`{"configJson":"{\"x\":2}"}`)
+
+	mutable, _, err := GeneratePatch(document, patch, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(mutable), "configJson") {
+		t.Fatalf("genuine content change must keep the op, got %s", string(mutable))
+	}
+}
+
+func TestGeneratePatch_FallbackKeepsOpOnInvalidJSON(t *testing.T) {
+	schema := pkgmodel.Schema{Fields: []string{"configJson"}, Hints: map[string]pkgmodel.FieldHint{"configJson": {Format: "json"}}}
+	document := []byte(`{"configJson":"{\"x\":1}"}`)
+	patch := []byte(`{"configJson":"not json"}`)
+
+	mutable, _, err := GeneratePatch(document, patch, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(mutable), "configJson") {
+		t.Fatalf("uncanonicalizable change must keep the op, got %s", string(mutable))
+	}
+}
+
+func TestGeneratePatch_CreateOnlyHinted_SerializationOnly_NoReplacement(t *testing.T) {
+	schema := pkgmodel.Schema{Fields: []string{"configJson"}, Hints: map[string]pkgmodel.FieldHint{"configJson": {Format: "json", CreateOnly: true}}}
+	document := []byte(`{"configJson":"{\"x\":1,\"y\":2}"}`)
+	patch := []byte(`{"configJson":"{\"y\":2,\"x\":1}"}`)
+	mutable, createOnly, err := GeneratePatch(document, patch, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(createOnly) != 0 {
+		t.Fatalf("serialization-only createOnly hinted field must not trigger replacement, got %s", string(createOnly))
+	}
+	if strings.Contains(string(mutable), "configJson") {
+		t.Fatalf("op must be dropped, got %s", string(mutable))
+	}
+}
+
+func TestGeneratePatch_ArrayPathNeverDropped(t *testing.T) {
+	// A same-named hint must not drop an array-index op.
+	schema := pkgmodel.Schema{Fields: []string{"tags"}, Hints: map[string]pkgmodel.FieldHint{"tags": {Format: "json"}}}
+	document := []byte(`{"tags":["a","b"]}`)
+	patch := []byte(`{"tags":["a","c"]}`)
+	mutable, _, err := GeneratePatch(document, patch, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(mutable), "tags") {
+		t.Fatalf("array-element change must survive, got %s", string(mutable))
 	}
 }

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator.go
@@ -205,16 +205,6 @@ func (c *PluginCoordinator) HandleMessage(from gen.PID, message any) error {
 
 		c.Log().Debug("Received capabilities for namespace %s: %d resources, %d schemas", msg.Namespace, len(caps.SupportedResources), len(caps.ResourceSchemas))
 
-		// Reject registration if any cached schema declares an unknown
-		// FieldHint.Format, so a typo'd/unsupported format fails fast rather than
-		// silently not canonicalizing at reconcile time (PLA-196).
-		for resourceType, schema := range caps.ResourceSchemas {
-			if err := canonicalize.ValidateSchemaFormats(resourceType, schema); err != nil {
-				c.Log().Error("Rejecting plugin registration: invalid schema format for namespace %s: %v", msg.Namespace, err)
-				return fmt.Errorf("plugin %s: %w", msg.Name, err)
-			}
-		}
-
 		announced := RegisteredPlugin{
 			Name:                 msg.Name,
 			Namespace:            msg.Namespace,
@@ -231,6 +221,16 @@ func (c *PluginCoordinator) HandleMessage(from gen.PID, message any) error {
 		merged, enabled := c.mergePluginConfig(msg.Name, msg.Namespace, announced)
 		if !enabled {
 			return nil
+		}
+
+		// Reject this plugin if any schema declares an unknown FieldHint.Format
+		// (typo/unsupported). Log and skip — a non-nil HandleMessage return would
+		// terminate the coordinator actor, taking down every registered plugin (PLA-196).
+		for resourceType, schema := range merged.ResourceSchemas {
+			if err := canonicalize.ValidateSchemaFormats(resourceType, schema); err != nil {
+				c.Log().Error("Rejecting plugin %s registration: invalid schema format for namespace %s: %v", msg.Name, msg.Namespace, err)
+				return nil
+			}
 		}
 
 		c.plugins[msg.Namespace] = &merged

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator.go
@@ -14,6 +14,7 @@ import (
 	"ergo.services/ergo/gen"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/canonicalize"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/changeset"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/pkg/model"
@@ -203,6 +204,16 @@ func (c *PluginCoordinator) HandleMessage(from gen.PID, message any) error {
 		caps := msg.Capabilities
 
 		c.Log().Debug("Received capabilities for namespace %s: %d resources, %d schemas", msg.Namespace, len(caps.SupportedResources), len(caps.ResourceSchemas))
+
+		// Reject registration if any cached schema declares an unknown
+		// FieldHint.Format, so a typo'd/unsupported format fails fast rather than
+		// silently not canonicalizing at reconcile time (PLA-196).
+		for resourceType, schema := range caps.ResourceSchemas {
+			if err := canonicalize.ValidateSchemaFormats(resourceType, schema); err != nil {
+				c.Log().Error("Rejecting plugin registration: invalid schema format for namespace %s: %v", msg.Namespace, err)
+				return fmt.Errorf("plugin %s: %w", msg.Name, err)
+			}
+		}
 
 		announced := RegisteredPlugin{
 			Name:                 msg.Name,

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator_test.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator_test.go
@@ -7,7 +7,10 @@ package plugin_coordinator
 import (
 	"testing"
 
+	"ergo.services/ergo/gen"
+	"ergo.services/ergo/testing/unit"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	"github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,4 +75,86 @@ func TestPluginCoordinator_GetPluginInfo_CaseInsensitive(t *testing.T) {
 	resp = c.getPluginInfo(messages.GetPluginInfo{Namespace: "Azure"})
 	assert.True(t, resp.Found)
 	assert.Equal(t, "Azure", resp.Namespace)
+}
+
+// newCoordinatorForTest spawns a PluginCoordinator in the ergo unit-test harness.
+// HandleMessage touches c.Log()/c.Send(), so it needs a live (test) process — a
+// bare &PluginCoordinator{} would nil-panic. RetryConfig env is required by Init.
+func newCoordinatorForTest(t *testing.T) (*unit.TestActor, gen.PID) {
+	t.Helper()
+	listener, err := unit.Spawn(t, NewPluginCoordinator, unit.WithEnv(map[gen.Env]any{
+		gen.Env("RetryConfig"): model.RetryConfig{},
+	}))
+	require.NoError(t, err)
+	return listener, gen.PID{Node: "test", ID: 100}
+}
+
+func announcement(namespace string, schemas map[string]model.Schema) messages.PluginAnnouncement {
+	return messages.PluginAnnouncement{
+		Name:                 namespace,
+		Namespace:            namespace,
+		Version:              "1.0.0",
+		MaxRequestsPerSecond: 10,
+		Capabilities: plugin.PluginCapabilities{
+			ResourceSchemas: schemas,
+		},
+	}
+}
+
+// TestPluginCoordinator_RejectsBadFieldHintFormatWithoutCrashing is the PLA-196
+// regression test. A PluginAnnouncement carrying a schema with an unknown
+// FieldHint.Format must be rejected (not registered) WITHOUT terminating the
+// coordinator actor. A non-nil HandleMessage return would crash the actor,
+// dropping every registered plugin — this asserts ShouldNotTerminate. (Against
+// the buggy `return fmt.Errorf(...)` version the actor terminates, so this
+// test fails — which is the point.)
+func TestPluginCoordinator_RejectsBadFieldHintFormatWithoutCrashing(t *testing.T) {
+	listener, sender := newCoordinatorForTest(t)
+
+	badSchema := map[string]model.Schema{
+		"Grafana::Dashboard": {
+			Identifier: "uid",
+			Fields:     []string{"configJson"},
+			Hints: map[string]model.FieldHint{
+				"configJson": {Format: "jsn"}, // typo: unknown format
+			},
+		},
+	}
+
+	listener.SendMessage(sender, announcement("grafana", badSchema))
+
+	// The actor must survive a bad-metadata announcement.
+	require.False(t, listener.IsTerminated(),
+		"coordinator must not terminate on a plugin's bad FieldHint.Format (reason: %v)", listener.TerminationReason())
+
+	// And the offending plugin must NOT be registered.
+	c := listener.Behavior().(*PluginCoordinator)
+	_, ok := c.plugins["grafana"]
+	assert.False(t, ok, "plugin with unknown FieldHint.Format must be rejected, not registered")
+}
+
+// TestPluginCoordinator_RegistersValidFieldHintFormat is the happy path: a known
+// format (or no format) registers normally.
+func TestPluginCoordinator_RegistersValidFieldHintFormat(t *testing.T) {
+	listener, sender := newCoordinatorForTest(t)
+
+	goodSchema := map[string]model.Schema{
+		"Grafana::Dashboard": {
+			Identifier: "uid",
+			Fields:     []string{"configJson"},
+			Hints: map[string]model.FieldHint{
+				"configJson": {Format: "json"}, // registered canonicalizer
+			},
+		},
+	}
+
+	listener.SendMessage(sender, announcement("grafana", goodSchema))
+
+	require.False(t, listener.IsTerminated(),
+		"coordinator must not terminate on a valid announcement (reason: %v)", listener.TerminationReason())
+
+	c := listener.Behavior().(*PluginCoordinator)
+	reg, ok := c.plugins["grafana"]
+	require.True(t, ok, "plugin with valid FieldHint.Format must be registered")
+	assert.Equal(t, "grafana", reg.Namespace)
 }

--- a/internal/metastructure/resource_update/resource_comparison.go
+++ b/internal/metastructure/resource_update/resource_comparison.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
+	"github.com/platform-engineering-labs/formae/internal/metastructure/canonicalize"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/transformations"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
@@ -20,7 +21,7 @@ import (
 
 // EnforceSetOnceAndCompareResourceForUpdate prepares resources for update by applying transformations,
 // normalization, and SetOnce filtering, then compares them to detect meaningful changes
-func EnforceSetOnceAndCompareResourceForUpdate(existing, new *pkgmodel.Resource) (bool, json.RawMessage, error) {
+func EnforceSetOnceAndCompareResourceForUpdate(existing, new *pkgmodel.Resource, schema pkgmodel.Schema) (bool, json.RawMessage, error) {
 	filteredRawProps, err := filterSetOnceProps(existing.Properties, new.Properties, new.Label)
 	if err != nil {
 		return false, nil, err
@@ -34,11 +35,47 @@ func EnforceSetOnceAndCompareResourceForUpdate(existing, new *pkgmodel.Resource)
 		return false, nil, err
 	}
 
-	equal, err := util.JsonEqualIgnoreArrayOrder(existing.Properties, hashedForComparison.Properties)
+	// Canonicalize Format-hinted serialized fields on BOTH sides, for comparison
+	// only — never feeds the returned filteredRawProps (PLA-196).
+	existingForCompare := canonicalizeHintedFields(existing.Properties, schema)
+	newForCompare := canonicalizeHintedFields(hashedForComparison.Properties, schema)
+
+	equal, err := util.JsonEqualIgnoreArrayOrder(existingForCompare, newForCompare)
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to compare properties: %w", err)
 	}
 	return !equal, filteredRawProps, nil
+}
+
+// canonicalizeHintedFields returns a copy of props in which each Format-hinted
+// plain-String field is replaced by its canonical form, for comparison only. On
+// any per-field error the field is left raw, so the comparison can only ever
+// over-report a change, never under-report one. Uses string-returning sjson.Set
+// so the input json.RawMessage is never mutated.
+func canonicalizeHintedFields(props json.RawMessage, schema pkgmodel.Schema) json.RawMessage {
+	formats := schema.FormatHints()
+	if len(formats) == 0 || len(props) == 0 {
+		return props
+	}
+	out := string(props)
+	for field, format := range formats {
+		val := gjson.Get(out, field)
+		if !val.Exists() || val.Type != gjson.String {
+			continue // absent, or not a plain JSON string (e.g. a resolvable envelope)
+		}
+		canon, err := canonicalize.Canonicalize(format, val.String())
+		if err != nil {
+			slog.Warn("skipping canonicalization of hinted field", "field", field, "format", format, "error", err)
+			continue
+		}
+		updated, err := sjson.Set(out, field, canon)
+		if err != nil {
+			slog.Warn("failed to write canonicalized hinted field", "field", field, "error", err)
+			continue
+		}
+		out = updated
+	}
+	return json.RawMessage(out)
 }
 
 // SuppressUnchangedOpaqueValues removes opaque leaf properties whose desired

--- a/internal/metastructure/resource_update/resource_comparison.go
+++ b/internal/metastructure/resource_update/resource_comparison.go
@@ -59,6 +59,12 @@ func canonicalizeHintedFields(props json.RawMessage, schema pkgmodel.Schema) jso
 	}
 	out := string(props)
 	for field, format := range formats {
+		// The hint key is used as a gjson path (dot = nesting). v1 targets
+		// top-level fields whose names contain no gjson-special chars
+		// (`.`/`*`/`?`); the grafana `configJson` consumer satisfies this. A
+		// top-level field literally named with a `.` would not be matched
+		// (canonicalization silently skipped — safe-direction, never drops a
+		// real change).
 		val := gjson.Get(out, field)
 		if !val.Exists() || val.Type != gjson.String {
 			continue // absent, or not a plain JSON string (e.g. a resolvable envelope)

--- a/internal/metastructure/resource_update/resource_comparison_test.go
+++ b/internal/metastructure/resource_update/resource_comparison_test.go
@@ -459,3 +459,34 @@ func TestGate_HintedResolvableLeaf_SkippedNoPanic(t *testing.T) {
 		t.Fatalf("must not panic/error on a resolvable leaf: %v", err)
 	}
 }
+
+// TestGate_HintedResolvableLeaf_SameContent_NoChange asserts that when a hinted
+// field is a resolvable ENVELOPE (object, not a plain string) the canonicalize
+// skip (val.Type != gjson.String) leaves comparison to the raw/structural
+// compare — which sees identical envelopes and reports no change.
+func TestGate_HintedResolvableLeaf_SameContent_NoChange(t *testing.T) {
+	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"configJson": {Format: "json"}}}
+	existing := &pkgmodel.Resource{Properties: json.RawMessage(`{"configJson":{"$ref":"formae://x","$value":"{\"a\":1}"}}`)}
+	newRes := &pkgmodel.Resource{Properties: json.RawMessage(`{"configJson":{"$ref":"formae://x","$value":"{\"a\":1}"}}`)}
+
+	hasChanges, _, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes, schema)
+	require.NoError(t, err)
+	assert.False(t, hasChanges, "identical resolvable envelopes must not be a change")
+}
+
+// TestGate_HintedResolvableLeaf_DifferentContent_IsChange is the behavioural
+// counterpart to the skip guard. The hinted field is a resolvable ENVELOPE whose
+// $value differs between the two sides. Because the field is an object (not a
+// gjson.String), canonicalization is skipped and the raw/structural compare must
+// still detect the genuine difference. Deleting or inverting the
+// `val.Type != gjson.String` guard (canonicalizing the envelope object instead)
+// would let this real change slip through — this test catches that.
+func TestGate_HintedResolvableLeaf_DifferentContent_IsChange(t *testing.T) {
+	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"configJson": {Format: "json"}}}
+	existing := &pkgmodel.Resource{Properties: json.RawMessage(`{"configJson":{"$ref":"formae://x","$value":"{\"a\":1}"}}`)}
+	newRes := &pkgmodel.Resource{Properties: json.RawMessage(`{"configJson":{"$ref":"formae://x","$value":"{\"a\":2}"}}`)}
+
+	hasChanges, _, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes, schema)
+	require.NoError(t, err)
+	assert.True(t, hasChanges, "differing resolvable envelope $value must be detected as a change")
+}

--- a/internal/metastructure/resource_update/resource_comparison_test.go
+++ b/internal/metastructure/resource_update/resource_comparison_test.go
@@ -22,7 +22,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			Properties: json.RawMessage(`{"prop": "value"}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(resource, resource)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(resource, resource, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.False(t, hasChanges)
@@ -43,7 +43,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.False(t, hasChanges)
@@ -62,7 +62,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.True(t, hasChanges)
@@ -83,7 +83,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.True(t, hasChanges)
@@ -106,7 +106,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.True(t, hasChanges)
@@ -133,7 +133,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.True(t, hasChanges)
@@ -152,7 +152,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			Properties: json.RawMessage(`{"prop": "new-value"}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.True(t, hasChanges)
@@ -167,7 +167,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			Properties: json.RawMessage(`{"prop": "value", "emptyArray": []}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.False(t, hasChanges)
@@ -182,7 +182,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			Properties: json.RawMessage(`{"prop": "value", "Tags": null}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.False(t, hasChanges)
@@ -197,7 +197,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			Properties: json.RawMessage(`{"Tags": null}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.True(t, hasChanges)
@@ -226,7 +226,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, new, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.False(t, hasChanges)
@@ -261,7 +261,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.False(t, hasChanges)
@@ -292,7 +292,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.False(t, hasChanges)
@@ -318,7 +318,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.True(t, hasChanges)
@@ -346,7 +346,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.True(t, hasChanges)
@@ -373,7 +373,7 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.True(t, hasChanges)
@@ -398,10 +398,64 @@ func TestPrepareAndCompareResourceForUpdate(t *testing.T) {
 			}`),
 		}
 
-		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes)
+		hasChanges, filteredProps, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes, pkgmodel.Schema{})
 
 		require.NoError(t, err)
 		assert.True(t, hasChanges)
 		assert.Contains(t, string(filteredProps), "new-name")
 	})
+}
+
+func TestGate_SerializationOnlyConfigJson_NoChange(t *testing.T) {
+	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"configJson": {Format: "json"}}}
+	existing := &pkgmodel.Resource{Properties: json.RawMessage(`{"configJson":"{\"a\":1,\"b\":2}"}`)}
+	// same content, different serialization (pretty + reordered keys)
+	newRes := &pkgmodel.Resource{Properties: json.RawMessage(`{"configJson":"{\n  \"b\": 2,\n  \"a\": 1\n}"}`)}
+
+	hasChanges, _, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasChanges {
+		t.Fatal("serialization-only difference must not be a change")
+	}
+}
+
+func TestGate_GenuineConfigJsonChange_IsChange(t *testing.T) {
+	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"configJson": {Format: "json"}}}
+	existing := &pkgmodel.Resource{Properties: json.RawMessage(`{"configJson":"{\"a\":1}"}`)}
+	newRes := &pkgmodel.Resource{Properties: json.RawMessage(`{"configJson":"{\"a\":2}"}`)}
+
+	hasChanges, _, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasChanges {
+		t.Fatal("genuine content change must be a change")
+	}
+}
+
+func TestGate_NoHint_UnchangedBehavior(t *testing.T) {
+	schema := pkgmodel.Schema{} // no Format hint
+	existing := &pkgmodel.Resource{Properties: json.RawMessage(`{"configJson":"{\"a\":1}"}`)}
+	newRes := &pkgmodel.Resource{Properties: json.RawMessage(`{"configJson":"{ \"a\": 1 }"}`)}
+
+	hasChanges, _, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasChanges {
+		t.Fatal("without a Format hint, a serialization difference is still a raw string change")
+	}
+}
+
+func TestGate_HintedResolvableLeaf_SkippedNoPanic(t *testing.T) {
+	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"configJson": {Format: "json"}}}
+	// configJson is itself a resolvable envelope (object), not a plain string.
+	props := json.RawMessage(`{"configJson":{"$ref":"formae://x","$value":"{\"a\":1}"}}`)
+	existing := &pkgmodel.Resource{Properties: props}
+	newRes := &pkgmodel.Resource{Properties: props}
+	if _, _, err := resource_update.EnforceSetOnceAndCompareResourceForUpdate(existing, newRes, schema); err != nil {
+		t.Fatalf("must not panic/error on a resolvable leaf: %v", err)
+	}
 }

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -47,7 +47,7 @@ func NewResourceUpdateForExisting(
 	// the properties might be identical
 	stackChanged := existingResource.Stack != newResource.Stack
 
-	hasChanges, filteredProps, err := EnforceSetOnceAndCompareResourceForUpdate(&existingResource, &newResource)
+	hasChanges, filteredProps, err := EnforceSetOnceAndCompareResourceForUpdate(&existingResource, &newResource, newResource.Schema)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compare resources: %w", err)
 	}

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -218,6 +218,7 @@ open class FieldHint extends Annotation {
     hidden edgeKind: EdgeKind = "default"        // NEW
     hidden indexField: String?
     hidden updateMethod: FieldUpdateMethod?
+    hidden format: String = ""                   // NEW: serialized-content format (e.g. "json"); PLA-196
 
     hidden outputField: String?
     hidden outputTransformation: ((Any) -> Any)?
@@ -233,6 +234,7 @@ open class FieldHint extends Annotation {
     fixed EdgeKind: String = edgeKind
     fixed UpdateMethod: String = updateMethod ?? ""
     fixed IndexField: String = indexField ?? ""
+    fixed Format: String = format                // NEW
 }
 
 /// Annotation for target config fields to declare mutability.

--- a/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
+++ b/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
@@ -94,6 +94,7 @@ examples {
         EdgeKind = "default"
         UpdateMethod = ""
         IndexField = ""
+        Format = ""
       }
       ["Region"] {
         CreateOnly = true
@@ -105,6 +106,7 @@ examples {
         EdgeKind = "default"
         UpdateMethod = ""
         IndexField = ""
+        Format = ""
       }
       ["Tags"] {
         CreateOnly = false
@@ -116,6 +118,7 @@ examples {
         EdgeKind = "default"
         UpdateMethod = ""
         IndexField = ""
+        Format = ""
       }
     }
   }
@@ -138,6 +141,7 @@ examples {
           EdgeKind = "default"
           UpdateMethod = ""
           IndexField = ""
+          Format = ""
         }
         ["Region"] {
           CreateOnly = true
@@ -149,6 +153,7 @@ examples {
           EdgeKind = "default"
           UpdateMethod = ""
           IndexField = ""
+          Format = ""
         }
         ["Tags"] {
           CreateOnly = false
@@ -160,6 +165,7 @@ examples {
           EdgeKind = "default"
           UpdateMethod = ""
           IndexField = ""
+          Format = ""
         }
       }
       Discoverable = true
@@ -213,6 +219,7 @@ examples {
             EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
+            Format = ""
           }
           ["Region"] {
             CreateOnly = true
@@ -224,6 +231,7 @@ examples {
             EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
+            Format = ""
           }
           ["Tags"] {
             CreateOnly = false
@@ -235,6 +243,7 @@ examples {
             EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
+            Format = ""
           }
         }
         Discoverable = true
@@ -296,6 +305,7 @@ examples {
             EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
+            Format = ""
           }
           ["Region"] {
             CreateOnly = true
@@ -307,6 +317,7 @@ examples {
             EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
+            Format = ""
           }
           ["Tags"] {
             CreateOnly = false
@@ -318,6 +329,7 @@ examples {
             EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
+            Format = ""
           }
         }
         Discoverable = true
@@ -363,6 +375,7 @@ examples {
             EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
+            Format = ""
           }
           ["nested"] {
             CreateOnly = false
@@ -374,6 +387,7 @@ examples {
             EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
+            Format = ""
           }
           ["nested.configName"] {
             CreateOnly = false
@@ -385,6 +399,7 @@ examples {
             EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
+            Format = ""
           }
           ["nested.TestConfigValue"] {
             CreateOnly = false
@@ -396,6 +411,7 @@ examples {
             EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
+            Format = ""
           }
           ["nested.setting"] {
             CreateOnly = false
@@ -407,6 +423,7 @@ examples {
             EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
+            Format = ""
           }
           ["nested.setting.setting1"] {
             CreateOnly = false
@@ -418,6 +435,7 @@ examples {
             EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
+            Format = ""
           }
           ["nested.setting.SettingTwo"] {
             CreateOnly = false
@@ -429,6 +447,7 @@ examples {
             EdgeKind = "default"
             UpdateMethod = ""
             IndexField = ""
+            Format = ""
           }
         }
         Discoverable = true
@@ -469,6 +488,7 @@ examples {
         EdgeKind = "default"
         UpdateMethod = ""
         IndexField = ""
+        Format = ""
       }
       ["Region"] {
         CreateOnly = true
@@ -480,6 +500,7 @@ examples {
         EdgeKind = "default"
         UpdateMethod = ""
         IndexField = ""
+        Format = ""
       }
       ["Tags"] {
         CreateOnly = false
@@ -491,6 +512,7 @@ examples {
         EdgeKind = "default"
         UpdateMethod = ""
         IndexField = ""
+        Format = ""
       }
     }
   }
@@ -513,6 +535,7 @@ examples {
           EdgeKind = "default"
           UpdateMethod = ""
           IndexField = ""
+          Format = ""
         }
         ["Region"] {
           CreateOnly = true
@@ -524,6 +547,7 @@ examples {
           EdgeKind = "default"
           UpdateMethod = ""
           IndexField = ""
+          Format = ""
         }
         ["Tags"] {
           CreateOnly = false
@@ -535,6 +559,7 @@ examples {
           EdgeKind = "default"
           UpdateMethod = ""
           IndexField = ""
+          Format = ""
         }
       }
       Discoverable = true

--- a/pkg/model/schema.go
+++ b/pkg/model/schema.go
@@ -49,6 +49,7 @@ type FieldHint struct {
 
 	IndexField   string            `json:"IndexField" pkl:"IndexField"`
 	UpdateMethod FieldUpdateMethod `json:"UpdateMethod" pkl:"UpdateMethod"`
+	Format       string            `json:"Format" pkl:"Format"` // "" = opaque String; "json" = serialized JSON document (PLA-196)
 }
 
 // UnmarshalJSON normalizes the deprecated AttachesTo alias into EdgeKind so
@@ -107,4 +108,16 @@ func (s Schema) WriteOnly() []string {
 
 func (s Schema) HasProviderDefault() []string {
 	return filterFields(s, func(h FieldHint) bool { return h.HasProviderDefault }, true)
+}
+
+// FormatHints returns field→format for every field whose FieldHint declares a
+// non-empty Format (e.g. {"configJson": "json"}). Empty result when none.
+func (s Schema) FormatHints() map[string]string {
+	out := map[string]string{}
+	for field, h := range s.Hints {
+		if h.Format != "" {
+			out[field] = h.Format
+		}
+	}
+	return out
 }

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -95,3 +95,25 @@ func TestSchema_ParentFields_DefaultsForLegacyJSON(t *testing.T) {
 	require.Equal(t, "", s.Parent)
 	require.Nil(t, s.ParentMappings)
 }
+
+func TestFieldHintFormatRoundTripsThroughJSON(t *testing.T) {
+	raw := `{"Identifier":"X","Fields":["configJson"],"Hints":{"configJson":{"Format":"json"}}}`
+	var s Schema
+	if err := json.Unmarshal([]byte(raw), &s); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.Hints["configJson"].Format; got != "json" {
+		t.Fatalf("Format = %q, want json", got)
+	}
+}
+
+func TestSchemaFormatHints(t *testing.T) {
+	s := Schema{Hints: map[string]FieldHint{
+		"configJson": {Format: "json"},
+		"name":       {CreateOnly: true},
+	}}
+	fh := s.FormatHints()
+	if len(fh) != 1 || fh["configJson"] != "json" {
+		t.Fatalf("FormatHints = %v, want {configJson: json}", fh)
+	}
+}


### PR DESCRIPTION
## Summary

formae core compares a resource's String fields by value. A String field that carries a *serialized structured document* (JSON) reports a perpetual `update` whenever the desired serialization differs from the recorded serialization, even when the content is byte-for-byte identical — e.g. a `GRAFANA::Core::Dashboard.configJson` authored as pretty-printed source JSON versus the plugin's compact, alphabetized, HTML-escaped `Read` output. The plugin can't fix this on its own (its `Read` is already canonical; the desired value arrives from PKL and never passes through the plugin before the compare), and a generic renderer on the desired side can't byte-match Go's `json.Marshal` HTML-escaping. Only core can canonicalize *both* sides with one serializer.

This adds an opt-in schema hint and applies it at two **compare-only** sites:

- **`@formae.FieldHint { format = "json" }`** (`pkg/model` + the PKL annotation) declares that a String field carries a serialized JSON document. Format-valued (not boolean) so other formats can be added later without a schema migration.
- **New `internal/metastructure/canonicalize` package** — a format→canonicalizer registry (v1: `json`). The JSON canonicalizer decodes with `UseNumber()` and re-serializes with `json.Marshal` (sorted keys, compact, array order preserved, large-integer fidelity), and rejects duplicate object keys.
- **Update-diff gate** — canonicalizes Format-hinted fields on both sides into throwaway comparison copies before the equality check. Stored desired state is untouched (string-returning `sjson.Set`, no aliasing).
- **Patch generation** — drops a serialization-only op for a Format-hinted top-level field whose old and new are canonically equal, so a resource that changes for another reason doesn't emit a cosmetic `replace`, and a `createOnly` hinted field doesn't trigger a spurious replacement.
- **Load-time validation** — a plugin announcing an unregistered format is rejected at registration (only that plugin; the coordinator keeps running).

Governing invariant throughout: canonicalization may only ever *suppress a spurious diff*, never *suppress a real change*. On any canonicalizer error or degenerate input (parse failure, duplicate keys, a non-string leaf, a nested/array path) it falls back to the raw comparison — the gate reports a diff, the patch keeps the op.

First consumer is `GRAFANA::Core::Dashboard.configJson`, declared in the grafana plugin separately (gated on this landing).

Tracking: PLA-196 (PLA-151 is the originating symptom).