### PR TITLE
fix(secrets): persist opaque values as canonical formae.Value with $strategy

### DIFF
--- a/internal/metastructure/resource_update/resource_comparison_test.go
+++ b/internal/metastructure/resource_update/resource_comparison_test.go
@@ -500,10 +500,13 @@ func TestGate_HintedResolvableLeaf_DifferentContent_IsChange(t *testing.T) {
 // with like.
 func TestEnforceSetOnce_NoSpuriousUpdateForUnchangedSecret(t *testing.T) {
 	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"SecretString": {Opaque: true}}}
-	// existing = already-hashed stored state
+	// existing = already-hashed stored state, in the CANONICAL form the persist
+	// transformer now writes (carries $strategy — see PersistValueTransformer /
+	// PLA-361). The desired plaintext hashes to the same canonical envelope, so the
+	// whole-resource compare must see no change.
 	hashed := (&pkgmodel.Value{Value: "super-secret", Visibility: pkgmodel.VisibilityOpaque}).Hash()
 	existing := &pkgmodel.Resource{Schema: schema,
-		Properties: json.RawMessage(`{"SecretString":{"$value":"` + hashed.Value.(string) + `","$visibility":"Opaque","$hashed":true}}`)}
+		Properties: json.RawMessage(`{"SecretString":{"$value":"` + hashed.Value.(string) + `","$visibility":"Opaque","$strategy":"Update","$hashed":true}}`)}
 	// new = desired plaintext, same secret
 	newRes := &pkgmodel.Resource{Schema: schema,
 		Properties: json.RawMessage(`{"SecretString":"super-secret"}`)}

--- a/internal/metastructure/resource_update/resource_comparison_test.go
+++ b/internal/metastructure/resource_update/resource_comparison_test.go
@@ -501,8 +501,8 @@ func TestGate_HintedResolvableLeaf_DifferentContent_IsChange(t *testing.T) {
 func TestEnforceSetOnce_NoSpuriousUpdateForUnchangedSecret(t *testing.T) {
 	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"SecretString": {Opaque: true}}}
 	// existing = already-hashed stored state, in the CANONICAL form the persist
