### PR TITLE
fix(sync): re-hash a $res resolvable's opaque value on read-merge

### DIFF
--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -541,6 +541,24 @@ func (m *propertyMerger) mergeObject(path string, userVal, pluginVal gjson.Resul
 		return
 	}
 
+	// Check if this is a $res object — a STRUCTURED resolvable reference in its
+	// pre-resolution shape ({"$res":true,"$label":..,"$type":..,"$stack":..,
+	// "$property":..[,"$value":..]}). This shape survives at rest on the
+	// non-translating paths (Synchronize/Discovery/Destroy/seed) where a user
+	// apply's $res->$ref rewrite never runs. Without this branch it would fall
+	// through to the generic recursive merge below, which walks the envelope's
+	// keys against the plugin's live value and OVERWRITES $value with plaintext —
+	// and because a $res envelope that points at another resource's Opaque
+	// property carries no schema-opaque field of its own, the persist transformer
+	// would never hash it, leaking the resolved secret in CLEARTEXT at rest.
+	// Handle it exactly like $ref: preserve the resolvable structure, refresh
+	// $value, and (when inherited-Opaque) drop the stale $hashed marker so the
+	// persist transformer re-hashes the field.
+	if userVal.Get("$res").Bool() {
+		m.mergeResObject(path, userVal, pluginVal)
+		return
+	}
+
 	// Check if this is a $embed object — preserve the user's envelope wholesale.
 	// The plugin value is always the assembled result of the template; we never
 	// let the plugin overwrite the user's $embed declaration.
@@ -607,6 +625,53 @@ func (m *propertyMerger) mergeRefObject(path string, userVal, pluginVal gjson.Re
 	}
 
 	*m.result, _ = sjson.SetRaw(*m.result, cleanPath, updatedRef)
+}
+
+// mergeResObject handles merging of $res objects (structured resolvable references
+// in their pre-resolution shape). It mirrors mergeRefObject: it preserves the user's
+// $res envelope wholesale and only refreshes $value from the plugin read.
+//
+// The plugin may echo the resolvable back either as a bare scalar (the resolved
+// live value) or as a $res/$value object; selectRefValue handles both (it already
+// unwraps $ref/$value objects, and a $res echo likewise carries the live value at
+// $value — normalized below).
+//
+// Opacity is INHERITED: a $res that resolves another resource's Opaque property is
+// itself opaque even though the consumer's own schema does not mark this field. When
+// the envelope carries the inherited $visibility:Opaque marker and we adopted the
+// plugin's fresh (plaintext) value, the stale $hashed marker must be dropped so the
+// persist transformer re-hashes the field at rest — exactly as mergeRefObject does
+// for $ref. Leaving $hashed:true would persist cleartext while claiming it is hashed
+// (a plaintext-at-rest leak that the transformer's idempotency guard would then skip).
+func (m *propertyMerger) mergeResObject(path string, userVal, pluginVal gjson.Result) {
+	cleanPath := m.cleanPath(path)
+
+	userValue := userVal.Get("$value")
+
+	// A plugin that round-trips the resolvable echoes it back as a $res/$value
+	// object; unwrap to its $value so we compare live-value-to-live-value.
+	effectivePluginVal := pluginVal
+	if pluginVal.IsObject() && (pluginVal.Get("$res").Exists() || pluginVal.Get("$ref").Exists()) {
+		effectivePluginVal = pluginVal.Get("$value")
+	}
+
+	valueToSet := m.preferNonNullValue(userValue, effectivePluginVal)
+	// Determine "did we keep the stored value?" against the SAME unwrapped value
+	// used for valueToSet. keptUserValue only unwraps $ref, so passing the raw
+	// pluginVal would treat a plugin's $res echo (a non-empty object) as a fresh
+	// value even when its $value is empty — deleting $hashed while the stored hash
+	// is retained, which makes the persist transformer hash the digest again
+	// (hash-of-hash). Use effectivePluginVal so the two decisions stay consistent.
+	keptUser := m.keptUserValue(userValue, effectivePluginVal)
+
+	updatedRes, _ := sjson.Set(userVal.Raw, "$value", valueToSet)
+
+	if userVal.Get("$visibility").String() == pkgmodel.VisibilityOpaque &&
+		userVal.Get("$hashed").Bool() && !keptUser {
+		updatedRes, _ = sjson.Delete(updatedRes, "$hashed")
+	}
+
+	*m.result, _ = sjson.SetRaw(*m.result, cleanPath, updatedRes)
 }
 
 // keptUserValue reports whether selectRefValue preserved the user's stored $value

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -666,6 +666,30 @@ func generateResourceUpdatesForSync(
 			continue
 		}
 
