### PR TITLE
feat(plugin): pass the caller's prior model to plugin Read

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -45,6 +45,34 @@ jobs:
         run: |
           aws-nuke nuke -c tests/e2e/config/nuke-config.yaml --no-prompt --prompt-delay 3
 
+      - name: Purge leftover formae-e2e IAM roles
+        # aws-nuke's conformance-protect allowlist keys on the Name property,
+        # which inline IAMRolePolicy resources lack, so it protects them and
+        # then cannot delete the owning role (DeleteConflict). Remove any
+        # formae-e2e-* roles and their inline/attached policies first so the
+        # nuke does not wedge on a role left behind by a failed test run.
+        run: |
+          set -euo pipefail
+          for role in $(aws iam list-roles \
+            --query "Roles[?starts_with(RoleName, 'formae-e2e-')].RoleName" \
+            --output text); do
+            echo "Purging leftover role: $role"
+            for pol in $(aws iam list-role-policies --role-name "$role" \
+              --query "PolicyNames" --output text); do
+              aws iam delete-role-policy --role-name "$role" --policy-name "$pol"
+            done
+            for arn in $(aws iam list-attached-role-policies --role-name "$role" \
+              --query "AttachedPolicies[].PolicyArn" --output text); do
+              aws iam detach-role-policy --role-name "$role" --policy-arn "$arn"
+            done
+            for ip in $(aws iam list-instance-profiles-for-role --role-name "$role" \
+              --query "InstanceProfiles[].InstanceProfileName" --output text); do
+              aws iam remove-role-from-instance-profile \
+                --instance-profile-name "$ip" --role-name "$role"
+            done
+            aws iam delete-role --role-name "$role"
+          done
+
       - name: Nuke AWS
         run: |
           aws-nuke nuke -c tests/e2e/config/nuke-config.yaml --no-prompt --no-dry-run
@@ -263,7 +291,15 @@ jobs:
           # Install only the plugins this test needs. The agent refreshes
           # orbital's repository cache at startup, so the install candidate
           # solver has fresh metadata to work with.
-          dist/e2e/bin/formae plugin install ${{ matrix.system_plugins }} --channel stable
+          # Bridge: pin aws to 0.1.12. aws 0.1.13's Role read embeds
+          # sibling-managed inline policies, so the drift guard rejects the
+          # patch (TestPatchApply/AWS). Remove the pin once aws 0.1.14 ships.
+          plugins=""
+          for p in ${{ matrix.system_plugins }}; do
+            if [ "$p" = "aws" ]; then p="aws@0.1.12"; fi
+            plugins="$plugins $p"
+          done
+          dist/e2e/bin/formae plugin install $plugins --channel stable
 
           # Stop the bootstrap agent so the test harness can spawn its own.
           kill -TERM "$AGENT_PID" || true
@@ -340,6 +376,34 @@ jobs:
       - name: Nuke Discovery
         run: |
           aws-nuke nuke -c tests/e2e/config/nuke-config.yaml --no-prompt --prompt-delay 3
+
+      - name: Purge leftover formae-e2e IAM roles
+        # aws-nuke's conformance-protect allowlist keys on the Name property,
+        # which inline IAMRolePolicy resources lack, so it protects them and
+        # then cannot delete the owning role (DeleteConflict). Remove any
+        # formae-e2e-* roles and their inline/attached policies first so the
+        # nuke does not wedge on a role left behind by a failed test run.
+        run: |
+          set -euo pipefail
+          for role in $(aws iam list-roles \
+            --query "Roles[?starts_with(RoleName, 'formae-e2e-')].RoleName" \
+            --output text); do
+            echo "Purging leftover role: $role"
+            for pol in $(aws iam list-role-policies --role-name "$role" \
+              --query "PolicyNames" --output text); do
+              aws iam delete-role-policy --role-name "$role" --policy-name "$pol"
+            done
+            for arn in $(aws iam list-attached-role-policies --role-name "$role" \
+              --query "AttachedPolicies[].PolicyArn" --output text); do
+              aws iam detach-role-policy --role-name "$role" --policy-arn "$arn"
+            done
+            for ip in $(aws iam list-instance-profiles-for-role --role-name "$role" \
+              --query "InstanceProfiles[].InstanceProfileName" --output text); do
+              aws iam remove-role-from-instance-profile \
+                --instance-profile-name "$ip" --role-name "$role"
+            done
+            aws iam delete-role --role-name "$role"
+          done
 
       - name: Nuke AWS
         run: |

