### PR TITLE
feat(schema): @formae.Flag to override CLI flag for typed Props members

### DIFF
--- a/internal/schema/pkl/pkl_test.go
+++ b/internal/schema/pkl/pkl_test.go
@@ -302,3 +302,25 @@ func TestDeprecationWarning_LegacyArtifactsURL(t *testing.T) {
 	assert.Equal(t, "example.org", config.Artifacts.Repositories[0].URI.Host)
 	assert.Equal(t, model.RepositoryTypeBinary, config.Artifacts.Repositories[0].Type)
 }
+
+// TestPkl_TypedPropsFlagAnnotation covers @formae.Flag on a typed Props member:
+// the statically-typed member `certArn` is fed by the CLI flag / prop key
+// `cert-arn`, the injected value reaches resources via late binding, and the
+// manifest Prop reports the overridden flag name.
+func TestPkl_TypedPropsFlagAnnotation(t *testing.T) {
+	const arn = "arn:aws:acm:us-east-1:123456789012:certificate/abc"
+	props := map[string]string{"cert-arn": arn}
+
+	p := PKL{}
+	forma, err := p.Evaluate("./testdata/forma/extends_props_test.pkl", model.CommandApply, model.FormaApplyModeReconcile, props)
+	require.NoError(t, err)
+
+	jsonString := forma.ToJSON()
+
+	// Manifest: member key stays `certArn`, flag carries the override.
+	assert.Equal(t, "cert-arn", gjson.Get(jsonString, "Properties.certArn.Flag").String())
+	assert.Equal(t, arn, gjson.Get(jsonString, "Properties.certArn.Value").String())
+
+	// Injected value carried into the resource via typed access.
+	assert.Equal(t, "pel-8080-"+arn+"-queue", gjson.Get(jsonString, "Resources.0.Properties.QueueName").String())
+}

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -459,6 +459,18 @@ open class Prop {
 
 // ---- typed CLI properties (RFC-105) ----------------------------------------
 
+/// Overrides the CLI flag / `prop:` key for a typed Props member, decoupling the
+/// statically-typed member name (e.g. `certArn`) from the flag a user passes on
+/// the CLI (e.g. `--cert-arn`). Mirrors the legacy `Prop.flag` override, but the
+/// member stays typed so `properties.certArn` resolves in editors.
+open class Flag extends Annotation {
+    name: String
+}
+
+/// flagName: the member's `@Flag` override if present, else the member name.
+function flagName(p): String =
+    p.annotations.filterIsInstance(Flag).firstOrNull?.name ?? p.name
+
 /// Resolve a reflected type to its simple name, unwrapping nullables.
 function typeName(t): String =
     if (t is reflect.DeclaredType) t.referent.name
@@ -472,7 +484,7 @@ function typeName(t): String =
 function fillProps(clazz: Class): Typed =
     new Mapping {
         for (n, p in reflect.Class(clazz).properties) {
-            [n] = let (raw = read?("prop:\(n)"))
+            [n] = let (raw = read?("prop:\(flagName(p))"))
                 if (raw == null) p.defaultValue
                 else
                     let (tn = typeName(p.type))
@@ -500,7 +512,7 @@ function renderProperties(opts: Any?): Any? =
         new Mapping {
             for (name, p in reflect.Class(opts.getClass()).properties) {
                 [name] = new Prop {
-                    flag = name
+                    flag = flagName(p)
                     default = p.defaultValue as (String|Boolean|Int|Float)?
                     value = inst[name] as (String|Boolean|Int|Float)?
                 }

--- a/internal/schema/pkl/testdata/forma/extends_props_test.pkl
+++ b/internal/schema/pkl/testdata/forma/extends_props_test.pkl
@@ -19,6 +19,10 @@ class Props {
 
   /// Port to listen on
   port: Int(this > 0) = 8080
+
+  /// ARN of the ACM certificate. Typed member `certArn`, CLI flag `--cert-arn`.
+  @formae.Flag { name = "cert-arn" }
+  certArn: String = ""
 }
 
 forma {
@@ -34,6 +38,7 @@ forma {
 
   new queue.Queue {
     label = "q"
-    queueName = "\(properties.name)-\(properties.port)-queue"
+    // typed access to the @Flag member; injected `--cert-arn` lands here
+    queueName = "\(properties.name)-\(properties.port)-\(properties.certArn)-queue"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #546. Typed Props (RFC-105) welded the member name to the CLI flag — `fillProps` reads `prop:<member>` and `renderProperties` sets `flag = <member>`. That forced a member to be named after its flag, so you couldn't have a statically-typed camelCase member `properties.certArn` exposed on the CLI as `--cert-arn`.

This restores the decoupling the legacy `Prop.flag` field gave, without giving up typed access:

```pkl
class Props {
  /// ARN of the ACM certificate
  @formae.Flag { name = "cert-arn" }
  certArn: String = ""
}

forma {
  new lb.Listener { certificateArn = properties.certArn }  // typed, no red squiggle
}
```

`formae apply -p cert-arn=arn:...` injects into `certArn`; manifest + `--help` show `cert-arn`.

## Changes

- **`formae.pkl`**: new `Flag extends Annotation { name }` + `flagName(p)` helper (annotation override, else member name). `fillProps` reads `prop:\(flagName(p))`; `renderProperties` emits `flag = flagName(p)`. Manifest key stays the member name — same `member`/`flag` split as the legacy `Prop`.
- **`extends_props_test.pkl`**: `@formae.Flag`-annotated `certArn` member, referenced in a resource to prove late-binding injection.
- **`pkl_test.go`**: `TestPkl_TypedPropsFlagAnnotation` — `-p cert-arn=X` lands in `certArn`, reaches the resource, manifest reports `Flag = "cert-arn"`.

## Verification

- `go test -tags=integration -run TestPkl_ ./internal/schema/pkl` green (full pkl integration suite).
- `pkl test tests/formae.pkl` green (66/66) — Flag class doesn't disturb existing schema.
- Members without `@Flag` unchanged: `flagName` falls back to the member name, byte-identical output.

## Not in this PR

- Auto camelCase→kebab conversion (deliberately explicit opt-in only).
- Docs / scaffold template mention of `@formae.Flag`.