### PR TITLE
feat(schema): extend --schema-location local to the formae core schema

### DIFF
--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/platform-engineering-labs/formae/internal/network/all"
 	"github.com/platform-engineering-labs/formae/internal/schema"
 	_ "github.com/platform-engineering-labs/formae/internal/schema/all"
+	"github.com/platform-engineering-labs/formae/internal/schema/pkl"
 	"github.com/platform-engineering-labs/formae/internal/usage"
 	"github.com/platform-engineering-labs/formae/internal/util"
 	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
@@ -722,8 +723,15 @@ func (a *App) buildDependencyStrings(forma *pkgmodel.Forma, location schema.Sche
 	}
 
 	var deps []string
-	if formae.Version != "0.0.0" {
-		deps = append(deps, "pkl.formae@"+formae.Version)
+	// Formae core: remote emits pkl.formae@<version> (hub-resolved); local
+	// materializes the binary's embedded schema and emits local:formae:<path>
+	// so extract output resolves @formae/... against this exact binary.
+	coreDep, err := pkl.CoreSchemaDep(location, formae.Version)
+	if err != nil {
+		return nil, err
+	}
+	if coreDep != "" {
+		deps = append(deps, coreDep)
 	}
 
 	seen := make(map[string]bool)

--- a/internal/schema/pkl/assets/tests/PklProjectTemplate_test.pkl
+++ b/internal/schema/pkl/assets/tests/PklProjectTemplate_test.pkl
@@ -174,6 +174,13 @@ examples {
     "  [\"\(name)\"] = import(\"\(path)\")"
   }
 
+  ["generating local dependency line for formae core"] {
+    local p = "local:formae:/home/me/.pel/formae/schema/0.87.0/PklProject"
+    local name = p.split(":")[1]
+    local path = p.replaceFirst("local:" + name + ":", "")
+    "  [\"\(name)\"] = import(\"\(path)\")"
+  }
+
   ["classifying mixed packages"] {
     local packages = List("pkl.formae@\(testVersion)", "local:aws:/path/to/aws", "gcp.gcp@\(testVersion)")
     new Mapping {

--- a/internal/schema/pkl/assets/tests/PklProjectTemplate_test.pkl-expected.pcf
+++ b/internal/schema/pkl/assets/tests/PklProjectTemplate_test.pkl-expected.pcf
@@ -22,6 +22,9 @@ examples {
   ["generating local dependency line"] {
     #"  ["aws"] = import("/path/to/aws/PklProject")"#
   }
+  ["generating local dependency line for formae core"] {
+    #"  ["formae"] = import("/home/me/.pel/formae/schema/0.87.0/PklProject")"#
+  }
   ["classifying mixed packages"] {
     new {
       ["remote"] = List("pkl.formae@1.0.0", "gcp.gcp@1.0.0")

--- a/internal/schema/pkl/core_schema.go
+++ b/internal/schema/pkl/core_schema.go
@@ -1,0 +1,94 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package pkl
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/platform-engineering-labs/formae/internal/schema"
+)
+
+// versionReadExpr is the in-repo version lookup in schema/PklProject. It reads
+// ../../../../version.semver relative to the repo layout, which does not exist
+// once the schema is materialized outside the tree — so the materializer swaps
+// it for the literal version.
+const versionReadExpr = `read("../../../../version.semver").text.trim()`
+
+// coreSchemaDir returns the default materialization directory for the given
+// version: <base>/schema/<version>, where <base> is the parent of the plugin
+// dir (so ~/.pel/formae/schema/<version> by default, and it honors
+// FORMAE_PLUGIN_DIR for free).
+func coreSchemaDir(version string) string {
+	return filepath.Join(filepath.Dir(defaultPluginDir()), "schema", version)
+}
+
+// MaterializeCoreSchema writes the embedded formae core schema plus a
+// self-contained PklProject (version inlined) to dir, overwriting any existing
+// content. When dir is "" it defaults to coreSchemaDir(version). It returns the
+// path to the materialized PklProject, suitable for a local: dependency string.
+func MaterializeCoreSchema(dir, version string) (string, error) {
+	if dir == "" {
+		dir = coreSchemaDir(version)
+	}
+
+	// Unconditional overwrite keeps dev builds (same version, changed schema)
+	// self-healing and avoids stale-content bugs — the whole tree is tiny.
+	if err := os.RemoveAll(dir); err != nil {
+		return "", fmt.Errorf("clearing core schema dir %q: %w", dir, err)
+	}
+
+	err := fs.WalkDir(coreSchema, "schema", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel := strings.TrimPrefix(p, "schema/")
+		target := filepath.Join(dir, rel)
+		if mkErr := os.MkdirAll(filepath.Dir(target), 0o755); mkErr != nil {
+			return fmt.Errorf("creating %q: %w", filepath.Dir(target), mkErr)
+		}
+		data, readErr := coreSchema.ReadFile(p)
+		if readErr != nil {
+			return readErr
+		}
+		if rel == ProjectFile {
+			data = []byte(strings.Replace(string(data), versionReadExpr, fmt.Sprintf("%q", version), 1))
+		}
+		if wErr := os.WriteFile(target, data, 0o644); wErr != nil {
+			return fmt.Errorf("writing %q: %w", target, wErr)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("materializing core schema to %q: %w", dir, err)
+	}
+
+	return filepath.Join(dir, ProjectFile), nil
+}
+
+// CoreSchemaDep returns the formae-core dependency string for a generated
+// PklProject. For SchemaLocationLocal it materializes the embedded schema and
+// returns local:formae:<PklProject path>; for remote it returns
+// pkl.formae@<version> (empty for the 0.0.0 dev build, matching prior behavior
+// of suppressing the core dep for unstamped binaries).
+func CoreSchemaDep(location schema.SchemaLocation, version string) (string, error) {
+	if location == schema.SchemaLocationLocal {
+		projPath, err := MaterializeCoreSchema("", version)
+		if err != nil {
+			return "", err
+		}
+		return "local:formae:" + projPath, nil
+	}
+	if version != "0.0.0" {
+		return "pkl.formae@" + version, nil
+	}
+	return "", nil
+}

--- a/internal/schema/pkl/core_schema_test.go
+++ b/internal/schema/pkl/core_schema_test.go
@@ -1,0 +1,105 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package pkl
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/internal/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaterializeCoreSchema_WritesFilesAndInlinesVersion(t *testing.T) {
+	dir := t.TempDir()
+	projPath, err := MaterializeCoreSchema(dir, "1.2.3")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "PklProject"), projPath)
+
+	// Core schema files land at the package root so @formae/forma.pkl resolves.
+	for _, f := range []string{"forma.pkl", "formae.pkl", "PklProject", "ext/URI.pkl"} {
+		_, statErr := os.Stat(filepath.Join(dir, f))
+		assert.NoError(t, statErr, "expected %s to be materialized", f)
+	}
+
+	// PklProject must carry the literal version — the in-repo read() breaks
+	// outside the repo tree.
+	proj, err := os.ReadFile(projPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(proj), `version = "1.2.3"`)
+	assert.NotContains(t, string(proj), "read(")
+
+	// tests/ and debug/ are dev-only; they must not be embedded.
+	_, statErr := os.Stat(filepath.Join(dir, "tests"))
+	assert.True(t, os.IsNotExist(statErr), "tests/ must not be materialized")
+}
+
+func TestMaterializeCoreSchema_IdempotentOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	_, err := MaterializeCoreSchema(dir, "1.2.3")
+	require.NoError(t, err)
+
+	// Corrupt a materialized file, re-materialize, confirm it is restored.
+	formaPath := filepath.Join(dir, "forma.pkl")
+	require.NoError(t, os.WriteFile(formaPath, []byte("// clobbered\n"), 0644))
+
+	_, err = MaterializeCoreSchema(dir, "1.2.3")
+	require.NoError(t, err)
+
+	restored, err := os.ReadFile(formaPath)
+	require.NoError(t, err)
+	assert.NotEqual(t, "// clobbered\n", string(restored))
+	assert.Contains(t, string(restored), "formae.pkl")
+}
+
+func TestMaterializeCoreSchema_UnwritableDirErrorsWithPath(t *testing.T) {
+	// A path whose parent is a regular file cannot be created.
+	parent := filepath.Join(t.TempDir(), "afile")
+	require.NoError(t, os.WriteFile(parent, []byte("x"), 0644))
+	target := filepath.Join(parent, "schema", "1.0.0")
+
+	_, err := MaterializeCoreSchema(target, "1.0.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), target)
+}
+
+func TestCoreSchemaDep_Remote(t *testing.T) {
+	dep, err := CoreSchemaDep(schema.SchemaLocationRemote, "0.87.0")
+	require.NoError(t, err)
+	assert.Equal(t, "pkl.formae@0.87.0", dep)
+}
+
+func TestCoreSchemaDep_RemoteDevBuildSkips(t *testing.T) {
+	dep, err := CoreSchemaDep(schema.SchemaLocationRemote, "0.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, "", dep)
+}
+
+func TestCoreSchemaDep_Local(t *testing.T) {
+	// Redirect the default schema dir into a temp tree via FORMAE_PLUGIN_DIR.
+	base := t.TempDir()
+	t.Setenv("FORMAE_PLUGIN_DIR", filepath.Join(base, "plugins"))
+
+	dep, err := CoreSchemaDep(schema.SchemaLocationLocal, "0.87.0")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(dep, "local:formae:"), "got %q", dep)
+
+	path := strings.TrimPrefix(dep, "local:formae:")
+	assert.Equal(t, filepath.Join(base, "schema", "0.87.0", "PklProject"), path)
+	_, statErr := os.Stat(path)
+	assert.NoError(t, statErr)
+}
+
+func TestCoreSchemaDep_LocalDevBuildMaterializes(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("FORMAE_PLUGIN_DIR", filepath.Join(base, "plugins"))
+
+	dep, err := CoreSchemaDep(schema.SchemaLocationLocal, "0.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, "local:formae:"+filepath.Join(base, "schema", "0.0.0", "PklProject"), dep)
+}

--- a/internal/schema/pkl/pkl.go
+++ b/internal/schema/pkl/pkl.go
@@ -35,6 +35,15 @@ var assets embed.FS
 //go:embed generator/*
 var generator embed.FS
 
+// coreSchema holds the formae core schema (forma.pkl, formae.pkl, ext/) plus
+// its PklProject template. It is materialized to disk for --schema-location
+// local so extract output resolves @formae/... against the running binary's
+// own schema instead of a hub-published package. Dev-only tests/ and debug/
+// are deliberately excluded.
+//
+//go:embed schema/forma.pkl schema/formae.pkl schema/ext schema/PklProject
+var coreSchema embed.FS
+
 // Compile time check to satisfy protocol
 var _ schema.SchemaPlugin = PKL{}
 

--- a/internal/schema/pkl/project_deps_test.go
+++ b/internal/schema/pkl/project_deps_test.go
@@ -53,6 +53,27 @@ dependencies {
 	}, deps)
 }
 
+func TestParsePklProjectDeps_LocalCore(t *testing.T) {
+	// --schema-location local renders the formae core dep as an import() too;
+	// it must round-trip back to a local: spec with the "formae" name.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "PklProject")
+	require.NoError(t, os.WriteFile(path, []byte(`amends "pkl:Project"
+
+dependencies {
+  ["formae"] = import("/home/me/.pel/formae/schema/0.87.0/PklProject")
+  ["aws"] = import("/home/me/.pel/formae/plugins/aws/v0.1.5/schema/pkl/PklProject")
+}
+`), 0644))
+
+	deps, err := parsePklProjectDeps(path)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		"local:formae:/home/me/.pel/formae/schema/0.87.0/PklProject",
+		"local:aws:/home/me/.pel/formae/plugins/aws/v0.1.5/schema/pkl/PklProject",
+	}, deps)
+}
+
 func TestParsePklProjectDeps_Mixed(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "PklProject")

--- a/tests/e2e/go/discovery_test.go
+++ b/tests/e2e/go/discovery_test.go
@@ -160,8 +160,8 @@ func testDiscoveryAWS(t *testing.T, cli *FormaeCLI) {
 	extractDir := t.TempDir()
 	rolesFile := filepath.Join(extractDir, "roles.pkl")
 	policiesFile := filepath.Join(extractDir, "policies.pkl")
-	cli.ExtractToFile(t, "type:AWS::IAM::Role managed:false stack:$unmanaged", rolesFile)
-	cli.ExtractToFile(t, "type:AWS::IAM::RolePolicy managed:false stack:$unmanaged", policiesFile)
+	cli.ExtractToFile(t, "type:AWS::IAM::Role managed:false stack:$unmanaged", rolesFile, "--schema-location", "local")
+	cli.ExtractToFile(t, "type:AWS::IAM::RolePolicy managed:false stack:$unmanaged", policiesFile, "--schema-location", "local")
 
 	// Step 9: Filter extracted files to keep only test resources.
 	// The roles extract includes pre-existing AWS service-linked roles

--- a/tests/e2e/go/extract_reapply_test.go
+++ b/tests/e2e/go/extract_reapply_test.go
@@ -42,7 +42,7 @@ func TestExtractAndReapply(t *testing.T) {
 
 	// Step 3: Extract the stack to a PKL file.
 	extractedPath := filepath.Join(t.TempDir(), "extracted.pkl")
-	cli.ExtractToFile(t, "stack:e2e-extract-reapply-aws", extractedPath)
+	cli.ExtractToFile(t, "stack:e2e-extract-reapply-aws", extractedPath, "--schema-location", "local")
 
 	// Step 3b: Verify the extracted PKL contains a Resolvable reference for
 	// the RolePolicy's roleName, not a plain string.

--- a/tests/e2e/go/reconcile_drift_test.go
+++ b/tests/e2e/go/reconcile_drift_test.go
@@ -59,7 +59,7 @@ func testSoftReconcileAWS(t *testing.T, cli *FormaeCLI) {
 
 	// Step 6: Extract the current state to absorb the OOB change into IaC.
 	extractedPath := filepath.Join(t.TempDir(), "extracted.pkl")
-	cli.ExtractToFile(t, "stack:e2e-soft-reconcile-aws", extractedPath)
+	cli.ExtractToFile(t, "stack:e2e-soft-reconcile-aws", extractedPath, "--schema-location", "local")
 
 	// Step 7: Apply the extracted PKL (which reflects the current cloud state
 	// including the OOB tag) — this updates formae's desired state to match reality.


### PR DESCRIPTION
## Problem

`--schema-location local` localized only **plugin** schemas; the formae core dependency was always hub-resolved — `buildDependencyStrings` emitted `pkl.formae@<version>` unconditionally. Extract output was coupled to whatever the hub served under that version, not the schema the binary was built with. PR #546 hit this: extract began emitting `extends "@formae/forma.pkl"` (valid in-repo) but the hub's published package predated the change, failing every extract round-trip with `Cannot extend non-open module 'Forma'`.

## Change

- **Embed** the core schema (`forma.pkl`, `formae.pkl`, `ext/`) plus its `PklProject` in `internal/schema/pkl` (excludes `tests/`, `debug/`).
- **Materializer** (`core_schema.go`): `MaterializeCoreSchema` writes the embedded schema to `~/.pel/formae/schema/<version>/`, rewriting `PklProject` with the version inlined (the in-repo `read("../../../../version.semver")` breaks outside the repo tree). Overwrites unconditionally; returns the `PklProject` path.
- **Wire**: `buildDependencyStrings` emits `local:formae:<path>/PklProject` in local mode via `CoreSchemaDep`; **remote mode stays byte-identical**. The `0.0.0` dev build materializes in local mode instead of dropping the core dep.
- **e2e**: AWS extract round-trips (`TestDiscovery`, `TestSoftReconcile`, `TestExtractAndReapply`) switched to `--schema-location local`; **Azure extract paths kept remote** to retain hub coverage.

## Tests

- `go test ./...`: 547 passed
- `make test-pkl`: pass (schema + generator + descriptors); `PklProjectTemplate` gains a `local:formae` example
- New: materializer unit tests, `project_deps` `local:formae` round-trip
- Hermetic eval verified locally: materialize → `pkl eval` resolves `@formae/forma.pkl` from the local dep

Follow-up to #546 — removes the failure class permanently instead of unblocking via a `schema-prerelease` republish.