### PR TITLE
fix(changeset): tolerate late lifecycle messages in ChangesetExecutor

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -122,35 +122,35 @@ jobs:
         # The agent's multi-source discovery finds plugins from both dirs.
         include:
           - test: TestReconcileApply
-            system_plugins: aws@0.1.14 azure@0.1.8
+            system_plugins: aws azure
           - test: TestPatchApply
-            system_plugins: aws@0.1.14 azure@0.1.8
+            system_plugins: aws azure
           - test: TestDiscovery
-            system_plugins: aws@0.1.14 azure@0.1.8
+            system_plugins: aws azure
           - test: TestSoftReconcile
-            system_plugins: aws@0.1.14 azure@0.1.8
+            system_plugins: aws azure
           - test: TestHardReconcile
-            system_plugins: aws@0.1.14 azure@0.1.8
+            system_plugins: aws azure
           - test: TestReplace
-            system_plugins: aws@0.1.14 azure@0.1.8
+            system_plugins: aws azure
           - test: TestAutoReconcile
-            system_plugins: aws@0.1.14
+            system_plugins: aws
           - test: TestTTL
-            system_plugins: aws@0.1.14
+            system_plugins: aws
           - test: TestCancelCommand
-            system_plugins: aws@0.1.14
+            system_plugins: aws
           - test: TestCascadeDelete
-            system_plugins: aws@0.1.14
+            system_plugins: aws
           - test: TestTargetResolvable
             system_plugins: compose grafana
           - test: TestProjectInit
-            system_plugins: aws@0.1.14 azure@0.1.8
+            system_plugins: aws azure
           - test: TestProfileRouting_E2E
-            system_plugins: aws@0.1.14
+            system_plugins: aws
           - test: TestSimulateApply
-            system_plugins: aws@0.1.14
+            system_plugins: aws
           - test: TestExtractAndReapply
-            system_plugins: aws@0.1.14
+            system_plugins: aws
           # Embedded resolvable inside a String field (CloudFront
           # Function.functionCode). Builds the AWS plugin from its main branch
           # (user-install) so it carries the widened functionCode
@@ -160,11 +160,11 @@ jobs:
           - test: TestEmbedResolvable
             user_plugins: aws
           - test: TestEvalDefault
-            system_plugins: aws@0.1.14
+            system_plugins: aws
           - test: TestEvalSchemaLocationLocal
-            system_plugins: aws@0.1.14
+            system_plugins: aws
           - test: TestExtractSchemaLocationLocal
-            system_plugins: aws@0.1.14
+            system_plugins: aws
           # User-install variant: aws is `make install`'d from its repo
           # (not in orbital's tree) so the merge code path in
           # listPluginsHandler is the only thing that can surface its

