### PR TITLE
fix(resolver): stop resolved secrets leaking into marshal-error logs

### DIFF
--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -312,7 +312,7 @@ func (pr *propertyResolver) marshalWithLogging(value any, context string, path s
 		slog.Error("Failed to marshal value",
 			"context", context,
 			"path", path,
-			"value", value,
+			"value", pkgmodel.RedactOpaqueForLog(value),
 			"error", err)
 	}
 	return result, err

--- a/internal/metastructure/resolver/resolver_scrub_test.go
+++ b/internal/metastructure/resolver/resolver_scrub_test.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/platform-engineering-labs/formae/internal/logging"
 )
 
@@ -30,20 +33,15 @@ func TestMarshalWithLogging_DoesNotLogOpaquePlaintextOnError(t *testing.T) {
 		"unmarshalable": make(chan int),
 	}
 
-	if _, err := pr.marshalWithLogging(value, "reference resolution", "config.auth"); err == nil {
-		t.Fatal("expected a marshal error to exercise the logging branch")
-	}
+	_, err := pr.marshalWithLogging(value, "reference resolution", "config.auth")
+	require.Error(t, err, "expected a marshal error to exercise the logging branch")
 
 	found := false
 	for _, entry := range capture.GetEntries() {
-		if strings.Contains(entry, "super-secret") {
-			t.Fatalf("plaintext secret leaked into a log entry: %q", entry)
-		}
+		assert.NotContains(t, entry, "super-secret", "plaintext secret leaked into a log entry")
 		if strings.Contains(entry, "<redacted>") {
 			found = true
 		}
 	}
-	if !found {
-		t.Fatalf("expected at least one log entry to contain %q, but none did", "<redacted>")
-	}
+	assert.True(t, found, "expected at least one log entry to contain \"<redacted>\"")
 }

