### PR TITLE
feat(cli): add Nord, Gruvbox, Tokyo Night, Rosé Pine, and Catppuccin Latte themes

### DIFF
--- a/internal/cli/tui/theme/colorvalue.go
+++ b/internal/cli/tui/theme/colorvalue.go
@@ -37,6 +37,16 @@ func (c *colorValue) UnmarshalTOML(v any) error {
 	}
 }
 
+// MarshalTOML emits a bare hex string when light and dark match, else an inline
+// { light, dark } table. It is the inverse of UnmarshalTOML so a theme file
+// round-trips (write then re-parse) without loss.
+func (c colorValue) MarshalTOML() ([]byte, error) {
+	if c.Light == c.Dark {
+		return []byte(fmt.Sprintf("%q", c.Light)), nil
+	}
+	return []byte(fmt.Sprintf("{ light = %q, dark = %q }", c.Light, c.Dark)), nil
+}
+
 // adaptive converts to the lipgloss form used throughout the theme.
 func (c colorValue) adaptive() lipgloss.AdaptiveColor {
 	return lipgloss.AdaptiveColor{Light: c.Light, Dark: c.Dark}

--- a/internal/cli/tui/theme/loader_test.go
+++ b/internal/cli/tui/theme/loader_test.go
@@ -42,7 +42,10 @@ func TestLoadBuiltinUnknown(t *testing.T) {
 }
 
 func TestBuiltinNames(t *testing.T) {
-	assert.ElementsMatch(t, []string{"quiet", "rich", "colorblind"}, builtinNames())
+	assert.ElementsMatch(t, []string{
+		"quiet", "rich", "colorblind",
+		"nord", "gruvbox", "tokyo-night", "rose-pine", "catppuccin-latte",
+	}, builtinNames())
 }
 
 // TestBuiltinsAreCompleteRoots guards the design decision that every built-in

--- a/internal/cli/tui/theme/omarchy.go
+++ b/internal/cli/tui/theme/omarchy.go
@@ -90,15 +90,19 @@ func mapOmarchyPalette(oc omarchyColors) paletteFile {
 		ErrorSubtle:     mirror(oc.Color1),
 		ErrorBright:     mirror(oc.Color1),
 		Warning:         mirror(oc.Color3),
-		Done:            mirror(oc.Color2),
-		InProgress:      mirror(pick(oc.Color8, oc.Color7)),
-		Pending:         mirror(oc.Color8),
-		OpCreate:        mirror(oc.Color2),
-		OpUpdate:        mirror(oc.Color3),
-		OpDelete:        mirror(oc.Color1),
-		OpReplace:       mirror(secondary),
-		OpDetach:        mirror(oc.Color8),
-		OpKeep:          mirror(oc.Color8),
+		// Unmanaged mirrors Error (both color1), matching quiet's own
+		// unmanaged==error relationship, so the inventory marker follows the
+		// palette instead of a fixed red.
+		Unmanaged:  mirror(oc.Color1),
+		Done:       mirror(oc.Color2),
+		InProgress: mirror(pick(oc.Color8, oc.Color7)),
+		Pending:    mirror(oc.Color8),
+		OpCreate:   mirror(oc.Color2),
+		OpUpdate:   mirror(oc.Color3),
+		OpDelete:   mirror(oc.Color1),
+		OpReplace:  mirror(secondary),
+		OpDetach:   mirror(oc.Color8),
+		OpKeep:     mirror(oc.Color8),
 		// Color the logo wordmark with the OS accent so the printed logo follows
 		// the Omarchy theme, mirroring how rich tints its wordmark. The propeller
 		// stays brand orange.

--- a/internal/cli/tui/theme/omarchy_gen_test.go
+++ b/internal/cli/tui/theme/omarchy_gen_test.go
@@ -1,0 +1,98 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package theme
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// omarchyThemeSources lists the built-in themes generated from a vendored
+// Omarchy palette (palettes/<name>.colors.toml) plus attribution. Their glyphs,
+// spinner, progress, and behavior come from the "quiet" base; only the palette
+// is Omarchy-derived.
+var omarchyThemeSources = []struct{ name, credit string }{
+	{"nord", "Nord color scheme (https://www.nordtheme.com)"},
+	{"gruvbox", "Gruvbox color scheme by Pavel Pertsev (https://github.com/morhetz/gruvbox)"},
+	{"tokyo-night", "Tokyo Night color scheme by enkia (https://github.com/enkia/tokyo-night-vscode-theme)"},
+	{"rose-pine", "Rosé Pine color scheme (https://rosepinetheme.com)"},
+	{"catppuccin-latte", "Catppuccin Latte color scheme (https://catppuccin.com)"},
+}
+
+// resolvedBaseFile returns a built-in's fully resolved themeFile (glyphs,
+// progress, spinner, behavior), used as the non-palette scaffold for a
+// generated theme.
+func resolvedBaseFile(t *testing.T, name string) *themeFile {
+	t.Helper()
+	f, err := readBuiltin(name)
+	require.NoError(t, err)
+	m, err := resolveExtends(f)
+	require.NoError(t, err)
+	return m
+}
+
+// generateOmarchyTheme builds the complete-root theme TOML (attribution header +
+// body) for one Omarchy source, mapping its vendored palette onto the quiet base.
+func generateOmarchyTheme(t *testing.T, name, credit string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("palettes", name+".colors.toml"))
+	require.NoError(t, err, "vendored palette for %q", name)
+	oc, err := parseOmarchyColors(data)
+	require.NoError(t, err)
+
+	base := resolvedBaseFile(t, "quiet")
+	overlay := &themeFile{Name: name, Palette: mapOmarchyPalette(oc)}
+	merged := mergeThemeFiles(base, overlay)
+	merged.Extends = "" // built-in themes are complete, self-contained roots
+
+	var body bytes.Buffer
+	require.NoError(t, toml.NewEncoder(&body).Encode(merged))
+
+	header := fmt.Sprintf(`# %s — built-in formae CLI theme (generated; do not edit by hand).
+# Palette derived from the Omarchy %q theme, based on the %s.
+# Glyphs, spinner, progress, and behavior follow the built-in "quiet" theme.
+# Regenerate: FORMAE_UPDATE_THEMES=1 go test -tags=unit -run TestOmarchyThemesUpToDate ./internal/cli/tui/theme
+
+`, name, name, credit)
+	return append([]byte(header), body.Bytes()...)
+}
+
+// TestOmarchyThemesUpToDate guards that the committed built-in Omarchy themes
+// match what the generator produces from the vendored palettes. Set
+// FORMAE_UPDATE_THEMES=1 to (re)write them instead of asserting.
+func TestOmarchyThemesUpToDate(t *testing.T) {
+	update := os.Getenv("FORMAE_UPDATE_THEMES") != ""
+	for _, s := range omarchyThemeSources {
+		t.Run(s.name, func(t *testing.T) {
+			want := generateOmarchyTheme(t, s.name, s.credit)
+
+			// The generated file must re-parse and be complete against quiet.
+			reparsed, err := parseThemeFile(want)
+			require.NoError(t, err)
+			assert.Empty(t, reparsed.missingAgainst(quietRequiredFields()),
+				"generated %q is incomplete", s.name)
+
+			path := filepath.Join("themes", s.name+".toml")
+			if update {
+				require.NoError(t, os.WriteFile(path, want, 0o644))
+				t.Logf("wrote %s", path)
+				return
+			}
+			got, err := os.ReadFile(path)
+			require.NoError(t, err, "missing built-in theme %s; run with FORMAE_UPDATE_THEMES=1", path)
+			assert.Equal(t, string(want), string(got),
+				"%s is stale; regenerate with FORMAE_UPDATE_THEMES=1", path)
+		})
+	}
+}

--- a/internal/cli/tui/theme/palettes/catppuccin-latte.colors.toml
+++ b/internal/cli/tui/theme/palettes/catppuccin-latte.colors.toml
@@ -1,0 +1,28 @@
+# Source palette for the built-in "catppuccin-latte" formae CLI theme.
+# Vendored from the Omarchy "catppuccin-latte" theme, based on the Catppuccin Latte color scheme (https://catppuccin.com)
+# color scheme. Consumed by the theme generator (omarchy_gen_test.go);
+# not embedded or loaded at runtime.
+
+accent = "#1e66f5"
+cursor = "#dc8a78"
+foreground = "#4c4f69"
+background = "#eff1f5"
+selection_foreground = "#eff1f5"
+selection_background = "#dc8a78"
+
+color0 = "#bcc0cc"
+color1 = "#d20f39"
+color2 = "#40a02b"
+color3 = "#df8e1d"
+color4 = "#1e66f5"
+color5 = "#ea76cb"
+color6 = "#179299"
+color7 = "#5c5f77"
+color8 = "#acb0be"
+color9 = "#d20f39"
+color10 = "#40a02b"
+color11 = "#df8e1d"
+color12 = "#1e66f5"
+color13 = "#ea76cb"
+color14 = "#179299"
+color15 = "#6c6f85"

--- a/internal/cli/tui/theme/palettes/gruvbox.colors.toml
+++ b/internal/cli/tui/theme/palettes/gruvbox.colors.toml
@@ -1,0 +1,28 @@
+# Source palette for the built-in "gruvbox" formae CLI theme.
+# Vendored from the Omarchy "gruvbox" theme, based on the Gruvbox color scheme by Pavel Pertsev (https://github.com/morhetz/gruvbox)
+# color scheme. Consumed by the theme generator (omarchy_gen_test.go);
+# not embedded or loaded at runtime.
+
+accent = "#7daea3"
+cursor = "#bdae93"
+foreground = "#d4be98"
+background = "#282828"
+selection_foreground = "#ebdbb2"
+selection_background = "#d65d0e"
+
+color0 = "#3c3836"
+color1 = "#ea6962"
+color2 = "#a9b665"
+color3 = "#d8a657"
+color4 = "#7daea3"
+color5 = "#d3869b"
+color6 = "#89b482"
+color7 = "#d4be98"
+color8 = "#3c3836"
+color9 = "#ea6962"
+color10 = "#a9b665"
+color11 = "#d8a657"
+color12 = "#7daea3"
+color13 = "#d3869b"
+color14 = "#89b482"
+color15 = "#d4be98"

--- a/internal/cli/tui/theme/palettes/nord.colors.toml
+++ b/internal/cli/tui/theme/palettes/nord.colors.toml
@@ -1,0 +1,28 @@
+# Source palette for the built-in "nord" formae CLI theme.
+# Vendored from the Omarchy "nord" theme, based on the Nord color scheme (https://www.nordtheme.com)
+# color scheme. Consumed by the theme generator (omarchy_gen_test.go);
+# not embedded or loaded at runtime.
+
+accent = "#81a1c1"
+cursor = "#d8dee9"
+foreground = "#d8dee9"
+background = "#2e3440"
+selection_foreground = "#d8dee9"
+selection_background = "#4c566a"
+
+color0 = "#3b4252"
+color1 = "#bf616a"
+color2 = "#a3be8c"
+color3 = "#ebcb8b"
+color4 = "#81a1c1"
+color5 = "#b48ead"
+color6 = "#88c0d0"
+color7 = "#e5e9f0"
+color8 = "#4c566a"
+color9 = "#bf616a"
+color10 = "#a3be8c"
+color11 = "#ebcb8b"
+color12 = "#81a1c1"
+color13 = "#b48ead"
+color14 = "#8fbcbb"
+color15 = "#eceff4"

--- a/internal/cli/tui/theme/palettes/rose-pine.colors.toml
+++ b/internal/cli/tui/theme/palettes/rose-pine.colors.toml
@@ -1,0 +1,28 @@
+# Source palette for the built-in "rose-pine" formae CLI theme.
+# Vendored from the Omarchy "rose-pine" theme, based on the Rose Pine color scheme (https://rosepinetheme.com)
+# color scheme. Consumed by the theme generator (omarchy_gen_test.go);
+# not embedded or loaded at runtime.
+
+accent = "#56949f"
+cursor = "#cecacd"
+foreground = "#575279"
+background = "#faf4ed"
+selection_foreground = "#575279"
+selection_background = "#dfdad9"
+
+color0 = "#f2e9e1"
+color1 = "#b4637a"
+color2 = "#286983"
+color3 = "#ea9d34"
+color4 = "#56949f"
+color5 = "#907aa9"
+color6 = "#d7827e"
+color7 = "#575279"
+color8 = "#9893a5"
+color9 = "#b4637a"
+color10 = "#286983"
+color11 = "#ea9d34"
+color12 = "#56949f"
+color13 = "#907aa9"
+color14 = "#d7827e"
+color15 = "#575279"

--- a/internal/cli/tui/theme/palettes/tokyo-night.colors.toml
+++ b/internal/cli/tui/theme/palettes/tokyo-night.colors.toml
@@ -1,0 +1,28 @@
+# Source palette for the built-in "tokyo-night" formae CLI theme.
+# Vendored from the Omarchy "tokyo-night" theme, based on the Tokyo Night color scheme by enkia (https://github.com/enkia/tokyo-night-vscode-theme)
+# color scheme. Consumed by the theme generator (omarchy_gen_test.go);
+# not embedded or loaded at runtime.
+
+accent = "#7aa2f7"
+cursor = "#c0caf5"
+foreground = "#a9b1d6"
+background = "#1a1b26"
+selection_foreground = "#c0caf5"
+selection_background = "#7aa2f7"
+
+color0 = "#32344a"
+color1 = "#f7768e"
+color2 = "#9ece6a"
+color3 = "#e0af68"
+color4 = "#7aa2f7"
+color5 = "#ad8ee6"
+color6 = "#449dab"
+color7 = "#787c99"
+color8 = "#444b6a"
+color9 = "#ff7a93"
+color10 = "#b9f27c"
+color11 = "#ff9e64"
+color12 = "#7da6ff"
+color13 = "#bb9af7"
+color14 = "#0db9d7"
+color15 = "#acb0d0"

--- a/internal/cli/tui/theme/resolve.go
+++ b/internal/cli/tui/theme/resolve.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -54,9 +55,35 @@ func resolveWithDir(name, userDir string, warn func(string)) *Theme {
 
 	// Step 4: warn + fall back to quiet.
 	warn(fmt.Sprintf("formae: unknown cli.theme %q, falling back to quiet (available: %s)",
-		name, strings.Join(builtinNames(), ", ")))
+		name, strings.Join(availableThemeNames(userDir), ", ")))
 	th, _ := loadBuiltin("quiet")
 	return th
