### PR TITLE
fix(cli): suppress kitty graphics acks that leak into the shell

### DIFF
--- a/internal/cli/tui/logo/graphics.go
+++ b/internal/cli/tui/logo/graphics.go
@@ -178,8 +178,10 @@ func kittyEncodeImage(img image.Image, cols, rows int) string {
 			}
 			fmt.Fprintf(&seq, "\033_Ga=T,f=100,C=1,q=2,%sm=%d;%s\033\\", footprint, more, chunk)
 		} else {
-			// Continuation chunks
-			fmt.Fprintf(&seq, "\033_Gm=%d;%s\033\\", more, chunk)
+			// Continuation chunks: the spec allows only m and optionally q
+			// here. Kitty proper inherits q from the first chunk, but repeat
+			// q=2 for implementations that don't.
+			fmt.Fprintf(&seq, "\033_Gq=2,m=%d;%s\033\\", more, chunk)
 		}
 	}
 

--- a/internal/cli/tui/logo/graphics.go
+++ b/internal/cli/tui/logo/graphics.go
@@ -168,11 +168,15 @@ func kittyEncodeImage(img image.Image, cols, rows int) string {
 			// First chunk: a=T (transmit+display), f=100 (PNG format), C=1 (no cursor advance), m=more.
 			// c=/r= pin the image to a fixed cell footprint so its size (and the
 			// version text positioned beside it) stays put across font zoom.
+			// q=2 suppresses ALL terminal responses: we never read the tty, so
+			// any ack (iTerm2 3.6+ replies "ESC_Gi=0;OK" even without an image
+			// id) would sit in the input buffer and echo into the shell as
+			// stray "Gi=0,p=0;OK" text after the command exits.
 			footprint := ""
 			if cols > 0 && rows > 0 {
 				footprint = fmt.Sprintf("c=%d,r=%d,", cols, rows)
 			}
-			fmt.Fprintf(&seq, "\033_Ga=T,f=100,C=1,%sm=%d;%s\033\\", footprint, more, chunk)
+			fmt.Fprintf(&seq, "\033_Ga=T,f=100,C=1,q=2,%sm=%d;%s\033\\", footprint, more, chunk)
 		} else {
 			// Continuation chunks
 			fmt.Fprintf(&seq, "\033_Gm=%d;%s\033\\", more, chunk)

--- a/internal/cli/tui/logo/graphics_test.go
+++ b/internal/cli/tui/logo/graphics_test.go
@@ -103,6 +103,31 @@ func TestKittyFullLogo_PinsCellFootprint(t *testing.T) {
 	}
 }
 
+// TestKittyFullLogo_SuppressesTerminalResponses asserts the Kitty transmit
+// command carries q=2 (suppress all responses). formae writes the logo and
+// exits without ever reading the tty; without q=2, terminals that acknowledge
+// graphics commands (e.g. iTerm2 3.6+ replies "ESC_Gi=0,p=0;OK" even when no
+// image id is given) leave their acks in the input buffer, and the shell
+// echoes them as stray "Gi=0,p=0;OK" text after the command exits.
+func TestKittyFullLogo_SuppressesTerminalResponses(t *testing.T) {
+	t.Parallel()
+
+	out := encodeKittyFullLogo(true, graphicsFullLogoWidthPx, nil)
+	if out == "" {
+		t.Fatal("encodeKittyFullLogo returned empty string")
+	}
+
+	// The control keys live in the first chunk's params, between the APC
+	// introducer and the payload separator ';'.
+	params, _, ok := strings.Cut(strings.TrimPrefix(out, "\033_G"), ";")
+	if !ok {
+		t.Fatalf("no payload separator in Kitty escape; head: %q", out[:min(len(out), 96)])
+	}
+	if !strings.Contains(params+",", "q=2,") {
+		t.Errorf("Kitty transmit must set q=2 to suppress terminal acks (they leak into the shell); params: %q", params)
+	}
+}
+
 // TestRender_KittyFullLogo asserts that SizeFull + CapKitty output:
 //   - contains the C=1 Kitty graphics escape (the full wordmark image)
 //   - drops graphicsFullLogoVersionRow rows then positions the version via CHA

--- a/internal/cli/tui/logo/graphics_test.go
+++ b/internal/cli/tui/logo/graphics_test.go
@@ -11,6 +11,7 @@ import (
 	"image"
 	"image/color"
 	_ "image/png"
+	"slices"
 	"strings"
 	"testing"
 
@@ -103,12 +104,16 @@ func TestKittyFullLogo_PinsCellFootprint(t *testing.T) {
 	}
 }
 
