### PR TITLE
fix(datastore): honor --max-results above the default in status queries

### DIFF
--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -1145,7 +1145,7 @@ func (d *DatastoreAuroraDataAPI) QueryFormaCommands(statusQuery *datastore.Statu
 	queryStr += " ORDER BY timestamp DESC"
 
 	limit := datastore.DefaultFormaCommandsQueryLimit
-	if statusQuery.N > 0 && statusQuery.N < limit {
+	if statusQuery.N > 0 {
 		limit = statusQuery.N
 	}
 	queryStr += fmt.Sprintf(" LIMIT %d", limit)

--- a/internal/datastore/dstest/suite_forma_commands.go
+++ b/internal/datastore/dstest/suite_forma_commands.go
@@ -568,6 +568,13 @@ func RunQueryFormaCommands(t *testing.T, newDS func(t *testing.T) TestDatastore)
 			assert.Equal(t, pkgmodel.CommandApply, result.Command)
 		}
 
+		// A max-results (N) above the default page size returns up to N rows:
+		// DefaultFormaCommandsQueryLimit is a fallback for unset N, not a ceiling.
+		query = &datastore.StatusQuery{N: 15}
+		results, err = ds.QueryFormaCommands(query)
+		assert.NoError(t, err)
+		assert.Len(t, results, 15)
+
 		query = &datastore.StatusQuery{
 			Status: &datastore.QueryItem[string]{
 				Item:       string(forma_command.CommandStateSuccess),

--- a/internal/datastore/mssql/mssql_datastore.go
+++ b/internal/datastore/mssql/mssql_datastore.go
@@ -739,7 +739,7 @@ func (d *DatastoreMSSQL) QueryFormaCommands(query *datastore.StatusQuery) ([]*fo
 
 	limit := datastore.DefaultFormaCommandsQueryLimit
 	if query.N > 0 {
-		limit = min(datastore.DefaultFormaCommandsQueryLimit, query.N)
+		limit = query.N
 	}
 
 	subqueryStr := fmt.Sprintf("SELECT TOP (%d) command_id FROM forma_commands WHERE 1=1", limit)

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -681,7 +681,7 @@ func (d DatastorePostgres) QueryFormaCommands(query *datastore.StatusQuery) ([]*
 	subqueryStr += " ORDER BY timestamp DESC"
 	if query.N > 0 {
 		subqueryStr += fmt.Sprintf(" LIMIT $%d", len(args)+1)
-		args = append(args, min(datastore.DefaultFormaCommandsQueryLimit, query.N))
+		args = append(args, query.N)
 	} else {
 		subqueryStr += fmt.Sprintf(" LIMIT %d", datastore.DefaultFormaCommandsQueryLimit)
 	}

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -897,7 +897,7 @@ func (d DatastoreSQLite) QueryFormaCommands(query *datastore.StatusQuery) ([]*fo
 	subqueryStr += " ORDER BY timestamp DESC"
 	if query.N > 0 {
 		subqueryStr += " LIMIT ?"
-		args = append(args, min(datastore.DefaultFormaCommandsQueryLimit, query.N))
+		args = append(args, query.N)
 	} else {
 		subqueryStr += fmt.Sprintf(" LIMIT %d", datastore.DefaultFormaCommandsQueryLimit)
 	}


### PR DESCRIPTION
The forma-commands status query capped its LIMIT at `min(DefaultFormaCommandsQueryLimit, query.N)`, so any requested max-results above the default (10) was silently clamped to 10 across all four backends (postgres, sqlite, mssql, aurora). The default is a fallback for an unset N, not a ceiling: when N > 0 the query now uses N directly. Adds a regression test that an N above the default returns up to N rows.