### PR TITLE
fix(datastore): reference-don't-store — never persist a resolved secret in target config

### DIFF
--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -2668,6 +2668,10 @@ func (d *DatastoreAuroraDataAPI) CreateTarget(target *pkgmodel.Target) (string, 
 	if err != nil {
 		return "", err
 	}
+	configJSON, err = datastore.StripOpaqueRefValues(configJSON)
+	if err != nil {
+		return "", fmt.Errorf("failed to strip opaque ref values from target config: %w", err)
+	}
 
 	var configSchemaParam types.Field
 	if len(target.ConfigSchema.Hints) > 0 {
@@ -2778,6 +2782,10 @@ func (d *DatastoreAuroraDataAPI) UpdateTarget(target *pkgmodel.Target) (string, 
 	configJSON, err := json.Marshal(target.Config)
 	if err != nil {
 		return "", err
+	}
+	configJSON, err = datastore.StripOpaqueRefValues(configJSON)
+	if err != nil {
+		return "", fmt.Errorf("failed to strip opaque ref values from target config: %w", err)
 	}
 
 	var configSchemaParam types.Field
@@ -4036,7 +4044,12 @@ func (d *DatastoreAuroraDataAPI) BulkStoreResourceUpdates(commandID string, upda
 
 	for _, ru := range updates {
 		resourceJSON, _ := json.Marshal(ru.DesiredState)
-		resourceTargetJSON, _ := json.Marshal(ru.ResourceTarget)
+		resourceTargetJSONRaw, _ := json.Marshal(ru.ResourceTarget)
+		resourceTargetJSON, err := datastore.StripOpaqueRefValues(resourceTargetJSONRaw)
+		if err != nil {
+			_ = d.rollbackTransaction(ctx, txID)
+			return fmt.Errorf("failed to strip opaque ref values from resource target: %w", err)
+		}
 		existingResourceJSON, _ := json.Marshal(ru.PriorState)
 		existingTargetJSON, _ := json.Marshal(ru.ExistingTarget)
 		progressResultJSON, _ := json.Marshal(ru.ProgressResult)
@@ -4091,7 +4104,7 @@ func (d *DatastoreAuroraDataAPI) BulkStoreResourceUpdates(commandID string, upda
 			{Name: aws.String("previous_properties"), Value: &types.FieldMemberStringValue{Value: string(previousPropertiesJSON)}},
 		}
 
-		_, err := d.executeStatementInTransaction(ctx, txID, query, params)
+		_, err = d.executeStatementInTransaction(ctx, txID, query, params)
 		if err != nil {
 			_ = d.rollbackTransaction(ctx, txID)
 			return fmt.Errorf("failed to store resource update: %w", err)
@@ -4366,6 +4379,12 @@ func (d *DatastoreAuroraDataAPI) UpdateFormaCommandProgress(commandID string, st
 
 func (d *DatastoreAuroraDataAPI) UpdateFormaCommandTargetUpdates(commandID string, targetUpdatesJSON json.RawMessage, state forma_command.CommandState, modifiedTs time.Time) error {
 	ctx := context.Background()
+
+	var err error
+	targetUpdatesJSON, err = datastore.StripOpaqueRefValues(targetUpdatesJSON)
+	if err != nil {
+		return fmt.Errorf("failed to strip opaque ref values from target updates: %w", err)
+	}
 
 	query := `UPDATE forma_commands SET target_updates = :target_updates, state = :state, modified_ts = :modified_ts::timestamp WHERE command_id = :command_id`
 	params := []types.SqlParameter{

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -729,6 +729,10 @@ func (d *DatastoreAuroraDataAPI) StoreFormaCommand(fa *forma_command.FormaComman
 	if err != nil {
 		return fmt.Errorf("failed to marshal target updates: %w", err)
 	}
+	targetUpdatesJSON, err = datastore.StripOpaqueRefValues(targetUpdatesJSON)
+	if err != nil {
+		return fmt.Errorf("failed to strip opaque ref values from target updates: %w", err)
+	}
 
 	stackUpdatesJSON, err := json.Marshal(fa.StackUpdates)
 	if err != nil {
@@ -4051,6 +4055,7 @@ func (d *DatastoreAuroraDataAPI) BulkStoreResourceUpdates(commandID string, upda
 			return fmt.Errorf("failed to strip opaque ref values from resource target: %w", err)
 		}
 		existingResourceJSON, _ := json.Marshal(ru.PriorState)
+		// existing_target is read-side state (already stored stripped) — intentionally not re-stripped here.
 		existingTargetJSON, _ := json.Marshal(ru.ExistingTarget)
 		progressResultJSON, _ := json.Marshal(ru.ProgressResult)
 		mostRecentProgressJSON, _ := json.Marshal(ru.MostRecentProgressResult)

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -4055,8 +4055,13 @@ func (d *DatastoreAuroraDataAPI) BulkStoreResourceUpdates(commandID string, upda
 			return fmt.Errorf("failed to strip opaque ref values from resource target: %w", err)
 		}
 		existingResourceJSON, _ := json.Marshal(ru.PriorState)
-		// existing_target is read-side state (already stored stripped) — intentionally not re-stripped here.
-		existingTargetJSON, _ := json.Marshal(ru.ExistingTarget)
+		// existing_target is stripped too: a pre-change (legacy) target row may still carry a plaintext opaque $ref value, so we never re-persist it unstripped.
+		existingTargetJSONRaw, _ := json.Marshal(ru.ExistingTarget)
+		existingTargetJSON, err := datastore.StripOpaqueRefValues(existingTargetJSONRaw)
+		if err != nil {
+			_ = d.rollbackTransaction(ctx, txID)
+			return fmt.Errorf("failed to strip opaque ref values from existing target: %w", err)
+		}
 		progressResultJSON, _ := json.Marshal(ru.ProgressResult)
 		mostRecentProgressJSON, _ := json.Marshal(ru.MostRecentProgressResult)
 		remainingResolvablesJSON, _ := json.Marshal(ru.RemainingResolvables)

--- a/internal/datastore/mssql/mssql_datastore.go
+++ b/internal/datastore/mssql/mssql_datastore.go
@@ -824,6 +824,10 @@ func (d *DatastoreMSSQL) BulkStoreResourceUpdates(commandID string, updates []re
 		if err != nil {
 			return fmt.Errorf("failed to marshal resource target: %w", err)
 		}
+		resourceTargetJSON, err = datastore.StripOpaqueRefValues(resourceTargetJSON)
+		if err != nil {
+			return fmt.Errorf("failed to strip opaque ref values from resource target: %w", err)
+		}
 		existingResourceJSON, err := json.Marshal(ru.PriorState)
 		if err != nil {
 			return fmt.Errorf("failed to marshal existing resource: %w", err)
@@ -922,6 +926,12 @@ func (d *DatastoreMSSQL) UpdateFormaCommandProgress(commandID string, state form
 func (d *DatastoreMSSQL) UpdateFormaCommandTargetUpdates(commandID string, targetUpdatesJSON json.RawMessage, state forma_command.CommandState, modifiedTs time.Time) error {
 	ctx, span := mssqlTracer.Start(context.Background(), "UpdateFormaCommandTargetUpdates")
 	defer span.End()
+
+	var err error
+	targetUpdatesJSON, err = datastore.StripOpaqueRefValues(targetUpdatesJSON)
+	if err != nil {
+		return fmt.Errorf("failed to strip opaque ref values from target updates: %w", err)
+	}
 
 	result, err := d.conn.ExecContext(ctx,
 		fmt.Sprintf("UPDATE %s SET target_updates = @p1, state = @p2, modified_ts = @p3 WHERE command_id = @p4", datastore.CommandsTable),

--- a/internal/datastore/mssql/mssql_datastore.go
+++ b/internal/datastore/mssql/mssql_datastore.go
@@ -454,6 +454,10 @@ func (d *DatastoreMSSQL) StoreFormaCommand(fa *forma_command.FormaCommand, comma
 	if err != nil {
 		return fmt.Errorf("failed to marshal target updates: %w", err)
 	}
+	targetUpdatesJSON, err = datastore.StripOpaqueRefValues(targetUpdatesJSON)
+	if err != nil {
+		return fmt.Errorf("failed to strip opaque ref values from target updates: %w", err)
+	}
 	stackUpdatesJSON, err := json.Marshal(fa.StackUpdates)
 	if err != nil {
 		return fmt.Errorf("failed to marshal stack updates: %w", err)
@@ -832,6 +836,7 @@ func (d *DatastoreMSSQL) BulkStoreResourceUpdates(commandID string, updates []re
 		if err != nil {
 			return fmt.Errorf("failed to marshal existing resource: %w", err)
 		}
+		// existing_target is read-side state (already stored stripped) — intentionally not re-stripped here.
 		existingTargetJSON, err := json.Marshal(ru.ExistingTarget)
 		if err != nil {
 			return fmt.Errorf("failed to marshal existing target: %w", err)

--- a/internal/datastore/mssql/mssql_datastore.go
+++ b/internal/datastore/mssql/mssql_datastore.go
@@ -836,10 +836,14 @@ func (d *DatastoreMSSQL) BulkStoreResourceUpdates(commandID string, updates []re
 		if err != nil {
 			return fmt.Errorf("failed to marshal existing resource: %w", err)
 		}
-		// existing_target is read-side state (already stored stripped) — intentionally not re-stripped here.
+		// existing_target is stripped too: a pre-change (legacy) target row may still carry a plaintext opaque $ref value, so we never re-persist it unstripped.
 		existingTargetJSON, err := json.Marshal(ru.ExistingTarget)
 		if err != nil {
 			return fmt.Errorf("failed to marshal existing target: %w", err)
+		}
+		existingTargetJSON, err = datastore.StripOpaqueRefValues(existingTargetJSON)
+		if err != nil {
+			return fmt.Errorf("failed to strip opaque ref values from existing target: %w", err)
 		}
 		progressResultJSON, err := json.Marshal(ru.ProgressResult)
 		if err != nil {

--- a/internal/datastore/mssql/mssql_targets.go
+++ b/internal/datastore/mssql/mssql_targets.go
@@ -101,6 +101,10 @@ func (d *DatastoreMSSQL) CreateTarget(target *pkgmodel.Target) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	cfg, err = datastore.StripOpaqueRefValues(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to strip opaque ref values from target config: %w", err)
+	}
 
 	configSchemaJSON, err := marshalConfigSchema(target)
 	if err != nil {
@@ -152,6 +156,10 @@ func (d *DatastoreMSSQL) UpdateTarget(target *pkgmodel.Target) (string, error) {
 	cfg, err := json.Marshal(target.Config)
 	if err != nil {
 		return "", err
+	}
+	cfg, err = datastore.StripOpaqueRefValues(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to strip opaque ref values from target config: %w", err)
 	}
 
 	configSchemaJSON, err := marshalConfigSchema(target)

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -3874,6 +3874,10 @@ func (d DatastorePostgres) CreateTarget(target *pkgmodel.Target) (string, error)
 	if err != nil {
 		return "", err
 	}
+	cfg, err = datastore.StripOpaqueRefValues(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to strip opaque ref values from target config: %w", err)
+	}
 
 	var configSchemaJSON []byte
 	if len(target.ConfigSchema.Hints) > 0 {
@@ -3946,6 +3950,10 @@ func (d DatastorePostgres) UpdateTarget(target *pkgmodel.Target) (string, error)
 	cfg, err := json.Marshal(target.Config)
 	if err != nil {
 		return "", err
+	}
+	cfg, err = datastore.StripOpaqueRefValues(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to strip opaque ref values from target config: %w", err)
 	}
 
 	var configSchemaJSON []byte
@@ -4453,6 +4461,10 @@ func (d DatastorePostgres) BulkStoreResourceUpdates(commandID string, updates []
 		if err != nil {
 			return fmt.Errorf("failed to marshal resource target: %w", err)
 		}
+		resourceTargetJSON, err = datastore.StripOpaqueRefValues(resourceTargetJSON)
+		if err != nil {
+			return fmt.Errorf("failed to strip opaque ref values from resource target: %w", err)
+		}
 
 		existingResourceJSON, err := json.Marshal(ru.PriorState)
 		if err != nil {
@@ -4823,6 +4835,12 @@ func (d DatastorePostgres) UpdateFormaCommandProgress(commandID string, state fo
 func (d DatastorePostgres) UpdateFormaCommandTargetUpdates(commandID string, targetUpdatesJSON json.RawMessage, state forma_command.CommandState, modifiedTs time.Time) error {
 	ctx, span := tracer.Start(context.Background(), "UpdateFormaCommandTargetUpdates")
 	defer span.End()
+
+	var err error
+	targetUpdatesJSON, err = datastore.StripOpaqueRefValues(targetUpdatesJSON)
+	if err != nil {
+		return fmt.Errorf("failed to strip opaque ref values from target updates: %w", err)
+	}
 
 	query := `UPDATE forma_commands SET target_updates = $1, state = $2, modified_ts = $3 WHERE command_id = $4`
 	result, err := d.pool.Exec(ctx, query, string(targetUpdatesJSON), string(state), modifiedTs.UTC(), commandID)

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -4475,10 +4475,14 @@ func (d DatastorePostgres) BulkStoreResourceUpdates(commandID string, updates []
 			return fmt.Errorf("failed to marshal existing resource: %w", err)
 		}
 
-		// existing_target is read-side state (already stored stripped) — intentionally not re-stripped here.
+		// existing_target is stripped too: a pre-change (legacy) target row may still carry a plaintext opaque $ref value, so we never re-persist it unstripped.
 		existingTargetJSON, err := json.Marshal(ru.ExistingTarget)
 		if err != nil {
 			return fmt.Errorf("failed to marshal existing target: %w", err)
+		}
+		existingTargetJSON, err = datastore.StripOpaqueRefValues(existingTargetJSON)
+		if err != nil {
+			return fmt.Errorf("failed to strip opaque ref values from existing target: %w", err)
 		}
 
 		progressResultJSON, err := json.Marshal(ru.ProgressResult)

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -192,6 +192,10 @@ func (d DatastorePostgres) StoreFormaCommand(fa *forma_command.FormaCommand, com
 	if err != nil {
 		return fmt.Errorf("failed to marshal target updates: %w", err)
 	}
+	targetUpdatesJSON, err = datastore.StripOpaqueRefValues(targetUpdatesJSON)
+	if err != nil {
+		return fmt.Errorf("failed to strip opaque ref values from target updates: %w", err)
+	}
 
 	stackUpdatesJSON, err := json.Marshal(fa.StackUpdates)
 	if err != nil {
@@ -4471,6 +4475,7 @@ func (d DatastorePostgres) BulkStoreResourceUpdates(commandID string, updates []
 			return fmt.Errorf("failed to marshal existing resource: %w", err)
 		}
 
+		// existing_target is read-side state (already stored stripped) — intentionally not re-stripped here.
 		existingTargetJSON, err := json.Marshal(ru.ExistingTarget)
 		if err != nil {
 			return fmt.Errorf("failed to marshal existing target: %w", err)

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -2958,6 +2958,10 @@ func (d DatastoreSQLite) CreateTarget(target *pkgmodel.Target) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	cfg, err = datastore.StripOpaqueRefValues(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to strip opaque ref values from target config: %w", err)
+	}
 
 	var configSchemaJSON []byte
 	if len(target.ConfigSchema.Hints) > 0 {
@@ -3013,6 +3017,10 @@ func (d DatastoreSQLite) UpdateTarget(target *pkgmodel.Target) (string, error) {
 	cfg, err := json.Marshal(target.Config)
 	if err != nil {
 		return "", err
+	}
+	cfg, err = datastore.StripOpaqueRefValues(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to strip opaque ref values from target config: %w", err)
 	}
 
 	var configSchemaJSON []byte
@@ -4664,6 +4672,10 @@ func (d DatastoreSQLite) BulkStoreResourceUpdates(commandID string, updates []re
 		if err != nil {
 			return fmt.Errorf("failed to marshal resource target: %w", err)
 		}
+		resourceTargetJSON, err = datastore.StripOpaqueRefValues(resourceTargetJSON)
+		if err != nil {
+			return fmt.Errorf("failed to strip opaque ref values from resource target: %w", err)
+		}
 
 		existingResourceJSON, err := json.Marshal(ru.PriorState)
 		if err != nil {
@@ -5065,6 +5077,12 @@ func (d DatastoreSQLite) UpdateFormaCommandTargetUpdates(commandID string, targe
 	defer func() {
 		slog.Debug("SQLite END", "method", "UpdateFormaCommandTargetUpdates", "commandID", commandID, "duration", time.Since(start))
 	}()
+
+	var err error
+	targetUpdatesJSON, err = datastore.StripOpaqueRefValues(targetUpdatesJSON)
+	if err != nil {
+		return fmt.Errorf("failed to strip opaque ref values from target updates: %w", err)
+	}
 
 	modifiedTsUTC := modifiedTs.UTC().Format(time.RFC3339Nano)
 

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -4686,10 +4686,14 @@ func (d DatastoreSQLite) BulkStoreResourceUpdates(commandID string, updates []re
 			return fmt.Errorf("failed to marshal existing resource: %w", err)
 		}
 
-		// existing_target is read-side state (already stored stripped) — intentionally not re-stripped here.
+		// existing_target is stripped too: a pre-change (legacy) target row may still carry a plaintext opaque $ref value, so we never re-persist it unstripped.
 		existingTargetJSON, err := json.Marshal(ru.ExistingTarget)
 		if err != nil {
 			return fmt.Errorf("failed to marshal existing target: %w", err)
+		}
+		existingTargetJSON, err = datastore.StripOpaqueRefValues(existingTargetJSON)
+		if err != nil {
+			return fmt.Errorf("failed to strip opaque ref values from existing target: %w", err)
 		}
 
 		progressResultJSON, err := json.Marshal(ru.ProgressResult)

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -143,6 +143,10 @@ func (d DatastoreSQLite) StoreFormaCommand(fa *forma_command.FormaCommand, comma
 	if err != nil {
 		return fmt.Errorf("failed to marshal target updates: %w", err)
 	}
+	targetUpdatesJSON, err = datastore.StripOpaqueRefValues(targetUpdatesJSON)
+	if err != nil {
+		return fmt.Errorf("failed to strip opaque ref values from target updates: %w", err)
+	}
 
 	stackUpdatesJSON, err := json.Marshal(fa.StackUpdates)
 	if err != nil {
@@ -4682,6 +4686,7 @@ func (d DatastoreSQLite) BulkStoreResourceUpdates(commandID string, updates []re
 			return fmt.Errorf("failed to marshal existing resource: %w", err)
 		}
 
+		// existing_target is read-side state (already stored stripped) — intentionally not re-stripped here.
 		existingTargetJSON, err := json.Marshal(ru.ExistingTarget)
 		if err != nil {
 			return fmt.Errorf("failed to marshal existing target: %w", err)

--- a/internal/datastore/sqlite/sqlite_test.go
+++ b/internal/datastore/sqlite/sqlite_test.go
@@ -336,3 +336,78 @@ func TestStoreDeleteStore(t *testing.T) {
 		assert.Equal(t, nativeID, loaded.NativeID)
 	}
 }
+
+// TestCreateTarget_StripsOpaqueRefValue verifies that CreateTarget does not
+// persist a $value from an opaque $ref envelope in targets.config. The
+// stored config must retain $ref and $visibility but must not contain $value
+// or the resolved secret.
+func TestCreateTarget_StripsOpaqueRefValue(t *testing.T) {
+	cfg := &pkgmodel.DatastoreConfig{
+		DatastoreType: pkgmodel.SqliteDatastore,
+		Sqlite:        pkgmodel.SqliteConfig{FilePath: ":memory:"},
+	}
+	ds, err := dssqlite.NewDatastoreSQLite(context.Background(), cfg, "test")
+	require.NoError(t, err)
+	d, _ := ds.(dssqlite.DatastoreSQLite)
+	defer d.CleanUp() //nolint:errcheck
+
+	opaqueConfig := json.RawMessage(`{"auth":{"$ref":"formae://x","$visibility":"Opaque","$value":"super-secret"}}`)
+	_, err = ds.CreateTarget(&pkgmodel.Target{
+		Label:     "opaque-create",
+		Namespace: "AWS",
+		Config:    opaqueConfig,
+	})
+	require.NoError(t, err)
+
+	// Read the raw stored bytes directly from the DB — bypassing any unmarshalling.
+	var raw string
+	err = d.Conn().QueryRow(
+		`SELECT config FROM targets WHERE label = 'opaque-create' ORDER BY version DESC LIMIT 1`,
+	).Scan(&raw)
+	require.NoError(t, err)
+
+	assert.Contains(t, raw, `$ref`, "stored config must preserve $ref")
+	assert.Contains(t, raw, `$visibility`, "stored config must preserve $visibility")
+	assert.NotContains(t, raw, `$value`, "stored config must not contain $value")
+	assert.NotContains(t, raw, "super-secret", "stored config must not contain the resolved secret")
+}
+
+// TestUpdateTarget_StripsOpaqueRefValue verifies that UpdateTarget does not
+// persist a $value from an opaque $ref envelope in targets.config.
+func TestUpdateTarget_StripsOpaqueRefValue(t *testing.T) {
+	cfg := &pkgmodel.DatastoreConfig{
+		DatastoreType: pkgmodel.SqliteDatastore,
+		Sqlite:        pkgmodel.SqliteConfig{FilePath: ":memory:"},
+	}
+	ds, err := dssqlite.NewDatastoreSQLite(context.Background(), cfg, "test")
+	require.NoError(t, err)
+	d, _ := ds.(dssqlite.DatastoreSQLite)
+	defer d.CleanUp() //nolint:errcheck
+
+	// Seed with a clean config first.
+	_, err = ds.CreateTarget(&pkgmodel.Target{
+		Label:     "opaque-update",
+		Namespace: "AWS",
+		Config:    json.RawMessage(`{"Region":"us-east-1"}`),
+	})
+	require.NoError(t, err)
+
+	loaded, err := ds.LoadTarget("opaque-update")
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+
+	// Update with a config that carries an opaque $ref $value.
+	loaded.Config = json.RawMessage(`{"auth":{"$ref":"formae://x","$visibility":"Opaque","$value":"super-secret"}}`)
+	_, err = ds.UpdateTarget(loaded)
+	require.NoError(t, err)
+
+	var raw string
+	err = d.Conn().QueryRow(
+		`SELECT config FROM targets WHERE label = 'opaque-update' ORDER BY version DESC LIMIT 1`,
+	).Scan(&raw)
+	require.NoError(t, err)
+
+	assert.Contains(t, raw, `$ref`, "stored config must preserve $ref")
+	assert.NotContains(t, raw, `$value`, "stored config must not contain $value")
+	assert.NotContains(t, raw, "super-secret", "stored config must not contain the resolved secret")
+}

--- a/internal/datastore/sqlite/sqlite_test.go
+++ b/internal/datastore/sqlite/sqlite_test.go
@@ -463,3 +463,60 @@ func TestStoreFormaCommand_StripsOpaqueRefValueFromTargetUpdates(t *testing.T) {
 	assert.NotContains(t, raw, `$value`, "stored target_updates must not contain $value")
 	assert.NotContains(t, raw, "super-secret", "stored target_updates must not contain the resolved secret")
 }
+
+// TestBulkStoreResourceUpdates_StripsOpaqueRefValueFromExistingTarget verifies
+// that BulkStoreResourceUpdates does not persist a $value from an opaque $ref
+// envelope in resource_updates.existing_target. A legacy target row written
+// before stripping was introduced may still carry a plaintext opaque $ref
+// $value; re-persisting it unstripped would re-introduce the secret.
+func TestBulkStoreResourceUpdates_StripsOpaqueRefValueFromExistingTarget(t *testing.T) {
+	cfg := &pkgmodel.DatastoreConfig{
+		DatastoreType: pkgmodel.SqliteDatastore,
+		Sqlite:        pkgmodel.SqliteConfig{FilePath: ":memory:"},
+	}
+	ds, err := dssqlite.NewDatastoreSQLite(context.Background(), cfg, "test")
+	require.NoError(t, err)
+	d, _ := ds.(dssqlite.DatastoreSQLite)
+	defer d.CleanUp() //nolint:errcheck
+
+	opaqueConfig := json.RawMessage(`{"auth":{"$ref":"formae://x","$visibility":"Opaque","$value":"super-secret"}}`)
+
+	commandID := util.NewID()
+	ksuid := util.NewID()
+
+	ru := resource_update.ResourceUpdate{
+		DesiredState: pkgmodel.Resource{
+			Ksuid:  ksuid,
+			Stack:  "default",
+			Type:   "AWS::S3::Bucket",
+			Label:  "my-bucket",
+			Target: "tgt",
+		},
+		ResourceTarget: pkgmodel.Target{
+			Label:     "tgt",
+			Namespace: "AWS",
+			Config:    json.RawMessage(`{}`),
+		},
+		ExistingTarget: pkgmodel.Target{
+			Label:     "tgt",
+			Namespace: "AWS",
+			Config:    opaqueConfig,
+		},
+		Operation: resource_update.OperationCreate,
+		State:     resource_update.ResourceUpdateStateNotStarted,
+	}
+
+	require.NoError(t, ds.BulkStoreResourceUpdates(commandID, []resource_update.ResourceUpdate{ru}))
+
+	// Read the raw stored bytes directly from the DB — bypassing any unmarshalling.
+	var raw string
+	err = d.Conn().QueryRow(
+		`SELECT existing_target FROM resource_updates WHERE command_id = ?`, commandID,
+	).Scan(&raw)
+	require.NoError(t, err)
+
+	assert.Contains(t, raw, `$ref`, "stored existing_target must preserve $ref")
+	assert.Contains(t, raw, `$visibility`, "stored existing_target must preserve $visibility")
+	assert.NotContains(t, raw, `$value`, "stored existing_target must not contain $value")
+	assert.NotContains(t, raw, "super-secret", "stored existing_target must not contain the resolved secret")
+}

--- a/internal/datastore/sqlite/sqlite_test.go
+++ b/internal/datastore/sqlite/sqlite_test.go
@@ -17,7 +17,10 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/datastore"
 	"github.com/platform-engineering-labs/formae/internal/datastore/dstest"
 	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/stretchr/testify/assert"
@@ -410,4 +413,53 @@ func TestUpdateTarget_StripsOpaqueRefValue(t *testing.T) {
 	assert.Contains(t, raw, `$ref`, "stored config must preserve $ref")
 	assert.NotContains(t, raw, `$value`, "stored config must not contain $value")
 	assert.NotContains(t, raw, "super-secret", "stored config must not contain the resolved secret")
+}
+
+// TestStoreFormaCommand_StripsOpaqueRefValueFromTargetUpdates verifies that
+// StoreFormaCommand does not persist $value from an opaque $ref envelope in
+// forma_commands.target_updates. The stored blob must retain $ref but must not
+// contain $value or the resolved secret.
+func TestStoreFormaCommand_StripsOpaqueRefValueFromTargetUpdates(t *testing.T) {
+	cfg := &pkgmodel.DatastoreConfig{
+		DatastoreType: pkgmodel.SqliteDatastore,
+		Sqlite:        pkgmodel.SqliteConfig{FilePath: ":memory:"},
+	}
+	ds, err := dssqlite.NewDatastoreSQLite(context.Background(), cfg, "test")
+	require.NoError(t, err)
+	d, _ := ds.(dssqlite.DatastoreSQLite)
+	defer d.CleanUp() //nolint:errcheck
+
+	opaqueConfig := json.RawMessage(`{"auth":{"$ref":"formae://x","$visibility":"Opaque","$value":"super-secret"}}`)
+
+	commandID := util.NewID()
+	fc := &forma_command.FormaCommand{
+		ID:      commandID,
+		Command: pkgmodel.CommandApply,
+		State:   forma_command.CommandStateNotStarted,
+		Config:  config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
+		TargetUpdates: []target_update.TargetUpdate{
+			{
+				Target: pkgmodel.Target{
+					Label:     "opaque-target",
+					Namespace: "AWS",
+					Config:    opaqueConfig,
+				},
+				Operation: target_update.TargetOperationCreate,
+				State:     target_update.TargetUpdateStateNotStarted,
+			},
+		},
+	}
+
+	require.NoError(t, ds.StoreFormaCommand(fc, commandID))
+
+	// Read the raw stored bytes directly from the DB — bypassing any unmarshalling.
+	var raw string
+	err = d.Conn().QueryRow(
+		`SELECT target_updates FROM forma_commands WHERE command_id = ?`, commandID,
+	).Scan(&raw)
+	require.NoError(t, err)
+
+	assert.Contains(t, raw, `$ref`, "stored target_updates must preserve $ref")
+	assert.NotContains(t, raw, `$value`, "stored target_updates must not contain $value")
+	assert.NotContains(t, raw, "super-secret", "stored target_updates must not contain the resolved secret")
 }

--- a/internal/datastore/strip_opaque_ref_values.go
+++ b/internal/datastore/strip_opaque_ref_values.go
@@ -32,7 +32,8 @@ func StripOpaqueRefValues(raw json.RawMessage) (json.RawMessage, error) {
 func stripOpaqueRefValues(v any) any {
 	switch t := v.(type) {
 	case map[string]any:
-		opaqueRef := t["$ref"] != nil && t["$visibility"] == "Opaque"
+		_, hasRef := t["$ref"]
+		opaqueRef := hasRef && t["$visibility"] == "Opaque"
 		out := make(map[string]any, len(t))
 		for k, val := range t {
 			if opaqueRef && k == "$value" {
@@ -55,7 +56,7 @@ func stripOpaqueRefValues(v any) any {
 func assertNoOpaqueRefValue(v any, path string) error {
 	switch t := v.(type) {
 	case map[string]any:
-		if t["$ref"] != nil && t["$visibility"] == "Opaque" {
+		if _, hasRef := t["$ref"]; hasRef && t["$visibility"] == "Opaque" {
 			if _, has := t["$value"]; has {
 				return fmt.Errorf("opaque $ref at %q still carries $value after normalization", path)
 			}

--- a/internal/datastore/strip_opaque_ref_values.go
+++ b/internal/datastore/strip_opaque_ref_values.go
@@ -1,0 +1,76 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package datastore
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// StripOpaqueRefValues removes $value from every opaque $ref envelope (an object
+// carrying both "$ref" and "$visibility":"Opaque") in raw, returning a copy. The
+// reference pointer is preserved; the resolved/authored secret value is never
+// persisted. It then validates that no opaque $ref envelope still carries $value
+// and errors if one does (a shape it could not normalize). Input is not mutated.
+func StripOpaqueRefValues(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 {
+		return raw, nil
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return raw, nil // not JSON we manage; leave as-is
+	}
+	stripped := stripOpaqueRefValues(v)
+	if err := assertNoOpaqueRefValue(stripped, ""); err != nil {
+		return nil, err
+	}
+	return json.Marshal(stripped)
+}
+
+func stripOpaqueRefValues(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		opaqueRef := t["$ref"] != nil && t["$visibility"] == "Opaque"
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			if opaqueRef && k == "$value" {
+				continue // drop the resolved value; keep the reference
+			}
+			out[k] = stripOpaqueRefValues(val)
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, val := range t {
+			out[i] = stripOpaqueRefValues(val)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func assertNoOpaqueRefValue(v any, path string) error {
+	switch t := v.(type) {
+	case map[string]any:
+		if t["$ref"] != nil && t["$visibility"] == "Opaque" {
+			if _, has := t["$value"]; has {
+				return fmt.Errorf("opaque $ref at %q still carries $value after normalization", path)
+			}
+		}
+		for k, val := range t {
+			if err := assertNoOpaqueRefValue(val, path+"/"+k); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for i, val := range t {
+			if err := assertNoOpaqueRefValue(val, fmt.Sprintf("%s/%d", path, i)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/datastore/strip_opaque_ref_values_test.go
+++ b/internal/datastore/strip_opaque_ref_values_test.go
@@ -172,6 +172,47 @@ func TestStripOpaqueRefValues_StripsInsideArray(t *testing.T) {
 	assert.NotContains(t, string(out), "hidden")
 }
 
+// TestStripOpaqueRefValues_StripsNullRefOpaqueValue verifies that an envelope
+// whose $ref key is present but JSON null, together with $visibility:"Opaque",
+// is still treated as an opaque $ref envelope and has its $value stripped. The
+// envelope is defined by the presence of the $ref key, not by its value being
+// non-null.
+func TestStripOpaqueRefValues_StripsNullRefOpaqueValue(t *testing.T) {
+	input := json.RawMessage(`{
+		"credentials": {
+			"$ref": null,
+			"$visibility": "Opaque",
+			"$value": "super-secret-plaintext"
+		}
+	}`)
+
+	out, err := StripOpaqueRefValues(input)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	creds := result["credentials"].(map[string]any)
+	_, hasValue := creds["$value"]
+	assert.False(t, hasValue, "$value must be stripped even when $ref is null")
+	assert.NotContains(t, string(out), "super-secret-plaintext")
+}
+
+// TestAssertNoOpaqueRefValue_RejectsNullRefWithValue verifies the reject-guard
+// treats a present-but-null $ref key together with $visibility:"Opaque" as an
+// opaque $ref envelope, so a surviving $value is rejected rather than persisted.
+func TestAssertNoOpaqueRefValue_RejectsNullRefWithValue(t *testing.T) {
+	envelope := map[string]any{
+		"$ref":        nil,
+		"$visibility": "Opaque",
+		"$value":      "super-secret",
+	}
+
+	err := assertNoOpaqueRefValue(envelope, "")
+	require.Error(t, err, "guard must reject a null-$ref opaque envelope that still carries $value")
+	assert.NotContains(t, err.Error(), "super-secret", "error must not leak the secret value")
+}
+
 // TestStripOpaqueRefValues_EmptyInput verifies that an empty RawMessage is
 // returned as-is without error.
 func TestStripOpaqueRefValues_EmptyInput(t *testing.T) {

--- a/internal/datastore/strip_opaque_ref_values_test.go
+++ b/internal/datastore/strip_opaque_ref_values_test.go
@@ -181,11 +181,11 @@ func TestStripOpaqueRefValues_EmptyInput(t *testing.T) {
 }
 
 // TestAssertNoOpaqueRefValue_RejectsOpaqueRefWithValue verifies the reject-guard
-// directly: an opaque $ref envelope that still carries $value (the regression
-// state the strip is designed to prevent) must produce an error, and that error
-// must not contain the plaintext secret value.
+// directly: an opaque $ref envelope that still carries $value (the shape the
+// strip must reject) must produce an error, and that error must not contain
+// the plaintext secret value.
 func TestAssertNoOpaqueRefValue_RejectsOpaqueRefWithValue(t *testing.T) {
-	// Construct the exact regression state: an opaque $ref that was NOT stripped.
+	// Construct that shape directly: an opaque $ref that still carries $value.
 	envelope := map[string]any{
 		"$ref":        "formae://x",
 		"$visibility": "Opaque",

--- a/internal/datastore/strip_opaque_ref_values_test.go
+++ b/internal/datastore/strip_opaque_ref_values_test.go
@@ -1,0 +1,223 @@
+//go:build unit
+
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package datastore_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+)
+
+// TestStripOpaqueRefValues_StripsNestedOpaqueRefValue verifies that $value is
+// removed from an opaque $ref envelope nested inside a larger JSON object.
+func TestStripOpaqueRefValues_StripsNestedOpaqueRefValue(t *testing.T) {
+	input := json.RawMessage(`{
+		"name": "my-secret",
+		"credentials": {
+			"$ref": "secrets://my-org/prod/db-password",
+			"$visibility": "Opaque",
+			"$value": "super-secret-plaintext"
+		}
+	}`)
+	// Keep a copy of the original to assert input not mutated.
+	original := make(json.RawMessage, len(input))
+	copy(original, input)
+
+	out, err := datastore.StripOpaqueRefValues(input)
+	require.NoError(t, err)
+
+	// Input must not have been mutated.
+	assert.Equal(t, string(original), string(input))
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	creds, ok := result["credentials"].(map[string]any)
+	require.True(t, ok, "credentials should be a map")
+
+	assert.Equal(t, "secrets://my-org/prod/db-password", creds["$ref"], "$ref must be preserved")
+	assert.Equal(t, "Opaque", creds["$visibility"], "$visibility must be preserved")
+	_, hasValue := creds["$value"]
+	assert.False(t, hasValue, "$value must be stripped")
+
+	// The plaintext must not appear anywhere in the output.
+	assert.NotContains(t, string(out), "super-secret-plaintext")
+}
+
+// TestStripOpaqueRefValues_KeepsRefVisibilityStrategy verifies that $ref,
+// $visibility, and $strategy are all preserved after stripping $value.
+func TestStripOpaqueRefValues_KeepsRefVisibilityStrategy(t *testing.T) {
+	input := json.RawMessage(`{
+		"token": {
+			"$ref": "secrets://vault/token",
+			"$visibility": "Opaque",
+			"$strategy": "inline",
+			"$value": "tok-abc123"
+		}
+	}`)
+
+	out, err := datastore.StripOpaqueRefValues(input)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	token := result["token"].(map[string]any)
+	assert.Equal(t, "secrets://vault/token", token["$ref"])
+	assert.Equal(t, "Opaque", token["$visibility"])
+	assert.Equal(t, "inline", token["$strategy"])
+	_, hasValue := token["$value"]
+	assert.False(t, hasValue, "$value must be stripped")
+}
+
+// TestStripOpaqueRefValues_LeavesNonOpaqueUntouched verifies that an object
+// with $ref but without $visibility:"Opaque" is left entirely unchanged.
+func TestStripOpaqueRefValues_LeavesNonOpaqueUntouched(t *testing.T) {
+	input := json.RawMessage(`{
+		"ptr": {
+			"$ref": "other://some/path",
+			"$visibility": "Plaintext",
+			"$value": "visible-value"
+		}
+	}`)
+
+	out, err := datastore.StripOpaqueRefValues(input)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	ptr := result["ptr"].(map[string]any)
+	assert.Equal(t, "visible-value", ptr["$value"], "$value must remain for non-opaque ref")
+}
+
+// TestStripOpaqueRefValues_LeavesPlainRefUntouched verifies that a plain $ref
+// object (no $visibility key at all) is left unchanged.
+func TestStripOpaqueRefValues_LeavesPlainRefUntouched(t *testing.T) {
+	input := json.RawMessage(`{"link": {"$ref": "resource://some/thing"}}`)
+
+	out, err := datastore.StripOpaqueRefValues(input)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	link := result["link"].(map[string]any)
+	assert.Equal(t, "resource://some/thing", link["$ref"])
+}
+
+// TestStripOpaqueRefValues_LeavesInlineOpaqueWithoutRefUntouched verifies that
+// an object with $visibility:"Opaque" but no $ref is not modified.
+func TestStripOpaqueRefValues_LeavesInlineOpaqueWithoutRefUntouched(t *testing.T) {
+	input := json.RawMessage(`{
+		"secret": {
+			"$visibility": "Opaque",
+			"$value": "inline-secret"
+		}
+	}`)
+
+	out, err := datastore.StripOpaqueRefValues(input)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(out, &result))
+
+	secret := result["secret"].(map[string]any)
+	assert.Equal(t, "inline-secret", secret["$value"], "$value must be kept when $ref is absent")
+}
+
+// TestStripOpaqueRefValues_InputNotMutated verifies that the original
+// json.RawMessage bytes are unchanged after the call.
+func TestStripOpaqueRefValues_InputNotMutated(t *testing.T) {
+	input := json.RawMessage(`{"pw": {"$ref": "s://x", "$visibility": "Opaque", "$value": "sekret"}}`)
+	original := string(input)
+
+	_, err := datastore.StripOpaqueRefValues(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, original, string(input), "input slice must not be mutated")
+}
+
+// TestStripOpaqueRefValues_PlaintextGoneFromOutput verifies that after
+// stripping, the resolved secret string does not appear in the JSON output.
+func TestStripOpaqueRefValues_PlaintextGoneFromOutput(t *testing.T) {
+	input := json.RawMessage(`{
+		"a": {"$ref": "s://a", "$visibility": "Opaque", "$value": "plaintext-secret-a"},
+		"b": {"$ref": "s://b", "$visibility": "Opaque", "$value": "plaintext-secret-b"}
+	}`)
+
+	out, err := datastore.StripOpaqueRefValues(input)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(out), "plaintext-secret-a")
+	assert.NotContains(t, string(out), "plaintext-secret-b")
+}
+
+// TestStripOpaqueRefValues_StripsInsideArray verifies that stripping works on
+// opaque $ref envelopes that appear inside a JSON array.
+func TestStripOpaqueRefValues_StripsInsideArray(t *testing.T) {
+	input := json.RawMessage(`[
+		{"$ref": "s://x", "$visibility": "Opaque", "$value": "hidden"},
+		{"$ref": "s://y", "$visibility": "Opaque", "$value": "also-hidden"}
+	]`)
+
+	out, err := datastore.StripOpaqueRefValues(input)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "hidden")
+}
+
+// TestStripOpaqueRefValues_EmptyInput verifies that an empty RawMessage is
+// returned as-is without error.
+func TestStripOpaqueRefValues_EmptyInput(t *testing.T) {
+	out, err := datastore.StripOpaqueRefValues(json.RawMessage{})
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+// TestStripOpaqueRefValues_MalformedOpaqueRefReturnsError verifies the
+// reject-guard: if an opaque $ref envelope still carries $value after
+// normalization (a shape the transformer could not normalize), an error is
+// returned. This is exercised by constructing a raw JSON payload that manually
+// triggers the guard — i.e. the transformer sees the envelope but cannot strip
+// it because the key is not "$value" in the stripping pass (simulated here
+// with a type assertion bypass: we inject a raw message that still has $value
+// present and test that assertNoOpaqueRefValue fires the error).
+//
+// In practice, StripOpaqueRefValues strips correctly, so to reach the guard we
+// verify the error path by checking the public contract: passing a valid opaque
+// envelope returns no error, confirming the guard only fires on unexpected shapes.
+//
+// To directly test the guard's error branch, we rely on the fact that
+// StripOpaqueRefValues returns an error when the internal walk leaves $value
+// present. We construct a pathological JSON blob that encodes a map where
+// JSON unmarshalling yields the right keys but the stripping condition is not
+// met — there is no such input (strip always removes it). Instead, we test the
+// indirect surface: a pre-stripped input with no $value must not error, and
+// a direct test of the exported function with a valid opaque-ref-with-$value
+// input must strip correctly (no error, no $value in output).
+func TestStripOpaqueRefValues_MalformedOpaqueRefReturnsError(t *testing.T) {
+	// The reject-guard fires when, after the strip walk, an opaque $ref envelope
+	// still has $value. This cannot happen through normal stripOpaqueRefValues
+	// execution, so we test the guard indirectly by asserting that a well-formed
+	// input with $value present is handled correctly (no error), and separately
+	// by testing a contrived scenario:
+	//
+	// We can verify the error path exists by calling StripOpaqueRefValues with
+	// JSON that contains a nested opaque $ref and confirming a clean round-trip.
+	// The assertNoOpaqueRefValue guard is tested by the other test cases
+	// collectively: if stripping ever missed a case, the guard would fire.
+
+	// Verify a clean opaque-ref input strips without error.
+	input := json.RawMessage(`{"pw": {"$ref": "s://x", "$visibility": "Opaque", "$value": "sekret"}}`)
+	out, err := datastore.StripOpaqueRefValues(input)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "sekret")
+}

--- a/internal/datastore/strip_opaque_ref_values_test.go
+++ b/internal/datastore/strip_opaque_ref_values_test.go
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: FSL-1.1-ALv2
 
-package datastore_test
+package datastore
 
 import (
 	"encoding/json"
@@ -12,8 +12,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/platform-engineering-labs/formae/internal/datastore"
 )
 
 // TestStripOpaqueRefValues_StripsNestedOpaqueRefValue verifies that $value is
@@ -31,7 +29,7 @@ func TestStripOpaqueRefValues_StripsNestedOpaqueRefValue(t *testing.T) {
 	original := make(json.RawMessage, len(input))
 	copy(original, input)
 
-	out, err := datastore.StripOpaqueRefValues(input)
+	out, err := StripOpaqueRefValues(input)
 	require.NoError(t, err)
 
 	// Input must not have been mutated.
@@ -64,7 +62,7 @@ func TestStripOpaqueRefValues_KeepsRefVisibilityStrategy(t *testing.T) {
 		}
 	}`)
 
-	out, err := datastore.StripOpaqueRefValues(input)
+	out, err := StripOpaqueRefValues(input)
 	require.NoError(t, err)
 
 	var result map[string]any
@@ -89,7 +87,7 @@ func TestStripOpaqueRefValues_LeavesNonOpaqueUntouched(t *testing.T) {
 		}
 	}`)
 
-	out, err := datastore.StripOpaqueRefValues(input)
+	out, err := StripOpaqueRefValues(input)
 	require.NoError(t, err)
 
 	var result map[string]any
@@ -104,7 +102,7 @@ func TestStripOpaqueRefValues_LeavesNonOpaqueUntouched(t *testing.T) {
 func TestStripOpaqueRefValues_LeavesPlainRefUntouched(t *testing.T) {
 	input := json.RawMessage(`{"link": {"$ref": "resource://some/thing"}}`)
 
-	out, err := datastore.StripOpaqueRefValues(input)
+	out, err := StripOpaqueRefValues(input)
 	require.NoError(t, err)
 
 	var result map[string]any
@@ -124,7 +122,7 @@ func TestStripOpaqueRefValues_LeavesInlineOpaqueWithoutRefUntouched(t *testing.T
 		}
 	}`)
 
-	out, err := datastore.StripOpaqueRefValues(input)
+	out, err := StripOpaqueRefValues(input)
 	require.NoError(t, err)
 
 	var result map[string]any
@@ -140,7 +138,7 @@ func TestStripOpaqueRefValues_InputNotMutated(t *testing.T) {
 	input := json.RawMessage(`{"pw": {"$ref": "s://x", "$visibility": "Opaque", "$value": "sekret"}}`)
 	original := string(input)
 
-	_, err := datastore.StripOpaqueRefValues(input)
+	_, err := StripOpaqueRefValues(input)
 	require.NoError(t, err)
 
 	assert.Equal(t, original, string(input), "input slice must not be mutated")
@@ -154,7 +152,7 @@ func TestStripOpaqueRefValues_PlaintextGoneFromOutput(t *testing.T) {
 		"b": {"$ref": "s://b", "$visibility": "Opaque", "$value": "plaintext-secret-b"}
 	}`)
 
-	out, err := datastore.StripOpaqueRefValues(input)
+	out, err := StripOpaqueRefValues(input)
 	require.NoError(t, err)
 
 	assert.NotContains(t, string(out), "plaintext-secret-a")
@@ -169,7 +167,7 @@ func TestStripOpaqueRefValues_StripsInsideArray(t *testing.T) {
 		{"$ref": "s://y", "$visibility": "Opaque", "$value": "also-hidden"}
 	]`)
 
-	out, err := datastore.StripOpaqueRefValues(input)
+	out, err := StripOpaqueRefValues(input)
 	require.NoError(t, err)
 	assert.NotContains(t, string(out), "hidden")
 }
@@ -177,47 +175,37 @@ func TestStripOpaqueRefValues_StripsInsideArray(t *testing.T) {
 // TestStripOpaqueRefValues_EmptyInput verifies that an empty RawMessage is
 // returned as-is without error.
 func TestStripOpaqueRefValues_EmptyInput(t *testing.T) {
-	out, err := datastore.StripOpaqueRefValues(json.RawMessage{})
+	out, err := StripOpaqueRefValues(json.RawMessage{})
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
 
-// TestStripOpaqueRefValues_MalformedOpaqueRefReturnsError verifies the
-// reject-guard: if an opaque $ref envelope still carries $value after
-// normalization (a shape the transformer could not normalize), an error is
-// returned. This is exercised by constructing a raw JSON payload that manually
-// triggers the guard — i.e. the transformer sees the envelope but cannot strip
-// it because the key is not "$value" in the stripping pass (simulated here
-// with a type assertion bypass: we inject a raw message that still has $value
-// present and test that assertNoOpaqueRefValue fires the error).
-//
-// In practice, StripOpaqueRefValues strips correctly, so to reach the guard we
-// verify the error path by checking the public contract: passing a valid opaque
-// envelope returns no error, confirming the guard only fires on unexpected shapes.
-//
-// To directly test the guard's error branch, we rely on the fact that
-// StripOpaqueRefValues returns an error when the internal walk leaves $value
-// present. We construct a pathological JSON blob that encodes a map where
-// JSON unmarshalling yields the right keys but the stripping condition is not
-// met — there is no such input (strip always removes it). Instead, we test the
-// indirect surface: a pre-stripped input with no $value must not error, and
-// a direct test of the exported function with a valid opaque-ref-with-$value
-// input must strip correctly (no error, no $value in output).
-func TestStripOpaqueRefValues_MalformedOpaqueRefReturnsError(t *testing.T) {
-	// The reject-guard fires when, after the strip walk, an opaque $ref envelope
-	// still has $value. This cannot happen through normal stripOpaqueRefValues
-	// execution, so we test the guard indirectly by asserting that a well-formed
-	// input with $value present is handled correctly (no error), and separately
-	// by testing a contrived scenario:
-	//
-	// We can verify the error path exists by calling StripOpaqueRefValues with
-	// JSON that contains a nested opaque $ref and confirming a clean round-trip.
-	// The assertNoOpaqueRefValue guard is tested by the other test cases
-	// collectively: if stripping ever missed a case, the guard would fire.
+// TestAssertNoOpaqueRefValue_RejectsOpaqueRefWithValue verifies the reject-guard
+// directly: an opaque $ref envelope that still carries $value (the regression
+// state the strip is designed to prevent) must produce an error, and that error
+// must not contain the plaintext secret value.
+func TestAssertNoOpaqueRefValue_RejectsOpaqueRefWithValue(t *testing.T) {
+	// Construct the exact regression state: an opaque $ref that was NOT stripped.
+	envelope := map[string]any{
+		"$ref":        "formae://x",
+		"$visibility": "Opaque",
+		"$value":      "super-secret",
+	}
 
-	// Verify a clean opaque-ref input strips without error.
-	input := json.RawMessage(`{"pw": {"$ref": "s://x", "$visibility": "Opaque", "$value": "sekret"}}`)
-	out, err := datastore.StripOpaqueRefValues(input)
-	require.NoError(t, err)
-	assert.NotContains(t, string(out), "sekret")
+	err := assertNoOpaqueRefValue(envelope, "")
+	require.Error(t, err, "guard must reject an opaque $ref that still carries $value")
+	assert.NotContains(t, err.Error(), "super-secret", "error must not leak the secret value")
+}
+
+// TestAssertNoOpaqueRefValue_AcceptsStrippedOpaqueRef verifies that the guard
+// returns nil when an opaque $ref envelope has had $value correctly removed.
+func TestAssertNoOpaqueRefValue_AcceptsStrippedOpaqueRef(t *testing.T) {
+	envelope := map[string]any{
+		"$ref":        "formae://x",
+		"$visibility": "Opaque",
+		// no $value — correctly stripped
+	}
+
+	err := assertNoOpaqueRefValue(envelope, "")
+	require.NoError(t, err, "guard must accept a properly-stripped opaque $ref")
 }

--- a/internal/workflow_tests/local/apply_forma/secret_hashing_test.go
+++ b/internal/workflow_tests/local/apply_forma/secret_hashing_test.go
@@ -10,7 +10,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -471,25 +470,12 @@ func TestSecretHashing_ResolveCacheDoesNotLogSecret(t *testing.T) {
 	})
 }
 
-// TestSecretHashing_TargetConfigResolvedSecretStoredAsPlaintext_KnownGap documents a
-// REAL, currently-unaddressed plaintext leak found while writing the workflow tests
-// above: when a target's Config $refs a schema-opaque resource property (e.g. a
-// SecretsManager SecretString), ResolveCache.preserveRefMetadata correctly re-wraps
-// the resolved value in an {"$value":...,"$visibility":"Opaque"} envelope, but nothing
-// downstream (TargetUpdater / resource_persister's target-store path) hashes that
-// envelope before it is persisted to the targets table — unlike the resources and
-// resource_updates tables, which hash at their write choke
-// points. The plaintext secret is stored verbatim in targets.config.
-//
-// This sink is outside the hash-at-rest scope (which covers resource properties/
-// resource_updates, not target configs) and fixing it is more than a wiring fix — a
-// target Config has no per-field schema the way a resource does, and the resolved
-// value here is later read back and sent live to a plugin as TargetConfig, so hashing
-// it here needs its own design (mirroring the resource-side hash-at-rest +
-// hash-vs-hash drift convergence work) rather than a quick patch. Left as a SKIPPED,
-// self-documenting test that pins the known gap — un-skip once a target-config
-// hashing fix lands.
-func TestSecretHashing_TargetConfigResolvedSecretStoredAsPlaintext_KnownGap(t *testing.T) {
+// TestSecretHashing_TargetConfigResolvedSecretStoredAsReference verifies that when a
+// target's Config contains a $ref pointing to a schema-opaque resource property (e.g.
+// a SecretsManager SecretString), the persisted targets.config retains the $ref pointer
+// but does not store the resolved plaintext value or the intermediate $value envelope.
+// Only the reference is persisted; the opaque value is stripped at the write boundary.
+func TestSecretHashing_TargetConfigResolvedSecretStoredAsReference(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		const plaintextSecret = "resolve-cache-must-not-log-this-secret"
 
@@ -533,14 +519,9 @@ func TestSecretHashing_TargetConfigResolvedSecretStoredAsPlaintext_KnownGap(t *t
 		require.NotNil(t, consumerTarget)
 		t.Logf("targets.config for %q: %s", "consumer", consumerTarget.Config)
 
-		// Skip (rather than fail) while the gap is open, so this file's required suite
-		// stays green; the moment the underlying leak is fixed, this reverts to a plain
-		// assertion and the test starts passing for real with no code change needed.
-		if strings.Contains(string(consumerTarget.Config), plaintextSecret) {
-			t.Skip("KNOWN GAP: targets.config stores a $ref-resolved schema-opaque value as " +
-				"plaintext — see this test's doc comment. Tracked for a follow-up fix; not " +
-				"addressed by the schema-keyed opaque-value hashing this test covers.")
-		}
+		// The $ref pointer is preserved in persisted config; the resolved opaque value is not.
+		assert.Contains(t, string(consumerTarget.Config), "$ref")
+		assert.NotContains(t, string(consumerTarget.Config), `"$value"`)
 		assert.NotContains(t, string(consumerTarget.Config), plaintextSecret)
 	})
 }


### PR DESCRIPTION
## Summary

- Adds `datastore.StripOpaqueRefValues` — a single recursive normalize-and-validate that removes `$value` from every opaque `$ref` envelope (an object carrying both `$ref` and `$visibility:"Opaque"`) while preserving the reference pointer, then fails closed (reject-guard) if any opaque `$ref` still carries `$value`.
- Wires it into **every** target-side persistence write path across all four datastore backends (sqlite, postgres, aurora, mssql): `targets.config` (create + update), `resource_updates.resource_target`, and `forma_commands.target_updates` (both writers — `UpdateFormaCommandTargetUpdates` and `StoreFormaCommand`). A `$ref`-resolved schema-opaque value is therefore never stored in cleartext at rest; only the reference is persisted.
- Leaves inline opaque values (stored hashed, no `$ref`) and plain references untouched — the predicate requires both `$ref` and `$visibility:"Opaque"`.
- Flips the previously-skipped target-config plaintext test to a live assertion that `targets.config` persists reference-only (`$ref` present, no `$value`, no plaintext).

## Why

Closes a real plaintext-at-rest gap: when a target's config referenced a schema-opaque resource property, the resolved secret was written verbatim into `targets.config` (and the target-bearing audit/resource-update columns), because — unlike the resource tables — the target-config write paths had no hash/strip choke point. Persisting only the reference keeps the value out of every durable target-side representation while the live value is still resolved at the plugin-call boundary.

Notes: no shared target-config serializer existed, so the strip is applied uniformly at each backend's write site (grep-verified complete). Postgres/aurora/mssql integration paths are covered by the shared-helper unit tests + the sqlite write-boundary tests + inspection that each site calls the strip. Stacked on the `.json()` branch (base `secrets-stage2b-json-nav`); GitHub retargets as parents land.