### PR TITLE
feat(build): bundle standard-bundle plugin examples into the formae opkg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,9 +146,19 @@ jobs:
   pkg_opkg:
     uses: "./.github/workflows/package.yml"
     secrets: inherit
-    if: ${{ contains(fromJSON('["", "pkg_opkg", "all"]'), inputs.pkg_job) && github.actor != 'peldroid[bot]' }}
+    # pkg_opkg builds the formae opkg, which bundles the standard-bundle members'
+    # examples and resolve-gates them against formae@$(VERSION). That schema is
+    # published by pkg_pkl (make publish-pkl), so pkg_opkg must wait for it -
+    # otherwise the resolve gate races the schema publish. The `!cancelled()` +
+    # explicit pkg_job=='pkg_opkg' clause keeps the manual `pkg_job=pkg_opkg`
+    # dispatch working even though pkg_pkl is skipped there.
+    if: ${{ !cancelled()
+          && github.actor != 'peldroid[bot]'
+          && contains(fromJSON('["", "pkg_opkg", "all"]'), inputs.pkg_job)
+          && (inputs.pkg_job == 'pkg_opkg' || needs.pkg_pkl.result == 'success') }}
     needs:
       - verify
+      - pkg_pkl
 
   pkg_container:
     uses: "./.github/workflows/container.yml"

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ docs/design/
 
 # External plugin cache (cloned plugin repos during build)
 .plugins/
+/bundle-examples

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,20 @@ pkg-bin: clean build
 	mkdir -p ./dist/pel/bin
 	cp -Rp ./formae ./dist/pel/bin
 	cp -Rp ./pkl-reader-helm ./dist/pel/bin
+	$(MAKE) bundle-examples
+
+## bundle-examples: Fetch standard-bundle members' examples at their release
+## tags, version-rewrite + resolve their pins, and stage them into the dist so
+## they ship in the formae opkg at /opt/pel/formae/examples/<plugin>/. Requires
+## pkl on PATH and network access to GitHub + the Hub. The formae pin is THIS
+## build's version ($(VERSION)) - the examples ship in this binary.
+bundle-examples:
+	go run ./cmd/bundle-examples --dist ./dist/pel/formae/examples --manifest ./.out/examples-manifest.json --formae-version $(VERSION)
+
+## verify-examples-opkg: assert the built opkg records every required member's
+## examples. Run after `just pkg` (which produces *.opkg). Requires orbital ops.
+verify-examples-opkg:
+	go run ./cmd/bundle-examples --skip-stage --manifest ./.out/examples-manifest.json --opkg './*.opkg'
 
 gen-pkl:
 	echo '${VERSION}' > ./version.semver
@@ -288,4 +302,4 @@ add-license:
 
 all: clean build gen-pkl api-docs
 
-.PHONY: api-docs clean build install-gremlins build-debug pkg-bin publish-bin gen-pkl pkg-pkl publish-pkl run tidy-all test-build test-all test-unit test-unit-postgres test-unit-auroradataapi test-unit-summary test-integration test-e2e test-property mutation-test test-descriptors-pkl verify-schema-fakeaws version full-e2e lint lint-reuse add-license postgres-up postgres-down mssql-up mssql-down local-data-api-up local-data-api-down all
+.PHONY: api-docs clean build install-gremlins build-debug pkg-bin bundle-examples verify-examples-opkg publish-bin gen-pkl pkg-pkl publish-pkl run tidy-all test-build test-all test-unit test-unit-postgres test-unit-auroradataapi test-unit-summary test-integration test-e2e test-property mutation-test test-descriptors-pkl verify-schema-fakeaws version full-e2e lint lint-reuse add-license postgres-up postgres-down mssql-up mssql-down local-data-api-up local-data-api-down all