--- a/internal/metastructure/resolver/resolver_scrub_test.go
+++ b/internal/metastructure/resolver/resolver_scrub_test.go
@@ -1,0 +1,42 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resolver
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/internal/logging"
+)
+
+// marshalWithLogging must never emit an opaque value's plaintext, even when the
+// marshal it is logging about has failed.
+func TestMarshalWithLogging_DoesNotLogOpaquePlaintextOnError(t *testing.T) {
+	capture := logging.NewTestLogCaptureQuiet()
+	slog.SetDefault(slog.New(slog.NewTextHandler(capture, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	pr := &propertyResolver{}
+	// A resolved opaque ref envelope, plus a value json.Marshal cannot encode,
+	// so the error branch that logs the value is exercised.
+	value := map[string]any{
+		"$ref":          "formae://secret",
+		"$visibility":   "Opaque",
+		"$value":        "super-secret",
+		"unmarshalable": make(chan int),
+	}
+
+	if _, err := pr.marshalWithLogging(value, "reference resolution", "config.auth"); err == nil {
+		t.Fatal("expected a marshal error to exercise the logging branch")
+	}
+
+	for _, entry := range capture.GetEntries() {
+		if strings.Contains(entry, "super-secret") {
+			t.Fatalf("plaintext secret leaked into a log entry: %q", entry)
+		}
+	}
+}

--- a/internal/metastructure/resolver/resolver_scrub_test.go
+++ b/internal/metastructure/resolver/resolver_scrub_test.go
@@ -34,9 +34,16 @@ func TestMarshalWithLogging_DoesNotLogOpaquePlaintextOnError(t *testing.T) {
 		t.Fatal("expected a marshal error to exercise the logging branch")
 	}
 
+	found := false
 	for _, entry := range capture.GetEntries() {
 		if strings.Contains(entry, "super-secret") {
 			t.Fatalf("plaintext secret leaked into a log entry: %q", entry)
 		}
+		if strings.Contains(entry, "<redacted>") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected at least one log entry to contain %q, but none did", "<redacted>")
 	}
 }

--- a/pkg/model/redact.go
+++ b/pkg/model/redact.go
@@ -13,6 +13,9 @@ const RedactedForLog = "<redacted>"
 // by RedactedForLog. An opaque envelope is a map carrying "$visibility": "Opaque"
 // (with or without a "$ref"). Maps and slices are walked recursively; every other
 // kind of data is returned unchanged. The input is never mutated.
+// It descends only into map[string]any and []any values; a json.RawMessage or
+// []byte (an already-serialized payload) is treated as a leaf and is not walked.
+// Pass decoded JSON so nested opaque values are found.
 func RedactOpaqueForLog(v any) any {
 	switch t := v.(type) {
 	case map[string]any:

--- a/pkg/model/redact.go
+++ b/pkg/model/redact.go
@@ -1,0 +1,38 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package model
+
+// RedactedForLog is substituted for the plaintext of an opaque value when it is
+// prepared for logging or other diagnostics.
+const RedactedForLog = "<redacted>"
+
+// RedactOpaqueForLog returns a deep copy of v that is safe to pass to slog or
+// json.Marshal for diagnostics: the "$value" of every opaque envelope is replaced
+// by RedactedForLog. An opaque envelope is a map carrying "$visibility": "Opaque"
+// (with or without a "$ref"). Maps and slices are walked recursively; every other
+// kind of data is returned unchanged. The input is never mutated.
+func RedactOpaqueForLog(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		opaque := t["$visibility"] == VisibilityOpaque
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			if opaque && k == "$value" {
+				out[k] = RedactedForLog
+				continue
+			}
+			out[k] = RedactOpaqueForLog(val)
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, val := range t {
+			out[i] = RedactOpaqueForLog(val)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/pkg/model/redact.go
+++ b/pkg/model/redact.go
@@ -4,6 +4,8 @@
 
 package model
 
+import "encoding/json"
+
 // RedactedForLog is substituted for the plaintext of an opaque value when it is
 // prepared for logging or other diagnostics.
 const RedactedForLog = "<redacted>"
@@ -13,9 +15,9 @@ const RedactedForLog = "<redacted>"
 // by RedactedForLog. An opaque envelope is a map carrying "$visibility": "Opaque"
 // (with or without a "$ref"). Maps and slices are walked recursively; every other
 // kind of data is returned unchanged. The input is never mutated.
-// It descends only into map[string]any and []any values; a json.RawMessage or
-// []byte (an already-serialized payload) is treated as a leaf and is not walked.
-// Pass decoded JSON so nested opaque values are found.
+// json.RawMessage and []byte values are attempted as JSON: if they parse
+// successfully the decoded value is recursed into and the (redacted) decoded
+// result is returned; unparseable byte slices are returned unchanged.
 func RedactOpaqueForLog(v any) any {
 	switch t := v.(type) {
 	case map[string]any:
@@ -35,6 +37,18 @@ func RedactOpaqueForLog(v any) any {
 			out[i] = RedactOpaqueForLog(val)
 		}
 		return out
+	case json.RawMessage:
+		var decoded any
+		if err := json.Unmarshal(t, &decoded); err != nil {
+			return v
+		}
+		return RedactOpaqueForLog(decoded)
+	case []byte:
+		var decoded any
+		if err := json.Unmarshal(t, &decoded); err != nil {
+			return v
+		}
+		return RedactOpaqueForLog(decoded)
 	default:
 		return v
 	}

--- a/pkg/model/redact_test.go
+++ b/pkg/model/redact_test.go
@@ -7,7 +7,9 @@
 package model
 
 import (
+	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -20,6 +22,11 @@ func TestRedactOpaqueForLog_RedactsOpaqueValue(t *testing.T) {
 	}
 	if in["$value"] != "super-secret" {
 		t.Fatalf("input was mutated: $value = %v", in["$value"])
+	}
+
+	// Positive assertion: output $value must equal RedactedForLog exactly.
+	if got, want := out["$value"], any(RedactedForLog); got != want {
+		t.Fatalf("expected $value == %q, got %v", want, got)
 	}
 }
 
@@ -76,5 +83,60 @@ func TestRedactOpaqueForLog_PassesThroughScalars(t *testing.T) {
 	nested := []any{"a", map[string]any{"k": "v"}}
 	if got := RedactOpaqueForLog(nested); !reflect.DeepEqual(got, nested) {
 		t.Fatalf("non-opaque structure changed: %v", got)
+	}
+}
+
+func TestRedactOpaqueForLog_RedactsOpaqueInsideJSONRawMessage(t *testing.T) {
+	raw := json.RawMessage(`{"auth":{"$visibility":"Opaque","$value":"super-secret"}}`)
+	in := map[string]any{
+		"payload": raw,
+	}
+	out := RedactOpaqueForLog(in).(map[string]any)
+
+	// The payload must have been decoded and recursed into, producing a map.
+	payload, ok := out["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected payload to be map[string]any after redaction, got %T", out["payload"])
+	}
+	auth, ok := payload["auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected auth to be map[string]any, got %T", payload["auth"])
+	}
+
+	// Positive assertion: $value must equal RedactedForLog.
+	if got := auth["$value"]; got != RedactedForLog {
+		t.Fatalf("expected $value = %q, got %v", RedactedForLog, got)
+	}
+
+	// Confirm plaintext does not appear when the result is serialized.
+	// Use a bytes.Buffer + json.Encoder with HTML escaping disabled so we can
+	// also check for the literal RedactedForLog string.
+	var buf strings.Builder
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(out); err != nil {
+		t.Fatalf("failed to encode result: %v", err)
+	}
+	result := buf.String()
+
+	if strings.Contains(result, "super-secret") {
+		t.Fatalf("plaintext secret leaked into redacted output: %s", result)
+	}
+	if !strings.Contains(result, RedactedForLog) {
+		t.Fatalf("expected %q in redacted output, got: %s", RedactedForLog, result)
+	}
+}
+
+func TestRedactOpaqueForLog_UnparseableByteSlicePassedThrough(t *testing.T) {
+	bad := []byte{0xff, 0xfe}
+	in := map[string]any{"raw": bad}
+	out := RedactOpaqueForLog(in).(map[string]any)
+
+	got, ok := out["raw"].([]byte)
+	if !ok {
+		t.Fatalf("expected []byte, got %T", out["raw"])
+	}
+	if !reflect.DeepEqual(got, bad) {
+		t.Fatalf("unparseable []byte was modified: %v", got)
 	}
 }

--- a/pkg/model/redact_test.go
+++ b/pkg/model/redact_test.go
@@ -1,0 +1,80 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package model
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRedactOpaqueForLog_RedactsOpaqueValue(t *testing.T) {
+	in := map[string]any{"$visibility": "Opaque", "$value": "super-secret"}
+	out := RedactOpaqueForLog(in).(map[string]any)
+
+	if out["$value"] != RedactedForLog {
+		t.Fatalf("expected $value = %q, got %v", RedactedForLog, out["$value"])
+	}
+	if in["$value"] != "super-secret" {
+		t.Fatalf("input was mutated: $value = %v", in["$value"])
+	}
+}
+
+func TestRedactOpaqueForLog_RedactsOpaqueRefEnvelope(t *testing.T) {
+	in := map[string]any{
+		"$ref":        "formae://res",
+		"$visibility": "Opaque",
+		"$value":      "super-secret",
+	}
+	out := RedactOpaqueForLog(in).(map[string]any)
+
+	if out["$value"] != RedactedForLog {
+		t.Fatalf("expected $value redacted, got %v", out["$value"])
+	}
+	if out["$ref"] != "formae://res" {
+		t.Fatalf("expected $ref preserved, got %v", out["$ref"])
+	}
+}
+
+func TestRedactOpaqueForLog_RedactsNestedAndInSlice(t *testing.T) {
+	in := map[string]any{
+		"config": map[string]any{
+			"auth": map[string]any{"$visibility": "Opaque", "$value": "super-secret"},
+		},
+		"list": []any{
+			map[string]any{"$visibility": "Opaque", "$value": "another-secret"},
+		},
+	}
+	out := RedactOpaqueForLog(in).(map[string]any)
+
+	auth := out["config"].(map[string]any)["auth"].(map[string]any)
+	if auth["$value"] != RedactedForLog {
+		t.Fatalf("nested opaque value not redacted: %v", auth["$value"])
+	}
+	elem := out["list"].([]any)[0].(map[string]any)
+	if elem["$value"] != RedactedForLog {
+		t.Fatalf("opaque value in slice not redacted: %v", elem["$value"])
+	}
+}
+
+func TestRedactOpaqueForLog_PreservesClearValue(t *testing.T) {
+	in := map[string]any{"$visibility": "Clear", "$value": "public"}
+	out := RedactOpaqueForLog(in).(map[string]any)
+
+	if out["$value"] != "public" {
+		t.Fatalf("clear value must be preserved, got %v", out["$value"])
+	}
+}
+
+func TestRedactOpaqueForLog_PassesThroughScalars(t *testing.T) {
+	if got := RedactOpaqueForLog("plain"); got != "plain" {
+		t.Fatalf("scalar changed: %v", got)
+	}
+	nested := []any{"a", map[string]any{"k": "v"}}
+	if got := RedactOpaqueForLog(nested); !reflect.DeepEqual(got, nested) {
+		t.Fatalf("non-opaque structure changed: %v", got)
+	}
+}

--- a/pkg/model/redact_test.go
+++ b/pkg/model/redact_test.go
@@ -8,26 +8,19 @@ package model
 
 import (
 	"encoding/json"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRedactOpaqueForLog_RedactsOpaqueValue(t *testing.T) {
 	in := map[string]any{"$visibility": "Opaque", "$value": "super-secret"}
 	out := RedactOpaqueForLog(in).(map[string]any)
 
-	if out["$value"] != RedactedForLog {
-		t.Fatalf("expected $value = %q, got %v", RedactedForLog, out["$value"])
-	}
-	if in["$value"] != "super-secret" {
-		t.Fatalf("input was mutated: $value = %v", in["$value"])
-	}
-
-	// Positive assertion: output $value must equal RedactedForLog exactly.
-	if got, want := out["$value"], any(RedactedForLog); got != want {
-		t.Fatalf("expected $value == %q, got %v", want, got)
-	}
+	assert.Equal(t, RedactedForLog, out["$value"])
+	assert.Equal(t, "super-secret", in["$value"], "input must not be mutated")
 }
 
 func TestRedactOpaqueForLog_RedactsOpaqueRefEnvelope(t *testing.T) {
@@ -38,12 +31,8 @@ func TestRedactOpaqueForLog_RedactsOpaqueRefEnvelope(t *testing.T) {
 	}
 	out := RedactOpaqueForLog(in).(map[string]any)
 
-	if out["$value"] != RedactedForLog {
-		t.Fatalf("expected $value redacted, got %v", out["$value"])
-	}
-	if out["$ref"] != "formae://res" {
-		t.Fatalf("expected $ref preserved, got %v", out["$ref"])
-	}
+	assert.Equal(t, RedactedForLog, out["$value"])
+	assert.Equal(t, "formae://res", out["$ref"], "$ref must be preserved")
 }
 
 func TestRedactOpaqueForLog_RedactsNestedAndInSlice(t *testing.T) {
@@ -58,32 +47,22 @@ func TestRedactOpaqueForLog_RedactsNestedAndInSlice(t *testing.T) {
 	out := RedactOpaqueForLog(in).(map[string]any)
 
 	auth := out["config"].(map[string]any)["auth"].(map[string]any)
-	if auth["$value"] != RedactedForLog {
-		t.Fatalf("nested opaque value not redacted: %v", auth["$value"])
-	}
+	assert.Equal(t, RedactedForLog, auth["$value"], "nested opaque value must be redacted")
 	elem := out["list"].([]any)[0].(map[string]any)
-	if elem["$value"] != RedactedForLog {
-		t.Fatalf("opaque value in slice not redacted: %v", elem["$value"])
-	}
+	assert.Equal(t, RedactedForLog, elem["$value"], "opaque value in slice must be redacted")
 }
 
 func TestRedactOpaqueForLog_PreservesClearValue(t *testing.T) {
 	in := map[string]any{"$visibility": "Clear", "$value": "public"}
 	out := RedactOpaqueForLog(in).(map[string]any)
 
-	if out["$value"] != "public" {
-		t.Fatalf("clear value must be preserved, got %v", out["$value"])
-	}
+	assert.Equal(t, "public", out["$value"], "clear value must be preserved")
 }
 
 func TestRedactOpaqueForLog_PassesThroughScalars(t *testing.T) {
-	if got := RedactOpaqueForLog("plain"); got != "plain" {
-		t.Fatalf("scalar changed: %v", got)
-	}
+	assert.Equal(t, "plain", RedactOpaqueForLog("plain"))
 	nested := []any{"a", map[string]any{"k": "v"}}
-	if got := RedactOpaqueForLog(nested); !reflect.DeepEqual(got, nested) {
-		t.Fatalf("non-opaque structure changed: %v", got)
-	}
+	assert.Equal(t, nested, RedactOpaqueForLog(nested), "non-opaque structure must be unchanged")
 }
 
 func TestRedactOpaqueForLog_RedactsOpaqueInsideJSONRawMessage(t *testing.T) {
@@ -95,36 +74,22 @@ func TestRedactOpaqueForLog_RedactsOpaqueInsideJSONRawMessage(t *testing.T) {
 
 	// The payload must have been decoded and recursed into, producing a map.
 	payload, ok := out["payload"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected payload to be map[string]any after redaction, got %T", out["payload"])
-	}
+	require.Truef(t, ok, "expected payload to be map[string]any after redaction, got %T", out["payload"])
 	auth, ok := payload["auth"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected auth to be map[string]any, got %T", payload["auth"])
-	}
+	require.Truef(t, ok, "expected auth to be map[string]any, got %T", payload["auth"])
 
-	// Positive assertion: $value must equal RedactedForLog.
-	if got := auth["$value"]; got != RedactedForLog {
-		t.Fatalf("expected $value = %q, got %v", RedactedForLog, got)
-	}
+	assert.Equal(t, RedactedForLog, auth["$value"])
 
-	// Confirm plaintext does not appear when the result is serialized.
-	// Use a bytes.Buffer + json.Encoder with HTML escaping disabled so we can
-	// also check for the literal RedactedForLog string.
+	// Confirm plaintext does not appear when the result is serialized. Disable
+	// HTML escaping so we can also check for the literal RedactedForLog string.
 	var buf strings.Builder
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
-	if err := enc.Encode(out); err != nil {
-		t.Fatalf("failed to encode result: %v", err)
-	}
+	require.NoError(t, enc.Encode(out))
 	result := buf.String()
 
-	if strings.Contains(result, "super-secret") {
-		t.Fatalf("plaintext secret leaked into redacted output: %s", result)
-	}
-	if !strings.Contains(result, RedactedForLog) {
-		t.Fatalf("expected %q in redacted output, got: %s", RedactedForLog, result)
-	}
+	assert.NotContains(t, result, "super-secret", "plaintext secret must not leak into redacted output")
+	assert.Contains(t, result, RedactedForLog)
 }
 
 func TestRedactOpaqueForLog_UnparseableByteSlicePassedThrough(t *testing.T) {
@@ -133,10 +98,6 @@ func TestRedactOpaqueForLog_UnparseableByteSlicePassedThrough(t *testing.T) {
 	out := RedactOpaqueForLog(in).(map[string]any)
 
 	got, ok := out["raw"].([]byte)
-	if !ok {
-		t.Fatalf("expected []byte, got %T", out["raw"])
-	}
-	if !reflect.DeepEqual(got, bad) {
-		t.Fatalf("unparseable []byte was modified: %v", got)
-	}
+	require.Truef(t, ok, "expected []byte, got %T", out["raw"])
+	assert.Equal(t, bad, got, "unparseable []byte must not be modified")
 }


### PR DESCRIPTION
## Summary

- Add `RedactOpaqueForLog` to `pkg/model`: a small, reusable helper that returns a log-safe deep copy of arbitrary JSON-shaped data, replacing the `$value` of any opaque envelope (a map carrying `$visibility: "Opaque"`, with or without a `$ref`) with `<redacted>`. It walks maps and slices recursively and never mutates its input. It descends only into `map[string]any`/`[]any`, not already-serialized payloads.
- Fix a cleartext-secret leak in the resolver: on a marshal failure, `marshalWithLogging` logged the raw reference object, which carries the resolved secret's `$value`. Because that object is a plain map rather than a typed `Value`, it bypassed the existing `Value.LogValue()` redactor. The logged value is now routed through `RedactOpaqueForLog`.
- Add unit tests for the redactor and a regression test that fails without the fix and asserts the resolver error path emits no plaintext.

## Why

A resolved secret should never reach a log in cleartext. The typed redactor only covers values logged as `*Value`; the resolver logs a `map[string]any`, so a marshal-error path could emit the secret verbatim. This closes that path and provides the shared redaction primitive that later secret-reference work routes its new log and error paths through.

Behavior is unchanged apart from the redacted log field.