+}
+
+// availableThemeNames lists the theme names a user can select: every built-in,
+// the live "omarchy" theme, and any *.toml in the user theme dir. Used to make
+// the unknown-theme warning a discovery aid. Sorted and de-duplicated (a user
+// theme may shadow a built-in name).
+func availableThemeNames(userDir string) []string {
+	set := map[string]struct{}{"omarchy": {}}
+	for _, n := range builtinNames() {
+		set[n] = struct{}{}
+	}
+	if userDir != "" {
+		if entries, err := os.ReadDir(userDir); err == nil {
+			for _, e := range entries {
+				if !e.IsDir() && strings.HasSuffix(e.Name(), ".toml") {
+					set[strings.TrimSuffix(e.Name(), ".toml")] = struct{}{}
+				}
+			}
+		}
+	}
+	names := make([]string, 0, len(set))
+	for n := range set {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // loadUserTheme loads ~/.config/formae/themes/<name>.toml, resolving one level

--- a/internal/cli/tui/theme/themefile.go
+++ b/internal/cli/tui/theme/themefile.go
@@ -15,7 +15,7 @@ import (
 // key stays nil through an extends merge (Task 5).
 type themeFile struct {
 	Name    string       `toml:"name"`
-	Extends string       `toml:"extends"`
+	Extends string       `toml:"extends,omitempty"`
 	Palette paletteFile  `toml:"palette"`
 	Glyphs  glyphsFile   `toml:"glyphs"`
 	Prog    progressFile `toml:"progress"`

--- a/internal/cli/tui/theme/themes/catppuccin-latte.toml
+++ b/internal/cli/tui/theme/themes/catppuccin-latte.toml
@@ -1,0 +1,78 @@
+# catppuccin-latte — built-in formae CLI theme (generated; do not edit by hand).
+# Palette derived from the Omarchy "catppuccin-latte" theme, based on the Catppuccin Latte color scheme (https://catppuccin.com).
+# Glyphs, spinner, progress, and behavior follow the built-in "quiet" theme.
+# Regenerate: FORMAE_UPDATE_THEMES=1 go test -tags=unit -run TestOmarchyThemesUpToDate ./internal/cli/tui/theme
+
+name = "catppuccin-latte"
+
+[palette]
+  base = "#eff1f5"
+  surface = "#eff1f5"
+  text_primary = "#4c4f69"
+  text_secondary = "#5c5f77"
+  text_subtle = "#acb0be"
+  border = "#acb0be"
+  selection = "#dc8a78"
+  primary_accent = "#1e66f5"
+  secondary_accent = "#ea76cb"
+  error = "#d20f39"
+  error_subtle = "#d20f39"
+  error_bright = "#d20f39"
+  warning = "#df8e1d"
+  unmanaged = "#d20f39"
+  done = "#40a02b"
+  in_progress = "#acb0be"
+  pending = "#acb0be"
+  op_create = "#40a02b"
+  op_update = "#df8e1d"
+  op_delete = "#d20f39"
+  op_replace = "#ea76cb"
+  op_detach = "#acb0be"
+  op_keep = "#acb0be"
+  logo_wordmark = "#1e66f5"
+
+[glyphs]
+  op_create = "+"
+  op_update = "✎"
+  op_delete = "✕"
+  op_replace = "↻"
+  op_detach = "⊘"
+  op_keep = "="
+  status_done = "✓"
+  status_failed = "✗"
+  status_pending = "·"
+  status_inprogress = "◐"
+  status_skipped = "⊘"
+  status_canceled = "⊘"
+  ack_done = "✓"
+  ack_skip = "·"
+  ack_warn = "!"
+  ack_fail = "✗"
+  tree_branch = "├"
+  tree_last = "└"
+  expand_open = "▾"
+  expand_closed = "▸"
+  checkbox_on = "[x]"
+  checkbox_off = "[ ]"
+  transition = "→"
+
+[progress]
+  fill_done = "█"
+  fill_inprogress = "▓"
+  fill_pending = "░"
+  animation = "static"
+
+[spinner]
+  frames = ["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"]
+  interval_ms = 100
+  static_frame = "⣾"
+
+[confirmation_bar]
+  color = "brand"
+
+[header]
+  highlight = "brighten"
+
+[rows]
+  label_accent = false
+  delete_whole_row = false

--- a/internal/cli/tui/theme/themes/gruvbox.toml
+++ b/internal/cli/tui/theme/themes/gruvbox.toml
@@ -1,0 +1,78 @@
+# gruvbox — built-in formae CLI theme (generated; do not edit by hand).
+# Palette derived from the Omarchy "gruvbox" theme, based on the Gruvbox color scheme by Pavel Pertsev (https://github.com/morhetz/gruvbox).
+# Glyphs, spinner, progress, and behavior follow the built-in "quiet" theme.
+# Regenerate: FORMAE_UPDATE_THEMES=1 go test -tags=unit -run TestOmarchyThemesUpToDate ./internal/cli/tui/theme
+
+name = "gruvbox"
+
+[palette]
+  base = "#282828"
+  surface = "#282828"
+  text_primary = "#d4be98"
+  text_secondary = "#d4be98"
+  text_subtle = "#3c3836"
+  border = "#3c3836"
+  selection = "#d65d0e"
+  primary_accent = "#7daea3"
+  secondary_accent = "#d3869b"
+  error = "#ea6962"
+  error_subtle = "#ea6962"
+  error_bright = "#ea6962"
+  warning = "#d8a657"
+  unmanaged = "#ea6962"
+  done = "#a9b665"
+  in_progress = "#3c3836"
+  pending = "#3c3836"
+  op_create = "#a9b665"
+  op_update = "#d8a657"
+  op_delete = "#ea6962"
+  op_replace = "#d3869b"
+  op_detach = "#3c3836"
+  op_keep = "#3c3836"
+  logo_wordmark = "#7daea3"
+
+[glyphs]
+  op_create = "+"
+  op_update = "✎"
+  op_delete = "✕"
+  op_replace = "↻"
+  op_detach = "⊘"
+  op_keep = "="
+  status_done = "✓"
+  status_failed = "✗"
+  status_pending = "·"
+  status_inprogress = "◐"
+  status_skipped = "⊘"
+  status_canceled = "⊘"
+  ack_done = "✓"
+  ack_skip = "·"
+  ack_warn = "!"
+  ack_fail = "✗"
+  tree_branch = "├"
+  tree_last = "└"
+  expand_open = "▾"
+  expand_closed = "▸"
+  checkbox_on = "[x]"
+  checkbox_off = "[ ]"
+  transition = "→"
+
+[progress]
+  fill_done = "█"
+  fill_inprogress = "▓"
+  fill_pending = "░"
+  animation = "static"
+
+[spinner]
+  frames = ["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"]
+  interval_ms = 100
+  static_frame = "⣾"
+
+[confirmation_bar]
+  color = "brand"
+
+[header]
+  highlight = "brighten"
+
+[rows]
+  label_accent = false
+  delete_whole_row = false

--- a/internal/cli/tui/theme/themes/nord.toml
+++ b/internal/cli/tui/theme/themes/nord.toml
@@ -1,0 +1,78 @@
+# nord — built-in formae CLI theme (generated; do not edit by hand).
+# Palette derived from the Omarchy "nord" theme, based on the Nord color scheme (https://www.nordtheme.com).
+# Glyphs, spinner, progress, and behavior follow the built-in "quiet" theme.
+# Regenerate: FORMAE_UPDATE_THEMES=1 go test -tags=unit -run TestOmarchyThemesUpToDate ./internal/cli/tui/theme
+
+name = "nord"
+
+[palette]
+  base = "#2e3440"
+  surface = "#2e3440"
+  text_primary = "#d8dee9"
+  text_secondary = "#e5e9f0"
+  text_subtle = "#4c566a"
+  border = "#4c566a"
+  selection = "#4c566a"
+  primary_accent = "#81a1c1"
+  secondary_accent = "#b48ead"
+  error = "#bf616a"
+  error_subtle = "#bf616a"
+  error_bright = "#bf616a"
+  warning = "#ebcb8b"
+  unmanaged = "#bf616a"
+  done = "#a3be8c"
+  in_progress = "#4c566a"
+  pending = "#4c566a"
+  op_create = "#a3be8c"
+  op_update = "#ebcb8b"
+  op_delete = "#bf616a"
+  op_replace = "#b48ead"
+  op_detach = "#4c566a"
+  op_keep = "#4c566a"
+  logo_wordmark = "#81a1c1"
+
+[glyphs]
+  op_create = "+"
+  op_update = "✎"
+  op_delete = "✕"
+  op_replace = "↻"
+  op_detach = "⊘"
+  op_keep = "="
+  status_done = "✓"
+  status_failed = "✗"
+  status_pending = "·"
+  status_inprogress = "◐"
+  status_skipped = "⊘"
+  status_canceled = "⊘"
+  ack_done = "✓"
+  ack_skip = "·"
+  ack_warn = "!"
+  ack_fail = "✗"
+  tree_branch = "├"
+  tree_last = "└"
+  expand_open = "▾"
+  expand_closed = "▸"
+  checkbox_on = "[x]"
+  checkbox_off = "[ ]"
+  transition = "→"
+
+[progress]
+  fill_done = "█"
+  fill_inprogress = "▓"
+  fill_pending = "░"
+  animation = "static"
+
+[spinner]
+  frames = ["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"]
+  interval_ms = 100
+  static_frame = "⣾"
+
+[confirmation_bar]
+  color = "brand"
+
+[header]
+  highlight = "brighten"
+
+[rows]
+  label_accent = false
+  delete_whole_row = false

--- a/internal/cli/tui/theme/themes/rose-pine.toml
+++ b/internal/cli/tui/theme/themes/rose-pine.toml
@@ -1,0 +1,78 @@
+# rose-pine — built-in formae CLI theme (generated; do not edit by hand).
+# Palette derived from the Omarchy "rose-pine" theme, based on the Rosé Pine color scheme (https://rosepinetheme.com).
+# Glyphs, spinner, progress, and behavior follow the built-in "quiet" theme.
+# Regenerate: FORMAE_UPDATE_THEMES=1 go test -tags=unit -run TestOmarchyThemesUpToDate ./internal/cli/tui/theme
+
+name = "rose-pine"
+
+[palette]
+  base = "#faf4ed"
+  surface = "#faf4ed"
+  text_primary = "#575279"
+  text_secondary = "#575279"
+  text_subtle = "#9893a5"
+  border = "#9893a5"
+  selection = "#dfdad9"
+  primary_accent = "#56949f"
+  secondary_accent = "#907aa9"
+  error = "#b4637a"
+  error_subtle = "#b4637a"
+  error_bright = "#b4637a"
+  warning = "#ea9d34"
+  unmanaged = "#b4637a"
+  done = "#286983"
+  in_progress = "#9893a5"
+  pending = "#9893a5"
+  op_create = "#286983"
+  op_update = "#ea9d34"
+  op_delete = "#b4637a"
+  op_replace = "#907aa9"
+  op_detach = "#9893a5"
+  op_keep = "#9893a5"
+  logo_wordmark = "#56949f"
+
+[glyphs]
+  op_create = "+"
+  op_update = "✎"
+  op_delete = "✕"
+  op_replace = "↻"
+  op_detach = "⊘"
+  op_keep = "="
+  status_done = "✓"
+  status_failed = "✗"
+  status_pending = "·"
+  status_inprogress = "◐"
+  status_skipped = "⊘"
+  status_canceled = "⊘"
+  ack_done = "✓"
+  ack_skip = "·"
+  ack_warn = "!"
+  ack_fail = "✗"
+  tree_branch = "├"
+  tree_last = "└"
+  expand_open = "▾"
+  expand_closed = "▸"
+  checkbox_on = "[x]"
+  checkbox_off = "[ ]"
+  transition = "→"
+
+[progress]
+  fill_done = "█"
+  fill_inprogress = "▓"
+  fill_pending = "░"
+  animation = "static"
+
+[spinner]
+  frames = ["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"]
+  interval_ms = 100
+  static_frame = "⣾"
+
+[confirmation_bar]
+  color = "brand"
+
+[header]
+  highlight = "brighten"
+
+[rows]
+  label_accent = false
+  delete_whole_row = false

--- a/internal/cli/tui/theme/themes/tokyo-night.toml
+++ b/internal/cli/tui/theme/themes/tokyo-night.toml
@@ -1,0 +1,78 @@
+# tokyo-night — built-in formae CLI theme (generated; do not edit by hand).
+# Palette derived from the Omarchy "tokyo-night" theme, based on the Tokyo Night color scheme by enkia (https://github.com/enkia/tokyo-night-vscode-theme).
+# Glyphs, spinner, progress, and behavior follow the built-in "quiet" theme.
+# Regenerate: FORMAE_UPDATE_THEMES=1 go test -tags=unit -run TestOmarchyThemesUpToDate ./internal/cli/tui/theme
+
+name = "tokyo-night"
+
+[palette]
+  base = "#1a1b26"
+  surface = "#1a1b26"
+  text_primary = "#a9b1d6"
+  text_secondary = "#787c99"
+  text_subtle = "#444b6a"
+  border = "#444b6a"
+  selection = "#7aa2f7"
+  primary_accent = "#7aa2f7"
+  secondary_accent = "#ad8ee6"
+  error = "#f7768e"
+  error_subtle = "#f7768e"
+  error_bright = "#f7768e"
+  warning = "#e0af68"
+  unmanaged = "#f7768e"
+  done = "#9ece6a"
+  in_progress = "#444b6a"
+  pending = "#444b6a"
+  op_create = "#9ece6a"
+  op_update = "#e0af68"
+  op_delete = "#f7768e"
+  op_replace = "#ad8ee6"
+  op_detach = "#444b6a"
+  op_keep = "#444b6a"
+  logo_wordmark = "#7aa2f7"
+
+[glyphs]
+  op_create = "+"
+  op_update = "✎"
+  op_delete = "✕"
+  op_replace = "↻"
+  op_detach = "⊘"
+  op_keep = "="
+  status_done = "✓"
+  status_failed = "✗"
+  status_pending = "·"
+  status_inprogress = "◐"
+  status_skipped = "⊘"
+  status_canceled = "⊘"
+  ack_done = "✓"
+  ack_skip = "·"
+  ack_warn = "!"
+  ack_fail = "✗"
+  tree_branch = "├"
+  tree_last = "└"
+  expand_open = "▾"
+  expand_closed = "▸"
+  checkbox_on = "[x]"
+  checkbox_off = "[ ]"
+  transition = "→"
+
+[progress]
+  fill_done = "█"
+  fill_inprogress = "▓"
+  fill_pending = "░"
+  animation = "static"
+
+[spinner]
+  frames = ["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"]
+  interval_ms = 100
+  static_frame = "⣾"
+
+[confirmation_bar]
+  color = "brand"
+
+[header]
+  highlight = "brighten"
+
+[rows]
+  label_accent = false
+  delete_whole_row = false


### PR DESCRIPTION
## Summary

- Add five built-in CLI themes — Nord, Gruvbox, Tokyo Night, Rosé Pine, and Catppuccin Latte — that pair a well-known color scheme with the `quiet` theme's restrained behavior: neutral glyphs and layout, with each operation tinted from the scheme (create green, delete red, and so on).
- Each theme is generated from a vendored Omarchy palette by mapping it onto the `quiet` base, and committed as a complete, self-contained root so users can `extends` it like any other built-in.
- `TestOmarchyThemesUpToDate` regenerates the embedded themes from the vendored palettes when `FORMAE_UPDATE_THEMES=1`, and otherwise guards against drift.
- Add `colorValue.MarshalTOML` (the inverse of the existing `UnmarshalTOML`) so a theme file round-trips, and mark `themeFile.extends` `omitempty`.
- Map the `unmanaged` palette slot from `color1` so the inventory marker follows the palette instead of a fixed red — this also improves the live `omarchy` theme.
- The unknown-theme warning now lists every available theme, including your own in `~/.config/formae/themes/`, as a discovery aid.

Reference docs for the themes page are updated separately on the docs Mintlify migration branch.