### PR TITLE
fix(secrets): opaque-secret conformance + extract round-trip

### DIFF
--- a/internal/schema/pkl/generator/pklGenerator.pkl
+++ b/internal/schema/pkl/generator/pklGenerator.pkl
@@ -305,7 +305,13 @@ function generateFormaFile(parsed: json.Value): String =
     ).distinct.filter((p) -> importExists(p)))
     // Combine and deduplicate - for flat package structures, resourceImport and namespaceImport may be the same
     let (imports = (resourceImports + namespaceBaseImports).distinct)
-    let (dependencyImports = pklMaps.flatMap((pklMap) -> gen.generateImportStatements(pklMap)).distinct.filter((e) -> !imports.contains(e)))
+    // `@formae/formae.pkl` is always imported by headerImports() (binding the
+    // name `formae`), so it must never re-appear as an aliased dependency
+    // import — modulePathToAlias would alias it back to `formae`, producing a
+    // duplicate `formae` member. It reaches generateImportStatements as the
+    // __import_statement__ of any value rendered through the formae fluent API
+    // (e.g. an opaque `formae.value("...").opaque.hashed` secret).
+    let (dependencyImports = pklMaps.flatMap((pklMap) -> gen.generateImportStatements(pklMap)).distinct.filter((e) -> !imports.contains(e) && e != "@formae/formae.pkl"))
     let (allImports = (imports + dependencyImports).distinct)
 
     // Phase 3: Render resources with collision-aware aliases

--- a/pkg/plugin-conformance-tests/runner.go
+++ b/pkg/plugin-conformance-tests/runner.go
@@ -384,6 +384,68 @@ func isEmbed(value any) bool {
 	return ok && embed
 }
 
+// isOpaqueValue reports whether value is a serialized opaque secret value, i.e.
+// a model.Value with $visibility == "Opaque" (or the $hashed marker set). Secret
+// fields (schema FieldHint.Opaque) are hashed at rest, so the value read back
+// from inventory or emitted by `formae extract` is not the authored plaintext
+// but an opaque envelope: {"$visibility":"Opaque","$hashed":true,"$value":<sha256>}.
+func isOpaqueValue(value any) bool {
+	m, ok := value.(map[string]any)
+	if !ok {
+		return false
+	}
+	if vis, ok := m["$visibility"].(string); ok && vis == pkgmodel.VisibilityOpaque {
+		return true
+	}
+	hashed, ok := m["$hashed"].(bool)
+	return ok && hashed
+}
+
+// compareOpaqueValue validates an actual opaque secret value against the authored
+// expected value. Because formae hashes secret values at rest (unsalted SHA-256)
+// and cannot recover the plaintext, we never compare plaintext directly. Instead:
+//   - when the actual value carries the $hashed digest, assert it equals
+//     ComputeValueHash(expected) — a real integrity check that the plugin stored
+//     the authored secret, not a blind skip;
+//   - when $value is absent (e.g. after extraction, where the digest may be
+//     omitted), accept the opaque envelope as-is, mirroring compareResolvable.
+//
+// The expected value is normally the authored plaintext scalar, but may itself
+// already be an opaque envelope (if the fixture authored a model.Value); both are
+// handled. Neither plaintext nor digest is ever echoed into error text.
+func compareOpaqueValue(r testReporter, name string, expected, actual any, context string) bool {
+	actualMap, ok := actual.(map[string]any)
+	if !ok {
+		// Should not happen — callers gate on isOpaqueValue(actual).
+		return true
+	}
+
+	digest, hasDigest := actualMap["$value"].(string)
+	hashed, _ := actualMap["$hashed"].(bool)
+	if !hasDigest || digest == "" || !hashed {
+		// No digest to verify (e.g. omitted on extract). The envelope is opaque
+		// by construction; accept it rather than leaking anything by comparing.
+		r.Logf("Opaque value %s present without a verifiable digest (%s); accepting", name, context)
+		return true
+	}
+
+	// Derive the expected plaintext. If the fixture authored an opaque envelope,
+	// prefer its plaintext $value; otherwise use the scalar as authored.
+	expectedPlaintext := fmt.Sprintf("%v", expected)
+	if expMap, ok := expected.(map[string]any); ok {
+		if ev, ok := expMap["$value"]; ok {
+			expectedPlaintext = fmt.Sprintf("%v", ev)
+		}
+	}
+
+	if pkgmodel.ComputeValueHash(expectedPlaintext) != digest {
+		r.Errorf("Opaque value %s digest does not match the authored secret (%s)", name, context)
+		return false
+	}
+	r.Logf("Opaque value %s verified against authored secret via SHA-256 digest (%s)", name, context)
+	return true
+}
+
 // normalizeEmbedTemplate canonicalizes a $embed $template for comparison: each
 // framed span's envelope is stripped of $value/$visibility/$strategy and
 // re-encoded with sorted keys. An authored template (pre-resolution, no $value,
@@ -998,6 +1060,15 @@ func compareMap(r testReporter, name string, expected, actual map[string]any, co
 			}
 			continue
 		}
