### PR TITLE
feat(cli): add opt-in cli.api.insecureSkipVerify for self-signed agents

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,6 +31,13 @@ func NewClient(cfg pkgmodel.APIConfig, auth http.Header, net *http.Client) *Clie
 
 	if net != nil {
 		client = resty.NewWithClient(net)
+	}
+
+	if cfg.InsecureSkipVerify {
+		// Opt-in (off by default): lets the CLI reach an agent fronted by a
+		// self-signed cert, e.g. the bootstrap ALB, whose AWS-generated FQDN
+		// no certificate SAN can match ahead of time.
+		client.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}) //nolint:gosec // opt-in, off by default
 	}
 
 	if auth != nil {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -5,9 +5,16 @@
 package api
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
 	"testing"
 
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormatEndpointStandardPort(t *testing.T) {
@@ -50,4 +57,30 @@ func TestFormatEndpointHTTPSWith80(t *testing.T) {
 	got := formatEndpoint("https://example.com", 80)
 
 	assert.Equal(t, want, got)
+}
+
+// TestNewClientInsecureSkipVerify verifies the opt-in insecureSkipVerify knob:
+// with it set, the client reaches an agent fronted by a self-signed cert; without
+// it (the default), the self-signed cert is rejected at the TLS layer.
+func TestNewClientInsecureSkipVerify(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(u.Port())
+	require.NoError(t, err)
+	base := "https://" + u.Hostname()
+
+	insecure := NewClient(pkgmodel.APIConfig{URL: base, Port: port, InsecureSkipVerify: true}, nil, nil)
+	_, err = insecure.Stats()
+	require.NoError(t, err, "insecureSkipVerify client should reach the self-signed server")
+
+	secure := NewClient(pkgmodel.APIConfig{URL: base, Port: port}, nil, nil)
+	_, err = secure.Stats()
+	require.Error(t, err, "default client should reject the self-signed cert")
+	require.Contains(t, strings.ToLower(err.Error()), "certificate")
 }

--- a/internal/schema/pkl/assets/formae/Config.pkl
+++ b/internal/schema/pkl/assets/formae/Config.pkl
@@ -262,6 +262,11 @@ class ApiConfig {
     url: String = "http://localhost"
 
     port: Port = 49684
+
+    /// Skip TLS certificate verification when talking to the agent. Opt-in and off
+    /// by default. Use only for an agent fronted by a self-signed certificate whose
+    /// SAN cannot be matched ahead of time (e.g. a load balancer's generated FQDN).
+    insecureSkipVerify: Boolean = false
 }
 
 class Repository {

--- a/internal/schema/pkl/model/config.go
+++ b/internal/schema/pkl/model/config.go
@@ -186,8 +186,9 @@ type AgentConfig struct {
 }
 
 type APIConfig struct {
-	URL  string `pkl:"url"`
-	Port int32  `pkl:"port"`
+	URL                string `pkl:"url"`
+	Port               int32  `pkl:"port"`
+	InsecureSkipVerify bool   `pkl:"insecureSkipVerify"`
 }
 
 type Repository struct {

--- a/internal/schema/pkl/pkl.go
+++ b/internal/schema/pkl/pkl.go
@@ -245,8 +245,9 @@ func translateConfig(config *pklmodel.Config) *pkgmodel.Config {
 		Artifacts: translateArtifactConfig(&config.Artifacts),
 		Cli: pkgmodel.CliConfig{
 			API: pkgmodel.APIConfig{
-				URL:  config.Cli.API.URL,
-				Port: int(config.Cli.API.Port),
+				URL:                config.Cli.API.URL,
+				Port:               int(config.Cli.API.Port),
+				InsecureSkipVerify: config.Cli.API.InsecureSkipVerify,
 			},
 			DisableUsageReporting: config.Cli.DisableUsageReporting,
 			Auth:                  translateAuthConfig(&config.Cli.Auth),

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -235,8 +235,9 @@ type AgentConfig struct {
 }
 
 type APIConfig struct {
-	URL  string
-	Port int
+	URL                string
+	Port               int
+	InsecureSkipVerify bool
 }
 
 // RepositoryType discriminates orbital repositories by purpose.


### PR DESCRIPTION
- Add an opt-in insecureSkipVerify boolean to cli.api
- When set, the CLI skips TLS cert verification when calling agent

**Why:** the CLI's API client (api/client.go) does full TLS verification with no escape hatch, so it can't reach an agent behind a self-signed or custom-CA cert