--- a/cmd/bundle-examples/main.go
+++ b/cmd/bundle-examples/main.go
@@ -1,0 +1,492 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/platform-engineering-labs/formae/internal/bundleexamples"
+)
+
+var httpClient = &http.Client{Timeout: 60 * time.Second}
+
+var ghURL = regexp.MustCompile(`^https://github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$`)
+
+// ManifestEntry records what was resolved and staged for one standard-bundle
+// member: the resolved release tag, the commit that tag points at, and whether
+// examples were staged. The post-build opkg assertion reads this back.
+type ManifestEntry struct {
+	Member          string `json:"member"`
+	Tag             string `json:"tag"`
+	CommitSHA       string `json:"commit_sha"`
+	ExamplesPresent bool   `json:"examples_present"`
+}
+
+// Manifest is the checked intent of a stage run: this build's formae version and
+// the per-member resolution. The expected set for the resolve gate and the opkg
+// assertion is the checked-in policy (RequiredMembers), recorded here.
+type Manifest struct {
+	FormaeVersion string          `json:"formae_version"`
+	Members       []ManifestEntry `json:"members"`
+}
+
+func main() {
+	dist := flag.String("dist", "dist/pel/formae/examples", "stage dir")
+	manifest := flag.String("manifest", ".out/examples-manifest.json", "staged-member manifest (JSON)")
+	formaeVer := flag.String("formae-version", "", "REQUIRED: this build's formae X.Y.Z (Makefile passes $(VERSION))")
+	opkgGlob := flag.String("opkg", "", "opkg path or glob for the contents assertion")
+	skipStage := flag.Bool("skip-stage", false, "only assert opkg contents against the manifest")
+	stdRepo := flag.String("standard-repo", "https://github.com/platform-engineering-labs/formae-plugin-standard.git", "")
+	hub := flag.String("hub", "https://hub.platform.engineering", "")
+	flag.Parse()
+
+	var err error
+	if *skipStage {
+		err = assertOpkg(*opkgGlob, *manifest)
+	} else {
+		err = stage(*dist, *manifest, *formaeVer, *stdRepo, *hub)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bundle-examples: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func stage(dist, manifestPath, formaeVer, stdRepo, hub string) error {
+	// formaeVer is REQUIRED (the Makefile passes formae's own $(VERSION)); the
+	// examples ship in this formae binary, so they pin its version, not "latest".
+	if formaeVer == "" {
+		return fmt.Errorf("--formae-version is required (this build's formae X.Y.Z)")
+	}
+
+	stdURL, err := validateGH(stdRepo)
+	if err != nil {
+		return fmt.Errorf("standard repo url: %w", err)
+	}
+	stdTag, _, err := latestTag(stdRepo)
+	if err != nil {
+		return fmt.Errorf("standard tag: %w", err)
+	}
+	if stdTag == "" {
+		return fmt.Errorf("no stable tag on standard bundle")
+	}
+	opkgfile, err := fetchBytes(fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/Opkgfile", stdURL, stdTag))
+	if err != nil {
+		return fmt.Errorf("fetch standard Opkgfile: %w", err)
+	}
+	members := bundleexamples.Members(string(opkgfile))
+	if len(members) == 0 {
+		return fmt.Errorf("standard Opkgfile parsed to zero members")
+	}
+	// Fail closed on any standard-bundle member that is not classified in the
+	// examples policy: a new member must be a deliberate decision, not a silent
+	// skip.
+	if err := bundleexamples.CheckMembers(members); err != nil {
+		return err
+	}
+
+	// Fail-closed Hub presence check for formae@<VERSION>, wrapped in a bounded
+	// retry with exponential backoff (~30s) as insurance against CDN/cache lag
+	// right after the schema S3 sync. A genuine 404 after retries still fails.
+	// The pkg_pkl->pkg_opkg ordering in release.yml is what makes it resolvable.
+	formaeURL := fmt.Sprintf("%s/plugins/pkl/schema/pkl/formae/formae@%s", hub, formaeVer)
+	if err := probeGETWithRetry(formaeURL, 5, 2*time.Second); err != nil {
+		return fmt.Errorf("formae@%s not on hub (is pkg_pkl ordered before pkg_opkg?): %w", formaeVer, err)
+	}
+
+	m := Manifest{FormaeVersion: formaeVer}
+	staged := map[string]bool{}
+	for _, member := range members {
+		switch bundleexamples.PolicyFor(member) {
+		case bundleexamples.ExamplesNone:
+			fmt.Printf("bundle-examples: %s policy=none, skipping\n", member)
+			continue
+		case bundleexamples.ExamplesUnknown:
+			// Unreachable: CheckMembers already failed. Belt and suspenders.
+			return fmt.Errorf("member %q not in examples policy", member)
+		}
+
+		repo, err := hubRepo(hub, member)
+		if err != nil {
+			return fmt.Errorf("resolve repo for %q: %w", member, err)
+		}
+		tag, sha, err := latestTag(repo)
+		if err != nil {
+			return fmt.Errorf("tag for %q: %w", member, err)
+		}
+		if tag == "" {
+			return fmt.Errorf("no stable tag for %q (%s)", member, repo)
+		}
+		tmp, err := os.MkdirTemp("", "ex-"+member+"-")
+		if err != nil {
+			return err
+		}
+		defer func() { _ = os.RemoveAll(tmp) }()
+
+		hasDir, files, err := fetchExamples(repo, tag, tmp)
+		if err != nil {
+			return fmt.Errorf("fetch %q@%s: %w", member, tag, err)
+		}
+		// Policy says this member is REQUIRED to ship examples; an absent dir or
+		// an empty dir is a build failure, not a skip.
+		if !hasDir {
+			return fmt.Errorf("%s@%s is required to ship examples but has no examples/ dir", member, tag)
+		}
+		if files == 0 {
+			return fmt.Errorf("%s@%s has an examples/ dir but no files were staged", member, tag)
+		}
+		if err := rewriteTree(tmp, member, tag, formaeVer); err != nil {
+			return fmt.Errorf("rewrite %q: %w", member, err)
+		}
+		if err := resolveTree(tmp); err != nil {
+			return fmt.Errorf("resolve %q: %w", member, err)
+		}
+		dest := filepath.Join(dist, member)
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return err
+		}
+		if err := os.RemoveAll(dest); err != nil {
+			return err
+		}
+		if err := os.Rename(tmp, dest); err != nil {
+			return fmt.Errorf("swap %q into place: %w", member, err)
+		}
+		fmt.Printf("bundle-examples: staged %s@%s (%s, %d files)\n", member, tag, shortSHA(sha), files)
+		staged[member] = true
+		m.Members = append(m.Members, ManifestEntry{
+			Member:          member,
+			Tag:             tag,
+			CommitSHA:       sha,
+			ExamplesPresent: true,
+		})
+	}
+
+	// Guard against intent, not outcome: every REQUIRED member must have staged.
+	if missing := bundleexamples.MissingRequired(staged); len(missing) > 0 {
+		return fmt.Errorf("required members produced no examples: %s", strings.Join(missing, ", "))
+	}
+
+	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		return err
+	}
+	blob, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(manifestPath, append(blob, '\n'), 0o644)
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
+}
+
+func validateGH(u string) (string, error) {
+	m := ghURL.FindStringSubmatch(u)
+	if m == nil {
+		return "", fmt.Errorf("not a public https github url: %q", u)
+	}
+	return m[1] + "/" + m[2], nil
+}
+
+func hubRepo(hub, member string) (string, error) {
+	body, err := fetchBytes(fmt.Sprintf("%s/api/v1/plugins/%s", hub, member))
+	if err != nil {
+		return "", err
+	}
+	var v struct {
+		GithubRepoURL string `json:"github_repo_url"`
+	}
+	if err := json.Unmarshal(body, &v); err != nil {
+		return "", err
+	}
+	if _, err := validateGH(v.GithubRepoURL); err != nil {
+		return "", fmt.Errorf("hub returned %w", err)
+	}
+	return v.GithubRepoURL, nil
+}
+
+// latestTag returns the highest stable X.Y.Z tag on a remote and the commit SHA
+// that tag points at (the dereferenced commit for annotated tags).
+func latestTag(gitURL string) (tag, sha string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "git", "ls-remote", "--tags", gitURL).Output()
+	if err != nil {
+		return "", "", fmt.Errorf("git ls-remote %s: %w", gitURL, err)
+	}
+	plain := map[string]string{}
+	deref := map[string]string{}
+	seen := map[string]bool{}
+	var tags []string
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		refSHA, ref := fields[0], fields[1]
+		i := strings.LastIndex(ref, "refs/tags/")
+		if i < 0 {
+			continue
+		}
+		raw := ref[i+len("refs/tags/"):]
+		if strings.HasSuffix(raw, "^{}") {
+			deref[strings.TrimSuffix(raw, "^{}")] = refSHA
+			continue
+		}
+		plain[raw] = refSHA
+		if !seen[raw] {
+			seen[raw] = true
+			tags = append(tags, raw)
+		}
+	}
+	best := bundleexamples.LatestStable(tags)
+	if best == "" {
+		return "", "", nil
+	}
+	commit := deref[best]
+	if commit == "" {
+		commit = plain[best]
+	}
+	return best, commit, nil
+}
+
+func fetchBytes(url string) ([]byte, error) {
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func probeGET(url string) error {
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return err
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("%s", resp.Status)
+	}
+	return nil
+}
+
+// probeGETWithRetry probes url up to attempts times with exponential backoff
+// (base, 2*base, 4*base, ...), returning nil on the first success and the last
+// error if all attempts fail.
+func probeGETWithRetry(url string, attempts int, base time.Duration) error {
+	var last error
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			delay := base * time.Duration(1<<uint(i-1))
+			fmt.Printf("bundle-examples: waiting %s before retrying %s (attempt %d/%d)\n", delay, url, i+1, attempts)
+			time.Sleep(delay)
+		}
+		last = probeGET(url)
+		if last == nil {
+			return nil
+		}
+	}
+	return last
+}
+
+// fetchExamples downloads <repo>@<tag> and extracts the examples/ subtree into
+// dst. Returns (hasExamplesDir, filesWritten). Unsupported tar entry types fail.
+func fetchExamples(gitURL, tag, dst string) (bool, int, error) {
+	or, err := validateGH(gitURL)
+	if err != nil {
+		return false, 0, err
+	}
+	url := fmt.Sprintf("https://github.com/%s/archive/refs/tags/%s.tar.gz", or, tag)
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return false, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		return false, 0, fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return false, 0, err
+	}
+	tr := tar.NewReader(gz)
+	cleanDst := filepath.Clean(dst)
+	hasDir, files := false, 0
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return false, 0, err
+		}
+		parts := strings.SplitN(h.Name, "/", 2)
+		if len(parts) != 2 || (parts[1] != "examples" && !strings.HasPrefix(parts[1], "examples/")) {
+			continue
+		}
+		hasDir = true
+		rel := strings.TrimPrefix(strings.TrimPrefix(parts[1], "examples"), "/")
+		if rel == "" {
+			continue
+		}
+		target := filepath.Join(cleanDst, rel)
+		if target != cleanDst && !strings.HasPrefix(target, cleanDst+string(os.PathSeparator)) {
+			return false, 0, fmt.Errorf("tar path escape: %s", h.Name)
+		}
+		switch h.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return false, 0, err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return false, 0, err
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, h.FileInfo().Mode().Perm())
+			if err != nil {
+				return false, 0, err
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				_ = f.Close()
+				return false, 0, err
+			}
+			if err := f.Close(); err != nil {
+				return false, 0, err
+			}
+			files++
+		default:
+			return false, 0, fmt.Errorf("unsupported tar entry %q (type %d) under examples/", h.Name, h.Typeflag)
+		}
+	}
+	return hasDir, files, nil
+}
+
+func rewriteTree(root, member, tag, formaeVer string) error {
+	escape := regexp.MustCompile(`import\(\s*"\.\.[^"]*schema/pkl`)
+	return filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		base := filepath.Base(p)
+		if base == "PklProject.deps.json" {
+			return os.Remove(p)
+		}
+		if info.IsDir() || base != "PklProject" {
+			return nil
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		out := bundleexamples.RewritePklProject(string(b), member, tag, formaeVer)
+		if escape.MatchString(out) {
+			return fmt.Errorf("self-schema escape survived in %s", p)
+		}
+		return os.WriteFile(p, []byte(out), info.Mode())
+	})
+}
+
+func resolveTree(root string) error {
+	return filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || filepath.Base(p) != "PklProject" {
+			return nil
+		}
+		dir := filepath.Dir(p)
+		cmd := exec.Command("pkl", "project", "resolve", dir)
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("pkl project resolve %s: %w", dir, err)
+		}
+		return nil
+	})
+}
+
+// resolveOpkg picks the opkg to assert against. An exact existing file path is
+// used directly (preferred); otherwise the arg is treated as a glob and the
+// newest match by modtime wins.
+func resolveOpkg(arg string) (string, error) {
+	if fi, err := os.Stat(arg); err == nil && !fi.IsDir() {
+		return arg, nil
+	}
+	matches, _ := filepath.Glob(arg)
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no opkg matched %q", arg)
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	newest, newestT := "", time.Time{}
+	for _, mm := range matches {
+		fi, err := os.Stat(mm)
+		if err != nil {
+			return "", err
+		}
+		if fi.ModTime().After(newestT) {
+			newest, newestT = mm, fi.ModTime()
+		}
+	}
+	return newest, nil
+}
+
+func assertOpkg(opkgArg, manifestPath string) error {
+	mb, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read manifest %s: %w", manifestPath, err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(mb, &m); err != nil {
+		return fmt.Errorf("parse manifest %s: %w", manifestPath, err)
+	}
+	opkg, err := resolveOpkg(opkgArg)
+	if err != nil {
+		return err
+	}
+	out, err := exec.Command("ops", "opkg", "contents", opkg).Output()
+	if err != nil {
+		return fmt.Errorf("ops opkg contents %s: %w", opkg, err)
+	}
+	// The expected set is the checked-in policy, recorded in the manifest as the
+	// members with examples present - not "whatever staged".
+	checked := 0
+	for _, e := range m.Members {
+		if !e.ExamplesPresent {
+			continue
+		}
+		want := "formae/examples/" + e.Member + "/"
+		if !strings.Contains(string(out), want) {
+			return fmt.Errorf("opkg %s missing %s", opkg, want)
+		}
+		checked++
+	}
+	if checked == 0 {
+		return fmt.Errorf("manifest %s records no members with examples", manifestPath)
+	}
+	fmt.Printf("bundle-examples: opkg %s contains examples for %d member(s)\n", opkg, checked)
+	return nil
+}

