### PR TITLE
fix(metastructure): forget unmanaged resources when their target is deleted

### DIFF
--- a/internal/metastructure/resource_persister/resource_persister.go
+++ b/internal/metastructure/resource_persister/resource_persister.go
@@ -13,6 +13,7 @@ import (
 	"ergo.services/ergo/act"
 	"ergo.services/ergo/gen"
 
+	"github.com/platform-engineering-labs/formae/internal/constants"
 	"github.com/platform-engineering-labs/formae/internal/datastore"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/discovery"
@@ -378,6 +379,33 @@ func (rp *ResourcePersister) processResourceUpdate(commandID string, rc resource
 			}
 
 			if currentResource == nil {
+				// A successful Read with no current row would (re)create the resource.
+				// Guard against resurrecting a resource whose target has since been
+				// deleted: a target delete tombstones the target's unmanaged resources
+				// (see forgetUnmanagedResourcesOnTarget), but a sync/discovery Read
+				// snapshotted before that delete can land here afterwards with live
+				// properties. Storing it would orphan an $unmanaged row pointing at a
+				// target that no longer exists. If the target is gone, the absent row is
+				// the intended end state — leave it tombstoned. When the target still
+				// exists this is a legitimate newly-discovered resource, so store it.
+				// (LoadTarget and any DeleteTarget are serialized through this actor's
+				// mailbox, so there is no check-then-act race here.)
+				target, targetErr := rp.datastore.LoadTarget(rc.DesiredState.Target)
+				if targetErr != nil {
+					slog.Error("Failed to load target while persisting read resource",
+						"resourceLabel", rc.DesiredState.Label,
+						"target", rc.DesiredState.Target,
+						"error", targetErr)
+					return "", fmt.Errorf("failed to load target %s for resource %s: %w", rc.DesiredState.Target, rc.DesiredState.Label, targetErr)
+				}
+				if target == nil {
+					slog.Debug("Skipping read persist for resource whose target no longer exists",
+						"resourceLabel", rc.DesiredState.Label,
+						"target", rc.DesiredState.Target,
+						"stackLabel", stackLabel)
+					return "", nil
+				}
+
 				slog.Debug("Resource not found, creating new one",
 					"resourceLabel", rc.DesiredState.Label,
 					"stackLabel", stackLabel)
@@ -467,7 +495,7 @@ func (rp *ResourcePersister) persistTargetUpdates(updates []target_update.Target
 	versions := make([]string, 0, len(updates))
 	for i := range updates {
 		rp.Log().Debug("Persisting target update index=%d label=%s", i, updates[i].Target.Label)
-		if err := rp.persistTargetUpdate(&updates[i]); err != nil {
+		if err := rp.persistTargetUpdate(&updates[i], commandID); err != nil {
 			rp.Log().Error("Failed to persist target update index=%d label=%s: %v", i, updates[i].Target.Label, err)
 			return nil, fmt.Errorf("failed to persist target update for %s: %w", updates[i].Target.Label, err)
 		}
@@ -479,7 +507,7 @@ func (rp *ResourcePersister) persistTargetUpdates(updates []target_update.Target
 	return versions, nil
 }
 
-func (rp *ResourcePersister) persistTargetUpdate(update *target_update.TargetUpdate) error {
+func (rp *ResourcePersister) persistTargetUpdate(update *target_update.TargetUpdate, commandID string) error {
 	var version string
 	var err error
 
@@ -502,7 +530,23 @@ func (rp *ResourcePersister) persistTargetUpdate(update *target_update.TargetUpd
 	case target_update.TargetOperationUpdate:
 		version, err = rp.datastore.UpdateTarget(&update.Target)
 	case target_update.TargetOperationDelete:
-		version, err = rp.datastore.DeleteTarget(update.Target.Label)
+		// Managed resources on this target are removed through the changeset
+		// cascade (ordered resource deletes that call the plugin). Unmanaged
+		// (discovered) resources are never part of a changeset, so deleting the
+		// target row would orphan them in the DB until a later sync tick tombstones
+		// them — and permanently if synchronization is disabled. Forget them here,
+		// before the target row is gone, so cleanup is immediate and independent of
+		// sync.
+		//
+		// Cleanup is not atomic with the target delete: a failure partway through
+		// leaves some unmanaged rows already tombstoned and the target still present
+		// (DeleteTarget only runs once cleanup returns nil). The error propagates so
+		// the target update is marked failed and retried, and the retry is safe —
+		// tombstoning is idempotent and the re-query only returns rows not yet
+		// tombstoned — so a retry converges rather than double-deleting.
+		if err = rp.forgetUnmanagedResourcesOnTarget(update.Target.Label, commandID); err == nil {
+			version, err = rp.datastore.DeleteTarget(update.Target.Label)
+		}
 	default:
 		err = fmt.Errorf("unknown target operation: %s", update.Operation)
 	}
@@ -541,6 +585,32 @@ func (rp *ResourcePersister) persistTargetUpdate(update *target_update.TargetUpd
 		}
 	}
 
+	return nil
+}
+
+// forgetUnmanagedResourcesOnTarget tombstones the unmanaged (discovered)
+// resources that belong to targetLabel. It is a DB-only forget: unmanaged
+// resources were only ever discovered, never managed by formae, so removing the
+// record never touches the cloud (mirroring the sync "NotFound" path). The query
+// is scoped strictly to the $unmanaged stack AND managed=false so a managed
+// resource is never DB-deleted here (managed resources go through the proper
+// cloud-delete cascade). DeleteResource appends a tombstone version, so a double
+// tombstone (e.g. if sync already ran) is a harmless no-op at the visible level.
+func (rp *ResourcePersister) forgetUnmanagedResourcesOnTarget(targetLabel, commandID string) error {
+	unmanaged, err := rp.datastore.QueryResources(&datastore.ResourceQuery{
+		Stack:   &datastore.QueryItem[string]{Item: constants.UnmanagedStack, Constraint: datastore.Required},
+		Managed: &datastore.QueryItem[bool]{Item: false, Constraint: datastore.Required},
+		Target:  &datastore.QueryItem[string]{Item: targetLabel, Constraint: datastore.Required},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to query unmanaged resources for deleted target %s: %w", targetLabel, err)
+	}
+
+	for _, res := range unmanaged {
+		if _, err := rp.datastore.DeleteResource(res, commandID); err != nil {
+			return fmt.Errorf("failed to forget unmanaged resource %s on deleted target %s: %w", res.Ksuid, targetLabel, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/metastructure/resource_persister/resource_persister_test.go
+++ b/internal/metastructure/resource_persister/resource_persister_test.go
@@ -1101,6 +1101,113 @@ func TestResourcePersister_ReadPreservesCurrentStack(t *testing.T) {
 	assert.Empty(t, unmanagedResources, "Resource should not appear in $unmanaged stack")
 }
 
+// TestResourcePersister_ReadDoesNotResurrectResourceWhoseTargetIsGone covers the
+// resurrection race: a sync/discovery Read snapshotted before a target was deleted
+// can land at the persister afterwards with live properties. Because the target's
+// unmanaged resources are tombstoned when the target is deleted, the current row is
+// absent — and the persister must not re-create it against a target that no longer
+// exists. Here the target was never created (stands in for "already deleted"), so
+// the successful Read must be dropped and the $unmanaged stack must stay empty.
+func TestResourcePersister_ReadDoesNotResurrectResourceWhoseTargetIsGone(t *testing.T) {
+	persister, sender, ds, err := newResourcePersisterForTest(t)
+	require.NoError(t, err)
+
+	syncUpdate := resource_update.ResourceUpdate{
+		DesiredState: pkgmodel.Resource{
+			Label:      "orphan-bucket",
+			Type:       "FakeAWS::S3::Bucket",
+			Properties: json.RawMessage(`{"BucketName":"orphan-bucket"}`),
+			Stack:      "$unmanaged",
+			Target:     "gone-target",
+			Ksuid:      util.NewID(),
+			NativeID:   "native-orphan",
+			Managed:    false,
+		},
+		ResourceTarget: pkgmodel.Target{Label: "gone-target", Namespace: "aws"},
+		State:          resource_update.ResourceUpdateStateSuccess,
+		StackLabel:     "$unmanaged",
+		ProgressResult: []plugin.TrackedProgress{
+			{
+				ProgressResult: resource.ProgressResult{
+					Operation:          resource.OperationRead,
+					OperationStatus:    resource.OperationStatusSuccess,
+					NativeID:           "native-orphan",
+					ResourceProperties: json.RawMessage(`{"BucketName":"orphan-bucket"}`),
+				},
+				ResourceType: "FakeAWS::S3::Bucket",
+				StartTs:      util.TimeNow(),
+				ModifiedTs:   util.TimeNow(),
+			},
+		},
+	}
+
+	readResult := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "sync-cmd",
+		ResourceOperation: resource_update.OperationRead,
+		PluginOperation:   resource.OperationRead,
+		ResourceUpdate:    syncUpdate,
+	})
+	require.NoError(t, readResult.Error)
+
+	unmanaged, err := ds.LoadResourcesByStack("$unmanaged")
+	require.NoError(t, err)
+	assert.Empty(t, unmanaged, "a read must not resurrect an unmanaged resource whose target has been deleted")
+}
+
+// TestResourcePersister_ReadCreatesNewlyDiscoveredResourceWhenTargetExists is the
+// companion to the guard above: when the target still exists, a Read with no current
+// row is a legitimate newly-discovered resource and must be stored. This ensures the
+// target-existence guard does not suppress ordinary discovery.
+func TestResourcePersister_ReadCreatesNewlyDiscoveredResourceWhenTargetExists(t *testing.T) {
+	persister, sender, ds, err := newResourcePersisterForTest(t)
+	require.NoError(t, err)
+
+	_, err = ds.CreateTarget(&pkgmodel.Target{Label: "live-target", Namespace: "aws"})
+	require.NoError(t, err)
+
+	syncUpdate := resource_update.ResourceUpdate{
+		DesiredState: pkgmodel.Resource{
+			Label:      "discovered-bucket",
+			Type:       "FakeAWS::S3::Bucket",
+			Properties: json.RawMessage(`{"BucketName":"discovered-bucket"}`),
+			Stack:      "$unmanaged",
+			Target:     "live-target",
+			Ksuid:      util.NewID(),
+			NativeID:   "native-discovered",
+			Managed:    false,
+		},
+		ResourceTarget: pkgmodel.Target{Label: "live-target", Namespace: "aws"},
+		State:          resource_update.ResourceUpdateStateSuccess,
+		StackLabel:     "$unmanaged",
+		ProgressResult: []plugin.TrackedProgress{
+			{
+				ProgressResult: resource.ProgressResult{
+					Operation:          resource.OperationRead,
+					OperationStatus:    resource.OperationStatusSuccess,
+					NativeID:           "native-discovered",
+					ResourceProperties: json.RawMessage(`{"BucketName":"discovered-bucket"}`),
+				},
+				ResourceType: "FakeAWS::S3::Bucket",
+				StartTs:      util.TimeNow(),
+				ModifiedTs:   util.TimeNow(),
+			},
+		},
+	}
+
+	readResult := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "sync-cmd",
+		ResourceOperation: resource_update.OperationRead,
+		PluginOperation:   resource.OperationRead,
+		ResourceUpdate:    syncUpdate,
+	})
+	require.NoError(t, readResult.Error)
+
+	unmanaged, err := ds.LoadResourcesByStack("$unmanaged")
+	require.NoError(t, err)
+	require.Len(t, unmanaged, 1, "a newly-discovered resource on an existing target should be stored")
+	assert.Equal(t, "discovered-bucket", unmanaged[0].Label)
+}
+
 func TestResourcePersister_CleanupEmptyStacks(t *testing.T) {
 	persister, sender, ds, err := newResourcePersisterForTest(t)
 	assert.NoError(t, err)

--- a/internal/workflow_tests/local/synchronizer_test.go
+++ b/internal/workflow_tests/local/synchronizer_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
 	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/discovery"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
@@ -1196,20 +1196,24 @@ func TestSynchronizer_SyncPicksUpNewSchemaFields(t *testing.T) {
 	})
 }
 
-// TestSynchronizer_SyncCleansUpOrphanedResources_TargetDeleted reproduces a
-// real cross-cloud scenario:
+// TestSynchronizer_TargetDeleteCleanupIsIdempotentWithSync checks that a full sync
+// cycle run after a target delete leaves the eagerly-cleaned state untouched:
 //
-//  1. Deploy: static target → EKS cluster → nested K8S target ($ref to
-//     cluster endpoint) → K8S resource on the nested target
-//  2. Discovery finds an additional unmanaged resource on the nested target
-//  3. Destroy the stack — managed resources + nested target are deleted
-//  4. Sync cycle runs — the orphaned unmanaged resource (whose target no
-//     longer exists) should be cleaned up via the "deleted OOB" path
+//  1. Deploy: static provider target → cluster → nested consumer target ($ref to
+//     the cluster endpoint) → app resource
+//  2. Discovery finds one unmanaged resource on the consumer target and one on the
+//     surviving provider target
+//  3. Destroy the stack — managed resources + the consumer target are deleted, and
+//     the consumer target's unmanaged resource is forgotten at destroy time; the
+//     provider target and its unmanaged resource survive
+//  4. Periodic sync (enabled at a 1s interval) keeps running — across several
+//     cycles it must neither resurrect the forgotten consumer resource nor drop
+//     the surviving provider one
 //
-// Without the fix, the sync generator panics on nil target dereference or the
-// ResourceUpdater sends an empty target config to the plugin, producing
-// repeated UnforeseenError logs on every sync tick.
-func TestSynchronizer_SyncCleansUpOrphanedResources_TargetDeleted(t *testing.T) {
+// Enabling periodic sync (rather than a single ForceSync, whose transient sync
+// command is pruned and cannot be observed) guarantees repeated real cycles run
+// during the stability window.
+func TestSynchronizer_TargetDeleteCleanupIsIdempotentWithSync(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		clusterProps := `{"BucketName":"eks-cluster","Endpoint":"https://eks.example.com"}`
 		clusterKsuid := "2MiD2rA1SJbLMGZgTL0hCxjkjjr"
@@ -1264,14 +1268,13 @@ func TestSynchronizer_SyncCleansUpOrphanedResources_TargetDeleted(t *testing.T) 
 				if request.ResourceType != "FakeAWS::S3::Bucket" {
 					return &resource.ListResult{}, nil
 				}
-				// Only the consumer target should yield a discovered resource.
+				// The consumer (nested, deleted-on-destroy) target yields one
+				// discovered resource; the surviving provider target yields another
+				// so a post-destroy sync cycle has real work and is observable.
 				if isConsumerTarget(request.TargetConfig) {
-					return &resource.ListResult{
-						NativeIDs:     []string{"discovered-ns"},
-						NextPageToken: nil,
-					}, nil
+					return &resource.ListResult{NativeIDs: []string{"discovered-ns"}}, nil
 				}
-				return &resource.ListResult{}, nil
+				return &resource.ListResult{NativeIDs: []string{"discovered-provider"}}, nil
 			},
 			Delete: func(request *resource.DeleteRequest) (*resource.DeleteResult, error) {
 				return &resource.DeleteResult{ProgressResult: &resource.ProgressResult{
@@ -1283,7 +1286,8 @@ func TestSynchronizer_SyncCleansUpOrphanedResources_TargetDeleted(t *testing.T) 
 		}
 
 		cfg := test_helpers.NewTestMetastructureConfig()
-		cfg.Agent.Synchronization.Enabled = false
+		cfg.Agent.Synchronization.Enabled = true
+		cfg.Agent.Synchronization.Interval = 1 * time.Second
 		cfg.Agent.Retry.MaxRetries = 0
 		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
 		defer def()
@@ -1303,13 +1307,13 @@ func TestSynchronizer_SyncCleansUpOrphanedResources_TargetDeleted(t *testing.T) 
 				},
 				{
 					Label: "app", Type: "FakeAWS::S3::Bucket", Stack: "infra", Target: "consumer",
-					Managed: true,
+					Managed:    true,
 					Schema:     pkgmodel.Schema{Identifier: "BucketName", Fields: []string{"BucketName"}, Portable: true},
 					Properties: json.RawMessage(`{"BucketName":"my-app"}`),
 				},
 			},
 			Targets: []pkgmodel.Target{
-				{Label: "provider", Namespace: "FakeAWS", Config: json.RawMessage(`{"region":"us-east-1"}`)},
+				{Label: "provider", Namespace: "FakeAWS", Discoverable: true, Config: json.RawMessage(`{"region":"us-east-1"}`)},
 				{
 					Label:        "consumer",
 					Namespace:    "FakeAWS",
@@ -1336,7 +1340,8 @@ func TestSynchronizer_SyncCleansUpOrphanedResources_TargetDeleted(t *testing.T) 
 		require.Len(t, infraResources, 2, "cluster + app should exist after apply")
 
 		// ── Step 2: Discovery ───────────────────────────────────────────
-		// Discover an unmanaged resource on the consumer target.
+		// Discover one unmanaged resource on the consumer target and one on the
+		// surviving provider target.
 		incoming := make(chan any, 1)
 		_, err = testutil.StartTestHelperActor(m.Node, incoming)
 		require.NoError(t, err)
@@ -1349,8 +1354,8 @@ func TestSynchronizer_SyncCleansUpOrphanedResources_TargetDeleted(t *testing.T) 
 			if err != nil {
 				return false
 			}
-			return len(unmanaged) >= 1
-		}, 10*time.Second, 100*time.Millisecond, "discovery should find unmanaged resource")
+			return len(unmanaged) >= 2
+		}, 10*time.Second, 100*time.Millisecond, "discovery should find unmanaged resources on both targets")
 
 		// ── Step 3: Destroy ─────────────────────────────────────────────
 		// Destroy the forma. This deletes:
@@ -1380,26 +1385,200 @@ func TestSynchronizer_SyncCleansUpOrphanedResources_TargetDeleted(t *testing.T) 
 		require.NoError(t, err)
 		assert.Nil(t, consumerTarget, "consumer target should be deleted (has $ref)")
 
-		// The discovered resource is still in the DB — orphaned.
-		unmanaged, err := m.Datastore.LoadResourcesByStack("$unmanaged")
-		require.NoError(t, err)
-		require.NotEmpty(t, unmanaged, "discovered resource should still exist (orphaned)")
+		// The consumer's discovered resource is forgotten at destroy time along with
+		// its target, while the surviving provider target's discovered resource
+		// remains. Periodic sync is enabled (1s interval), so settling into and
+		// holding this state also exercises the sync path.
+		onlyProviderRemains := func() bool {
+			unmanaged, err := m.Datastore.LoadResourcesByStack("$unmanaged")
+			if err != nil || len(unmanaged) != 1 {
+				return false
+			}
+			return unmanaged[0].Target == "provider"
+		}
+		require.Eventually(t, onlyProviderRemains, 10*time.Second, 100*time.Millisecond,
+			"consumer's unmanaged resource should be forgotten when its target is deleted")
 
-		// ── Step 5: Sync ────────────────────────────────────────────────
-		// The sync cycle encounters the orphaned resource whose target no
-		// longer exists. It should detect the missing target and clean up
-		// the resource via the "deleted out-of-band" path.
-		err = m.ForceSync()
+		// ── Step 5: The cleaned-up state is stable under repeated sync ──
+		// Sync fires every second, so the window below spans several real sync
+		// cycles. Across all of them the forgotten consumer resource must stay gone
+		// (steady-state sync never rediscovers a resource for the deleted target) and
+		// the surviving provider resource must never be dropped.
+		assert.Never(t, func() bool {
+			unmanaged, err := m.Datastore.LoadResourcesByStack("$unmanaged")
+			if err != nil {
+				return true
+			}
+			return len(unmanaged) != 1 || unmanaged[0].Target != "provider"
+		}, 5*time.Second, 250*time.Millisecond,
+			"repeated sync cycles must not resurrect the deleted target's unmanaged resource nor drop the surviving one")
+	})
+}
+
+// TestTargetDelete_ForgetsUnmanagedResourcesImmediately asserts that deleting a
+// target eagerly removes that target's unmanaged (discovered) resources from the
+// datastore at destroy time — without waiting for a sync tick — while leaving
+// unmanaged resources on other, surviving targets untouched.
+//
+// Setup: two discoverable targets. "provider" is a static target that survives
+// the destroy; "consumer" is a nested target ($ref to the cluster endpoint) that
+// is deleted along with the managed resources. Discovery finds two unmanaged
+// resources on the consumer and one on the surviving provider. After DestroyForma
+// completes — and before any ForceSync — the consumer's two unmanaged resources
+// must be gone, and the provider's one must remain.
+func TestTargetDelete_ForgetsUnmanagedResourcesImmediately(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		clusterProps := `{"BucketName":"eks-cluster","Endpoint":"https://eks.example.com"}`
+		clusterKsuid := "2MiD2rA1SJbLMGZgTL0hCxjkjjr"
+
+		isConsumerTarget := func(targetConfig json.RawMessage) bool {
+			var cfg map[string]any
+			if err := json.Unmarshal(targetConfig, &cfg); err != nil {
+				return false
+			}
+			_, hasEndpoint := cfg["endpoint"]
+			return hasEndpoint
+		}
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          request.Label,
+					NativeID:           "native-" + request.Label,
+					ResourceProperties: request.Properties,
+				}}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				if request.NativeID == "native-cluster" {
+					return &resource.ReadResult{
+						ResourceType: "FakeAWS::S3::Bucket",
+						Properties:   clusterProps,
+					}, nil
+				}
+				return &resource.ReadResult{
+					ResourceType: "FakeAWS::S3::Bucket",
+					Properties:   fmt.Sprintf(`{"BucketName":"%s"}`, request.NativeID),
+				}, nil
+			},
+			List: func(request *resource.ListRequest) (*resource.ListResult, error) {
+				if request.ResourceType != "FakeAWS::S3::Bucket" {
+					return &resource.ListResult{}, nil
+				}
+				// The consumer (nested) target yields two discovered resources;
+				// the surviving provider target yields one.
+				if isConsumerTarget(request.TargetConfig) {
+					return &resource.ListResult{NativeIDs: []string{"discovered-a", "discovered-b"}}, nil
+				}
+				return &resource.ListResult{NativeIDs: []string{"discovered-provider"}}, nil
+			},
+			Delete: func(request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+				return &resource.DeleteResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationDelete,
+					OperationStatus: resource.OperationStatusSuccess,
+					NativeID:        request.NativeID,
+				}}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		cfg.Agent.Retry.MaxRetries = 0
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
 		require.NoError(t, err)
 
