### PR TITLE
fix(e2e): unpin aws plugin now that the Role read fix has shipped

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -291,15 +291,7 @@ jobs:
           # Install only the plugins this test needs. The agent refreshes
           # orbital's repository cache at startup, so the install candidate
           # solver has fresh metadata to work with.
-          # Bridge: pin aws to 0.1.12. aws 0.1.13's Role read embeds
-          # sibling-managed inline policies, so the drift guard rejects the
-          # patch (TestPatchApply/AWS). Remove the pin once aws 0.1.14 ships.
-          plugins=""
-          for p in ${{ matrix.system_plugins }}; do
-            if [ "$p" = "aws" ]; then p="aws@0.1.12"; fi
-            plugins="$plugins $p"
-          done
-          dist/e2e/bin/formae plugin install $plugins --channel stable
+          dist/e2e/bin/formae plugin install ${{ matrix.system_plugins }} --channel stable
 
           # Stop the bootstrap agent so the test harness can spawn its own.
           kill -TERM "$AGENT_PID" || true


### PR DESCRIPTION
## Summary

- Remove the temporary `aws@0.1.12` pin from the e2e plugin install and go back to installing the current stable aws plugin.
- The pin worked around an aws Role read that embedded sibling-managed inline policies and tripped the drift guard on patch (surfaced by `TestPatchApply`). That fix has since shipped, so the workaround is no longer needed.
- This PR's own e2e run validates the real fix end-to-end (agent built from source + current stable aws plugin), rather than just the pinned older plugin.