--- a/internal/bundleexamples/members.go
+++ b/internal/bundleexamples/members.go
@@ -1,0 +1,58 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package bundleexamples
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	reqAssign = regexp.MustCompile(`requirements\s*=`)
+	nameDecl  = regexp.MustCompile(`name\s*=\s*"([^"]+)"`)
+)
+
+// requirementsBlock returns the text between the braces of the
+// `requirements = new Listing<...> { ... }` assignment, brace-matched so
+// nested `new { ... }` records are included.
+func requirementsBlock(text string) (string, bool) {
+	loc := reqAssign.FindStringIndex(text)
+	if loc == nil {
+		return "", false
+	}
+	open := strings.IndexByte(text[loc[1]:], '{')
+	if open < 0 {
+		return "", false
+	}
+	start := loc[1] + open
+	depth := 0
+	for i := start; i < len(text); i++ {
+		switch text[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return text[start+1 : i], true
+			}
+		}
+	}
+	return "", false
+}
+
+// Members extracts each requirement's name from the standard bundle Opkgfile,
+// scoped to the brace-matched `requirements` Listing so the metapackage's own
+// `name` and any out-of-block `name` fields are excluded.
+func Members(opkgfileText string) []string {
+	block, ok := requirementsBlock(opkgfileText)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, m := range nameDecl.FindAllStringSubmatch(block, -1) {
+		out = append(out, m[1])
+	}
+	return out
+}