-		// ── Step 6: Verify cleanup ──────────────────────────────────────
+		// ── Apply: provider (static) → cluster → consumer (nested $ref) → app ──
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "infra"}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label: "cluster", Type: "FakeAWS::S3::Bucket", Stack: "infra", Target: "provider",
+					Managed: true, Ksuid: clusterKsuid,
+					Schema:     pkgmodel.Schema{Identifier: "BucketName", Fields: []string{"BucketName", "Endpoint"}, Portable: true},
+					Properties: json.RawMessage(clusterProps),
+				},
+				{
+					Label: "app", Type: "FakeAWS::S3::Bucket", Stack: "infra", Target: "consumer",
+					Managed:    true,
+					Schema:     pkgmodel.Schema{Identifier: "BucketName", Fields: []string{"BucketName"}, Portable: true},
+					Properties: json.RawMessage(`{"BucketName":"my-app"}`),
+				},
+			},
+			Targets: []pkgmodel.Target{
+				{Label: "provider", Namespace: "FakeAWS", Discoverable: true, Config: json.RawMessage(`{"region":"us-east-1"}`)},
+				{
+					Label:        "consumer",
+					Namespace:    "FakeAWS",
+					Discoverable: true,
+					Config: json.RawMessage(fmt.Sprintf(`{
+						"endpoint": {"$ref": "formae://%s#/Endpoint"}
+					}`, clusterKsuid)),
+				},
+			},
+		}
+
+		_, err = m.ApplyForma(forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+		require.NoError(t, err)
+
+		assert.Eventually(t, func() bool {
+			incomplete, _ := m.Datastore.LoadIncompleteFormaCommands()
+			return len(incomplete) == 0
+		}, 10*time.Second, 100*time.Millisecond, "apply should complete")
+
+		// ── Discovery: two unmanaged on consumer, one on provider ──
+		incoming := make(chan any, 1)
+		_, err = testutil.StartTestHelperActor(m.Node, incoming)
+		require.NoError(t, err)
+
+		err = testutil.Send(m.Node, "Discovery", discovery.Discover{})
+		require.NoError(t, err)
+
 		assert.Eventually(t, func() bool {
 			unmanaged, err := m.Datastore.LoadResourcesByStack("$unmanaged")
 			if err != nil {
 				return false
 			}
-			return len(unmanaged) == 0
+			return len(unmanaged) >= 3
+		}, 10*time.Second, 100*time.Millisecond, "discovery should find three unmanaged resources")
+
+		// ── Destroy: deletes managed resources + the consumer target ──
+		_, err = m.DestroyForma(forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+		require.NoError(t, err)
+
+		assert.Eventually(t, func() bool {
+			cmds, _ := m.Datastore.LoadFormaCommands()
+			incomplete, _ := m.Datastore.LoadIncompleteFormaCommands()
+			return len(cmds) >= 2 && len(incomplete) == 0
+		}, 10*time.Second, 100*time.Millisecond, "destroy should complete")
+
+		consumerTarget, err := m.Datastore.LoadTarget("consumer")
+		require.NoError(t, err)
+		require.Nil(t, consumerTarget, "consumer target should be deleted (has $ref)")
+
+		providerTarget, err := m.Datastore.LoadTarget("provider")
+		require.NoError(t, err)
+		require.NotNil(t, providerTarget, "provider target should survive (no $ref)")
+
+		// ── Assert cleanup happened at destroy time, before any ForceSync ──
+		// Synchronization is disabled and no ForceSync is issued, so reaching the
+		// steady state below can only be the eager target-delete cleanup: the
+		// deleted consumer target's two unmanaged resources are forgotten, while
+		// the surviving provider target's one unmanaged resource is untouched.
+		assert.Eventually(t, func() bool {
+			unmanaged, err := m.Datastore.LoadResourcesByStack("$unmanaged")
+			if err != nil {
+				return false
+			}
+			remainingTargets := make([]string, 0, len(unmanaged))
+			for _, r := range unmanaged {
+				remainingTargets = append(remainingTargets, r.Target)
+			}
+			return len(remainingTargets) == 1 && remainingTargets[0] == "provider"
 		}, 10*time.Second, 100*time.Millisecond,
-			"orphaned unmanaged resource should be cleaned up by sync after target deletion")
+			"only the surviving provider target's unmanaged resource should remain after target deletion")
 	})
 }


### PR DESCRIPTION
## Summary

- Deleting a nested target left its unmanaged (discovered) resources orphaned in the datastore. Managed resources are removed via the changeset cascade, but unmanaged resources are never part of a changeset, so they lingered pointing at a deleted target until a later sync tick tombstoned them — and permanently if synchronization was disabled.
- The `ResourcePersister` now tombstones a target's unmanaged resources (`$unmanaged` stack, `managed=false`) before deleting the target row, so cleanup is immediate and independent of sync. It is scoped strictly to unmanaged resources so managed ones still go through the proper cloud-delete cascade. Cleanup errors propagate so the target delete is retried rather than left half-complete (tombstoning is idempotent, so retries converge).
- Also guards the read-persist path against resurrecting a resource whose target has been deleted: a sync or discovery read snapshotted before the delete could otherwise re-create the tombstoned row against a now-missing target. When the current row is absent and the target no longer exists, the read is dropped; when the target still exists it is stored as before (normal first-time discovery).