### PR TITLE
fix(cli): theme the agent-start banner to the configured theme

### DIFF
--- a/internal/cli/agent/agent.go
+++ b/internal/cli/agent/agent.go
@@ -17,6 +17,16 @@ import (
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
+// themeBanner resolves the configured CLI theme from the command's
+// --config/--profile flags and applies it to the banner, so the printed logo
+// wordmark follows the user's theme. The agent subcommands print their banner
+// from PersistentPreRun (before the app/config is loaded in Run), so they can't
+// use (*app.App).PrintBanner; they resolve the theme straight from config the
+// same way the root help screen does. Package var so tests can observe the call.
+var themeBanner = func(c *cobra.Command) {
+	banner.SetTheme(cmd.ResolveConfiguredTheme(c))
+}
+
 func startCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "start",
@@ -58,7 +68,8 @@ func startCmd() *cobra.Command {
 
 			a.Wait()
 		},
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(command *cobra.Command, args []string) {
+			themeBanner(command)
 			banner.PrintBanner()
 		},
 		SilenceErrors: true,
@@ -80,7 +91,8 @@ func stopCmd() *cobra.Command {
 				return
 			}
 		},
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(command *cobra.Command, args []string) {
+			themeBanner(command)
 			banner.PrintBanner()
 		},
 		SilenceErrors: true,

--- a/internal/cli/agent/agent_test.go
+++ b/internal/cli/agent/agent_test.go
@@ -1,0 +1,51 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStartCmd_PersistentPreRunThemesBanner verifies that `agent start` applies
+// the configured CLI theme to the banner before printing it, so the logo
+// wordmark follows the user's theme (rich/omarchy/…) instead of the default.
+//
+// The theme resolution itself loads config through the PKL schema plugin, which
+// is exercised elsewhere; here we assert the wiring — that the command's
+// lifecycle themes the banner at all — via the themeBanner seam.
+func TestStartCmd_PersistentPreRunThemesBanner(t *testing.T) {
+	orig := themeBanner
+	t.Cleanup(func() { themeBanner = orig })
+
+	var themed bool
+	themeBanner = func(_ *cobra.Command) { themed = true }
+
+	c := startCmd()
+	require.NotNil(t, c.PersistentPreRun, "agent start must have a PersistentPreRun that prints the banner")
+	c.PersistentPreRun(c, nil)
+
+	assert.True(t, themed, "agent start must apply the configured theme to the banner before printing it")
+}
+
+// TestStopCmd_PersistentPreRunThemesBanner verifies the same for `agent stop`.
+func TestStopCmd_PersistentPreRunThemesBanner(t *testing.T) {
+	orig := themeBanner
+	t.Cleanup(func() { themeBanner = orig })
+
+	var themed bool
+	themeBanner = func(_ *cobra.Command) { themed = true }
+
+	c := stopCmd()
+	require.NotNil(t, c.PersistentPreRun, "agent stop must have a PersistentPreRun that prints the banner")
+	c.PersistentPreRun(c, nil)
+
+	assert.True(t, themed, "agent stop must apply the configured theme to the banner before printing it")
+}


### PR DESCRIPTION
## What

`formae agent start` (and `agent stop`) printed the formae logo banner without the configured CLI theme — the logo wordmark always used the default (quiet) palette instead of following the users theme (rich/omarchy/…).

## Root cause

The agent subcommands print their banner from `PersistentPreRun` by calling `banner.PrintBanner()` **directly**, with no preceding `banner.SetTheme(...)`. Every other entry point sets the theme first:

- Human-readable command flows → `(*app.App).PrintBanner` → `banner.SetTheme(a.Theme())`.
- The root help screen → `banner.SetTheme(cmd.ResolveConfiguredTheme(c))`.

The `banner` package defaults `th` to `theme.New("formae")` (quiet), and the agent commands `PersistentPreRun` overrides the root commands, so nothing ever re-themed the banner for the agent path.

## Fix

The agent commands print the banner before the app/config is loaded in `Run`, so they cant use `(*app.App).PrintBanner`. Resolve the theme straight from the commands `--config`/`--profile` the same way the root help screen does (`cmd.ResolveConfiguredTheme`), then `banner.SetTheme` before printing. Extracted into a `themeBanner` seam and wired into both `start` and `stop`.

## Tests

TDD. New `internal/cli/agent/agent_test.go` asserts both `start` and `stop` theme the banner in their `PersistentPreRun` before printing (fails without the fix). `make lint` clean; all CLI test packages pass.