### PR TITLE
feat(schema): add first-class secret base types and map .at() accessor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,8 @@ mutation-test: build
 
 test-schema-pkl:
 	cd internal/schema/pkl/schema && pkl test tests/formae.pkl
+	cd internal/schema/pkl/schema && pkl test tests/collection_resolvable_test.pkl
+	cd internal/schema/pkl/schema && pkl test tests/secret_resolvable_test.pkl
 	cd internal/schema/pkl/assets && pkl test tests/PklProjectTemplate_test.pkl
 
 test-generator-pkl:

--- a/internal/schema/pkl/pkl_test.go
+++ b/internal/schema/pkl/pkl_test.go
@@ -255,6 +255,18 @@ func TestPkl_FormaeConfig(t *testing.T) {
 	assert.Equal(t, "auto", config.Cli.Appearance)
 }
 
+func TestPkl_SecretShapeMisuse_AtOnScalarFailsEval(t *testing.T) {
+	p := PKL{}
+	_, err := p.Evaluate("./testdata/forma/secret_at_on_scalar_test.pkl", model.CommandApply, model.FormaApplyModeReconcile, nil)
+	assert.Error(t, err)
+}
+
+func TestPkl_SecretShapeMisuse_BareMapSecretValueFailsEval(t *testing.T) {
+	p := PKL{}
+	_, err := p.Evaluate("./testdata/forma/secret_bare_map_value_test.pkl", model.CommandApply, model.FormaApplyModeReconcile, nil)
+	assert.Error(t, err)
+}
+
 func TestTranslateResourcePluginConfig(t *testing.T) {
 	p := PKL{}
 	config, err := p.FormaeConfig("./testdata/config/test_resource_plugin_config.pkl")

--- a/internal/schema/pkl/pkl_test.go
+++ b/internal/schema/pkl/pkl_test.go
@@ -258,13 +258,15 @@ func TestPkl_FormaeConfig(t *testing.T) {
 func TestPkl_SecretShapeMisuse_AtOnScalarFailsEval(t *testing.T) {
 	p := PKL{}
 	_, err := p.Evaluate("./testdata/forma/secret_at_on_scalar_test.pkl", model.CommandApply, model.FormaApplyModeReconcile, nil)
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "Cannot find method `at`")
 }
 
 func TestPkl_SecretShapeMisuse_BareMapSecretValueFailsEval(t *testing.T) {
 	p := PKL{}
 	_, err := p.Evaluate("./testdata/forma/secret_bare_map_value_test.pkl", model.CommandApply, model.FormaApplyModeReconcile, nil)
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "SecretMapAccessor")
 }
 
 func TestTranslateResourcePluginConfig(t *testing.T) {

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -53,6 +53,13 @@ open class Resource {
     }
 }
 