--- a/internal/bundleexamples/members_test.go
+++ b/internal/bundleexamples/members_test.go
@@ -1,0 +1,67 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package bundleexamples
+
+import "testing"
+
+func has(xs []string, w string) bool {
+	for _, x := range xs {
+		if x == w {
+			return true
+		}
+	}
+	return false
+}
+
+// TestMembersRealStandardShape uses the exact requirements block shape of
+// formae-plugin-standard's Opkgfile at its latest stable tag.
+func TestMembersRealStandardShape(t *testing.T) {
+	std := `
+amends "orbital:/opkg.pkl"
+
+name        = "standard"
+maintainer  = new { name = "platform" }
+requirements = new Listing<requirement.Requirement> {
+  new { name = "aws"        method = "depends" operator = "ANY" }
+  new { name = "azure"      method = "depends" operator = "ANY" }
+  new { name = "gcp"        method = "depends" operator = "ANY" }
+  new {
+    name = "k8s"
+    method = "depends"
+  }
+  new { name = "auth-basic" method = "depends" operator = "ANY" }
+}
+
+metadata {
+  ["display"] {
+    ["kind"]     = "metapackage"
+  }
+}
+`
+	got := Members(std)
+	for _, w := range []string{"aws", "azure", "gcp", "k8s", "auth-basic"} {
+		if !has(got, w) {
+			t.Fatalf("missing %q; got %v", w, got)
+		}
+	}
+	if has(got, "standard") {
+		t.Fatalf("must not include metapackage name 'standard'; got %v", got)
+	}
+	if has(got, "platform") {
+		t.Fatalf("must not include out-of-block name 'platform'; got %v", got)
+	}
+	if has(got, "display") {
+		t.Fatalf("must not include metadata keys; got %v", got)
+	}
+}
+
+func TestMembersEmptyAndNoBlock(t *testing.T) {
+	if len(Members("")) != 0 {
+		t.Fatal("empty -> no members")
+	}
+	if len(Members(`name = "standard"`)) != 0 {
+		t.Fatal("no requirements block -> no members")
+	}
+}