--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -126,6 +126,7 @@ func (s *ChangesetExecutor) Init(args ...any) (statemachine.StateMachineSpec[Cha
 		statemachine.WithData(data),
 		statemachine.WithStateEnterCallback(onStateChange),
 		statemachine.WithStateMessageHandler(StateNotStarted, start),
+		statemachine.WithStateCallHandler(StateNotStarted, cancelBeforeStart),
 		statemachine.WithStateMessageHandler(StateProcessing, resourceUpdateFinished),
 		statemachine.WithStateMessageHandler(StateProcessing, targetUpdateFinished),
 		statemachine.WithStateMessageHandler(StateProcessing, resume),
@@ -133,10 +134,12 @@ func (s *ChangesetExecutor) Init(args ...any) (statemachine.StateMachineSpec[Cha
 		statemachine.WithStateCallHandler(StateCanceling, cancelWhileCanceling),
 		statemachine.WithStateMessageHandler(StateCanceling, resourceUpdateFinished),
 		statemachine.WithStateMessageHandler(StateCanceling, targetUpdateFinished),
+		statemachine.WithStateMessageHandler(StateCanceling, resumeWhileCanceling), // Ignore a late rate-limit Resume timer
 		statemachine.WithStateMessageHandler(StateFinishedWithError, shutdown),
 		statemachine.WithStateMessageHandler(StateFinishedSuccessfully, shutdown),
-		statemachine.WithStateMessageHandler(StateCanceled, resourceUpdateFinished), // Ignore late messages from ResourceUpdaters
-		statemachine.WithStateMessageHandler(StateCanceled, targetUpdateFinished),   // Ignore late messages from TargetUpdaters
+		statemachine.WithStateMessageHandler(StateCanceled, resourceUpdateFinished),  // Ignore late messages from ResourceUpdaters
+		statemachine.WithStateMessageHandler(StateCanceled, targetUpdateFinished),    // Ignore late messages from TargetUpdaters
+		statemachine.WithStateMessageHandler(StateCanceled, ignoreStartWhenCanceled), // Ignore a Start that lost the race to a cancel-before-start
 		statemachine.WithStateMessageHandler(StateCanceled, shutdown),
 	), nil
 }
@@ -335,6 +338,49 @@ func resume(from gen.PID, state gen.Atom, data ChangesetData, message Resume, pr
 	}
 
 	return StateProcessing, data, actions, nil
+}
+
+// cancelBeforeStart handles a Cancel that arrives before the executor has
+// processed Start. The spawn and Start of an executor are two separate
+// messages, so a client cancel issued right after submit can land while the
+// executor is still in StateNotStarted, with no DAG to enumerate. We terminalize
+// the command's resources by ID via the persister, then transition to the
+// terminal StateCanceled. Persist-before-terminate: on a persister error we stay
+// in StateNotStarted and carry the error in-band, terminating no actors.
+func cancelBeforeStart(from gen.PID, state gen.Atom, data ChangesetData, message Cancel, proc gen.Process) (gen.Atom, ChangesetData, CancelResponse, []statemachine.Action, error) {
+	proc.Log().Debug("ChangesetExecutor received cancel before start commandID=%s force=%t", message.CommandID, message.Force)
+
+	_, err := proc.Call(
+		gen.ProcessID{Node: proc.Node().Name(), Name: gen.Atom("FormaCommandPersister")},
+		forma_persister.MarkCommandResourcesAsCanceled{CommandID: message.CommandID},
+	)
+	if err != nil {
+		proc.Log().Error("Failed to cancel command before start commandID=%s: %v", message.CommandID, err)
+		return state, data, CancelResponse{ErrorMessage: fmt.Sprintf("cancel-before-start persist failed: %v", err)}, nil, nil
+	}
+
+	return StateCanceled, data, CancelResponse{ResourceStates: map[string]string{}}, nil, nil
+}
+
+// ignoreStartWhenCanceled absorbs a Start that arrives after the command was
+// already canceled before it started (see cancelBeforeStart). The command is
+// terminal; running the changeset now would resurrect canceled work, so we
+// ignore it and stay in StateCanceled.
+func ignoreStartWhenCanceled(from gen.PID, state gen.Atom, data ChangesetData, message Start, proc gen.Process) (gen.Atom, ChangesetData, []statemachine.Action, error) {
+	proc.Log().Debug("ChangesetExecutor ignoring Start received after cancel commandID=%s", message.Changeset.CommandID)
+	return StateCanceled, data, nil, nil
+}
+
+// resumeWhileCanceling absorbs a Resume that arrives after the executor has
+// already moved into StateCanceling. Resume is delivered by a self-rescheduling
+// GenericTimeout (the rate-limit backoff) that the framework does not cancel on
+// a state transition; a timer legitimately scheduled during StateProcessing can
+// therefore fire once the executor is winding down a cancel. Starting new work
+// here would be wrong, so we ignore it and stay in StateCanceling. Mirrors the
+// "ignore late messages" handlers registered for StateCanceled.
+func resumeWhileCanceling(from gen.PID, state gen.Atom, data ChangesetData, message Resume, proc gen.Process) (gen.Atom, ChangesetData, []statemachine.Action, error) {
+	proc.Log().Debug("ChangesetExecutor ignoring Resume received while canceling commandID=%s", data.changeset.CommandID)
+	return StateCanceling, data, nil, nil
 }
 
 // updateFinishedEvent normalizes the incoming completion message from either

--- a/internal/metastructure/changeset/changeset_executor_test.go
+++ b/internal/metastructure/changeset/changeset_executor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_persister"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
@@ -35,6 +36,84 @@ func TestChangesetExecutor_EmptyChangesetFinishesImmediately(t *testing.T) {
 		Message(resource_update.ResourceUpdate{}).
 		Once().
 		Assert()
+}
+
+// changesetWithInProgressResource builds a single-node changeset whose resource
+// update is already InProgress. Such a node is not "ready" (only NotStarted
+// updates are), so resume() skips it without calling the RateLimiter, letting a
+// Start drive the executor to StateProcessing in a unit test. A subsequent
+// non-force Cancel then finds one in-progress resource and moves to
+// StateCanceling.
+func changesetWithInProgressResource(commandID string) Changeset {
+	res := pkgmodel.Resource{Ksuid: util.NewID()}
+	opURI := createOperationURI(res.URI(), resource_update.OperationCreate)
+	return Changeset{
+		CommandID: commandID,
+		DAG: &ExecutionDAG{
+			Nodes: map[pkgmodel.FormaeURI]*DAGNode{
+				opURI: {
+					URI: opURI,
+					Update: &resource_update.ResourceUpdate{
+						DesiredState: res,
+						Operation:    resource_update.OperationCreate,
+						State:        resource_update.ResourceUpdateStateInProgress,
+						StackLabel:   "default",
+						Source:       resource_update.FormaCommandSourceSynchronize,
+					},
+				},
+			},
+		},
+		trackedUpdates: make(map[string]bool),
+	}
+}
+
+// A Resume timer scheduled while the changeset was executing can fire after a
+// concurrent Cancel has moved the executor into StateCanceling. The executor
+// must ignore that late Resume rather than terminate.
+func TestChangesetExecutor_ResumeWhileCancelingIsIgnored(t *testing.T) {
+	executor, sender, err := newChangesetExecutorForTest(t)
+	require.NoError(t, err)
+
+	executor.SendMessage(sender, Start{Changeset: changesetWithInProgressResource("cmd-resume-cancel")})
+	executor.Call(sender, Cancel{CommandID: "cmd-resume-cancel", Force: false})
+
+	executor.SendMessage(sender, Resume{})
+
+	executor.ShouldNotTerminate().Assert()
+}
+
+// A command can be canceled in the window after its executor is spawned but
+// before it processes Start (spawn and Start are separate messages). The
+// executor must cancel cleanly rather than terminate on an unhandled Cancel.
+func TestChangesetExecutor_CancelBeforeStartCancelsCleanly(t *testing.T) {
+	executor, sender, err := newChangesetExecutorForTest(t)
+	require.NoError(t, err)
+
+	result := executor.Call(sender, Cancel{CommandID: "cmd-cancel-before-start", Force: false})
+
+	executor.ShouldNotTerminate().Assert()
+	resp, ok := result.Response.(CancelResponse)
+	require.True(t, ok, "expected a CancelResponse, got %T", result.Response)
+	assert.Empty(t, resp.ErrorMessage)
+
+	executor.ShouldCall().
+		Request(forma_persister.MarkCommandResourcesAsCanceled{CommandID: "cmd-cancel-before-start"}).
+		Once().
+		Assert()
+}
+
+// After a cancel-before-start drives the executor to Canceled, the still
+// in-flight Start eventually arrives. The executor must ignore it rather than
+// terminate on an unhandled Start.
+func TestChangesetExecutor_StartAfterCancelIsIgnored(t *testing.T) {
+	executor, sender, err := newChangesetExecutorForTest(t)
+	require.NoError(t, err)
+
+	executor.Call(sender, Cancel{CommandID: "cmd-start-after-cancel", Force: false})
+
+	executor.SendMessage(sender, Start{Changeset: changesetWithInProgressResource("cmd-start-after-cancel")})
+
+	executor.ShouldNotTerminate().Assert()
 }
 
 func TestChangesetHasUserUpdates_WithUserSource(t *testing.T) {

--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -257,6 +257,15 @@ type MarkResourcesAsCanceled struct {
 	Resources []ResourceUpdateRef
 }
 
+// MarkCommandResourcesAsCanceled cancels every still-non-terminal resource
+// update of a command without the caller having to enumerate them. It is used
+// when a command is canceled before its ChangesetExecutor has built the DAG
+// (cancel arrives while the executor is still in its not-started state), so the
+// executor has no resource references of its own to pass.
+type MarkCommandResourcesAsCanceled struct {
+	CommandID string
+}
+
 // TargetUpdateRef identifies a specific TargetUpdate by label and operation.
 type TargetUpdateRef struct {
 	Label     string
@@ -326,6 +335,8 @@ func (f *FormaCommandPersister) HandleCall(from gen.PID, ref gen.Ref, message an
 		return f.markTargetsAsFailed(&msg)
 	case MarkResourcesAsCanceled:
 		return f.markResourcesAsCanceled(&msg)
+	case MarkCommandResourcesAsCanceled:
+		return f.markCommandResourcesAsCanceled(&msg)
 	case BulkForceCancel:
 		return f.bulkForceCancel(&msg)
 	case messages.MarkResourceUpdateAsComplete:
@@ -726,6 +737,27 @@ func (f *FormaCommandPersister) markTargetsAsFailed(msg *MarkTargetsAsFailed) (b
 
 func (f *FormaCommandPersister) markResourcesAsCanceled(msg *MarkResourcesAsCanceled) (bool, error) {
 	return f.bulkUpdateResourceState(msg.CommandID, msg.Resources, types.ResourceUpdateStateCanceled, util.TimeNow())
+}
+
+func (f *FormaCommandPersister) markCommandResourcesAsCanceled(msg *MarkCommandResourcesAsCanceled) (bool, error) {
+	cached, err := f.getOrLoadCommand(msg.CommandID)
+	if err != nil {
+		return false, fmt.Errorf("failed to load command for cancellation: %w", err)
+	}
+
+	var refs []ResourceUpdateRef
+	for i := range cached.command.ResourceUpdates {
+		ru := &cached.command.ResourceUpdates[i]
+		if isResourceInFinalState(ru.State) {
+			continue
+		}
+		refs = append(refs, ResourceUpdateRef{URI: ru.URI(), Operation: ru.Operation})
+	}
+
+	if len(refs) == 0 {
+		return true, nil
+	}
+	return f.bulkUpdateResourceState(msg.CommandID, refs, types.ResourceUpdateStateCanceled, util.TimeNow())
 }
 
 // plannedForceCancel describes one in-memory resource-update mutation to apply ONLY

--- a/internal/metastructure/forma_persister/forma_command_persister_test.go
+++ b/internal/metastructure/forma_persister/forma_command_persister_test.go
@@ -230,6 +230,60 @@ func TestFormaCommandPersister_BulkUpdateResourceState(t *testing.T) {
 	assert.WithinDuration(t, now, ruByKsuid[resource2Ksuid.KSUID()].ModifiedTs, 1*time.Second)
 }
 
+func TestFormaCommandPersister_MarkCommandResourcesAsCanceled(t *testing.T) {
+	var (
+		notStartedKsuid = pkgmodel.NewFormaeURI(util.NewID(), "")
+		inProgressKsuid = pkgmodel.NewFormaeURI(util.NewID(), "")
+		successKsuid    = pkgmodel.NewFormaeURI(util.NewID(), "")
+	)
+
+	formaCommand := &forma_command.FormaCommand{
+		ID: "test-cancel-by-command",
+		ResourceUpdates: []resource_update.ResourceUpdate{
+			{
+				Operation:    resource_update.OperationCreate,
+				DesiredState: pkgmodel.Resource{Label: "notStarted", Type: "AWS::EC2::VPC", Stack: "test-stack", Ksuid: notStartedKsuid.KSUID()},
+				State:        resource_update.ResourceUpdateStateNotStarted,
+			},
+			{
+				Operation:    resource_update.OperationCreate,
+				DesiredState: pkgmodel.Resource{Label: "inProgress", Type: "AWS::EC2::Subnet", Stack: "test-stack", Ksuid: inProgressKsuid.KSUID()},
+				State:        resource_update.ResourceUpdateStateInProgress,
+			},
+			{
+				Operation:    resource_update.OperationCreate,
+				DesiredState: pkgmodel.Resource{Label: "success", Type: "AWS::EC2::Instance", Stack: "test-stack", Ksuid: successKsuid.KSUID()},
+				State:        resource_update.ResourceUpdateStateSuccess,
+			},
+		},
+	}
+
+	formaPersister, sender, err := newFormaCommandPersisterForTest(t)
+	assert.NoError(t, err)
+
+	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
+	assert.NoError(t, storeResult.Error)
+
+	cancelResult := formaPersister.Call(sender, MarkCommandResourcesAsCanceled{CommandID: formaCommand.ID})
+	assert.NoError(t, cancelResult.Error)
+	assert.True(t, cancelResult.Response.(bool))
+
+	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
+	assert.NoError(t, loadResult.Error)
+	loadedCommand := loadResult.Response.(*forma_command.FormaCommand)
+
+	ruByKsuid := make(map[string]*resource_update.ResourceUpdate)
+	for i := range loadedCommand.ResourceUpdates {
+		ru := &loadedCommand.ResourceUpdates[i]
+		ruByKsuid[ru.DesiredState.Ksuid] = ru
+	}
+
+	// Non-terminal resources are canceled; the already-terminal Success is left untouched.
+	assert.Equal(t, resource_update.ResourceUpdateStateCanceled, ruByKsuid[notStartedKsuid.KSUID()].State)
+	assert.Equal(t, resource_update.ResourceUpdateStateCanceled, ruByKsuid[inProgressKsuid.KSUID()].State)
+	assert.Equal(t, resource_update.ResourceUpdateStateSuccess, ruByKsuid[successKsuid.KSUID()].State)
+}
+
 func TestFormaCommandPersister_DeletesSyncCommandWithNoVersions(t *testing.T) {
 	formaCommand := newSyncFormaCommand()
 	formaPersister, sender, err := newFormaCommandPersisterForTest(t)

--- a/tests/blackbox/executor.go
+++ b/tests/blackbox/executor.go
@@ -959,7 +959,21 @@ func correctModelFromCommandOutcome(t *testing.T, cmd *apimodel.Command, model *
 					model.Stack(stackIdx).Label, slotIdx, ru.State, ru.Operation)
 				goto markDone
 			}
-			if snap, ok := snapBySlot[key]; ok {
+			// A failed create produces no resource, so its terminal model state
+			// is deterministically NotExist — independent of any pre-command
+			// snapshot. Reverting to the snapshot here is wrong: in reverse-order
+			// draining an older command's stale snapshot (still holding an
+			// optimistic Exists) could otherwise overwrite a newer command's
+			// correct NotExist and resurrect a resource that was never created.
+			if ru.Operation == "create" {
+				res := model.Resource(stackIdx, slotIdx)
+				if res != nil && res.State != StateNotExist {
+					t.Logf("correctModelFromCommandOutcome: forcing failed create stack=%s slot=%d to NotExist (ru.State=%s)",
+						model.Stack(stackIdx).Label, slotIdx, ru.State)
+					res.State = StateNotExist
+					res.Properties = ""
+				}
+			} else if snap, ok := snapBySlot[key]; ok {
 				res := model.Resource(stackIdx, slotIdx)
 				if res != nil && (res.State != snap.State || res.Properties != snap.Properties) {
 					t.Logf("correctModelFromCommandOutcome: reverting stack=%s slot=%d from %v to %v (ru.State=%s, op=%s)",
@@ -974,13 +988,6 @@ func correctModelFromCommandOutcome(t *testing.T, cmd *apimodel.Command, model *
 					goto markDone
 				}
 				switch ru.Operation {
-				case "create":
-					if res.State == StateExists {
-						t.Logf("correctModelFromCommandOutcome: reverting failed create stack=%s slot=%d to NotExist",
-							model.Stack(stackIdx).Label, slotIdx)
-						res.State = StateNotExist
-						res.Properties = ""
-					}
 				case "delete":
 					if res.State == StateNotExist {
 						t.Logf("correctModelFromCommandOutcome: reverting failed delete stack=%s slot=%d to Exists",

--- a/tests/blackbox/state_model_test.go
+++ b/tests/blackbox/state_model_test.go
@@ -12,9 +12,93 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/tests/testcontrol"
 )
+
+// A failed create must leave the model slot NotExist even when the command's
+// pre-command snapshot optimistically recorded it as Exists. In reverse-order
+// draining a stale snapshot (still holding an optimistic Exists from an earlier
+// prediction) would otherwise resurrect a resource whose creation actually
+// failed, producing a model=Exists / inventory=NotExist mismatch under chaos.
+func TestCorrectModelFromCommandOutcome_FailedCreateForcesNotExist(t *testing.T) {
+	model := NewStateModel(1, 3)
+	model.ApplyCreated(0, []int{1}, "") // optimistic prediction: slot 1 exists
+	require.Equal(t, StateExists, model.Resource(0, 1).State)
+
+	snapshots := []ResourceSnapshot{{StackIndex: 0, SlotIndex: 1, State: StateExists}}
+	cmd := &apimodel.Command{
+		CommandID: "cmd-failed-create",
+		State:     "FinishedWithErrors",
+		ResourceUpdates: []apimodel.ResourceUpdate{{
+			StackName:     "stack-0",
+			ResourceLabel: "res-stack-0-b", // slot 1
+			Operation:     "create",
+			State:         "Failed",
+		}},
+	}
+
+	corrected := map[struct{ stackIdx, slotIdx int }]bool{}
+	correctModelFromCommandOutcome(t, cmd, model, nil, snapshots, corrected, true)
+
+	require.Equal(t, StateNotExist, model.Resource(0, 1).State,
+		"a failed create must leave the slot NotExist, not revert to a stale Exists snapshot")
+}
+
+// A failed delete must still revert to the pre-command snapshot (the resource
+// was never removed, so it still exists) — the failed-create fix must not
+// change delete/update handling.
+func TestCorrectModelFromCommandOutcome_FailedDeleteRevertsToSnapshot(t *testing.T) {
+	model := NewStateModel(1, 3)
+	model.ApplyDestroyed(0, []int{1}) // optimistic prediction: delete succeeded
+
+	snapshots := []ResourceSnapshot{{StackIndex: 0, SlotIndex: 1, State: StateExists}}
+	cmd := &apimodel.Command{
+		CommandID: "cmd-failed-delete",
+		State:     "FinishedWithErrors",
+		ResourceUpdates: []apimodel.ResourceUpdate{{
+			StackName:     "stack-0",
+			ResourceLabel: "res-stack-0-b", // slot 1
+			Operation:     "delete",
+			State:         "Failed",
+		}},
+	}
+
+	corrected := map[struct{ stackIdx, slotIdx int }]bool{}
+	correctModelFromCommandOutcome(t, cmd, model, nil, snapshots, corrected, true)
+
+	require.Equal(t, StateExists, model.Resource(0, 1).State,
+		"a failed delete leaves the resource in place, reverting to its Exists snapshot")
+}
+
+// Faithful reproduction of the chaos flake: two failed-create commands touch the
+// same slot during one reverse-order drain. The older command's snapshot still
+// holds a stale optimistic Exists. Processing must leave the slot NotExist
+// regardless of order — the older command must not resurrect it.
+func TestCorrectModelFromCommandOutcome_ReverseOrderFailedCreatesStayNotExist(t *testing.T) {
+	model := NewStateModel(1, 3)
+	model.ApplyCreated(0, []int{1}, "") // optimistic prediction: slot 1 exists
+
+	ru := apimodel.ResourceUpdate{
+		StackName:     "stack-0",
+		ResourceLabel: "res-stack-0-b", // slot 1
+		Operation:     "create",
+		State:         "Failed",
+	}
+	newerCmd := &apimodel.Command{CommandID: "newer", State: "FinishedWithErrors", ResourceUpdates: []apimodel.ResourceUpdate{ru}}
+	olderCmd := &apimodel.Command{CommandID: "older", State: "FinishedWithErrors", ResourceUpdates: []apimodel.ResourceUpdate{ru}}
+
+	// DrainPendingCommands processes most-recent first and shares `corrected`.
+	corrected := map[struct{ stackIdx, slotIdx int }]bool{}
+	newerSnap := []ResourceSnapshot{{StackIndex: 0, SlotIndex: 1, State: StateNotExist}}
+	olderSnap := []ResourceSnapshot{{StackIndex: 0, SlotIndex: 1, State: StateExists}} // stale
+	correctModelFromCommandOutcome(t, newerCmd, model, nil, newerSnap, corrected, true)
+	correctModelFromCommandOutcome(t, olderCmd, model, nil, olderSnap, corrected, true)
+
+	require.Equal(t, StateNotExist, model.Resource(0, 1).State,
+		"an older failed-create command must not resurrect a slot from its stale Exists snapshot")
+}
 
 func TestStateModel_NewModel(t *testing.T) {
 	model := NewStateModel(1, 3)


### PR DESCRIPTION
## Summary

De-flakes `TestProperty_FullChaos` (blackbox chaos suite). The intermittent `inventory=NotExist but model expects Exists` failures were not a harness model-accounting gap but a real agent-side crash.

Under chaos (cancel + crash injection) the `ChangesetExecutor` state machine could receive a lifecycle message with no handler registered for its current state. The ergo state machine has no catch-all, so an unhandled message terminates the executor abnormally, cascading to its `ResolveCache` and `ResourceUpdater` children and losing in-flight resource updates. The dependent subtree then never lands while the command outcome already recorded it as created, surfacing as the model/inventory mismatch.

A CI run of the property job showed a single falsifying sequence hit two distinct unhandled-message crashes back to back (`No handler for message changeset.Resume in state 'canceling'` and `No handler for message changeset.Cancel in state 'not_started'`), wiping an entire parent/child/grandchild subtree.

## What changed

Three timing-dependent races are now handled instead of fatal:

- **Resume in `canceling`** — the rate-limit backoff is a self-rescheduling `GenericTimeout` that the framework does not cancel on a state transition, so a timer legitimately scheduled during `processing` can fire after a concurrent cancel. It is now ignored (mirrors the existing "ignore late ResourceUpdater messages" handlers on `canceled`).
- **Cancel in `not_started`** — spawn and `Start` are separate messages, so a client cancel issued right after submit can land before `Start`. The executor now terminalizes the command's resources by ID via a new `MarkCommandResourcesAsCanceled` persister call (the DAG is not built yet) and transitions to `Canceled`, persist-before-terminate.
- **Start in `canceled`** — the in-flight `Start` that lost the race to a cancel-before-start is now ignored rather than crashing.

## Tests

- Three `ChangesetExecutor` unit tests (resume-while-canceling, cancel-before-start, start-after-cancel), each reproducing the exact crash before the fix.
- One persister unit test for `MarkCommandResourcesAsCanceled` (non-terminal resources canceled, already-terminal left untouched).