### PR TITLE
fix(migration): page the secret backfill to bound startup memory

### DIFF
--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -1345,6 +1345,72 @@ func (d *DatastoreAuroraDataAPI) LoadAllResourceVersions() ([]datastore.Resource
 	return versions, nil
 }
 
+func (d *DatastoreAuroraDataAPI) LoadFormaCommandIDs() ([]string, error) {
+	ctx := context.Background()
+	output, err := d.executeStatement(ctx, `SELECT command_id FROM forma_commands ORDER BY command_id`, nil)
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for _, record := range output.Records {
+		if len(record) < 1 {
+			continue
+		}
+		id, err := getStringField(record[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse command_id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func (d *DatastoreAuroraDataAPI) LoadResourceVersionsPage(afterURI string, afterVersion string, limit int) ([]datastore.ResourceVersion, error) {
+	ctx := context.Background()
+	query := `SELECT uri, version, data, ksuid FROM resources
+		WHERE uri > :after_uri OR (uri = :after_uri AND version > :after_version)
+		ORDER BY uri, version
+		LIMIT :page_limit`
+	params := []types.SqlParameter{
+		{Name: aws.String("after_uri"), Value: &types.FieldMemberStringValue{Value: afterURI}},
+		{Name: aws.String("after_version"), Value: &types.FieldMemberStringValue{Value: afterVersion}},
+		{Name: aws.String("page_limit"), Value: &types.FieldMemberLongValue{Value: int64(limit)}},
+	}
+	output, err := d.executeStatement(ctx, query, params)
+	if err != nil {
+		return nil, err
+	}
+	var versions []datastore.ResourceVersion
+	for _, record := range output.Records {
+		if len(record) < 4 {
+			continue
+		}
+		uri, err := getStringField(record[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse uri: %w", err)
+		}
+		version, err := getStringField(record[1])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse version: %w", err)
+		}
+		jsonData, err := getStringField(record[2])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse data: %w", err)
+		}
+		ksuid, err := getStringField(record[3])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse ksuid: %w", err)
+		}
+		var resource pkgmodel.Resource
+		if err := json.Unmarshal([]byte(jsonData), &resource); err != nil {
+			return nil, err
+		}
+		resource.Ksuid = ksuid
+		versions = append(versions, datastore.ResourceVersion{URI: uri, Version: version, Resource: &resource})
+	}
+	return versions, nil
+}
+
 func (d *DatastoreAuroraDataAPI) UpdateResourceVersionData(uri string, version string, resource *pkgmodel.Resource) error {
 	ctx := context.Background()
 

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -183,6 +183,12 @@ type Datastore interface {
 	StoreFormaCommand(fa *forma_command.FormaCommand, commandID string) error
 	// LoadFormaCommands returns all stored FormaCommands
 	LoadFormaCommands() ([]*forma_command.FormaCommand, error)
+	// LoadFormaCommandIDs returns the IDs of all stored FormaCommands, ordered by
+	// command_id. Cheap (IDs only) so a caller can page through commands one at a
+	// time via GetFormaCommandByCommandID instead of materializing every command
+	// and all its resource updates at once — used by the secret backfill to bound
+	// memory on large datasets.
+	LoadFormaCommandIDs() ([]string, error)
 	// LoadIncompleteFormaCommands returns FormaCommands that haven't reached a terminal state
 	LoadIncompleteFormaCommands() ([]*forma_command.FormaCommand, error)
 	// DeleteFormaCommand removes a FormaCommand and its associated ResourceUpdates
@@ -221,6 +227,14 @@ type Datastore interface {
 	// latest version per URI). Used by the one-time secret backfill to scrub
 	// plaintext opaque values from resource history.
 	LoadAllResourceVersions() ([]ResourceVersion, error)
+	// LoadResourceVersionsPage returns a bounded page of resource versions whose
+	// (uri, version) keyset is strictly after (afterURI, afterVersion), ordered by
+	// (uri, version), at most limit rows. Pass "", "" to start. Lets the secret
+	// backfill scrub history without loading every version into memory at once;
+	// callers page until a short (< limit) page is returned. Rewriting a version's
+	// data in place (UpdateResourceVersionData) does not move its keyset position,
+	// so paging stays stable across the scrub.
+	LoadResourceVersionsPage(afterURI string, afterVersion string, limit int) ([]ResourceVersion, error)
 	// UpdateResourceVersionData overwrites the persisted data of a single
 	// resource version in place (keyed by uri+version), without appending a new
 	// version. Used by the secret backfill to rewrite a superseded version's

--- a/internal/datastore/dstest/suite_scrub_resource_versions.go
+++ b/internal/datastore/dstest/suite_scrub_resource_versions.go
@@ -8,6 +8,7 @@ package dstest
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/platform-engineering-labs/formae/internal/datastore"
@@ -83,5 +84,70 @@ func RunScrubResourceVersions(t *testing.T, newDS func(t *testing.T) TestDatasto
 			assert.JSONEq(t, `{"secret":"SCRUBBED"}`, string(v.Resource.Properties),
 				"every version's data must reflect the in-place update")
 		}
+	})
+
+	// LoadResourceVersionsPage is what the backfill actually uses so it never
+	// loads the whole resources table into memory. This checks the keyset paging
+	// returns every stored version exactly once, in ascending (uri, version)
+	// order, across multiple page boundaries — on every dialect.
+	t.Run("LoadResourceVersionsPagePagesEveryVersionExactlyOnce", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		target := &pkgmodel.Target{Label: "pg-target", Namespace: "default", Config: json.RawMessage(`{}`)}
+		_, err := ds.CreateTarget(target)
+		require.NoError(t, err)
+
+		const n = 7
+		for i := 0; i < n; i++ {
+			r := &pkgmodel.Resource{
+				NativeID:   fmt.Sprintf("native-page-%02d", i),
+				Stack:      "stack-page",
+				Type:       "type-page",
+				Label:      fmt.Sprintf("label-page-%02d", i),
+				Target:     "pg-target",
+				Managed:    true,
+				Properties: json.RawMessage(`{"k":"v"}`),
+			}
+			_, err := ds.StoreResource(r, fmt.Sprintf("cmd-page-%02d", i))
+			require.NoError(t, err)
+		}
+
+		// Ground truth: every version via the load-all method.
+		all, err := ds.LoadAllResourceVersions()
+		require.NoError(t, err)
+		wantKeys := make(map[string]bool)
+		for _, v := range all {
+			wantKeys[v.URI+"@"+v.Version] = true
+		}
+		require.GreaterOrEqual(t, len(wantKeys), n, "expected at least the stored versions")
+
+		// Page with a small limit so paging crosses several boundaries.
+		gotKeys := make(map[string]bool)
+		afterURI, afterVersion := "", ""
+		for {
+			page, err := ds.LoadResourceVersionsPage(afterURI, afterVersion, 2)
+			require.NoError(t, err)
+			if len(page) == 0 {
+				break
+			}
+			require.LessOrEqual(t, len(page), 2, "page must honor the limit")
+			for _, v := range page {
+				key := v.URI + "@" + v.Version
+				require.False(t, gotKeys[key], "version %s returned more than once by paging", key)
+				gotKeys[key] = true
+				afterURI, afterVersion = v.URI, v.Version
+			}
+			if len(page) < 2 {
+				break
+			}
+		}
+		// The keyset predicate and ORDER BY share the columns' collation, so paging
+		// is internally consistent whatever the DB collation is — asserting a
+		// specific (Go byte-order) sort here would wrongly fail under a locale
+		// collation (KSUIDs are mixed-case). The correctness property is simply
+		// that every stored version is returned exactly once.
+		require.Equal(t, wantKeys, gotKeys, "paging must return exactly every stored version, once")
 	})
 }

--- a/internal/datastore/migration/secret_backfill.go
+++ b/internal/datastore/migration/secret_backfill.go
@@ -55,12 +55,20 @@ func BackfillHashedSecrets(ds datastore.Datastore) error {
 }
 
 func backfillFormaCommands(ds datastore.Datastore, t *transformations.PersistValueTransformer) error {
-	cmds, err := ds.LoadFormaCommands()
+	// Page over command IDs and load one command at a time. LoadFormaCommands
+	// would materialize every command and all its resource updates at once, which
+	// OOMs the agent at startup on large datasets; loading per command bounds
+	// memory to a single command's updates.
+	ids, err := ds.LoadFormaCommandIDs()
 	if err != nil {
-		return fmt.Errorf("backfill: load commands: %w", err)
+		return fmt.Errorf("backfill: load command ids: %w", err)
 	}
 
-	for _, cmd := range cmds {
+	for _, id := range ids {
+		cmd, err := ds.GetFormaCommandByCommandID(id)
+		if err != nil {
+			return fmt.Errorf("backfill: load command %s: %w", id, err)
+		}
 		dirty := false
 
 		for i := range cmd.ResourceUpdates {
@@ -115,27 +123,45 @@ func backfillFormaCommands(ds datastore.Datastore, t *transformations.PersistVal
 	return nil
 }
 
+// resourceVersionPageSize bounds how many resource versions the backfill holds
+// in memory at once. The resources table can hold tens of thousands of versions
+// (each with a potentially large data blob), so the scrub pages through them
+// rather than loading them all at once — loading everything OOMs the agent at
+// startup.
+const resourceVersionPageSize = 500
+
 // backfillResourcesTable scrubs plaintext opaque values from EVERY stored
 // resource version, not just the current one. The resources table keeps version
 // history, so a superseded version can still hold a pre-fix plaintext secret at
 // rest; each such version is rewritten in place (keyed by uri+version) so no new
-// version is appended and no plaintext lingers in history.
+// version is appended and no plaintext lingers in history. It pages by the
+// (uri, version) keyset so memory stays bounded regardless of dataset size;
+// rewriting a version's data in place never moves its keyset position, so paging
+// stays stable across the scrub.
 func backfillResourcesTable(ds datastore.Datastore, t *transformations.PersistValueTransformer) error {
-	versions, err := ds.LoadAllResourceVersions()
-	if err != nil {
-		return fmt.Errorf("backfill: load resource versions: %w", err)
-	}
-
-	for _, v := range versions {
-		changed, err := hashResourceValuesInPlace(t, v.Resource)
+	afterURI, afterVersion := "", ""
+	for {
+		page, err := ds.LoadResourceVersionsPage(afterURI, afterVersion, resourceVersionPageSize)
 		if err != nil {
-			return fmt.Errorf("backfill: hash resource %s version %s: %w", v.Resource.Label, v.Version, err)
+			return fmt.Errorf("backfill: load resource versions page: %w", err)
 		}
-		if !changed {
-			continue
+		if len(page) == 0 {
+			break
 		}
-		if err := ds.UpdateResourceVersionData(v.URI, v.Version, v.Resource); err != nil {
-			return fmt.Errorf("backfill: update resource %s version %s: %w", v.Resource.Label, v.Version, err)
+		for _, v := range page {
+			changed, err := hashResourceValuesInPlace(t, v.Resource)
+			if err != nil {
+				return fmt.Errorf("backfill: hash resource %s version %s: %w", v.Resource.Label, v.Version, err)
+			}
+			if changed {
+				if err := ds.UpdateResourceVersionData(v.URI, v.Version, v.Resource); err != nil {
+					return fmt.Errorf("backfill: update resource %s version %s: %w", v.Resource.Label, v.Version, err)
+				}
+			}
+			afterURI, afterVersion = v.URI, v.Version
+		}
+		if len(page) < resourceVersionPageSize {
+			break
 		}
 	}
 

--- a/internal/datastore/migration/secret_backfill_test.go
+++ b/internal/datastore/migration/secret_backfill_test.go
@@ -9,6 +9,7 @@ package migration
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -375,4 +376,43 @@ func TestBackfillHashedSecrets_HashesResourcesTable(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resourcesAfter, 1)
 	assert.JSONEq(t, string(resources[0].Properties), string(resourcesAfter[0].Properties))
+}
+
+// TestBackfillHashedSecrets_PagesAllResourceVersionsAtVolume seeds more than one
+// page (resourceVersionPageSize) of SecretsManager resources so the resources-table
+// scrub must page. Every stored SecretString must end up hashed — proving keyset
+// paging drops nothing across page boundaries. This is the regression guard for
+// the memory-bounded rewrite: loading the whole table at once OOMs at prod scale.
+func TestBackfillHashedSecrets_PagesAllResourceVersionsAtVolume(t *testing.T) {
+	ds := newTestDatastore(t)
+
+	const total = resourceVersionPageSize + 137 // spans full pages + a short final page
+	for i := 0; i < total; i++ {
+		r := &pkgmodel.Resource{
+			NativeID:   fmt.Sprintf("native-vol-%04d", i),
+			Stack:      "vol",
+			Type:       knownSecretType,
+			Label:      fmt.Sprintf("vol-%04d", i),
+			Schema:     staleSecretSchema(),
+			Properties: json.RawMessage(fmt.Sprintf(`{"SecretString":"plaintext-%04d"}`, i)),
+			Ksuid:      util.NewID(),
+		}
+		_, err := ds.StoreResource(r, fmt.Sprintf("cmd-vol-%04d", i))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, BackfillHashedSecrets(ds))
+
+	versions, err := ds.LoadAllResourceVersions()
+	require.NoError(t, err)
+	seen := 0
+	for _, v := range versions {
+		if v.Resource.Type != knownSecretType {
+			continue
+		}
+		seen++
+		require.True(t, isHashed(t, v.Resource.Properties, "SecretString"),
+			"resource %s SecretString must be hashed after paged backfill", v.Resource.Label)
+	}
+	require.Equal(t, total, seen, "every stored SecretsManager version must be present and hashed")
 }

--- a/internal/datastore/mock_datastore_test.go
+++ b/internal/datastore/mock_datastore_test.go
@@ -63,6 +63,10 @@ func (m *mockDatastore) LoadResourceByNativeID(_, _ string) (*pkgmodel.Resource,
 }
 func (m *mockDatastore) LoadAllResources() ([]*pkgmodel.Resource, error)     { return nil, nil }
 func (m *mockDatastore) LoadAllResourceVersions() ([]ResourceVersion, error) { return nil, nil }
+func (m *mockDatastore) LoadFormaCommandIDs() ([]string, error)              { return nil, nil }
+func (m *mockDatastore) LoadResourceVersionsPage(_ string, _ string, _ int) ([]ResourceVersion, error) {
+	return nil, nil
+}
 func (m *mockDatastore) UpdateResourceVersionData(_ string, _ string, _ *pkgmodel.Resource) error {
 	return nil
 }

--- a/internal/datastore/mssql/mssql_resources.go
+++ b/internal/datastore/mssql/mssql_resources.go
@@ -681,6 +681,55 @@ func (d *DatastoreMSSQL) LoadAllResourceVersions() ([]datastore.ResourceVersion,
 	return versions, rows.Err()
 }
 
+func (d *DatastoreMSSQL) LoadFormaCommandIDs() ([]string, error) {
+	ctx, span := mssqlTracer.Start(context.Background(), "LoadFormaCommandIDs")
+	defer span.End()
+	rows, err := d.conn.QueryContext(ctx, `SELECT command_id FROM forma_commands ORDER BY command_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func (d *DatastoreMSSQL) LoadResourceVersionsPage(afterURI string, afterVersion string, limit int) ([]datastore.ResourceVersion, error) {
+	ctx, span := mssqlTracer.Start(context.Background(), "LoadResourceVersionsPage")
+	defer span.End()
+	// MSSQL has no LIMIT; TOP (@p3) with a parameter caps the page. The keyset
+	// predicate + ORDER BY (uri, version) makes the page deterministic.
+	rows, err := d.conn.QueryContext(ctx,
+		`SELECT TOP (@p3) uri, version, data, ksuid FROM resources
+		 WHERE uri > @p1 OR (uri = @p1 AND version > @p2)
+		 ORDER BY uri, version`,
+		afterURI, afterVersion, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var versions []datastore.ResourceVersion
+	for rows.Next() {
+		var uri, version, jsonData, ksuid string
+		if err := rows.Scan(&uri, &version, &jsonData, &ksuid); err != nil {
+			return nil, err
+		}
+		var resource pkgmodel.Resource
+		if err := json.Unmarshal([]byte(jsonData), &resource); err != nil {
+			return nil, err
+		}
+		resource.Ksuid = ksuid
+		versions = append(versions, datastore.ResourceVersion{URI: uri, Version: version, Resource: &resource})
+	}
+	return versions, rows.Err()
+}
+
 func (d *DatastoreMSSQL) UpdateResourceVersionData(uri string, version string, resource *pkgmodel.Resource) error {
 	ctx, span := mssqlTracer.Start(context.Background(), "UpdateResourceVersionData")
 	defer span.End()

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -1143,6 +1143,54 @@ func (d DatastorePostgres) LoadAllResourceVersions() ([]datastore.ResourceVersio
 	return versions, rows.Err()
 }
 
+func (d DatastorePostgres) LoadFormaCommandIDs() ([]string, error) {
+	ctx, span := tracer.Start(context.Background(), "LoadFormaCommandIDs")
+	defer span.End()
+	rows, err := d.pool.Query(ctx, `SELECT command_id FROM forma_commands ORDER BY command_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func (d DatastorePostgres) LoadResourceVersionsPage(afterURI string, afterVersion string, limit int) ([]datastore.ResourceVersion, error) {
+	ctx, span := tracer.Start(context.Background(), "LoadResourceVersionsPage")
+	defer span.End()
+	rows, err := d.pool.Query(ctx,
+		`SELECT uri, version, data, ksuid FROM resources
+		 WHERE uri > $1 OR (uri = $1 AND version > $2)
+		 ORDER BY uri, version
+		 LIMIT $3`,
+		afterURI, afterVersion, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var versions []datastore.ResourceVersion
+	for rows.Next() {
+		var uri, version, jsonData, ksuid string
+		if err := rows.Scan(&uri, &version, &jsonData, &ksuid); err != nil {
+			return nil, err
+		}
+		var resource pkgmodel.Resource
+		if err := json.Unmarshal([]byte(jsonData), &resource); err != nil {
+			return nil, err
+		}
+		resource.Ksuid = ksuid
+		versions = append(versions, datastore.ResourceVersion{URI: uri, Version: version, Resource: &resource})
+	}
+	return versions, rows.Err()
+}
+
 func (d DatastorePostgres) UpdateResourceVersionData(uri string, version string, resource *pkgmodel.Resource) error {
 	ctx, span := tracer.Start(context.Background(), "UpdateResourceVersionData")
 	defer span.End()

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -1376,6 +1376,54 @@ func (d DatastoreSQLite) LoadAllResourceVersions() ([]datastore.ResourceVersion,
 	return versions, rows.Err()
 }
 
+func (d DatastoreSQLite) LoadFormaCommandIDs() ([]string, error) {
+	_, span := sqliteTracer.Start(context.Background(), "LoadFormaCommandIDs")
+	defer span.End()
+	rows, err := d.conn.Query(`SELECT command_id FROM forma_commands ORDER BY command_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer closeRows(rows)
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func (d DatastoreSQLite) LoadResourceVersionsPage(afterURI string, afterVersion string, limit int) ([]datastore.ResourceVersion, error) {
+	_, span := sqliteTracer.Start(context.Background(), "LoadResourceVersionsPage")
+	defer span.End()
+	rows, err := d.conn.Query(
+		`SELECT uri, version, data, ksuid FROM resources
+		 WHERE uri > ? OR (uri = ? AND version > ?)
+		 ORDER BY uri, version
+		 LIMIT ?`,
+		afterURI, afterURI, afterVersion, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer closeRows(rows)
+	var versions []datastore.ResourceVersion
+	for rows.Next() {
+		var uri, version, jsonData, ksuid string
+		if err := rows.Scan(&uri, &version, &jsonData, &ksuid); err != nil {
+			return nil, err
+		}
+		var resource pkgmodel.Resource
+		if err := json.Unmarshal([]byte(jsonData), &resource); err != nil {
+			return nil, err
+		}
+		resource.Ksuid = ksuid
+		versions = append(versions, datastore.ResourceVersion{URI: uri, Version: version, Resource: &resource})
+	}
+	return versions, rows.Err()
+}
+
 func (d DatastoreSQLite) UpdateResourceVersionData(uri string, version string, resource *pkgmodel.Resource) error {
 	_, span := sqliteTracer.Start(context.Background(), "UpdateResourceVersionData")
 	defer span.End()

--- a/internal/metastructure/extract_resources_test.go
+++ b/internal/metastructure/extract_resources_test.go
@@ -109,6 +109,12 @@ func (m *mockExtractDatastore) LoadAllResources() ([]*pkgmodel.Resource, error) 
 func (m *mockExtractDatastore) LoadAllResourceVersions() ([]datastore.ResourceVersion, error) {
 	panic("not implemented")
 }
+func (m *mockExtractDatastore) LoadFormaCommandIDs() ([]string, error) {
+	panic("not implemented")
+}
+func (m *mockExtractDatastore) LoadResourceVersionsPage(_ string, _ string, _ int) ([]datastore.ResourceVersion, error) {
+	panic("not implemented")
+}
 func (m *mockExtractDatastore) UpdateResourceVersionData(_ string, _ string, _ *pkgmodel.Resource) error {
 	panic("not implemented")
 }


### PR DESCRIPTION
The one-time secret backfill loaded the whole dataset into memory at agent startup, which OOM-kills the process before the actor node starts on a large datastore — the agent can't boot.

This pages both sweeps:
- forma commands: walk command IDs, load one command at a time
- resources: keyset-ordered pages by (uri, version)

Memory is now bounded regardless of dataset size; rewriting a version in place never moves its keyset position, so paging stays stable. Covered by a cross-dialect paging conformance test and a volume test that seeds more than one page of secrets and verifies none are dropped across page boundaries.