### PR TITLE
fix(cli): make the hashed-secret guard error actionable

### DIFF
--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -92,7 +92,7 @@ func scanHashed(v any, path string) error {
 	switch val := v.(type) {
 	case map[string]any:
 		if h, ok := val["$hashed"].(bool); ok && h {
-			return fmt.Errorf("refusing to send hashed secret at %q to plugin: hashed values are terminal (needs live resolution)", path)
+			return fmt.Errorf("cannot write secret field %q: its value is stored hashed and formae cannot recover the plaintext to send to the provider — re-supply the value in your forma, or accept the current out-of-band value instead of overwriting", path)
 		}
 		for k, child := range val {
 			if err := scanHashed(child, path+"/"+k); err != nil {

--- a/internal/metastructure/resolver/resolver_test.go
+++ b/internal/metastructure/resolver/resolver_test.go
@@ -1583,5 +1583,11 @@ func TestToPluginFormat_ErrorsOnHashedValue(t *testing.T) {
 	props := json.RawMessage(`{"SecretString":{"$value":"deadbeef","$visibility":"Opaque","$hashed":true}}`)
 	_, err := ConvertToPluginFormat(props) // exported entry at resolver.go:33
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "hashed")
+	// The message must be actionable, not just internally descriptive: name the
+	// offending field, explain why the value can't be written (stored hashed, no
+	// plaintext to recover), and tell the user what to do (re-supply or accept).
+	msg := err.Error()
+	assert.Contains(t, msg, "SecretString", "names the offending secret field")
+	assert.Contains(t, msg, "hashed", "explains the value is stored hashed")
+	assert.Contains(t, msg, "re-supply", "tells the user how to proceed")
 }


### PR DESCRIPTION
## Summary

When a reconcile or forced overwrite would send a secret whose value is only known as a stored hash to a provider, the plugin-boundary guard (`resolver.guardNoHashedValues`) correctly rejects it — formae hashes secret values at rest and cannot reconstruct the plaintext to write back. But the error was internal jargon (`hashed values are terminal (needs live resolution)`) that gave the user no idea what happened or what to do, and it surfaces as a bare resource-update failure.

This rewrites the message to name the field, explain that the value is stored hashed and the plaintext can't be recovered, and tell the user how to proceed — re-supply the value in the forma, or accept the current out-of-band value. It is the concrete reason `--force` cannot revert a secret-value drift.

Follow-up (not in this PR): surface this at plan/drift time so the drift view marks secret modifications as non-overwritable before the user chooses "overwrite", rather than failing mid-apply.