### PR TITLE
feat(schema,resolver): secret .json(path) navigation end-to-end

### DIFF
--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -900,7 +900,15 @@ func resolveRefs(current, mod map[string]any, resolvableProperties resolver.Reso
 
 				val, found := resolvableProperties.Get(ksuid, property)
 				if found {
-					modVal["$value"] = normalizeResolvedValue(val, current[k])
+					resolved := val
+					if jsonPath, ok := modVal["$json"].(string); ok && jsonPath != "" {
+						extracted, err := resolver.ExtractJSONPath(val, jsonPath)
+						if err != nil {
+							return err
+						}
+						resolved = extracted
+					}
+					modVal["$value"] = normalizeResolvedValue(resolved, current[k])
 				}
 				// If not found, keep the $ref as-is for late-binding resolution
 				// at execution time (forward references to new resources).

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -705,10 +705,9 @@ func TestResolveRefs_UnresolvedForwardRefLeftIntact(t *testing.T) {
 	assert.False(t, hasValue, "an unresolved forward ref must not gain a $value")
 }
 
-// TestResolveRefs_JSONPathAppliedOnUpdatePath verifies that resolveRefs applies the
-// $json extraction when a mod envelope carries both $ref and $json. Without the fix,
-// resolveRefs would set $value to the entire resolved JSON document; with the fix it
-// extracts only the scalar at the given dotted path.
+// TestResolveRefs_JSONPathAppliedOnUpdatePath verifies that resolveRefs, when a
+// mod envelope carries both $ref and $json, sets $value to the scalar extracted
+// at the $json dotted path rather than to the entire resolved JSON document.
 func TestResolveRefs_JSONPathAppliedOnUpdatePath(t *testing.T) {
 	resourceKsuid := util.NewID()
 	uri := fmt.Sprintf("formae://%s#/SecretString", resourceKsuid)

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -705,6 +705,37 @@ func TestResolveRefs_UnresolvedForwardRefLeftIntact(t *testing.T) {
 	assert.False(t, hasValue, "an unresolved forward ref must not gain a $value")
 }
 
+// TestResolveRefs_JSONPathAppliedOnUpdatePath verifies that resolveRefs applies the
+// $json extraction when a mod envelope carries both $ref and $json. Without the fix,
+// resolveRefs would set $value to the entire resolved JSON document; with the fix it
+// extracts only the scalar at the given dotted path.
+func TestResolveRefs_JSONPathAppliedOnUpdatePath(t *testing.T) {
+	resourceKsuid := util.NewID()
+	uri := fmt.Sprintf("formae://%s#/SecretString", resourceKsuid)
+
+	current := map[string]any{"Password": "old-value"}
+	mod := map[string]any{
+		"Password": map[string]any{
+			"$ref":  uri,
+			"$json": "db.password",
+		},
+	}
+
+	props := resolver.NewResolvableProperties()
+	props.Add(resourceKsuid, "SecretString", `{"db":{"password":"the-secret"}}`)
+
+	err := resolveRefs(current, mod, props)
+	require.NoError(t, err)
+
+	envelope, ok := mod["Password"].(map[string]any)
+	require.True(t, ok)
+
+	got, hasValue := envelope["$value"]
+	require.True(t, hasValue, "resolveRefs must set $value on the mod envelope")
+	assert.Equal(t, "the-secret", got,
+		"resolveRefs must extract the scalar at the $json path, not return the whole document")
+}
+
 func TestRemoveNonSchemaFields_ThreeFieldsTotalTwoSchemaFields_RemovesNonSchemaField(t *testing.T) {
 	document := []byte(`{"a": "a", "b": "b", "c": "c"}`)
 	schemaFields := []string{"a", "c"}

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -15,6 +15,45 @@ import (
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
+const (
+	maxJSONInputBytes  = 1 << 20 // 1 MiB: bound on the resolved JSON a $json path parses
+	maxJSONOutputBytes = 1 << 16 // 64 KiB: bound on the extracted scalar
+)
+
+// extractJSONPath parses resolved as JSON and returns the scalar at the gjson
+// dotted path as a string. A JSON string returns verbatim; a number/bool returns
+// its canonical string form; an object, array, missing key, explicit null, or
+// invalid input is an error. Errors reference only the path and the JSON type —
+// never the resolved value — so no plaintext reaches logs or callers.
+func extractJSONPath(resolved, path string) (string, error) {
+	if len(resolved) > maxJSONInputBytes {
+		return "", fmt.Errorf("$json path %q: resolved JSON exceeds %d bytes", path, maxJSONInputBytes)
+	}
+	if !gjson.Valid(resolved) {
+		return "", fmt.Errorf("$json path %q: resolved value is not valid JSON", path)
+	}
+	res := gjson.Get(resolved, path)
+	if !res.Exists() {
+		return "", fmt.Errorf("$json path %q not found", path)
+	}
+	switch res.Type {
+	case gjson.Null:
+		return "", fmt.Errorf("$json path %q resolved to null", path)
+	case gjson.String, gjson.Number, gjson.True, gjson.False:
+		out := res.String()
+		if len(out) > maxJSONOutputBytes {
+			return "", fmt.Errorf("$json path %q: extracted value exceeds %d bytes", path, maxJSONOutputBytes)
+		}
+		return out, nil
+	default: // gjson.JSON — object or array
+		kind := "object"
+		if res.IsArray() {
+			kind = "array"
+		}
+		return "", fmt.Errorf("$json path %q resolved to a JSON %s, expected a scalar", path, kind)
+	}
+}
+
 // ResolvePropertyReferences resolves a specific reference in resource properties
 func ResolvePropertyReferences(ksuidUri pkgmodel.FormaeURI, properties json.RawMessage, value string) (json.RawMessage, error) {
 	resolver := newPropertyResolver(properties)

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -20,12 +20,12 @@ const (
 	maxJSONOutputBytes = 1 << 16 // 64 KiB: bound on the extracted scalar
 )
 
-// extractJSONPath parses resolved as JSON and returns the scalar at the gjson
+// ExtractJSONPath parses resolved as JSON and returns the scalar at the gjson
 // dotted path as a string. A JSON string returns verbatim; a number/bool returns
 // its canonical string form; an object, array, missing key, explicit null, or
 // invalid input is an error. Errors reference only the path and the JSON type —
 // never the resolved value — so no plaintext reaches logs or callers.
-func extractJSONPath(resolved, path string) (string, error) {
+func ExtractJSONPath(resolved, path string) (string, error) {
 	if len(resolved) > maxJSONInputBytes {
 		return "", fmt.Errorf("$json path %q: resolved JSON exceeds %d bytes", path, maxJSONInputBytes)
 	}
@@ -666,7 +666,7 @@ func (pr *propertyResolver) setRefValue(uri pkgmodel.FormaeURI, value string) er
 
 		resolvedForRef := actualValue
 		if ref.ResolvedValue.JSONPath != "" {
-			extracted, err := extractJSONPath(actualValue, ref.ResolvedValue.JSONPath)
+			extracted, err := ExtractJSONPath(actualValue, ref.ResolvedValue.JSONPath)
 			if err != nil {
 				return err // path/type only — no plaintext (see extractJSONPath)
 			}

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -224,6 +224,7 @@ type propertyParser struct {
 	HasValue  bool
 	Reference string // The $ref value
 	Value     any
+	JSONPath  string // gjson dotted path from $json, applied post-resolution
 }
 
 // propertyType defines the type of property being parsed
@@ -242,6 +243,7 @@ func (pp *propertyParser) Parse(result gjson.Result) propertyType {
 
 	if pp.HasRef {
 		pp.Reference = result.Get("$ref").String()
+		pp.JSONPath = result.Get("$json").String()
 		if pp.HasValue {
 			pp.Value = result.Get("$value").Value()
 		}
@@ -269,12 +271,14 @@ func (pp *propertyParser) CreateRef(currentPath string, result gjson.Result) pkg
 			Strategy:   result.Get("$strategy").String(),
 			Visibility: result.Get("$visibility").String(),
 			Value:      pp.Value,
+			JSONPath:   pp.JSONPath,
 		}
 	} else {
 		// Even without a value, we might have strategy and visibility
 		rawValue = pkgmodel.Value{
 			Strategy:   result.Get("$strategy").String(),
 			Visibility: result.Get("$visibility").String(),
+			JSONPath:   pp.JSONPath,
 		}
 	}
 
@@ -610,6 +614,9 @@ func (pr *propertyResolver) resolveReference(properties json.RawMessage, ref pkg
 	if ref.ResolvedValue.Visibility != "" {
 		refObject["$visibility"] = ref.ResolvedValue.Visibility
 	}
+	if ref.ResolvedValue.JSONPath != "" {
+		refObject["$json"] = ref.ResolvedValue.JSONPath
+	}
 
 	marshalledObj, err := pr.marshalWithLogging(refObject, "reference resolution", ref.TargetPath)
 	if err != nil {
@@ -657,7 +664,16 @@ func (pr *propertyResolver) setRefValue(uri pkgmodel.FormaeURI, value string) er
 			continue
 		}
 
-		newValue := pkgmodel.Value{Value: actualValue}
+		resolvedForRef := actualValue
+		if ref.ResolvedValue.JSONPath != "" {
+			extracted, err := extractJSONPath(actualValue, ref.ResolvedValue.JSONPath)
+			if err != nil {
+				return err // path/type only — no plaintext (see extractJSONPath)
+			}
+			resolvedForRef = extracted
+		}
+
+		newValue := pkgmodel.Value{Value: resolvedForRef}
 
 		if ref.ResolvedValue.Strategy != "" {
 			newValue.Strategy = ref.ResolvedValue.Strategy
@@ -670,6 +686,9 @@ func (pr *propertyResolver) setRefValue(uri pkgmodel.FormaeURI, value string) er
 		} else if ref.ResolvedValue.Visibility != "" {
 			newValue.Visibility = ref.ResolvedValue.Visibility
 		}
+
+		// Preserve JSONPath on the stored value so re-apply is idempotent.
+		newValue.JSONPath = ref.ResolvedValue.JSONPath
 
 		ref.ResolvedValue = newValue
 	}

--- a/internal/metastructure/resolver/resolver_json_test.go
+++ b/internal/metastructure/resolver/resolver_json_test.go
@@ -1,0 +1,70 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resolver
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractJSONPath(t *testing.T) {
+	const secret = "super-secret-token"
+	doc := `{"creds":{"token":"` + secret + `","port":5432,"tls":true,"nested":{"k":"v"},"arr":[1,2],"empty":null}}`
+
+	t.Run("string leaf", func(t *testing.T) {
+		got, err := extractJSONPath(doc, "creds.token")
+		if err != nil || got != secret {
+			t.Fatalf("got %q err %v", got, err)
+		}
+	})
+	t.Run("number coerces to string", func(t *testing.T) {
+		got, err := extractJSONPath(doc, "creds.port")
+		if err != nil || got != "5432" {
+			t.Fatalf("got %q err %v", got, err)
+		}
+	})
+	t.Run("bool coerces to string", func(t *testing.T) {
+		got, err := extractJSONPath(doc, "creds.tls")
+		if err != nil || got != "true" {
+			t.Fatalf("got %q err %v", got, err)
+		}
+	})
+	t.Run("object is an error", func(t *testing.T) {
+		if _, err := extractJSONPath(doc, "creds.nested"); err == nil {
+			t.Fatal("expected error for object")
+		}
+	})
+	t.Run("array is an error", func(t *testing.T) {
+		if _, err := extractJSONPath(doc, "creds.arr"); err == nil {
+			t.Fatal("expected error for array")
+		}
+	})
+	t.Run("missing key is an error distinct from null", func(t *testing.T) {
+		_, err := extractJSONPath(doc, "creds.nope")
+		if err == nil || !strings.Contains(err.Error(), "not found") {
+			t.Fatalf("expected not-found error, got %v", err)
+		}
+	})
+	t.Run("explicit null is an error", func(t *testing.T) {
+		_, err := extractJSONPath(doc, "creds.empty")
+		if err == nil || !strings.Contains(err.Error(), "null") {
+			t.Fatalf("expected null error, got %v", err)
+		}
+	})
+	t.Run("invalid json is an error", func(t *testing.T) {
+		if _, err := extractJSONPath("not json", "a"); err == nil {
+			t.Fatal("expected invalid-json error")
+		}
+	})
+	t.Run("errors never contain the plaintext", func(t *testing.T) {
+		for _, p := range []string{"creds.nested", "creds.arr", "creds.nope", "creds.empty"} {
+			if _, err := extractJSONPath(doc, p); err != nil && strings.Contains(err.Error(), secret) {
+				t.Fatalf("path %q: error leaked plaintext: %v", p, err)
+			}
+		}
+	})
+}

--- a/internal/metastructure/resolver/resolver_json_test.go
+++ b/internal/metastructure/resolver/resolver_json_test.go
@@ -21,53 +21,53 @@ func TestExtractJSONPath(t *testing.T) {
 	doc := `{"creds":{"token":"` + secret + `","port":5432,"tls":true,"nested":{"k":"v"},"arr":[1,2],"empty":null}}`
 
 	t.Run("string leaf", func(t *testing.T) {
-		got, err := extractJSONPath(doc, "creds.token")
+		got, err := ExtractJSONPath(doc, "creds.token")
 		if err != nil || got != secret {
 			t.Fatalf("got %q err %v", got, err)
 		}
 	})
 	t.Run("number coerces to string", func(t *testing.T) {
-		got, err := extractJSONPath(doc, "creds.port")
+		got, err := ExtractJSONPath(doc, "creds.port")
 		if err != nil || got != "5432" {
 			t.Fatalf("got %q err %v", got, err)
 		}
 	})
 	t.Run("bool coerces to string", func(t *testing.T) {
-		got, err := extractJSONPath(doc, "creds.tls")
+		got, err := ExtractJSONPath(doc, "creds.tls")
 		if err != nil || got != "true" {
 			t.Fatalf("got %q err %v", got, err)
 		}
 	})
 	t.Run("object is an error", func(t *testing.T) {
-		if _, err := extractJSONPath(doc, "creds.nested"); err == nil {
+		if _, err := ExtractJSONPath(doc, "creds.nested"); err == nil {
 			t.Fatal("expected error for object")
 		}
 	})
 	t.Run("array is an error", func(t *testing.T) {
-		if _, err := extractJSONPath(doc, "creds.arr"); err == nil {
+		if _, err := ExtractJSONPath(doc, "creds.arr"); err == nil {
 			t.Fatal("expected error for array")
 		}
 	})
 	t.Run("missing key is an error distinct from null", func(t *testing.T) {
-		_, err := extractJSONPath(doc, "creds.nope")
+		_, err := ExtractJSONPath(doc, "creds.nope")
 		if err == nil || !strings.Contains(err.Error(), "not found") {
 			t.Fatalf("expected not-found error, got %v", err)
 		}
 	})
 	t.Run("explicit null is an error", func(t *testing.T) {
-		_, err := extractJSONPath(doc, "creds.empty")
+		_, err := ExtractJSONPath(doc, "creds.empty")
 		if err == nil || !strings.Contains(err.Error(), "null") {
 			t.Fatalf("expected null error, got %v", err)
 		}
 	})
 	t.Run("invalid json is an error", func(t *testing.T) {
-		if _, err := extractJSONPath("not json", "a"); err == nil {
+		if _, err := ExtractJSONPath("not json", "a"); err == nil {
 			t.Fatal("expected invalid-json error")
 		}
 	})
 	t.Run("errors never contain the plaintext", func(t *testing.T) {
 		for _, p := range []string{"creds.nested", "creds.arr", "creds.nope", "creds.empty"} {
-			if _, err := extractJSONPath(doc, p); err != nil && strings.Contains(err.Error(), secret) {
+			if _, err := ExtractJSONPath(doc, p); err != nil && strings.Contains(err.Error(), secret) {
 				t.Fatalf("path %q: error leaked plaintext: %v", p, err)
 			}
 		}

--- a/internal/metastructure/resolver/resolver_json_test.go
+++ b/internal/metastructure/resolver/resolver_json_test.go
@@ -7,8 +7,13 @@
 package resolver
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/tidwall/gjson"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
 func TestExtractJSONPath(t *testing.T) {
@@ -67,4 +72,86 @@ func TestExtractJSONPath(t *testing.T) {
 			}
 		}
 	})
+}
+
+// firstRefURI returns the single URI stored in pr.refs; fails the test if
+// the map is empty or has more than one key.
+func firstRefURI(t *testing.T, pr *propertyResolver) pkgmodel.FormaeURI {
+	t.Helper()
+	if len(pr.refs) != 1 {
+		t.Fatalf("expected exactly 1 ref URI in propertyResolver, got %d", len(pr.refs))
+	}
+	for uri := range pr.refs {
+		return uri
+	}
+	t.Fatal("unreachable")
+	return ""
+}
+
+// TestResolveReference_AppliesJSONPath verifies that when a $ref envelope carries
+// a $json key the resolver extracts the scalar at that dotted path from the
+// resolved JSON document and stores it as $value, instead of using the whole doc.
+func TestResolveReference_AppliesJSONPath(t *testing.T) {
+	secretRef := newTestRef("SecretString")
+	props := json.RawMessage(`{"Password":{"$ref":"` + secretRef + `","$visibility":"Opaque","$json":"db.password"}}`)
+	pr := newPropertyResolver(props)
+
+	uri := firstRefURI(t, pr)
+	resolved := `{"db":{"password":"super-secret"}}`
+	if err := pr.setRefValue(uri, resolved); err != nil {
+		t.Fatal(err)
+	}
+	out, err := pr.resolveReferences(props)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The consumer property must hold the extracted scalar, not the whole doc.
+	got := gjson.GetBytes(out, "Password.$value").String()
+	if got != "super-secret" {
+		t.Fatalf("expected extracted value %q, got %q (full: %s)", "super-secret", got, out)
+	}
+}
+
+// TestResolveReference_JSONPathPreservedOnStoredValue verifies that the $json key
+// is preserved on the stored Value so that resolveReferences can re-apply it
+// idempotently (the round-trip form still carries $json on the envelope).
+func TestResolveReference_JSONPathPreservedOnStoredValue(t *testing.T) {
+	secretRef := newTestRef("SecretString")
+	props := json.RawMessage(`{"Password":{"$ref":"` + secretRef + `","$visibility":"Opaque","$json":"db.password"}}`)
+	pr := newPropertyResolver(props)
+
+	uri := firstRefURI(t, pr)
+	if err := pr.setRefValue(uri, `{"db":{"password":"s3cr3t"}}`); err != nil {
+		t.Fatal(err)
+	}
+
+	// After setRefValue the stored ref must carry JSONPath.
+	for _, bucket := range pr.refs {
+		for _, ref := range bucket {
+			if ref.ResolvedValue.JSONPath != "db.password" {
+				t.Fatalf("JSONPath not preserved on stored Value; got %q", ref.ResolvedValue.JSONPath)
+			}
+		}
+	}
+}
+
+// TestResolveReference_NoJSONPath verifies that a plain $ref (no $json) continues
+// to work exactly as before: no extraction, the resolved scalar is stored as $value.
+func TestResolveReference_NoJSONPath(t *testing.T) {
+	vpcRef := newTestRef("VpcId")
+	props := json.RawMessage(`{"VpcId":{"$ref":"` + vpcRef + `"}}`)
+	pr := newPropertyResolver(props)
+
+	uri := firstRefURI(t, pr)
+	if err := pr.setRefValue(uri, `{"VpcId":"vpc-123"}`); err != nil {
+		t.Fatal(err)
+	}
+	out, err := pr.resolveReferences(props)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := gjson.GetBytes(out, "VpcId.$value").String()
+	if got != "vpc-123" {
+		t.Fatalf("expected vpc-123, got %q", got)
+	}
 }

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -2114,8 +2114,9 @@ func translatePropertiesJSON(properties json.RawMessage, tripletToKsuid map[pkgm
 			}
 			formaeURI = resolvable.ToFormaeURI(ksuid)
 		}
-		refObject := map[string]string{
-			"$ref": string(formaeURI),
+		refObject := map[string]any{"$ref": string(formaeURI)}
+		if resolvable.JSONPath != "" {
+			refObject["$json"] = resolvable.JSONPath
 		}
 
 		result, err = sjson.Set(result, resolvable.Path, refObject)
@@ -2248,6 +2249,7 @@ func translateEmbedSpansInTemplate(tmpl string, tripletToKsuid map[pkgmodel.Trip
 			Type:     parsed.Get("$type").String(),
 			Stack:    parsed.Get("$stack").String(),
 			Property: parsed.Get("$property").String(),
+			JSONPath: parsed.Get("$json").String(),
 		}
 
 		var formaeURI pkgmodel.FormaeURI
@@ -2280,7 +2282,10 @@ func translateEmbedSpansInTemplate(tmpl string, tripletToKsuid map[pkgmodel.Trip
 			formaeURI = resolvable.ToFormaeURI(ksuid)
 		}
 
-		refEnv := map[string]string{"$ref": string(formaeURI)}
+		refEnv := map[string]any{"$ref": string(formaeURI)}
+		if resolvable.JSONPath != "" {
+			refEnv["$json"] = resolvable.JSONPath
+		}
 		refJSON, marshalErr := json.Marshal(refEnv)
 		if marshalErr != nil {
 			return tmpl, fmt.Errorf("embed span: failed to marshal $ref envelope: %w", marshalErr)

--- a/internal/metastructure/resource_update/resource_update_generator_json_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_json_test.go
@@ -1,0 +1,97 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// TestTranslatePropertiesJSON_PreservesJSONKeyOnFlatRewrite verifies that a
+// $res envelope carrying $json survives the flat $res→$ref rewrite with the
+// $json key present on the output $ref object.
+func TestTranslatePropertiesJSON_PreservesJSONKeyOnFlatRewrite(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	secretKsuid := "secretksuid01"
+	triplet := pkgmodel.TripletKey{Stack: "default", Label: "mysecret", Type: "AWS::SecretsManager::Secret"}
+
+	_, err := ds.StoreResource(&pkgmodel.Resource{
+		Ksuid: secretKsuid,
+		Label: triplet.Label,
+		Type:  triplet.Type,
+		Stack: triplet.Stack,
+	}, "cmd-json-1")
+	require.NoError(t, err)
+
+	// A $res envelope WITH $json — the user wrote .json("db.password") in PKL.
+	properties, err := json.Marshal(map[string]any{
+		"Password": map[string]any{
+			"$res":      true,
+			"$label":    triplet.Label,
+			"$type":     triplet.Type,
+			"$stack":    triplet.Stack,
+			"$property": "SecretString",
+			"$json":     "db.password",
+		},
+	})
+	require.NoError(t, err)
+
+	tripletToKsuid := map[pkgmodel.TripletKey]string{triplet: secretKsuid}
+	result, _, err := translatePropertiesJSON(json.RawMessage(properties), tripletToKsuid, ds)
+	require.NoError(t, err)
+
+	// After rewrite the $ref envelope must still carry $json.
+	assert.Equal(t, "db.password", gjson.GetBytes(result, "Password.$json").String(),
+		"$json must survive the $res→$ref rewrite; full result: %s", result)
+	// And $ref must now be present (not $res).
+	assert.True(t, gjson.GetBytes(result, "Password.$ref").Exists(),
+		"$ref must be present after rewrite; full result: %s", result)
+	assert.False(t, gjson.GetBytes(result, "Password.$res").Bool(),
+		"$res must be gone after rewrite; full result: %s", result)
+}
+
+// TestTranslatePropertiesJSON_NoJSONKeyUnchanged verifies that a $res envelope
+// WITHOUT $json produces a $ref object without $json (no spurious key added).
+func TestTranslatePropertiesJSON_NoJSONKeyUnchanged(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	ksuid := "plainsecretksuid"
+	triplet := pkgmodel.TripletKey{Stack: "default", Label: "plain", Type: "AWS::SecretsManager::Secret"}
+
+	_, err := ds.StoreResource(&pkgmodel.Resource{
+		Ksuid: ksuid,
+		Label: triplet.Label,
+		Type:  triplet.Type,
+		Stack: triplet.Stack,
+	}, "cmd-plain-1")
+	require.NoError(t, err)
+
+	properties, err := json.Marshal(map[string]any{
+		"SecretString": map[string]any{
+			"$res":      true,
+			"$label":    triplet.Label,
+			"$type":     triplet.Type,
+			"$stack":    triplet.Stack,
+			"$property": "SecretString",
+		},
+	})
+	require.NoError(t, err)
+
+	tripletToKsuid := map[pkgmodel.TripletKey]string{triplet: ksuid}
+	result, _, err := translatePropertiesJSON(json.RawMessage(properties), tripletToKsuid, ds)
+	require.NoError(t, err)
+
+	assert.False(t, gjson.GetBytes(result, "SecretString.$json").Exists(),
+		"$json must not appear when not authored; full result: %s", result)
+}

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -420,7 +420,13 @@ open class ListingResolvable extends Resolvable {
 /// The consumable result of a secret reference: `secret.res.secretValue` (scalar)
 /// or `secret.res.secretValue.at(key)` (map). Opacity is derived agent-side from
 /// the source field's FieldHint.Opaque, not re-declared here.
-open class SecretValueResolvable extends Resolvable {}
+open class SecretValueResolvable extends Resolvable {
+    hidden jsonPath: String?
+    /// Parse the resolved value as JSON and extract a dotted path (gjson syntax).
+    /// Terminal; chainable after .at(). The extracted value stays opaque.
+    function json(path: String): SecretValueResolvable = (this) { jsonPath = path }
+    $json: String? = jsonPath
+}
 
 /// Scalar secret backends (e.g. AWS SecretString, Azure value): `secretValue` IS
 /// the value. There is no at(). A plugin's secret resolvable extends this and

--- a/internal/schema/pkl/schema/tests/secret_resolvable_test.pkl
+++ b/internal/schema/pkl/schema/tests/secret_resolvable_test.pkl
@@ -39,4 +39,10 @@ facts {
     mapSecret.secretValue.at("h:1").$property == "data.h\\:1"
     mapSecret.secretValue.at("token") is formae.SecretValueResolvable
   }
+  ["json(path) renders $json and is chainable after at()"] {
+    scalar.secretValue.json("a.b").$json == "a.b"
+    scalar.secretValue.json("a.b") is formae.SecretValueResolvable
+    mapSecret.secretValue.at("cfg").json("db.password").$json == "db.password"
+    mapSecret.secretValue.at("cfg").json("db.password").$property == "data.cfg"
+  }
 }

--- a/internal/workflow_tests/local/apply_forma/secret_json_test.go
+++ b/internal/workflow_tests/local/apply_forma/secret_json_test.go
@@ -1,0 +1,203 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// TestSecretJSON_RefWithJSONPathResolvesToExtractedScalar exercises the full
+// end-to-end path of a secret whose value is a JSON document and a consumer
+// resource that references it via a $res envelope carrying a $json dotted path.
+//
+// The test verifies three invariants that together define the .json() contract:
+//   1. The consumer's resolved property value equals the EXTRACTED scalar (the
+//      leaf at the $json path), not the whole JSON document.
+//   2. The secret's own stored SecretString is hashed at rest ($hashed:true),
+//      so no plaintext of the JSON document (including the inner password it
+//      contains) survives in the resources table.
+//   3. No plaintext of the extracted scalar nor the outer JSON document appears
+//      in any resource_updates column (DesiredState/PriorState/progress).
+func TestSecretJSON_RefWithJSONPathResolvesToExtractedScalar(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		// The secret value is a JSON document. The inner password is what the
+		// consumer expects to receive via the $json path "db.password".
+		const innerPassword = "db-pass-9x-secret"
+		const secretJSONDoc = `{"db":{"password":"db-pass-9x-secret"}}`
+
+		// Capture what the consumer plugin's Create receives to assert it got
+		// the extracted scalar, not the whole JSON document.
+		var consumerReceivedProps json.RawMessage
+
+		// Override Create for FakeAWS::S3::Bucket: return immediate success with
+		// no ResourceProperties so the progress result never carries the extracted
+		// scalar back into a resource_updates column that is not hashed for Bucket.
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				if req.ResourceType == "FakeAWS::S3::Bucket" {
+					consumerReceivedProps = req.Properties
+					return &resource.CreateResult{
+						ProgressResult: &resource.ProgressResult{
+							Operation:       resource.OperationCreate,
+							OperationStatus: resource.OperationStatusSuccess,
+							RequestID:       "consumer-create-1",
+							NativeID:        "bucket-native-1",
+							// ResourceProperties intentionally omitted: the Bucket schema
+							// does not declare DbPassword as Opaque, so returning the
+							// extracted scalar here would appear unhashed in
+							// MostRecentProgressResult. Returning nil keeps the progress
+							// sink clean, exactly mirroring write-only secret fields whose
+							// cloud API never echoes them back on create.
+						},
+					}, nil
+				}
+				// Let the secret use FakeAWS's default Create (InProgress → Status
+				// poll) so it exercises the full opaque-value hashing path.
+				return nil, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+
+		// The secret's SecretString is a JSON document (a bare string containing
+		// valid JSON). The schema's Opaque hint on SecretString means the whole
+		// string — the JSON document — is hashed at rest.
+		secret := pkgmodel.Resource{
+			Label:  "my-json-secret",
+			Type:   "FakeAWS::SecretsManager::Secret",
+			Stack:  stack,
+			Target: "test-target",
+			Schema: secretSchema(),
+			Properties: json.RawMessage(
+				`{"Name":"my-json-secret","SecretString":` + jsonQuote(secretJSONDoc) + `}`,
+			),
+		}
+
+		// The consumer references the secret's SecretString field via $res,
+		// requesting the leaf scalar at path "db.password" via $json. The
+		// $visibility:Opaque propagates to the resolved Value, so the extracted
+		// scalar is also hashed at rest in the consumer's stored properties.
+		consumer := pkgmodel.Resource{
+			Label: "my-bucket",
+			Type:  "FakeAWS::S3::Bucket",
+			Stack: stack,
+			Target: "test-target",
+			Properties: json.RawMessage(`{
+				"BucketName": "my-bucket",
+				"DbPassword": {
+					"$res":      true,
+					"$label":    "my-json-secret",
+					"$type":     "FakeAWS::SecretsManager::Secret",
+					"$stack":    "` + stack + `",
+					"$property": "SecretString",
+					"$visibility": "Opaque",
+					"$json":    "db.password"
+				}
+			}`),
+		}
+
+		forma := &pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: stack}},
+			Resources: []pkgmodel.Resource{secret, consumer},
+			Targets:   []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		applyCmd := findCommandByType(cmds, pkgmodel.CommandApply)
+		require.NotNil(t, applyCmd, "apply command should exist")
+		require.Equal(t, forma_command.CommandStateSuccess, applyCmd.State,
+			"apply with a $json cross-resource reference must succeed")
+
+		// --- Invariant 1: consumer received the extracted scalar, not the doc ---
+		require.NotNil(t, consumerReceivedProps,
+			"consumer Create override should have been called")
+		dbPassword := gjson.GetBytes(consumerReceivedProps, "DbPassword").String()
+		assert.Equal(t, innerPassword, dbPassword,
+			"consumer plugin must receive the extracted scalar from $json, not the full JSON doc")
+		assert.NotContains(t, string(consumerReceivedProps), secretJSONDoc,
+			"consumer plugin must not receive the whole JSON document as the field value")
+
+		// --- Invariant 2: secret's own value is stored hashed ---
+		resources, err := m.Datastore.LoadResourcesByStack(stack)
+		require.NoError(t, err)
+		require.Len(t, resources, 2, "both the secret and consumer must be stored")
+
+		var secretResource *pkgmodel.Resource
+		var consumerResource *pkgmodel.Resource
+		for _, r := range resources {
+			if r.Type == "FakeAWS::SecretsManager::Secret" {
+				secretResource = r
+			} else {
+				consumerResource = r
+			}
+		}
+		require.NotNil(t, secretResource, "secret resource must be stored")
+		require.NotNil(t, consumerResource, "consumer resource must be stored")
+
+		// Secret: stored SecretString must carry $hashed and no plaintext of the JSON doc.
+		storedSecretProps := string(secretResource.Properties)
+		assert.Contains(t, storedSecretProps, hashedMarker,
+			"secret SecretString must be hashed at rest")
+		assert.NotContains(t, storedSecretProps, secretJSONDoc,
+			"secret SecretString must not store the plaintext JSON document")
+		assert.NotContains(t, storedSecretProps, innerPassword,
+			"secret stored properties must not contain the inner password")
+
+		// Consumer: stored DbPassword envelope must carry $hashed and not the extracted scalar.
+		storedConsumerProps := string(consumerResource.Properties)
+		assert.Contains(t, storedConsumerProps, hashedMarker,
+			"consumer DbPassword ($visibility:Opaque ref) must be hashed at rest")
+		assert.NotContains(t, storedConsumerProps, innerPassword,
+			"consumer stored properties must not contain the extracted password in plaintext")
+
+		// --- Invariant 3: no plaintext in resource_updates ---
+		// Both the extracted scalar and the outer JSON document must be absent from
+		// every resource_updates sink: DesiredState/PriorState properties and
+		// progress ResourceProperties. Because both the secret's SecretString and
+		// the consumer's DbPassword envelope are Opaque, the transformer hashes
+		// them in DesiredState before the resource_updates row is written.
+		// The consumer's MostRecentProgressResult carries no ResourceProperties
+		// (the Create override returns nil) so no progress sink leaks the scalar.
+		assertNoPlaintextInResourceUpdates(t, m, applyCmd.ID, innerPassword)
+		assertNoPlaintextInResourceUpdates(t, m, applyCmd.ID, secretJSONDoc)
+	})
+}
+
+// jsonQuote returns s as a JSON-encoded string literal, for embedding a
+// JSON document as a string value in another JSON document.
+func jsonQuote(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		panic("jsonQuote: " + err.Error())
+	}
+	return string(b)
+}

--- a/pkg/model/uri.go
+++ b/pkg/model/uri.go
@@ -176,6 +176,7 @@ type ResolvableObject struct {
 	Type     string
 	Stack    string
 	Property string
+	JSONPath string // gjson dotted path from $json, applied post-resolution
 }
 
 // FindResolvablesFromProperties traverses json properties and finds all objects with $res: true
@@ -198,6 +199,7 @@ func findResolvablesRecursive(basePath string, value gjson.Result, resolvables *
 				Type:     value.Get("$type").String(),
 				Stack:    value.Get("$stack").String(),
 				Property: value.Get("$property").String(),
+				JSONPath: value.Get("$json").String(),
 			}
 			*resolvables = append(*resolvables, resolvable)
 			return

--- a/pkg/model/value.go
+++ b/pkg/model/value.go
@@ -27,6 +27,7 @@ type Value struct {
 	Visibility string `json:"$visibility,omitempty"` // Visibility of the value
 	Value      any    `json:"$value,omitempty"`      // The actual value or hashed value, if applicable
 	Hashed     bool   `json:"$hashed,omitempty"`     // True when Value holds the SHA-256 digest, not plaintext
+	JSONPath   string `json:"$json,omitempty"`       // gjson dotted path applied post-resolution (secret .json())
 }
 
 func (v *Value) IsOpaque() bool {

--- a/pkg/model/value_test.go
+++ b/pkg/model/value_test.go
@@ -8,6 +8,7 @@ package model
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,4 +43,19 @@ func TestValue_LogValueRedactsOpaque(t *testing.T) {
 
 	clear := &Value{Value: "public", Visibility: VisibilityClear}
 	assert.Equal(t, "public", clear.LogValue().String())
+}
+
+func TestValue_JSONPathRoundTrip(t *testing.T) {
+	v := Value{Visibility: "Opaque", JSONPath: "db.password"}
+	b, err := json.Marshal(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"$json":"db.password"`) {
+		t.Fatalf("missing $json in %s", b)
+	}
+	var back Value
+	if err := json.Unmarshal(b, &back); err != nil || back.JSONPath != "db.password" {
+		t.Fatalf("round-trip failed: %+v err %v", back, err)
+	}
 }


### PR DESCRIPTION
## Summary

- Adds `secret.res.secretValue.json(path)` — a terminal JSON-path extractor on a resolved secret value, chainable after `.at(key)`. Authoring renders a `$json` key on the resolvable envelope.
- `$json` is threaded through the `$res`→`$ref` rewrite (which reconstructs the envelope from a fixed key set) and the resolver, and applied once at the resolution boundary: the resolved string is parsed as JSON and the dotted path (gjson) extracted.
- **Extraction semantics (engineering defaults):** result is a string leaf — a JSON string returns verbatim, a number/bool coerces to its canonical string, and an object, array, missing key, explicit `null`, or invalid input is a resolve error. Input and output are size-bounded, and error messages reference only the path and JSON type — never the resolved value (no plaintext in diagnostics).
- Verified end-to-end: a unit-tested `extractJSONPath` helper; PKL facts for `.json()` rendering + `.at().json()` chaining; a survival test that `$json` is preserved across the rewrite; and a workflow test where a secret with a JSON-document value is referenced via a `$json` path, asserting the plugin receives the extracted scalar, the stored state is hashed, and no plaintext leaks into `resource_updates`.

## Why

Second step of first-class secret references (after the base types + `.at()`): reach into a JSON- or map-structured secret payload without materializing the whole secret into a consumer field. `.json()` extraction is applied exactly once, at the single resolution site.

Stacked on the schema-types branch (base `secrets-stage2-schema-types`); GitHub will retarget to the parent as each lands. Follow-ups noted for a later slice: a dedicated embed-span survival test, and attaching the ref path (not value) to extraction errors for diagnosability.