-	// transformer now writes (carries $strategy — see PersistValueTransformer /
-	// PLA-361). The desired plaintext hashes to the same canonical envelope, so the
+	// transformer now writes (carries $strategy — see PersistValueTransformer).
+	// The desired plaintext hashes to the same canonical envelope, so the
 	// whole-resource compare must see no change.
 	hashed := (&pkgmodel.Value{Value: "super-secret", Visibility: pkgmodel.VisibilityOpaque}).Hash()
 	existing := &pkgmodel.Resource{Schema: schema,

--- a/internal/metastructure/transformations/persist_value_transformer.go
+++ b/internal/metastructure/transformations/persist_value_transformer.go
@@ -172,7 +172,7 @@ func (pv *PersistValueTransformer) hashOpaqueField(v any) (map[string]any, bool)
 	// generator does not recognize as an opaque value (its opaque-value branch
 	// keys on $value+$visibility+$strategy); on a field whose type union includes
 	// formae.Resolvable, union resolution then falls to the Resolvable arm and
-	// emits a label-less {$res,$visibility:Opaque} that fails to evaluate (PLA-361).
+	// emits a label-less {$res,$visibility:Opaque} that fails to evaluate.
 	value := &pkgmodel.Value{Value: v, Visibility: pkgmodel.VisibilityOpaque, Strategy: pkgmodel.StrategyUpdate}
 	hashed := value.Hash()
 	return map[string]any{
@@ -187,8 +187,8 @@ func (pv *PersistValueTransformer) hashOpaqueField(v any) (map[string]any, bool)
 func (pv *PersistValueTransformer) hashEnvelope(val map[string]any) (map[string]any, bool) {
 	if h, ok := val["$hashed"].(bool); ok && h {
 		// Already hashed — never re-hash. But canonicalize a missing $strategy so a
-		// legacy value persisted before the canonicalization fix (see hashOpaqueField
-		// / PLA-361) still round-trips through extract as a formae.Value rather than a
+		// legacy value persisted before the canonicalization fix (see hashOpaqueField)
+		// still round-trips through extract as a formae.Value rather than a
 		// label-less $res. Adding $strategy does not change the digest.
 		if s, ok := val["$strategy"].(string); !ok || s == "" {
 			val["$strategy"] = pkgmodel.StrategyUpdate
@@ -203,7 +203,7 @@ func (pv *PersistValueTransformer) hashEnvelope(val map[string]any) (map[string]
 	} else {
 		// Default an absent strategy to "Update" so the persisted envelope is a
 		// canonical formae.Value the extract generator recognizes (see
-		// hashOpaqueField / PLA-361). Never override an explicit SetOnce.
+		// hashOpaqueField). Never override an explicit SetOnce.
 		value.Strategy = pkgmodel.StrategyUpdate
 	}
 	hashed := value.Hash()

--- a/internal/metastructure/transformations/persist_value_transformer.go
+++ b/internal/metastructure/transformations/persist_value_transformer.go
@@ -164,24 +164,51 @@ func (pv *PersistValueTransformer) hashOpaqueField(v any) (map[string]any, bool)
 	if m, ok := v.(map[string]any); ok {
 		return pv.hashEnvelope(m)
 	}
-	// Bare scalar: wrap + hash.
-	value := &pkgmodel.Value{Value: v, Visibility: pkgmodel.VisibilityOpaque}
+	// Bare scalar (e.g. an opaque field supplied as a plain string literal, RDS
+	// MasterUserPassword): wrap + hash into a CANONICAL formae.Value envelope. It
+	// must carry $strategy — the same shape a `formae.value(x).opaque` literal
+	// produces (PKL defaults the strategy to "Update"). Omitting it leaves a
+	// non-canonical {$value,$visibility,$hashed} value that the extract PKL
+	// generator does not recognize as an opaque value (its opaque-value branch
+	// keys on $value+$visibility+$strategy); on a field whose type union includes
+	// formae.Resolvable, union resolution then falls to the Resolvable arm and
+	// emits a label-less {$res,$visibility:Opaque} that fails to evaluate (PLA-361).
+	value := &pkgmodel.Value{Value: v, Visibility: pkgmodel.VisibilityOpaque, Strategy: pkgmodel.StrategyUpdate}
 	hashed := value.Hash()
-	return map[string]any{"$value": hashed.Value, "$visibility": pkgmodel.VisibilityOpaque, "$hashed": true}, true
+	return map[string]any{
+		"$value":      hashed.Value,
+		"$visibility": pkgmodel.VisibilityOpaque,
+		"$strategy":   hashed.Strategy,
+		"$hashed":     true,
+	}, true
 }
 
 // hashEnvelope hashes an existing {$value,$visibility,...} map in place, unless already $hashed.
 func (pv *PersistValueTransformer) hashEnvelope(val map[string]any) (map[string]any, bool) {
 	if h, ok := val["$hashed"].(bool); ok && h {
+		// Already hashed — never re-hash. But canonicalize a missing $strategy so a
+		// legacy value persisted before the canonicalization fix (see hashOpaqueField
+		// / PLA-361) still round-trips through extract as a formae.Value rather than a
+		// label-less $res. Adding $strategy does not change the digest.
+		if s, ok := val["$strategy"].(string); !ok || s == "" {
+			val["$strategy"] = pkgmodel.StrategyUpdate
+			return val, true
+		}
 		return val, false
 	}
 	original := val["$value"]
 	value := &pkgmodel.Value{Value: original, Visibility: pkgmodel.VisibilityOpaque}
-	if strategy, ok := val["$strategy"].(string); ok {
+	if strategy, ok := val["$strategy"].(string); ok && strategy != "" {
 		value.Strategy = strategy
+	} else {
+		// Default an absent strategy to "Update" so the persisted envelope is a
+		// canonical formae.Value the extract generator recognizes (see
+		// hashOpaqueField / PLA-361). Never override an explicit SetOnce.
+		value.Strategy = pkgmodel.StrategyUpdate
 	}
 	hashed := value.Hash()
 	val["$value"] = hashed.Value
+	val["$strategy"] = hashed.Strategy
 	val["$hashed"] = true
 	return val, true
 }
@@ -223,10 +250,11 @@ func (pv *PersistValueTransformer) transformPatchDocument(patchDoc json.RawMessa
 				}
 			}
 			if s, ok := value.(string); ok {
-				hashed := (&pkgmodel.Value{Value: s, Visibility: pkgmodel.VisibilityOpaque}).Hash()
+				hashed := (&pkgmodel.Value{Value: s, Visibility: pkgmodel.VisibilityOpaque, Strategy: pkgmodel.StrategyUpdate}).Hash()
 				patchOps[i]["value"] = map[string]any{
 					"$value":      hashed.Value,
 					"$visibility": pkgmodel.VisibilityOpaque,
+					"$strategy":   hashed.Strategy,
 					"$hashed":     true,
 				}
 				continue

--- a/internal/metastructure/transformations/persist_value_transformer_test.go
+++ b/internal/metastructure/transformations/persist_value_transformer_test.go
@@ -265,6 +265,12 @@ func TestApplyToResource_HashesBareStringAtSchemaOpaquePath(t *testing.T) {
 	assert.Equal(t, true, sv["$hashed"])
 	assert.Len(t, sv["$value"].(string), 64)
 	assert.NotEqual(t, "super-secret-password", sv["$value"])
+	// PLA-361: a bare-string literal on an opaque field must be wrapped into a
+	// CANONICAL formae.Value carrying $strategy (the shape a `formae.value(x).opaque`
+	// literal produces). Without it the extract PKL generator does not recognize the
+	// value as opaque and, on a field whose type union includes formae.Resolvable,
+	// emits a label-less {$res,$visibility:Opaque} that fails to evaluate.
+	assert.Equal(t, "Update", sv["$strategy"], "hashed bare-scalar opaque value must carry the default $strategy")
 }
 
 func TestApplyToResource_HashesEnvelopedOpaque(t *testing.T) {
@@ -310,6 +316,42 @@ func TestApplyToResource_HashesTopLevelScalarPatchOpValue(t *testing.T) {
 	assert.Equal(t, "Opaque", value["$visibility"])
 	assert.NotEqual(t, "super-secret-password", value["$value"])
 	assert.Len(t, value["$value"].(string), 64)
+	assert.Equal(t, "Update", value["$strategy"], "hashed bare-scalar patch-op value must carry the default $strategy (PLA-361)")
+}
+
+// TestApplyToResource_EnvelopeWithoutStrategyGetsCanonicalStrategy covers the
+// PLA-361 canonicalization for an opaque envelope that arrives WITHOUT $strategy
+// (e.g. an enriched plugin Read that wraps only {$value,$visibility}): hashing it
+// at rest must default $strategy to "Update" so the stored value is a canonical
+// formae.Value.
+func TestApplyToResource_EnvelopeWithoutStrategyGetsCanonicalStrategy(t *testing.T) {
+	r := &pkgmodel.Resource{
+		Schema:     schemaWithOpaque("SecretString"),
+		Properties: json.RawMessage(`{"SecretString":{"$value":"plaintext","$visibility":"Opaque"}}`),
+	}
+	out, err := NewPersistValueTransformer().ApplyToResource(r)
+	require.NoError(t, err)
+	var props map[string]any
+	require.NoError(t, json.Unmarshal(out.Properties, &props))
+	sv := props["SecretString"].(map[string]any)
+	assert.Equal(t, true, sv["$hashed"])
+	assert.Equal(t, "Update", sv["$strategy"], "an opaque envelope missing $strategy must be canonicalized to Update")
+}
+
+// TestApplyToResource_EnvelopePreservesExplicitSetOnce guards that
+// canonicalization never overrides an explicitly-declared SetOnce strategy.
+func TestApplyToResource_EnvelopePreservesExplicitSetOnce(t *testing.T) {
+	r := &pkgmodel.Resource{
+		Schema:     schemaWithOpaque("SecretString"),
+		Properties: json.RawMessage(`{"SecretString":{"$value":"plaintext","$visibility":"Opaque","$strategy":"SetOnce"}}`),
+	}
+	out, err := NewPersistValueTransformer().ApplyToResource(r)
+	require.NoError(t, err)
+	var props map[string]any
+	require.NoError(t, json.Unmarshal(out.Properties, &props))
+	sv := props["SecretString"].(map[string]any)
+	assert.Equal(t, true, sv["$hashed"])
+	assert.Equal(t, "SetOnce", sv["$strategy"], "explicit SetOnce must be preserved, not overridden")
 }
 
 // TestApplyToResource_PatchOpNonSecretValueCollidingWithSecretPlaintextIsUntouched guards

--- a/internal/metastructure/transformations/persist_value_transformer_test.go
+++ b/internal/metastructure/transformations/persist_value_transformer_test.go
@@ -265,11 +265,11 @@ func TestApplyToResource_HashesBareStringAtSchemaOpaquePath(t *testing.T) {
 	assert.Equal(t, true, sv["$hashed"])
 	assert.Len(t, sv["$value"].(string), 64)
 	assert.NotEqual(t, "super-secret-password", sv["$value"])
-	// PLA-361: a bare-string literal on an opaque field must be wrapped into a
-	// CANONICAL formae.Value carrying $strategy (the shape a `formae.value(x).opaque`
-	// literal produces). Without it the extract PKL generator does not recognize the
-	// value as opaque and, on a field whose type union includes formae.Resolvable,
-	// emits a label-less {$res,$visibility:Opaque} that fails to evaluate.
+	// A bare-string literal on an opaque field must be wrapped into a CANONICAL
+	// formae.Value carrying $strategy (the shape a `formae.value(x).opaque` literal
+	// produces). Without it the extract PKL generator does not recognize the value
+	// as opaque and, on a field whose type union includes formae.Resolvable, emits
+	// a label-less {$res,$visibility:Opaque} that fails to evaluate.
 	assert.Equal(t, "Update", sv["$strategy"], "hashed bare-scalar opaque value must carry the default $strategy")
 }
 
@@ -316,11 +316,11 @@ func TestApplyToResource_HashesTopLevelScalarPatchOpValue(t *testing.T) {
 	assert.Equal(t, "Opaque", value["$visibility"])
 	assert.NotEqual(t, "super-secret-password", value["$value"])
 	assert.Len(t, value["$value"].(string), 64)
-	assert.Equal(t, "Update", value["$strategy"], "hashed bare-scalar patch-op value must carry the default $strategy (PLA-361)")
+	assert.Equal(t, "Update", value["$strategy"], "hashed bare-scalar patch-op value must carry the default $strategy")
 }
 
-// TestApplyToResource_EnvelopeWithoutStrategyGetsCanonicalStrategy covers the
-// PLA-361 canonicalization for an opaque envelope that arrives WITHOUT $strategy
+// TestApplyToResource_EnvelopeWithoutStrategyGetsCanonicalStrategy covers
+// canonicalization for an opaque envelope that arrives WITHOUT $strategy
 // (e.g. an enriched plugin Read that wraps only {$value,$visibility}): hashing it
 // at rest must default $strategy to "Update" so the stored value is a canonical
 // formae.Value.

--- a/internal/workflow_tests/local/apply_forma/pla361_writeonly_opaque_test.go
+++ b/internal/workflow_tests/local/apply_forma/pla361_writeonly_opaque_test.go
@@ -1,0 +1,107 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// TestPLA361_WriteOnlyOpaqueLiteralStoredAsCanonicalValue reproduces the PLA-361
+// scenario end to end through ApplyForma: a schema-opaque field supplied as a
+// literal string, whose plugin Read NEVER returns a value (mirroring AWS RDS
+// MasterUserPassword, which the cloud omits on every read).
+//
+// The stored resources.Properties (and the ExtractResources model output, which
+// reads it verbatim) must be a CANONICAL formae.Value envelope carrying $strategy
+// — not a bare {$value,$visibility,$hashed}. Without $strategy the extract PKL
+// generator does not recognize the value as opaque and, on a field whose type
+// union includes formae.Resolvable (RDS masterUserPassword), emits a label-less
+// {$res,$visibility:Opaque} that fails to evaluate. Asserting $strategy at rest
+// guards the root cause at the full-apply-path level; the generator render is
+// covered end to end by the plugin repo's rds-dbinstance conformance.
+func TestPLA361_WriteOnlyOpaqueLiteralStoredAsCanonicalValue(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const plaintextSecret = "TestPassword123!"
+
+		// Write-only: the plugin Read never returns SecretString.
+		overrides := &plugin.ResourcePluginOverrides{
+			Read: func(r *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{
+					ResourceType: r.ResourceType,
+					Properties:   `{"Name":"my-secret"}`,
+				}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: stack}},
+			Resources: []pkgmodel.Resource{{
+				Label:      "my-secret",
+				Type:       "FakeAWS::SecretsManager::Secret",
+				Stack:      stack,
+				Target:     "test-target",
+				Schema:     secretSchema(),
+				Properties: json.RawMessage(`{"Name":"my-secret","SecretString":"` + plaintextSecret + `"}`),
+			}},
+			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		assertCanonicalOpaque := func(t *testing.T, props json.RawMessage, where string) {
+			t.Helper()
+			var m map[string]any
+			require.NoError(t, json.Unmarshal(props, &m))
+			sv, ok := m["SecretString"].(map[string]any)
+			require.Truef(t, ok, "%s: SecretString must be an opaque envelope, got %v", where, m["SecretString"])
+			assert.Equalf(t, "Opaque", sv["$visibility"], "%s: visibility", where)
+			assert.Equalf(t, true, sv["$hashed"], "%s: hashed marker", where)
+			assert.Equalf(t, "Update", sv["$strategy"], "%s: canonical $strategy (PLA-361)", where)
+			assert.NotEqualf(t, plaintextSecret, sv["$value"], "%s: value must be hashed", where)
+		}
+
+		resources, err := m.Datastore.LoadResourcesByStack(stack)
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+		assertCanonicalOpaque(t, resources[0].Properties, "resources table")
+
+		extracted, err := m.ExtractResources("stack:" + stack)
+		require.NoError(t, err)
+		require.NotNil(t, extracted)
+		require.Len(t, extracted.Resources, 1)
+		assertCanonicalOpaque(t, extracted.Resources[0].Properties, "ExtractResources")
+
+		// A sync must not regress the canonical shape.
+		require.NoError(t, m.ForceSync())
+		waitForApplyComplete(t, m)
+		resourcesAfter, err := m.Datastore.LoadResourcesByStack(stack)
+		require.NoError(t, err)
+		require.Len(t, resourcesAfter, 1)
+		assertCanonicalOpaque(t, resourcesAfter[0].Properties, "resources table after sync")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/writeonly_opaque_test.go
+++ b/internal/workflow_tests/local/apply_forma/writeonly_opaque_test.go
@@ -22,20 +22,18 @@ import (
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
-// TestPLA361_WriteOnlyOpaqueLiteralStoredAsCanonicalValue reproduces the PLA-361
-// scenario end to end through ApplyForma: a schema-opaque field supplied as a
-// literal string, whose plugin Read NEVER returns a value (mirroring AWS RDS
-// MasterUserPassword, which the cloud omits on every read).
+// TestWriteOnlyOpaqueLiteralStoredAsCanonicalValue checks that a schema-opaque
+// field supplied as a literal string, whose plugin Read never returns a value
+// (a write-only field, as with an AWS RDS master password that the cloud omits
+// on every read), is persisted through ApplyForma as a canonical formae.Value
+// envelope carrying $strategy, not a bare {$value,$visibility,$hashed}.
 //
-// The stored resources.Properties (and the ExtractResources model output, which
-// reads it verbatim) must be a CANONICAL formae.Value envelope carrying $strategy
-// — not a bare {$value,$visibility,$hashed}. Without $strategy the extract PKL
-// generator does not recognize the value as opaque and, on a field whose type
-// union includes formae.Resolvable (RDS masterUserPassword), emits a label-less
-// {$res,$visibility:Opaque} that fails to evaluate. Asserting $strategy at rest
-// guards the root cause at the full-apply-path level; the generator render is
-// covered end to end by the plugin repo's rds-dbinstance conformance.
-func TestPLA361_WriteOnlyOpaqueLiteralStoredAsCanonicalValue(t *testing.T) {
+// $strategy is what the extract generator uses to recognize the value as opaque.
+// On a field whose type union includes formae.Resolvable it must be present, or
+// the generator emits a label-less {$res,$visibility:Opaque} that fails to
+// evaluate. The test asserts the canonical shape at rest in the resources table,
+// in ExtractResources output, and again after a sync.
+func TestWriteOnlyOpaqueLiteralStoredAsCanonicalValue(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		const plaintextSecret = "TestPassword123!"
 
@@ -81,7 +79,7 @@ func TestPLA361_WriteOnlyOpaqueLiteralStoredAsCanonicalValue(t *testing.T) {
 			require.Truef(t, ok, "%s: SecretString must be an opaque envelope, got %v", where, m["SecretString"])
 			assert.Equalf(t, "Opaque", sv["$visibility"], "%s: visibility", where)
 			assert.Equalf(t, true, sv["$hashed"], "%s: hashed marker", where)
-			assert.Equalf(t, "Update", sv["$strategy"], "%s: canonical $strategy (PLA-361)", where)
+			assert.Equalf(t, "Update", sv["$strategy"], "%s: canonical $strategy", where)
 			assert.NotEqualf(t, plaintextSecret, sv["$value"], "%s: value must be hashed", where)
 		}
 


### PR DESCRIPTION
## Summary

- `formae extract` of a write-only opaque field the cloud never returns (e.g. RDS `AWS::RDS::DBInstance.MasterUserPassword`) produced an **un-evaluable** forma. The field rendered as a targetless, label-less resolvable and eval failed:

  ```pkl
  masterUserPassword = new formae.Resolvable {
    $res = true
    $visibility = "Opaque"
  }
  ```
  ```
  cannot evaluate forma: Resolvable in resource '...' property 'masterUserPassword' is missing required label
  ```

- Root cause: the value is stored at rest as a hashed opaque envelope, but `PersistValueTransformer` wrapped a bare-string literal into `{$value,$visibility,$hashed}` **without `$strategy`**. The extract PKL generator only recognizes an opaque value when the envelope carries `$value`+`$visibility`+`$strategy`; without `$strategy` it falls through, and on a field whose type union includes `formae.Resolvable` it renders the value as a resolvable — dropping the value and the label. A `formae.value(x).opaque` literal always carries `$strategy` (default `Update`), so only the bare-scalar-literal path produced the non-canonical envelope.

- The `formae.Resolvable` arm is intentional on consumer secret fields that can reference a managed secret (`RDS masterUserPassword`/`tdeCredentialPassword`, `RDS::DBCluster masterUserPassword`, `IAM privateKey`, `EC2`/`ELBv2 clientSecret`, `preSharedKey`, `Lambda eventSourceToken`). A secret's *own* value field (`SecretsManager secretString`, `IAM user password`) has no `formae.Resolvable` arm — which is why this only bit consumer fields and slipped past the existing secret-hashing tests, which are built on a Resolvable-less field.

- Fix: `PersistValueTransformer` now persists opaque values as a canonical `formae.Value` carrying `$strategy` (default `Update`, preserving an explicit `SetOnce`) across the bare-scalar, envelope, and patch-document paths. Legacy already-hashed envelopes gain `$strategy` on the next persist — and via the every-boot backfill sweep — without re-hashing (the digest is unchanged).

- Result: extract of both fresh and pre-existing opaque values round-trips as `formae.value("<hash>").opaque.hashed`; the extracted forma evaluates. A straight re-apply of an unchanged managed resource stays a no-op (unchanged opaque values are suppressed by digest before the plugin boundary), and materializing a secret from its hash still trips the plugin-boundary guard with an actionable error rather than writing the digest as the live value.

- Covered by new transformer unit tests and an end-to-end apply→extract workflow test.

Refs PLA-361.