### PR TITLE
ci(release): update plugin nightly gate to the tier-1 set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,11 +73,10 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PLUGINS=(
-            "platform-engineering-labs/formae-plugin-azure"
             "platform-engineering-labs/formae-plugin-aws"
+            "platform-engineering-labs/formae-plugin-azure"
             "platform-engineering-labs/formae-plugin-gcp"
-            "platform-engineering-labs/formae-plugin-oci"
-            "platform-engineering-labs/formae-plugin-ovh"
+            "platform-engineering-labs/formae-plugin-kubernetes"
           )
           echo "Checking last nightly run for each plugin..."
           FAILED=""


### PR DESCRIPTION
## Summary

- The release workflow's plugin nightly-verification gate was stale. It checked `azure, aws, gcp, oci, ovh` and did not check the Kubernetes plugin at all.
- Point the gate at the currently-maintained tier-1 plugins: **aws, azure, gcp, and the Kubernetes plugin** (`formae-plugin-kubernetes`, formerly `formae-plugin-k8s`).
- Drops `oci` and `ovh` (no longer tier 1) and the stale `formae-plugin-k8s` reference.
- Note: `auth-basic` is tier 1 but has no Nightly workflow, so it cannot be added to a nightly-based gate here.