+		// Opaque secret fields are hashed at rest, so the actual value is an
+		// opaque envelope rather than the authored plaintext. Verify by digest
+		// instead of a plaintext scalar comparison.
+		if isOpaqueValue(actualValue) || isOpaqueValue(expectedValue) {
+			if !compareOpaqueValue(r, name+"."+key, expectedValue, actualValue, context) {
+				ok = false
+			}
+			continue
+		}
 		if expectedArr, isArray := expectedValue.([]any); isArray {
 			if !compareArrayUnordered(r, name+"."+key, expectedArr, actualValue, context, providerDefaults) {
 				ok = false
@@ -1100,6 +1171,16 @@ func compareProperties(r testReporter, expectedProperties map[string]any, actual
 		if isResolvable(expectedValue) {
 			r.Logf("Validating resolvable property %s (resolved at runtime)", key)
 			if !compareResolvable(r, key, expectedValue, actualValue, context) {
+				hasErrors = true
+			}
+			continue
+		}
+
+		// Validate opaque secret properties by digest — they are hashed at rest,
+		// so the actual value is an opaque envelope, not the authored plaintext.
+		if isOpaqueValue(actualValue) || isOpaqueValue(expectedValue) {
+			r.Logf("Validating opaque secret property %s (hashed at rest)", key)
+			if !compareOpaqueValue(r, key, expectedValue, actualValue, context) {
 				hasErrors = true
 			}
 			continue

--- a/pkg/plugin-conformance-tests/runner_test.go
+++ b/pkg/plugin-conformance-tests/runner_test.go
@@ -516,6 +516,54 @@ func TestCompareEmbed_DifferentLiteralFails(t *testing.T) {
 	}
 }
 
+// An opaque secret field is hashed at rest, so inventory returns an opaque
+// envelope rather than the authored plaintext. compareProperties must verify it
+// by digest (positive: correct SHA-256 of the authored plaintext).
+func TestCompareProperties_OpaqueSecret_VerifiedByDigest(t *testing.T) {
+	expectedProperties := map[string]any{
+		"MasterUserPassword": "TestPassword123!",
+	}
+	actualResource := map[string]any{
+		"Properties": map[string]any{
+			"MasterUserPassword": map[string]any{
+				"$visibility": pkgmodel.VisibilityOpaque,
+				"$hashed":     true,
+				"$value":      pkgmodel.ComputeValueHash("TestPassword123!"),
+			},
+		},
+	}
+	if !compareProperties(t, expectedProperties, actualResource, "after create", map[string]providerDefault{}) {
+		t.Errorf("compareProperties should pass when the opaque value's digest matches the authored secret")
+	}
+}
+
+// A digest that does not match the authored plaintext MUST be flagged (negative).
+func TestCompareProperties_OpaqueSecret_WrongDigestFails(t *testing.T) {
+	expected := map[string]any{"MasterUserPassword": "TestPassword123!"}
+	actual := map[string]any{
+		"Properties": map[string]any{
+			"MasterUserPassword": map[string]any{
+				"$visibility": pkgmodel.VisibilityOpaque,
+				"$hashed":     true,
+				"$value":      pkgmodel.ComputeValueHash("a-different-password"),
+			},
+		},
+	}
+	rec := &recordingReporter{}
+	if compareProperties(rec, expected, actual, "after create", map[string]providerDefault{}) || rec.errors == 0 {
+		t.Errorf("compareProperties should fail when the opaque digest does not match the authored secret")
+	}
+}
+
+// After extraction the digest may be omitted; the opaque envelope is then
+// accepted as-is (no plaintext to leak), mirroring resolvable handling.
+func TestCompareOpaqueValue_NoDigestAccepted(t *testing.T) {
+	actual := map[string]any{"$visibility": pkgmodel.VisibilityOpaque}
+	if !compareOpaqueValue(t, "MasterUserPassword", "TestPassword123!", actual, "after extract") {
+		t.Errorf("compareOpaqueValue should accept an opaque envelope with no verifiable digest")
+	}
+}
+
 // recordingReporter captures errors without failing the test (for negative cases).
 type recordingReporter struct{ errors int }
 


### PR DESCRIPTION
Makes opaque (hashed-at-rest) secret values work end to end through the conformance harness. Two commits:

## 1. Conformance SDK: compare opaque values by digest (pkg/plugin-conformance-tests)
Secret fields marked FieldHint.Opaque are hashed at rest, so a plugin returns the value as an opaque envelope `{"$visibility":"Opaque","$hashed":true,"$value":<sha256>}`, not the authored plaintext. The property comparison fell through to a scalar compare and failed (e.g. AWS::RDS::DBInstance MasterUserPassword). Adds `isOpaqueValue`/`compareOpaqueValue` (mirroring the resolvable handling): verify the field by recomputing `model.ComputeValueHash(expected)` and matching the stored digest, tolerating an absent digest after extraction; never echo plaintext/digest. Wired into `compareProperties` and `compareMap`, with unit tests.

## 2. Extract generator: don't duplicate the formae import (internal/schema/pkl/generator)
Extracting a resource with a hashed opaque secret produced PKL that failed to eval with "Duplicate definition of member `formae`": the header always emits `import "@formae/formae.pkl"`, and the fluent-API value (`formae.value("<digest>").opaque.hashed`) also reported `@formae/formae.pkl` as a dependency import, which `modulePathToAlias` aliased back to `formae` — a second binding. Only surfaced when a resource had both a dependency-import-bearing value and the header import (e.g. RDS DBInstance with a hashed MasterUserPassword alongside a resolvable DBSubnetGroupName). Excludes `@formae/formae.pkl` from the aliased dependency imports.

## Validation
Conformance SDK unit tests green. The rds-dbinstance conformance case (the resource that exercises both halves) validated end to end via a debug-conformance run building formae from this branch.