### PR TITLE
feat(schema): split WriteOnly into WriteOnly + RequiredOnUpdate hints

### DIFF
--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -93,7 +93,7 @@ func generatePatch(document []byte, patch []byte, properties resolver.Resolvable
 		}
 	}
 
-	patchOps, err := createPatchDocument(flattenedDocument, flattenedPatch, schema.Fields, schema.WriteOnly(), schema.HasProviderDefault(), entitySetProviderDefaultsFromHints(schema.Hints), collectionSemanticsFromFieldHints(schema.Hints), defaultIgnoredFields, strategy)
+	patchOps, err := createPatchDocument(flattenedDocument, flattenedPatch, schema.Fields, schema.RequiredOnUpdate(), schema.HasProviderDefault(), entitySetProviderDefaultsFromHints(schema.Hints), collectionSemanticsFromFieldHints(schema.Hints), defaultIgnoredFields, strategy)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create patch document: %w", err)
 	}
@@ -146,18 +146,23 @@ func generatePatch(document []byte, patch []byte, properties resolver.Resolvable
 	return json.RawMessage(patchJson), createOnlyJson, nil
 }
 
-func createPatchDocument(document []byte, patch []byte, schemaFields []string, writeOnlyFields []string, hasProviderDefaultFields []string, entitySetProviderDefaults map[string]string, collections jsonpatch.Collections, ignoredFields []jsonpatch.Path, strategy jsonpatch.PatchStrategy) ([]jsonpatch.JsonPatchOperation, error) {
+func createPatchDocument(document []byte, patch []byte, schemaFields []string, requiredOnUpdateFields []string, hasProviderDefaultFields []string, entitySetProviderDefaults map[string]string, collections jsonpatch.Collections, ignoredFields []jsonpatch.Path, strategy jsonpatch.PatchStrategy) ([]jsonpatch.JsonPatchOperation, error) {
 	patchWithSchemaFieldsOnly, err := removeNonSchemaFields(patch, schemaFields)
 	if err != nil {
 		return nil, err
 	}
 
-	// Remove writeOnly fields from the document (existing state).
-	// WriteOnly fields (like passwords) are never returned by the cloud provider's Read operation,
-	// but Formae stores them. By removing them from the document before comparison,
-	// jsonpatch will generate an "add" operation for these fields, ensuring they're always
-	// included in the patch sent to the cloud provider.
-	documentWithoutWriteOnly, err := removeWriteOnlyFields(document, writeOnlyFields)
+	// Force-resend requiredOnUpdate fields by stripping them from the document
+	// (existing state) before the diff. These are fields the provider mandates
+	// in every update payload (e.g. passwords) even when unchanged. Formae
+	// stores them, so removing them from the document makes jsonpatch emit an
+	// "add" op, guaranteeing they're in the patch sent to the provider.
+	//
+	// This is keyed off requiredOnUpdate, NOT writeOnly: a field can be writeOnly
+	// (excluded from drift detection because Read never returns it) without
+	// being requiredOnUpdate, in which case an unchanged value must produce no
+	// op rather than a phantom re-send.
+	documentForceResent, err := removeWriteOnlyFields(document, requiredOnUpdateFields)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +177,7 @@ func createPatchDocument(document []byte, patch []byte, schemaFields []string, w
 	// invisible to the diff regardless of their value, which is the behavior we
 	// want for a hasProviderDefault annotation on a sub-field of a list
 	// element. See removeProviderDefaultFields for details.
-	patchWithSchemaFieldsOnly, documentWithoutProviderDefaults, err := removeProviderDefaultFieldsBoth(documentWithoutWriteOnly, patchWithSchemaFieldsOnly, hasProviderDefaultFields)
+	patchWithSchemaFieldsOnly, documentWithoutProviderDefaults, err := removeProviderDefaultFieldsBoth(documentForceResent, patchWithSchemaFieldsOnly, hasProviderDefaultFields)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -851,12 +851,13 @@ func TestCollectionSemanticsFromFieldHints(t *testing.T) {
 	assert.Equal(t, expectedCollections, collections)
 }
 
-func TestGeneratePatch_WriteOnlyFieldsGenerateAddOperation(t *testing.T) {
+func TestGeneratePatch_RequiredOnUpdateFieldsGenerateAddOperation(t *testing.T) {
 	// This simulates an AWS CloudControl scenario where:
-	// - Password is a writeOnly field (AWS never returns it)
+	// - Password is writeOnly (AWS never returns it) AND requiredOnUpdate
+	//   (AWS mandates it in every update payload)
 	// - Formae stores the password in its own state
-	// - When generating a patch, we need to always include writeOnly fields
-	//   even if they haven't changed, because AWS doesn't have them
+	// - When generating a patch, requiredOnUpdate fields must be re-added
+	//   even if they haven't changed, because AWS requires them on every update
 
 	// Existing state (what Formae has stored - includes Password)
 	document := []byte(`{
@@ -881,7 +882,8 @@ func TestGeneratePatch_WriteOnlyFieldsGenerateAddOperation(t *testing.T) {
 		Fields: []string{"LoginProfile", "UserName", "Tags"},
 		Hints: map[string]pkgmodel.FieldHint{
 			"LoginProfile.Password": {
-				WriteOnly: true,
+				WriteOnly:        true,
+				RequiredOnUpdate: true,
 			},
 		},
 	}
@@ -897,9 +899,9 @@ func TestGeneratePatch_WriteOnlyFieldsGenerateAddOperation(t *testing.T) {
 
 	// We expect:
 	// 1. An "add" operation for Tags
-	// 2. An "add" operation for LoginProfile/Password (because it's writeOnly and
-	//    must be re-added since AWS CloudControl won't have it in current state)
-	require.Len(t, patches, 2, "Expected 2 operations: one for Tags, one for writeOnly Password")
+	// 2. An "add" operation for LoginProfile/Password (because it's requiredOnUpdate
+	//    and must be re-added since AWS CloudControl won't have it in current state)
+	require.Len(t, patches, 2, "Expected 2 operations: one for Tags, one for requiredOnUpdate Password")
 
 	// Find the operations by path
 	var tagsOp, passwordOp *jsonpatch.JsonPatchOperation
@@ -915,8 +917,8 @@ func TestGeneratePatch_WriteOnlyFieldsGenerateAddOperation(t *testing.T) {
 	assert.NotNil(t, tagsOp, "Should have an operation for Tags")
 	assert.Equal(t, "add", tagsOp.Operation)
 
-	assert.NotNil(t, passwordOp, "Should have an add operation for writeOnly Password")
-	assert.Equal(t, "add", passwordOp.Operation, "WriteOnly fields should use 'add' operation")
+	assert.NotNil(t, passwordOp, "Should have an add operation for requiredOnUpdate Password")
+	assert.Equal(t, "add", passwordOp.Operation, "requiredOnUpdate fields should use 'add' operation")
 	assert.Equal(t, "secret123", passwordOp.Value, "Password value should be preserved")
 }
 
@@ -959,6 +961,46 @@ func TestGeneratePatch_WriteOnlyCreateOnlyFieldsNoPhantomReplacement(t *testing.
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "writeOnly+createOnly field should NOT trigger replacement")
 	assert.Nil(t, patchDoc, "No patch should be generated when only writeOnly+createOnly fields differ")
+}
+
+func TestGeneratePatch_WriteOnlyFieldUnchanged_NoAddOperation(t *testing.T) {
+	// A field that is writeOnly but NOT requiredOnUpdate is excluded from drift
+	// detection (the provider's Read never returns it) yet must not be
+	// force-resent on every update. Formae stores the last-applied value, so
+	// when the stored state and the desired state carry the same value there is
+	// no real change and no patch op should be generated.
+
+	// Existing state (what Formae has stored — includes the writeOnly source).
+	document := []byte(`{
+		"Code": {
+			"S3Bucket": "artifacts",
+			"S3Key": "app.jar"
+		},
+		"FunctionName": "my-func"
+	}`)
+
+	// Desired state (from PKL — same source location, nothing changed).
+	patch := []byte(`{
+		"Code": {
+			"S3Bucket": "artifacts",
+			"S3Key": "app.jar"
+		},
+		"FunctionName": "my-func"
+	}`)
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"Code", "FunctionName"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Code.S3Bucket": {WriteOnly: true},
+			"Code.S3Key":    {WriteOnly: true},
+		},
+	}
+	props := resolver.NewResolvableProperties()
+
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, props, schema, pkgmodel.FormaApplyModePatch)
+	require.NoError(t, err)
+	assert.Empty(t, createOnlyPatch)
+	assert.Nil(t, patchDoc, "writeOnly-only field unchanged should not force an add op")
 }
 
 func TestGeneratePatch_AddTagsWhileRetainingExisting(t *testing.T) {

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -213,6 +213,11 @@ open class FieldHint extends Annotation {
     hidden writeOnly: Boolean = false
     hidden required: Boolean = false
     hidden requiredOnCreate: Boolean = false
+    /// The provider mandates this field in every update payload. When set, the
+    /// patch engine force-resends the field on each update even when its value
+    /// is unchanged (e.g. password-class fields). Distinct from writeOnly,
+    /// which only excludes a field from drift detection.
+    hidden requiredOnUpdate: Boolean = false
     hidden hasProviderDefault: Boolean = false
     hidden attachesTo: Boolean = false           // DEPRECATED; use edgeKind instead
     hidden edgeKind: EdgeKind = "default"        // NEW
@@ -228,6 +233,7 @@ open class FieldHint extends Annotation {
     fixed WriteOnly: Boolean = writeOnly
     fixed Required: Boolean = required
     fixed RequiredOnCreate: Boolean = requiredOnCreate
+    fixed RequiredOnUpdate: Boolean = requiredOnUpdate
     fixed HasProviderDefault: Boolean = hasProviderDefault
     fixed AttachesTo: Boolean = attachesTo
     fixed EdgeKind: String = edgeKind

--- a/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
+++ b/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
@@ -89,6 +89,7 @@ examples {
         WriteOnly = false
         Required = true
         RequiredOnCreate = false
+        RequiredOnUpdate = false
         HasProviderDefault = false
         AttachesTo = false
         EdgeKind = "default"
@@ -100,6 +101,7 @@ examples {
         WriteOnly = false
         Required = false
         RequiredOnCreate = false
+        RequiredOnUpdate = false
         HasProviderDefault = false
         AttachesTo = false
         EdgeKind = "default"
@@ -111,6 +113,7 @@ examples {
         WriteOnly = false
         Required = false
         RequiredOnCreate = false
+        RequiredOnUpdate = false
         HasProviderDefault = false
         AttachesTo = false
         EdgeKind = "default"
@@ -133,6 +136,7 @@ examples {
           WriteOnly = false
           Required = true
           RequiredOnCreate = false
+          RequiredOnUpdate = false
           HasProviderDefault = false
           AttachesTo = false
           EdgeKind = "default"
@@ -144,6 +148,7 @@ examples {
           WriteOnly = false
           Required = false
           RequiredOnCreate = false
+          RequiredOnUpdate = false
           HasProviderDefault = false
           AttachesTo = false
           EdgeKind = "default"
@@ -155,6 +160,7 @@ examples {
           WriteOnly = false
           Required = false
           RequiredOnCreate = false
+          RequiredOnUpdate = false
           HasProviderDefault = false
           AttachesTo = false
           EdgeKind = "default"
@@ -208,6 +214,7 @@ examples {
             WriteOnly = false
             Required = true
             RequiredOnCreate = false
+            RequiredOnUpdate = false
             HasProviderDefault = false
             AttachesTo = false
             EdgeKind = "default"
@@ -219,6 +226,7 @@ examples {
             WriteOnly = false
             Required = false
             RequiredOnCreate = false
+            RequiredOnUpdate = false
             HasProviderDefault = false
             AttachesTo = false
             EdgeKind = "default"
@@ -230,6 +238,7 @@ examples {
             WriteOnly = false
             Required = false
             RequiredOnCreate = false
+            RequiredOnUpdate = false
             HasProviderDefault = false
             AttachesTo = false
             EdgeKind = "default"
@@ -291,6 +300,7 @@ examples {
             WriteOnly = false
             Required = true
             RequiredOnCreate = false
+            RequiredOnUpdate = false
             HasProviderDefault = false
             AttachesTo = false
             EdgeKind = "default"
@@ -302,6 +312,7 @@ examples {
             WriteOnly = false
             Required = false
             RequiredOnCreate = false
+            RequiredOnUpdate = false
             HasProviderDefault = false
             AttachesTo = false
             EdgeKind = "default"
@@ -313,6 +324,7 @@ examples {
             WriteOnly = false
             Required = false
             RequiredOnCreate = false
+            RequiredOnUpdate = false
             HasProviderDefault = false
             AttachesTo = false
             EdgeKind = "default"
@@ -358,6 +370,7 @@ examples {
             WriteOnly = false
             Required = true
             RequiredOnCreate = false
+            RequiredOnUpdate = false
             HasProviderDefault = false
             AttachesTo = false
             EdgeKind = "default"
@@ -369,6 +382,7 @@ examples {
             WriteOnly = false
             Required = true
             RequiredOnCreate = false
+            RequiredOnUpdate = false
             HasProviderDefault = false
             AttachesTo = false
             EdgeKind = "default"
@@ -380,6 +394,7 @@ examples {
             WriteOnly = true
             Required = true
             RequiredOnCreate = false
+            RequiredOnUpdate = false
             HasProviderDefault = false
             AttachesTo = false
             EdgeKind = "default"
@@ -391,6 +406,7 @@ examples {
             WriteOnly = false
             Required = true
             RequiredOnCreate = false
+            RequiredOnUpdate = false
             HasProviderDefault = false
             AttachesTo = false
             EdgeKind = "default"
@@ -402,6 +418,7 @@ examples {
             WriteOnly = false
             Required = true
             RequiredOnCreate = false
+            RequiredOnUpdate = false
             HasProviderDefault = false
             AttachesTo = false
             EdgeKind = "default"
@@ -413,6 +430,7 @@ examples {
             WriteOnly = true
             Required = true
             RequiredOnCreate = false
+            RequiredOnUpdate = false
             HasProviderDefault = false
             AttachesTo = false
             EdgeKind = "default"
@@ -424,6 +442,7 @@ examples {
             WriteOnly = false
             Required = true
             RequiredOnCreate = false
+            RequiredOnUpdate = false
             HasProviderDefault = false
             AttachesTo = false
             EdgeKind = "default"
@@ -464,6 +483,7 @@ examples {
         WriteOnly = false
         Required = true
         RequiredOnCreate = false
+        RequiredOnUpdate = false
         HasProviderDefault = false
         AttachesTo = false
         EdgeKind = "default"
@@ -475,6 +495,7 @@ examples {
         WriteOnly = false
         Required = false
         RequiredOnCreate = false
+        RequiredOnUpdate = false
         HasProviderDefault = false
         AttachesTo = false
         EdgeKind = "default"
@@ -486,6 +507,7 @@ examples {
         WriteOnly = false
         Required = false
         RequiredOnCreate = false
+        RequiredOnUpdate = false
         HasProviderDefault = false
         AttachesTo = false
         EdgeKind = "default"
@@ -508,6 +530,7 @@ examples {
           WriteOnly = false
           Required = true
           RequiredOnCreate = false
+          RequiredOnUpdate = false
           HasProviderDefault = false
           AttachesTo = false
           EdgeKind = "default"
@@ -519,6 +542,7 @@ examples {
           WriteOnly = false
           Required = false
           RequiredOnCreate = false
+          RequiredOnUpdate = false
           HasProviderDefault = false
           AttachesTo = false
           EdgeKind = "default"
@@ -530,6 +554,7 @@ examples {
           WriteOnly = false
           Required = false
           RequiredOnCreate = false
+          RequiredOnUpdate = false
           HasProviderDefault = false
           AttachesTo = false
           EdgeKind = "default"

--- a/pkg/model/schema.go
+++ b/pkg/model/schema.go
@@ -43,6 +43,7 @@ type FieldHint struct {
 	WriteOnly          bool `json:"WriteOnly" pkl:"WriteOnly"`
 	Required           bool `json:"Required" pkl:"Required"`
 	RequiredOnCreate   bool `json:"RequiredOnCreate" pkl:"RequiredOnCreate"`
+	RequiredOnUpdate   bool `json:"RequiredOnUpdate" pkl:"RequiredOnUpdate"`
 	HasProviderDefault bool `json:"HasProviderDefault" pkl:"HasProviderDefault"`
 	AttachesTo         bool     `json:"AttachesTo" pkl:"AttachesTo"` // DEPRECATED: kept for one release; engine derives EdgeKind from this when set.
 	EdgeKind           EdgeKind `json:"EdgeKind" pkl:"EdgeKind"`    // NEW
@@ -103,6 +104,10 @@ func (s Schema) RequiredOnCreate() []string {
 
 func (s Schema) WriteOnly() []string {
 	return filterFields(s, func(h FieldHint) bool { return h.WriteOnly }, true)
+}
+
+func (s Schema) RequiredOnUpdate() []string {
+	return filterFields(s, func(h FieldHint) bool { return h.RequiredOnUpdate }, true)
 }
 
 func (s Schema) HasProviderDefault() []string {

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -53,6 +53,36 @@ func TestFieldHintAttachesToDefaultsFalse(t *testing.T) {
 	assert.False(t, decoded.AttachesTo, "AttachesTo should default false for pre-existing stored schemas")
 }
 
+func TestFieldHint_RequiredOnUpdate_JSONRoundTrip(t *testing.T) {
+	original := FieldHint{WriteOnly: true, RequiredOnUpdate: true}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded FieldHint
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.True(t, decoded.RequiredOnUpdate, "RequiredOnUpdate should round-trip through JSON (raw=%s)", string(data))
+}
+
+func TestFieldHint_RequiredOnUpdate_DefaultsFalseForLegacyJSON(t *testing.T) {
+	// Schemas published before RequiredOnUpdate existed carry only WriteOnly;
+	// they must default RequiredOnUpdate to false so writeOnly fields stop
+	// force-resending rather than silently inheriting the old behavior.
+	var decoded FieldHint
+	require.NoError(t, json.Unmarshal([]byte(`{"WriteOnly":true}`), &decoded))
+	assert.False(t, decoded.RequiredOnUpdate, "RequiredOnUpdate should default false for pre-existing stored schemas")
+}
+
+func TestSchema_RequiredOnUpdate_CollectsTaggedFields(t *testing.T) {
+	s := Schema{
+		Hints: map[string]FieldHint{
+			"LoginProfile.Password": {WriteOnly: true, RequiredOnUpdate: true},
+			"Code.S3Bucket":         {WriteOnly: true},
+		},
+	}
+	assert.ElementsMatch(t, []string{"LoginProfile.Password"}, s.RequiredOnUpdate())
+}
+
 func TestSchema_ParentMappings_Unmarshal(t *testing.T) {
 	var s Schema
 	raw := `{


### PR DESCRIPTION
## Summary

Splits the `WriteOnly` field hint into two single-fact hints so that "the provider's Read never returns this field" (drift exclusion) is decoupled from "the provider mandates this field in every update payload" (force-resend).

Previously the patch engine's force-add keyed off `WriteOnly`, so every write-only field was re-emitted on every update even when unchanged. That made fields like `AWS::Lambda::Function` `Code` (write-only, since no AWS API returns the S3 source location) re-emit `set Code.S3Bucket/S3Key` and trigger a real `UpdateFunctionCode` redeploy on every reconcile.

This adds a separate `RequiredOnUpdate` hint (default off) to `FieldHint` (`internal/schema/pkl/schema/formae.pkl` and `pkg/model/schema.go`) and re-keys the force-add in `removeWriteOnlyFields` off `RequiredOnUpdate` instead of `WriteOnly`. `WriteOnly` now means drift exclusion only; an unchanged field the provider never returns no longer produces a phantom `add` op. Fields the provider genuinely requires on every update (password-class and OIDC secrets) opt in via `RequiredOnUpdate`.