### PR TITLE
feat(cli): sudo-less plugin/update reads and a new 'formae refresh'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.0.0-00010101000000-000000000000
 	github.com/platform-engineering-labs/formae/tests/testcontrol v0.0.0-00010101000000-000000000000
 	github.com/platform-engineering-labs/jsonpatch v0.0.0-20260620044942-701436c7758c
-	github.com/platform-engineering-labs/orbital v0.1.41
+	github.com/platform-engineering-labs/orbital v0.2.5
 	github.com/posthog/posthog-go v1.6.3
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -401,6 +401,8 @@ github.com/platform-engineering-labs/jsonpatch v0.0.0-20260620044942-701436c7758
 github.com/platform-engineering-labs/jsonpatch v0.0.0-20260620044942-701436c7758c/go.mod h1:pKZWs1WAxW55mYtE0kAtpvrIMPzaQhZoBWSKqUMndvY=
 github.com/platform-engineering-labs/orbital v0.1.41 h1:+gbT761JoyhhdapaGGRkpGNGg8V0BKLd6+DVa/wOS2o=
 github.com/platform-engineering-labs/orbital v0.1.41/go.mod h1:wwVPqOmW5RO78dDzL/G5CN1Ioao0P/aUsOZVrPVx64s=
+github.com/platform-engineering-labs/orbital v0.2.5 h1:7rihasWnR68ORytqLubR5WMJchv/mxoWSCB7MqaB9tU=
+github.com/platform-engineering-labs/orbital v0.2.5/go.mod h1:wwVPqOmW5RO78dDzL/G5CN1Ioao0P/aUsOZVrPVx64s=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/cli/clean/clean.go
+++ b/internal/cli/clean/clean.go
@@ -31,13 +31,13 @@ func CleanCmd() *cobra.Command {
 				return err
 			}
 
