### PR TITLE
fix(build): make bundled example dirs world-readable

### DIFF
--- a/cmd/bundle-examples/main.go
+++ b/cmd/bundle-examples/main.go
@@ -137,6 +137,13 @@ func stage(dist, manifestPath, formaeVer, stdRepo, hub string) error {
 			return err
 		}
 		defer func() { _ = os.RemoveAll(tmp) }()
+		// os.MkdirTemp creates the dir 0700, but this tree is renamed into place
+		// as dist/pel/formae/examples/<member>/ and shipped in the opkg. It must
+		// be world-readable (0755) like its parent and its subdirs, otherwise the
+		// installed <member>/ dir needs sudo to read.
+		if err := os.Chmod(tmp, 0o755); err != nil {
+			return err
+		}
 
 		hasDir, files, err := fetchExamples(repo, tag, tmp)
 		if err != nil {


### PR DESCRIPTION
## Summary

The examples-bundling added in the previous change stages each standard-bundle member's examples into a temporary directory created with `os.MkdirTemp` (which always uses mode 0700) and then renames it into place as `dist/pel/formae/examples/<member>/`. Because that directory ships in the formae opkg, the installed `aws`/`azure`/`gcp`/`k8s` example directories were readable only by root and required `sudo` to access, even though their parent `examples/` directory and their own subdirectories (created with 0755) were world-readable.

Chmod the staging directory to 0755 right after creating it so the shipped member directory matches the rest of the tree. Verified against a real `bundle-examples` run: the `examples/<member>/` directories are now `drwxr-xr-x`.