+		// Refresh each freshly-loaded existing resource's schema from the forma
+		// resource (which may carry a plugin-refreshed schema) before anything
+		// downstream reads opacity from it.
+		for _, existingResource := range existingResources {
+			for _, resource := range forma.Resources {
+				if resource.Stack == stack.SingleStackLabel() &&
+					resource.Label == existingResource.Label &&
+					resource.Type == existingResource.Type {
+					existingResource.Schema = resource.Schema
+				}
+			}
+		}
+
+		// Normalize inherited-Opaque $res resolvables on the freshly-loaded rows
+		// before they become ResourceUpdates. A structured $res reference pointing at
+		// another resource's Opaque property is itself opaque, but the pre-resolution
+		// $res shape that reaches at-rest storage on non-translating paths carries no
+		// $visibility marker — so without this the sync merge refreshes its $value from
+		// the plugin's live read yet the persist transformer never hashes it, leaking
+		// the resolved secret in CLEARTEXT at rest (PLA-355 sibling). Here — with every
+		// sibling row of the stack in hand — we stamp $visibility:Opaque on such $res
+		// envelopes so the merge drops any stale $hashed and persist re-hashes.
+		markInheritedOpaqueResolvables(existingResources)
+
 		// Normal sync - create read resource updates for existing resources
 		for _, existingResource := range existingResources {
 			for _, resource := range forma.Resources {
@@ -2270,4 +2294,103 @@ func translateEmbedSpansInTemplate(tmpl string, tripletToKsuid map[pkgmodel.Trip
 		}
 	}
 	return tmpl, nil
+}
+
+// markInheritedOpaqueResolvables walks each resource's properties for structured
+// $res resolvables and, when a resolvable points at another resource's Opaque
+// property, stamps $visibility:Opaque on the $res envelope in place.
+//
+// A structured $res reference in its pre-resolution shape ({"$res":true,"$label":..,
+// "$type":..,"$stack":..,"$property":..[,"$value":..]}) survives at rest on the
+// non-translating paths (Synchronize/Discovery/Destroy/seed) where a user apply's
+// $res->$ref rewrite never runs. Unlike the resolved $ref shape — which inherits
+// opacity via preserveRefMetadata/the resolver at apply time — a raw $res carries no
+// $visibility marker, so on a sync the merge refreshes its $value from the plugin's
+// live read while the persist transformer never hashes it: the resolved secret leaks
+// in CLEARTEXT at rest (the PLA-355 sibling). Stamping $visibility:Opaque here lets
+// both the sync merge (drop stale $hashed) and the persist transformer (re-hash)
+// treat the field exactly like an Opaque $ref.
+//
+// Opacity is looked up strictly from the referenced resource (keyed by the
+// resolvable's $stack/$label/$type): a property counts as opaque if the referenced
+// resource's schema marks it Opaque OR its stored value already carries a
+// $visibility:Opaque envelope (the authoritative at-rest form, which survives even
+// when a plugin's runtime schema drops FieldHint.Opaque). Non-secret $res references
+// (native IDs, ARNs, etc.) are left untouched.
+func markInheritedOpaqueResolvables(resources []*pkgmodel.Resource) {
+	opaqueByTriplet := make(map[pkgmodel.TripletKey]map[string]bool)
+	for _, res := range resources {
+		set := make(map[string]bool)
+		for _, f := range res.Schema.Opaque() {
+			set[f] = true
+		}
+		gjson.ParseBytes(res.Properties).ForEach(func(key, val gjson.Result) bool {
+			if val.IsObject() && val.Get("$visibility").String() == pkgmodel.VisibilityOpaque {
+				set[key.String()] = true
+			}
+			return true
+		})
+		if len(set) == 0 {
+			continue
+		}
+		opaqueByTriplet[pkgmodel.TripletKey{Stack: res.Stack, Label: res.Label, Type: res.Type}] = set
+	}
+	if len(opaqueByTriplet) == 0 {
+		return
+	}
+
+	for _, res := range resources {
+		if len(res.Properties) == 0 {
+			continue
+		}
+		if updated, changed := markOpaqueResolvablesInProps(string(res.Properties), opaqueByTriplet); changed {
+			res.Properties = json.RawMessage(updated)
+		}
+	}
+}
+
+// markOpaqueResolvablesInProps returns props with $visibility:Opaque stamped on every
+// $res envelope that references a known Opaque property, and whether anything changed.
+func markOpaqueResolvablesInProps(propsJSON string, opaqueByTriplet map[pkgmodel.TripletKey]map[string]bool) (string, bool) {
+	var paths []string
+	collectOpaqueResolvablePaths("", gjson.Parse(propsJSON), opaqueByTriplet, &paths)
+	if len(paths) == 0 {
+		return propsJSON, false
+	}
+	result := propsJSON
+	for _, p := range paths {
+		result, _ = sjson.Set(result, p+".$visibility", pkgmodel.VisibilityOpaque)
+	}
+	return result, true
+}
+
+// collectOpaqueResolvablePaths records the gjson/sjson path of every $res envelope
+// that references a known Opaque property and does not already carry $visibility.
+func collectOpaqueResolvablePaths(basePath string, value gjson.Result, opaqueByTriplet map[pkgmodel.TripletKey]map[string]bool, paths *[]string) {
+	if !value.IsObject() && !value.IsArray() {
+		return
+	}
+	if value.IsObject() && pkgmodel.IsResolvableObject(value) {
+		if value.Get("$visibility").String() != "" {
+			return
+		}
+		triplet := pkgmodel.TripletKey{
+			Stack: value.Get("$stack").String(),
+			Label: value.Get("$label").String(),
+			Type:  value.Get("$type").String(),
+		}
+		property := value.Get("$property").String()
+		if set, ok := opaqueByTriplet[triplet]; ok && property != "" && set[property] {
+			*paths = append(*paths, basePath)
+		}
+		return
+	}
+	value.ForEach(func(key, val gjson.Result) bool {
+		childPath := key.String()
+		if basePath != "" {
+			childPath = basePath + "." + childPath
+		}
+		collectOpaqueResolvablePaths(childPath, val, opaqueByTriplet, paths)
+		return true
+	})
 }

--- a/internal/metastructure/resource_update/resource_update_test.go
+++ b/internal/metastructure/resource_update/resource_update_test.go
@@ -525,6 +525,42 @@ func Test_mergeRefsPreservingUserRefs_OpaqueEnvelope_ReplacesHashWithLiveReadVal
 	assert.Equal(t, "my-secret", mergedMap["Name"])
 }
 