-// TestKittyFullLogo_SuppressesTerminalResponses asserts the Kitty transmit
-// command carries q=2 (suppress all responses). formae writes the logo and
-// exits without ever reading the tty; without q=2, terminals that acknowledge
-// graphics commands (e.g. iTerm2 3.6+ replies "ESC_Gi=0,p=0;OK" even when no
-// image id is given) leave their acks in the input buffer, and the shell
-// echoes them as stray "Gi=0,p=0;OK" text after the command exits.
+// TestKittyFullLogo_SuppressesTerminalResponses asserts every chunk of the
+// Kitty transmit carries q=2 (suppress all responses). formae writes the logo
+// and exits without ever reading the tty; without q=2, terminals that
+// acknowledge graphics commands (e.g. iTerm2 3.6+ replies "ESC_Gi=0,p=0;OK"
+// even when no image id is given) leave their acks in the input buffer, and
+// the shell echoes them as stray "Gi=0,p=0;OK" text after the command exits.
+// Kitty proper inherits q from the first chunk, but the spec allows q on
+// continuation chunks too ("Subsequent chunks must have only the m and
+// optionally q keys") — repeating it guards against implementations that
+// don't inherit, the very class of deviation this fix is for.
 func TestKittyFullLogo_SuppressesTerminalResponses(t *testing.T) {
 	t.Parallel()
 
@@ -117,14 +122,25 @@ func TestKittyFullLogo_SuppressesTerminalResponses(t *testing.T) {
 		t.Fatal("encodeKittyFullLogo returned empty string")
 	}
 
-	// The control keys live in the first chunk's params, between the APC
-	// introducer and the payload separator ';'.
-	params, _, ok := strings.Cut(strings.TrimPrefix(out, "\033_G"), ";")
-	if !ok {
-		t.Fatalf("no payload separator in Kitty escape; head: %q", out[:min(len(out), 96)])
+	chunks := strings.Split(out, "\033\\")
+	chunks = chunks[:len(chunks)-1] // drop the empty tail after the final ST
+	if len(chunks) < 2 {
+		t.Fatalf("expected a multi-chunk transmission to exercise continuation chunks, got %d chunk(s)", len(chunks))
 	}
-	if !strings.Contains(params+",", "q=2,") {
-		t.Errorf("Kitty transmit must set q=2 to suppress terminal acks (they leak into the shell); params: %q", params)
+
+	for n, chunk := range chunks {
+		if !strings.HasPrefix(chunk, "\033_G") {
+			t.Fatalf("chunk %d does not start with the APC introducer; head: %q", n, chunk[:min(len(chunk), 32)])
+		}
+		// The control keys live between the APC introducer and the payload
+		// separator ';'.
+		params, _, ok := strings.Cut(strings.TrimPrefix(chunk, "\033_G"), ";")
+		if !ok {
+			t.Fatalf("chunk %d has no payload separator; head: %q", n, chunk[:min(len(chunk), 96)])
+		}
+		if !slices.Contains(strings.Split(params, ","), "q=2") {
+			t.Errorf("chunk %d must set q=2 to suppress terminal acks (they leak into the shell); params: %q", n, params)
+		}
 	}
 }
 

--- a/internal/cli/tui/logo/logo_regression_test.go
+++ b/internal/cli/tui/logo/logo_regression_test.go
@@ -74,7 +74,7 @@ func TestRender_ITerm2FallbackToBraille(t *testing.T) {
 // Note: NOT parallel — mutates the package-level encodeKittyFn seam.
 func TestRender_KittyFullLogoComposition(t *testing.T) {
 	origKitty := encodeKittyFn
-	encodeKittyFn = func(_ bool, _ int, _ color.Color) string { return "\x1b_Ga=T,f=100,C=1,m=0;AAAA\x1b\\" }
+	encodeKittyFn = func(_ bool, _ int, _ color.Color) string { return "\x1b_Ga=T,f=100,C=1,q=2,m=0;AAAA\x1b\\" }
 	t.Cleanup(func() { encodeKittyFn = origKitty })
 
 	art, rows := Render(CapKitty, SizeFull, "1.2.3")


### PR DESCRIPTION
## Summary

- After any banner-printing command (`formae eval`, `formae agent --help`, …) in iTerm2 3.6+, stray text like `Gi=0,p=0;OK` was echoed into the shell after the command exited.
- Root cause: the logo's kitty graphics transmit command (`ESC_Ga=T,f=100,C=1,…`) carried no `q=` (quiet) key. iTerm2's kitty-protocol implementation acknowledges the transmit and placement (`ESC_Gi=0,p=0;OK`, `ESC_Gi=0;OK`) even when no image id is given. formae never reads the tty, so the acks sat in the input buffer and zsh echoed their printable characters. Real kitty stays silent without an image id, which is why this only surfaced once iTerm2 gained kitty graphics support and the capability probe started routing iTerm2 down the kitty path.
- Fix: set `q=2` (suppress all responses) on the transmit command — the protocol's fire-and-forget mode for clients that don't read responses. This is robust for any terminal implementing the protocol, not just iTerm2.
- Adds a unit test asserting the transmit params carry `q=2`, and updates the regression-test mock sequence to match the real encoder.