### PR TITLE
fix(cli): don't warn when XDG_CONFIG_HOME equals $HOME/.config

### DIFF
--- a/internal/cli/profile/store/paths.go
+++ b/internal/cli/profile/store/paths.go
@@ -37,6 +37,12 @@ func ResolveConfigDir() (string, error) {
 	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
 		xdg = filepath.Join(x, "formae")
 	}
+	// When XDG_CONFIG_HOME is $HOME/.config (common on Linux), the xdg
+	// candidate is the very same directory as legacy. It is not a competing
+	// location, so drop it to avoid a bogus both-populated tie-break warning.
+	if xdg == legacy {
+		xdg = ""
+	}
 
 	legacyPop := hasUserConfig(legacy)
 	xdgPop := xdg != "" && hasUserConfig(xdg)

--- a/internal/cli/profile/store/paths_warn_internal_test.go
+++ b/internal/cli/profile/store/paths_warn_internal_test.go
@@ -49,3 +49,37 @@ func TestResolveConfigDir_BothPopulatedEmitsWarning(t *testing.T) {
 		t.Errorf("expected both-populated warning, got %q", buf.String())
 	}
 }
+
+// On Linux, XDG_CONFIG_HOME is commonly set to $HOME/.config, making the xdg
+// candidate the very same directory as legacy. That is a single populated dir,
+// not a competing pair, so it must not emit the both-populated warning.
+func TestResolveConfigDir_XDGEqualsLegacyNoWarning(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("FORMAE_CONFIG_DIR", "")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	legacy := filepath.Join(home, ".config", "formae")
+	p := filepath.Join(legacy, "profiles", "default.pkl")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	old := warnTo
+	warnTo = &buf
+	defer func() { warnTo = old }()
+
+	got, err := ResolveConfigDir()
+	if err != nil {
+		t.Fatalf("ResolveConfigDir: %v", err)
+	}
+	if got != legacy {
+		t.Errorf("got %q, want legacy %q", got, legacy)
+	}
+	if buf.String() != "" {
+		t.Errorf("expected no warning, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary

- On Linux, `XDG_CONFIG_HOME` is commonly set to `$HOME/.config`. That makes the xdg config candidate (`$XDG_CONFIG_HOME/formae`) resolve to the exact same directory as the legacy `$HOME/.config/formae`.
- `ResolveConfigDir` then treated a single directory as two competing candidates, saw "both populated", and emitted a bogus tie-break warning that named the same path twice (visible on e.g. `formae agent --help`).
- Fix: when the xdg candidate equals legacy, drop it — it isn't a competing location — so no warning fires and the config dir resolves as before. macOS/WSL are unaffected since they typically leave `XDG_CONFIG_HOME` unset.
- Adds a regression test covering `XDG_CONFIG_HOME=$HOME/.config`; the existing genuine both-populated (two distinct dirs) test still passes.