+// Test_mergeRefsPreservingUserRefs_ResEnvelope_EmptyPluginEchoPreservesHash covers the $res
+// sibling of the opaque-envelope merge. A structured $res resolvable that points at another
+// resource's Opaque property survives at rest on non-translating paths as a $res envelope. If
+// the plugin round-trips the resolvable back as a $res object whose $value is absent/empty
+// (unresolved), the merge must KEEP the stored hash AND retain $hashed:true. Regression guard:
+// keptUserValue only unwraps $ref, so mergeResObject must feed it the unwrapped plugin value —
+// otherwise a non-empty $res echo object is mistaken for a fresh value, $hashed is deleted, and
+// the persist transformer hashes the already-hashed digest again (hash-of-hash corruption).
+func Test_mergeRefsPreservingUserRefs_ResEnvelope_EmptyPluginEchoPreservesHash(t *testing.T) {
+	storedHash := pkgmodel.ComputeValueHash("v1")
+	userProps := []byte(`{
+        "name": "the-consumer",
+        "consumes": {"$res":true,"$label":"the-secret","$type":"FakeAWS::Resource","$stack":"s","$property":"secret","$hashed":true,"$value":"` + storedHash + `","$visibility":"Opaque"}
+    }`)
+	// Plugin echoes the resolvable back as a $res object with NO resolved $value.
+	pluginProps := []byte(`{
+        "name": "the-consumer",
+        "consumes": {"$res":true,"$label":"the-secret","$type":"FakeAWS::Resource","$stack":"s","$property":"secret"}
+    }`)
+
+	merged, err := mergeRefsPreservingUserRefs(userProps, pluginProps, pkgmodel.Schema{})
+	require.NoError(t, err)
+
+	var mergedMap map[string]any
+	require.NoError(t, json.Unmarshal(merged, &mergedMap))
+
+	consumes, ok := mergedMap["consumes"].(map[string]any)
+	require.True(t, ok, "consumes must remain a $res envelope")
+	assert.Equal(t, true, consumes["$res"])
+	assert.Equal(t, "Opaque", consumes["$visibility"])
+	assert.Equal(t, storedHash, consumes["$value"],
+		"stored hash must be retained when the plugin echo carries no resolved value")
+	assert.Equal(t, true, consumes["$hashed"],
+		"$hashed must be retained (no hash-of-hash): $value is still the stored digest, not a fresh plaintext")
+}
+
 func Test_mergeRefsPreservingUserRefs_RemovesArrayElements(t *testing.T) {
 	hostedZoneKsuid := util.NewID()
 

--- a/internal/workflow_tests/local/synchronizer_secret_consumer_test.go
+++ b/internal/workflow_tests/local/synchronizer_secret_consumer_test.go
@@ -347,3 +347,234 @@ func TestSynchronizer_SecretConsumerOutOfBandDrift(t *testing.T) {
 		mu.Unlock()
 	})
 }
