### PR TITLE
feat(schema): typed CLI properties for extends-based formae

### DIFF
--- a/internal/schema/pkl/assets/EntryPoint.pkl
+++ b/internal/schema/pkl/assets/EntryPoint.pkl
@@ -4,23 +4,25 @@
  * SPDX-License-Identifier: FSL-1.1-ALv2
  */
 
-amends "@formae/forma.pkl"
+extends "@formae/forma.pkl"
 import "@formae/formae.pkl"
 
 // Import your resource plugin schema here, e.g.:
 // import "@aws/aws.pkl"
 // import "@ovh/ovh.pkl"
 
-properties {
-  name = new formae.Prop {
-    flag = "name"
-    default = "my-name"
-  }
+properties: Props
+
+/// CLI properties for this forma: each member becomes a typed flag
+/// (member name = flag, declared default = default, doc comment = --help text).
+class Props {
+  /// The name to deploy
+  name: String = "my-name"
 }
 
 forma {
   new formae.Stack {
-    label = "my-stack"
+    label = "\(properties.name)-stack"
     description = "Stack for my resources"
   }
 

--- a/internal/schema/pkl/generator/pklGenerator.pkl
+++ b/internal/schema/pkl/generator/pklGenerator.pkl
@@ -37,13 +37,13 @@ typeMap = resourceTypes.fold(Map(), (acc: Map<String, resources.Resource>, elem)
 
 function headerImports(): String =
     """
-    amends "@formae/forma.pkl"
+    extends "@formae/forma.pkl"
     import "@formae/formae.pkl"
     """
 
 function getImports(type: String, dependencies: List<String>): String =
     """
-    amends "@formae/forma.pkl"
+    extends "@formae/forma.pkl"
     import "@formae/formae.pkl"
 
 

--- a/internal/schema/pkl/generator/tests/pklGenerator.pkl
+++ b/internal/schema/pkl/generator/tests/pklGenerator.pkl
@@ -28,7 +28,7 @@ facts {
 
     ["SQS Queue - generates forma block with stacks and targets"] {
         let (result = generator.generateFormaFile(sqsJson))
-        result.contains("amends \"@formae/forma.pkl\"") &&
+        result.contains("extends \"@formae/forma.pkl\"") &&
         result.contains("import \"@formae/formae.pkl\"") &&
         result.contains("formae.Stack") &&
         result.contains("label = \"queue-stack\"") &&

--- a/internal/schema/pkl/schema/forma.pkl
+++ b/internal/schema/pkl/schema/forma.pkl
@@ -36,6 +36,12 @@ hidden injected: Boolean = false
 // NOTE: a lot of this would be uneeded if bugs or unfinished implementation issues were resolved in PKL
 output {
     value =
+        // `properties is Typed` = the new extends shape (typed Props class).
+        // LEGACY: amends-based formae assign a Dynamic `properties {}` block,
+        // fail this check, and skip injection entirely - their Prop members
+        // self-read `prop:` values as before. Remove this discriminator (and
+        // the legacy passthrough in formae.renderProperties) when the legacy
+        // block is dropped after the deprecation window.
         if (!injected && properties != null && properties is Typed)
             let (m = module)
             ((m) { injected = true; properties = m.fill(m.properties.getClass()) }).output.value

--- a/internal/schema/pkl/schema/forma.pkl
+++ b/internal/schema/pkl/schema/forma.pkl
@@ -4,12 +4,16 @@
  * SPDX-License-Identifier: FSL-1.1-ALv2
  */
 
-module Forma
+open module Forma
 
 import "formae.pkl"
 
 description: formae.Description?
-properties: Dynamic?
+properties: Any?
+
+/// fill: entry point used by the self-injecting output below; constructs a
+/// typed instance of the user's properties class from external `prop:` values.
+function fill(clazz: Class): Typed = formae.fillProps(clazz)
 hidden forma: Listing<formae.Resource|formae.Resolvable|formae.Stack|formae.Target|formae.Policy>
 
 /// defaultStack: returns the first defined Stack
@@ -22,17 +26,27 @@ hidden defaultTarget: formae.TargetResolvable =
 forma.toList().filterIsInstance(formae.Target).firstOrNull?.res
 ?? forma.toList().filterIsInstance(formae.TargetResolvable).firstOrNull ?? throw("no default target found")
 
+// hidden guard for the self-injecting output: the first evaluation amends this
+// module with a filled `properties` instance (reading `prop:` values), the
+// second renders normally with the injected values visible everywhere via
+// late binding. Same mechanism pkl:Command's runtime uses ("synthesize a
+// module that amends the command module and sets options").
+hidden injected: Boolean = false
+
 // NOTE: a lot of this would be uneeded if bugs or unfinished implementation issues were resolved in PKL
 output {
     value =
-        if (formae.mode() == "properties")
+        if (!injected && properties != null && properties is Typed)
+            let (m = module)
+            ((m) { injected = true; properties = m.fill(m.properties.getClass()) }).output.value
+        else if (formae.mode() == "properties")
             new formae.FormaRender {
-                Properties = module.properties
+                Properties = formae.renderProperties(module.properties)
             }
         else
             new formae.FormaRender {
                 Description = module.description
-                Properties = module.properties
+                Properties = formae.renderProperties(module.properties)
                 Stacks = forma.toList().filterIsInstance(formae.Stack).toListing()
                 Targets = forma.toList().filterIsInstance(formae.Target).toListing()
                 Policies = forma.toList().filterIsInstance(formae.Policy).map((p) -> p.render()).toListing()

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -465,6 +465,10 @@ function fillProps(clazz: Class): Typed =
 /// so manifest and resources cannot disagree.
 function renderProperties(opts: Any?): Any? =
     if (opts == null) new Mapping {}
+    // LEGACY: a Dynamic `properties {}` block (amends-based formae) passes
+    // through unchanged, preserving today's wire output byte for byte.
+    // Remove together with forma.pkl's `is Typed` discriminator when the
+    // legacy block is dropped after the deprecation window.
     else if (!(opts is Typed)) opts
     else
         let (inst = opts.toDynamic().toMap())

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -432,12 +432,58 @@ open class Prop {
     fixed Value: (String|Boolean|Int|Float)? = value
 }
 
+// ---- typed CLI properties (RFC-105) ----------------------------------------
+
+/// Resolve a reflected type to its simple name, unwrapping nullables.
+function typeName(t): String =
+    if (t is reflect.DeclaredType) t.referent.name
+    else if (t is reflect.NullableType) typeName(t.member)
+    else "unknown"
+
+/// fillProps constructs a typed instance of `clazz`, reading `prop:<member>`
+/// per member, coercing to the declared type, and falling back to the declared
+/// default. Type constraints on the class members are validated by `toTyped`.
+/// Prior art: pkl-pantry `pkl.experimental.structuredRead`.
+function fillProps(clazz: Class): Typed =
+    new Mapping {
+        for (n, p in reflect.Class(clazz).properties) {
+            [n] = let (raw = read?("prop:\(n)"))
+                if (raw == null) p.defaultValue
+                else
+                    let (tn = typeName(p.type))
+                    if (tn == "Int") raw.toInt()
+                    else if (tn == "Float") raw.toFloat()
+                    else if (tn == "Boolean") raw.toBoolean()
+                    else raw
+        }
+    }.toMap().toTyped(clazz)
+
+/// renderProperties turns the module's `properties` value into the manifest the
+/// CLI/agent consume. Typed instances (the extends shape) are reflected into
+/// `{ name -> Prop }`; legacy Dynamic blocks pass through unchanged. The
+/// manifest Value always comes from the INSTANCE (never a self-reading Prop),
+/// so manifest and resources cannot disagree.
+function renderProperties(opts: Any?): Any? =
+    if (opts == null) new Mapping {}
+    else if (!(opts is Typed)) opts
+    else
+        let (inst = opts.toDynamic().toMap())
+        new Mapping {
+            for (name, p in reflect.Class(opts.getClass()).properties) {
+                [name] = new Prop {
+                    flag = name
+                    default = p.defaultValue as (String|Boolean|Int|Float)?
+                    value = inst[name] as (String|Boolean|Int|Float)?
+                }
+            }
+        }
+
 /// FormaeRender is an ouput class notice the casing difference
 class FormaRender {
     local self = this
 
     Description: Description?
-    Properties: Dynamic?
+    Properties: Any?
     Stacks: Listing<Stack>
     Targets: Listing<Target>
     Policies: Listing<Dynamic>?

--- a/internal/schema/pkl/testdata/forma/extends_props_test.pkl
+++ b/internal/schema/pkl/testdata/forma/extends_props_test.pkl
@@ -1,0 +1,39 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+/// RFC-105 target shape: extends + pure-schema typed properties.
+extends "@formae/forma.pkl"
+
+import "@formae/formae.pkl"
+import "@fakeaws/fakeaws.pkl"
+import "@fakeaws/sqs/queue.pkl"
+
+properties: Props
+
+class Props {
+  /// The name to deploy
+  name: String = "pel"
+
+  /// Port to listen on
+  port: Int(this > 0) = 8080
+}
+
+forma {
+  new formae.Stack {
+    label = "\(properties.name)-stack"
+    description = "stack for \(properties.name)"
+  }
+
+  new formae.Target {
+    label = "default-target"
+    config = new fakeaws.Config { region = "us-east-1" }
+  }
+
+  new queue.Queue {
+    label = "q"
+    queueName = "\(properties.name)-\(properties.port)-queue"
+  }
+}


### PR DESCRIPTION
## Summary

- Forma files can now `extends "@formae/forma.pkl"` and declare CLI properties as a plain typed class (`properties: Props` + `class Props { name: String = "pel" }`). Member name = flag, declared default = default, doc comment = help text, pkl type constraints validate CLI input (`-p port=-5` fails the `Int(this > 0)` constraint).
- Property access becomes statically typed: editors resolve `properties.name` instead of flagging it as an unresolved reference, which is the biggest source of red squiggles in forma files today.
- Injection is self-contained in `forma.pkl`: the output amends the module once with a properties instance filled from external `prop:` values, then renders normally — late binding carries injected values into all resources. Same mechanism pkl's own `pkl:Command` runtime uses. Plain `pkl eval -p name=test forma.pkl` works unchanged; no evaluator/Go changes.
- Backward compatible by construction: `properties` widens to `Any?`, legacy `properties {}` blocks pass through the render untouched, `amends`-based formae keep working against the now-open module.

## Verification

- `make test-pkl` and `go test ./internal/schema/pkl/...` green with the existing (unmigrated) testdata.
- Serialized JSON of legacy formae is byte-identical to main.
- New shape covered by `testdata/forma/extends_props_test.pkl`: defaults, `-p` injection into resources and manifest, constraint violations.
- Stray module properties (e.g. `Clouds = …`) never reach the rendered output — only `FormaRender` serializes.

## Deliberately not in this PR

- Validation throw for unknown/typo'd module properties under extends (`form {}` currently vanishes silently — same follow-up as the design discussion).
- Scaffold template + testdata migration to the new shape, docs.
- Optional CLI enrichment (doc comments → `--help`, typed flags).