--- a/pkg/plugin/plugin_operator.go
+++ b/pkg/plugin/plugin_operator.go
@@ -554,6 +554,7 @@ func read(from gen.PID, state gen.Atom, data PluginUpdateData, operation ReadRes
 		ResourceType:    operation.ResourceType,
 		TargetConfig:    operation.TargetConfig,
 		RedactSensitive: operation.RedactSensitive,
+		PriorProperties: operation.ExistingResource.Properties,
 	})
 	if err != nil {
 		proc.Log().Debug("PluginOperator: failed to read resource: %v", err)

--- a/pkg/plugin/resource/resource.go
+++ b/pkg/plugin/resource/resource.go
@@ -61,6 +61,31 @@ type ReadRequest struct {
 
 	// RedactSensitive declares intent to remove sensitive properties
 	RedactSensitive bool
+
+	// PriorProperties carries the caller's last-known model for this resource
+	// (the stored row), as an OPTIONAL hint. It is never required to satisfy a
+	// Read: a plugin may ignore it entirely, and most should. A Read still
+	// reports actual cloud state — this is not an input the read is computed
+	// from.
+	//
+	// Its purpose is disambiguation, not data. Some resources have an ambiguous
+	// boundary: an IAM role's inline policies, for example, are a separate,
+	// queryable sub-resource, so "read the role" can legitimately mean with or
+	// without them embedded. Which projection is correct depends on how the
+	// caller models the resource — inline, versus as standalone child resources
+	// — and only the caller's model knows that. A plugin may consult
+	// PriorProperties to report the projection the caller manages, so a caller
+	// that manages a child as a standalone resource is not shown phantom drift
+	// (or driven to destroy it on a reconcile).
+	//
+	// Trade-off: this couples Read to the caller's model, which is a small leak
+	// in an otherwise pure operation. Prefer designing resource types with an
+	// unambiguous boundary so the hint is unnecessary; reach for it only where
+	// the cloud API genuinely conflates a resource with its children.
+	//
+	// Empty when the caller has no prior state (create/status read-back,
+	// discovery). Treat empty as "unknown" and fall back to default behaviour.
+	PriorProperties json.RawMessage
 }
 
 type ReadResult struct {


### PR DESCRIPTION
## Summary

- Add an optional `PriorProperties` field to the plugin SDK's `ReadRequest`,
  carrying the caller's last-known model (the stored row), and populate it in the
  plugin operator's read path from the existing resource.
- Some resources have an ambiguous boundary — e.g. an IAM role's inline policies
  are a separate, queryable sub-resource, so "read the role" can legitimately mean
  with or without them embedded. Which projection is correct depends on how the
  caller models the resource (inline vs. standalone child resources), and only the
  caller's model knows that. A plugin may now consult `PriorProperties` to report
  the projection the caller manages, so a caller that manages a child as a
  standalone resource is not shown phantom drift or driven to destroy it on a
  reconcile.
- The field is additive and optional: existing plugins compile and behave
  unchanged. As with any SDK change, plugins must be rebuilt against the new SDK
  to load, but no source changes are required.
- Add a purge step before `aws-nuke` in the e2e cleanup jobs: aws-nuke's allowlist
  keys on the `Name` property, which inline `IAMRolePolicy` resources lack, so it
  protects them and then cannot delete the owning role (`DeleteConflict`) — a role
  left behind by a failed test run wedges the entire cleanup. The step deletes
  `formae-e2e-*` roles and their inline/attached policies first, also clearing any
  current orphan on the next run.
- Pin the e2e aws plugin install to `0.1.12` as a temporary bridge: `0.1.13`'s Role
  read embeds sibling-managed inline policies, tripping the drift guard on patch.
  Removed once the fixed aws plugin ships and consumes the new SDK field.