--- a/internal/bundleexamples/policy.go
+++ b/internal/bundleexamples/policy.go
@@ -1,0 +1,88 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package bundleexamples
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ExamplesPolicy is the checked-in expectation of whether a standard-bundle
+// member ships examples. It is a deliberate contract, not an inference from
+// whatever a fetch happened to yield: a required member that silently loses its
+// examples, or a brand-new member nobody has classified, must fail the build
+// rather than quietly ship an incomplete bundle.
+type ExamplesPolicy int
+
+const (
+	// ExamplesUnknown means the member is absent from the policy (fail closed).
+	ExamplesUnknown ExamplesPolicy = iota
+	// ExamplesRequired means the member MUST yield staged examples.
+	ExamplesRequired
+	// ExamplesNone means the member is expected to ship no examples.
+	ExamplesNone
+)
+
+// examplesPolicy classifies every current standard-bundle member. Adding a
+// member to the bundle requires adding it here (or CheckMembers fails closed).
+var examplesPolicy = map[string]ExamplesPolicy{
+	"aws":        ExamplesRequired,
+	"azure":      ExamplesRequired,
+	"gcp":        ExamplesRequired,
+	"k8s":        ExamplesRequired,
+	"auth-basic": ExamplesNone,
+}
+
+// PolicyFor returns the examples policy for a standard-bundle member.
+func PolicyFor(member string) ExamplesPolicy {
+	if p, ok := examplesPolicy[member]; ok {
+		return p
+	}
+	return ExamplesUnknown
+}
+
+// RequiredMembers returns, sorted, the members that MUST yield examples.
+func RequiredMembers() []string {
+	var out []string
+	for m, p := range examplesPolicy {
+		if p == ExamplesRequired {
+			out = append(out, m)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// CheckMembers validates the parsed standard-bundle members against the policy:
+// every member must be classified. An unclassified (new/unknown) member fails
+// closed so it is an explicit decision, never a silent skip.
+func CheckMembers(members []string) error {
+	var unknown []string
+	for _, m := range members {
+		if PolicyFor(m) == ExamplesUnknown {
+			unknown = append(unknown, m)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return fmt.Errorf("standard-bundle member(s) not in the examples policy: %s (classify them in internal/bundleexamples/policy.go)", strings.Join(unknown, ", "))
+	}
+	return nil
+}
+
+// MissingRequired returns, sorted, the required members not present in the given
+// set (e.g. the members actually staged). A non-empty result means the build
+// must fail: a required member's examples went missing.
+func MissingRequired(present map[string]bool) []string {
+	var out []string
+	for _, m := range RequiredMembers() {
+		if !present[m] {
+			out = append(out, m)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/bundleexamples/policy_test.go
+++ b/internal/bundleexamples/policy_test.go
@@ -1,0 +1,57 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package bundleexamples
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPolicyClassification(t *testing.T) {
+	for _, m := range []string{"aws", "azure", "gcp", "k8s"} {
+		if PolicyFor(m) != ExamplesRequired {
+			t.Fatalf("%q should be ExamplesRequired", m)
+		}
+	}
+	if PolicyFor("auth-basic") != ExamplesNone {
+		t.Fatal("auth-basic should be ExamplesNone")
+	}
+	if PolicyFor("something-new") != ExamplesUnknown {
+		t.Fatal("an unclassified member should be ExamplesUnknown")
+	}
+}
+
+func TestRequiredMembers(t *testing.T) {
+	if got, want := RequiredMembers(), []string{"aws", "azure", "gcp", "k8s"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("RequiredMembers() = %v, want %v", got, want)
+	}
+}
+
+// CheckMembers fails closed when the standard bundle carries a member that no
+// one has classified in the policy - a new member must be an explicit decision,
+// never a silent skip.
+func TestCheckMembersFailsOnUnknown(t *testing.T) {
+	if err := CheckMembers([]string{"aws", "azure", "gcp", "k8s", "auth-basic"}); err != nil {
+		t.Fatalf("all-classified members should pass: %v", err)
+	}
+	err := CheckMembers([]string{"aws", "brand-new"})
+	if err == nil {
+		t.Fatal("an unclassified member must fail closed")
+	}
+}
+
+// MissingRequired is the regression guard: if a required member's examples go
+// missing (not staged), the build must fail rather than ship an incomplete
+// bundle.
+func TestMissingRequiredCatchesDroppedExamples(t *testing.T) {
+	all := map[string]bool{"aws": true, "azure": true, "gcp": true, "k8s": true}
+	if got := MissingRequired(all); len(got) != 0 {
+		t.Fatalf("nothing should be missing when all required present; got %v", got)
+	}
+	dropped := map[string]bool{"aws": true, "azure": true, "k8s": true} // gcp went missing
+	if got := MissingRequired(dropped); !reflect.DeepEqual(got, []string{"gcp"}) {
+		t.Fatalf("MissingRequired should catch dropped gcp; got %v", got)
+	}
+}

--- a/internal/bundleexamples/rewrite.go
+++ b/internal/bundleexamples/rewrite.go
@@ -1,0 +1,62 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package bundleexamples
+
+import "regexp"
+
+const hub = "package://hub.platform.engineering/plugins"
+
+// selfURI is the published self-schema package pin for a member. The path uses
+// the member id as both the Hub plugin id segment and the Pkl package name
+// (verified against the aws and k8s schema PklProjects, whose package.name
+// equals the member id). Only the GitHub repo slug diverges from the member id
+// (e.g. formae-plugin-kubernetes for k8s), and that is resolved via the Hub API
+// in the orchestrator, never here.
+func selfURI(member, version string) string {
+	return hub + "/" + member + "/schema/pkl/" + member + "/" + member + "@" + version
+}
+
+// RewritePklProject rewrites an example PklProject's dependency declarations so
+// the bundled examples pin to published packages instead of relative imports.
+//
+//  1. The self-schema import form `["<alias>"] = import("../.../schema/pkl/...")`
+//     becomes a package block `["<alias>"] { uri = "<selfURI>@<version>" }`. The
+//     alias is captured verbatim rather than assumed to equal the member id, so a
+//     divergent alias (e.g. ["kubernetes"] for member "k8s") is preserved while
+//     the URI path uses the member/package id.
+//  2. An already-present self-dep package pin inside a `uri = "..."` value has its
+//     version bumped to <version>.
+//  3. A formae pin inside a `uri = "..."` value is bumped to <formaeVersion>.
+//
+// All rewrites are scoped to `uri = "..."` values (and the import form), so
+// comments, cross-plugin pins, and local `./` project imports are never touched.
+func RewritePklProject(text, member, version, formaeVersion string) string {
+	q := regexp.QuoteMeta(member)
+	h := regexp.QuoteMeta(hub)
+
+	// Rule 1: self-schema import form -> package block. The import must climb via
+	// "../" into a "schema/pkl" path (local "./" project imports and cross-plugin
+	// package pins do not match). The alias key is captured (group 2) and
+	// preserved. \s* tolerates newlines between tokens. (?m) so ^ and the
+	// leading-indent capture (group 1) are per-line.
+	selfImport := regexp.MustCompile(
+		`(?m)^([ \t]*)\["([^"]+)"\]\s*=\s*import\(\s*"\.\.[^"]*schema/pkl[^"]*"\s*\)`)
+	text = selfImport.ReplaceAllString(text,
+		"${1}[\"${2}\"] {\n${1}  uri = \""+selfURI(member, version)+"\"\n${1}}")
+
+	// Rule 2: self-dep package pin inside a uri value -> version. Keyed on the
+	// member/package path so cross-plugin pins are untouched. The old version is
+	// any run of non-quote chars, so build metadata is handled.
+	selfPin := regexp.MustCompile(
+		`(uri\s*=\s*"[^"]*` + h + `/` + q + `/schema/pkl/` + q + `/` + q + `)@[^"]*(")`)
+	text = selfPin.ReplaceAllString(text, "${1}@"+version+"${2}")
+
+	// Rule 3: formae pin inside a uri value -> this build's formae version.
+	formaePin := regexp.MustCompile(
+		`(uri\s*=\s*"[^"]*` + h + `/pkl/schema/pkl/formae/formae)@[^"]*(")`)
+	text = formaePin.ReplaceAllString(text, "${1}@"+formaeVersion+"${2}")
+
+	return text
+}

--- a/internal/bundleexamples/rewrite_test.go
+++ b/internal/bundleexamples/rewrite_test.go
@@ -1,0 +1,196 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package bundleexamples
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func self(p, v string) string {
+	return "package://hub.platform.engineering/plugins/" + p + "/schema/pkl/" + p + "/" + p + "@" + v
+}
+func formaePkg(v string) string {
+	return "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@" + v
+}
+
+func TestRewriteSelfImportAndFormae(t *testing.T) {
+	src := "dependencies {\n  [\"aws\"] = import(\"../schema/pkl/PklProject\")\n  [\"formae\"] {\n    uri = \"" + formaePkg("0.84.0") + "\"\n  }\n}"
+	out := RewritePklProject(src, "aws", "0.1.14", "0.87.1")
+	if !strings.Contains(out, "uri = \""+self("aws", "0.1.14")+"\"") {
+		t.Fatalf("self import not rewritten:\n%s", out)
+	}
+	if regexp.MustCompile(`import\(`).MatchString(out) {
+		t.Fatalf("self import survived:\n%s", out)
+	}
+	if !strings.Contains(out, "uri = \""+formaePkg("0.87.1")+"\"") {
+		t.Fatalf("formae not bumped:\n%s", out)
+	}
+}
+
+func TestRewriteVariableDepthMainAndIndent(t *testing.T) {
+	for _, src := range []string{
+		"  [\"k8s\"] = import(\"../../schema/pkl/generated/PklProject\")",
+		"  [\"k8s\"] = import(\"../../schema/pkl/main/PklProject\")",
+		"  [\"k8s\"] = import(\"../../../schema/pkl/generated/PklProject\")",
+	} {
+		out := RewritePklProject(src, "k8s", "0.1.7", "0.87.1")
+		if !strings.Contains(out, "uri = \""+self("k8s", "0.1.7")+"\"") {
+			t.Fatalf("not rewritten: %q -> %q", src, out)
+		}
+		if !strings.HasPrefix(out, "  [\"k8s\"] {") {
+			t.Fatalf("indent not preserved: %q", out)
+		}
+	}
+}
+
+func TestRewriteMultilineImport(t *testing.T) {
+	src := "  [\"aws\"] =\n    import(\"../schema/pkl/PklProject\")"
+	out := RewritePklProject(src, "aws", "0.1.14", "0.87.1")
+	if !strings.Contains(out, self("aws", "0.1.14")) {
+		t.Fatalf("multiline import not rewritten:\n%s", out)
+	}
+}
+
+func TestRewriteExistingPinCrossPluginAndComments(t *testing.T) {
+	az := "  [\"azure\"] {\n    uri = \"" + self("azure", "0.1.2") + "\"\n  }"
+	if !strings.Contains(RewritePklProject(az, "azure", "0.1.7", "0.87.1"), self("azure", "0.1.7")) {
+		t.Fatal("azure self pin not bumped")
+	}
+	// k8s: cross-plugin aws pin unchanged; k8s import rewritten; comment untouched.
+	k := "// see aws@0.1.7 for details\n  [\"aws\"] {\n    uri = \"" + self("aws", "0.1.7") + "\"\n  }\n  [\"k8s\"] = import(\"../../schema/pkl/generated/PklProject\")"
+	out := RewritePklProject(k, "k8s", "0.1.7", "0.87.1")
+	if !strings.Contains(out, self("aws", "0.1.7")) {
+		t.Fatal("cross-plugin aws pin altered")
+	}
+	if !strings.Contains(out, "// see aws@0.1.7 for details") {
+		t.Fatal("comment was rewritten")
+	}
+	if !strings.Contains(out, self("k8s", "0.1.7")) {
+		t.Fatal("k8s self import not rewritten")
+	}
+}
+
+func TestRewriteLeavesIntraImports(t *testing.T) {
+	src := "  [\"clusters\"] = import(\"./clusters/PklProject\")"
+	if got := RewritePklProject(src, "k8s", "0.1.7", "0.87.1"); got != src {
+		t.Fatalf("intra ./ import altered: %q", got)
+	}
+}
+
+// TestRewriteRealK8sRootShape exercises the exact shape of
+// formae-plugin-kubernetes examples/PklProject at its release tag: the self
+// dependency is an import aliased ["k8s"] climbing to ../schema/pkl; the block
+// also carries cross-plugin package pins (aws/azure/gcp/oci/grafana) that MUST
+// remain untouched, local ./ project imports that MUST remain imports, and a
+// formae pin that MUST be bumped to this build's version.
+func TestRewriteRealK8sRootShape(t *testing.T) {
+	src := `amends "pkl:Project"
+
+dependencies {
+  ["formae"] {
+    uri = "` + formaePkg("0.86.1") + `"
+  }
+  ["aws"] {
+    uri = "` + self("aws", "0.1.7") + `"
+  }
+  ["azure"] {
+    uri = "` + self("azure", "0.1.3") + `"
+  }
+  ["gcp"] {
+    uri = "` + self("gcp", "0.1.7") + `"
+  }
+  ["oci"] {
+    uri = "` + self("oci", "0.1.3") + `"
+  }
+  ["grafana"] {
+    uri = "` + self("grafana", "0.1.3") + `"
+  }
+  ["k8s"] = import("../schema/pkl/PklProject")
+  ["clusters"] = import("./clusters/PklProject")
+  ["apps"] = import("./apps/PklProject")
+  ["formae-formations"] = import("./formations/PklProject")
+}
+
+evaluatorSettings {
+  externalResourceReaders {
+    ["reader+helm"] {
+      executable = "pkl-reader-helm"
+    }
+  }
+}`
+	out := RewritePklProject(src, "k8s", "0.1.7", "0.87.1")
+
+	// self import -> package pin at the build tag
+	if !strings.Contains(out, "[\"k8s\"] {") || !strings.Contains(out, self("k8s", "0.1.7")) {
+		t.Fatalf("k8s self import not rewritten to a package pin:\n%s", out)
+	}
+	// formae bumped
+	if !strings.Contains(out, formaePkg("0.87.1")) || strings.Contains(out, formaePkg("0.86.1")) {
+		t.Fatalf("formae pin not bumped:\n%s", out)
+	}
+	// cross-plugin pins untouched
+	for _, p := range []struct{ n, v string }{{"aws", "0.1.7"}, {"azure", "0.1.3"}, {"gcp", "0.1.7"}, {"oci", "0.1.3"}, {"grafana", "0.1.3"}} {
+		if !strings.Contains(out, self(p.n, p.v)) {
+			t.Fatalf("cross-plugin pin %s@%s was altered:\n%s", p.n, p.v, out)
+		}
+	}
+	// local ./ project imports remain imports
+	for _, imp := range []string{`["clusters"] = import("./clusters/PklProject")`, `["apps"] = import("./apps/PklProject")`, `["formae-formations"] = import("./formations/PklProject")`} {
+		if !strings.Contains(out, imp) {
+			t.Fatalf("local project import altered: %q\n%s", imp, out)
+		}
+	}
+	// no self-schema import escape survives
+	if regexp.MustCompile(`import\(\s*"\.\.[^"]*schema/pkl`).MatchString(out) {
+		t.Fatalf("self-schema escape import survived:\n%s", out)
+	}
+	// evaluatorSettings untouched
+	if !strings.Contains(out, `executable = "pkl-reader-helm"`) {
+		t.Fatalf("evaluatorSettings altered:\n%s", out)
+	}
+}
+
+// TestRewriteRealAwsShape exercises the aws examples/PklProject shape: a leading
+// comment before the self import, and a single formae pin.
+func TestRewriteRealAwsShape(t *testing.T) {
+	src := `dependencies {
+  // Reference local plugin schema during development
+  ["aws"] = import("../schema/pkl/PklProject")
+
+  // Formae schema - fetched from public registry
+  ["formae"] {
+    uri = "` + formaePkg("0.87.0") + `"
+  }
+}`
+	out := RewritePklProject(src, "aws", "0.1.14", "0.87.1")
+	if !strings.Contains(out, self("aws", "0.1.14")) {
+		t.Fatalf("aws self import not rewritten:\n%s", out)
+	}
+	if !strings.Contains(out, formaePkg("0.87.1")) {
+		t.Fatalf("formae not bumped:\n%s", out)
+	}
+	// comments preserved verbatim
+	if !strings.Contains(out, "// Reference local plugin schema during development") ||
+		!strings.Contains(out, "// Formae schema - fetched from public registry") {
+		t.Fatalf("comment was altered:\n%s", out)
+	}
+}
+
+// TestRewriteAliasDivergesFromMember is the carry-forward robustness guard: if
+// an example ever aliases its self-schema import under a name other than the
+// bundle member id (e.g. ["kubernetes"] for member "k8s"), the alias key MUST be
+// preserved while the package URI path uses the member/package id.
+func TestRewriteAliasDivergesFromMember(t *testing.T) {
+	src := `  ["kubernetes"] = import("../schema/pkl/PklProject")`
+	out := RewritePklProject(src, "k8s", "0.1.7", "0.87.1")
+	if !strings.Contains(out, `["kubernetes"] {`) {
+		t.Fatalf("diverging alias not preserved:\n%s", out)
+	}
+	if !strings.Contains(out, self("k8s", "0.1.7")) {
+		t.Fatalf("package URI should use member id k8s:\n%s", out)
+	}
+}

--- a/internal/bundleexamples/version.go
+++ b/internal/bundleexamples/version.go
@@ -1,0 +1,34 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package bundleexamples
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var stableTag = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
+// LatestStable returns the highest X.Y.Z tag (no prefix or suffix), or "".
+func LatestStable(tags []string) string {
+	best := ""
+	var bp [3]int
+	for _, t := range tags {
+		if !stableTag.MatchString(t) {
+			continue
+		}
+		var p [3]int
+		for i, s := range strings.SplitN(t, ".", 3) {
+			p[i], _ = strconv.Atoi(s)
+		}
+		if best == "" || p[0] > bp[0] ||
+			(p[0] == bp[0] && p[1] > bp[1]) ||
+			(p[0] == bp[0] && p[1] == bp[1] && p[2] > bp[2]) {
+			best, bp = t, p
+		}
+	}
+	return best
+}

--- a/internal/bundleexamples/version_test.go
+++ b/internal/bundleexamples/version_test.go
@@ -1,0 +1,28 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package bundleexamples
+
+import "testing"
+
+func TestLatestStable(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"ignores dev and v-prefix", []string{"0.1.0", "0.2.0", "0.2.0-dev.1", "0.10.0", "v0.3.0"}, "0.10.0"},
+		{"numeric not lexical", []string{"0.1.9", "0.1.10", "0.1.2"}, "0.1.10"},
+		{"dup annotated tags ok", []string{"0.1.4", "0.1.4", "0.1.3"}, "0.1.4"},
+		{"none stable", []string{"0.1.0-dev.1", "v0.2.0", "garbage"}, ""},
+		{"empty", nil, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := LatestStable(c.in); got != c.want {
+				t.Fatalf("LatestStable(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/justfile
+++ b/justfile
@@ -31,6 +31,7 @@ setup:
 
 pkg: clean build setup
     ops opkg build --secure --target-path dist/pel
+    make verify-examples-opkg
 
 publish: pkg
     ops publish --repo pel --channel {{ CHANNEL }} *.opkg


### PR DESCRIPTION
## What & why

`/opt/pel/formae/examples/<plugin>/` stopped shipping with formae at **0.80.0** (commit `2bd985af`, Jan 24): the examples moved out to the plugin repos, but the packaging side was never updated to ship them again. They've been absent for ~6 months. This re-bundles them from the **formae core packaging build**.

## Approach

A new `cmd/bundle-examples` Go tool (with tested `internal/bundleexamples` helpers), wired into `pkg-bin`:

1. Reads the `formae-plugin-standard` bundle for its members (brace-matched `requirements` block).
2. Resolves each member's GitHub repo via the **Hub API** (`/api/v1/plugins/<member>` → `github_repo_url`) — not a naming convention, since `k8s` → `formae-plugin-kubernetes`.
3. Fetches each member's `examples/` at its **latest stable tag**, into a temp dir, atomically swapped into place (idempotent reruns).
4. Rewrites the `PklProject` pins, scoped to `uri` values: self-dep → `member@tag`, `formae@` → **this build's `$(VERSION)`** (the examples ship in this binary, so they pin its schema). Cross-plugin pins and `./` imports untouched. The Pkl dep alias is preserved verbatim while the URI path uses the member/package id.
5. Strips stale `PklProject.deps.json`, runs `pkl project resolve` as a **gate**, and ships the regenerated lockfiles.
6. Stages into `dist/pel/formae/examples/<plugin>/` → installs to `/opt/pel/formae/examples/<plugin>/`.

**Anti-regression guards (check intent, not outcome):** a checked-in expected-examples policy (`aws/azure/gcp/k8s` required, `auth-basic` none) — unknown members and dropped required examples fail the build closed; the resolve gate; and an opkg-contents assertion against the policy set via a JSON manifest (recording tag + resolved commit SHA).

**Release ordering:** `pkg_opkg` now `needs: [verify, pkg_pkl]` so the core formae schema is published to the Hub before the resolve gate reads `formae@<VERSION>` — fixing a real race (both jobs previously only needed `verify`). The `if:` uses a status function so the manual `pkg_job=pkg_opkg` dispatch still works when `pkg_pkl` is skipped.

## Testing

- `go test ./internal/bundleexamples/`, `go vet`, `gofmt`, `golangci-lint`, REUSE — all clean.
- Live `make bundle-examples` — staged `aws@0.1.14`, `azure@0.1.7`, `gcp@0.1.8`, `k8s@0.1.7`; `auth-basic` skipped (policy=none); no self-schema-escape imports remain; formae pinned to `$(VERSION)`; cross-plugin pins untouched; `deps.json` regenerated and shipped; idempotency and required-`--formae-version` fail-closed both confirmed.
- **Not exercised locally:** `just pkg` / `verify-examples-opkg` (the opkg-contents assertion) — `ops` (orbital) isn't installed in the dev environment; the code path builds/vets clean and runs in CI.

## Notes

- `deps.json` is shipped resolved so the resolution step is pre-done; it is a lockfile, not the schema contents, so first `pkl eval` still fetches the pinned packages from the Hub (not full offline).