-			orb, err := opsmgr.New(slog.Default(), app.Config.Artifacts.URL, "")
+			orb, err := opsmgr.New(slog.Default(), app.Config.Artifacts.URL, "", true, true)
 			if err != nil {
 				return err
 			}
 
 			if !orb.Ready() {
-				return fmt.Errorf("no managed installation root detected at: %s\n", orb.Path)
+				return fmt.Errorf("no managed installation root detected at: %s\n", orb.Path())
 			}
 
 			if all {

--- a/internal/cli/plugin/info.go
+++ b/internal/cli/plugin/info.go
@@ -31,9 +31,8 @@ func PluginInfoCmd() *cobra.Command {
 		Long: `Show the description, version, and metadata for a single
 plugin from the configured plugin repositories.
 
-On a stock install the plugin store lives at a path that only root can
-write to, so this command may prompt for sudo to refresh the
-repository metadata.`,
+This reads the locally cached package index without sudo; the data may
+be stale until you run 'formae refresh'.`,
 		Annotations: map[string]string{
 			"args": "<name>",
 		},
@@ -114,7 +113,7 @@ func runInfoForMachines(app *app.App, opts *InfoOptions) error {
 }
 
 func fetchPluginInfo(app *app.App, opts *InfoOptions) (*apimodel.Plugin, error) {
-	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel, true, true)
+	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/plugin/info.go
+++ b/internal/cli/plugin/info.go
@@ -114,7 +114,7 @@ func runInfoForMachines(app *app.App, opts *InfoOptions) error {
 }
 
 func fetchPluginInfo(app *app.App, opts *InfoOptions) (*apimodel.Plugin, error) {
-	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel)
+	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel, true, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/plugin/install.go
+++ b/internal/cli/plugin/install.go
@@ -99,7 +99,7 @@ func validateInstallOptions(opts *InstallOptions) error {
 }
 
 func runInstallForHumans(app *app.App, opts *InstallOptions) error {
-	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel)
+	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel, true, true)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func runInstallForHumans(app *app.App, opts *InstallOptions) error {
 }
 
 func runInstallForMachines(app *app.App, opts *InstallOptions) error {
-	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel)
+	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel, true, true)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/plugin/list.go
+++ b/internal/cli/plugin/list.go
@@ -99,7 +99,7 @@ func runListForMachines(app *app.App, opts *ListOptions) error {
 // sudo when the tree path is privileged; callers should be prepared to
 // re-run under sudo if the elevation prompt is undesirable.
 func installedPlugins(app *app.App) ([]apimodel.Plugin, error) {
-	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, "")
+	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, "", false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/plugin/list.go
+++ b/internal/cli/plugin/list.go
@@ -28,9 +28,7 @@ func PluginListCmd() *cobra.Command {
 		Short: "List installed plugins on this host",
 		Long: `List the plugins installed on this host with their version.
 
-On a stock install the plugin store lives at a path that only root can
-write to, so this command may prompt for sudo to read the install
-metadata.`,
+This reads the local package store without sudo.`,
 		RunE: func(cc *cobra.Command, args []string) error {
 			opts := &ListOptions{}
 			consumer, _ := cc.Flags().GetString("output-consumer")
@@ -95,9 +93,8 @@ func runListForMachines(app *app.App, opts *ListOptions) error {
 
 // installedPlugins reads the local orbital tree directly. The CLI runs
 // no agent / actor system locally, so this is the only source of truth
-// for what is installed on this host. orbital re-execs the CLI under
-// sudo when the tree path is privileged; callers should be prepared to
-// re-run under sudo if the elevation prompt is undesirable.
+// for what is installed on this host. The tree is opened read-only
+// (sudo=false, writable=false), so this never elevates.
 func installedPlugins(app *app.App) ([]apimodel.Plugin, error) {
 	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, "", false, false)
 	if err != nil {

--- a/internal/cli/plugin/manager.go
+++ b/internal/cli/plugin/manager.go
@@ -106,9 +106,6 @@ func (pm *CLIPluginManager) ListInstalled() ([]apimodel.Plugin, error) {
 // AvailableVersions populated) so the CLI can stand alone without an
 // agent.
 func (pm *CLIPluginManager) LocalSearch(query, category, typ string) ([]apimodel.Plugin, error) {
-	if err := pm.orb.Refresh(); err != nil {
-		pm.logger.Warn("refresh failed, using cached repository data", "error", err)
-	}
 	avail, err := pm.orb.Available()
 	if err != nil {
 		return nil, fmt.Errorf("querying available packages: %w", err)
@@ -147,9 +144,6 @@ func (pm *CLIPluginManager) LocalSearch(query, category, typ string) ([]apimodel
 // metadata or the package is unknown. Mirrors the agent-side
 // PluginManager.Info.
 func (pm *CLIPluginManager) LocalInfo(name string) (*apimodel.Plugin, error) {
-	if err := pm.orb.Refresh(); err != nil {
-		pm.logger.Warn("refresh failed, using cached repository data", "error", err)
-	}
 	status, err := pm.orb.AvailableFor(name)
 	if err != nil {
 		// orbital's AvailableFor returns "no available packages for: <name>"

--- a/internal/cli/plugin/manager.go
+++ b/internal/cli/plugin/manager.go
@@ -41,16 +41,16 @@ type CLIPluginManager struct {
 // every later call would panic). Mirrors the agent-side
 // plugin_manager.New guard so dev binaries get a clear message rather
 // than a nil-pointer crash.
-func NewCLIPluginManager(logger *slog.Logger, repos []pkgmodel.Repository, channel string) (*CLIPluginManager, error) {
+func NewCLIPluginManager(logger *slog.Logger, repos []pkgmodel.Repository, channel string, sudo bool, writable bool) (*CLIPluginManager, error) {
 	if len(repos) == 0 {
 		return nil, nil
 	}
-	orb, err := opsmgr.NewFromRepositories(logger, repos, channel)
+	orb, err := opsmgr.NewFromRepositories(logger, repos, channel, sudo, writable)
 	if err != nil {
 		return nil, err
 	}
 	if !orb.Ready() {
-		return nil, fmt.Errorf("plugin store at %s is not initialized; install formae from the official installer, or set %s to point at an existing install (e.g. /opt/pel)", orb.Path, opsmgr.FormaePelRootEnv)
+		return nil, fmt.Errorf("plugin store at %s is not initialized; install formae from the official installer, or set %s to point at an existing install (e.g. /opt/pel)", orb.Path(), opsmgr.FormaePelRootEnv)
 	}
 	return &CLIPluginManager{orb: orb, logger: logger}, nil
 }

--- a/internal/cli/plugin/search.go
+++ b/internal/cli/plugin/search.go
@@ -115,7 +115,7 @@ func runSearchForMachines(app *app.App, opts *SearchOptions) error {
 }
 
 func searchPlugins(app *app.App, opts *SearchOptions) ([]apimodel.Plugin, error) {
-	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel)
+	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel, true, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/plugin/search.go
+++ b/internal/cli/plugin/search.go
@@ -35,9 +35,8 @@ configured plugin repositories. With no arguments, every available
 plugin is listed; with a query, only plugins whose name, summary, or
 description matches are returned.
 
-On a stock install the plugin store lives at a path that only root can
-write to, so this command may prompt for sudo to refresh the
-repository metadata.`,
+This reads the locally cached package index without sudo; the data may
+be stale until you run 'formae refresh'.`,
 		Annotations: map[string]string{
 			"args": "[<query>]",
 		},
@@ -115,7 +114,7 @@ func runSearchForMachines(app *app.App, opts *SearchOptions) error {
 }
 
 func searchPlugins(app *app.App, opts *SearchOptions) ([]apimodel.Plugin, error) {
-	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel, true, true)
+	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/plugin/uninstall.go
+++ b/internal/cli/plugin/uninstall.go
@@ -84,7 +84,7 @@ func validateUninstallOptions(opts *UninstallOptions) error {
 }
 
 func runUninstallForHumans(app *app.App, opts *UninstallOptions) error {
-	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, "")
+	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, "", true, true)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func runUninstallForHumans(app *app.App, opts *UninstallOptions) error {
 }
 
 func runUninstallForMachines(app *app.App, opts *UninstallOptions) error {
-	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, "")
+	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, "", true, true)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/plugin/update.go
+++ b/internal/cli/plugin/update.go
@@ -84,7 +84,7 @@ func validateUpdateOptions(opts *UpdateOptions) error {
 }
 
 func runUpdateForHumans(app *app.App, opts *UpdateOptions) error {
-	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel)
+	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel, true, true)
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func runUpdateForHumans(app *app.App, opts *UpdateOptions) error {
 }
 
 func runUpdateForMachines(app *app.App, opts *UpdateOptions) error {
-	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel)
+	mgr, err := NewCLIPluginManager(slog.Default(), app.Config.Artifacts.Repositories, opts.Channel, true, true)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/refresh/refresh.go
+++ b/internal/cli/refresh/refresh.go
@@ -5,8 +5,10 @@
 package refresh
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 
 	clicmd "github.com/platform-engineering-labs/formae/internal/cli/cmd"
 	"github.com/platform-engineering-labs/formae/internal/cli/config"
@@ -16,6 +18,22 @@ import (
 	"github.com/platform-engineering-labs/orbital/mgr"
 	"github.com/spf13/cobra"
 )
+
+// refreshErrorCounter wraps a slog.Handler and counts records logged at ERROR
+// level. orbital's Refresh() logs per-repository fetch/validation failures
+// (o.Error(...)) but always returns nil, so refresh counts those records to
+// detect failures the API swallows rather than printing a false "done.".
+type refreshErrorCounter struct {
+	slog.Handler
+	count *atomic.Int64
+}
+
+func (h refreshErrorCounter) Handle(ctx context.Context, r slog.Record) error {
+	if r.Level >= slog.LevelError {
+		h.count.Add(1)
+	}
+	return h.Handler.Handle(ctx, r)
+}
 
 // RefreshCmd refreshes the locally cached package index for every configured
 // repository across all channels. It writes to the package store, so on a
@@ -47,12 +65,18 @@ sudo.`,
 				return err
 			}
 
+			// orbital's Refresh() always returns nil, logging per-repository
+			// fetch failures at ERROR level instead. Count those so we don't
+			// report success when a repo/channel was not actually warmed.
+			var refreshErrors atomic.Int64
+			logger := slog.New(refreshErrorCounter{Handler: slog.Default().Handler(), count: &refreshErrors})
+
 			for _, channel := range constants.AllChannels {
 				var orb *mgr.Manager
 				if len(app.Config.Artifacts.Repositories) > 0 {
-					orb, err = opsmgr.NewFromRepositories(slog.Default(), app.Config.Artifacts.Repositories, channel, true, true)
+					orb, err = opsmgr.NewFromRepositories(logger, app.Config.Artifacts.Repositories, channel, true, true)
 				} else {
-					orb, err = opsmgr.New(slog.Default(), app.Config.Artifacts.URL, channel, true, true)
+					orb, err = opsmgr.New(logger, app.Config.Artifacts.URL, channel, true, true)
 				}
 				if err != nil {
 					return err
@@ -66,6 +90,10 @@ sudo.`,
 				if err := orb.Refresh(); err != nil {
 					return err
 				}
+			}
+
+			if n := refreshErrors.Load(); n > 0 {
+				return fmt.Errorf("refresh completed with %d repository error(s); some package metadata may be stale — see the log for details", n)
 			}
 
 			fmt.Println("done.")

--- a/internal/cli/refresh/refresh.go
+++ b/internal/cli/refresh/refresh.go
@@ -1,0 +1,80 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package refresh
+
+import (
+	"fmt"
+	"log/slog"
+
+	clicmd "github.com/platform-engineering-labs/formae/internal/cli/cmd"
+	"github.com/platform-engineering-labs/formae/internal/cli/config"
+	"github.com/platform-engineering-labs/formae/internal/constants"
+	"github.com/platform-engineering-labs/formae/internal/logging"
+	"github.com/platform-engineering-labs/formae/internal/opsmgr"
+	"github.com/platform-engineering-labs/orbital/mgr"
+	"github.com/spf13/cobra"
+)
+
+// RefreshCmd refreshes the locally cached package index for every configured
+// repository across all channels. It writes to the package store, so on a
+// stock (root-owned) install it elevates via sudo.
+func RefreshCmd() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "refresh",
+		Short: "Refresh the local package index for all channels",
+		Long: `Refresh the locally cached package index for every configured
+repository across all channels (stable and dev).
+
+The non-destructive commands (plugin list/search/info, update list) read
+this cache without sudo, so their data can be stale until you refresh. On
+a stock install the package store is root-owned, so refresh may prompt for
+sudo.`,
+		Annotations: map[string]string{
+			"type":     "Manage",
+			"examples": "{{.Name}} {{.Command}}",
+		},
+		SilenceErrors: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			logging.SetupClientLogging(fmt.Sprintf("%s/log/client.log", config.Config.DataDirectory()))
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configFile, _ := cmd.Flags().GetString("config")
+
+			app, err := clicmd.AppFromContext(cmd.Context(), configFile, "", cmd)
+			if err != nil {
+				return err
+			}
+
+			for _, channel := range constants.AllChannels {
+				var orb *mgr.Manager
+				if len(app.Config.Artifacts.Repositories) > 0 {
+					orb, err = opsmgr.NewFromRepositories(slog.Default(), app.Config.Artifacts.Repositories, channel, true, true)
+				} else {
+					orb, err = opsmgr.New(slog.Default(), app.Config.Artifacts.URL, channel, true, true)
+				}
+				if err != nil {
+					return err
+				}
+
+				if !orb.Ready() {
+					return fmt.Errorf("no managed installation root detected at: %s", orb.Path())
+				}
+
+				fmt.Printf("refreshing %s...\n", channel)
+				if err := orb.Refresh(); err != nil {
+					return err
+				}
+			}
+
+			fmt.Println("done.")
+			return nil
+		},
+	}
+
+	command.SetUsageTemplate(clicmd.SimpleCmdUsageTemplate)
+	clicmd.AddConfigFlags(command)
+
+	return command
+}

--- a/internal/cli/refresh/refresh_test.go
+++ b/internal/cli/refresh/refresh_test.go
@@ -1,0 +1,32 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package refresh
+
+import (
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+)
+
+// orbital's Refresh() logs per-repository fetch/validation failures at ERROR
+// level but always returns nil. refreshErrorCounter must count exactly those
+// ERROR records (not INFO/WARN) so refresh can report a failure instead of a
+// false "done.".
+func TestRefreshErrorCounter_CountsOnlyErrorRecords(t *testing.T) {
+	var n atomic.Int64
+	log := slog.New(refreshErrorCounter{Handler: slog.NewTextHandler(io.Discard, nil), count: &n})
+
+	log.Info("refreshing pel#stable")
+	log.Warn("no metadata: community#stable")
+	log.Error("refresh failed: pel#stable")
+	log.Error("metadata validation failed: community#stable")
+
+	if got := n.Load(); got != 2 {
+		t.Errorf("expected 2 ERROR records counted, got %d", got)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/cli/plugin"
 	"github.com/platform-engineering-labs/formae/internal/cli/profile"
 	"github.com/platform-engineering-labs/formae/internal/cli/project"
+	"github.com/platform-engineering-labs/formae/internal/cli/refresh"
 	"github.com/platform-engineering-labs/formae/internal/cli/status"
 	"github.com/platform-engineering-labs/formae/internal/cli/update"
 	"github.com/spf13/cobra"
@@ -227,6 +228,7 @@ func init() {
 	rootCmd.AddCommand(status.StatusCmd())
 	rootCmd.AddCommand(extract.ExtractCmd())
 	rootCmd.AddCommand(update.UpdateCmd())
+	rootCmd.AddCommand(refresh.RefreshCmd())
 	rootCmd.AddCommand(inventory.InventoryCmd())
 
 	if !strings.HasSuffix(os.Args[0], "formae") {

--- a/internal/cli/update/update.go
+++ b/internal/cli/update/update.go
@@ -45,9 +45,9 @@ func UpdateCmd() *cobra.Command {
 
 			var orb *mgr.Manager
 			if len(app.Config.Artifacts.Repositories) > 0 {
-				orb, err = opsmgr.NewFromRepositoriesFiltered(slog.Default(), app.Config.Artifacts.Repositories, channel, pkgmodel.RepositoryTypeBinary)
+				orb, err = opsmgr.NewFromRepositoriesFiltered(slog.Default(), app.Config.Artifacts.Repositories, channel, true, true, pkgmodel.RepositoryTypeBinary)
 			} else {
-				orb, err = opsmgr.New(slog.Default(), app.Config.Artifacts.URL, channel)
+				orb, err = opsmgr.New(slog.Default(), app.Config.Artifacts.URL, channel, true, true)
 			}
 			if err != nil {
 				return err
@@ -55,7 +55,7 @@ func UpdateCmd() *cobra.Command {
 
 			// init root if needed
 			if !orb.Ready() {
-				fmt.Printf("no managed installation root detected at: %s\n", orb.Path)
+				fmt.Printf("no managed installation root detected at: %s\n", orb.Path())
 				fmt.Print("initialize? [y/n]: ")
 				var response string
 
@@ -152,16 +152,16 @@ func UpdateListCmd() *cobra.Command {
 
 			var orb *mgr.Manager
 			if len(app.Config.Artifacts.Repositories) > 0 {
-				orb, err = opsmgr.NewFromRepositoriesFiltered(slog.Default(), app.Config.Artifacts.Repositories, channel, pkgmodel.RepositoryTypeBinary)
+				orb, err = opsmgr.NewFromRepositoriesFiltered(slog.Default(), app.Config.Artifacts.Repositories, channel, true, true, pkgmodel.RepositoryTypeBinary)
 			} else {
-				orb, err = opsmgr.New(slog.Default(), app.Config.Artifacts.URL, channel)
+				orb, err = opsmgr.New(slog.Default(), app.Config.Artifacts.URL, channel, true, true)
 			}
 			if err != nil {
 				return err
 			}
 
 			if !orb.Ready() {
-				return fmt.Errorf("no managed installation root detected at: %s\n", orb.Path)
+				return fmt.Errorf("no managed installation root detected at: %s\n", orb.Path())
 			}
 
 			err = orb.Refresh()

--- a/internal/cli/update/update.go
+++ b/internal/cli/update/update.go
@@ -152,9 +152,9 @@ func UpdateListCmd() *cobra.Command {
 
 			var orb *mgr.Manager
 			if len(app.Config.Artifacts.Repositories) > 0 {
-				orb, err = opsmgr.NewFromRepositoriesFiltered(slog.Default(), app.Config.Artifacts.Repositories, channel, true, true, pkgmodel.RepositoryTypeBinary)
+				orb, err = opsmgr.NewFromRepositoriesFiltered(slog.Default(), app.Config.Artifacts.Repositories, channel, false, false, pkgmodel.RepositoryTypeBinary)
 			} else {
-				orb, err = opsmgr.New(slog.Default(), app.Config.Artifacts.URL, channel, true, true)
+				orb, err = opsmgr.New(slog.Default(), app.Config.Artifacts.URL, channel, false, false)
 			}
 			if err != nil {
 				return err
@@ -162,11 +162,6 @@ func UpdateListCmd() *cobra.Command {
 
 			if !orb.Ready() {
 				return fmt.Errorf("no managed installation root detected at: %s\n", orb.Path())
-			}
-
-			err = orb.Refresh()
-			if err != nil {
-				return err
 			}
 
 			available, err := orb.AvailableForSimple("formae")

--- a/internal/cli/update/update.go
+++ b/internal/cli/update/update.go
@@ -132,6 +132,50 @@ func UpdateCmd() *cobra.Command {
 	return command
 }
 
+// formatAvailableVersions renders the `update list` output for the formae
+// package: an "installed" line when a version is installed, then the distinct
+// available versions (annotating the installed one). It reads the full
+// candidate list directly rather than orbital's AvailableForSimple, which
+// skips the candidate at index 0 — so a cold index (nothing installed) would
+// omit the newest version or render an empty list.
+func formatAvailableVersions(available []*records.Package) string {
+	var installed *records.Package
+	for _, pkg := range available {
+		if pkg != nil && pkg.Installed && pkg.Version != nil {
+			installed = pkg
+			break
+		}
+	}
+
+	var b strings.Builder
+	if installed != nil {
+		fmt.Fprintf(&b, "installed: %s (%s)\n\n", installed.Version.Short(), installed.Version.Timestamp.String())
+	}
+
+	b.WriteString("available versions:\n\n")
+	seen := make(map[string]bool, len(available))
+	for _, entry := range available {
+		if entry == nil || entry.Version == nil {
+			continue
+		}
+		short := entry.Version.Short()
+		if seen[short] {
+			continue
+		}
+		seen[short] = true
+		if installed != nil && entry.Version.Semver().EQ(installed.Version.Semver()) {
+			age := "Newer"
+			if entry.Version.LT(installed.Version) {
+				age = "Older"
+			}
+			fmt.Fprintf(&b, "  %s %s: (%s)\n", short, age, entry.Version.Timestamp.String())
+		} else {
+			fmt.Fprintf(&b, "  %s\n", short)
+		}
+	}
+	return b.String()
+}
+
 func UpdateListCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "list",
@@ -164,28 +208,12 @@ func UpdateListCmd() *cobra.Command {
 				return fmt.Errorf("no managed installation root detected at: %s\n", orb.Path())
 			}
 
-			available, err := orb.AvailableForSimple("formae")
+			available, err := orb.AvailableFor("formae")
 			if err != nil {
 				return err
 			}
 
-			if available.Installed != nil {
-				fmt.Printf("installed: %s (%s)\n\n", available.Installed.Version.Short(), available.Installed.Version.Timestamp.String())
-			}
-
-			fmt.Print("available versions:\n\n")
-			for _, entry := range available.Available {
-				if available.Installed != nil && entry.Version.Semver().EQ(available.Installed.Version.Semver()) {
-					age := "Newer"
-					if entry.Version.LT(available.Installed.Version) {
-						age = "Older"
-					}
-
-					fmt.Printf("  %s %s: (%s)\n", entry.Version.Short(), age, entry.Version.Timestamp.String())
-				} else {
-					fmt.Printf("  %s\n", entry.Version.Short())
-				}
-			}
+			fmt.Print(formatAvailableVersions(available.Available))
 
 			return nil
 		},

--- a/internal/cli/update/update.go
+++ b/internal/cli/update/update.go
@@ -175,7 +175,7 @@ func UpdateListCmd() *cobra.Command {
 
 			fmt.Print("available versions:\n\n")
 			for _, entry := range available.Available {
-				if entry.Version.Semver().EQ(available.Installed.Version.Semver()) {
+				if available.Installed != nil && entry.Version.Semver().EQ(available.Installed.Version.Semver()) {
 					age := "Newer"
 					if entry.Version.LT(available.Installed.Version) {
 						age = "Older"

--- a/internal/cli/update/update_test.go
+++ b/internal/cli/update/update_test.go
@@ -1,0 +1,79 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package update
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/platform-engineering-labs/orbital/opm/records"
+	"github.com/platform-engineering-labs/orbital/ops"
+)
+
+func pkg(major, minor, patch uint64, installed bool) *records.Package {
+	return &records.Package{
+		Installed: installed,
+		Header: &ops.Header{
+			Version: &ops.Version{
+				Major:     major,
+				Minor:     minor,
+				Patch:     patch,
+				Timestamp: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+}
+
+// A cold index with a single, not-yet-installed version must still list that
+// version. orbital's AvailableForSimple drops the candidate at index 0, so a
+// cold index rendered an empty list; formatAvailableVersions must not.
+func TestFormatAvailableVersions_ColdSingleCandidateNotDropped(t *testing.T) {
+	out := formatAvailableVersions([]*records.Package{pkg(0, 88, 0, false)})
+
+	if !strings.Contains(out, "0.88.0") {
+		t.Errorf("expected the only available version 0.88.0 to be listed, got:\n%s", out)
+	}
+	if strings.Contains(out, "installed:") {
+		t.Errorf("expected no installed line when nothing is installed, got:\n%s", out)
+	}
+}
+
+// With multiple not-installed candidates and nothing installed, every distinct
+// version must appear (AvailableForSimple would omit the first).
+func TestFormatAvailableVersions_MultipleCandidatesAllListed(t *testing.T) {
+	out := formatAvailableVersions([]*records.Package{
+		pkg(0, 88, 0, false),
+		pkg(0, 87, 1, false),
+	})
+
+	for _, want := range []string{"0.88.0", "0.87.1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected version %s to be listed, got:\n%s", want, out)
+		}
+	}
+}
+
+// The installed version is surfaced on its own line and de-duplicated in the
+// available list.
+func TestFormatAvailableVersions_InstalledSurfacedAndDeduped(t *testing.T) {
+	out := formatAvailableVersions([]*records.Package{
+		pkg(0, 87, 1, true),
+		pkg(0, 87, 1, false), // same version present in both tree and repo
+		pkg(0, 88, 0, false),
+	})
+
+	if !strings.Contains(out, "installed: 0.87.1") {
+		t.Errorf("expected installed line for 0.87.1, got:\n%s", out)
+	}
+	if !strings.Contains(out, "0.88.0") {
+		t.Errorf("expected available version 0.88.0, got:\n%s", out)
+	}
+	if n := strings.Count(out, "0.87.1"); n != 2 { // installed line + one deduped entry
+		t.Errorf("expected 0.87.1 exactly twice (installed line + one list entry), got %d in:\n%s", n, out)
+	}
+}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -7,3 +7,8 @@ package constants
 const (
 	UnmanagedStack = "$unmanaged"
 )
+
+// AllChannels lists every release channel formae publishes to. `formae
+// refresh` warms the local package index for all of them so sudo-less
+// reads (plugin search/info, update list) see fresh data on any channel.
+var AllChannels = []string{"stable", "dev"}

--- a/internal/metastructure/plugin_manager/plugin_manager.go
+++ b/internal/metastructure/plugin_manager/plugin_manager.go
@@ -148,7 +148,7 @@ type PluginManager struct {
 // 503s on every plugin command.
 func New(logger *slog.Logger, repos []pkgmodel.Repository, pluginDirs []string) (*PluginManager, error) {
 	factory := func(channel string) (orbitalClient, error) {
-		return opsmgr.NewFromRepositories(logger, repos, channel)
+		return opsmgr.NewFromRepositories(logger, repos, channel, false, false)
 	}
 	listOrb, err := factory("")
 	if err != nil {

--- a/internal/opsmgr/opsmgr.go
+++ b/internal/opsmgr/opsmgr.go
@@ -10,9 +10,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/orbital"
 	"github.com/platform-engineering-labs/orbital/mgr"
 	"github.com/platform-engineering-labs/orbital/opm/security"
 	"github.com/platform-engineering-labs/orbital/opm/tree"
@@ -22,22 +22,22 @@ import (
 
 // New constructs a Manager from a single URL + channel.
 // Kept for backwards compatibility. Prefer NewFromRepositories.
-func New(logger *slog.Logger, uri url.URL, channel string) (*mgr.Manager, error) {
+func New(logger *slog.Logger, uri url.URL, channel string, sudo bool, writable bool) (*mgr.Manager, error) {
 	repos := []pkgmodel.Repository{{URI: uri, Type: pkgmodel.RepositoryTypeBinary}}
-	return NewFromRepositories(logger, repos, channel)
+	return NewFromRepositories(logger, repos, channel, sudo, writable)
 }
 
 // NewFromRepositories constructs a Manager with all configured repos loaded.
 // Channel (if non-empty) overrides the URI fragment for every repo.
-func NewFromRepositories(logger *slog.Logger, repos []pkgmodel.Repository, channel string) (*mgr.Manager, error) {
-	return newManager(logger, repos, channel)
+func NewFromRepositories(logger *slog.Logger, repos []pkgmodel.Repository, channel string, sudo bool, writable bool) (*mgr.Manager, error) {
+	return newManager(logger, repos, channel, sudo, writable)
 }
 
 // NewFromRepositoriesFiltered constructs a Manager containing only repos whose
 // type is in the allowed set. Empty allowed = all types.
-func NewFromRepositoriesFiltered(logger *slog.Logger, repos []pkgmodel.Repository, channel string, allowed ...pkgmodel.RepositoryType) (*mgr.Manager, error) {
+func NewFromRepositoriesFiltered(logger *slog.Logger, repos []pkgmodel.Repository, channel string, sudo bool, writable bool, allowed ...pkgmodel.RepositoryType) (*mgr.Manager, error) {
 	if len(allowed) == 0 {
-		return newManager(logger, repos, channel)
+		return newManager(logger, repos, channel, sudo, writable)
 	}
 	allow := make(map[pkgmodel.RepositoryType]bool, len(allowed))
 	for _, a := range allowed {
@@ -52,7 +52,7 @@ func NewFromRepositoriesFiltered(logger *slog.Logger, repos []pkgmodel.Repositor
 	if len(filtered) == 0 {
 		return nil, fmt.Errorf("no matching repositories after filtering")
 	}
-	return newManager(logger, filtered, channel)
+	return newManager(logger, filtered, channel, sudo, writable)
 }
 
 // FormaePelRootEnv overrides the orbital tree root that opsmgr would
@@ -65,7 +65,7 @@ func NewFromRepositoriesFiltered(logger *slog.Logger, repos []pkgmodel.Repositor
 // dev runs and isolated tests.
 const FormaePelRootEnv = "FORMAE_PEL_ROOT"
 
-func newManager(logger *slog.Logger, repos []pkgmodel.Repository, channel string) (*mgr.Manager, error) {
+func newManager(logger *slog.Logger, repos []pkgmodel.Repository, channel string, sudo bool, writable bool) (*mgr.Manager, error) {
 	treePath, err := resolveTreePath()
 	if err != nil {
 		return nil, err
@@ -84,12 +84,26 @@ func newManager(logger *slog.Logger, repos []pkgmodel.Repository, channel string
 		return nil, fmt.Errorf("no repositories configured")
 	}
 
-	return mgr.New(logger, treePath, &tree.Config{
-		OS:           platform.Current().OS,
-		Arch:         platform.Current().Arch,
-		Security:     security.Default,
-		Repositories: opsRepos,
-	})
+	var opts []orbital.Option
+
+	if sudo {
+		opts = append(opts, orbital.WithSudo())
+	}
+
+	if writable {
+		opts = append(opts, orbital.WithWritable())
+	}
+
+	opts = append(opts, orbital.WithEmbedded(
+		treePath, &tree.Config{
+			OS:           platform.Current().OS,
+			Arch:         platform.Current().Arch,
+			Security:     security.Default,
+			Repositories: opsRepos,
+		},
+	))
+
+	return mgr.New(logger, opts...)
 }
 
 // resolveTreePath returns FORMAE_PEL_ROOT when set, otherwise the
@@ -104,34 +118,4 @@ func resolveTreePath() (string, error) {
 		return "", fmt.Errorf("could not determine binary path: %w", err)
 	}
 	return filepath.Dir(filepath.Dir(binPath)), nil
-}
-
-// TreeRequiresElevation reports whether constructing an orbital manager
-// against the configured tree would re-exec the process under sudo.
-// orbital's tree.New triggers a sudo re-exec whenever the tree path is
-// root-owned and the caller is not root — including for read-only
-// operations like List(). Callers that want to remain unprivileged
-// (e.g. `plugin list`) check this first and skip the local arm when it
-// would force a sudo prompt.
-//
-// Returns false (with no error) if the tree path can't be stat'd; the
-// caller can then attempt orbital construction and rely on the existing
-// Ready() guard.
-func TreeRequiresElevation() bool {
-	path, err := resolveTreePath()
-	if err != nil {
-		return false
-	}
-	stat, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	sys, ok := stat.Sys().(*syscall.Stat_t)
-	if !ok {
-		return false
-	}
-	if sys.Uid != 0 {
-		return false
-	}
-	return os.Geteuid() != 0
 }

--- a/internal/opsmgr/opsmgr_test.go
+++ b/internal/opsmgr/opsmgr_test.go
@@ -1,0 +1,46 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package opsmgr_test
+
+import (
+	"log/slog"
+	"net/url"
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/internal/opsmgr"
+	"github.com/stretchr/testify/require"
+)
+
+// A writable manager can initialize a fresh tree; a read-only manager over
+// that initialized tree constructs and lists without any privilege check.
+// This is the contract the sudo-less read commands depend on.
+func TestReadOnlyManagerOverInitializedTree(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(opsmgr.FormaePelRootEnv, root)
+
+	u, err := url.Parse("https://example.invalid/repo#stable")
+	require.NoError(t, err)
+
+	// Writable manager initializes the (non-privileged) temp tree.
+	w, err := opsmgr.New(slog.Default(), *u, "", false, true)
+	require.NoError(t, err)
+	if !w.Ready() {
+		_, err = w.Initialize()
+		require.NoError(t, err)
+	}
+	require.True(t, w.Ready())
+
+	// Read-only manager over the initialized tree: constructs, no elevation,
+	// and reads succeed (empty install set).
+	ro, err := opsmgr.New(slog.Default(), *u, "", false, false)
+	require.NoError(t, err)
+	require.True(t, ro.Ready())
+
+	pkgs, err := ro.List()
+	require.NoError(t, err)
+	require.Empty(t, pkgs)
+}

--- a/tests/e2e/go/plugin_readonly_test.go
+++ b/tests/e2e/go/plugin_readonly_test.go
@@ -170,3 +170,19 @@ func TestPluginReadCommands_PrivilegedTree(t *testing.T) {
 		}
 	}
 }
+
+// TestRefresh_WarmsWritableTree proves `formae refresh` succeeds against a
+// writable tree. Requires network to the hub (it fetches repo metadata for
+// both channels).
+func TestRefresh_WarmsWritableTree(t *testing.T) {
+	tree := cloneWarmTree(t)
+	env := newReadEnv(t, tree)
+
+	out, err := runFormae(t, env, "refresh")
+	if err != nil {
+		t.Fatalf("`formae refresh` failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "done.") {
+		t.Errorf("expected 'done.' in refresh output, got:\n%s", out)
+	}
+}

--- a/tests/e2e/go/plugin_readonly_test.go
+++ b/tests/e2e/go/plugin_readonly_test.go
@@ -1,0 +1,172 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build e2e
+
+package e2e_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newReadEnv builds a process environment for a CLI-local plugin/update
+// command: a hermetic HOME/XDG config dir holding a minimal config (so
+// artifacts.repositories resolve to the defaults) plus FORMAE_PEL_ROOT
+// pointed at the given orbital tree. Later env entries win over os.Environ.
+func newReadEnv(t *testing.T, treeRoot string) []string {
+	t.Helper()
+	home := t.TempDir()
+	cfgDir := filepath.Join(home, ".config", "formae")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	cfg := filepath.Join(cfgDir, "formae.conf.pkl")
+	if err := os.WriteFile(cfg, []byte("amends \"formae:/Config.pkl\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return append(os.Environ(),
+		"HOME="+home,
+		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
+		"FORMAE_PEL_ROOT="+treeRoot,
+	)
+}
+
+// runFormae runs the formae binary with the given environment. No agent is
+// involved — plugin list/search/info and update list are CLI-local orbital
+// operations.
+func runFormae(t *testing.T, env []string, args ...string) ([]byte, error) {
+	t.Helper()
+	cmd := exec.Command(FormaeBinary(t), args...)
+	cmd.Env = env
+	return cmd.CombinedOutput()
+}
+
+// cloneWarmTree finds an already-initialized/warm orbital tree, copies it
+// into t.TempDir() so the copy can be mutated (chmod/chown), and returns the
+// copy path. Skips when no usable warm tree exists.
+func cloneWarmTree(t *testing.T) string {
+	t.Helper()
+	src := resolveWarmTreeSource(t)
+	if src == "" {
+		t.Skip("no usable warm orbital tree (set FORMAE_PEL_ROOT to a warm tree or install formae)")
+	}
+	dst := filepath.Join(t.TempDir(), "tree")
+	if out, err := exec.Command("cp", "-a", src, dst).CombinedOutput(); err != nil {
+		t.Fatalf("clone warm tree %s -> %s: %v\n%s", src, dst, err, out)
+	}
+	return dst
+}
+
+// resolveWarmTreeSource returns the first candidate tree that `plugin list`
+// succeeds against, or "" if none. Order: FORMAE_PEL_ROOT, the binary-derived
+// root (dist/e2e under make test-e2e), then /opt/pel.
+func resolveWarmTreeSource(t *testing.T) string {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, c := range []string{
+		os.Getenv("FORMAE_PEL_ROOT"),
+		filepath.Dir(filepath.Dir(FormaeBinary(t))),
+		"/opt/pel",
+	} {
+		if c == "" || seen[c] {
+			continue
+		}
+		seen[c] = true
+		env := newReadEnv(t, c)
+		if _, err := runFormae(t, env, "plugin", "list", "--output-consumer", "machine", "--output-schema", "json"); err == nil {
+			return c
+		}
+	}
+	return ""
+}
+
+// firstInstalledPlugin returns the name of the first installed plugin, or ""
+// if none / unparseable.
+func firstInstalledPlugin(t *testing.T, env []string) string {
+	t.Helper()
+	out, err := runFormae(t, env, "plugin", "list", "--output-consumer", "machine", "--output-schema", "json")
+	if err != nil {
+		return ""
+	}
+	var resp struct {
+		Plugins []struct {
+			Name string `json:"Name"`
+		} `json:"Plugins"`
+	}
+	if json.Unmarshal(out, &resp) != nil || len(resp.Plugins) == 0 {
+		return ""
+	}
+	return resp.Plugins[0].Name
+}
+
+// readCommandCases returns the sudo-less read commands to assert, including a
+// `plugin info` case only when an installed plugin name is available.
+func readCommandCases(pkg string) [][]string {
+	cases := [][]string{
+		{"plugin", "list", "--output-consumer", "machine", "--output-schema", "json"},
+		{"plugin", "search", "--output-consumer", "machine", "--output-schema", "json"},
+		{"update", "list"},
+	}
+	if pkg != "" {
+		cases = append(cases, []string{"plugin", "info", pkg, "--output-consumer", "machine", "--output-schema", "json"})
+	}
+	return cases
+}
+
+// TestPluginReadCommands_ReadOnlyTree proves the non-destructive plugin/update
+// read commands work against a NON-WRITABLE tree — no refresh, no elevation. A
+// regression that re-introduced a refresh on a read path fails here.
+func TestPluginReadCommands_ReadOnlyTree(t *testing.T) {
+	tree := cloneWarmTree(t)
+	env := newReadEnv(t, tree)
+	pkg := firstInstalledPlugin(t, env)
+
+	if out, err := exec.Command("chmod", "-R", "a-w", tree).CombinedOutput(); err != nil {
+		t.Fatalf("chmod read-only: %v\n%s", err, out)
+	}
+	t.Cleanup(func() { _ = exec.Command("chmod", "-R", "u+w", tree).Run() })
+
+	for _, args := range readCommandCases(pkg) {
+		if out, err := runFormae(t, env, args...); err != nil {
+			t.Errorf("`formae %s` failed against a read-only tree (should be sudo-less, no refresh): %v\n%s",
+				strings.Join(args, " "), err, out)
+		}
+	}
+}
+
+// TestPluginReadCommands_PrivilegedTree proves the read commands still run
+// sudo-less as a non-root user against a ROOT-OWNED tree — the production
+// scenario (default install is root-owned /opt/pel). Skipped without
+// passwordless sudo so local runs never hang on a prompt.
+func TestPluginReadCommands_PrivilegedTree(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; the privileged-tree elevation path is not exercised")
+	}
+	if err := exec.Command("sudo", "-n", "true").Run(); err != nil {
+		t.Skip("passwordless sudo unavailable; cannot set up a root-owned tree")
+	}
+	tree := cloneWarmTree(t)
+	env := newReadEnv(t, tree)
+	pkg := firstInstalledPlugin(t, env)
+
+	if out, err := exec.Command("sudo", "-n", "chown", "-R", "root:root", tree).CombinedOutput(); err != nil {
+		t.Fatalf("chown root: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("sudo", "-n", "chown", "-R", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()), tree).Run()
+	})
+
+	for _, args := range readCommandCases(pkg) {
+		if out, err := runFormae(t, env, args...); err != nil {
+			t.Errorf("`formae %s` needed elevation against a root-owned tree (should be sudo-less): %v\n%s",
+				strings.Join(args, " "), err, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Make every non-destructive plugin/update CLI command runnable without sudo against a read-only package store, and add an explicit command to warm the cache.

- `plugin list`, `plugin search`, `plugin info`, and `update list` now open the package store read-only and no longer call `Refresh()`, so they run without elevation — on a stock (root-owned) install they read the locally cached index directly. Their help text is updated to describe the sudo-less, cached behavior.
- New top-level `formae refresh` warms the local package index for every configured repository across both channels (`stable` and `dev`). It writes to the store, so it elevates via sudo on a managed install, and it honors `--config`/`--profile`. It reports per-repository refresh failures instead of always printing success.
- `update list` now lists every available version even on a cold index — previously it could omit the newest candidate or render an empty list.
- Read-only manager construction is pinned by an `opsmgr` unit test; e2e coverage exercises the read commands against read-only and root-owned trees.

## Why

The read paths pulled fresh metadata through orbital's `Refresh()`, which needs a writable store — so a stock root-owned install forced a sudo prompt (and on a genuinely read-only tree the lock is never created, so `Refresh()` would nil-panic). Splitting "read the cache" from "warm the cache" lets the common, non-destructive commands run unprivileged, while `formae refresh` (and the existing mutating commands) do the warming behind sudo. Sudo-less reads serve the cached index and may be stale until a refresh runs; that tradeoff is stated in the command help.