+
+// TestSynchronizer_SecretConsumer_ResEnvelope_OutOfBandDrift is the $res sibling
+// of TestSynchronizer_SecretConsumerOutOfBandDrift. It reproduces PLA-355's
+// unfixed twin: a consumer R whose "consumes" field is persisted at rest as a
+// STRUCTURED $res resolvable (NOT a $ref envelope) pointing at S's Opaque
+// "secret" property. Such a $res envelope enters at rest via non-translating
+// paths (Synchronize/Discovery/Destroy/seed) — a USER apply would rewrite $res
+// -> $ref, so the $ref twin never exercises this shape.
+//
+// The bug: on an OOB drift of S's secret v1->v2 followed by a sync, the merge
+// has no $res branch, so it recurses field-by-field and OVERWRITES the
+// envelope's $value with the plugin's LIVE plaintext v2; because the $res
+// envelope never carried $visibility:Opaque, the persist transformer never
+// hashes it — so cleartext "v2" is written to the datastore at rest.
+//
+// The fix must leave R.consumes.$value == sha256("v2") at rest, exactly like
+// the $ref case, and NEVER the literal cleartext.
+func TestSynchronizer_SecretConsumer_ResEnvelope_OutOfBandDrift(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const sLabel = "the-secret"
+		const rLabel = "the-consumer"
+		const sNative = "s-native"
+		const rNative = "r-native"
+
+		var mu sync.Mutex
+		sCurrentSecret := "v1" // live value S's Read reports; flipped for OOB drift
+		stack := "test-stack-" + util.NewID()
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				nid := rNative
+				if req.Label == sLabel {
+					nid = sNative
+				}
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          req.Label,
+					NativeID:           nid,
+					ResourceProperties: req.Properties,
+				}}, nil
+			},
+			Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				nid := rNative
+				if req.Label == sLabel {
+					nid = sNative
+				}
+				return &resource.UpdateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationUpdate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          req.Label,
+					NativeID:           nid,
+					ResourceProperties: req.DesiredProperties,
+				}}, nil
+			},
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				mu.Lock()
+				cur := sCurrentSecret
+				mu.Unlock()
+				switch req.NativeID {
+				case sNative:
+					return &resource.ReadResult{
+						ResourceType: req.ResourceType,
+						Properties:   fmt.Sprintf(`{"name":%q,"secret":%q}`, sLabel, cur),
+					}, nil
+				case rNative:
+					// The consumer's cloud-native view holds the resolved secret. A
+					// provider that round-trips the resolvable it was handed echoes back
+					// a $res envelope carrying the LIVE plaintext at $value — which is
+					// what the sync merge sees and (unfixed) writes to $value at rest.
+					return &resource.ReadResult{
+						ResourceType: req.ResourceType,
+						Properties: fmt.Sprintf(
+							`{"name":%q,"consumes":{"$res":true,"$label":%q,"$type":"FakeAWS::Resource","$stack":%q,"$property":"secret","$value":%q}}`,
+							rLabel, sLabel, stack, cur),
+					}, nil
+				default:
+					return &resource.ReadResult{ResourceType: req.ResourceType, Properties: `{}`}, nil
+				}
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false // manual sync control
+		cfg.Agent.Retry.MaxRetries = 0
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		sKsuid := util.NewID()
+
+		sSchema := pkgmodel.Schema{
+			Identifier: "name",
+			Fields:     []string{"name", "secret"},
+			Hints:      map[string]pkgmodel.FieldHint{"secret": {Opaque: true}},
+		}
+		rSchema := pkgmodel.Schema{
+			Identifier: "name",
+			Fields:     []string{"name", "consumes"},
+		}
+
+		buildForma := func(secretVal string) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks: []pkgmodel.Stack{{Label: stack}},
+				Resources: []pkgmodel.Resource{
+					{
+						Label:      sLabel,
+						Type:       "FakeAWS::Resource",
+						Stack:      stack,
+						Target:     "test-target",
+						Ksuid:      sKsuid,
+						Schema:     sSchema,
+						Properties: json.RawMessage(fmt.Sprintf(`{"name":%q,"secret":%q}`, sLabel, secretVal)),
+					},
+					{
+						Label:      rLabel,
+						Type:       "FakeAWS::Resource",
+						Stack:      stack,
+						Target:     "test-target",
+						Schema:     rSchema,
+						Properties: json.RawMessage(fmt.Sprintf(`{"name":%q,"consumes":%q}`, rLabel, secretVal)),
+					},
+				},
+				Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			}
+		}
+
+		field := func(label, path string) gjson.Result {
+			resources, err := m.Datastore.LoadResourcesByStack(stack)
+			require.NoError(t, err)
+			for _, r := range resources {
+				if r.Label == label {
+					return gjson.GetBytes(r.Properties, path)
+				}
+			}
+			return gjson.Result{}
+		}
+		load := func(label string) *pkgmodel.Resource {
+			resources, err := m.Datastore.LoadResourcesByStack(stack)
+			require.NoError(t, err)
+			for _, r := range resources {
+				if r.Label == label {
+					return r
+				}
+			}
+			return nil
+		}
+		dumpState := func(label string) {
+			t.Logf("=================== %s ===================", label)
+			resources, err := m.Datastore.LoadResourcesByStack(stack)
+			require.NoError(t, err)
+			for _, r := range resources {
+				t.Logf("  [datastore] %s/%s: props=%s", r.Type, r.Label, string(r.Properties))
+			}
+		}
+
+		hashV1 := pkgmodel.ComputeValueHash("v1")
+		hashV2 := pkgmodel.ComputeValueHash("v2")
+
+		// ───────────────────────── STEP 1: APPLY ─────────────────────────
+		// Author S and R without any cross-resource reference, so that both land
+		// at rest as plain managed resources with correct native IDs. R.consumes
+		// starts as a plain opaque-secret-carrying field; we then rewrite it, at
+		// rest, into the STRUCTURED $res envelope that a non-translating path
+		// would have persisted.
+		_, err = m.ApplyForma(buildForma("v1"), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+		dumpState("after STEP 1 apply")
+
+		// ─── Seed R.consumes at rest as a STRUCTURED $res envelope ──────────
+		// This is the prod-observed shape (throwaway stack, PLA-355 sibling):
+		//   {"$res":true,"$label":<S>,"$type":<S-type>,"$stack":<stack>,
+		//    "$property":"secret","$value":<hash-of-v1>}
+		// — a resolvable pointing at S's Opaque "secret" property, carrying the
+		// (correctly hashed) v1 value but NO $hashed/$visibility markers.
+		r := load(rLabel)
+		require.NotNil(t, r, "R must exist after apply")
+		resEnvelope := map[string]any{
+			"$res":      true,
+			"$label":    sLabel,
+			"$type":     "FakeAWS::Resource",
+			"$stack":    stack,
+			"$property": "secret",
+			"$value":    hashV1,
+		}
+		newProps := map[string]any{"name": rLabel, "consumes": resEnvelope}
+		rawProps, mErr := json.Marshal(newProps)
+		require.NoError(t, mErr)
+		r.Properties = json.RawMessage(rawProps)
+		_, err = m.Datastore.StoreResource(r, "seed-res-envelope")
+		require.NoError(t, err)
+
+		require.True(t, field(rLabel, "consumes.$res").Bool(), "R.consumes seeded as a $res envelope")
+		require.Equal(t, hashV1, field(rLabel, "consumes.$value").String(), "R.consumes seeded hashed(v1)")
+		dumpState("after seeding $res envelope")
+
+		// ─────────────── STEP 2: OOB drift on S + sync ────────────────────
+		mu.Lock()
+		sCurrentSecret = "v2" // S's live secret changed out of band
+		mu.Unlock()
+		t.Log("########## STEP 2: OOB drift S.secret v1->v2, then ForceSync ##########")
+		require.NoError(t, m.ForceSync())
+		require.Eventually(t, func() bool {
+			resources, err := m.Datastore.LoadResourcesByStack(stack)
+			if err != nil {
+				return false
+			}
+			for _, res := range resources {
+				if res.Label == sLabel {
+					return gjson.GetBytes(res.Properties, "secret.$value").String() == hashV2
+				}
+			}
+			return false
+		}, 10*time.Second, 100*time.Millisecond, "sync should ingest S.secret->hashed(v2)")
+		dumpState("after STEP 2 sync")
+
+		// The heart of the test: after the sync refreshes R.consumes' $value from
+		// S's new live secret, the resolved value MUST be HASHED at rest — sha256(v2)
+		// — exactly like the $ref case. The cleartext "v2" must NEVER appear in the
+		// stored $res envelope.
+		require.Equal(t, hashV2, field(sLabel, "secret.$value").String(), "S.secret must be ingested as hashed(v2)")
+		require.Equal(t, hashV2, field(rLabel, "consumes.$value").String(),
+			"R.consumes.$value must be re-hashed to sha256(v2) on sync (no plaintext at rest)")
+		require.NotContains(t, field(rLabel, "consumes").Raw, "v2",
+			"the cleartext secret 'v2' must never appear in R's stored $res envelope")
+		// Structural integrity: the resolvable envelope survives the sync merge.
+		require.True(t, field(rLabel, "consumes.$res").Bool(), "R.consumes keeps its $res resolvable structure after sync")
+		require.Equal(t, sLabel, field(rLabel, "consumes.$label").String(), "R.consumes keeps its $label pointing at S")
+	})
+}


