### PR TITLE
chore: remove internal ticket references and bug-tracker framing from tests

### DIFF
--- a/internal/cli/tui/components/querybar_test.go
+++ b/internal/cli/tui/components/querybar_test.go
@@ -148,13 +148,12 @@ func TestQueryBar_ViewStates(t *testing.T) {
 	assert.Contains(t, v, "esc: cancel")
 }
 
-// TestQueryBar_WithThemePreservesEditingState gates the PLA-348 fix for a
-// live theme swap (e.g. the Omarchy watcher's async ApplyThemeMsg) arriving
-// while the user is mid-edit. Before the fix, Model.ApplyTheme rebuilt the
-// bar via NewQueryBar(t, q.Query()), which only carries over the applied
-// query and zero-values focused/edit — silently un-focusing the bar and
-// discarding the in-progress edit buffer. WithTheme must swap only the theme
-// field and leave focus/edit/applied untouched.
+// TestQueryBar_WithThemePreservesEditingState covers a live theme swap
+// (e.g. the Omarchy watcher's async ApplyThemeMsg) arriving while the user
+// is mid-edit. Rebuilding the bar via NewQueryBar(t, q.Query()) would carry
+// over only the applied query and zero-value focused/edit — silently
+// un-focusing the bar and discarding the in-progress edit buffer. WithTheme
+// must swap only the theme field and leave focus/edit/applied untouched.
 func TestQueryBar_WithThemePreservesEditingState(t *testing.T) {
 	q := NewQueryBar(theme.New("quiet"), "state:InProgress")
 	q = q.Focus()

--- a/internal/cli/tui/components/table_test.go
+++ b/internal/cli/tui/components/table_test.go
@@ -132,8 +132,8 @@ func TestVisibleColumnIndexes_NarrowDropsLowPriority(t *testing.T) {
 	assert.Equal(t, []int{0}, got)
 }
 
-// TestTable_SetThemeRebuildsHeaderAndCellStyles gates the PLA-348 fix for a
-// live theme swap (the Omarchy watcher firing theme.ApplyThemeMsg): Table
+// TestTable_SetThemeRebuildsHeaderAndCellStyles covers a live theme swap
+// (the Omarchy watcher firing theme.ApplyThemeMsg): Table
 // bakes header/cell/selected-row styles into the wrapped bubbles/table.Model
 // once, at NewTable time (see NewTable), and every subsequent View() reuses
 // those baked styles verbatim — a bare struct-field swap of a *theme.Theme

--- a/internal/cli/tui/inventoryview/applytheme_test.go
+++ b/internal/cli/tui/inventoryview/applytheme_test.go
@@ -42,20 +42,20 @@ func TestUpdate_ApplyThemeMsgApplies(t *testing.T) {
 	}
 }
 
-// TestApplyTheme_RebuildsTabStyledCells gates a live theme swap while a tab
+// TestApplyTheme_RebuildsTabStyledCells covers a live theme swap while a tab
 // holds cached per-cell styled replacements. tabModel.sync builds
 // styledCells ONCE per fetch/sort/filter event from the tabModel's own th
 // field (see tab.go's styleCell application), and loadedView/applyCellStyles
-// (tabview.go) reuse those cached strings verbatim every frame. Before the
-// fix, ApplyTheme swapped tabs[i].th but never re-ran sync, so a cell already
-// on screen (e.g. the "⚠ unmanaged" Stack cell, styled red via
-// th.Styles.StatusFailed) stayed rendered in the OLD theme's color until the
-// next unrelated fetch/sort/filter happened to call sync again. This proves
-// the styled replacement is actually re-rendered, not just that th changed.
+// (tabview.go) reuse those cached strings verbatim every frame. If ApplyTheme
+// swaps tabs[i].th but never re-runs sync, a cell already on screen (e.g. the
+// "⚠ unmanaged" Stack cell, styled red via th.Styles.StatusFailed) stays
+// rendered in the OLD theme's color until the next unrelated fetch/sort/filter
+// happens to call sync again. This proves the styled replacement is actually
+// re-rendered, not just that th changed.
 //
 // quiet and rich have different Error colors (light #DC2626 vs #FF0000, dark
 // #F87171 vs #FF0000), so StatusFailed's rendering genuinely differs between
