### PR TITLE
feat(cli): add cancel --force to drive stuck commands to terminal Canceled

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -239,6 +239,12 @@ const docTemplate = `{
                         "description": "Optional query string to select commands to cancel. If not provided, cancels the most recent command.",
                         "name": "query",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "If true, abandon in-progress work and drive the command to a terminal 'Canceled' state immediately instead of waiting for in-progress resources to finish. Defaults to false.",
+                        "name": "force",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -735,6 +741,10 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "Forced": {
+                    "description": "Forced is true when the cancellation was requested with --force. The CLI\nuses this to surface the force-cancel warning and the list of resources\nthat were abandoned mid-operation.",
+                    "type": "boolean"
+                },
                 "ResourceUpdateStates": {
                     "type": "object",
                     "additionalProperties": {
@@ -746,6 +756,10 @@ const docTemplate = `{
         "model.CancelResourceState": {
             "type": "object",
             "properties": {
+                "ForceCanceled": {
+                    "description": "ForceCanceled is true when this resource update was force-canceled while an\noperation was actually in progress (it carries an OperationStatusCanceled\nprogress entry). These are the resources whose cloud-side state may be\norphaned and need manual verification.",
+                    "type": "boolean"
+                },
                 "State": {
                     "description": "\"Canceled\", \"InProgress\", \"Success\", \"Failed\"",
                     "type": "string"
@@ -771,14 +785,36 @@ const docTemplate = `{
                 }
             }
         },
+        "model.EdgeKind": {
+            "type": "string",
+            "enum": [
+                "default",
+                "attachesTo",
+                "runtimeDependency"
+            ],
+            "x-enum-varnames": [
+                "EdgeKindDefault",
+                "EdgeKindAttachesTo",
+                "EdgeKindRuntimeDependency"
+            ]
+        },
         "model.FieldHint": {
             "type": "object",
             "properties": {
                 "AttachesTo": {
+                    "description": "DEPRECATED: kept for one release; engine derives EdgeKind from this when set.",
                     "type": "boolean"
                 },
                 "CreateOnly": {
                     "type": "boolean"
+                },
+                "EdgeKind": {
+                    "description": "NEW",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.EdgeKind"
+                        }
+                    ]
                 },
                 "HasProviderDefault": {
                     "type": "boolean"
@@ -790,6 +826,9 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "RequiredOnCreate": {
+                    "type": "boolean"
+                },
+                "RequiredOnUpdate": {
                     "type": "boolean"
                 },
                 "UpdateMethod": {
@@ -957,6 +996,17 @@ const docTemplate = `{
                 }
             }
         },
+        "model.ParentMapping": {
+            "type": "object",
+            "properties": {
+                "childProperty": {
+                    "type": "string"
+                },
+                "parentProperty": {
+                    "type": "string"
+                }
+            }
+        },
         "model.PluginInfo": {
             "type": "object",
             "properties": {
@@ -1097,6 +1147,10 @@ const docTemplate = `{
         "model.Resource": {
             "type": "object",
             "properties": {
+                "Alias": {
+                    "description": "RFC-0041: previous label, used to rename in place",
+                    "type": "string"
+                },
                 "Group": {
                     "type": "string"
                 },
@@ -1198,6 +1252,10 @@ const docTemplate = `{
                 "NativeId": {
                     "type": "string"
                 },
+                "OldLabel": {
+                    "description": "OldLabel is the resource's previous label. Populated only when a\nlabel rename is part of this update (RFC-0041 alias path); empty\notherwise. The renderer uses it to surface the rename to the user.",
+                    "type": "string"
+                },
                 "OldProperties": {
                     "type": "array",
                     "items": {
@@ -1285,6 +1343,17 @@ const docTemplate = `{
                 },
                 "Identifier": {
                     "type": "string"
+                },
+                "Parent": {
+                    "description": "NEW: from ResourceHint.parent; \"\" when unset.",
+                    "type": "string"
+                },
+                "ParentMappings": {
+                    "description": "NEW: from ResourceHint.parentRefs[*]; nil when unset.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ParentMapping"
+                    }
                 },
                 "Portable": {
                     "type": "boolean"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -233,6 +233,12 @@
                         "description": "Optional query string to select commands to cancel. If not provided, cancels the most recent command.",
                         "name": "query",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "If true, abandon in-progress work and drive the command to a terminal 'Canceled' state immediately instead of waiting for in-progress resources to finish. Defaults to false.",
+                        "name": "force",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -729,6 +735,10 @@
                         "type": "string"
                     }
                 },
+                "Forced": {
+                    "description": "Forced is true when the cancellation was requested with --force. The CLI\nuses this to surface the force-cancel warning and the list of resources\nthat were abandoned mid-operation.",
+                    "type": "boolean"
+                },
                 "ResourceUpdateStates": {
                     "type": "object",
                     "additionalProperties": {
@@ -740,6 +750,10 @@
         "model.CancelResourceState": {
             "type": "object",
             "properties": {
+                "ForceCanceled": {
+                    "description": "ForceCanceled is true when this resource update was force-canceled while an\noperation was actually in progress (it carries an OperationStatusCanceled\nprogress entry). These are the resources whose cloud-side state may be\norphaned and need manual verification.",
+                    "type": "boolean"
+                },
                 "State": {
                     "description": "\"Canceled\", \"InProgress\", \"Success\", \"Failed\"",
                     "type": "string"
@@ -765,14 +779,36 @@
                 }
             }
         },
+        "model.EdgeKind": {
+            "type": "string",
+            "enum": [
+                "default",
+                "attachesTo",
+                "runtimeDependency"
+            ],
+            "x-enum-varnames": [
+                "EdgeKindDefault",
+                "EdgeKindAttachesTo",
+                "EdgeKindRuntimeDependency"
+            ]
+        },
         "model.FieldHint": {
             "type": "object",
             "properties": {
                 "AttachesTo": {
+                    "description": "DEPRECATED: kept for one release; engine derives EdgeKind from this when set.",
                     "type": "boolean"
                 },
                 "CreateOnly": {
                     "type": "boolean"
+                },
+                "EdgeKind": {
+                    "description": "NEW",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.EdgeKind"
+                        }
+                    ]
                 },
                 "HasProviderDefault": {
                     "type": "boolean"
@@ -784,6 +820,9 @@
                     "type": "boolean"
                 },
                 "RequiredOnCreate": {
+                    "type": "boolean"
+                },
+                "RequiredOnUpdate": {
                     "type": "boolean"
                 },
                 "UpdateMethod": {
@@ -951,6 +990,17 @@
                 }
             }
         },
+        "model.ParentMapping": {
+            "type": "object",
+            "properties": {
+                "childProperty": {
+                    "type": "string"
+                },
+                "parentProperty": {
+                    "type": "string"
+                }
+            }
+        },
         "model.PluginInfo": {
             "type": "object",
             "properties": {
@@ -1091,6 +1141,10 @@
         "model.Resource": {
             "type": "object",
             "properties": {
+                "Alias": {
+                    "description": "RFC-0041: previous label, used to rename in place",
+                    "type": "string"
+                },
                 "Group": {
                     "type": "string"
                 },
@@ -1192,6 +1246,10 @@
                 "NativeId": {
                     "type": "string"
                 },
+                "OldLabel": {
+                    "description": "OldLabel is the resource's previous label. Populated only when a\nlabel rename is part of this update (RFC-0041 alias path); empty\notherwise. The renderer uses it to surface the rename to the user.",
+                    "type": "string"
+                },
                 "OldProperties": {
                     "type": "array",
                     "items": {
@@ -1279,6 +1337,17 @@
                 },
                 "Identifier": {
                     "type": "string"
+                },
+                "Parent": {
+                    "description": "NEW: from ResourceHint.parent; \"\" when unset.",
+                    "type": "string"
+                },
+                "ParentMappings": {
+                    "description": "NEW: from ResourceHint.parentRefs[*]; nil when unset.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.ParentMapping"
+                    }
                 },
                 "Portable": {
                     "type": "boolean"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -49,6 +49,12 @@ definitions:
         items:
           type: string
         type: array
+      Forced:
+        description: |-
+          Forced is true when the cancellation was requested with --force. The CLI
+          uses this to surface the force-cancel warning and the list of resources
+          that were abandoned mid-operation.
+        type: boolean
       ResourceUpdateStates:
         additionalProperties:
           $ref: '#/definitions/model.CancelResourceState'
@@ -56,6 +62,13 @@ definitions:
     type: object
   model.CancelResourceState:
     properties:
+      ForceCanceled:
+        description: |-
+          ForceCanceled is true when this resource update was force-canceled while an
+          operation was actually in progress (it carries an OperationStatusCanceled
+          progress entry). These are the resources whose cloud-side state may be
+          orphaned and need manual verification.
+        type: boolean
       State:
         description: '"Canceled", "InProgress", "Success", "Failed"'
         type: string
@@ -72,12 +85,28 @@ definitions:
           $ref: '#/definitions/model.ConfigFieldHint'
         type: object
     type: object
+  model.EdgeKind:
+    enum:
+    - default
+    - attachesTo
+    - runtimeDependency
+    type: string
+    x-enum-varnames:
+    - EdgeKindDefault
+    - EdgeKindAttachesTo
+    - EdgeKindRuntimeDependency
   model.FieldHint:
     properties:
       AttachesTo:
+        description: 'DEPRECATED: kept for one release; engine derives EdgeKind from
+          this when set.'
         type: boolean
       CreateOnly:
         type: boolean
+      EdgeKind:
+        allOf:
+        - $ref: '#/definitions/model.EdgeKind'
+        description: NEW
       HasProviderDefault:
         type: boolean
       IndexField:
@@ -85,6 +114,8 @@ definitions:
       Required:
         type: boolean
       RequiredOnCreate:
+        type: boolean
+      RequiredOnUpdate:
         type: boolean
       UpdateMethod:
         $ref: '#/definitions/model.FieldUpdateMethod'
@@ -214,6 +245,13 @@ definitions:
           $ref: '#/definitions/model.ResourceModification'
         type: array
     type: object
+  model.ParentMapping:
+    properties:
+      childProperty:
+        type: string
+      parentProperty:
+        type: string
+    type: object
   model.PluginInfo:
     properties:
       DiscoveryFilters:
@@ -308,6 +346,9 @@ definitions:
     type: object
   model.Resource:
     properties:
+      Alias:
+        description: 'RFC-0041: previous label, used to rename in place'
+        type: string
       Group:
         type: string
       Ksuid:
@@ -382,6 +423,12 @@ definitions:
         type: integer
       NativeId:
         type: string
+      OldLabel:
+        description: |-
+          OldLabel is the resource's previous label. Populated only when a
+          label rename is part of this update (RFC-0041 alias path); empty
+          otherwise. The renderer uses it to surface the rename to the user.
+        type: string
       OldProperties:
         items:
           type: integer
@@ -440,6 +487,14 @@ definitions:
         type: object
       Identifier:
         type: string
+      Parent:
+        description: 'NEW: from ResourceHint.parent; "" when unset.'
+        type: string
+      ParentMappings:
+        description: 'NEW: from ResourceHint.parentRefs[*]; nil when unset.'
+        items:
+          $ref: '#/definitions/model.ParentMapping'
+        type: array
       Portable:
         type: boolean
     type: object
@@ -790,6 +845,12 @@ paths:
         in: query
         name: query
         type: string
+      - description: If true, abandon in-progress work and drive the command to a
+          terminal 'Canceled' state immediately instead of waiting for in-progress
+          resources to finish. Defaults to false.
+        in: query
+        name: force
+        type: boolean
       produces:
       - application/json
       responses:

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -210,7 +210,7 @@ func (c *Client) DestroyByQuery(query string, simulate bool, clientID string) (*
 	}
 }
 
-func (c *Client) CancelCommands(query string, clientID string) (*apimodel.CancelCommandResponse, error) {
+func (c *Client) CancelCommands(query string, force bool, clientID string) (*apimodel.CancelCommandResponse, error) {
 	var result apimodel.CancelCommandResponse
 
 	req := c.resty.R().
@@ -219,6 +219,9 @@ func (c *Client) CancelCommands(query string, clientID string) (*apimodel.Cancel
 
 	if query != "" {
 		req.SetQueryParam("query", query)
+	}
+	if force {
+		req.SetQueryParam("force", "true")
 	}
 
 	resp, err := req.Post(c.endpoint + "/api/v1/commands/cancel")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -762,6 +762,7 @@ func mapError(c echo.Context, err error) error {
 // @Produce json
 // @Param Client-ID header string true "Unique identifier for the client."
 // @Param query query string false "Optional query string to select commands to cancel. If not provided, cancels the most recent command."
+// @Param force query boolean false "If true, abandon in-progress work and drive the command to a terminal 'Canceled' state immediately instead of waiting for in-progress resources to finish. Defaults to false."
 // @Success 202 {object} apimodel.CancelCommandResponse "Accepted: Commands are being canceled."
 // @Success 404 {string} string "Not Found: No in-progress commands found to cancel."
 // @Failure 400 {string} string "Bad Request: Invalid query or missing Client-ID."
@@ -774,8 +775,9 @@ func (s *Server) CancelCommands(c echo.Context) error {
 	}
 
 	query := c.QueryParam("query")
+	force := c.QueryParam("force") == "true"
 
-	result, err := s.metastructure.CancelCommandsByQuery(query, clientID)
+	result, err := s.metastructure.CancelCommandsByQuery(query, force, clientID)
 	if err != nil {
 		return mapError(c, err)
 	}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -98,11 +98,11 @@ func (m *FakeMetastructure) DestroyByQuery(query string, config *config.FormaCom
 	return nextResponse.SubmitCommandResponse, nextResponse.Error
 }
 
-func (m *FakeMetastructure) CancelCommand(commandID string, clientID string) (*changeset.CancelResponse, error) {
+func (m *FakeMetastructure) CancelCommand(commandID string, force bool, clientID string) (*changeset.CancelResponse, error) {
 	return nil, nil
 }
 
-func (m *FakeMetastructure) CancelCommandsByQuery(query string, clientID string) (*apimodel.CancelCommandResponse, error) {
+func (m *FakeMetastructure) CancelCommandsByQuery(query string, force bool, clientID string) (*apimodel.CancelCommandResponse, error) {
 	nextResponse := m.cancelResponses[0]
 	m.cancelResponses = m.cancelResponses[1:]
 

--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -276,7 +276,7 @@ func (a *App) Destroy(path string, query string, props map[string]string, simula
 	return resp, nags, nil
 }
 
-func (a *App) CancelCommand(query string) (*apimodel.CancelCommandResponse, error) {
+func (a *App) CancelCommand(query string, force bool) (*apimodel.CancelCommandResponse, error) {
 	auth, net, err := a.getAuthAndNetHandlers()
 	if err != nil {
 		return nil, err
@@ -293,7 +293,7 @@ func (a *App) CancelCommand(query string) (*apimodel.CancelCommandResponse, erro
 		return nil, err
 	}
 
-	res, err := client.CancelCommands(query, clientID)
+	res, err := client.CancelCommands(query, force, clientID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/cancel/cancel.go
+++ b/internal/cli/cancel/cancel.go
@@ -24,6 +24,7 @@ import (
 
 type CancelOptions struct {
 	Query          string
+	Force          bool
 	Watch          bool
 	StatusOutput   status.StatusOutput
 	OutputConsumer printer.Consumer
@@ -41,7 +42,18 @@ If a query is provided, cancels all in-progress commands matching the query.
 
 Note: Only commands in 'InProgress' state can be canceled.
 Commands that are already executing resources will complete those resources
-before transitioning to 'Canceled' state to avoid orphaned resources.`,
+before transitioning to 'Canceled' state to avoid orphaned resources.
+
+Use --force to abandon in-progress work and drive the command to a terminal
+'Canceled' state immediately, instead of waiting for in-progress resources to
+finish. This is an escape hatch for operations that will not complete (e.g. a
+plugin stuck in an unbounded poll loop). With --force:
+  - Cloud-side operations may keep running after the command is canceled.
+  - Update/Delete operations are self-healing: the synchronizer reconciles
+    formae's state against actual cloud state on its next cycle.
+  - A still-running Create may orphan a cloud resource that formae cannot track
+    (it has no native id yet). You may need to clean it up manually, or let
+    discovery pick it up.`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			logging.SetupClientLogging(fmt.Sprintf("%s/log/client.log", config.Config.DataDirectory()))
 		},
@@ -49,6 +61,7 @@ before transitioning to 'Canceled' state to avoid orphaned resources.`,
 			opts := &CancelOptions{}
 			query, _ := command.Flags().GetString("query")
 			opts.Query = strings.TrimSpace(query)
+			opts.Force, _ = command.Flags().GetBool("force")
 			opts.Watch, _ = command.Flags().GetBool("watch")
 			statusOutput, _ := command.Flags().GetString("status-output-layout")
 			opts.StatusOutput = status.StatusOutput(statusOutput)
@@ -72,6 +85,7 @@ before transitioning to 'Canceled' state to avoid orphaned resources.`,
 	command.SetUsageTemplate(cmd.SimpleCmdUsageTemplate)
 
 	command.Flags().String("query", "", "Query to select commands to cancel. If not provided, cancels the most recent command. Use * as a wildcard anywhere (e.g. foo*, *foo, *foo*, foo*bar). ? and regex are not yet supported.")
+	command.Flags().Bool("force", false, "Abandon in-progress work and drive the command to a terminal 'Canceled' state immediately, instead of waiting for in-progress resources to finish. Cloud-side operations may continue: Update/Delete are reconciled by the synchronizer, but a still-running Create may orphan a resource that needs manual cleanup.")
 	command.Flags().BoolP("watch", "w", false, "Watch the status of canceled commands until they complete")
 	command.Flags().String("status-output-layout", string(status.StatusOutputSummary), fmt.Sprintf("What to print as status output (%s | %s)", status.StatusOutputSummary, status.StatusOutputDetailed))
 	command.Flags().String("output-consumer", string(printer.ConsumerHuman), "Consumer of the command result (human | machine)")
@@ -108,7 +122,7 @@ func runCancel(app *app.App, opts *CancelOptions) error {
 func runCancelForHumans(app *app.App, opts *CancelOptions) error {
 	app.PrintBanner()
 
-	res, err := app.CancelCommand(opts.Query)
+	res, err := app.CancelCommand(opts.Query, opts.Force)
 	if err != nil {
 		msg, renderErr := renderer.RenderErrorMessage(err)
 		if renderErr != nil {
@@ -160,7 +174,7 @@ func runCancelForHumans(app *app.App, opts *CancelOptions) error {
 }
 
 func runCancelForMachines(app *app.App, opts *CancelOptions) error {
-	res, err := app.CancelCommand(opts.Query)
+	res, err := app.CancelCommand(opts.Query, opts.Force)
 	if err != nil {
 		return fmt.Errorf("error canceling commands: %v", err)
 	}

--- a/internal/cli/cancel/cancel.go
+++ b/internal/cli/cancel/cancel.go
@@ -16,6 +16,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/cli/config"
 	"github.com/platform-engineering-labs/formae/internal/cli/display"
 	"github.com/platform-engineering-labs/formae/internal/cli/printer"
+	"github.com/platform-engineering-labs/formae/internal/cli/prompter"
 	"github.com/platform-engineering-labs/formae/internal/cli/renderer"
 	"github.com/platform-engineering-labs/formae/internal/cli/status"
 	"github.com/platform-engineering-labs/formae/internal/logging"
@@ -25,6 +26,7 @@ import (
 type CancelOptions struct {
 	Query          string
 	Force          bool
+	Yes            bool
 	Watch          bool
 	StatusOutput   status.StatusOutput
 	OutputConsumer printer.Consumer
@@ -62,6 +64,7 @@ plugin stuck in an unbounded poll loop). With --force:
 			query, _ := command.Flags().GetString("query")
 			opts.Query = strings.TrimSpace(query)
 			opts.Force, _ = command.Flags().GetBool("force")
+			opts.Yes, _ = command.Flags().GetBool("yes")
 			opts.Watch, _ = command.Flags().GetBool("watch")
 			statusOutput, _ := command.Flags().GetString("status-output-layout")
 			opts.StatusOutput = status.StatusOutput(statusOutput)
@@ -86,6 +89,7 @@ plugin stuck in an unbounded poll loop). With --force:
 
 	command.Flags().String("query", "", "Query to select commands to cancel. If not provided, cancels the most recent command. Use * as a wildcard anywhere (e.g. foo*, *foo, *foo*, foo*bar). ? and regex are not yet supported.")
 	command.Flags().Bool("force", false, "Abandon in-progress work and drive the command to a terminal 'Canceled' state immediately, instead of waiting for in-progress resources to finish. Cloud-side operations may continue: Update/Delete are reconciled by the synchronizer, but a still-running Create may orphan a resource that needs manual cleanup.")
+	command.Flags().Bool("yes", false, "Allow the command to run without any confirmations")
 	command.Flags().BoolP("watch", "w", false, "Watch the status of canceled commands until they complete")
 	command.Flags().String("status-output-layout", string(status.StatusOutputSummary), fmt.Sprintf("What to print as status output (%s | %s)", status.StatusOutputSummary, status.StatusOutputDetailed))
 	command.Flags().String("output-consumer", string(printer.ConsumerHuman), "Consumer of the command result (human | machine)")
@@ -121,6 +125,33 @@ func runCancel(app *app.App, opts *CancelOptions) error {
 
 func runCancelForHumans(app *app.App, opts *CancelOptions) error {
 	app.PrintBanner()
+
+	// A plain cancel is safe (it waits for in-progress resources to finish). A
+	// --force cancel is a destructive escape hatch: it abandons in-progress work,
+	// can leave cloud-side operations running, and may orphan resources. Confirm
+	// before proceeding unless --yes was given.
+	if opts.Force && !opts.Yes {
+		target := "the most recent in-progress command"
+		if opts.Query != "" {
+			target = fmt.Sprintf("all in-progress commands matching %q", opts.Query)
+		}
+		prompt := fmt.Sprintf(
+			"%s\n\n"+
+				"This abandons in-progress work and drives %s straight to 'Canceled' "+
+				"without waiting for running resources to finish.\n\n"+
+				"  • Cloud-side operations already in flight may keep running.\n"+
+				"  • A still-running Create can orphan a resource formae cannot track — manual cleanup may be needed.\n"+
+				"  • Update/Delete operations are reconciled by the synchronizer on its next cycle.\n\n"+
+				"Only use this for operations that will not complete on their own.\n\n"+
+				"Force-cancel anyway?",
+			display.Gold("Warning: --force is a destructive escape hatch."),
+			target,
+		)
+		if !prompter.NewBasicPrompter().Confirm(prompt, false) {
+			fmt.Print(display.Red("\nCommand aborted\n"))
+			return nil
+		}
+	}
 
 	res, err := app.CancelCommand(opts.Query, opts.Force)
 	if err != nil {

--- a/internal/cli/renderer/renderer.go
+++ b/internal/cli/renderer/renderer.go
@@ -1584,9 +1584,37 @@ func RenderCancelCommandResponse(response *apimodel.CancelCommandResponse) (stri
 		return display.Gold("No commands to cancel.\n"), nil
 	}
 
-	buf.WriteString(display.Gold("Commands are being canceled:\n\n"))
+	if response.Forced {
+		buf.WriteString(display.Gold("Commands have been force-canceled:\n\n"))
+	} else {
+		buf.WriteString(display.Gold("Commands are being canceled:\n\n"))
+	}
 	for _, cmdID := range response.CommandIDs {
 		fmt.Fprintf(&buf, "  %s %s\n", display.Green("•"), cmdID)
+	}
+
+	if response.Forced {
+		// Collect the resources that were abandoned mid-operation. These are the
+		// ones whose cloud-side state may now be orphaned.
+		var forceCanceled []string
+		for uri, rs := range response.ResourceUpdateStates {
+			if rs.ForceCanceled {
+				forceCanceled = append(forceCanceled, uri)
+			}
+		}
+		sort.Strings(forceCanceled)
+
+		if len(forceCanceled) > 0 {
+			fmt.Fprintf(&buf, "\n%s\n", display.Gold("The following resources were abandoned mid-operation and may exist in your cloud provider:"))
+			for _, uri := range forceCanceled {
+				fmt.Fprintf(&buf, "  %s %s\n", display.Gold("⚠"), uri)
+			}
+		}
+
+		fmt.Fprintf(&buf, "\n%s\n", display.Grey("Force-cancel abandons in-progress work; cloud-side operations may still be running."))
+		fmt.Fprintf(&buf, "%s\n", display.Grey("Update/Delete operations are reconciled by the synchronizer on its next cycle."))
+		fmt.Fprintf(&buf, "%s\n", display.Grey("A still-running Create may orphan a resource: verify the resources above in your"))
+		fmt.Fprintf(&buf, "%s\n", display.Grey("cloud provider and clean up manually, or let discovery pick them up."))
 	}
 
 	fmt.Fprintf(&buf, "\n%s\n", display.Grey("Use 'formae status' to check the cancellation progress."))

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -3063,6 +3063,7 @@ func (d *DatastoreAuroraDataAPI) UpdateResourceUpdateState(commandID string, ksu
 	UPDATE resource_updates
 	SET state = :state, modified_ts = :modified_ts::timestamp
 	WHERE command_id = :command_id AND ksuid = :ksuid AND operation = :operation
+	  AND state NOT IN ('Success','Failed','Rejected','Canceled')
 	`
 	params := []types.SqlParameter{
 		{Name: aws.String("state"), Value: &types.FieldMemberStringValue{Value: string(state)}},
@@ -3078,7 +3079,8 @@ func (d *DatastoreAuroraDataAPI) UpdateResourceUpdateState(commandID string, ksu
 	}
 
 	if output.NumberOfRecordsUpdated == 0 {
-		return fmt.Errorf("resource update not found: command_id=%s, ksuid=%s, operation=%s", commandID, ksuid, operation)
+		slog.Debug("UpdateResourceUpdateState: row already in terminal state or not found, no-op", "commandID", commandID, "ksuid", ksuid)
+		return nil
 	}
 
 	return nil
@@ -3166,6 +3168,7 @@ func (d *DatastoreAuroraDataAPI) BatchUpdateResourceUpdateState(commandID string
 		UPDATE resource_updates
 		SET state = :state, modified_ts = :modified_ts::timestamp
 		WHERE command_id = :command_id AND ksuid = :ksuid AND operation = :operation
+		  AND state NOT IN ('Success','Failed','Rejected','Canceled')
 		`
 		params := []types.SqlParameter{
 			{Name: aws.String("state"), Value: &types.FieldMemberStringValue{Value: string(state)}},

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -4658,3 +4658,82 @@ func (d *DatastoreAuroraDataAPI) CleanUp() error {
 
 	return nil
 }
+
+// ForceCancelResourceUpdates CAS-terminalizes in-flight resource updates to Canceled in one
+// transaction. For InProgress rows it also writes force-cancel progress. Returns the rows
+// transitioned (split by prior state) and those already terminal (Skipped). Idempotent.
+// On an ambiguous commit error the method returns an error so the caller can retry.
+func (d *DatastoreAuroraDataAPI) ForceCancelResourceUpdates(commandID string, inProgress []datastore.ForceCancelRow, notStarted []datastore.ResourceUpdateRef, modifiedTs time.Time) (datastore.ForceCancelResult, error) {
+	ctx := context.Background()
+	var result datastore.ForceCancelResult
+
+	if len(inProgress) == 0 && len(notStarted) == 0 {
+		return result, nil
+	}
+
+	txID, err := d.beginTransaction(ctx)
+	if err != nil {
+		return result, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	modifiedTsStr := modifiedTs.UTC().Format(time.RFC3339Nano)
+
+	for _, row := range inProgress {
+		ref := datastore.ResourceUpdateRef{KSUID: row.KSUID, Operation: row.Operation}
+		query := `
+		UPDATE resource_updates
+		SET state = 'Canceled', modified_ts = :modified_ts::timestamp,
+		    progress_result = :progress_result, most_recent_progress = :most_recent_progress
+		WHERE command_id = :command_id AND ksuid = :ksuid AND operation = :operation AND state = 'InProgress'
+		`
+		params := []types.SqlParameter{
+			{Name: aws.String("modified_ts"), Value: &types.FieldMemberStringValue{Value: modifiedTsStr}},
+			{Name: aws.String("progress_result"), Value: &types.FieldMemberStringValue{Value: string(row.ProgressJSON)}},
+			{Name: aws.String("most_recent_progress"), Value: &types.FieldMemberStringValue{Value: string(row.MostRecentProgressJSON)}},
+			{Name: aws.String("command_id"), Value: &types.FieldMemberStringValue{Value: commandID}},
+			{Name: aws.String("ksuid"), Value: &types.FieldMemberStringValue{Value: row.KSUID}},
+			{Name: aws.String("operation"), Value: &types.FieldMemberStringValue{Value: string(row.Operation)}},
+		}
+		out, execErr := d.executeStatementInTransaction(ctx, txID, query, params)
+		if execErr != nil {
+			_ = d.rollbackTransaction(ctx, txID)
+			return result, fmt.Errorf("failed to force-cancel InProgress row %s: %w", row.KSUID, execErr)
+		}
+		if out.NumberOfRecordsUpdated > 0 {
+			result.CanceledInProgress = append(result.CanceledInProgress, ref)
+		} else {
+			result.Skipped = append(result.Skipped, ref)
+		}
+	}
+
+	for _, ref := range notStarted {
+		query := `
+		UPDATE resource_updates
+		SET state = 'Canceled', modified_ts = :modified_ts::timestamp
+		WHERE command_id = :command_id AND ksuid = :ksuid AND operation = :operation AND state = 'NotStarted'
+		`
+		params := []types.SqlParameter{
+			{Name: aws.String("modified_ts"), Value: &types.FieldMemberStringValue{Value: modifiedTsStr}},
+			{Name: aws.String("command_id"), Value: &types.FieldMemberStringValue{Value: commandID}},
+			{Name: aws.String("ksuid"), Value: &types.FieldMemberStringValue{Value: ref.KSUID}},
+			{Name: aws.String("operation"), Value: &types.FieldMemberStringValue{Value: string(ref.Operation)}},
+		}
+		out, execErr := d.executeStatementInTransaction(ctx, txID, query, params)
+		if execErr != nil {
+			_ = d.rollbackTransaction(ctx, txID)
+			return result, fmt.Errorf("failed to force-cancel NotStarted row %s: %w", ref.KSUID, execErr)
+		}
+		if out.NumberOfRecordsUpdated > 0 {
+			result.CanceledNotStarted = append(result.CanceledNotStarted, ref)
+		} else {
+			result.Skipped = append(result.Skipped, ref)
+		}
+	}
+
+	if err := d.commitTransaction(ctx, txID); err != nil {
+		// Ambiguous commit: return error so caller can retry.
+		return result, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -91,6 +91,26 @@ type ResourceUpdateRef struct {
 	Operation types.OperationType
 }
 
+// ForceCancelRow is an in-progress resource update that should be force-canceled.
+// It carries the progress JSON to append to the row's progress_result, and the
+// serialized most-recent-progress entry to store as most_recent_progress.
+type ForceCancelRow struct {
+	KSUID                  string
+	Operation              types.OperationType
+	ProgressJSON           json.RawMessage // full serialized []plugin.TrackedProgress to write as progress_result
+	MostRecentProgressJSON json.RawMessage // serialized plugin.TrackedProgress to write as most_recent_progress
+}
+
+// ForceCancelResult reports the outcome of a ForceCancelResourceUpdates call.
+type ForceCancelResult struct {
+	// CanceledInProgress are rows whose prior state was InProgress and are now Canceled.
+	CanceledInProgress []ResourceUpdateRef
+	// CanceledNotStarted are rows whose prior state was NotStarted and are now Canceled.
+	CanceledNotStarted []ResourceUpdateRef
+	// Skipped are rows that were already in a terminal state (CAS no-op).
+	Skipped []ResourceUpdateRef
+}
+
 // ExpiredStackInfo contains information about a stack whose TTL policy has expired.
 type ExpiredStackInfo struct {
 	StackLabel   string
@@ -298,4 +318,11 @@ type Datastore interface {
 	// (state, modified_ts) without re-writing ResourceUpdates. Used by markTargetUpdateAsComplete
 	// to persist target state changes that would otherwise only live in the in-memory cache.
 	UpdateFormaCommandTargetUpdates(commandID string, targetUpdatesJSON json.RawMessage, state forma_command.CommandState, modifiedTs time.Time) error
+
+	// ForceCancelResourceUpdates CAS-terminalizes in-flight resource updates to Canceled in one
+	// transaction. For rows whose prior state was InProgress it also writes the provided progress
+	// JSON (force-cancel marker) and most_recent_progress. Returns the rows actually transitioned
+	// (split by prior state) and the intended rows that were already terminal (Skipped). Idempotent:
+	// a retry affects zero rows and returns the same Skipped set.
+	ForceCancelResourceUpdates(commandID string, inProgress []ForceCancelRow, notStarted []ResourceUpdateRef, modifiedTs time.Time) (ForceCancelResult, error)
 }

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -38,6 +38,9 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunGetMostRecentNonReconcileFormaCommandsByStack(t, newDS)
 	RunQueryFormaCommands(t, newDS)
 	RunQueryFormaCommands_StackWildcardEscape(t, newDS)
+	RunTerminalStatesLiteralsTest(t, newDS)
+	RunMonotonicTerminalityTest(t, newDS)
+	RunMonotonicTerminalityRaceTest(t, newDS)
 
 	RunStoreResource(t, newDS)
 	RunUpdateResource(t, newDS)

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -41,6 +41,7 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunTerminalStatesLiteralsTest(t, newDS)
 	RunMonotonicTerminalityTest(t, newDS)
 	RunMonotonicTerminalityRaceTest(t, newDS)
+	RunForceCancelResourceUpdatesTest(t, newDS)
 
 	RunStoreResource(t, newDS)
 	RunUpdateResource(t, newDS)

--- a/internal/datastore/dstest/suite_forma_commands.go
+++ b/internal/datastore/dstest/suite_forma_commands.go
@@ -787,6 +787,128 @@ func RunMonotonicTerminalityTest(t *testing.T, newDS func(t *testing.T) TestData
 	})
 }
 
+// RunForceCancelResourceUpdatesTest verifies ForceCancelResourceUpdates:
+//   - transitions InProgress+NotStarted rows to Canceled
+//   - writes force-cancel progress for the InProgress row
+//   - leaves already-terminal rows untouched and reports them in Skipped
+//   - is idempotent: a second call makes zero further changes
+func RunForceCancelResourceUpdatesTest(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("ForceCancelResourceUpdates", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		inProgressKsuid := util.NewID()
+		notStartedKsuid := util.NewID()
+		successKsuid := util.NewID()
+
+		cmd := &forma_command.FormaCommand{
+			ID:          util.NewID(),
+			Command:     pkgmodel.CommandApply,
+			State:       forma_command.CommandStateInProgress,
+			Description: pkgmodel.Description{},
+			ResourceUpdates: []resource_update.ResourceUpdate{
+				{
+					DesiredState:   pkgmodel.Resource{Ksuid: inProgressKsuid, Properties: json.RawMessage("{}")},
+					ResourceTarget: pkgmodel.Target{Label: "t", Namespace: "default", Config: json.RawMessage("{}")},
+					Operation:      resource_update.OperationCreate,
+					State:          resource_update.ResourceUpdateStateInProgress,
+				},
+				{
+					DesiredState:   pkgmodel.Resource{Ksuid: notStartedKsuid, Properties: json.RawMessage("{}")},
+					ResourceTarget: pkgmodel.Target{Label: "t", Namespace: "default", Config: json.RawMessage("{}")},
+					Operation:      resource_update.OperationCreate,
+					State:          resource_update.ResourceUpdateStateNotStarted,
+				},
+				{
+					DesiredState:   pkgmodel.Resource{Ksuid: successKsuid, Properties: json.RawMessage("{}")},
+					ResourceTarget: pkgmodel.Target{Label: "t", Namespace: "default", Config: json.RawMessage("{}")},
+					Operation:      resource_update.OperationCreate,
+					State:          resource_update.ResourceUpdateStateSuccess,
+				},
+			},
+		}
+		err := ds.StoreFormaCommand(cmd, cmd.ID)
+		assert.NoError(t, err)
+
+		// Build the force-cancel progress JSON for the InProgress row.
+		forceCancelProgress := plugin.TrackedProgress{
+			ProgressResult: pkgresource.ProgressResult{
+				StatusMessage: "force-canceled",
+			},
+		}
+		progressList := []plugin.TrackedProgress{forceCancelProgress}
+		progressJSON, err := json.Marshal(progressList)
+		assert.NoError(t, err)
+		mostRecentJSON, err := json.Marshal(forceCancelProgress)
+		assert.NoError(t, err)
+
+		inProgressRow := datastore.ForceCancelRow{
+			KSUID:                  inProgressKsuid,
+			Operation:              resource_update.OperationCreate,
+			ProgressJSON:           progressJSON,
+			MostRecentProgressJSON: mostRecentJSON,
+		}
+		notStartedRef := datastore.ResourceUpdateRef{
+			KSUID:      notStartedKsuid,
+			Operation:  resource_update.OperationCreate,
+		}
+		successRef := datastore.ResourceUpdateRef{
+			KSUID:      successKsuid,
+			Operation:  resource_update.OperationCreate,
+		}
+
+		now := time.Now()
+		result, err := ds.ForceCancelResourceUpdates(
+			cmd.ID,
+			[]datastore.ForceCancelRow{inProgressRow},
+			[]datastore.ResourceUpdateRef{notStartedRef, successRef},
+			now,
+		)
+		assert.NoError(t, err)
+
+		// Verify result split: inProgress → CanceledInProgress, notStarted → CanceledNotStarted, success → Skipped
+		assert.Len(t, result.CanceledInProgress, 1)
+		assert.Equal(t, inProgressKsuid, result.CanceledInProgress[0].KSUID)
+		assert.Len(t, result.CanceledNotStarted, 1)
+		assert.Equal(t, notStartedKsuid, result.CanceledNotStarted[0].KSUID)
+		assert.Len(t, result.Skipped, 1)
+		assert.Equal(t, successKsuid, result.Skipped[0].KSUID)
+
+		// Verify the DB reflects the state changes
+		updates, err := ds.LoadResourceUpdates(cmd.ID)
+		assert.NoError(t, err)
+		assert.Len(t, updates, 3)
+
+		byKsuid := make(map[string]resource_update.ResourceUpdate)
+		for _, u := range updates {
+			byKsuid[u.DesiredState.Ksuid] = u
+		}
+
+		assert.Equal(t, resource_update.ResourceUpdateStateCanceled, byKsuid[inProgressKsuid].State)
+		assert.Equal(t, resource_update.ResourceUpdateStateCanceled, byKsuid[notStartedKsuid].State)
+		assert.Equal(t, resource_update.ResourceUpdateStateSuccess, byKsuid[successKsuid].State, "already-terminal row must not be modified")
+
+		// Verify the InProgress row now has the force-cancel progress entry
+		assert.Equal(t, "force-canceled", byKsuid[inProgressKsuid].MostRecentProgressResult.ProgressResult.StatusMessage)
+		assert.Len(t, byKsuid[inProgressKsuid].ProgressResult, 1)
+		assert.Equal(t, "force-canceled", byKsuid[inProgressKsuid].ProgressResult[0].ProgressResult.StatusMessage)
+
+		// --- Idempotency: call again; all three rows are now terminal ---
+		result2, err := ds.ForceCancelResourceUpdates(
+			cmd.ID,
+			[]datastore.ForceCancelRow{inProgressRow},
+			[]datastore.ResourceUpdateRef{notStartedRef, successRef},
+			now,
+		)
+		assert.NoError(t, err)
+
+		assert.Empty(t, result2.CanceledInProgress, "retry must not re-cancel already-Canceled rows")
+		assert.Empty(t, result2.CanceledNotStarted, "retry must not re-cancel already-Canceled rows")
+		assert.Len(t, result2.Skipped, 3, "all rows must be reported as Skipped on retry")
+	})
+}
+
 // RunMonotonicTerminalityRaceTest fires two concurrent UpdateResourceUpdateState calls
 // on the same ResourceUpdate — one writing Success, one writing Failed. First write wins.
 // Within the agent these are serialized by the FormaCommandPersister actor; this test

--- a/internal/datastore/dstest/suite_forma_commands.go
+++ b/internal/datastore/dstest/suite_forma_commands.go
@@ -9,6 +9,7 @@ package dstest
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/types"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
@@ -719,6 +721,128 @@ func RunQueryFormaCommands_StackWildcardEscape(t *testing.T, newDS func(t *testi
 		assert.Len(t, results, 1)
 		if len(results) == 1 {
 			assert.Equal(t, "client-a", results[0].ClientID)
+		}
+	})
+}
+
+// RunTerminalStatesLiteralsTest asserts that the SQL IN-list literals used by the
+// datastore backends exactly match types.TerminalStates.
+func RunTerminalStatesLiteralsTest(t *testing.T, _ func(t *testing.T) TestDatastore) {
+	t.Run("TerminalStatesLiterals", func(t *testing.T) {
+		sqlLiterals := []string{"Success", "Failed", "Rejected", "Canceled"}
+		var typeStrings []string
+		for _, s := range types.TerminalStates {
+			typeStrings = append(typeStrings, string(s))
+		}
+		assert.ElementsMatch(t, sqlLiterals, typeStrings,
+			"SQL IN-list literals must match types.TerminalStates exactly")
+	})
+}
+
+// RunMonotonicTerminalityTest verifies that once a ResourceUpdate reaches a terminal
+// state, subsequent state writes are no-ops (not errors) and the state is preserved.
+// Within the agent, state writes are serialized by the FormaCommandPersister actor;
+// this DB-level test proves the fence holds independently.
+func RunMonotonicTerminalityTest(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("MonotonicTerminality", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		resourceKsuid := util.NewID()
+		cmd := &forma_command.FormaCommand{
+			ID:          util.NewID(),
+			Command:     pkgmodel.CommandApply,
+			State:       forma_command.CommandStateInProgress,
+			Description: pkgmodel.Description{},
+			ResourceUpdates: []resource_update.ResourceUpdate{
+				{
+					DesiredState:   pkgmodel.Resource{Ksuid: resourceKsuid, Properties: json.RawMessage("{}")},
+					ResourceTarget: pkgmodel.Target{Label: "t", Namespace: "default", Config: json.RawMessage("{}")},
+					Operation:      resource_update.OperationCreate,
+					State:          resource_update.ResourceUpdateStateInProgress,
+				},
+			},
+		}
+		err := ds.StoreFormaCommand(cmd, cmd.ID)
+		assert.NoError(t, err)
+
+		now := time.Now()
+
+		// First write: InProgress → Success (should succeed)
+		err = ds.UpdateResourceUpdateState(cmd.ID, resourceKsuid, resource_update.OperationCreate, resource_update.ResourceUpdateStateSuccess, now)
+		assert.NoError(t, err, "transition to Success should succeed")
+
+		// Second write: try to overwrite Success with Failed (should be a no-op, not an error)
+		err = ds.UpdateResourceUpdateState(cmd.ID, resourceKsuid, resource_update.OperationCreate, resource_update.ResourceUpdateStateFailed, now)
+		assert.NoError(t, err, "attempt to overwrite terminal state should be a no-op, not an error")
+
+		// Reload and assert state is still Success
+		loaded, err := ds.GetFormaCommandByCommandID(cmd.ID)
+		assert.NoError(t, err)
+		if assert.Len(t, loaded.ResourceUpdates, 1) {
+			assert.Equal(t, resource_update.ResourceUpdateStateSuccess, loaded.ResourceUpdates[0].State,
+				"terminal state Success must not be overwritten by Failed")
+		}
+	})
+}
+
+// RunMonotonicTerminalityRaceTest fires two concurrent UpdateResourceUpdateState calls
+// on the same ResourceUpdate — one writing Success, one writing Failed. First write wins.
+// Within the agent these are serialized by the FormaCommandPersister actor; this test
+// proves the DB fence holds independently of that serialization.
+func RunMonotonicTerminalityRaceTest(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("MonotonicTerminalityRace", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		resourceKsuid := util.NewID()
+		cmd := &forma_command.FormaCommand{
+			ID:          util.NewID(),
+			Command:     pkgmodel.CommandApply,
+			State:       forma_command.CommandStateInProgress,
+			Description: pkgmodel.Description{},
+			ResourceUpdates: []resource_update.ResourceUpdate{
+				{
+					DesiredState:   pkgmodel.Resource{Ksuid: resourceKsuid, Properties: json.RawMessage("{}")},
+					ResourceTarget: pkgmodel.Target{Label: "t", Namespace: "default", Config: json.RawMessage("{}")},
+					Operation:      resource_update.OperationCreate,
+					State:          resource_update.ResourceUpdateStateInProgress,
+				},
+			},
+		}
+		err := ds.StoreFormaCommand(cmd, cmd.ID)
+		assert.NoError(t, err)
+
+		now := time.Now()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		var err1, err2 error
+		go func() {
+			defer wg.Done()
+			err1 = ds.UpdateResourceUpdateState(cmd.ID, resourceKsuid, resource_update.OperationCreate, resource_update.ResourceUpdateStateSuccess, now)
+		}()
+		go func() {
+			defer wg.Done()
+			err2 = ds.UpdateResourceUpdateState(cmd.ID, resourceKsuid, resource_update.OperationCreate, resource_update.ResourceUpdateStateFailed, now)
+		}()
+		wg.Wait()
+
+		// Both calls must return nil (one transitions, the other is a no-op)
+		assert.NoError(t, err1)
+		assert.NoError(t, err2)
+
+		// Final state must be one of the two terminal states and must be stable
+		loaded, err := ds.GetFormaCommandByCommandID(cmd.ID)
+		assert.NoError(t, err)
+		if assert.Len(t, loaded.ResourceUpdates, 1) {
+			finalState := loaded.ResourceUpdates[0].State
+			assert.True(t,
+				finalState == resource_update.ResourceUpdateStateSuccess || finalState == resource_update.ResourceUpdateStateFailed,
+				"final state must be either Success or Failed, got: %s", finalState)
 		}
 	})
 }

--- a/internal/datastore/mock_datastore_test.go
+++ b/internal/datastore/mock_datastore_test.go
@@ -163,3 +163,6 @@ func (m *mockDatastore) UpdateFormaCommandProgress(_ string, _ forma_command.Com
 func (m *mockDatastore) UpdateFormaCommandTargetUpdates(_ string, _ json.RawMessage, _ forma_command.CommandState, _ time.Time) error {
 	return nil
 }
+func (m *mockDatastore) ForceCancelResourceUpdates(_ string, _ []ForceCancelRow, _ []ResourceUpdateRef, _ time.Time) (ForceCancelResult, error) {
+	return ForceCancelResult{}, nil
+}

--- a/internal/datastore/mssql/mssql_resourceupdates.go
+++ b/internal/datastore/mssql/mssql_resourceupdates.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	json "github.com/goccy/go-json"
@@ -423,7 +424,8 @@ func (d *DatastoreMSSQL) UpdateResourceUpdateState(commandID string, ksuid strin
 	query := `
 		UPDATE resource_updates
 		SET state = @p1, modified_ts = @p2
-		WHERE command_id = @p3 AND ksuid = @p4 AND operation = @p5`
+		WHERE command_id = @p3 AND ksuid = @p4 AND operation = @p5
+		  AND state NOT IN ('Success','Failed','Rejected','Canceled')`
 
 	result, err := d.conn.ExecContext(ctx, query, string(state), modifiedTs.UTC(), commandID, ksuid, string(operation))
 	if err != nil {
@@ -434,7 +436,8 @@ func (d *DatastoreMSSQL) UpdateResourceUpdateState(commandID string, ksuid strin
 		return fmt.Errorf("failed to get rows affected: %w", err)
 	}
 	if affected == 0 {
-		return fmt.Errorf("resource update not found: command_id=%s, ksuid=%s, operation=%s", commandID, ksuid, operation)
+		slog.Debug("UpdateResourceUpdateState: row already in terminal state or not found, no-op", "commandID", commandID, "ksuid", ksuid)
+		return nil
 	}
 	return nil
 }
@@ -513,7 +516,8 @@ func (d *DatastoreMSSQL) BatchUpdateResourceUpdateState(commandID string, refs [
 	const query = `
 		UPDATE resource_updates
 		SET state = @p1, modified_ts = @p2
-		WHERE command_id = @p3 AND ksuid = @p4 AND operation = @p5`
+		WHERE command_id = @p3 AND ksuid = @p4 AND operation = @p5
+		  AND state NOT IN ('Success','Failed','Rejected','Canceled')`
 
 	for _, ref := range refs {
 		if _, err = tx.ExecContext(ctx, query, string(state), modifiedTs.UTC(), commandID, ref.KSUID, string(ref.Operation)); err != nil {

--- a/internal/datastore/mssql/mssql_resourceupdates.go
+++ b/internal/datastore/mssql/mssql_resourceupdates.go
@@ -527,3 +527,71 @@ func (d *DatastoreMSSQL) BatchUpdateResourceUpdateState(commandID string, refs [
 	committed = true
 	return nil
 }
+
+// ForceCancelResourceUpdates CAS-terminalizes in-flight resource updates to Canceled in one
+// transaction. For InProgress rows it also writes force-cancel progress. Returns the rows
+// transitioned (split by prior state) and those already terminal (Skipped). Idempotent.
+func (d *DatastoreMSSQL) ForceCancelResourceUpdates(commandID string, inProgress []datastore.ForceCancelRow, notStarted []datastore.ResourceUpdateRef, modifiedTs time.Time) (datastore.ForceCancelResult, error) {
+	ctx, span := mssqlTracer.Start(context.Background(), "ForceCancelResourceUpdates")
+	defer span.End()
+
+	var result datastore.ForceCancelResult
+
+	if len(inProgress) == 0 && len(notStarted) == 0 {
+		return result, nil
+	}
+
+	tx, err := d.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return result, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	modifiedTsUTC := modifiedTs.UTC()
+
+	for _, row := range inProgress {
+		ref := datastore.ResourceUpdateRef{KSUID: row.KSUID, Operation: row.Operation}
+		res, execErr := tx.ExecContext(ctx, `
+			UPDATE resource_updates
+			SET state = 'Canceled', modified_ts = @p1, progress_result = @p2, most_recent_progress = @p3
+			WHERE command_id = @p4 AND ksuid = @p5 AND operation = @p6 AND state = 'InProgress'
+		`, modifiedTsUTC, string(row.ProgressJSON), string(row.MostRecentProgressJSON), commandID, row.KSUID, string(row.Operation))
+		if execErr != nil {
+			return result, fmt.Errorf("failed to force-cancel InProgress row %s: %w", row.KSUID, execErr)
+		}
+		n, _ := res.RowsAffected()
+		if n > 0 {
+			result.CanceledInProgress = append(result.CanceledInProgress, ref)
+		} else {
+			result.Skipped = append(result.Skipped, ref)
+		}
+	}
+
+	for _, ref := range notStarted {
+		res, execErr := tx.ExecContext(ctx, `
+			UPDATE resource_updates
+			SET state = 'Canceled', modified_ts = @p1
+			WHERE command_id = @p2 AND ksuid = @p3 AND operation = @p4 AND state = 'NotStarted'
+		`, modifiedTsUTC, commandID, ref.KSUID, string(ref.Operation))
+		if execErr != nil {
+			return result, fmt.Errorf("failed to force-cancel NotStarted row %s: %w", ref.KSUID, execErr)
+		}
+		n, _ := res.RowsAffected()
+		if n > 0 {
+			result.CanceledNotStarted = append(result.CanceledNotStarted, ref)
+		} else {
+			result.Skipped = append(result.Skipped, ref)
+		}
+	}
+
+	if err = tx.Commit(); err != nil {
+		return result, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	committed = true
+	return result, nil
+}

--- a/internal/datastore/mssql/resourceupdates_integration_test.go
+++ b/internal/datastore/mssql/resourceupdates_integration_test.go
@@ -176,12 +176,16 @@ func TestMSSQLResourceUpdatesStateLifecycle(t *testing.T) {
 		t.Errorf("k-b state = %q, want still NotStarted", loaded[1].State)
 	}
 
-	// UpdateResourceUpdateState on a missing row returns an error.
-	if err := ds.UpdateResourceUpdateState(commandID, "missing", types.OperationCreate, resource_update.ResourceUpdateStateSuccess, later); err == nil {
-		t.Errorf("expected error for missing ksuid, got nil")
+	// UpdateResourceUpdateState on a missing row is a no-op (affected == 0), not an error.
+	// The monotonic-CAS write filter cannot distinguish an absent row from a terminal one,
+	// and both are treated as a no-op, consistent across backends.
+	if err := ds.UpdateResourceUpdateState(commandID, "missing", types.OperationCreate, resource_update.ResourceUpdateStateSuccess, later); err != nil {
+		t.Errorf("missing ksuid should be a no-op, got error: %v", err)
 	}
 
-	// BatchUpdateResourceUpdateState flips both rows to Failed.
+	// BatchUpdateResourceUpdateState advances non-terminal rows toward the target state,
+	// but the monotonic CAS leaves already-terminal rows untouched. k-a is Success
+	// (terminal) so it is preserved; k-b is NotStarted so it flips to Failed.
 	refs := []datastore.ResourceUpdateRef{
 		{KSUID: "k-a", Operation: types.OperationCreate},
 		{KSUID: "k-b", Operation: types.OperationCreate},
@@ -191,8 +195,15 @@ func TestMSSQLResourceUpdatesStateLifecycle(t *testing.T) {
 	}
 	loaded, _ = ds.LoadResourceUpdates(commandID)
 	for _, ru := range loaded {
-		if ru.State != resource_update.ResourceUpdateStateFailed {
-			t.Errorf("%s state = %q, want Failed", ru.DesiredState.Ksuid, ru.State)
+		switch ru.DesiredState.Ksuid {
+		case "k-a":
+			if ru.State != resource_update.ResourceUpdateStateSuccess {
+				t.Errorf("k-a state = %q, want Success preserved (terminal, not overwritten by Failed)", ru.State)
+			}
+		case "k-b":
+			if ru.State != resource_update.ResourceUpdateStateFailed {
+				t.Errorf("k-b state = %q, want Failed", ru.State)
+			}
 		}
 	}
 

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -3835,3 +3835,70 @@ func (d DatastorePostgres) CleanUp() error {
 
 	return nil
 }
+
+// ForceCancelResourceUpdates CAS-terminalizes in-flight resource updates to Canceled in one
+// transaction. For InProgress rows it also writes force-cancel progress. Returns the rows
+// transitioned (split by prior state) and those already terminal (Skipped). Idempotent.
+func (d DatastorePostgres) ForceCancelResourceUpdates(commandID string, inProgress []datastore.ForceCancelRow, notStarted []datastore.ResourceUpdateRef, modifiedTs time.Time) (datastore.ForceCancelResult, error) {
+	ctx, span := tracer.Start(context.Background(), "ForceCancelResourceUpdates")
+	defer span.End()
+
+	var result datastore.ForceCancelResult
+
+	if len(inProgress) == 0 && len(notStarted) == 0 {
+		return result, nil
+	}
+
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return result, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+
+	modifiedTsUTC := modifiedTs.UTC()
+
+	for _, row := range inProgress {
+		ref := datastore.ResourceUpdateRef{KSUID: row.KSUID, Operation: row.Operation}
+		res, execErr := tx.Exec(ctx, `
+			UPDATE resource_updates
+			SET state = 'Canceled', modified_ts = $1, progress_result = $2, most_recent_progress = $3
+			WHERE command_id = $4 AND ksuid = $5 AND operation = $6 AND state = 'InProgress'
+		`, modifiedTsUTC, []byte(row.ProgressJSON), []byte(row.MostRecentProgressJSON), commandID, row.KSUID, string(row.Operation))
+		if execErr != nil {
+			err = execErr
+			return result, fmt.Errorf("failed to force-cancel InProgress row %s: %w", row.KSUID, err)
+		}
+		if res.RowsAffected() > 0 {
+			result.CanceledInProgress = append(result.CanceledInProgress, ref)
+		} else {
+			result.Skipped = append(result.Skipped, ref)
+		}
+	}
+
+	for _, ref := range notStarted {
+		res, execErr := tx.Exec(ctx, `
+			UPDATE resource_updates
+			SET state = 'Canceled', modified_ts = $1
+			WHERE command_id = $2 AND ksuid = $3 AND operation = $4 AND state = 'NotStarted'
+		`, modifiedTsUTC, commandID, ref.KSUID, string(ref.Operation))
+		if execErr != nil {
+			err = execErr
+			return result, fmt.Errorf("failed to force-cancel NotStarted row %s: %w", ref.KSUID, err)
+		}
+		if res.RowsAffected() > 0 {
+			result.CanceledNotStarted = append(result.CanceledNotStarted, ref)
+		} else {
+			result.Skipped = append(result.Skipped, ref)
+		}
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		return result, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -3666,6 +3666,7 @@ func (d DatastorePostgres) UpdateResourceUpdateState(commandID string, ksuid str
 		UPDATE resource_updates
 		SET state = $1, modified_ts = $2
 		WHERE command_id = $3 AND ksuid = $4 AND operation = $5
+		  AND state NOT IN ('Success','Failed','Rejected','Canceled')
 	`
 
 	result, err := d.pool.Exec(ctx, query, string(state), modifiedTs.UTC(), commandID, ksuid, string(operation))
@@ -3674,7 +3675,8 @@ func (d DatastorePostgres) UpdateResourceUpdateState(commandID string, ksuid str
 	}
 
 	if result.RowsAffected() == 0 {
-		return fmt.Errorf("resource update not found: command_id=%s, ksuid=%s, operation=%s", commandID, ksuid, operation)
+		slog.Debug("UpdateResourceUpdateState: row already in terminal state or not found, no-op", "commandID", commandID, "ksuid", ksuid)
+		return nil
 	}
 
 	return nil
@@ -3756,6 +3758,7 @@ func (d DatastorePostgres) BatchUpdateResourceUpdateState(commandID string, refs
 			UPDATE resource_updates
 			SET state = $1, modified_ts = $2
 			WHERE command_id = $3 AND ksuid = $4 AND operation = $5
+			  AND state NOT IN ('Success','Failed','Rejected','Canceled')
 		`, string(state), modifiedTs.UTC(), commandID, ref.KSUID, string(ref.Operation))
 		if err != nil {
 			return fmt.Errorf("failed to update resource update: %w", err)

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -4022,6 +4022,95 @@ func (d DatastoreSQLite) UpdateFormaCommandTargetUpdates(commandID string, targe
 	return nil
 }
 
+// ForceCancelResourceUpdates CAS-terminalizes in-flight resource updates to Canceled in one
+// transaction. For InProgress rows it also writes force-cancel progress. Returns the rows
+// transitioned (split by prior state) and those already terminal (Skipped). Idempotent.
+func (d DatastoreSQLite) ForceCancelResourceUpdates(commandID string, inProgress []datastore.ForceCancelRow, notStarted []datastore.ResourceUpdateRef, modifiedTs time.Time) (datastore.ForceCancelResult, error) {
+	slog.Debug("SQLite START", "method", "ForceCancelResourceUpdates", "commandID", commandID, "inProgressCount", len(inProgress), "notStartedCount", len(notStarted))
+	start := time.Now()
+	defer func() {
+		slog.Debug("SQLite END", "method", "ForceCancelResourceUpdates", "commandID", commandID, "duration", time.Since(start))
+	}()
+	_, span := sqliteTracer.Start(context.Background(), "ForceCancelResourceUpdates")
+	defer span.End()
+
+	var result datastore.ForceCancelResult
+
+	if len(inProgress) == 0 && len(notStarted) == 0 {
+		return result, nil
+	}
+
+	var err error
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return result, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	modifiedTsUTC := modifiedTs.UTC()
+
+	// InProgress rows: update state + progress columns, but only if still InProgress.
+	inProgressStmt, err := tx.Prepare(`
+		UPDATE resource_updates
+		SET state = 'Canceled', modified_ts = ?, progress_result = ?, most_recent_progress = ?
+		WHERE command_id = ? AND ksuid = ? AND operation = ? AND state = 'InProgress'
+	`)
+	if err != nil {
+		return result, fmt.Errorf("failed to prepare inProgress statement: %w", err)
+	}
+	defer func() { _ = inProgressStmt.Close() }()
+
+	for _, row := range inProgress {
+		ref := datastore.ResourceUpdateRef{KSUID: row.KSUID, Operation: row.Operation}
+		res, execErr := inProgressStmt.Exec(modifiedTsUTC, []byte(row.ProgressJSON), []byte(row.MostRecentProgressJSON), commandID, row.KSUID, string(row.Operation))
+		if execErr != nil {
+			err = execErr
+			return result, fmt.Errorf("failed to force-cancel InProgress row %s: %w", row.KSUID, err)
+		}
+		n, _ := res.RowsAffected()
+		if n > 0 {
+			result.CanceledInProgress = append(result.CanceledInProgress, ref)
+		} else {
+			result.Skipped = append(result.Skipped, ref)
+		}
+	}
+
+	// NotStarted rows: update state only, but only if still NotStarted.
+	notStartedStmt, err := tx.Prepare(`
+		UPDATE resource_updates
+		SET state = 'Canceled', modified_ts = ?
+		WHERE command_id = ? AND ksuid = ? AND operation = ? AND state = 'NotStarted'
+	`)
+	if err != nil {
+		return result, fmt.Errorf("failed to prepare notStarted statement: %w", err)
+	}
+	defer func() { _ = notStartedStmt.Close() }()
+
+	for _, ref := range notStarted {
+		res, execErr := notStartedStmt.Exec(modifiedTsUTC, commandID, ref.KSUID, string(ref.Operation))
+		if execErr != nil {
+			err = execErr
+			return result, fmt.Errorf("failed to force-cancel NotStarted row %s: %w", ref.KSUID, err)
+		}
+		n, _ := res.RowsAffected()
+		if n > 0 {
+			result.CanceledNotStarted = append(result.CanceledNotStarted, ref)
+		} else {
+			result.Skipped = append(result.Skipped, ref)
+		}
+	}
+
+	if err = tx.Commit(); err != nil {
+		return result, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return result, nil
+}
+
 func (d DatastoreSQLite) CleanUp() error {
 	// No cleanup needed for SQLite, this is only used in the Postgres integration tests
 	return nil

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -3819,6 +3819,7 @@ func (d DatastoreSQLite) UpdateResourceUpdateState(commandID string, ksuid strin
 		UPDATE resource_updates
 		SET state = ?, modified_ts = ?
 		WHERE command_id = ? AND ksuid = ? AND operation = ?
+		  AND state NOT IN ('Success','Failed','Rejected','Canceled')
 	`
 
 	// Normalize timestamp to UTC for consistent TEXT-based sorting in SQLite
@@ -3833,7 +3834,8 @@ func (d DatastoreSQLite) UpdateResourceUpdateState(commandID string, ksuid strin
 	}
 
 	if rowsAffected == 0 {
-		return fmt.Errorf("resource update not found: command_id=%s, ksuid=%s, operation=%s", commandID, ksuid, operation)
+		slog.Debug("UpdateResourceUpdateState: row already in terminal state or not found, no-op", "commandID", commandID, "ksuid", ksuid)
+		return nil
 	}
 
 	return nil
@@ -3932,6 +3934,7 @@ func (d DatastoreSQLite) BatchUpdateResourceUpdateState(commandID string, refs [
 		UPDATE resource_updates
 		SET state = ?, modified_ts = ?
 		WHERE command_id = ? AND ksuid = ? AND operation = ?
+		  AND state NOT IN ('Success','Failed','Rejected','Canceled')
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement: %w", err)

--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -75,11 +75,24 @@ type Resume struct{}
 
 type Cancel struct {
 	CommandID string
+	// Force abandons in-progress work and drives the command to a terminal
+	// Canceled state immediately, instead of waiting for in-progress resources
+	// to finish.
+	Force bool
 }
 
 // CancelResponse contains per-resource-update states at cancel time.
 type CancelResponse struct {
 	ResourceStates map[string]string // URI → state ("Canceled", "InProgress", "Success", "Failed")
+	// ForceCanceledInProgress lists the URIs of resource updates that were
+	// force-canceled while an operation was actually in progress (--force only).
+	// These are the resources whose cloud-side state may be orphaned.
+	ForceCanceledInProgress []string
+	// ErrorMessage is non-empty when a --force cancel failed to persist. It is
+	// carried in-band (rather than as a Go error from the call handler) so the
+	// executor stays alive and terminates no actors on a persist failure. The
+	// metastructure translates a non-empty ErrorMessage into a returned error.
+	ErrorMessage string
 }
 
 type ChangesetState string
@@ -117,6 +130,7 @@ func (s *ChangesetExecutor) Init(args ...any) (statemachine.StateMachineSpec[Cha
 		statemachine.WithStateMessageHandler(StateProcessing, targetUpdateFinished),
 		statemachine.WithStateMessageHandler(StateProcessing, resume),
 		statemachine.WithStateCallHandler(StateProcessing, cancel),
+		statemachine.WithStateCallHandler(StateCanceling, cancelWhileCanceling),
 		statemachine.WithStateMessageHandler(StateCanceling, resourceUpdateFinished),
 		statemachine.WithStateMessageHandler(StateCanceling, targetUpdateFinished),
 		statemachine.WithStateMessageHandler(StateFinishedWithError, shutdown),
@@ -627,7 +641,11 @@ func startTargetUpdate(tu *target_update.TargetUpdate, commandID string, proc ge
 }
 
 func cancel(from gen.PID, state gen.Atom, data ChangesetData, message Cancel, proc gen.Process) (gen.Atom, ChangesetData, CancelResponse, []statemachine.Action, error) {
-	proc.Log().Debug("ChangesetExecutor received cancel request commandID=%s", message.CommandID)
+	proc.Log().Debug("ChangesetExecutor received cancel request commandID=%s force=%t", message.CommandID, message.Force)
+
+	if message.Force {
+		return forceCancel(state, data, message, proc)
+	}
 
 	// Collect resources by state
 	var resourcesToCancel []forma_persister.ResourceUpdateRef
@@ -693,6 +711,149 @@ func cancel(from gen.PID, state gen.Atom, data ChangesetData, message Cancel, pr
 	}
 
 	return nextState, data, cancelResp, nil, nil
+}
+
+// forceCancel implements the --force escape hatch. It terminalizes ALL still-in-flight
+// resource and target updates (NotStarted + InProgress) to Canceled in a single durable
+// persister turn (BulkForceCancel) BEFORE terminating any actors.
+//
+// Persist-before-terminate is load-bearing: if the persister call fails we return the
+// error to the caller and terminate NO actors, so we never leave the durable DB state
+// non-terminal while the in-process actor tree has already been torn down (that would
+// re-introduce the split-brain class). On success the command's derived state is already
+// terminal Canceled; we then transition to StateCanceled, whose state-enter callback sends
+// Shutdown to self and lets Ticket A's LinkParent cascade best-effort terminate the
+// children (and, through them, the remote plugin operators).
+func forceCancel(state gen.Atom, data ChangesetData, message Cancel, proc gen.Process) (gen.Atom, ChangesetData, CancelResponse, []statemachine.Action, error) {
+	var resourcesToCancel []forma_persister.ResourceUpdateRef
+	var targetsToCancel []forma_persister.TargetUpdateRef
+	resourceStates := make(map[string]string)
+
+	for _, node := range data.changeset.DAG.Nodes {
+		switch u := node.Update.(type) {
+		case *resource_update.ResourceUpdate:
+			uri := string(u.URI())
+			switch u.State {
+			case resource_update.ResourceUpdateStateNotStarted, resource_update.ResourceUpdateStateInProgress:
+				// All still-in-flight work is force-canceled.
+				resourceStates[uri] = "Canceled"
+				resourcesToCancel = append(resourcesToCancel, forma_persister.ResourceUpdateRef{
+					URI:       u.URI(),
+					Operation: u.Operation,
+				})
+			case resource_update.ResourceUpdateStateSuccess:
+				resourceStates[uri] = "Success"
+			case resource_update.ResourceUpdateStateFailed:
+				resourceStates[uri] = "Failed"
+			case resource_update.ResourceUpdateStateCanceled:
+				resourceStates[uri] = "Canceled"
+			default:
+				resourceStates[uri] = string(u.State)
+			}
+		case *target_update.TargetUpdate:
+			// Targets carry no per-URI display state today, but in-flight ones must be
+			// terminalized so recovery's "all updates terminal" criterion converges.
+			// The persister's in-memory target fence drops any that are already terminal.
+			switch u.State {
+			case target_update.TargetUpdateStateNotStarted, target_update.TargetUpdateStateInProgress:
+				targetsToCancel = append(targetsToCancel, forma_persister.TargetUpdateRef{
+					Label:     u.Target.Label,
+					Operation: u.Operation,
+				})
+			}
+		}
+	}
+
+	// Persist FIRST. BulkForceCancel terminalizes all in-flight resource and target
+	// updates and recomputes the command's derived state to terminal Canceled at commit.
+	result, err := proc.Call(
+		gen.ProcessID{Node: proc.Node().Name(), Name: gen.Atom("FormaCommandPersister")},
+		forma_persister.BulkForceCancel{
+			CommandID: data.changeset.CommandID,
+			Resources: resourcesToCancel,
+			Targets:   targetsToCancel,
+		},
+	)
+	if err != nil {
+		// Persist-before-terminate: on persister error, terminate NO actors and stay
+		// in the current state. The durable DB state is still non-terminal; the user
+		// retries (or the agent-restart escape hatch remains). We carry the error in
+		// the CancelResponse (NOT as a Go error from this handler) because returning a
+		// non-nil error from a state call handler terminates the executor — exactly the
+		// teardown we must avoid here.
+		proc.Log().Error("BulkForceCancel failed, terminating no actors commandID=%s: %v", data.changeset.CommandID, err)
+		return state, data, CancelResponse{ErrorMessage: fmt.Sprintf("force-cancel persist failed: %v", err)}, nil, nil
+	}
+
+	resp, ok := result.(forma_persister.BulkForceCancelResponse)
+	if !ok {
+		proc.Log().Error("BulkForceCancel returned unexpected response type commandID=%s type=%T", data.changeset.CommandID, result)
+		return state, data, CancelResponse{ErrorMessage: fmt.Sprintf("force-cancel: unexpected persister response type %T", result)}, nil, nil
+	}
+
+	// The persister reports a persistence failure in-band (so it stays alive). Treat it
+	// exactly like a Call error: terminate no actors, stay in the current state, surface
+	// the error to the caller.
+	if resp.ErrorMessage != "" {
+		proc.Log().Error("BulkForceCancel reported persist failure, terminating no actors commandID=%s: %s", data.changeset.CommandID, resp.ErrorMessage)
+		return state, data, CancelResponse{ErrorMessage: resp.ErrorMessage}, nil, nil
+	}
+
+	// The resources that were force-canceled mid-operation (had an InProgress op) are
+	// the ones whose cloud-side state may now be orphaned.
+	var forceCanceledInProgress []string
+	for _, ref := range resp.ForceCanceledInProgress {
+		forceCanceledInProgress = append(forceCanceledInProgress, string(ref.URI))
+	}
+
+	proc.Log().Debug("Force-canceled command commandID=%s canceledCount=%d forceCanceledInProgress=%d targets=%d",
+		message.CommandID, len(resourcesToCancel), len(forceCanceledInProgress), len(targetsToCancel))
+
+	cancelResp := CancelResponse{
+		ResourceStates:          resourceStates,
+		ForceCanceledInProgress: forceCanceledInProgress,
+	}
+
+	// Durable terminal Canceled reached. Transition to StateCanceled; the state-enter
+	// callback tears down children (best-effort cascade) via Shutdown.
+	return StateCanceled, data, cancelResp, nil, nil
+}
+
+// cancelWhileCanceling handles a cancel request that arrives while the executor is
+// already in the waiting StateCanceling (a previously-issued non-force cancel is still
+// waiting for in-progress resources). A --force request here escalates: it terminalizes
+// the still-in-flight work immediately. A non-force request is an idempotent no-op — we
+// stay in StateCanceling and keep waiting.
+func cancelWhileCanceling(from gen.PID, state gen.Atom, data ChangesetData, message Cancel, proc gen.Process) (gen.Atom, ChangesetData, CancelResponse, []statemachine.Action, error) {
+	proc.Log().Debug("ChangesetExecutor received cancel request while canceling commandID=%s force=%t", message.CommandID, message.Force)
+
+	if message.Force {
+		return forceCancel(state, data, message, proc)
+	}
+
+	// Non-force cancel while already canceling: report current per-resource states and
+	// keep waiting. We do not re-issue MarkResourcesAsCanceled (the NotStarted resources
+	// were already terminalized when the first cancel ran).
+	resourceStates := make(map[string]string)
+	for _, node := range data.changeset.DAG.Nodes {
+		ru, ok := node.Update.(*resource_update.ResourceUpdate)
+		if !ok {
+			continue
+		}
+		uri := string(ru.URI())
+		switch ru.State {
+		case resource_update.ResourceUpdateStateInProgress:
+			resourceStates[uri] = "InProgress"
+		case resource_update.ResourceUpdateStateSuccess:
+			resourceStates[uri] = "Success"
+		case resource_update.ResourceUpdateStateFailed:
+			resourceStates[uri] = "Failed"
+		default:
+			resourceStates[uri] = "Canceled"
+		}
+	}
+
+	return StateCanceling, data, CancelResponse{ResourceStates: resourceStates}, nil, nil
 }
 
 func shutdown(from gen.PID, state gen.Atom, data ChangesetData, shutdown Shutdown, proc gen.Process) (gen.Atom, ChangesetData, []statemachine.Action, error) {

--- a/internal/metastructure/extract_resources_test.go
+++ b/internal/metastructure/extract_resources_test.go
@@ -237,6 +237,9 @@ func (m *mockExtractDatastore) UpdateFormaCommandProgress(_ string, _ forma_comm
 func (m *mockExtractDatastore) UpdateFormaCommandTargetUpdates(_ string, _ json.RawMessage, _ forma_command.CommandState, _ time.Time) error {
 	panic("not implemented")
 }
+func (m *mockExtractDatastore) ForceCancelResourceUpdates(_ string, _ []datastore.ForceCancelRow, _ []datastore.ResourceUpdateRef, _ time.Time) (datastore.ForceCancelResult, error) {
+	panic("not implemented")
+}
 
 func TestExtractResources_ManagedAndUnmanagedStacks(t *testing.T) {
 	managedStack := &pkgmodel.Stack{

--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -850,20 +850,14 @@ func (f *FormaCommandPersister) bulkForceCancel(msg *BulkForceCancel) (BulkForce
 		}
 	}
 
-	// Persist target updates blob (derived from the fenced in-memory state). A failure
-	// here is a best-effort durability miss: the resource rows are already durably
-	// terminal Canceled and recovery's finalizeIncompleteCommand backstop converges the
-	// command meta. We log and continue rather than crash the persister.
-	if len(msg.Targets) > 0 {
-		command.State = overallCommandState(command)
-		targetUpdatesJSON, merr := json.Marshal(command.TargetUpdates)
-		if merr != nil {
-			f.Log().Error("Failed to marshal target updates for BulkForceCancel commandID=%s: %v", msg.CommandID, merr)
-		} else if merr := f.datastore.UpdateFormaCommandTargetUpdates(command.ID, targetUpdatesJSON, command.State, ts); merr != nil {
-			f.Log().Error("Failed to persist target updates for BulkForceCancel commandID=%s: %v", msg.CommandID, merr)
-		}
-	}
-
+	// The terminalized targets live in memory on command.TargetUpdates; do NOT persist
+	// them here in a separate write. finalizeAndPersist (StoreFormaCommand) below is the
+	// single authoritative durable write — it persists the whole command, including the
+	// target updates and the overall state, in one shot. A separate earlier write would
+	// commit a terminal command state before that final store; if the store then failed
+	// we would surface a retryable error while the command already read terminal, and the
+	// retry path (CancelCommandsByQuery, which filters to InProgress) would skip it,
+	// stranding a live actor tree against a durably-terminal command.
 	command.ModifiedTs = ts
 	command.State = overallCommandState(command)
 
@@ -874,7 +868,9 @@ func (f *FormaCommandPersister) bulkForceCancel(msg *BulkForceCancel) (BulkForce
 		// resource rows. If it fails we have NOT confirmed durable terminality, so we
 		// must not report success: surface the failure in-band. The executor leaves all
 		// actors running and the caller is told to retry, rather than tearing down a
-		// command that durably still reads InProgress (with non-terminal targets).
+		// command that durably still reads InProgress (with non-terminal targets). No
+		// earlier write advanced the durable state, so the retry sees InProgress and
+		// converges.
 		f.Log().Error("Failed to finalize command meta after BulkForceCancel commandID=%s: %v", msg.CommandID, err)
 		resp.ErrorMessage = fmt.Sprintf("force-cancel: failed to persist terminal command state: %v", err)
 	}

--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -24,6 +24,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
 type FormaCommandPersister struct {
@@ -262,6 +263,20 @@ type TargetUpdateRef struct {
 	Operation types.OperationType
 }
 
+// BulkForceCancel terminalizes all still-in-flight resource and target updates for a command
+// in one persister turn. Used by the force-cancel flow.
+type BulkForceCancel struct {
+	CommandID string
+	Resources []ResourceUpdateRef
+	Targets   []TargetUpdateRef
+}
+
+// BulkForceCancelResponse reports the outcome of a BulkForceCancel.
+type BulkForceCancelResponse struct {
+	Skipped                 []ResourceUpdateRef // rows that were already terminal (no-op)
+	ForceCanceledInProgress []ResourceUpdateRef // rows that were InProgress (got force-cancel progress entries)
+}
+
 // MarkTargetsAsFailed is sent by the changeset executor when target updates
 // are cascade-failed due to a dependency failure in the DAG.
 type MarkTargetsAsFailed struct {
@@ -304,6 +319,8 @@ func (f *FormaCommandPersister) HandleCall(from gen.PID, ref gen.Ref, message an
 		return f.markTargetsAsFailed(&msg)
 	case MarkResourcesAsCanceled:
 		return f.markResourcesAsCanceled(&msg)
+	case BulkForceCancel:
+		return f.bulkForceCancel(&msg)
 	case messages.MarkResourceUpdateAsComplete:
 		return f.markResourceUpdateAsComplete(&msg)
 	case FinalizeIncompleteCommand:
@@ -683,6 +700,133 @@ func (f *FormaCommandPersister) markTargetsAsFailed(msg *MarkTargetsAsFailed) (b
 
 func (f *FormaCommandPersister) markResourcesAsCanceled(msg *MarkResourcesAsCanceled) (bool, error) {
 	return f.bulkUpdateResourceState(msg.CommandID, msg.Resources, types.ResourceUpdateStateCanceled, util.TimeNow())
+}
+
+func (f *FormaCommandPersister) bulkForceCancel(msg *BulkForceCancel) (BulkForceCancelResponse, error) {
+	ts := util.TimeNow()
+	resp := BulkForceCancelResponse{}
+
+	cached, err := f.getOrLoadCommand(msg.CommandID)
+	if err != nil {
+		return resp, fmt.Errorf("failed to load command for BulkForceCancel: %w", err)
+	}
+	command := cached.command
+
+	var inProgressRows []datastore.ForceCancelRow
+	var notStartedRefs []datastore.ResourceUpdateRef
+
+	for _, ref := range msg.Resources {
+		idx := cached.findResourceUpdateIndex(ref.URI.KSUID(), ref.Operation)
+		if idx == -1 {
+			continue
+		}
+		res := &command.ResourceUpdates[idx]
+
+		if isResourceInFinalState(res.State) {
+			resp.Skipped = append(resp.Skipped, ref)
+			continue
+		}
+
+		forceCancelProgress := plugin.TrackedProgress{
+			ProgressResult: resource.ProgressResult{
+				Operation:       resource.Operation(res.Operation),
+				OperationStatus: resource.OperationStatusCanceled,
+				StatusMessage:   "force-canceled",
+			},
+		}
+
+		if res.State == types.ResourceUpdateStateInProgress {
+			// Build the progress list: copy existing + append force-cancel entry
+			newProgressList := append(append([]plugin.TrackedProgress{}, res.ProgressResult...), forceCancelProgress)
+			progressJSON, merr := json.Marshal(newProgressList)
+			if merr != nil {
+				return resp, fmt.Errorf("failed to marshal progress for BulkForceCancel: %w", merr)
+			}
+			mostRecentJSON, merr := json.Marshal(forceCancelProgress)
+			if merr != nil {
+				return resp, fmt.Errorf("failed to marshal most-recent progress for BulkForceCancel: %w", merr)
+			}
+			inProgressRows = append(inProgressRows, datastore.ForceCancelRow{
+				KSUID:                  res.DesiredState.Ksuid,
+				Operation:              ref.Operation,
+				ProgressJSON:           progressJSON,
+				MostRecentProgressJSON: mostRecentJSON,
+			})
+			resp.ForceCanceledInProgress = append(resp.ForceCanceledInProgress, ref)
+
+			// Update in-memory progress
+			res.ProgressResult = append(res.ProgressResult, forceCancelProgress)
+			res.MostRecentProgressResult = forceCancelProgress
+		} else {
+			// NotStarted or any other non-final state
+			notStartedRefs = append(notStartedRefs, datastore.ResourceUpdateRef{
+				KSUID:     res.DesiredState.Ksuid,
+				Operation: ref.Operation,
+			})
+		}
+
+		// Terminalize in-memory + counter (mirror bulkUpdateResourceState exactly)
+		res.State = types.ResourceUpdateStateCanceled
+		res.ModifiedTs = ts
+		cached.pendingCompletions--
+		if cached.pendingCompletions < 0 {
+			return resp, fmt.Errorf("BulkForceCancel: pendingCompletions went below zero for command %s, this indicates a programming error", msg.CommandID)
+		}
+		key := resourceUpdateKey(ref.URI.KSUID(), ref.Operation)
+		if cached.terminalizedByBulk == nil {
+			cached.terminalizedByBulk = make(map[string]bool)
+		}
+		cached.terminalizedByBulk[key] = true
+	}
+
+	// Call datastore to CAS-terminalize the rows
+	result, err := f.datastore.ForceCancelResourceUpdates(msg.CommandID, inProgressRows, notStartedRefs, ts)
+	if err != nil {
+		return resp, fmt.Errorf("ForceCancelResourceUpdates failed for command %s: %w", msg.CommandID, err)
+	}
+	// Merge DB-reported skipped (already-terminal) into response
+	for _, r := range result.Skipped {
+		resp.Skipped = append(resp.Skipped, ResourceUpdateRef{
+			URI:       pkgmodel.NewFormaeURI(r.KSUID, ""),
+			Operation: r.Operation,
+		})
+	}
+
+	// Terminalize in-flight targets in-memory
+	for _, ref := range msg.Targets {
+		for i := range command.TargetUpdates {
+			tu := &command.TargetUpdates[i]
+			if tu.Target.Label != ref.Label || tu.Operation != ref.Operation {
+				continue
+			}
+			if isTargetInFinalState(tu.State) {
+				break
+			}
+			tu.State = types.TargetUpdateStateCanceled
+			tu.ModifiedTs = ts
+			break
+		}
+	}
+
+	// Persist target updates blob
+	if len(msg.Targets) > 0 {
+		targetUpdatesJSON, merr := json.Marshal(command.TargetUpdates)
+		if merr != nil {
+			return resp, fmt.Errorf("failed to marshal target updates for BulkForceCancel: %w", merr)
+		}
+		if merr := f.datastore.UpdateFormaCommandTargetUpdates(command.ID, targetUpdatesJSON, command.State, ts); merr != nil {
+			return resp, fmt.Errorf("failed to persist target updates for BulkForceCancel: %w", merr)
+		}
+	}
+
+	command.ModifiedTs = ts
+	command.State = overallCommandState(command)
+
+	if err := f.finalizeAndPersist(cached); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
 }
 
 func (f *FormaCommandPersister) markResourceUpdateAsComplete(msg *messages.MarkResourceUpdateAsComplete) (bool, error) {

--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -850,29 +850,42 @@ func (f *FormaCommandPersister) bulkForceCancel(msg *BulkForceCancel) (BulkForce
 		}
 	}
 
-	// The terminalized targets live in memory on command.TargetUpdates; do NOT persist
-	// them here in a separate write. finalizeAndPersist (StoreFormaCommand) below is the
-	// single authoritative durable write — it persists the whole command, including the
-	// target updates and the overall state, in one shot. A separate earlier write would
-	// commit a terminal command state before that final store; if the store then failed
-	// we would surface a retryable error while the command already read terminal, and the
-	// retry path (CancelCommandsByQuery, which filters to InProgress) would skip it,
-	// stranding a live actor tree against a durably-terminal command.
 	command.ModifiedTs = ts
 	command.State = overallCommandState(command)
 
+	// Authoritative durable terminality write. The resource rows were already durably
+	// terminalized by the CAS above, so the only durable state left to advance is the
+	// command row: its overall state and the terminalized target updates (which live
+	// only in the command blob). Use the single-statement update so this is ATOMIC — it
+	// either commits the terminal state or leaves the row untouched. Gating retryability
+	// on an atomic write is what makes "surface error → retry" safe: a failure here
+	// cannot partially advance the command, so the retry still sees InProgress (and
+	// CancelCommandsByQuery finds it), re-runs the CAS (resources report Skipped), and
+	// converges. We deliberately do NOT gate on StoreFormaCommand: it advances the
+	// command row and re-stores the resource rows in separate, non-atomic writes, so a
+	// mid-failure could leave the command durably terminal while we report a retryable
+	// error — stranding the still-live actor tree against a terminal command.
+	targetUpdatesJSON, merr := json.Marshal(command.TargetUpdates)
+	if merr != nil {
+		f.Log().Error("Failed to marshal target updates for BulkForceCancel commandID=%s: %v", msg.CommandID, merr)
+		resp.ErrorMessage = fmt.Sprintf("force-cancel: failed to encode terminal command state: %v", merr)
+		return resp, nil
+	}
+	if merr := f.datastore.UpdateFormaCommandTargetUpdates(command.ID, targetUpdatesJSON, command.State, ts); merr != nil {
+		f.Log().Error("Failed to persist terminal command state for BulkForceCancel commandID=%s: %v", msg.CommandID, merr)
+		resp.ErrorMessage = fmt.Sprintf("force-cancel: failed to persist terminal command state: %v", merr)
+		return resp, nil
+	}
+
+	// Durable terminality is now committed (resource rows via the CAS, command row +
+	// target updates via the atomic write above). The remaining finalize work —
+	// sensitive-data hashing, a full-command re-store, and cache eviction — is
+	// best-effort local bookkeeping that does NOT affect durable terminality. Its
+	// StoreFormaCommand is non-atomic, so it must NOT gate retryability: the command is
+	// already durably Canceled, so on failure we log and still let the executor tear down
+	// the actors rather than falsely telling the caller to retry a terminal command.
 	if err := f.finalizeAndPersist(cached); err != nil {
-		// finalizeAndPersist (StoreFormaCommand) is the authoritative durable write of
-		// the command: it persists the overall command state AND the target updates,
-		// which live only in the command blob and cannot be reconstructed from the
-		// resource rows. If it fails we have NOT confirmed durable terminality, so we
-		// must not report success: surface the failure in-band. The executor leaves all
-		// actors running and the caller is told to retry, rather than tearing down a
-		// command that durably still reads InProgress (with non-terminal targets). No
-		// earlier write advanced the durable state, so the retry sees InProgress and
-		// converges.
-		f.Log().Error("Failed to finalize command meta after BulkForceCancel commandID=%s: %v", msg.CommandID, err)
-		resp.ErrorMessage = fmt.Sprintf("force-cancel: failed to persist terminal command state: %v", err)
+		f.Log().Error("Best-effort finalize after BulkForceCancel failed (durable terminal state already committed) commandID=%s: %v", msg.CommandID, err)
 	}
 
 	return resp, nil

--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -868,10 +868,15 @@ func (f *FormaCommandPersister) bulkForceCancel(msg *BulkForceCancel) (BulkForce
 	command.State = overallCommandState(command)
 
 	if err := f.finalizeAndPersist(cached); err != nil {
-		// The resource rows are durably terminal; the command-meta finalize is a
-		// best-effort durability write covered by the recovery backstop. Log, do not
-		// crash the persister, and report success so the caller proceeds with teardown.
+		// finalizeAndPersist (StoreFormaCommand) is the authoritative durable write of
+		// the command: it persists the overall command state AND the target updates,
+		// which live only in the command blob and cannot be reconstructed from the
+		// resource rows. If it fails we have NOT confirmed durable terminality, so we
+		// must not report success: surface the failure in-band. The executor leaves all
+		// actors running and the caller is told to retry, rather than tearing down a
+		// command that durably still reads InProgress (with non-terminal targets).
 		f.Log().Error("Failed to finalize command meta after BulkForceCancel commandID=%s: %v", msg.CommandID, err)
+		resp.ErrorMessage = fmt.Sprintf("force-cancel: failed to persist terminal command state: %v", err)
 	}
 
 	return resp, nil

--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -39,8 +39,9 @@ type FormaCommandPersister struct {
 // cachedCommand holds an in-memory FormaCommand with optimized lookup structures.
 type cachedCommand struct {
 	command            *forma_command.FormaCommand
-	ksuidOpToIndex     map[string]int // O(1) lookup: "ksuid:operation" -> ResourceUpdates index
-	pendingCompletions int            // Number of MarkResourceUpdateAsComplete messages expected
+	ksuidOpToIndex     map[string]int  // O(1) lookup: "ksuid:operation" -> ResourceUpdates index
+	pendingCompletions int             // Number of MarkResourceUpdateAsComplete messages expected
+	terminalizedByBulk map[string]bool // Resources terminalized by bulkUpdateResourceState (counter already decremented)
 }
 
 // resourceUpdateKey creates a composite key for looking up a ResourceUpdate by ksuid and operation.
@@ -85,12 +86,33 @@ func countNonFinalResources(cmd *forma_command.FormaCommand) int {
 	return count
 }
 
+// buildTerminalizedByBulkIndex builds a set of resource update keys that are already
+// in a terminal state when loading from the database. This ensures that any late
+// MarkResourceUpdateAsComplete messages for these resources are treated as no-ops,
+// guarding against pendingCompletions underflow.
+func buildTerminalizedByBulkIndex(cmd *forma_command.FormaCommand) map[string]bool {
+	m := make(map[string]bool)
+	for _, ru := range cmd.ResourceUpdates {
+		if isResourceInFinalState(ru.State) {
+			m[resourceUpdateKey(ru.DesiredState.Ksuid, types.OperationType(ru.Operation))] = true
+		}
+	}
+	return m
+}
+
 // isResourceInFinalState checks if a resource update is in a final state.
 func isResourceInFinalState(state types.ResourceUpdateState) bool {
 	return state == types.ResourceUpdateStateSuccess ||
 		state == types.ResourceUpdateStateFailed ||
 		state == types.ResourceUpdateStateRejected ||
 		state == types.ResourceUpdateStateCanceled
+}
+
+// isTargetInFinalState checks if a target update is in a final state.
+func isTargetInFinalState(state types.TargetUpdateState) bool {
+	return state == types.TargetUpdateStateSuccess ||
+		state == types.TargetUpdateStateFailed ||
+		state == types.TargetUpdateStateCanceled
 }
 
 // findResourceUpdateIndex returns the index of the ResourceUpdate with the given ksuid and operation.
@@ -140,6 +162,7 @@ func (f *FormaCommandPersister) getOrLoadCommand(commandID string) (*cachedComma
 		command:            cmd,
 		ksuidOpToIndex:     buildResourceUpdateIndex(cmd),
 		pendingCompletions: countNonFinalResources(cmd),
+		terminalizedByBulk: buildTerminalizedByBulkIndex(cmd),
 	}
 	f.activeCommands[commandID] = cached
 
@@ -307,6 +330,7 @@ func (f *FormaCommandPersister) storeNewFormaCommand(command *forma_command.Form
 		command:            command,
 		ksuidOpToIndex:     buildResourceUpdateIndex(command),
 		pendingCompletions: len(command.ResourceUpdates),
+		terminalizedByBulk: make(map[string]bool),
 	}
 
 	f.Log().Debug("Stored and cached new Forma command commandID=%s", command.ID)
@@ -342,6 +366,15 @@ func (f *FormaCommandPersister) updateCommandFromProgress(progress *messages.Upd
 	idx := cached.findResourceUpdateIndex(progress.ResourceURI.KSUID(), progress.Operation)
 	if idx != -1 {
 		res := &command.ResourceUpdates[idx]
+
+		// Monotonic terminality guard: once a resource update is in a final state it must
+		// not be overwritten by a late progress message from a still-running actor.
+		if isResourceInFinalState(res.State) {
+			f.Log().Debug("Ignoring late progress update for already-terminal resource commandID=%s ksuid=%s operation=%s currentState=%s incomingState=%s",
+				progress.CommandID, progress.ResourceURI.KSUID(), progress.Operation, res.State, progress.ResourceState)
+			return true, nil
+		}
+
 		res.State = progress.ResourceState
 		res.StartTs = progress.ResourceStartTs
 		res.ModifiedTs = progress.ResourceModifiedTs
@@ -430,7 +463,44 @@ func (f *FormaCommandPersister) updateTargetStates(msg *target_update.UpdateTarg
 	}
 
 	command := cached.command
-	command.TargetUpdates = msg.TargetUpdates
+
+	// Merge incoming target updates with the cached state, preserving any target that has
+	// already reached a terminal state. A late UpdateTargetStates (e.g. from a TargetUpdater
+	// that raced with a cancel) must not clobber a Canceled/Failed/Success target.
+	if len(command.TargetUpdates) == 0 {
+		// No existing targets in cache — safe to replace wholesale.
+		command.TargetUpdates = msg.TargetUpdates
+	} else {
+		// Build a label+operation index into the existing (cached) slice for O(1) lookup.
+		type tuKey struct {
+			label     string
+			operation types.OperationType
+		}
+		existingIdx := make(map[tuKey]int, len(command.TargetUpdates))
+		for i, tu := range command.TargetUpdates {
+			existingIdx[tuKey{tu.Target.Label, tu.Operation}] = i
+		}
+
+		for _, incoming := range msg.TargetUpdates {
+			key := tuKey{incoming.Target.Label, incoming.Operation}
+			if idx, ok := existingIdx[key]; ok {
+				existing := &command.TargetUpdates[idx]
+				if isTargetInFinalState(existing.State) {
+					// Terminal state wins — drop the incoming non-terminal update.
+					f.Log().Debug("Ignoring late UpdateTargetStates for already-terminal target commandID=%s targetLabel=%s operation=%s currentState=%s incomingState=%s",
+						msg.CommandID, incoming.Target.Label, incoming.Operation, existing.State, incoming.State)
+					continue
+				}
+				// Non-terminal existing state: accept the incoming update.
+				*existing = incoming
+			} else {
+				// New target not previously seen — append it.
+				command.TargetUpdates = append(command.TargetUpdates, incoming)
+				existingIdx[key] = len(command.TargetUpdates) - 1
+			}
+		}
+	}
+
 	command.State = overallCommandState(command)
 
 	if err := f.persistCommand(cached); err != nil {
@@ -456,6 +526,14 @@ func (f *FormaCommandPersister) markTargetUpdateAsComplete(msg *messages.MarkTar
 		tu := &command.TargetUpdates[i]
 		if tu.Target.Label != msg.TargetLabel {
 			continue
+		}
+
+		// Monotonic terminality guard: once a target update is in a final state it must
+		// not be overwritten by a late completion message.
+		if isTargetInFinalState(tu.State) {
+			f.Log().Debug("Ignoring late MarkTargetUpdateAsComplete for already-terminal target commandID=%s targetLabel=%s operation=%s currentState=%s incomingFinalState=%s",
+				msg.CommandID, msg.TargetLabel, msg.TargetOperation, tu.State, msg.FinalState)
+			return true, nil
 		}
 
 		if string(tu.Operation) == msg.TargetOperation {
@@ -573,6 +651,12 @@ func (f *FormaCommandPersister) markTargetsAsFailed(msg *MarkTargetsAsFailed) (b
 		for i := range command.TargetUpdates {
 			tu := &command.TargetUpdates[i]
 			if tu.Target.Label == ref.Label && tu.Operation == ref.Operation {
+				// Monotonic terminality guard: never overwrite a target already in final state.
+				if isTargetInFinalState(tu.State) {
+					f.Log().Debug("Ignoring cascade failure for already-terminal target commandID=%s targetLabel=%s operation=%s currentState=%s",
+						msg.CommandID, ref.Label, ref.Operation, tu.State)
+					break
+				}
 				tu.State = types.TargetUpdateStateFailed
 				tu.ModifiedTs = msg.TargetModifiedTs
 				break
@@ -614,6 +698,25 @@ func (f *FormaCommandPersister) markResourceUpdateAsComplete(msg *messages.MarkR
 	idx := cached.findResourceUpdateIndex(msg.ResourceURI.KSUID(), msg.Operation)
 	if idx != -1 {
 		res := &cmd.ResourceUpdates[idx]
+
+		// Monotonic terminality guard: if this resource was already finalized via
+		// bulkUpdateResourceState (e.g. markResourcesAsCanceled ran before the
+		// ResourceUpdater's completion arrived), or if it was already terminal when the
+		// command was loaded from the database, the late completion message must be
+		// silently dropped. We must NOT decrement pendingCompletions here — the counter
+		// was already decremented when the terminal state was first assigned.
+		//
+		// Note: we intentionally do NOT guard solely on res.State here, because
+		// updateCommandFromProgress can set state to a terminal value (e.g. Success)
+		// without decrementing pendingCompletions. In that case markResourceUpdateAsComplete
+		// must still run to close out the resource and decrement the counter.
+		key := resourceUpdateKey(msg.ResourceURI.KSUID(), msg.Operation)
+		if cached.terminalizedByBulk[key] {
+			f.Log().Debug("Ignoring late MarkResourceUpdateAsComplete for already-terminalized resource commandID=%s ksuid=%s operation=%s currentState=%s incomingFinalState=%s",
+				msg.CommandID, msg.ResourceURI.KSUID(), msg.Operation, res.State, msg.FinalState)
+			return true, nil
+		}
+
 		res.State = msg.FinalState
 		res.StartTs = msg.ResourceStartTs
 		res.ModifiedTs = msg.ResourceModifiedTs
@@ -746,12 +849,28 @@ func (f *FormaCommandPersister) bulkUpdateResourceState(
 		if idx != -1 {
 			res := &command.ResourceUpdates[idx]
 
-			// If transitioning to final state, decrement counter
-			if !isResourceInFinalState(res.State) && isResourceInFinalState(state) {
+			// Monotonic terminality guard: never reassign a resource update that is already
+			// in a final state. This prevents double-decrement of pendingCompletions and
+			// state regression (e.g. re-canceling a resource that already succeeded).
+			if isResourceInFinalState(res.State) {
+				f.Log().Debug("Ignoring bulk state update for already-terminal resource commandID=%s ksuid=%s operation=%s currentState=%s incomingState=%s",
+					commandID, ref.URI.KSUID(), ref.Operation, res.State, state)
+				continue
+			}
+
+			// If transitioning to final state, decrement counter and record in the
+			// terminalizedByBulk set so that a late MarkResourceUpdateAsComplete for
+			// this resource can be detected and ignored without underflowing the counter.
+			if isResourceInFinalState(state) {
 				cached.pendingCompletions--
 				if cached.pendingCompletions < 0 {
 					return false, fmt.Errorf("unexpected state transition for command %s: pendingCompletions went below zero, this indicates a programming error", commandID)
 				}
+				key := resourceUpdateKey(ref.URI.KSUID(), ref.Operation)
+				if cached.terminalizedByBulk == nil {
+					cached.terminalizedByBulk = make(map[string]bool)
+				}
+				cached.terminalizedByBulk[key] = true
 			}
 
 			res.State = state
@@ -808,6 +927,8 @@ func overallCommandState(command *forma_command.FormaCommand) forma_command.Comm
 			return forma_command.CommandStateInProgress
 		case types.TargetUpdateStateFailed:
 			states = append(states, types.ResourceUpdateStateFailed)
+		case types.TargetUpdateStateCanceled:
+			states = append(states, types.ResourceUpdateStateCanceled)
 		}
 		// Success targets don't affect overall state
 	}

--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -272,9 +272,16 @@ type BulkForceCancel struct {
 }
 
 // BulkForceCancelResponse reports the outcome of a BulkForceCancel.
+//
+// A persistence failure is reported in-band via ErrorMessage rather than as a Go error
+// from HandleCall: returning a non-nil error from a persister HandleCall terminates the
+// persister actor and leaves the caller timing out. The force-cancel contract is
+// persist-before-terminate — the caller must learn the persist failed (and terminate no
+// actors) without crashing the persister. An empty ErrorMessage means success.
 type BulkForceCancelResponse struct {
 	Skipped                 []ResourceUpdateRef // rows that were already terminal (no-op)
 	ForceCanceledInProgress []ResourceUpdateRef // rows that were InProgress (got force-cancel progress entries)
+	ErrorMessage            string              // non-empty if the force-cancel persist failed
 }
 
 // MarkTargetsAsFailed is sent by the changeset executor when target updates
@@ -702,19 +709,36 @@ func (f *FormaCommandPersister) markResourcesAsCanceled(msg *MarkResourcesAsCanc
 	return f.bulkUpdateResourceState(msg.CommandID, msg.Resources, types.ResourceUpdateStateCanceled, util.TimeNow())
 }
 
+// plannedForceCancel describes one in-memory resource-update mutation to apply ONLY
+// after the durable resource-row CAS has succeeded. We compute the plan first, persist,
+// and apply in-memory afterward so that a persistence failure leaves the in-memory cache
+// (which is authoritative) untouched — no split-brain, terminate-no-actors holds.
+type plannedForceCancel struct {
+	idx           int
+	ref           ResourceUpdateRef
+	wasInProgress bool
+	progress      plugin.TrackedProgress
+}
+
 func (f *FormaCommandPersister) bulkForceCancel(msg *BulkForceCancel) (BulkForceCancelResponse, error) {
 	ts := util.TimeNow()
 	resp := BulkForceCancelResponse{}
 
 	cached, err := f.getOrLoadCommand(msg.CommandID)
 	if err != nil {
-		return resp, fmt.Errorf("failed to load command for BulkForceCancel: %w", err)
+		// A load failure means we never touched in-memory state; report it in-band so
+		// the persister stays alive and the caller terminates no actors.
+		resp.ErrorMessage = fmt.Sprintf("failed to load command for BulkForceCancel: %v", err)
+		return resp, nil
 	}
 	command := cached.command
 
 	var inProgressRows []datastore.ForceCancelRow
 	var notStartedRefs []datastore.ResourceUpdateRef
+	var plan []plannedForceCancel
 
+	// Pass 1: plan only — build the DB CAS args and the in-memory mutation plan WITHOUT
+	// mutating the authoritative in-memory cache yet.
 	for _, ref := range msg.Resources {
 		idx := cached.findResourceUpdateIndex(ref.URI.KSUID(), ref.Operation)
 		if idx == -1 {
@@ -735,16 +759,21 @@ func (f *FormaCommandPersister) bulkForceCancel(msg *BulkForceCancel) (BulkForce
 			},
 		}
 
+		p := plannedForceCancel{idx: idx, ref: ref, progress: forceCancelProgress}
+
 		if res.State == types.ResourceUpdateStateInProgress {
+			p.wasInProgress = true
 			// Build the progress list: copy existing + append force-cancel entry
 			newProgressList := append(append([]plugin.TrackedProgress{}, res.ProgressResult...), forceCancelProgress)
 			progressJSON, merr := json.Marshal(newProgressList)
 			if merr != nil {
-				return resp, fmt.Errorf("failed to marshal progress for BulkForceCancel: %w", merr)
+				resp.ErrorMessage = fmt.Sprintf("failed to marshal progress for BulkForceCancel: %v", merr)
+				return resp, nil
 			}
 			mostRecentJSON, merr := json.Marshal(forceCancelProgress)
 			if merr != nil {
-				return resp, fmt.Errorf("failed to marshal most-recent progress for BulkForceCancel: %w", merr)
+				resp.ErrorMessage = fmt.Sprintf("failed to marshal most-recent progress for BulkForceCancel: %v", merr)
+				return resp, nil
 			}
 			inProgressRows = append(inProgressRows, datastore.ForceCancelRow{
 				KSUID:                  res.DesiredState.Ksuid,
@@ -753,10 +782,6 @@ func (f *FormaCommandPersister) bulkForceCancel(msg *BulkForceCancel) (BulkForce
 				MostRecentProgressJSON: mostRecentJSON,
 			})
 			resp.ForceCanceledInProgress = append(resp.ForceCanceledInProgress, ref)
-
-			// Update in-memory progress
-			res.ProgressResult = append(res.ProgressResult, forceCancelProgress)
-			res.MostRecentProgressResult = forceCancelProgress
 		} else {
 			// NotStarted or any other non-final state
 			notStartedRefs = append(notStartedRefs, datastore.ResourceUpdateRef{
@@ -765,25 +790,42 @@ func (f *FormaCommandPersister) bulkForceCancel(msg *BulkForceCancel) (BulkForce
 			})
 		}
 
-		// Terminalize in-memory + counter (mirror bulkUpdateResourceState exactly)
+		plan = append(plan, p)
+	}
+
+	// Persist FIRST. The resource-row CAS is the durable terminal write. If it fails we
+	// have NOT mutated the in-memory cache, so the command stays non-terminal and the
+	// caller (the changeset executor) terminates no actors.
+	result, err := f.datastore.ForceCancelResourceUpdates(msg.CommandID, inProgressRows, notStartedRefs, ts)
+	if err != nil {
+		resp.ErrorMessage = fmt.Sprintf("ForceCancelResourceUpdates failed for command %s: %v", msg.CommandID, err)
+		// Clear the partially-built response lists: nothing was actually canceled.
+		resp.ForceCanceledInProgress = nil
+		resp.Skipped = nil
+		return resp, nil
+	}
+
+	// Pass 2: the durable resource CAS succeeded. Now apply the in-memory mutations.
+	for _, p := range plan {
+		res := &command.ResourceUpdates[p.idx]
+		if p.wasInProgress {
+			res.ProgressResult = append(res.ProgressResult, p.progress)
+			res.MostRecentProgressResult = p.progress
+		}
 		res.State = types.ResourceUpdateStateCanceled
 		res.ModifiedTs = ts
 		cached.pendingCompletions--
 		if cached.pendingCompletions < 0 {
-			return resp, fmt.Errorf("BulkForceCancel: pendingCompletions went below zero for command %s, this indicates a programming error", msg.CommandID)
+			cached.pendingCompletions = 0
+			f.Log().Error("BulkForceCancel: pendingCompletions went below zero for command %s, clamped to zero", msg.CommandID)
 		}
-		key := resourceUpdateKey(ref.URI.KSUID(), ref.Operation)
+		key := resourceUpdateKey(p.ref.URI.KSUID(), p.ref.Operation)
 		if cached.terminalizedByBulk == nil {
 			cached.terminalizedByBulk = make(map[string]bool)
 		}
 		cached.terminalizedByBulk[key] = true
 	}
 
-	// Call datastore to CAS-terminalize the rows
-	result, err := f.datastore.ForceCancelResourceUpdates(msg.CommandID, inProgressRows, notStartedRefs, ts)
-	if err != nil {
-		return resp, fmt.Errorf("ForceCancelResourceUpdates failed for command %s: %w", msg.CommandID, err)
-	}
 	// Merge DB-reported skipped (already-terminal) into response
 	for _, r := range result.Skipped {
 		resp.Skipped = append(resp.Skipped, ResourceUpdateRef{
@@ -808,14 +850,17 @@ func (f *FormaCommandPersister) bulkForceCancel(msg *BulkForceCancel) (BulkForce
 		}
 	}
 
-	// Persist target updates blob
+	// Persist target updates blob (derived from the fenced in-memory state). A failure
+	// here is a best-effort durability miss: the resource rows are already durably
+	// terminal Canceled and recovery's finalizeIncompleteCommand backstop converges the
+	// command meta. We log and continue rather than crash the persister.
 	if len(msg.Targets) > 0 {
+		command.State = overallCommandState(command)
 		targetUpdatesJSON, merr := json.Marshal(command.TargetUpdates)
 		if merr != nil {
-			return resp, fmt.Errorf("failed to marshal target updates for BulkForceCancel: %w", merr)
-		}
-		if merr := f.datastore.UpdateFormaCommandTargetUpdates(command.ID, targetUpdatesJSON, command.State, ts); merr != nil {
-			return resp, fmt.Errorf("failed to persist target updates for BulkForceCancel: %w", merr)
+			f.Log().Error("Failed to marshal target updates for BulkForceCancel commandID=%s: %v", msg.CommandID, merr)
+		} else if merr := f.datastore.UpdateFormaCommandTargetUpdates(command.ID, targetUpdatesJSON, command.State, ts); merr != nil {
+			f.Log().Error("Failed to persist target updates for BulkForceCancel commandID=%s: %v", msg.CommandID, merr)
 		}
 	}
 
@@ -823,7 +868,10 @@ func (f *FormaCommandPersister) bulkForceCancel(msg *BulkForceCancel) (BulkForce
 	command.State = overallCommandState(command)
 
 	if err := f.finalizeAndPersist(cached); err != nil {
-		return resp, err
+		// The resource rows are durably terminal; the command-meta finalize is a
+		// best-effort durability write covered by the recovery backstop. Log, do not
+		// crash the persister, and report success so the caller proceeds with teardown.
+		f.Log().Error("Failed to finalize command meta after BulkForceCancel commandID=%s: %v", msg.CommandID, err)
 	}
 
 	return resp, nil

--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -874,6 +874,17 @@ func (f *FormaCommandPersister) bulkForceCancel(msg *BulkForceCancel) (BulkForce
 	if merr := f.datastore.UpdateFormaCommandTargetUpdates(command.ID, targetUpdatesJSON, command.State, ts); merr != nil {
 		f.Log().Error("Failed to persist terminal command state for BulkForceCancel commandID=%s: %v", msg.CommandID, merr)
 		resp.ErrorMessage = fmt.Sprintf("force-cancel: failed to persist terminal command state: %v", merr)
+		// Pass 2 above has already advanced the in-memory cache, but that is safe and the
+		// command still converges. The resource mutations (state, pendingCompletions,
+		// terminalizedByBulk) mirror the resource-row CAS, which DID commit durably — so
+		// the cache matches the durable resource rows, and dropping a late completion for
+		// a durably-Canceled resource is the intended write-fence, not lost work. Only the
+		// command row stayed InProgress (this atomic write committed nothing). A retry is
+		// idempotent: the now-final in-memory resources report Skipped, so pendingCompletions
+		// is not decremented again, and the retry's atomic write persists the terminal state.
+		// If the agent crashes before a retry, the recovery backstop converges the command
+		// because the resource rows are already durably terminal. So we do not roll the cache
+		// back here — doing so would break retry idempotency for no gain.
 		return resp, nil
 	}
 

--- a/internal/metastructure/forma_persister/forma_command_persister_test.go
+++ b/internal/metastructure/forma_persister/forma_command_persister_test.go
@@ -677,7 +677,7 @@ func TestFormaCommandPersister_Completion_PreservesProperties(t *testing.T) {
 	assert.Equal(t, "final-version-hash", loaded.ResourceUpdates[0].Version)
 }
 
-func TestFormaCommandPersister_DuplicateCompletion_ReturnsError(t *testing.T) {
+func TestFormaCommandPersister_DuplicateCompletion_IsNoOp(t *testing.T) {
 	formaCommand := newFormaCommandWithCreateResourceUpdate()
 	formaPersister, sender, err := newFormaCommandPersisterForTest(t)
 	assert.NoError(t, err)
@@ -700,13 +700,15 @@ func TestFormaCommandPersister_DuplicateCompletion_ReturnsError(t *testing.T) {
 	// First completion: valid, should succeed
 	res1 := formaPersister.Call(sender, markComplete)
 	assert.NoError(t, res1.Error)
+	assert.True(t, res1.Response.(bool))
 
-	// Second completion for the same resource: unexpected duplicate.
-	// After the first completion the command reaches final state and is evicted from cache.
-	// On reload, pendingCompletions = countNonFinalResources = 0 (already final).
-	// Unconditional decrement would make it -1, which must return an error.
+	// Second completion for the same resource: the monotonic terminality guard treats this as
+	// a no-op. The resource is already in a terminal state (Success) so the late message is
+	// silently dropped rather than causing an error. This prevents pendingCompletions underflow
+	// when the command was evicted from cache and reloaded (countNonFinalResources=0).
 	res2 := formaPersister.Call(sender, markComplete)
-	assert.Error(t, res2.Error, "duplicate completion should return an error")
+	assert.NoError(t, res2.Error, "duplicate completion must be a no-op, not an error")
+	assert.True(t, res2.Response.(bool))
 }
 
 func TestIsResourceInFinalState_Success(t *testing.T) {
@@ -840,6 +842,277 @@ func TestFormaCommandPersister_TargetUpdateState_PersistedToDB(t *testing.T) {
 	// The target update state must be Success, not reverted to NotStarted.
 	assert.Equal(t, types.TargetUpdateStateSuccess, loaded.TargetUpdates[0].State,
 		"target update state should be persisted to DB, not just cached in memory")
+}
+
+// TestFormaCommandPersister_LateCompletion_TerminalResourceGuard verifies that a
+// MarkResourceUpdateAsComplete message arriving for a resource update that is already
+// in a terminal state (Canceled) is treated as a no-op. The resource state must not be
+// overwritten, pendingCompletions must not be decremented (which would corrupt the
+// counter), and the overall command state must remain Canceled.
+func TestFormaCommandPersister_LateCompletion_TerminalResourceGuard(t *testing.T) {
+	ksuid1 := util.NewID()
+	ksuid2 := util.NewID()
+
+	formaCommand := &forma_command.FormaCommand{
+		ID:      "test-terminal-resource-guard",
+		State:   forma_command.CommandStateInProgress,
+		Command: pkgmodel.CommandApply,
+		Config: config.FormaCommandConfig{
+			Mode:     pkgmodel.FormaApplyModeReconcile,
+			Simulate: false,
+		},
+		StartTs: util.TimeNow().Add(-1 * time.Hour),
+		ResourceUpdates: []resource_update.ResourceUpdate{
+			{
+				DesiredState: pkgmodel.Resource{
+					Label:      "resource0",
+					Type:       "test-type",
+					Stack:      "test-stack",
+					Properties: json.RawMessage(`{"a":"1"}`),
+					Ksuid:      ksuid1,
+				},
+				Operation: resource_update.OperationCreate,
+				State:     resource_update.ResourceUpdateStateNotStarted,
+			},
+			{
+				DesiredState: pkgmodel.Resource{
+					Label:      "resource1",
+					Type:       "test-type",
+					Stack:      "test-stack",
+					Properties: json.RawMessage(`{"b":"2"}`),
+					Ksuid:      ksuid2,
+				},
+				Operation: resource_update.OperationCreate,
+				State:     resource_update.ResourceUpdateStateNotStarted,
+			},
+		},
+	}
+
+	formaPersister, sender, err := newFormaCommandPersisterForTest(t)
+	assert.NoError(t, err)
+
+	// Store the command: pendingCompletions=2
+	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
+	assert.NoError(t, storeResult.Error)
+	assert.True(t, storeResult.Response.(bool))
+
+	now := util.TimeNow()
+
+	// Cancel resource0 via bulkUpdateResourceState (simulating cancel-command flow).
+	// This transitions resource0 to Canceled and decrements pendingCompletions (2→1).
+	cancelResult := formaPersister.Call(sender, MarkResourcesAsCanceled{
+		CommandID: formaCommand.ID,
+		Resources: []ResourceUpdateRef{
+			{URI: pkgmodel.NewFormaeURI(ksuid1, ""), Operation: resource_update.OperationCreate},
+		},
+	})
+	assert.NoError(t, cancelResult.Error)
+
+	// Deliver a late MarkResourceUpdateAsComplete(Success) for resource0, which is already Canceled.
+	// Without the guard this would decrement pendingCompletions (1→0) and potentially corrupt state.
+	// With the guard this must be a silent no-op.
+	lateComplete := messages.MarkResourceUpdateAsComplete{
+		CommandID:          formaCommand.ID,
+		ResourceURI:        pkgmodel.NewFormaeURI(ksuid1, ""),
+		Operation:          resource_update.OperationCreate,
+		FinalState:         resource_update.ResourceUpdateStateSuccess,
+		ResourceStartTs:    now,
+		ResourceModifiedTs: now,
+	}
+	lateRes := formaPersister.Call(sender, lateComplete)
+	assert.NoError(t, lateRes.Error, "late completion for already-terminal resource must not return an error")
+	assert.True(t, lateRes.Response.(bool))
+
+	// The resource state must still be Canceled (not overwritten to Success).
+	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
+	assert.NoError(t, loadResult.Error)
+	loaded := loadResult.Response.(*forma_command.FormaCommand)
+
+	ruByKsuid := make(map[string]*resource_update.ResourceUpdate)
+	for i := range loaded.ResourceUpdates {
+		ru := &loaded.ResourceUpdates[i]
+		ruByKsuid[ru.DesiredState.Ksuid] = ru
+	}
+	assert.Equal(t, resource_update.ResourceUpdateStateCanceled, ruByKsuid[ksuid1].State,
+		"terminal (Canceled) resource state must not be overwritten by a late completion")
+	assert.Equal(t, resource_update.ResourceUpdateStateNotStarted, ruByKsuid[ksuid2].State,
+		"sibling resource state must be unchanged")
+
+	// Now complete resource1 normally.
+	// pendingCompletions must still be 1 (the late write must not have decremented it).
+	// If it was incorrectly decremented to 0, this completion would underflow and return an error.
+	normalComplete := messages.MarkResourceUpdateAsComplete{
+		CommandID:          formaCommand.ID,
+		ResourceURI:        pkgmodel.NewFormaeURI(ksuid2, ""),
+		Operation:          resource_update.OperationCreate,
+		FinalState:         resource_update.ResourceUpdateStateCanceled,
+		ResourceStartTs:    now,
+		ResourceModifiedTs: now,
+	}
+	normalRes := formaPersister.Call(sender, normalComplete)
+	assert.NoError(t, normalRes.Error, "normal completion after a guarded late write must succeed")
+	assert.True(t, normalRes.Response.(bool))
+
+	// Both resources are now terminal; the overall command state must be Canceled.
+	finalLoad := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
+	assert.NoError(t, finalLoad.Error)
+	finalCmd := finalLoad.Response.(*forma_command.FormaCommand)
+	assert.Equal(t, forma_command.CommandStateCanceled, finalCmd.State,
+		"overall command state must be Canceled after all resources reach terminal state")
+}
+
+// TestFormaCommandPersister_LateTargetCompletion_TerminalTargetGuard verifies that a
+// MarkTargetUpdateAsComplete message arriving for a target already in a terminal state
+// (Canceled) is treated as a no-op. The target state must not be overwritten,
+// and the overall command state must remain Canceled.
+func TestFormaCommandPersister_LateTargetCompletion_TerminalTargetGuard(t *testing.T) {
+	resourceKsuid := util.NewID()
+
+	formaCommand := &forma_command.FormaCommand{
+		ID:      "test-terminal-target-guard",
+		State:   forma_command.CommandStateCanceled,
+		Command: pkgmodel.CommandApply,
+		Config: config.FormaCommandConfig{
+			Mode:     pkgmodel.FormaApplyModeReconcile,
+			Simulate: false,
+		},
+		StartTs: util.TimeNow().Add(-1 * time.Hour),
+		TargetUpdates: []target_update.TargetUpdate{
+			{
+				Target: pkgmodel.Target{
+					Label:     "test-target",
+					Namespace: "test-namespace",
+				},
+				Operation: target_update.TargetOperationCreate,
+				State:     types.TargetUpdateStateCanceled,
+			},
+		},
+		ResourceUpdates: []resource_update.ResourceUpdate{
+			{
+				DesiredState: pkgmodel.Resource{
+					Label:      "test-resource",
+					Type:       "test-type",
+					Stack:      "test-stack",
+					Properties: json.RawMessage(`{"foo":"bar"}`),
+					Ksuid:      resourceKsuid,
+				},
+				Operation: resource_update.OperationCreate,
+				State:     resource_update.ResourceUpdateStateCanceled,
+			},
+		},
+	}
+
+	formaPersister, sender, err := newFormaCommandPersisterForTest(t)
+	assert.NoError(t, err)
+
+	// Store the command with the target already Canceled.
+	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
+	assert.NoError(t, storeResult.Error)
+	assert.True(t, storeResult.Response.(bool))
+
+	now := util.TimeNow()
+
+	// Deliver a late MarkTargetUpdateAsComplete(Success) for the already-Canceled target.
+	// Without the guard this would overwrite the state to Success.
+	lateTargetComplete := messages.MarkTargetUpdateAsComplete{
+		CommandID:       formaCommand.ID,
+		TargetLabel:     "test-target",
+		TargetOperation: string(target_update.TargetOperationCreate),
+		FinalState:      types.TargetUpdateStateSuccess,
+		ModifiedTs:      now,
+	}
+	lateRes := formaPersister.Call(sender, lateTargetComplete)
+	assert.NoError(t, lateRes.Error, "late target completion for already-terminal target must not return an error")
+	assert.True(t, lateRes.Response.(bool))
+
+	// The target update state must still be Canceled (not overwritten to Success).
+	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
+	assert.NoError(t, loadResult.Error)
+	loaded := loadResult.Response.(*forma_command.FormaCommand)
+
+	assert.Equal(t, types.TargetUpdateStateCanceled, loaded.TargetUpdates[0].State,
+		"terminal (Canceled) target state must not be overwritten by a late completion")
+	assert.Equal(t, forma_command.CommandStateCanceled, loaded.State,
+		"overall command state must remain Canceled")
+}
+
+// TestFormaCommandPersister_UpdateTargetStates_MergesTerminalTargets verifies that
+// updateTargetStates (which replaces the whole TargetUpdates slice) does not clobber
+// targets that are already in a terminal state. If the incoming slice carries a
+// non-terminal state for an already-Canceled target, the Canceled state must win.
+func TestFormaCommandPersister_UpdateTargetStates_MergesTerminalTargets(t *testing.T) {
+	resourceKsuid := util.NewID()
+
+	formaCommand := &forma_command.FormaCommand{
+		ID:      "test-update-target-states-merge",
+		State:   forma_command.CommandStateCanceled,
+		Command: pkgmodel.CommandApply,
+		Config: config.FormaCommandConfig{
+			Mode:     pkgmodel.FormaApplyModeReconcile,
+			Simulate: false,
+		},
+		StartTs: util.TimeNow().Add(-1 * time.Hour),
+		TargetUpdates: []target_update.TargetUpdate{
+			{
+				Target: pkgmodel.Target{
+					Label:     "test-target",
+					Namespace: "test-namespace",
+				},
+				Operation: target_update.TargetOperationCreate,
+				State:     types.TargetUpdateStateCanceled,
+			},
+		},
+		ResourceUpdates: []resource_update.ResourceUpdate{
+			{
+				DesiredState: pkgmodel.Resource{
+					Label:      "test-resource",
+					Type:       "test-type",
+					Stack:      "test-stack",
+					Properties: json.RawMessage(`{"foo":"bar"}`),
+					Ksuid:      resourceKsuid,
+				},
+				Operation: resource_update.OperationCreate,
+				State:     resource_update.ResourceUpdateStateCanceled,
+			},
+		},
+	}
+
+	formaPersister, sender, err := newFormaCommandPersisterForTest(t)
+	assert.NoError(t, err)
+
+	// Store the command with the target already Canceled.
+	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
+	assert.NoError(t, storeResult.Error)
+	assert.True(t, storeResult.Response.(bool))
+
+	// Send updateTargetStates with the same target but a non-terminal state (InProgress).
+	// Without the merge guard, this would overwrite the Canceled state with InProgress.
+	lateUpdate := target_update.UpdateTargetStates{
+		CommandID: formaCommand.ID,
+		TargetUpdates: []target_update.TargetUpdate{
+			{
+				Target: pkgmodel.Target{
+					Label:     "test-target",
+					Namespace: "test-namespace",
+				},
+				Operation: target_update.TargetOperationCreate,
+				State:     target_update.TargetUpdateStateInProgress,
+			},
+		},
+	}
+	lateRes := formaPersister.Call(sender, lateUpdate)
+	assert.NoError(t, lateRes.Error, "late updateTargetStates must not return an error")
+	assert.True(t, lateRes.Response.(bool))
+
+	// The target must remain Canceled.
+	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
+	assert.NoError(t, loadResult.Error)
+	loaded := loadResult.Response.(*forma_command.FormaCommand)
+
+	assert.Equal(t, types.TargetUpdateStateCanceled, loaded.TargetUpdates[0].State,
+		"terminal (Canceled) target state must not be clobbered by a late updateTargetStates")
+	assert.Equal(t, forma_command.CommandStateCanceled, loaded.State,
+		"overall command state must remain Canceled")
 }
 
 func newFormaCommandPersisterForTest(t *testing.T) (*unit.TestActor, gen.PID, error) {

--- a/internal/metastructure/forma_persister/forma_command_persister_test.go
+++ b/internal/metastructure/forma_persister/forma_command_persister_test.go
@@ -1129,6 +1129,176 @@ func newFormaCommandPersisterForTest(t *testing.T) (*unit.TestActor, gen.PID, er
 	return newFormaCommandPersisterWithDatastore(t, ds)
 }
 
+// TestFormaCommandPersister_BulkForceCancel_TerminalizesInFlightWork verifies that
+// BulkForceCancel terminalizes all in-flight resource and target updates to Canceled in one
+// persister turn, writes force-cancel progress for InProgress rows, leaves already-terminal
+// rows untouched (Skipped), and correctly accounts for pendingCompletions so that a late
+// MarkResourceUpdateAsComplete is a no-op.
+func TestFormaCommandPersister_BulkForceCancel_TerminalizesInFlightWork(t *testing.T) {
+	ksuid1 := util.NewID()
+	ksuid2 := util.NewID()
+	ksuid3 := util.NewID() // already Success (terminal)
+
+	formaCommand := &forma_command.FormaCommand{
+		ID:      "test-bulk-force-cancel",
+		State:   forma_command.CommandStateInProgress,
+		Command: pkgmodel.CommandApply,
+		Config: config.FormaCommandConfig{
+			Mode:     pkgmodel.FormaApplyModeReconcile,
+			Simulate: false,
+		},
+		StartTs: util.TimeNow().Add(-1 * time.Hour),
+		TargetUpdates: []target_update.TargetUpdate{
+			{
+				Target: pkgmodel.Target{
+					Label:     "test-target",
+					Namespace: "test-namespace",
+				},
+				Operation: target_update.TargetOperationCreate,
+				State:     target_update.TargetUpdateStateNotStarted,
+			},
+		},
+		ResourceUpdates: []resource_update.ResourceUpdate{
+			{
+				DesiredState: pkgmodel.Resource{
+					Label:      "resource1",
+					Type:       "test-type",
+					Stack:      "test-stack",
+					Properties: json.RawMessage(`{"a":"1"}`),
+					Ksuid:      ksuid1,
+				},
+				Operation:      resource_update.OperationCreate,
+				State:          resource_update.ResourceUpdateStateNotStarted,
+				ProgressResult: []plugin.TrackedProgress{},
+			},
+			{
+				DesiredState: pkgmodel.Resource{
+					Label:      "resource2",
+					Type:       "test-type",
+					Stack:      "test-stack",
+					Properties: json.RawMessage(`{"b":"2"}`),
+					Ksuid:      ksuid2,
+				},
+				Operation:      resource_update.OperationCreate,
+				State:          resource_update.ResourceUpdateStateNotStarted,
+				ProgressResult: []plugin.TrackedProgress{},
+			},
+			{
+				DesiredState: pkgmodel.Resource{
+					Label:      "resource3",
+					Type:       "test-type",
+					Stack:      "test-stack",
+					Properties: json.RawMessage(`{"c":"3"}`),
+					Ksuid:      ksuid3,
+				},
+				Operation: resource_update.OperationCreate,
+				State:     resource_update.ResourceUpdateStateSuccess, // already terminal
+			},
+		},
+	}
+
+	formaPersister, sender, err := newFormaCommandPersisterForTest(t)
+	assert.NoError(t, err)
+
+	// Store: pendingCompletions=3 (all 3 RUs, incl. ksuid3 which is Success — stored as-is)
+	// Note: storeNewFormaCommand sets pendingCompletions = len(ResourceUpdates) = 3
+	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
+	assert.NoError(t, storeResult.Error)
+	assert.True(t, storeResult.Response.(bool))
+
+	// Advance ksuid1 and ksuid2 to InProgress via UpdateResourceProgress
+	now := util.TimeNow()
+	for _, ksuid := range []string{ksuid1, ksuid2} {
+		progress := messages.UpdateResourceProgress{
+			CommandID:          formaCommand.ID,
+			ResourceURI:        pkgmodel.NewFormaeURI(ksuid, ""),
+			Operation:          resource_update.OperationCreate,
+			ResourceStartTs:    now,
+			ResourceModifiedTs: now,
+			ResourceState:      resource_update.ResourceUpdateStateInProgress,
+			Progress: plugin.TrackedProgress{
+				ProgressResult: resource.ProgressResult{
+					Operation:       resource.OperationCreate,
+					OperationStatus: resource.OperationStatusInProgress,
+					RequestID:       "req-" + ksuid,
+				},
+			},
+		}
+		res := formaPersister.Call(sender, progress)
+		assert.NoError(t, res.Error)
+	}
+
+	// BulkForceCancel: include all 3 resources + the target
+	bulkCancel := BulkForceCancel{
+		CommandID: formaCommand.ID,
+		Resources: []ResourceUpdateRef{
+			{URI: pkgmodel.NewFormaeURI(ksuid1, ""), Operation: resource_update.OperationCreate},
+			{URI: pkgmodel.NewFormaeURI(ksuid2, ""), Operation: resource_update.OperationCreate},
+			{URI: pkgmodel.NewFormaeURI(ksuid3, ""), Operation: resource_update.OperationCreate},
+		},
+		Targets: []TargetUpdateRef{
+			{Label: "test-target", Operation: target_update.TargetOperationCreate},
+		},
+	}
+	cancelResult := formaPersister.Call(sender, bulkCancel)
+	assert.NoError(t, cancelResult.Error)
+
+	resp, ok := cancelResult.Response.(BulkForceCancelResponse)
+	assert.True(t, ok, "response must be BulkForceCancelResponse")
+
+	// ksuid3 (Success) must appear in Skipped
+	assert.Len(t, resp.Skipped, 1)
+	assert.Equal(t, ksuid3, resp.Skipped[0].URI.KSUID())
+
+	// ksuid1 and ksuid2 (InProgress) must appear in ForceCanceledInProgress
+	assert.Len(t, resp.ForceCanceledInProgress, 2)
+	forceCanceledKsuids := []string{
+		resp.ForceCanceledInProgress[0].URI.KSUID(),
+		resp.ForceCanceledInProgress[1].URI.KSUID(),
+	}
+	assert.Contains(t, forceCanceledKsuids, ksuid1)
+	assert.Contains(t, forceCanceledKsuids, ksuid2)
+
+	// Reload from DB (command was finalized and evicted from cache)
+	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
+	assert.NoError(t, loadResult.Error)
+	loaded := loadResult.Response.(*forma_command.FormaCommand)
+
+	// Build lookup by ksuid
+	ruByKsuid := make(map[string]*resource_update.ResourceUpdate)
+	for i := range loaded.ResourceUpdates {
+		ru := &loaded.ResourceUpdates[i]
+		ruByKsuid[ru.DesiredState.Ksuid] = ru
+	}
+
+	assert.Equal(t, resource_update.ResourceUpdateStateCanceled, ruByKsuid[ksuid1].State, "ksuid1 must be Canceled")
+	assert.Equal(t, resource_update.ResourceUpdateStateCanceled, ruByKsuid[ksuid2].State, "ksuid2 must be Canceled")
+	assert.Equal(t, resource_update.ResourceUpdateStateSuccess, ruByKsuid[ksuid3].State, "ksuid3 must remain Success")
+
+	assert.Equal(t, types.TargetUpdateStateCanceled, loaded.TargetUpdates[0].State, "target must be Canceled")
+	assert.Equal(t, forma_command.CommandStateCanceled, loaded.State, "command must be Canceled")
+
+	// Late MarkResourceUpdateAsComplete for ksuid1 (already Canceled) must be a no-op.
+	// The terminalizedByBulk guard fires, pendingCompletions must NOT underflow.
+	lateComplete := messages.MarkResourceUpdateAsComplete{
+		CommandID:          formaCommand.ID,
+		ResourceURI:        pkgmodel.NewFormaeURI(ksuid1, ""),
+		Operation:          resource_update.OperationCreate,
+		FinalState:         resource_update.ResourceUpdateStateSuccess,
+		ResourceStartTs:    now,
+		ResourceModifiedTs: now,
+	}
+	lateRes := formaPersister.Call(sender, lateComplete)
+	assert.NoError(t, lateRes.Error, "late completion for already-terminal resource must be a no-op")
+	assert.True(t, lateRes.Response.(bool))
+
+	// State must still be Canceled after the late no-op
+	finalLoad := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
+	assert.NoError(t, finalLoad.Error)
+	finalCmd := finalLoad.Response.(*forma_command.FormaCommand)
+	assert.Equal(t, forma_command.CommandStateCanceled, finalCmd.State)
+}
+
 func newFormaCommandPersisterWithDatastore(t *testing.T, ds datastore.Datastore) (*unit.TestActor, gen.PID, error) {
 	env := map[gen.Env]any{
 		"Datastore": ds,

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -50,8 +50,8 @@ type MetastructureAPI interface {
 	ApplyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string) (*apimodel.SubmitCommandResponse, error)
 	DestroyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string) (*apimodel.SubmitCommandResponse, error)
 	DestroyByQuery(query string, config *config.FormaCommandConfig, clientID string) (*apimodel.SubmitCommandResponse, error)
-	CancelCommand(commandID string, clientID string) (*changeset.CancelResponse, error)
-	CancelCommandsByQuery(query string, clientID string) (*apimodel.CancelCommandResponse, error)
+	CancelCommand(commandID string, force bool, clientID string) (*changeset.CancelResponse, error)
+	CancelCommandsByQuery(query string, force bool, clientID string) (*apimodel.CancelCommandResponse, error)
 	ListFormaCommandStatus(query string, clientID string, n int) (*apimodel.ListCommandStatusResponse, error)
 	ExtractResources(query string) (*pkgmodel.Forma, error)
 	ExtractTargets(query string) ([]*pkgmodel.Target, error)
@@ -824,8 +824,8 @@ func (m *Metastructure) DestroyByQuery(query string, config *config.FormaCommand
 	return m.DestroyForma(forma, config, clientID)
 }
 
-func (m *Metastructure) CancelCommand(commandID string, clientID string) (*changeset.CancelResponse, error) {
-	slog.Info("Canceling command", "commandID", commandID, "clientID", clientID)
+func (m *Metastructure) CancelCommand(commandID string, force bool, clientID string) (*changeset.CancelResponse, error) {
+	slog.Info("Canceling command", "commandID", commandID, "force", force, "clientID", clientID)
 
 	changesetExecutorPID := gen.ProcessID{
 		Name: actornames.ChangesetExecutor(commandID),
@@ -834,6 +834,7 @@ func (m *Metastructure) CancelCommand(commandID string, clientID string) (*chang
 
 	result, err := m.callActor(changesetExecutorPID, changeset.Cancel{
 		CommandID: commandID,
+		Force:     force,
 	})
 	if err != nil {
 		slog.Error("Failed to cancel command", "commandID", commandID, "error", err)
@@ -845,10 +846,17 @@ func (m *Metastructure) CancelCommand(commandID string, clientID string) (*chang
 		return nil, fmt.Errorf("unexpected response type from changeset executor: %T", result)
 	}
 
+	// A --force cancel that failed to persist carries its error in-band (the executor
+	// stayed alive and terminated no actors). Surface it as a returned error.
+	if cancelResp.ErrorMessage != "" {
+		slog.Error("Force-cancel failed to persist", "commandID", commandID, "error", cancelResp.ErrorMessage)
+		return nil, fmt.Errorf("failed to force-cancel command: %s", cancelResp.ErrorMessage)
+	}
+
 	return &cancelResp, nil
 }
 
-func (m *Metastructure) CancelCommandsByQuery(query string, clientID string) (*apimodel.CancelCommandResponse, error) {
+func (m *Metastructure) CancelCommandsByQuery(query string, force bool, clientID string) (*apimodel.CancelCommandResponse, error) {
 	var commandsToCancel []*forma_command.FormaCommand
 	var err error
 
@@ -875,7 +883,7 @@ func (m *Metastructure) CancelCommandsByQuery(query string, clientID string) (*a
 	allResourceStates := make(map[string]apimodel.CancelResourceState)
 	for _, cmd := range commandsToCancel {
 		if cmd.State == forma_command.CommandStateInProgress {
-			cancelResp, err := m.CancelCommand(cmd.ID, clientID)
+			cancelResp, err := m.CancelCommand(cmd.ID, force, clientID)
 			if err != nil {
 				slog.Warn("Failed to cancel command", "commandID", cmd.ID, "error", err)
 				// Continue with other commands even if one fails
@@ -883,8 +891,15 @@ func (m *Metastructure) CancelCommandsByQuery(query string, clientID string) (*a
 			}
 			canceledCommandIDs = append(canceledCommandIDs, cmd.ID)
 			if cancelResp != nil {
+				forceCanceled := make(map[string]bool, len(cancelResp.ForceCanceledInProgress))
+				for _, uri := range cancelResp.ForceCanceledInProgress {
+					forceCanceled[uri] = true
+				}
 				for uri, state := range cancelResp.ResourceStates {
-					allResourceStates[uri] = apimodel.CancelResourceState{State: state}
+					allResourceStates[uri] = apimodel.CancelResourceState{
+						State:         state,
+						ForceCanceled: forceCanceled[uri],
+					}
 				}
 			}
 		}
@@ -893,6 +908,7 @@ func (m *Metastructure) CancelCommandsByQuery(query string, clientID string) (*a
 	return &apimodel.CancelCommandResponse{
 		CommandIDs:           canceledCommandIDs,
 		ResourceUpdateStates: allResourceStates,
+		Forced:               force,
 	}, nil
 }
 

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -880,13 +880,21 @@ func (m *Metastructure) CancelCommandsByQuery(query string, force bool, clientID
 
 	// Filter to only InProgress commands
 	var canceledCommandIDs []string
+	var forceCancelFailures []string
 	allResourceStates := make(map[string]apimodel.CancelResourceState)
 	for _, cmd := range commandsToCancel {
 		if cmd.State == forma_command.CommandStateInProgress {
 			cancelResp, err := m.CancelCommand(cmd.ID, force, clientID)
 			if err != nil {
 				slog.Warn("Failed to cancel command", "commandID", cmd.ID, "error", err)
-				// Continue with other commands even if one fails
+				// A --force cancel that fails left the command running: the executor
+				// terminated no actors and the command is still non-terminal. Record it
+				// so the caller is told to retry rather than seeing a success with the
+				// command silently dropped. A graceful (non-force) cancel of a command
+				// that has since vanished is benign, so keep skipping those.
+				if force {
+					forceCancelFailures = append(forceCancelFailures, fmt.Sprintf("%s: %v", cmd.ID, err))
+				}
 				continue
 			}
 			canceledCommandIDs = append(canceledCommandIDs, cmd.ID)
@@ -903,6 +911,11 @@ func (m *Metastructure) CancelCommandsByQuery(query string, force bool, clientID
 				}
 			}
 		}
+	}
+
+	if len(forceCancelFailures) > 0 {
+		return nil, fmt.Errorf("force-cancel failed for %d command(s): %s",
+			len(forceCancelFailures), strings.Join(forceCancelFailures, "; "))
 	}
 
 	return &apimodel.CancelCommandResponse{

--- a/internal/metastructure/target_update/target_update.go
+++ b/internal/metastructure/target_update/target_update.go
@@ -29,6 +29,7 @@ const (
 	TargetUpdateStateInProgress = types.TargetUpdateStateInProgress
 	TargetUpdateStateSuccess    = types.TargetUpdateStateSuccess
 	TargetUpdateStateFailed     = types.TargetUpdateStateFailed
+	TargetUpdateStateCanceled   = types.TargetUpdateStateCanceled
 )
 
 // TargetUpdate represents an update to a target in the system

--- a/internal/metastructure/types/types.go
+++ b/internal/metastructure/types/types.go
@@ -62,6 +62,7 @@ const (
 	TargetUpdateStateInProgress TargetUpdateState = "InProgress"
 	TargetUpdateStateSuccess    TargetUpdateState = "Success"
 	TargetUpdateStateFailed     TargetUpdateState = "Failed"
+	TargetUpdateStateCanceled   TargetUpdateState = "Canceled"
 )
 
 // StackUpdateState represents the state of a stack update

--- a/internal/metastructure/types/types.go
+++ b/internal/metastructure/types/types.go
@@ -44,6 +44,16 @@ const (
 	ResourceUpdateStateRejected   ResourceUpdateState = "Rejected"
 )
 
+// TerminalStates is the authoritative set of ResourceUpdateState values from which
+// no further state transitions are permitted. Used by datastore backends to
+// implement monotonic terminality (CAS guard).
+var TerminalStates = []ResourceUpdateState{
+	ResourceUpdateStateSuccess,
+	ResourceUpdateStateFailed,
+	ResourceUpdateStateRejected,
+	ResourceUpdateStateCanceled,
+}
+
 // TargetUpdateState represents the state of a target update
 type TargetUpdateState string
 

--- a/internal/workflow_tests/local/cancel_command_test.go
+++ b/internal/workflow_tests/local/cancel_command_test.go
@@ -190,7 +190,7 @@ func TestMetastructure_CancelCommand(t *testing.T) {
 		}, 10*time.Second, 100*time.Millisecond, "Expected at least 2 resource updates to be in progress")
 
 		// Cancel the command while resources are still being processed
-		_, err = m.CancelCommand(commandID, "test-client")
+		_, err = m.CancelCommand(commandID, false, "test-client")
 		require.NoError(t, err)
 
 		// Verify the command was canceled

--- a/internal/workflow_tests/local/force_cancel_command_test.go
+++ b/internal/workflow_tests/local/force_cancel_command_test.go
@@ -235,11 +235,21 @@ func TestMetastructure_ForceCancelCommand_ConvergesWhereNonForceHangs(t *testing
 	})
 }
 
-// faultInjectingDatastore wraps a Datastore and fails ForceCancelResourceUpdates a
-// configurable number of times before delegating to the real implementation.
+// faultInjectingDatastore wraps a Datastore and can fail the two distinct durable
+// writes a BulkForceCancel performs: the early resource-row CAS
+// (ForceCancelResourceUpdates) and the late authoritative command-blob write
+// (StoreFormaCommand, via finalizeAndPersist). Each is independently configurable so
+// tests can exercise both the early-failure and late-failure branches of the
+// persist-before-terminate contract.
 type faultInjectingDatastore struct {
 	datastore.Datastore
 	failuresRemaining atomic.Int32
+	// finalizeFailuresRemaining fails the next StoreFormaCommand, but only once a CAS
+	// has succeeded (i.e. we are inside a force-cancel turn past the row CAS). This
+	// targets the finalizeAndPersist write specifically without disturbing the
+	// StoreFormaCommand calls made during normal apply.
+	finalizeFailuresRemaining atomic.Int32
+	finalizeFailArmed         atomic.Bool
 }
 
 func (d *faultInjectingDatastore) ForceCancelResourceUpdates(commandID string, inProgress []datastore.ForceCancelRow, notStarted []datastore.ResourceUpdateRef, modifiedTs time.Time) (datastore.ForceCancelResult, error) {
@@ -247,7 +257,21 @@ func (d *faultInjectingDatastore) ForceCancelResourceUpdates(commandID string, i
 		d.failuresRemaining.Add(-1)
 		return datastore.ForceCancelResult{}, fmt.Errorf("injected ForceCancelResourceUpdates failure")
 	}
+	// The row CAS is about to succeed; arm the next StoreFormaCommand to fail so the
+	// failure lands on the finalizeAndPersist write that follows in this same turn.
+	if d.finalizeFailuresRemaining.Load() > 0 {
+		d.finalizeFailArmed.Store(true)
+	}
 	return d.Datastore.ForceCancelResourceUpdates(commandID, inProgress, notStarted, modifiedTs)
+}
+
+func (d *faultInjectingDatastore) StoreFormaCommand(command *forma_command.FormaCommand, commandID string) error {
+	if d.finalizeFailArmed.Load() && d.finalizeFailuresRemaining.Load() > 0 {
+		d.finalizeFailArmed.Store(false)
+		d.finalizeFailuresRemaining.Add(-1)
+		return fmt.Errorf("injected StoreFormaCommand failure")
+	}
+	return d.Datastore.StoreFormaCommand(command, commandID)
 }
 
 // TestMetastructure_ForceCancelCommand_PersisterFailureTerminatesNoActors verifies the
@@ -299,6 +323,66 @@ func TestMetastructure_ForceCancelCommand_PersisterFailureTerminatesNoActors(t *
 		// Retry succeeds and the command converges to Canceled.
 		_, err = m.CancelCommand(commandID, true, "test-client")
 		require.NoError(t, err, "retry after a transient persister failure should succeed")
+
+		assert.Eventually(t, func() bool {
+			cmd := loadSingleCommand(t, m.Datastore)
+			return cmd.State == forma_command.CommandStateCanceled
+		}, 5*time.Second, 50*time.Millisecond, "retry should drive the command to Canceled")
+	})
+}
+
+// TestMetastructure_ForceCancelCommand_FinalizePersistFailureSurfaces covers the late
+// branch of the persist-before-terminate contract: the resource-row CAS succeeds but the
+// authoritative command-blob write (finalizeAndPersist/StoreFormaCommand) then fails.
+// That write is the only durable home of the overall command state and the target
+// updates, so its failure must surface in-band — the force-cancel reports an error,
+// terminates no actors, and the command stays InProgress until a retry converges it.
+func TestMetastructure_ForceCancelCommand_FinalizePersistFailureSurfaces(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		cfg := test_helpers.NewTestMetastructureConfig()
+		base, err := dssqlite.NewDatastoreSQLite(context.Background(), &cfg.Agent.Datastore, "test")
+		require.NoError(t, err)
+
+		ds := &faultInjectingDatastore{Datastore: base}
+		ds.finalizeFailuresRemaining.Store(1) // CAS succeeds, the following finalize write fails once
+
+		m, def, err := test_helpers.NewTestMetastructureWithEverything(t, neverReturningOverrides(), ds, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		resp, err := m.ApplyForma(twoBucketForma(), &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test-client")
+		require.NoError(t, err)
+		commandID := resp.CommandID
+
+		assert.Eventually(t, func() bool {
+			commands, err := m.Datastore.LoadFormaCommands()
+			if err != nil || len(commands) != 1 {
+				return false
+			}
+			inProgress := 0
+			for _, ru := range commands[0].ResourceUpdates {
+				if ru.State == resource_update.ResourceUpdateStateInProgress {
+					inProgress++
+				}
+			}
+			return inProgress >= 2
+		}, 10*time.Second, 50*time.Millisecond, "expected resources to be in progress")
+
+		// First force-cancel: the row CAS commits but the finalize write fails. The
+		// failure must surface even though the resource rows were durably terminalized.
+		_, err = m.CancelCommand(commandID, true, "test-client")
+		require.Error(t, err, "a finalize-write failure after the CAS must surface, not report success")
+
+		// No actors were terminated: the command is still non-terminal.
+		cmd := loadSingleCommand(t, m.Datastore)
+		assert.Equal(t, forma_command.CommandStateInProgress, cmd.State,
+			"command must stay InProgress when the finalize write fails (terminate no actors)")
+
+		// Retry succeeds and the command converges to Canceled.
+		_, err = m.CancelCommand(commandID, true, "test-client")
+		require.NoError(t, err, "retry after a transient finalize failure should succeed")
 
 		assert.Eventually(t, func() bool {
 			cmd := loadSingleCommand(t, m.Datastore)

--- a/internal/workflow_tests/local/force_cancel_command_test.go
+++ b/internal/workflow_tests/local/force_cancel_command_test.go
@@ -1,0 +1,396 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/types"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// neverReturningOverrides models a plugin whose operations never complete: Create
+// reports InProgress and Status keeps reporting InProgress forever. Without --force a
+// command using this plugin would hang indefinitely (no meaningful timeout exists for
+// legitimately-unbounded operations); --force is the escape hatch.
+func neverReturningOverrides() *plugin.ResourcePluginOverrides {
+	return &plugin.ResourcePluginOverrides{
+		Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+			return &resource.CreateResult{
+				ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationCreate,
+					OperationStatus: resource.OperationStatusInProgress,
+					RequestID:       "request-" + request.Label,
+					NativeID:        "native-" + request.Label,
+				},
+			}, nil
+		},
+		Status: func(request *resource.StatusRequest) (*resource.StatusResult, error) {
+			// Never completes.
+			return &resource.StatusResult{
+				ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationCreate,
+					OperationStatus: resource.OperationStatusInProgress,
+					RequestID:       request.RequestID,
+				},
+			}, nil
+		},
+	}
+}
+
+// twoBucketForma builds a forma with independent resources that all start immediately
+// and stay InProgress under the never-returning override.
+func twoBucketForma() *pkgmodel.Forma {
+	return &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label:      "bucket1",
+				Type:       "FakeAWS::S3::Bucket",
+				Properties: json.RawMessage(`{"BucketName": "test-bucket-1"}`),
+				Stack:      "test-stack",
+				Target:     "test-target",
+				Managed:    true,
+			},
+			{
+				Label:      "bucket2",
+				Type:       "FakeAWS::S3::Bucket",
+				Properties: json.RawMessage(`{"BucketName": "test-bucket-2"}`),
+				Stack:      "test-stack",
+				Target:     "test-target",
+				Managed:    true,
+			},
+			{
+				Label:      "vpc",
+				Type:       "FakeAWS::EC2::VPC",
+				Properties: json.RawMessage(`{"CidrBlock": "10.0.0.0/16"}`),
+				Stack:      "test-stack",
+				Target:     "test-target",
+				Managed:    true,
+			},
+		},
+		Targets: []pkgmodel.Target{{Label: "test-target"}},
+	}
+}
+
+// loadSingleCommand loads the (single) command from the datastore.
+func loadSingleCommand(t *testing.T, ds datastore.Datastore) *forma_command.FormaCommand {
+	t.Helper()
+	commands, err := ds.LoadFormaCommands()
+	require.NoError(t, err)
+	require.Len(t, commands, 1)
+	return commands[0]
+}
+
+// TestMetastructure_ForceCancelCommand_ReachesCanceledImmediately verifies that --force
+// drives a command with multiple InProgress resources (gated on a never-returning plugin)
+// to a terminal Canceled state, and that each force-canceled-in-progress resource update
+// gets a progress entry carrying OperationStatus = OperationStatusCanceled.
+func TestMetastructure_ForceCancelCommand_ReachesCanceledImmediately(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, def, err := test_helpers.NewTestMetastructure(t, neverReturningOverrides())
+		defer def()
+		require.NoError(t, err)
+
+		resp, err := m.ApplyForma(twoBucketForma(), &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test-client")
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		commandID := resp.CommandID
+
+		// Wait for at least 2 resources to be InProgress.
+		assert.Eventually(t, func() bool {
+			commands, err := m.Datastore.LoadFormaCommands()
+			if err != nil || len(commands) != 1 || len(commands[0].ResourceUpdates) != 3 {
+				return false
+			}
+			inProgress := 0
+			for _, ru := range commands[0].ResourceUpdates {
+				if ru.State == resource_update.ResourceUpdateStateInProgress {
+					inProgress++
+				}
+			}
+			return inProgress >= 2
+		}, 10*time.Second, 50*time.Millisecond, "expected at least 2 resource updates to be in progress")
+
+		// Force-cancel.
+		cancelResp, err := m.CancelCommand(commandID, true, "test-client")
+		require.NoError(t, err)
+		require.NotNil(t, cancelResp)
+
+		// The command must reach a terminal Canceled state quickly.
+		assert.Eventually(t, func() bool {
+			cmd := loadSingleCommand(t, m.Datastore)
+			return cmd.State == forma_command.CommandStateCanceled
+		}, 5*time.Second, 50*time.Millisecond, "expected command to reach Canceled state immediately")
+
+		cmd := loadSingleCommand(t, m.Datastore)
+		require.Len(t, cmd.ResourceUpdates, 3)
+
+		// Every resource update must be terminal Canceled.
+		forceCanceledMidOp := 0
+		for _, ru := range cmd.ResourceUpdates {
+			assert.Equal(t, resource_update.ResourceUpdateStateCanceled, ru.State,
+				"resource %s should be Canceled", ru.DesiredState.Label)
+
+			// In-progress resources get a force-cancel progress entry.
+			hasCanceledProgress := false
+			for _, p := range ru.ProgressResult {
+				if p.OperationStatus == resource.OperationStatusCanceled {
+					hasCanceledProgress = true
+				}
+			}
+			if hasCanceledProgress {
+				forceCanceledMidOp++
+			}
+		}
+
+		// At least the 2 InProgress resources must carry a Canceled progress entry.
+		assert.GreaterOrEqual(t, forceCanceledMidOp, 2,
+			"expected at least 2 force-canceled-in-progress resources to carry an OperationStatusCanceled progress entry")
+
+		// The cancel response must report the force-canceled-in-progress URIs.
+		assert.GreaterOrEqual(t, len(cancelResp.ForceCanceledInProgress), 2,
+			"expected the cancel response to report the force-canceled-in-progress resources")
+
+		// No resources should be persisted to the stack (none completed).
+		resources, err := m.Datastore.LoadResourcesByStack("test-stack")
+		if err == nil {
+			assert.Empty(t, resources, "no resources should be persisted: all were abandoned mid-create")
+		}
+	})
+}
+
+// TestMetastructure_ForceCancelCommand_ConvergesWhereNonForceHangs is the deterministic
+// version of the real escape-hatch case: under the never-returning plugin a non-force
+// cancel would leave the command waiting forever. With --force the command converges to
+// Canceled within a short, conservative bound.
+func TestMetastructure_ForceCancelCommand_ConvergesWhereNonForceHangs(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, def, err := test_helpers.NewTestMetastructure(t, neverReturningOverrides())
+		defer def()
+		require.NoError(t, err)
+
+		resp, err := m.ApplyForma(twoBucketForma(), &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test-client")
+		require.NoError(t, err)
+		commandID := resp.CommandID
+
+		// Wait for the resources to be InProgress.
+		assert.Eventually(t, func() bool {
+			commands, err := m.Datastore.LoadFormaCommands()
+			if err != nil || len(commands) != 1 {
+				return false
+			}
+			inProgress := 0
+			for _, ru := range commands[0].ResourceUpdates {
+				if ru.State == resource_update.ResourceUpdateStateInProgress {
+					inProgress++
+				}
+			}
+			return inProgress >= 2
+		}, 10*time.Second, 50*time.Millisecond, "expected resources to be in progress")
+
+		// A non-force cancel here would never converge (the plugin never returns).
+		// Issue it, confirm the command stays non-terminal for a short window.
+		_, err = m.CancelCommand(commandID, false, "test-client")
+		require.NoError(t, err)
+
+		assert.Never(t, func() bool {
+			cmd := loadSingleCommand(t, m.Datastore)
+			return cmd.State == forma_command.CommandStateCanceled
+		}, 1*time.Second, 100*time.Millisecond, "non-force cancel should NOT converge while resources hang")
+
+		// Now escalate with --force; it must converge to Canceled within a short bound.
+		_, err = m.CancelCommand(commandID, true, "test-client")
+		require.NoError(t, err)
+
+		assert.Eventually(t, func() bool {
+			cmd := loadSingleCommand(t, m.Datastore)
+			return cmd.State == forma_command.CommandStateCanceled
+		}, 5*time.Second, 50*time.Millisecond, "force-cancel should converge to Canceled within a short bound")
+	})
+}
+
+// faultInjectingDatastore wraps a Datastore and fails ForceCancelResourceUpdates a
+// configurable number of times before delegating to the real implementation.
+type faultInjectingDatastore struct {
+	datastore.Datastore
+	failuresRemaining atomic.Int32
+}
+
+func (d *faultInjectingDatastore) ForceCancelResourceUpdates(commandID string, inProgress []datastore.ForceCancelRow, notStarted []datastore.ResourceUpdateRef, modifiedTs time.Time) (datastore.ForceCancelResult, error) {
+	if d.failuresRemaining.Load() > 0 {
+		d.failuresRemaining.Add(-1)
+		return datastore.ForceCancelResult{}, fmt.Errorf("injected ForceCancelResourceUpdates failure")
+	}
+	return d.Datastore.ForceCancelResourceUpdates(commandID, inProgress, notStarted, modifiedTs)
+}
+
+// TestMetastructure_ForceCancelCommand_PersisterFailureTerminatesNoActors verifies the
+// persist-before-terminate contract: when the BulkForceCancel datastore write fails, the
+// force-cancel surfaces the error, terminates no actors (the command stays non-terminal),
+// and a retry succeeds.
+func TestMetastructure_ForceCancelCommand_PersisterFailureTerminatesNoActors(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		cfg := test_helpers.NewTestMetastructureConfig()
+		base, err := dssqlite.NewDatastoreSQLite(context.Background(), &cfg.Agent.Datastore, "test")
+		require.NoError(t, err)
+
+		ds := &faultInjectingDatastore{Datastore: base}
+		ds.failuresRemaining.Store(1) // fail the first force-cancel, succeed on retry
+
+		m, def, err := test_helpers.NewTestMetastructureWithEverything(t, neverReturningOverrides(), ds, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		resp, err := m.ApplyForma(twoBucketForma(), &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test-client")
+		require.NoError(t, err)
+		commandID := resp.CommandID
+
+		assert.Eventually(t, func() bool {
+			commands, err := m.Datastore.LoadFormaCommands()
+			if err != nil || len(commands) != 1 {
+				return false
+			}
+			inProgress := 0
+			for _, ru := range commands[0].ResourceUpdates {
+				if ru.State == resource_update.ResourceUpdateStateInProgress {
+					inProgress++
+				}
+			}
+			return inProgress >= 2
+		}, 10*time.Second, 50*time.Millisecond, "expected resources to be in progress")
+
+		// First force-cancel: the injected datastore failure must surface as an error.
+		_, err = m.CancelCommand(commandID, true, "test-client")
+		require.Error(t, err, "force-cancel should surface the persister error")
+
+		// No actors were terminated: the command is still non-terminal (InProgress).
+		cmd := loadSingleCommand(t, m.Datastore)
+		assert.Equal(t, forma_command.CommandStateInProgress, cmd.State,
+			"command must stay InProgress when the force-cancel persist fails (terminate no actors)")
+
+		// Retry succeeds and the command converges to Canceled.
+		_, err = m.CancelCommand(commandID, true, "test-client")
+		require.NoError(t, err, "retry after a transient persister failure should succeed")
+
+		assert.Eventually(t, func() bool {
+			cmd := loadSingleCommand(t, m.Datastore)
+			return cmd.State == forma_command.CommandStateCanceled
+		}, 5*time.Second, 50*time.Millisecond, "retry should drive the command to Canceled")
+	})
+}
+
+// TestMetastructure_ForceCancelCommand_WriteFenceDropsLateMessages verifies the monotonic
+// terminality write-fence at the workflow level: after a force-cancel commits, a late
+// completion message for a force-canceled resource update is dropped — the per-RU state
+// stays Canceled and the command stays Canceled.
+func TestMetastructure_ForceCancelCommand_WriteFenceDropsLateMessages(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, def, err := test_helpers.NewTestMetastructure(t, neverReturningOverrides())
+		defer def()
+		require.NoError(t, err)
+
+		// Spawn the test helper actor so we can Call the persister directly to inject
+		// late messages.
+		helperMessages := make(chan any, 16)
+		_, err = testutil.StartTestHelperActor(m.Node, helperMessages)
+		require.NoError(t, err)
+
+		resp, err := m.ApplyForma(twoBucketForma(), &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test-client")
+		require.NoError(t, err)
+		commandID := resp.CommandID
+
+		assert.Eventually(t, func() bool {
+			commands, err := m.Datastore.LoadFormaCommands()
+			if err != nil || len(commands) != 1 {
+				return false
+			}
+			inProgress := 0
+			for _, ru := range commands[0].ResourceUpdates {
+				if ru.State == resource_update.ResourceUpdateStateInProgress {
+					inProgress++
+				}
+			}
+			return inProgress >= 2
+		}, 10*time.Second, 50*time.Millisecond, "expected resources to be in progress")
+
+		_, err = m.CancelCommand(commandID, true, "test-client")
+		require.NoError(t, err)
+
+		assert.Eventually(t, func() bool {
+			cmd := loadSingleCommand(t, m.Datastore)
+			return cmd.State == forma_command.CommandStateCanceled
+		}, 5*time.Second, 50*time.Millisecond, "expected command to reach Canceled")
+
+		cmd := loadSingleCommand(t, m.Datastore)
+
+		// Pick a force-canceled resource update and inject a LATE completion as if its
+		// orphaned operator had finished after the force-cancel committed.
+		require.NotEmpty(t, cmd.ResourceUpdates)
+		victim := cmd.ResourceUpdates[0]
+
+		_, err = testutil.Call(m.Node, "FormaCommandPersister", messages.MarkResourceUpdateAsComplete{
+			CommandID:          commandID,
+			ResourceURI:        victim.DesiredState.URI(),
+			Operation:          victim.Operation,
+			FinalState:         types.ResourceUpdateStateSuccess,
+			ResourceModifiedTs: time.Now(),
+		})
+		require.NoError(t, err)
+
+		// Also inject a late progress update.
+		_, _ = testutil.Call(m.Node, "FormaCommandPersister", messages.UpdateResourceProgress{
+			CommandID:     commandID,
+			ResourceURI:   victim.DesiredState.URI(),
+			Operation:     victim.Operation,
+			ResourceState: types.ResourceUpdateStateInProgress,
+			Progress: plugin.TrackedProgress{
+				ProgressResult: resource.ProgressResult{
+					Operation:       resource.Operation(victim.Operation),
+					OperationStatus: resource.OperationStatusSuccess,
+				},
+			},
+		})
+
+		// The late messages must be dropped: the victim stays Canceled and the command
+		// stays Canceled.
+		cmd = loadSingleCommand(t, m.Datastore)
+		assert.Equal(t, forma_command.CommandStateCanceled, cmd.State,
+			"command must stay Canceled after late messages")
+		for _, ru := range cmd.ResourceUpdates {
+			if ru.DesiredState.Ksuid == victim.DesiredState.Ksuid {
+				assert.Equal(t, resource_update.ResourceUpdateStateCanceled, ru.State,
+					"force-canceled resource must stay Canceled after a late completion")
+			}
+		}
+	})
+}

--- a/internal/workflow_tests/local/force_cancel_command_test.go
+++ b/internal/workflow_tests/local/force_cancel_command_test.go
@@ -236,20 +236,19 @@ func TestMetastructure_ForceCancelCommand_ConvergesWhereNonForceHangs(t *testing
 }
 
 // faultInjectingDatastore wraps a Datastore and can fail the two distinct durable
-// writes a BulkForceCancel performs: the early resource-row CAS
-// (ForceCancelResourceUpdates) and the late authoritative command-blob write
-// (StoreFormaCommand, via finalizeAndPersist). Each is independently configurable so
-// tests can exercise both the early-failure and late-failure branches of the
-// persist-before-terminate contract.
+// writes a BulkForceCancel gates on: the early resource-row CAS
+// (ForceCancelResourceUpdates) and the authoritative atomic command-row write
+// (UpdateFormaCommandTargetUpdates). Each is independently configurable so tests can
+// exercise both branches of the persist-before-terminate contract.
 type faultInjectingDatastore struct {
 	datastore.Datastore
 	failuresRemaining atomic.Int32
-	// finalizeFailuresRemaining fails the next StoreFormaCommand, but only once a CAS
-	// has succeeded (i.e. we are inside a force-cancel turn past the row CAS). This
-	// targets the finalizeAndPersist write specifically without disturbing the
-	// StoreFormaCommand calls made during normal apply.
-	finalizeFailuresRemaining atomic.Int32
-	finalizeFailArmed         atomic.Bool
+	// commandWriteFailuresRemaining fails the next UpdateFormaCommandTargetUpdates, but
+	// only once a CAS has succeeded (i.e. we are inside a force-cancel turn past the row
+	// CAS). This targets the atomic command-row write specifically, without disturbing
+	// any command writes made during normal apply.
+	commandWriteFailuresRemaining atomic.Int32
+	commandWriteFailArmed         atomic.Bool
 }
 
 func (d *faultInjectingDatastore) ForceCancelResourceUpdates(commandID string, inProgress []datastore.ForceCancelRow, notStarted []datastore.ResourceUpdateRef, modifiedTs time.Time) (datastore.ForceCancelResult, error) {
@@ -257,21 +256,21 @@ func (d *faultInjectingDatastore) ForceCancelResourceUpdates(commandID string, i
 		d.failuresRemaining.Add(-1)
 		return datastore.ForceCancelResult{}, fmt.Errorf("injected ForceCancelResourceUpdates failure")
 	}
-	// The row CAS is about to succeed; arm the next StoreFormaCommand to fail so the
-	// failure lands on the finalizeAndPersist write that follows in this same turn.
-	if d.finalizeFailuresRemaining.Load() > 0 {
-		d.finalizeFailArmed.Store(true)
+	// The row CAS is about to succeed; arm the next command-row write to fail so the
+	// failure lands on the atomic terminality write that follows in this same turn.
+	if d.commandWriteFailuresRemaining.Load() > 0 {
+		d.commandWriteFailArmed.Store(true)
 	}
 	return d.Datastore.ForceCancelResourceUpdates(commandID, inProgress, notStarted, modifiedTs)
 }
 
-func (d *faultInjectingDatastore) StoreFormaCommand(command *forma_command.FormaCommand, commandID string) error {
-	if d.finalizeFailArmed.Load() && d.finalizeFailuresRemaining.Load() > 0 {
-		d.finalizeFailArmed.Store(false)
-		d.finalizeFailuresRemaining.Add(-1)
-		return fmt.Errorf("injected StoreFormaCommand failure")
+func (d *faultInjectingDatastore) UpdateFormaCommandTargetUpdates(commandID string, targetUpdatesJSON json.RawMessage, state forma_command.CommandState, modifiedTs time.Time) error {
+	if d.commandWriteFailArmed.Load() && d.commandWriteFailuresRemaining.Load() > 0 {
+		d.commandWriteFailArmed.Store(false)
+		d.commandWriteFailuresRemaining.Add(-1)
+		return fmt.Errorf("injected UpdateFormaCommandTargetUpdates failure")
 	}
-	return d.Datastore.StoreFormaCommand(command, commandID)
+	return d.Datastore.UpdateFormaCommandTargetUpdates(commandID, targetUpdatesJSON, state, modifiedTs)
 }
 
 // TestMetastructure_ForceCancelCommand_PersisterFailureTerminatesNoActors verifies the
@@ -331,20 +330,21 @@ func TestMetastructure_ForceCancelCommand_PersisterFailureTerminatesNoActors(t *
 	})
 }
 
-// TestMetastructure_ForceCancelCommand_FinalizePersistFailureSurfaces covers the late
-// branch of the persist-before-terminate contract: the resource-row CAS succeeds but the
-// authoritative command-blob write (finalizeAndPersist/StoreFormaCommand) then fails.
-// That write is the only durable home of the overall command state and the target
-// updates, so its failure must surface in-band — the force-cancel reports an error,
-// terminates no actors, and the command stays InProgress until a retry converges it.
-func TestMetastructure_ForceCancelCommand_FinalizePersistFailureSurfaces(t *testing.T) {
+// TestMetastructure_ForceCancelCommand_CommandWritePersistFailureSurfaces covers the
+// late branch of the persist-before-terminate contract: the resource-row CAS succeeds
+// but the authoritative atomic command-row write (UpdateFormaCommandTargetUpdates) then
+// fails. That single-statement write is the only durable home of the overall command
+// state and the target updates, so its failure must surface in-band — the force-cancel
+// reports an error, terminates no actors, and the command stays InProgress (the atomic
+// write committed nothing) until a retry converges it.
+func TestMetastructure_ForceCancelCommand_CommandWritePersistFailureSurfaces(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		cfg := test_helpers.NewTestMetastructureConfig()
 		base, err := dssqlite.NewDatastoreSQLite(context.Background(), &cfg.Agent.Datastore, "test")
 		require.NoError(t, err)
 
 		ds := &faultInjectingDatastore{Datastore: base}
-		ds.finalizeFailuresRemaining.Store(1) // CAS succeeds, the following finalize write fails once
+		ds.commandWriteFailuresRemaining.Store(1) // CAS succeeds, the following command-row write fails once
 
 		m, def, err := test_helpers.NewTestMetastructureWithEverything(t, neverReturningOverrides(), ds, cfg)
 		defer def()

--- a/pkg/api/model/types.go
+++ b/pkg/api/model/types.go
@@ -52,25 +52,34 @@ type CommandID struct {
 type CancelCommandResponse struct {
 	CommandIDs           []string                       `json:"CommandIds"`
 	ResourceUpdateStates map[string]CancelResourceState `json:"ResourceUpdateStates,omitempty"`
+	// Forced is true when the cancellation was requested with --force. The CLI
+	// uses this to surface the force-cancel warning and the list of resources
+	// that were abandoned mid-operation.
+	Forced bool `json:"Forced,omitempty"`
 }
 
 // CancelResourceState represents the state of a resource update at cancel time.
 type CancelResourceState struct {
 	State string `json:"State"` // "Canceled", "InProgress", "Success", "Failed"
+	// ForceCanceled is true when this resource update was force-canceled while an
+	// operation was actually in progress (it carries an OperationStatusCanceled
+	// progress entry). These are the resources whose cloud-side state may be
+	// orphaned and need manual verification.
+	ForceCanceled bool `json:"ForceCanceled,omitempty"`
 }
 
 type ResourceUpdate struct {
-	ResourceID      string            `json:"ResourceId"`
-	ResourceType    string            `json:"ResourceType"`
-	ResourceLabel   string            `json:"ResourceLabel,omitempty"`
+	ResourceID    string `json:"ResourceId"`
+	ResourceType  string `json:"ResourceType"`
+	ResourceLabel string `json:"ResourceLabel,omitempty"`
 	// OldLabel is the resource's previous label. Populated only when a
 	// label rename is part of this update (RFC-0041 alias path); empty
 	// otherwise. The renderer uses it to surface the rename to the user.
-	OldLabel        string            `json:"OldLabel,omitempty"`
-	StackName       string            `json:"StackName,omitempty"`
-	OldStackName    string            `json:"OldStackName,omitempty"`
-	Operation       string            `json:"Operation"`
-	PatchDocument   json.RawMessage   `json:"PatchDocument,omitempty"`
+	OldLabel      string          `json:"OldLabel,omitempty"`
+	StackName     string          `json:"StackName,omitempty"`
+	OldStackName  string          `json:"OldStackName,omitempty"`
+	Operation     string          `json:"Operation"`
+	PatchDocument json.RawMessage `json:"PatchDocument,omitempty"`
 	// CreateOnlyPatch is a JSON-patch document (same format as PatchDocument)
 	// listing only the ops against createOnly fields that triggered a
 	// resource replacement. Populated on the delete half of a replace pair
@@ -113,18 +122,18 @@ const (
 )
 
 type TargetUpdate struct {
-	TargetLabel    string              `json:"TargetLabel"`
-	Operation      string              `json:"Operation"`
-	State          string              `json:"State"`
-	Duration       int64               `json:"Duration,omitempty"` // milliseconds
-	ErrorMessage   string              `json:"ErrorMessage,omitempty"`
-	Discoverable   bool                `json:"Discoverable"`
-	ExistingConfig json.RawMessage     `json:"ExistingConfig,omitempty"`
-	DesiredConfig  json.RawMessage     `json:"DesiredConfig,omitempty"`
-	StartTs        time.Time           `json:"StartTs,omitempty"`
-	ModifiedTs     time.Time           `json:"ModifiedTs,omitempty"`
-	IsCascade      bool                `json:"IsCascade,omitempty"`
-	CascadeSource  string              `json:"CascadeSource,omitempty"`
+	TargetLabel    string          `json:"TargetLabel"`
+	Operation      string          `json:"Operation"`
+	State          string          `json:"State"`
+	Duration       int64           `json:"Duration,omitempty"` // milliseconds
+	ErrorMessage   string          `json:"ErrorMessage,omitempty"`
+	Discoverable   bool            `json:"Discoverable"`
+	ExistingConfig json.RawMessage `json:"ExistingConfig,omitempty"`
+	DesiredConfig  json.RawMessage `json:"DesiredConfig,omitempty"`
+	StartTs        time.Time       `json:"StartTs,omitempty"`
+	ModifiedTs     time.Time       `json:"ModifiedTs,omitempty"`
+	IsCascade      bool            `json:"IsCascade,omitempty"`
+	CascadeSource  string          `json:"CascadeSource,omitempty"`
 }
 
 type StackUpdate struct {
@@ -146,8 +155,8 @@ type PolicyUpdate struct {
 	State             string          `json:"State"`
 	Duration          int64           `json:"Duration,omitempty"` // milliseconds
 	ErrorMessage      string          `json:"ErrorMessage,omitempty"`
-	PolicyConfig      json.RawMessage `json:"PolicyConfig,omitempty"`    // Current policy configuration
-	OldPolicyConfig   json.RawMessage `json:"OldPolicyConfig,omitempty"` // Previous policy configuration (for updates)
+	PolicyConfig      json.RawMessage `json:"PolicyConfig,omitempty"`      // Current policy configuration
+	OldPolicyConfig   json.RawMessage `json:"OldPolicyConfig,omitempty"`   // Previous policy configuration (for updates)
 	ReferencingStacks []string        `json:"ReferencingStacks,omitempty"` // For skip operations - stacks still referencing this policy
 	StartTs           time.Time       `json:"StartTs,omitempty"`
 	ModifiedTs        time.Time       `json:"ModifiedTs,omitempty"`
@@ -179,15 +188,15 @@ type Stats struct {
 // PluginInfo represents information about a registered plugin
 // including the merged config (plugin defaults + user overrides).
 type PluginInfo struct {
-	Namespace               string           `json:"Namespace"`
-	Version                 string           `json:"Version"`
-	NodeName                string           `json:"NodeName"`
-	MaxRequestsPerSecond    int              `json:"MaxRequestsPerSecond"`
-	ResourceCount           int              `json:"ResourceCount"`
-	ResourceTypesToDiscover []string         `json:"ResourceTypesToDiscover,omitempty"`
-	RetryConfig             *pkgmodel.RetryConfig    `json:"RetryConfig,omitempty"`
-	LabelConfig             *pkgmodel.LabelConfig    `json:"LabelConfig,omitempty"`
-	DiscoveryFilters        []pkgmodel.MatchFilter   `json:"DiscoveryFilters,omitempty"`
+	Namespace               string                 `json:"Namespace"`
+	Version                 string                 `json:"Version"`
+	NodeName                string                 `json:"NodeName"`
+	MaxRequestsPerSecond    int                    `json:"MaxRequestsPerSecond"`
+	ResourceCount           int                    `json:"ResourceCount"`
+	ResourceTypesToDiscover []string               `json:"ResourceTypesToDiscover,omitempty"`
+	RetryConfig             *pkgmodel.RetryConfig  `json:"RetryConfig,omitempty"`
+	LabelConfig             *pkgmodel.LabelConfig  `json:"LabelConfig,omitempty"`
+	DiscoveryFilters        []pkgmodel.MatchFilter `json:"DiscoveryFilters,omitempty"`
 }
 
 type ForceReconcileResponse struct {
@@ -202,17 +211,17 @@ type ForceCheckTTLResponse struct {
 
 // Plugin describes a single plugin, used by the list and info endpoints.
 type Plugin struct {
-	Name              string                       `json:"name"`
-	Kind              string                       `json:"kind,omitempty"`
-	Type              string                       `json:"type"`
-	Namespace         string                       `json:"namespace,omitempty"`
-	Category          string                       `json:"category,omitempty"`
-	Summary           string                       `json:"summary,omitempty"`
-	Description       string                       `json:"description,omitempty"`
-	Publisher         string                       `json:"publisher,omitempty"`
-	License           string                       `json:"license,omitempty"`
-	InstalledVersion  string                       `json:"installedVersion,omitempty"`
-	AvailableVersions []string                     `json:"availableVersions,omitempty"`
+	Name              string   `json:"name"`
+	Kind              string   `json:"kind,omitempty"`
+	Type              string   `json:"type"`
+	Namespace         string   `json:"namespace,omitempty"`
+	Category          string   `json:"category,omitempty"`
+	Summary           string   `json:"summary,omitempty"`
+	Description       string   `json:"description,omitempty"`
+	Publisher         string   `json:"publisher,omitempty"`
+	License           string   `json:"license,omitempty"`
+	InstalledVersion  string   `json:"installedVersion,omitempty"`
+	AvailableVersions []string `json:"availableVersions,omitempty"`
 	// LocalPath is the absolute path on the agent's filesystem to the
 	// plugin's PklProject file (containing the plugin's PKL schema).
 	// Populated by the discovery scan when the plugin is installed
@@ -220,13 +229,13 @@ type Plugin struct {
 	// --schema-location local flow to import schemas via PklProject.deps
 	// rather than fetching from the hub. Same-box only — the path is
 	// only meaningful when the CLI shares a filesystem with the agent.
-	LocalPath string                       `json:"localPath,omitempty"`
+	LocalPath string `json:"localPath,omitempty"`
 
-	Channel           string                       `json:"channel,omitempty"`
-	Frozen            bool                         `json:"frozen,omitempty"`
-	ManagedBy         string                       `json:"managedBy,omitempty"`
-	LoadStatus        string                       `json:"loadStatus,omitempty"`
-	Metadata          map[string]map[string]string `json:"metadata,omitempty"`
+	Channel    string                       `json:"channel,omitempty"`
+	Frozen     bool                         `json:"frozen,omitempty"`
+	ManagedBy  string                       `json:"managedBy,omitempty"`
+	LoadStatus string                       `json:"loadStatus,omitempty"`
+	Metadata   map[string]map[string]string `json:"metadata,omitempty"`
 }
 
 // PluginOperation describes a single operation performed on a plugin.

--- a/pkg/plugin/resource/resource.go
+++ b/pkg/plugin/resource/resource.go
@@ -138,6 +138,7 @@ const (
 	OperationStatusFailure    OperationStatus = "Failure"
 	OperationStatusInProgress OperationStatus = "InProgress"
 	OperationStatusPending    OperationStatus = "Pending"
+	OperationStatusCanceled   OperationStatus = "Canceled"
 )
 
 type OperationErrorCode string

--- a/tests/blackbox/executor.go
+++ b/tests/blackbox/executor.go
@@ -1468,7 +1468,7 @@ func (h *TestHarness) executeCancel(t *testing.T, op *Operation, model *StateMod
 	// Cancel the most recent command (matches API behavior with no query).
 	target := model.AcceptedCommands[len(model.AcceptedCommands)-1]
 
-	resp, err := h.client.CancelCommands("", clientID)
+	resp, err := h.client.CancelCommands("", false, clientID)
 	if err != nil {
 		t.Logf("[op %d] Cancel command %s → error: %v", op.SequenceNum, target.CommandID, err)
 		return


### PR DESCRIPTION
## Summary

Adds `formae cancel --force`: an escape hatch that drives a command to terminal `Canceled` even when in-flight resource updates are stuck (e.g. a plugin operation that never returns). Plain `cancel` still asks the executor to stop gracefully and waits for convergence; `--force` additionally terminalizes the in-flight work directly so the command always reaches a terminal state.

## How it works

- **Monotonic terminality (datastore).** Resource- and target-update state writes go through a compare-and-set that only ever advances toward a terminal state and never moves *out* of one. This is the durable guard against the classic cancel race: a late in-flight write can no longer resurrect a row that force-cancel already terminalized. Applied transactionally across all four backends (sqlite, postgres, aurora, mssql), with matching in-memory guards on the updater actors.
- **`BulkForceCancel` (persister).** A new persister path plans the set of in-flight resource/target updates, CAS-terminalizes them in the datastore, and only then applies the result to the authoritative in-memory cache — persist-before-mutate, so a persister failure cannot leave the in-memory and durable views disagreeing. Post-CAS target-blob and command-metadata writes are best-effort: they refine bookkeeping but never gate the command reaching `Canceled`.
- **`cancel()` force path.** `--force` is a query param plumbed from the CLI through the API into the metastructure; the handler runs the normal graceful cancel and then `BulkForceCancel` to guarantee terminality.
- **CLI rendering.** On a forced cancel the CLI surfaces an orphan warning and lists the resources whose underlying cloud operations may still be in flight, so the operator knows what to reconcile.

## Notable design choices

- **In-band error reporting, not handler-returned Go errors.** Force-cancel failures are reported via an `ErrorMessage` field on the response rather than by returning an error from the statemachine/persister handler. Returning an error from those handlers terminates the actor and sends *no* reply — which would re-introduce exactly the split-brain (durable state advanced, caller never told) that this change exists to prevent.
- **Plan → DB CAS → in-memory apply ordering** in `bulkForceCancel`, so the durable store is authoritative and the in-memory cache is only updated after the persist succeeds.

## Persist-before-terminate failure semantics

The persister terminalizes durably *before* the executor tears down any actors, and the in-band error is gated on writes that are atomic, so a failure is always safely retryable:

- The resource rows are terminalized by a single transactional CAS (`ForceCancelResourceUpdates`). The remaining durable state — overall command state and target updates, which live only in the command blob — is committed by a single-statement atomic write (`UpdateFormaCommandTargetUpdates`). The error path is gated on *that* write, not on the non-atomic full-command store, so a failure commits nothing and the retry (which filters to `InProgress`) still finds the command and converges. `finalizeAndPersist` (sensitive-data hashing, full re-store, cache eviction) runs afterward as best-effort bookkeeping and no longer gates the result.
- On an atomic-command-write failure the in-memory cache has already advanced, but this is safe and convergent: the resource-level mutations mirror the resource CAS that *did* commit, so the cache matches the durable resource rows; a retry is idempotent (now-final resources report `Skipped`, so completion counters are not decremented twice); and a crash before retry still converges via the recovery backstop because the resource rows are durably terminal.

## Coverage

Workflow tests cover the escape hatch end to end: force-cancel reaches `Canceled` immediately; a command that hangs under plain cancel converges under `--force`; a persister failure terminates no actors and leaves no orphaned state; and the write fence drops late in-flight messages. Datastore suite extended with monotonic-CAS cases across the backends. Full build + vet clean.