### PR DESCRIPTION
## Summary

- The synchronizer read-merge only re-hashed a resolvable's opaque value for the `$ref` (formae:// URI) envelope. A **structured `$res` resolvable** — a field that references another resource's Opaque property — survives at rest unchanged on the non-translating paths (synchronize, discovery, destroy), where the apply-time `$res`->`$ref` rewrite never runs.
- On a sync that refreshed such a field from the plugin's live read, `mergeObject` had no `$res` branch, so the envelope fell through to the generic recursive merge that overwrote `$value` with the plugin's plaintext — and since a `$res` envelope carries no `$visibility` marker of its own, the persist transformer never hashed it. **The resolved secret was stored in cleartext at rest** (a sibling of the `$ref` leak that the prior fix closed, exercised only by references that reach at rest untranslated, e.g. via discovery or an extract round-trip).
- Fix: `mergeObject` routes `$res` envelopes through a new `mergeResObject` that mirrors the `$ref` path — preserves the resolvable structure, refreshes `$value` from the plugin, and drops the stale `$hashed` marker only when it actually adopted the plugin's fresh value, so the field is re-hashed at rest. Opacity is inherited, so `markInheritedOpaqueResolvables` stamps `$visibility:Opaque` on any `$res` envelope whose referenced property is opaque (determined strictly from the referenced resource's schema or its stored `$visibility`), leaving non-secret references untouched.
- `mergeResObject` feeds `keptUserValue` the unwrapped plugin value, closing a hash-of-hash corruption: `keptUserValue` only unwraps `$ref`, so a plugin echoing a `$res` object with no resolved value would otherwise be treated as a fresh value, deleting `$hashed` while the stored digest is retained and hashing the digest again.
- Tests: a workflow test that seeds the `$res` envelope at rest, drifts the source secret out of band, syncs, and asserts the stored value is the hash and never cleartext; plus a merge unit test guarding the empty-echo case. The existing `$ref` test and merge suite still pass.