+/// Base for first-class secret resources. A provider's secret (aws.Secret, the
+/// Azure Key Vault Secret, ...) extends this and names its value property. The
+/// rotation field is intentionally absent in this stage (deferred to Stage 2).
+abstract class Secret extends Resource {
+    hidden valueProperty: String
+}
+
 open class SubResource {
     function props(): Dynamic = module.fq.subresourceProps(reflect.Class(this.getClass()), this)
     function render(): Dynamic = this.props()
@@ -406,6 +413,61 @@ open class ListingResolvable extends Resolvable {
         property = if (_self.property != null)
             _self.property + "." + index.toString()
             else index.toString()
+        visibility = _self.visibility
+    }
+}
+
+/// The consumable result of a secret reference: `secret.res.secretValue` (scalar)
+/// or `secret.res.secretValue.at(key)` (map). Opacity is derived agent-side from
+/// the source field's FieldHint.Opaque, not re-declared here.
+open class SecretValueResolvable extends Resolvable {}
+
+/// Scalar secret backends (e.g. AWS SecretString, Azure value): `secretValue` IS
+/// the value. There is no at(). A plugin's secret resolvable extends this and
+/// sets valueProperty.
+open class ScalarSecretResolvable extends Resolvable {
+    local _self = this
+    hidden valueProperty: String
+    hidden secretValue: SecretValueResolvable = new {
+        label = _self.label
+        type = _self.type
+        stack = _self.stack
+        property = valueProperty
+        visibility = _self.visibility
+    }
+}
+
+/// Accessor for map secret backends. Intentionally NOT a Resolvable: a bare
+/// `secretValue` (a forgotten .at()) cannot be assigned to a Resolvable-typed
+/// consumer field, so the mistake is a PKL eval-time type error. Only .at(key)
+/// produces a Resolvable.
+class SecretMapAccessor {
+    hidden label: String?
+    hidden type: String(matches(Regex(#"^.*::.*$"#)))?
+    hidden stack: String?
+    hidden valueProperty: String
+    hidden visibility: "Clear"|"Opaque" = "Clear"
+    /// Access a value by key in the resolved map. Colons and dots are escaped for
+    /// gjson, matching MappingResolvable.at.
+    function at(key: String): SecretValueResolvable = new {
+        label = this.label
+        type = this.type
+        stack = this.stack
+        property = valueProperty + "." + key.replaceAll(":", "\\:").replaceAll(".", "\\.")
+        visibility = this.visibility
+    }
+}
+
+/// Map secret backends (e.g. Kubernetes data, a Vault KV path): `secretValue` is
+/// an accessor you must .at() into.
+open class MapSecretResolvable extends Resolvable {
+    local _self = this
+    hidden valueProperty: String
+    hidden secretValue: SecretMapAccessor = new {
+        label = _self.label
+        type = _self.type
+        stack = _self.stack
+        valueProperty = _self.valueProperty
         visibility = _self.visibility
     }
 }

--- a/internal/schema/pkl/schema/tests/secret_resolvable_test.pkl
+++ b/internal/schema/pkl/schema/tests/secret_resolvable_test.pkl
@@ -1,0 +1,42 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+/// Tests for SecretValueResolvable, ScalarSecretResolvable, SecretMapAccessor,
+/// and MapSecretResolvable.
+/// Run with: pkl test internal/schema/pkl/schema/tests/secret_resolvable_test.pkl
+amends "pkl:test"
+
+import "../formae.pkl"
+
+local class TestScalarSecret extends formae.ScalarSecretResolvable {
+  valueProperty = "SecretString"
+}
+local class TestMapSecret extends formae.MapSecretResolvable {
+  valueProperty = "data"
+}
+
+local scalar: TestScalarSecret = new { label = "db"; type = "Test::Secret"; stack = "default" }
+local mapSecret: TestMapSecret = new { label = "kv"; type = "Test::Secret"; stack = "default" }
+
+facts {
+  ["scalar secretValue targets the value property and is a SecretValueResolvable"] {
+    scalar.secretValue.$property == "SecretString"
+    scalar.secretValue is formae.SecretValueResolvable
+    scalar.secretValue.$res == true
+    scalar.secretValue.$label == "db"
+    scalar.secretValue.$stack == "default"
+  }
+  ["map secretValue is a SecretMapAccessor, NOT a Resolvable"] {
+    mapSecret.secretValue is formae.SecretMapAccessor
+    !(mapSecret.secretValue is formae.Resolvable)
+  }
+  ["map .at(key) folds the key into the property path (gjson escaping) and yields a Resolvable leaf"] {
+    mapSecret.secretValue.at("token").$property == "data.token"
+    mapSecret.secretValue.at("a.b").$property == "data.a\\.b"
+    mapSecret.secretValue.at("h:1").$property == "data.h\\:1"
+    mapSecret.secretValue.at("token") is formae.SecretValueResolvable
+  }
+}

--- a/internal/schema/pkl/testdata/forma/secret_at_on_scalar_test.pkl
+++ b/internal/schema/pkl/testdata/forma/secret_at_on_scalar_test.pkl
@@ -1,0 +1,41 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+// Shape-misuse test: calling .at() on a ScalarSecretResolvable's secretValue,
+// which is a SecretValueResolvable (no .at() method). PKL eval fails with a
+// method-not-found error because ScalarSecretResolvable has no .at() accessor.
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+import "@formae/debug/debug.pkl"
+import "@fakeaws/fakeaws.pkl"
+
+forma {
+  new formae.Stack {
+    label = "test-stack"
+    description = "Scalar secret shape misuse test"
+  }
+
+  new formae.Target {
+    label = "test-target"
+    config = new fakeaws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  local scalarRes = new formae.ScalarSecretResolvable {
+    label = "my-secret"
+    type = "FakeAWS::SecretsManager::Secret"
+    stack = "test-stack"
+    valueProperty = "SecretString"
+  }
+
+  // Misuse: SecretValueResolvable has no .at(); calling it is a PKL eval error.
+  new debug.Consumer {
+    label = "consumer"
+    value = scalarRes.secretValue.at("x")
+  }
+}

--- a/internal/schema/pkl/testdata/forma/secret_bare_map_value_test.pkl
+++ b/internal/schema/pkl/testdata/forma/secret_bare_map_value_test.pkl
@@ -1,0 +1,42 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+// Shape-misuse test: assigning a SecretMapAccessor (mapRes.secretValue) directly
+// to a Resolvable-typed consumer field without calling .at(key) first.
+// PKL eval fails with a type error because SecretMapAccessor is not a Resolvable.
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+import "@formae/debug/debug.pkl"
+import "@fakeaws/fakeaws.pkl"
+
+forma {
+  new formae.Stack {
+    label = "test-stack"
+    description = "Map secret shape misuse test"
+  }
+
+  new formae.Target {
+    label = "test-target"
+    config = new fakeaws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  local mapRes = new formae.MapSecretResolvable {
+    label = "my-map-secret"
+    type = "FakeAWS::SecretsManager::Secret"
+    stack = "test-stack"
+    valueProperty = "SecretString"
+  }
+
+  // Misuse: SecretMapAccessor is not a Resolvable; assigning it directly
+  // to a Resolvable-typed field is a PKL eval-time type error.
+  new debug.Consumer {
+    label = "consumer"
+    value = mapRes.secretValue
+  }
+}


### PR DESCRIPTION
## Summary

- Adds the first-class-secret PKL base types to the formae schema: `SecretValueResolvable` (the consumable resolved-secret leaf), `ScalarSecretResolvable` (scalar backends — `secretValue` IS the value), `MapSecretResolvable` + `SecretMapAccessor` (map backends — `secretValue.at(key)`), and `abstract class Secret extends Resource`.
- The scalar/map shape distinction is enforced at PKL eval time by the type system: `SecretMapAccessor` is deliberately NOT a `Resolvable`, so a bare map `secretValue` (a forgotten `.at()`) — or `.at()` on a scalar — is a type error rather than a runtime surprise. Covered by `pkl test` facts and Go eval-negative tests that assert the intended error substrings.
- `.at(key)` folds the key into the resolvable property path with the same gjson escaping as the existing `MappingResolvable.at`, so it rides the existing `$res`→`$ref` URI rewrite with no engine change.
- Pure schema addition: no resolver/value/Go changes, no `.json()`/`$json`, and no rotation field — all deferred to later slices.

## Why

First step toward first-class secret references: the authoring surface and its shape safety. Live resolution, reference-don't-store persistence, and JSON navigation land in subsequent slices. `abstract class Secret` is a forward-declaration that provider secret resources will subclass.

Stacked on the log-scrubbing prerequisite branch (base `secrets-stage1-slice1-scrubbing`); GitHub will retarget this to `main` once that merges.