-// them — a real (not synthetic) regression signal.
+// them.
 func TestApplyTheme_RebuildsTabStyledCells(t *testing.T) {
 	quiet := theme.New("quiet")
 	m := New(quiet, nil, Options{})
@@ -85,15 +85,15 @@ func TestCloseWatcher_NilSafe(t *testing.T) {
 	m.closeWatcher()                             // must not panic
 }
 
-// TestApplyTheme_RecolorsOpenDetailScreen gates PLA-348: the open detail
-// screen (opened via enter) keeps stale colors after a live Omarchy theme
-// change. openDetail bakes the colorized detail body into m.detailViewport
-// exactly once, via colorizeDetailLine(m.th, ...) piped into vp.SetContent —
-// see openDetail in model.go. Before the fix, ApplyTheme threaded the new
-// theme into tabs/table/query/spinner but never rebuilt the detail viewport,
-// so a resource's detail screen left open across a theme swap kept rendering
-// its "Key: value" lines in the OLD theme's colors until the user pressed
-// esc then enter again to force a rebuild.
+// TestApplyTheme_RecolorsOpenDetailScreen covers recoloring the open detail
+// screen (opened via enter) after a live Omarchy theme change. openDetail
+// bakes the colorized detail body into m.detailViewport exactly once, via
+// colorizeDetailLine(m.th, ...) piped into vp.SetContent — see openDetail in
+// model.go. If ApplyTheme threads the new theme into tabs/table/query/spinner
+// but never rebuilds the detail viewport, a resource's detail screen left
+// open across a theme swap keeps rendering its "Key: value" lines in the OLD
+// theme's colors until the user presses esc then enter again to force a
+// rebuild. ApplyTheme must rebuild the viewport in place.
 //
 // quiet and rich share identical TextPrimary/TextSecondary (see
 // TestTable_SetThemeRebuildsHeaderAndCellStyles), so this test builds a

--- a/internal/cli/tui/inventoryview/tab_render_test.go
+++ b/internal/cli/tui/inventoryview/tab_render_test.go
@@ -299,7 +299,7 @@ func TestSetSize_StoresDimensions(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Narrow-terminal regression: setSize at <30 cols must not panic and every
+// Narrow terminal: setSize at <30 cols must not panic and every
 // rendered line must be ≤ width printable columns (R8 overflow guard).
 // ---------------------------------------------------------------------------
 
@@ -331,7 +331,7 @@ func TestNarrowTerminal_NoPanicAndFitsWidth(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Wide-terminal regression: setSize on a terminal wider than the sum of the
+// Wide terminal: setSize on a terminal wider than the sum of the
 // declared column widths must grow the columns proportionally to consume the
 // available width, instead of leaving the surplus unused (values truncating
 // against slack).
@@ -493,7 +493,7 @@ func TestStyleCell_Targets_NoPlain(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Fix wave 3: column-bounded cell styling regression tests
+// column-bounded cell styling
 // ---------------------------------------------------------------------------
 
 // TestStyleCell_YesProdLabel_LabelCellNotCorrupted verifies that a target

--- a/internal/cli/tui/simview/render_test.go
+++ b/internal/cli/tui/simview/render_test.go
@@ -130,7 +130,7 @@ func TestRenderDeleteRowsHaveWarningColor(t *testing.T) {
 }
 
 // TestRenderRowLabelAndDeleteAreThemeDriven pins that row column coloring is
-// governed by the theme's [rows] plane (PLA-348):
+// governed by the theme's [rows] plane:
 //   - rich (label_accent + delete_whole_row): the label is the accent color,
 //     and a delete row's label AND type both take the delete op color.
 //   - quiet (neither): the label renders the same color as the other columns
@@ -189,7 +189,7 @@ func TestRenderRowLabelAndDeleteAreThemeDriven(t *testing.T) {
 }
 
 // TestRenderGroupColHeaderThemeHighlight pins the theme-driven header
-// emphasis (PLA-348): under "rich" (Header.Highlight="background") the
+// emphasis: under "rich" (Header.Highlight="background") the
 // navigated column header carries a background SGR sequence, matching the
 // row cursor; under "quiet" (Header.Highlight="brighten") the navigated
 // header carries only a foreground + bold, no background.

--- a/internal/cli/tui/statuswatch/detailmodel_test.go
+++ b/internal/cli/tui/statuswatch/detailmodel_test.go
@@ -225,10 +225,9 @@ func TestDetailModel_CancelStateLabels(t *testing.T) {
 // not the old hardcoded "○").
 // TestDetailModel_PinnedRowRunningGlyphIsStatic asserts the detail view's
 // pinned command row (SetCommand -> multiView.renderRows, the same shared
-// renderer as the multi-command table) inherits the PLA-348 fix that
-// replaced the redundant animated spinner in colStatus with the static
-// themed in-progress glyph. spinView is set to a distinctive animated frame
-// that must not leak into the pinned row now that it's unused there.
+// renderer as the multi-command table) renders colStatus with the static
+// themed in-progress glyph rather than an animated spinner. spinView is set
+// to a distinctive animated frame that must not leak into the pinned row.
 func TestDetailModel_PinnedRowRunningGlyphIsStatic(t *testing.T) {
 	th := theme.New("formae")
 	dm := newDetailModel(th, 100, 30)
@@ -632,14 +631,14 @@ func TestDetailModel_ColHeaderAlignment(t *testing.T) {
 	}
 }
 
-// TestDetailModel_ApplyThemeRebuildsPinnedStrings gates the PLA-348 fix for a
-// live theme swap while drilled into a command: SetCommand builds
-// pinnedHeader/pinnedRow ONCE from the theme in effect at the time, and View
-// reuses those cached strings verbatim every frame. Before the fix,
-// ApplyTheme only swapped d.th and left the cached strings rendered in the
-// old theme's colors until the next poll re-called SetCommand. This proves
-// the pinned row is actually re-rendered (not just that d.th changed) by
-// diffing the raw (ANSI-inclusive) pinnedRow/pinnedHeader before and after.
+// TestDetailModel_ApplyThemeRebuildsPinnedStrings covers a live theme swap
+// while drilled into a command: SetCommand builds pinnedHeader/pinnedRow ONCE
+// from the theme in effect at the time, and View reuses those cached strings
+// verbatim every frame. If ApplyTheme only swaps d.th, the cached strings
+// stay rendered in the old theme's colors until the next poll re-calls
+// SetCommand. This proves the pinned row is actually re-rendered (not just
+// that d.th changed) by diffing the raw (ANSI-inclusive)
+// pinnedRow/pinnedHeader before and after.
 func TestDetailModel_ApplyThemeRebuildsPinnedStrings(t *testing.T) {
 	quiet := theme.New("quiet")
 	rich := theme.New("rich")

--- a/internal/cli/tui/statuswatch/multiview_test.go
+++ b/internal/cli/tui/statuswatch/multiview_test.go
@@ -161,8 +161,8 @@ func TestMultiView_HeaderGlyphsFollowTheme(t *testing.T) {
 	assert.NotContains(t, h, "○")
 }
 
-// TestMultiView_HeaderThemeHighlight pins the theme-driven header emphasis
-// (PLA-348), mirroring simview's TestRenderGroupColHeaderThemeHighlight: under
+// TestMultiView_HeaderThemeHighlight pins the theme-driven header emphasis,
+// mirroring simview's TestRenderGroupColHeaderThemeHighlight: under
 // "rich" (Header.Highlight="background") the navigated (sortHi) column
 // carries a background SGR sequence like the row cursor, and the active-sort
 // column (when different from the navigated one) carries the PrimaryAccent

--- a/internal/metastructure/changeset/changeset_test.go
+++ b/internal/metastructure/changeset/changeset_test.go
@@ -209,7 +209,7 @@ func TestChangeset_ExecutionOrder_DeleteChainThenCreateChainWithParallelLeaves(t
 }
 
 func TestChangeset_RemoveNode_UnlinksAllDependentsWhenThreeOrMore(t *testing.T) {
-	// Regression test: removeNode must unlink ALL dependents, not just some.
+	// removeNode must unlink ALL dependents, not just some.
 	// With 3+ dependents, iterating node.Dependents while Unlink modifies
 	// the same slice causes elements to be skipped (Go range captures the
 	// backing array pointer but Unlink shifts elements via append).
@@ -2812,7 +2812,7 @@ func TestBuildDeleteDependencies_RuntimeDependency_MultipleRefsToSameProducer_Pr
 }
 
 // TestBuildCreateUpdateDependencies_RuntimeDependency_MultipleRefsToSameProducer_PrefersRuntimeDependency
-// is the create-side counterpart of the destroy-side regression test. Same
+// is the create-side counterpart of the destroy-side test. Same
 // shape: consumer carries two refs to the same producer KSUID — one default,
 // one runtimeDependency — and the planner must honor the runtimeDependency
 // hint regardless of map iteration order.

--- a/internal/metastructure/forma_persister/forma_command_persister_test.go
+++ b/internal/metastructure/forma_persister/forma_command_persister_test.go
@@ -872,9 +872,9 @@ func newFormaCommandWithTargetAndResourceUpdate() *forma_command.FormaCommand {
 // (due to pending resource updates), the target's new state is actually written to the
 // database -- not just held in the in-memory cache.
 //
-// This is a regression test: the bug is that markTargetUpdateAsComplete uses
-// UpdateFormaCommandProgress (which only writes state + modified_ts) in the non-final
-// branch, so the target_updates JSON blob is never updated on disk.
+// markTargetUpdateAsComplete must persist the target_updates JSON blob in the
+// non-final branch. UpdateFormaCommandProgress only writes state + modified_ts, so
+// relying on it there would leave the target's new state unwritten on disk.
 func TestFormaCommandPersister_TargetUpdateState_PersistedToDB(t *testing.T) {
 	// Create a shared datastore so a second persister can read back from the same DB.
 	ds, err := dssqlite.NewDatastoreSQLite(context.Background(), &pkgmodel.DatastoreConfig{

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -390,10 +390,9 @@ func TestGeneratePatch(t *testing.T) {
 // fields trigger a replacement instead of being silently shipped to
 // the plugin as a mutable patch.
 //
-// Regression: before the fix, isCreateOnlyPath compared dot-paths to
-// slash-paths raw, so nested createOnly violations weren't caught.
-// Users only learned about the immutability when the cloud API
-// rejected the apply (e.g. K8s "spec.selector: field is immutable"
+// isCreateOnlyPath must normalize dot-paths against slash-paths so nested
+// createOnly violations are caught before the apply, rather than surfacing
+// as a cloud API rejection (e.g. K8s "spec.selector: field is immutable"
 // on Deployment).
 func TestGeneratePatch_NestedCreateOnlyTriggersReplacement(t *testing.T) {
 	document := []byte(`{
@@ -605,7 +604,7 @@ func TestGeneratePatch_ObjectResolvableMatchingLiveValue_NoPatch(t *testing.T) {
 	assert.Nil(t, patchDoc)
 }
 
-// Regression guard: a String field whose legitimate value is JSON text (e.g. an
+// A String field whose legitimate value is JSON text (e.g. an
 // IAM policy document) sourced from a resolvable reads back as a string on the
 // live side, so the desired side must stay a string — a blind "parse anything
 // that looks like JSON" would turn this into perpetual drift.
@@ -728,8 +727,8 @@ func TestRemoveNonSchemaFields_ThreeFieldsTotalTwoSchemaFields_RemovesNonSchemaF
 	assert.Equal(t, "c", c)
 }
 
-// This reproduces an API Gateway method response issue where the database
-// contains objects with both nested structure and flattened keys
+// Exercises an API Gateway method response shape where the database
+// contains objects with both nested structure and flattened keys.
 func TestGeneratePatch_MixedNestedAndFlattenedStructures(t *testing.T) {
 	document := []byte(`{
 		"Integration": {
@@ -924,8 +923,8 @@ func TestGeneratePatch_RequiredOnUpdateFieldsGenerateAddOperation(t *testing.T) 
 }
 
 func TestGeneratePatch_WriteOnlyCreateOnlyFieldsNoPhantomReplacement(t *testing.T) {
-	// Reproduces GitHub Issue #21: fields marked both writeOnly AND createOnly
-	// trigger phantom resource replacement on re-apply.
+	// Fields marked both writeOnly AND createOnly must not trigger phantom
+	// resource replacement on re-apply.
 	//
 	// writeOnly fields are stripped from the document (Read never returns them).
 	// If the field is also createOnly, jsonpatch generates an "add" op,
@@ -1383,7 +1382,7 @@ func TestGeneratePatch_ReconcileRemovesOOBTagsWhenDesiredIsNull(t *testing.T) {
 }
 
 func TestGeneratePatch_AbsentDesiredVsEmptyActualArray_NoPatch(t *testing.T) {
-	// Reproducer: ECS TaskDef Tags. PKL renders Tags as absent (no key);
+	// ECS TaskDef Tags: PKL renders Tags as absent (no key);
 	// AWS Read returns `Tags: []`. Diff layer must NOT emit a remove op,
 	// otherwise CCAPI rejects with "patchDocument length >= 1".
 	//
@@ -1463,7 +1462,7 @@ func TestStripTopLevelEmptyCollectionsAbsentInPatch(t *testing.T) {
 			wantDocument: `{"Tags": [], "Name": "x"}`,
 		},
 		{
-			name:         "absent in patch, top-level object containing only nested empties → preserved (regression guard from adversarial review)",
+			name:         "absent in patch, top-level object containing only nested empties → preserved",
 			document:     `{"Outer": {"Inner": []}, "Name": "x"}`,
 			patch:        `{"Name": "x"}`,
 			wantDocument: `{"Outer": {"Inner": []}, "Name": "x"}`,
@@ -1483,7 +1482,7 @@ func TestStripTopLevelEmptyCollectionsAbsentInPatch(t *testing.T) {
 }
 
 func TestGeneratePatch_OuterWithOnlyNestedEmpties_NoSpuriousSuppression(t *testing.T) {
-	// Regression guard for the adversarial-review finding on placement.
+	// Guards helper placement relative to StripNestedEmptyCollections.
 	//
 	// The concern: if our new helper ran AFTER StripNestedEmptyCollections,
 	// it would observe `{Outer: {}, Name: x}` (because nested-strip collapses
@@ -1516,11 +1515,11 @@ func TestGeneratePatch_OuterWithOnlyNestedEmpties_NoSpuriousSuppression(t *testi
 }
 
 func TestGeneratePatch_AbsentDesiredVsEmptyActualArray_PatchMode_NoPatch(t *testing.T) {
-	// Same shape and hint configuration as the Reconcile reproducer
+	// Same shape and hint configuration as the Reconcile-mode case
 	// (TestGeneratePatch_AbsentDesiredVsEmptyActualArray_NoPatch). In Patch
 	// mode, PatchStrategyEnsureExists does not emit removes for absent-desired
-	// keys, so the new suppression must be a no-op here. This test pins the
-	// per-mode behavior: the fix must not regress Patch-mode no-op semantics.
+	// keys, so the suppression must be a no-op here. This test pins the
+	// per-mode behavior: Patch-mode no-op semantics must be preserved.
 	document := []byte(`{"Tags": [], "Family": "x"}`)
 	patch := []byte(`{"Family": "x"}`)
 
@@ -1551,8 +1550,8 @@ func TestGeneratePatch_AbsentDesiredVsEmptyActual_EntitySetField_NotAWSSpecific_
 	// Using HasProviderDefault: false here is load-bearing — with true,
 	// removeProviderDefaultEntitySetElements would delete the field before
 	// our helper sees it, degenerately passing the test without exercising
-	// the new suppression. Names also intentionally differ from AWS
-	// reproducer (Attributes/ID, not Tags/Family) to demonstrate the fix is
+	// the new suppression. Names also intentionally differ from the AWS
+	// case (Attributes/ID, not Tags/Family) to demonstrate the behavior is
 	// provider-agnostic.
 	document := []byte(`{"Attributes": [], "ID": "abc"}`)
 	patch := []byte(`{"ID": "abc"}`)
@@ -2075,8 +2074,8 @@ func TestGeneratePatch_EntitySetProviderDefaults_WithUserChange(t *testing.T) {
 	assert.Contains(t, ops[0].Path, "Value")
 }
 
-// Reproduces the exact bug from the issue: re-applying an unchanged ECS
-// TaskDefinition triggers a REPLACE because the provider populates
+// Re-applying an unchanged ECS TaskDefinition must not trigger a REPLACE
+// when the provider populates
 // ContainerDefinition.Cpu=0 on Read, and the diff through jsonpatch's set
 // semantics treats the document element {Name:x, Cpu:0} as different from
 // the desired element {Name:x}. Because ContainerDefinitions is createOnly,
@@ -2085,7 +2084,7 @@ func TestGeneratePatch_EntitySetProviderDefaults_WithUserChange(t *testing.T) {
 // This test passes with a single-element array today (the existing
 // fieldExistsInMap short-circuits "Cpu not anywhere in patch" = strip).
 // The next test exercises the mixed case where at least one sibling does
-// set Cpu, which is what the production bug looks like.
+// set Cpu.
 func TestGeneratePatch_ProviderDefaultInsideArray_SingleElement_NoReplace(t *testing.T) {
 	document := []byte(`{
 		"Family": "my-task",
@@ -2316,7 +2315,7 @@ func TestGeneratePatch_UserChangedFieldInsideArray_StillReplaces(t *testing.T) {
 // Negative test: at the top level, stripping must remain conditional. A user
 // who explicitly overrides a provider-default value should still see a diff
 // (this is the BucketEncryption override case we already test elsewhere,
-// repeated here to guard against regressions from the new recursive logic).
+// repeated here to guard the new recursive logic).
 func TestGeneratePatch_TopLevelProviderDefaultOverride_StillDiffs(t *testing.T) {
 	document := []byte(`{
 		"BucketName": "my-bucket",
@@ -2379,8 +2378,8 @@ func TestGeneratePatch_EntitySetProviderDefaults_ReconcileMode(t *testing.T) {
 	assert.Empty(t, patchDoc, "Expected no patch when only provider-default elements differ in reconcile mode")
 }
 
-// Regression test for the spurious ECS Service replace on reapply. The cloud
-// provider returns nested lists (Environment, PortMappings inside a
+// A reapply of an unchanged ECS Service must not trigger a spurious replace.
+// The cloud provider returns nested lists (Environment, PortMappings inside a
 // ContainerDefinition) in a canonicalised order that may differ from the
 // PKL-evaluated desired state. Each nested element is byte-identical across
 // the two sides; only the order within the nested list differs. At the outer

--- a/internal/metastructure/resource_update/opaque_suppression_test.go
+++ b/internal/metastructure/resource_update/opaque_suppression_test.go
@@ -230,7 +230,7 @@ func TestUpdate_OpaqueCreateOnlyChanged_StillReplaces(t *testing.T) {
 }
 
 // Direct unit coverage of the helper's per-leaf decisions (complements the
-// behavior-level regression tests above).
+// behavior-level tests above).
 func TestSuppressUnchangedOpaqueValues_Decisions(t *testing.T) {
 	t.Run("unchanged opaque dropped from both sides", func(t *testing.T) {
 		existing := json.RawMessage(`{"secret":` + opaqueLeaf("Update", pkgmodel.ComputeValueHash("s")) + `,"name":"old"}`)

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -685,7 +685,7 @@ func generateResourceUpdatesForSync(
 		// $res shape that reaches at-rest storage on non-translating paths carries no
 		// $visibility marker — so without this the sync merge refreshes its $value from
 		// the plugin's live read yet the persist transformer never hashes it, leaking
-		// the resolved secret in CLEARTEXT at rest (PLA-355 sibling). Here — with every
+		// the resolved secret in CLEARTEXT at rest (sibling of the cleartext-at-rest case). Here — with every
 		// sibling row of the stack in hand — we stamp $visibility:Opaque on such $res
 		// envelopes so the merge drops any stale $hashed and persist re-hashes.
 		markInheritedOpaqueResolvables(existingResources)
@@ -2307,7 +2307,7 @@ func translateEmbedSpansInTemplate(tmpl string, tripletToKsuid map[pkgmodel.Trip
 // opacity via preserveRefMetadata/the resolver at apply time — a raw $res carries no
 // $visibility marker, so on a sync the merge refreshes its $value from the plugin's
 // live read while the persist transformer never hashes it: the resolved secret leaks
-// in CLEARTEXT at rest (the PLA-355 sibling). Stamping $visibility:Opaque here lets
+// in CLEARTEXT at rest (the sibling of the cleartext-at-rest case). Stamping $visibility:Opaque here lets
 // both the sync merge (drop stale $hashed) and the persist transformer (re-hash)
 // treat the field exactly like an Opaque $ref.
 //

--- a/internal/schema/pkl/generator/tests/gen.pkl
+++ b/internal/schema/pkl/generator/tests/gen.pkl
@@ -367,8 +367,8 @@ facts {
         })
         let (resourceMap = Map("functionCode", fakeEmbedMap))
         let (rendered = gen.genMapToPklStringWithTypes("TestResource", resourceMap, "test"))
-        // Single-line form. The old multi-line """ rendering produced invalid PKL
-        // (content on the same line as """) and broke extract re-eval — see PLA-68.
+        // Single-line form. A multi-line """ rendering would produce invalid PKL
+        // (content on the same line as """) and break extract re-eval.
         rendered.contains("formae.embed(\"") && !rendered.contains("formae.embed(\"\"\"")
     }
 
@@ -410,8 +410,8 @@ facts {
     }
 
     ["EdgeFunction code body roundtrips with single escaping"] {
-        // Real-world repro: a Supabase EdgeFunction inline body containing
-        // double-quotes. Extract must escape each quote exactly once so the
+        // A Supabase EdgeFunction inline body containing double-quotes.
+        // Extract must escape each quote exactly once so the
         // generated forma parses back to the original source (no phantom drift).
         let (body = "Deno.serve(() => new Response(\"Hello from formae!\"))")
         let (applied = gen.apply(SimpleFoo, new Dynamic { x = 1; name = body; label = "fn" }))

--- a/internal/schema/pkl/generator/tests/schema/compute/server.pkl
+++ b/internal/schema/pkl/generator/tests/schema/compute/server.pkl
@@ -25,7 +25,7 @@ open class Server extends formae.Resource {
     imageId: String
 
     // String|formae.Embedded field — exercises extract-to-PKL regeneration of an
-    // embedded resolvable (formae.embed("…\(ref)…")). See PLA-68.
+    // embedded resolvable (formae.embed("…\(ref)…")).
     @testprovider.FieldHint
     userData: (String|formae.Embedded)?
 

--- a/internal/schema/pkl/pkl_test.go
+++ b/internal/schema/pkl/pkl_test.go
@@ -35,11 +35,11 @@ func TestPkl_Evaluate(t *testing.T) {
 	assert.Equal(t, "A", gjson.Get(jsonString, "Resources.1.Properties.Type").String())
 }
 
-// TestPkl_Evaluate_AutoResolvesUnresolvedProject reproduces the reported failure:
-// applying a forma whose directory has a PklProject but no resolved
-// PklProject.deps.json used to fail with a NoSuchFileException and force a manual
-// `pkl project resolve`. Evaluate now auto-resolves via pklrun. The deps file is
-// gitignored and regenerated, so removing it needs no cleanup.
+// TestPkl_Evaluate_AutoResolvesUnresolvedProject verifies that applying a forma
+// whose directory has a PklProject but no resolved PklProject.deps.json succeeds:
+// Evaluate auto-resolves via pklrun instead of failing with a NoSuchFileException
+// that would force a manual `pkl project resolve`. The deps file is gitignored
+// and regenerated, so removing it needs no cleanup.
 func TestPkl_Evaluate_AutoResolvesUnresolvedProject(t *testing.T) {
 	depsPath := "./testdata/forma/PklProject.deps.json"
 	if err := os.Remove(depsPath); err != nil && !os.IsNotExist(err) {

--- a/internal/workflow_tests/local/apply_forma/non_enriching_secret_guard_test.go
+++ b/internal/workflow_tests/local/apply_forma/non_enriching_secret_guard_test.go
@@ -105,9 +105,9 @@ func applyPatchDocumentForTest(t *testing.T, doc json.RawMessage, patchDoc *stri
 // every Read, refreshing the stored $hashed envelope back to plaintext before
 // the plugin-boundary guard (resolver.guardNoHashedValues) ever sees
 // it again. Plenty of real secret fields never come back on Read at all (e.g.
-// a writeOnly credential) — this override reproduces that: it returns only
+// a writeOnly credential) — this override models that: it returns only
 // Name, never SecretString, so the stored envelope stays hashed at rest
-// exactly as it was after create. This is what exercises the gap:
+// exactly as it was after create. This is what exercises the path where:
 // resource_updater.go's delete()/update() converting DesiredState/PriorState
 // with the GUARDED converter even though those conversions carry prior/
 // existing state, not a new value being written.

--- a/internal/workflow_tests/local/apply_forma/secret_hashing_test.go
+++ b/internal/workflow_tests/local/apply_forma/secret_hashing_test.go
@@ -301,8 +301,8 @@ func TestSecretHashing_NoPerpetualDrift(t *testing.T) {
 	})
 }
 
-// TestSecretHashing_UpdateNonSecretFieldOnSecretResourceSucceeds is the key regression
-// backstop: a RECONCILE apply that changes a non-secret field on a resource whose
+// TestSecretHashing_UpdateNonSecretFieldOnSecretResourceSucceeds verifies that
+// a RECONCILE apply that changes a non-secret field on a resource whose
 // secret is already hashed at rest must succeed — the plugin-boundary guard
 // (resolver.ConvertToPluginFormat's guardNoHashedValues) must not false-positive on
 // the pre-update out-of-band Read, the patch-generation diff, or the eventual Update
@@ -487,8 +487,8 @@ func TestSecretHashing_ResolveCacheDoesNotLogSecret(t *testing.T) {
 // value here is later read back and sent live to a plugin as TargetConfig, so hashing
 // it here needs its own design (mirroring the resource-side hash-at-rest +
 // hash-vs-hash drift convergence work) rather than a quick patch. Left as a SKIPPED,
-// self-documenting regression test rather than silently dropped or weakened — un-skip
-// once a target-config hashing fix lands.
+// self-documenting test that pins the known gap — un-skip once a target-config
+// hashing fix lands.
 func TestSecretHashing_TargetConfigResolvedSecretStoredAsPlaintext_KnownGap(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		const plaintextSecret = "resolve-cache-must-not-log-this-secret"

--- a/internal/workflow_tests/local/changeset_executor_test.go
+++ b/internal/workflow_tests/local/changeset_executor_test.go
@@ -321,11 +321,11 @@ func TestChangesetExecutor_CascadeFailure(t *testing.T) {
 // resources are Read operations with no inter-dependencies, so there is nothing
 // for a failure to cascade *to* — the only candidate is the failed Read itself.
 //
-// Reproduces the prod incident where a single-resource sync whose Read failed
-// produced a self-cascade: the executor reported the failed Read as a cascading
-// failure and pushed it to FormaCommandPersister.MarkResourcesAsFailed, which
-// (for an empty sync command already evicted from cache and deleted from the DB)
-// panicked the persister with "forma command not found".
+// Without this, a single-resource sync whose Read failed would produce a
+// self-cascade: the executor reports the failed Read as a cascading failure and
+// pushes it to FormaCommandPersister.MarkResourcesAsFailed, which (for an empty
+// sync command already evicted from cache and deleted from the DB) panics the
+// persister with "forma command not found".
 func TestChangesetExecutor_SyncReadFailureDoesNotCascade(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		logCapture := test_helpers.SetupTestLogger()
@@ -571,9 +571,9 @@ func newTestResourceUpdate(label string, dependencies []pkgmodel.FormaeURI, reso
 // changeset executor reaches a terminal state when a Read operation fails
 // during the synchronize phase of an Update workflow.
 //
-// Regression test for a bug where handleProgressUpdate() returned
-// StateFinishedWithError without calling MarkAsFailed() when
-// message.Failed() was true. This left ResourceUpdate.State as InProgress
+// It guards handleProgressUpdate(): when message.Failed() is true it must call
+// MarkAsFailed() rather than returning StateFinishedWithError alone. Omitting
+// the MarkAsFailed() call leaves ResourceUpdate.State as InProgress
 // (set by UpdateState() which short-circuited when fewer progress results
 // than required operations existed). The changeset's UpdatePipeline treated
 // InProgress as a no-op, stranding the update.

--- a/internal/workflow_tests/local/cross_stack_persist_test.go
+++ b/internal/workflow_tests/local/cross_stack_persist_test.go
@@ -26,8 +26,8 @@ import (
 // a command fails (some resources fail to create), other successfully-created
 // resources are still persisted to inventory.
 //
-// This reproduces an issue found by property tests where the command response
-// shows creates as Success, but the resources don't appear in inventory.
+// It guards against the command response showing creates as Success while the
+// resources fail to appear in inventory.
 func TestMetastructure_SuccessfulCreatePersistedInFailedCommand(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		// Fail creates for "res-b" to make the command fail while

--- a/internal/workflow_tests/local/destroy_forma_test.go
+++ b/internal/workflow_tests/local/destroy_forma_test.go
@@ -156,14 +156,13 @@ func TestMetastructure_ApplyThenDestroyForma(t *testing.T) {
 
 // TestMetastructure_DestroyPolicyOnlyForma tests that destroying a forma with only
 // standalone policies (no resources) completes successfully without hanging.
-// This is a regression test for a bug where policy-only destroy commands would hang
-// indefinitely because the policy updates were never processed/persisted.
+// It guards against policy-only destroy commands hanging indefinitely when the
+// policy updates are never processed/persisted.
 // TestMetastructure_DestroyReadThrottlingShouldRetryAndFail verifies that when a
 // recoverable error (Throttling) occurs during the Read/sync phase of a delete
 // operation, the error is properly retried and eventually causes the destroy to
-// fail. This is a regression test for a bug where TreatNotFoundAsSuccess=true
-// (set during delete reads) caused ALL error codes to be silently treated as
-// success, not just NotFound.
+// fail. It guards against TreatNotFoundAsSuccess=true (set during delete reads)
+// silently treating ALL error codes as success rather than only NotFound.
 func TestMetastructure_DestroyReadThrottlingShouldRetryAndFail(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		overrides := &plugin.ResourcePluginOverrides{

--- a/internal/workflow_tests/local/synchronizer_secret_consumer_test.go
+++ b/internal/workflow_tests/local/synchronizer_secret_consumer_test.go
@@ -282,7 +282,7 @@ func TestSynchronizer_SecretConsumerOutOfBandDrift(t *testing.T) {
 		// the stale $hashed marker so the persist transformer re-hashes it at rest.
 		// The field must therefore be stored as {"$hashed":true,"$value":sha256("v2")}
 		// — the resolved secret hashed, NEVER the literal cleartext. This is the
-		// integrity/no-leak guarantee at the heart of PLA-355.
+		// integrity/no-leak guarantee under test.
 		require.Equal(t, hashV2, field(sLabel, "secret.$value").String(), "S.secret must be ingested as hashed(v2)")
 		require.True(t, field(rLabel, "consumes.$hashed").Bool(), "R.consumes stays flagged $hashed:true after sync")
 		require.Equal(t, hashV2, field(rLabel, "consumes.$value").String(),
@@ -296,7 +296,7 @@ func TestSynchronizer_SecretConsumerOutOfBandDrift(t *testing.T) {
 		// Plain reconcile with the OLD desired (v1) is rejected because the OOB drift
 		// (S.secret is now v2 at rest) makes the stack "modified since the last
 		// reconcile". This is legitimate drift protection — desired v1 genuinely
-		// differs from the ingested current v2 — and is unrelated to the PLA-355 fix.
+		// differs from the ingested current v2 — and is unrelated to the hashing behavior.
 		require.Error(t, err3, "reconcile with stale desired (v1) after OOB drift to v2 must be rejected")
 		if err3 != nil {
 			t.Logf("STEP 3 reconcile ApplyForma RETURNED ERROR (submission-time rejection): %v", err3)
@@ -318,9 +318,9 @@ func TestSynchronizer_SecretConsumerOutOfBandDrift(t *testing.T) {
 		_, err4 := m.ApplyForma(buildForma("v2"), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
 		// With R.consumes correctly hashed(v2) at rest, the absorbed desired (v2,
 		// matching the live/ingested value) is now accepted — R is no longer
-		// perpetually "unabsorbed", so the guard clears WITHOUT Force. Before the
-		// PLA-355 fix the corrupted (plaintext) R.consumes made even this plain
-		// absorb reject; that over-rejection is now gone.
+		// perpetually "unabsorbed", so the guard clears WITHOUT Force. A corrupted
+		// (plaintext) R.consumes would make even this plain absorb reject; the
+		// re-hash on read-merge prevents that over-rejection.
 		require.NoError(t, err4, "plain-reconcile absorb (desired=v2) is accepted once R.consumes is not corrupt")
 		waitForApplyComplete(t, m)
 		dumpState("after STEP 4a plain absorb")
@@ -349,20 +349,20 @@ func TestSynchronizer_SecretConsumerOutOfBandDrift(t *testing.T) {
 }
 
 // TestSynchronizer_SecretConsumer_ResEnvelope_OutOfBandDrift is the $res sibling
-// of TestSynchronizer_SecretConsumerOutOfBandDrift. It reproduces PLA-355's
-// unfixed twin: a consumer R whose "consumes" field is persisted at rest as a
+// of TestSynchronizer_SecretConsumerOutOfBandDrift. It exercises the $res twin:
+// a consumer R whose "consumes" field is persisted at rest as a
 // STRUCTURED $res resolvable (NOT a $ref envelope) pointing at S's Opaque
 // "secret" property. Such a $res envelope enters at rest via non-translating
 // paths (Synchronize/Discovery/Destroy/seed) — a USER apply would rewrite $res
 // -> $ref, so the $ref twin never exercises this shape.
 //
-// The bug: on an OOB drift of S's secret v1->v2 followed by a sync, the merge
-// has no $res branch, so it recurses field-by-field and OVERWRITES the
+// On an OOB drift of S's secret v1->v2 followed by a sync, the merge must have
+// a $res branch: without one it would recurse field-by-field and OVERWRITE the
 // envelope's $value with the plugin's LIVE plaintext v2; because the $res
-// envelope never carried $visibility:Opaque, the persist transformer never
-// hashes it — so cleartext "v2" is written to the datastore at rest.
+// envelope never carried $visibility:Opaque, the persist transformer would not
+// hash it and cleartext "v2" would land in the datastore at rest.
 //
-// The fix must leave R.consumes.$value == sha256("v2") at rest, exactly like
+// The merge must leave R.consumes.$value == sha256("v2") at rest, exactly like
 // the $ref case, and NEVER the literal cleartext.
 func TestSynchronizer_SecretConsumer_ResEnvelope_OutOfBandDrift(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
@@ -518,7 +518,7 @@ func TestSynchronizer_SecretConsumer_ResEnvelope_OutOfBandDrift(t *testing.T) {
 		dumpState("after STEP 1 apply")
 
 		// ─── Seed R.consumes at rest as a STRUCTURED $res envelope ──────────
-		// This is the prod-observed shape (throwaway stack, PLA-355 sibling):
+		// This is the at-rest shape produced by non-translating paths:
 		//   {"$res":true,"$label":<S>,"$type":<S-type>,"$stack":<stack>,
 		//    "$property":"secret","$value":<hash-of-v1>}
 		// — a resolvable pointing at S's Opaque "secret" property, carrying the

--- a/pkg/plugin-conformance-tests/runner_test.go
+++ b/pkg/plugin-conformance-tests/runner_test.go
@@ -407,10 +407,10 @@ func TestTestCaseNames_Empty(t *testing.T) {
 }
 
 // TestCompareProperties_NestedResolvable verifies that compareProperties handles
-// Resolvable references nested inside SubResource maps. This reproduces the
-// elasticbeanstalk failure where ResourceLifecycleConfig.ServiceRole is a
-// Resolvable: Pkl eval produces $visibility:Clear, but after Formae resolves
-// the reference the inventory has $value with the actual ARN.
+// Resolvable references nested inside SubResource maps. Case in point:
+// ResourceLifecycleConfig.ServiceRole is a Resolvable where Pkl eval produces
+// $visibility:Clear, but after Formae resolves the reference the inventory has
+// $value with the actual ARN. The two must still compare equal.
 func TestCompareProperties_NestedResolvable(t *testing.T) {
 	// Expected: from Pkl eval — Resolvable has $visibility but no $value
 	expectedProperties := map[string]any{
@@ -474,9 +474,9 @@ func TestCompareProperties_NestedResolvable(t *testing.T) {
 	}
 }
 
-// Reproduces the conformance Verify failure: a $embed field's stored
-// $template carries the resolved $value and Go sorted-key envelope encoding,
-// while the authored expected $template has neither. They must compare equal.
+// TestCompareProperties_Embed verifies that a $embed field whose stored
+// $template carries the resolved $value and Go sorted-key envelope encoding
+// compares equal to an authored expected $template that has neither.
 func TestCompareProperties_Embed(t *testing.T) {
 	// Expected (from Pkl eval): $res span, insertion-order keys, no $value.
 	expectedSpan := pkgmodel.FrameEnvelope(

--- a/tests/e2e/go/fixtures/embed_resolvable_aws.pkl
+++ b/tests/e2e/go/fixtures/embed_resolvable_aws.pkl
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: FSL-1.1-ALv2
  */
 
-// E2E fixture for PLA-68: an embedded resolvable inside a String-typed field.
+// E2E fixture: an embedded resolvable inside a String-typed field.
 // The Function's functionCode is a cf-js-2.0 literal that references the
 // KeyValueStore's CloudFront-generated short Id, embedded into the source via
 // formae.embed(...). Applying this in one pass resolves the Id and ships a
-// plain String to CloudFront; pre-PLA-68 this required a two-apply manual
+// plain String to CloudFront; previously this required a two-apply manual
 // substitution.
 
 amends "@formae/forma.pkl"


### PR DESCRIPTION
## What

Remove internal references and bug-tracker framing from the codebase. formae is
open source; our issue tracker is internal, so neither ticket ids nor bug-history
narration belong in the tree.

- Strip ticket ids (and one "GitHub Issue #N" reference) from comments, string
  literals, and a couple of non-test source comments.
- Rewrite test comments that narrated a bug's history ("reproduces X",
  "regression test for X", "the bug is that…", "prod incident") so they describe
  only the behavior under test.
- Clean the same from pkl test fixtures and generator tests.

No logic changes; comments and one assertion message only. 23 files.

## Deliberately excluded

`internal/schema/pkl/schema/formae.pkl` carries one ticket reference but is the
**published** schema. Editing it changes `formae@0.88.0`'s package checksum,
which every released plugin pins — so it will be cleaned as part of the next
schema version bump, not here. Verified: this branch still packages
`formae@0.88.0` to the same checksum as `main`.

## Checks

- `go build ./...` clean
- Touched test packages vet clean (`-tags unit`/`integration` as applicable)
- Repo scan for ticket ids / bug-tracker framing is clean (outside the excluded
  schema file)
