### PR TITLE
fix(extract): use an accurate stack description for adopted resources

### DIFF
--- a/internal/metastructure/extract_resources_test.go
+++ b/internal/metastructure/extract_resources_test.go
@@ -308,7 +308,8 @@ func TestExtractResources_ManagedAndUnmanagedStacks(t *testing.T) {
 	// Unmanaged stack should be synthesized with a description
 	unmanaged, ok := stacksByLabel[constants.UnmanagedStack]
 	require.True(t, ok, "should have $unmanaged stack")
-	assert.NotEmpty(t, unmanaged.Description, "$unmanaged stack should have a non-empty description")
+	assert.Equal(t, "Resources imported with formae extract", unmanaged.Description,
+		"$unmanaged stack should be synthesized with the import description")
 
 	// Verify the forma can be serialized to JSON with Stacks present
 	jsonBytes, err := json.Marshal(forma)

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1017,7 +1017,7 @@ func (m *Metastructure) ExtractResources(query string) (*pkgmodel.Forma, error) 
 				// Stack not found in datastore (e.g., $unmanaged) - create a synthetic entry
 				forma.Stacks = append(forma.Stacks, pkgmodel.Stack{
 					Label:       label,
-					Description: "Unmanaged resources",
+					Description: "Resources imported with formae extract",
 				})
 			}
 		}


### PR DESCRIPTION
## Summary

- `formae extract` synthesizes a stack for the `$unmanaged` label with a hardcoded description of "Unmanaged resources". Once you uncomment the stack label to adopt the resources, they become managed, so the generated forma shipped with a description that contradicts its own state.
- Change the synthesized description to "Resources imported with formae extract", which stays accurate after adoption.
- Assert the new value in the extract test (it previously only checked the description was non-empty).