### PR TITLE
fix(cli): show only genuinely-changed properties in the plan

### DIFF
--- a/internal/cli/renderer/patches.go
+++ b/internal/cli/renderer/patches.go
@@ -40,6 +40,12 @@ type PropertyChange struct {
 	IsOpaque         bool
 	ExistsInPrevious bool
 
+	// NoOp marks a change the renderer should suppress entirely: a field that
+	// is force-resent on every update (requiredOnUpdate) but whose value did
+	// not change. The plugin still receives it; the user shouldn't see it as a
+	// "change" on an otherwise-clean reconcile.
+	NoOp bool
+
 	// IsCascadeResolvable signals a cascade-update synthetic op where the
 	// new value isn't knowable at plan time (e.g. provider-assigned
 	// identifiers like AWS ARNs). The renderer prints a friendly
@@ -72,6 +78,35 @@ func FormatPatchDocument(node *gtree.Node, patchDoc json.RawMessage, properties 
 	for _, patch := range patches {
 		formatSinglePatch(node, patch, props, previousProperties, refLabels)
 	}
+}
+
+// HasVisibleChanges reports whether formatting the patch document would emit at
+// least one change line. A patch whose only op is a suppressed NoOp (a
+// force-resent requiredOnUpdate field whose value is unchanged) renders
+// nothing, and the caller must not open an empty "by doing the following:"
+// block for it.
+func HasVisibleChanges(patchDoc json.RawMessage, properties json.RawMessage, previousProperties json.RawMessage, refLabels map[string]string) bool {
+	var rawPatches []map[string]any
+	if err := json.Unmarshal(patchDoc, &rawPatches); err != nil {
+		return true // a malformed patch document surfaces as a visible error line
+	}
+	var props map[string]any
+	if err := json.Unmarshal(properties, &props); err != nil {
+		return true // a parse error surfaces as a visible error line
+	}
+
+	discard := gtree.NewRoot("")
+	patches := parsePatchOperations(patchDoc, discard)
+	for _, patch := range patches {
+		if strings.Contains(patch.Path, "/Tags/") {
+			return true // tag changes always render
+		}
+		change, err := extractPropertyChange(patch, props, previousProperties, refLabels)
+		if err != nil || !change.NoOp {
+			return true
+		}
+	}
+	return false
 }
 
 func parsePatchOperations(patchDoc json.RawMessage, node *gtree.Node) []patchOperation {
@@ -117,7 +152,9 @@ func formatSinglePatch(node *gtree.Node, patch patchOperation, props map[string]
 
 	if change, err := extractPropertyChange(patch, props, previousProperties, refLabels); err != nil {
 		node.Add(display.Red(fmt.Sprintf("Error processing property patch: %v", err)))
-	} else {
+	} else if !change.NoOp {
+		// NoOp = a force-resent (requiredOnUpdate) field whose value didn't
+		// change; suppress it from the plan so a clean reconcile stays clean.
 		node.Add(formatPropertyChange(change))
 	}
 }
@@ -250,7 +287,61 @@ func extractPropertyChange(patch patchOperation, props map[string]any, previousP
 		}
 	}
 
+	// A force-resent field surfaces as an "add" whose path already exists in
+	// the previous state (a requiredOnUpdate field stripped before the diff).
+	// Carry its previous value so it renders as a change, and mark it a no-op
+	// when the value is unchanged so the caller can suppress it — the plugin
+	// still receives the re-send, but the user shouldn't see a "change" that
+	// isn't one.
+	//
+	// The no-op test compares JSON-canonical values, not rendered strings: a
+	// rendered compare would collapse distinct JSON types (the string "1" vs
+	// the number 1) into the same text and wrongly suppress a real change, and
+	// would never match an opaque re-send (whose rendered form is the
+	// "(opaque value)" placeholder) against its unchanged underlying secret.
+	if patch.Op == "add" && change.ExistsInPrevious {
+		if prev, ok := previousRawValue(previousProperties, patch.Path); ok {
+			change.OldValue = formatValueForDisplay(prev.Value())
+			change.HasOld = true
+			change.NoOp = canonicalValue(patch.Value) == canonicalValue(prev.Value())
+		}
+	}
+
 	return change, nil
+}
+
+// previousRawValue looks up the raw (un-rendered) previous value at a JSON
+// Pointer path, returning whether the path exists.
+func previousRawValue(oldProps json.RawMessage, path string) (gjson.Result, bool) {
+	if len(oldProps) == 0 {
+		return gjson.Result{}, false
+	}
+	jsonPath := strings.ReplaceAll(strings.TrimPrefix(path, "/"), "/", ".")
+	result := gjson.GetBytes(oldProps, jsonPath)
+	return result, result.Exists()
+}
+
+// canonicalValue normalizes a value for change detection. It unwraps Formae's
+// Value wrapper so an opaque re-send compares against its underlying secret
+// ($value), then serializes to JSON so that distinct JSON types never collapse
+// to the same text. Falls back to a best-effort string on marshal failure.
+func canonicalValue(v any) string {
+	v = unwrapFormaeValue(v)
+	if bytes, err := json.Marshal(v); err == nil {
+		return string(bytes)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+// unwrapFormaeValue returns the inner $value of a Formae Value wrapper, or the
+// value unchanged when it isn't a wrapper.
+func unwrapFormaeValue(v any) any {
+	if valueMap, ok := v.(map[string]any); ok {
+		if inner, ok := valueMap["$value"]; ok {
+			return inner
+		}
+	}
+	return v
 }
 
 // formatPropertyChange formats a PropertyChange for display
@@ -273,7 +364,7 @@ func formatPropertyChange(change PropertyChange) string {
 	case "add":
 		if change.IsOpaque {
 			if change.ExistsInPrevious {
-				return display.Gold(fmt.Sprintf(`set property "%s" (opaque value)`, displayPath))
+				return display.Gold(fmt.Sprintf(`change property "%s" (opaque value changed)`, displayPath))
 			}
 			if isArrayProperty(change.Path) {
 				return display.Green(fmt.Sprintf(`add new entry to "%s" (opaque value)`, displayPath))
@@ -282,9 +373,13 @@ func formatPropertyChange(change PropertyChange) string {
 		}
 		if change.ExistsInPrevious {
 			if isArrayProperty(change.Path) {
-				return display.Gold(fmt.Sprintf(`set entry "%s" in "%s" (write-only)`, change.Value, displayPath))
+				return display.Gold(fmt.Sprintf(`change entry "%s" in "%s"`, change.Value, displayPath))
 			}
-			return display.Gold(fmt.Sprintf(`set property "%s" to "%s" (write-only)`, displayPath, change.Value))
+			// Force-resent (writeOnly/requiredOnUpdate) field: it surfaces as an
+			// "add" because it was stripped before the diff. Show only the new
+			// value — the previous value is a secret we must not leak, and it
+			// exists here solely for the no-op suppression test.
+			return display.Gold(fmt.Sprintf(`change property "%s" to "%s"`, displayPath, change.Value))
 		}
 		if isArrayProperty(change.Path) {
 			return display.Green(fmt.Sprintf(`add new entry "%s" to "%s"`, change.Value, displayPath))

--- a/internal/cli/renderer/patches_test.go
+++ b/internal/cli/renderer/patches_test.go
@@ -165,7 +165,7 @@ func TestFormatPropertyChange_OpaqueAdd(t *testing.T) {
 
 		result := formatPropertyChange(change)
 
-		assert.Contains(t, result, `set property "SecretString" (opaque value)`)
+		assert.Contains(t, result, `change property "SecretString" (opaque value changed)`)
 		assert.NotContains(t, result, "L4clqcm50IFl")
 	})
 
@@ -198,8 +198,26 @@ func TestFormatPropertyChange_OpaqueAdd(t *testing.T) {
 	})
 }
 
-func TestFormatPropertyChange_WriteOnlyAdd(t *testing.T) {
-	t.Run("write-only add on existing resource shows set with write-only", func(t *testing.T) {
+func TestFormatPropertyChange_ForceResentField(t *testing.T) {
+	t.Run("changed force-resent scalar shows the new value only, never the old secret", func(t *testing.T) {
+		change := PropertyChange{
+			Path:             "LoginProfile.Password",
+			Value:            "newpass",
+			OldValue:         "oldpass",
+			HasOld:           true,
+			Operation:        "add",
+			ExistsInPrevious: true,
+		}
+
+		result := formatPropertyChange(change)
+
+		assert.Contains(t, result, `change property "LoginProfile.Password" to "newpass"`)
+		assert.NotContains(t, result, "oldpass")
+		assert.NotContains(t, result, "write-only")
+		assert.NotContains(t, result, "add new property")
+	})
+
+	t.Run("force-resent scalar with no known previous renders as a plain change", func(t *testing.T) {
 		change := PropertyChange{
 			Path:             "LoginProfile.Password",
 			Value:            "newpass",
@@ -209,11 +227,11 @@ func TestFormatPropertyChange_WriteOnlyAdd(t *testing.T) {
 
 		result := formatPropertyChange(change)
 
-		assert.Contains(t, result, `set property "LoginProfile.Password" to "newpass" (write-only)`)
-		assert.NotContains(t, result, "add new property")
+		assert.Contains(t, result, `change property "LoginProfile.Password" to "newpass"`)
+		assert.NotContains(t, result, "write-only")
 	})
 
-	t.Run("write-only add array entry on existing resource shows set with write-only", func(t *testing.T) {
+	t.Run("force-resent array entry renders as a change, no write-only jargon", func(t *testing.T) {
 		change := PropertyChange{
 			Path:             "Tokens[0]",
 			Value:            "tok-123",
@@ -223,7 +241,87 @@ func TestFormatPropertyChange_WriteOnlyAdd(t *testing.T) {
 
 		result := formatPropertyChange(change)
 
-		assert.Contains(t, result, `set entry "tok-123" in "Tokens" (write-only)`)
+		assert.Contains(t, result, `change entry "tok-123" in "Tokens"`)
+		assert.NotContains(t, result, "write-only")
+	})
+}
+
+func TestExtractPropertyChange_ForceResentNoOp(t *testing.T) {
+	prev := json.RawMessage(`{"LoginProfile":{"Password":"samepass"}}`)
+
+	t.Run("unchanged force-resend is marked NoOp", func(t *testing.T) {
+		patch := patchOperation{Op: "add", Path: "/LoginProfile/Password", Value: "samepass"}
+		change, err := extractPropertyChange(patch, map[string]any{}, prev, nil)
+		assert.NoError(t, err)
+		assert.True(t, change.NoOp, "an add whose value equals the previous value is a no-op force-resend")
+	})
+
+	t.Run("changed force-resend is not NoOp and carries the previous value", func(t *testing.T) {
+		patch := patchOperation{Op: "add", Path: "/LoginProfile/Password", Value: "newpass"}
+		change, err := extractPropertyChange(patch, map[string]any{}, prev, nil)
+		assert.NoError(t, err)
+		assert.False(t, change.NoOp)
+		assert.True(t, change.HasOld)
+	})
+
+	t.Run("type-changing re-send is not a NoOp (string vs number)", func(t *testing.T) {
+		// A rendered-string compare collapses the string "8080" and the number
+		// 8080 to the same text and would wrongly suppress this real change.
+		typed := json.RawMessage(`{"Port":"8080"}`)
+		patch := patchOperation{Op: "add", Path: "/Port", Value: float64(8080)}
+		change, err := extractPropertyChange(patch, map[string]any{}, typed, nil)
+		assert.NoError(t, err)
+		assert.False(t, change.NoOp, "a string->number re-send is a real change, not a no-op")
+	})
+
+	t.Run("unchanged opaque re-send is a NoOp (unwrap $value)", func(t *testing.T) {
+		opaque := json.RawMessage(`{"SecretString":{"$value":"sekret","$visibility":"Opaque"}}`)
+		patch := patchOperation{Op: "add", Path: "/SecretString", Value: "sekret"}
+		change, err := extractPropertyChange(patch, map[string]any{}, opaque, nil)
+		assert.NoError(t, err)
+		assert.True(t, change.NoOp, "an opaque re-send whose underlying value is unchanged is a no-op")
+	})
+
+	t.Run("changed opaque re-send is not a NoOp", func(t *testing.T) {
+		opaque := json.RawMessage(`{"SecretString":{"$value":"old","$visibility":"Opaque"}}`)
+		patch := patchOperation{Op: "add", Path: "/SecretString", Value: "new"}
+		change, err := extractPropertyChange(patch, map[string]any{}, opaque, nil)
+		assert.NoError(t, err)
+		assert.False(t, change.NoOp)
+	})
+}
+
+func TestHasVisibleChanges(t *testing.T) {
+	refLabels := map[string]string{}
+
+	t.Run("all-NoOp force-resend patch has no visible changes", func(t *testing.T) {
+		patchDoc := json.RawMessage(`[{"op":"add","path":"/LoginProfile/Password","value":"samepass"}]`)
+		prev := json.RawMessage(`{"LoginProfile":{"Password":"samepass"}}`)
+		assert.False(t, HasVisibleChanges(patchDoc, json.RawMessage("{}"), prev, refLabels))
+	})
+
+	t.Run("a real property change is visible", func(t *testing.T) {
+		patchDoc := json.RawMessage(`[{"op":"add","path":"/LoginProfile/Password","value":"newpass"}]`)
+		prev := json.RawMessage(`{"LoginProfile":{"Password":"oldpass"}}`)
+		assert.True(t, HasVisibleChanges(patchDoc, json.RawMessage("{}"), prev, refLabels))
+	})
+
+	t.Run("a tag change is visible", func(t *testing.T) {
+		patchDoc := json.RawMessage(`[{"op":"add","path":"/Tags/0","value":{"Key":"k","Value":"v"}}]`)
+		assert.True(t, HasVisibleChanges(patchDoc, json.RawMessage("{}"), json.RawMessage("{}"), refLabels))
+	})
+
+	t.Run("empty patch has no visible changes", func(t *testing.T) {
+		assert.False(t, HasVisibleChanges(json.RawMessage("[]"), json.RawMessage("{}"), json.RawMessage("{}"), refLabels))
+	})
+
+	t.Run("a NoOp re-send alongside a real change is still visible", func(t *testing.T) {
+		patchDoc := json.RawMessage(`[
+			{"op":"add","path":"/LoginProfile/Password","value":"samepass"},
+			{"op":"replace","path":"/Description","value":"new"}
+		]`)
+		prev := json.RawMessage(`{"LoginProfile":{"Password":"samepass"},"Description":"old"}`)
+		assert.True(t, HasVisibleChanges(patchDoc, json.RawMessage("{}"), prev, refLabels))
 	})
 }
 
@@ -276,8 +374,8 @@ func TestFormatPatchDocument_OpaqueWriteOnlyField(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Len(t, nodes, 2)
-		assert.Contains(t, nodes[1].Name(), "opaque value")
-		assert.Contains(t, nodes[1].Name(), `set property "SecretString"`)
+		assert.Contains(t, nodes[1].Name(), "opaque value changed")
+		assert.Contains(t, nodes[1].Name(), `change property "SecretString"`)
 		assert.NotContains(t, nodes[1].Name(), "L4clqcm50IFl")
 	})
 }

--- a/internal/cli/renderer/renderer.go
+++ b/internal/cli/renderer/renderer.go
@@ -438,7 +438,11 @@ func formatSimulatedResourceUpdate(root *gtree.Node, rc apimodel.ResourceUpdate)
 	// `change property` style. This keeps the diff body the single place
 	// the operator scans for what's actually changing.
 	renamed := rc.OldLabel != "" && rc.OldLabel != rc.ResourceLabel
-	hasPatch := rc.Operation == apimodel.OperationUpdate && len(rc.PatchDocument) > 0
+	// A patch counts only if it would render at least one line. A patch whose
+	// sole op is a suppressed NoOp (an unchanged force-resent field) renders
+	// nothing, so it must not open an empty `by doing the following:` block.
+	hasPatch := rc.Operation == apimodel.OperationUpdate && len(rc.PatchDocument) > 0 &&
+		HasVisibleChanges(rc.PatchDocument, rc.Properties, rc.OldProperties, rc.ReferenceLabels)
 	isBringingUnderManagement := rc.OldStackName == constants.UnmanagedStack && rc.StackName != constants.UnmanagedStack
 
 	// RFC-0041: where the `change label from "<old>" to "<new>"` line lives

--- a/internal/cli/renderer/renderer_test.go
+++ b/internal/cli/renderer/renderer_test.go
@@ -219,6 +219,43 @@ func TestRenderSimulation_Replacement_ShowsReason(t *testing.T) {
 	// TestFormatHumanReadableStatus_Replacement which does not carry the field.
 }
 
+func TestRenderSimulation_AllNoOpPatch_NoEmptyBlock(t *testing.T) {
+	// The only patch op is a force-resent (requiredOnUpdate) field whose value
+	// is unchanged. The renderer suppresses it, so there is nothing to put
+	// inside a "by doing the following:" block — and the block must not appear
+	// empty.
+	patchDoc := json.RawMessage(`[{"op":"add","path":"/LoginProfile/Password","value":"samepass"}]`)
+	props := json.RawMessage(`{"LoginProfile":{"Password":"samepass"}}`)
+
+	simulation := apimodel.Simulation{
+		ChangesRequired: true,
+		Command: apimodel.Command{
+			CommandID: "test-noop-block",
+			Command:   "apply",
+			ResourceUpdates: []apimodel.ResourceUpdate{
+				{
+					ResourceID:    util.NewID(),
+					ResourceType:  "FakeAWS::IAM::User",
+					ResourceLabel: "my-user",
+					StackName:     "test-stack",
+					Operation:     "update",
+					State:         "NotStarted",
+					Properties:    props,
+					OldProperties: props,
+					PatchDocument: patchDoc,
+				},
+			},
+		},
+	}
+
+	result, err := RenderSimulation(&simulation)
+	assert.NoError(t, err)
+	result = stripAnsiCodes(t, result)
+
+	assert.Contains(t, result, "update resource my-user")
+	assert.NotContains(t, result, "by doing the following:")
+}
+
 func TestFormatHumanReadableStatus_UnmanagedMigration(t *testing.T) {
 	status := apimodel.Command{
 		CommandID: "test-unmanaged-id",


### PR DESCRIPTION
## Summary

The plan renderer tagged force-resent `requiredOnUpdate` fields with a `(write-only)` jargon label and listed them as changes even when their value was unchanged, so a clean reconcile looked noisy and could open an empty diff block. This makes the plan show a field only when it is genuinely changing.

- **Suppress unchanged force-resent fields.** A `requiredOnUpdate` field is stripped before the diff and resurfaces as an `add`; when its value is unchanged this is now treated as a no-op and hidden. The comparison is JSON-canonical and unwraps opaque `$value` wrappers, so a type-changing re-send (string `"1"` vs number `1`) is still shown, while an unchanged opaque re-send is correctly hidden instead of mislabeled "(opaque value changed)".
- **Never render the previous value of a force-resent field.** A changed force-resent field renders as `change property "X" to "<new>"`; the previous value can be a secret and is used only for the no-op test.
- **Drop the empty "by doing the following:" block** when a patch's only op is a suppressed no-op.

The plugin still receives the force-resent op on every update; only its display in the plan is suppressed. Display-only change.