### PR TITLE
feat(changeset): resolve unchanged targets' secret references before plugin dispatch

### DIFF
--- a/internal/metastructure/auto_reconciler.go
+++ b/internal/metastructure/auto_reconciler.go
@@ -363,7 +363,7 @@ func prepareReconcile(ds datastore.Datastore, stackLabel string, clientID string
 	)
 
 	// Create changeset
-	cs, err := changeset.NewChangeset(resourceUpdates, nil, reconcileCommand.ID, pkgmodel.CommandApply)
+	cs, err := changeset.NewChangeset(resourceUpdates, nil, reconcileCommand.ID, pkgmodel.CommandApply, ds)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create changeset: %w", err)
 	}

--- a/internal/metastructure/auto_reconciler.go
+++ b/internal/metastructure/auto_reconciler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_persister"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
@@ -362,8 +363,15 @@ func prepareReconcile(ds datastore.Datastore, stackLabel string, clientID string
 		forma_command.SourceAutoReconciler,
 	)
 
-	// Create changeset
-	cs, err := changeset.NewChangeset(resourceUpdates, nil, reconcileCommand.ID, pkgmodel.CommandApply, ds)
+	// Generate any synthetic Resolve target ops, then build the changeset.
+	synth, err := target_update.SynthesizeResolveTargetUpdates(
+		resource_update.ReferencedTargetLabels(resourceUpdates),
+		resource_update.SourceTargetByKsuid(resourceUpdates),
+		nil, ds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create changeset: %w", err)
+	}
+	cs, err := changeset.NewChangeset(resourceUpdates, synth, reconcileCommand.ID, pkgmodel.CommandApply)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create changeset: %w", err)
 	}

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -146,6 +146,16 @@ func NewChangeset(
 	// Build implicit edges between target and resource nodes
 	changeset.DAG.buildTargetResourceEdges(targetUpdates)
 
+	// Re-run cycle detection over the FULL graph. DAG.Init runs its cycle check
+	// before any target node or target-resolvable edge exists, so a cycle formed
+	// purely by target-resolvable edges — two in-command targets whose configs
+	// reference each other's secrets, or a target referencing a secret hosted on
+	// itself — would otherwise slip through and hang the executor. This second
+	// pass turns any such cycle into a clean build-time error.
+	if changeset.DAG.HasCycles() {
+		return Changeset{}, fmt.Errorf("changeset has a dependency cycle involving target-resolvable references")
+	}
+
 	return changeset, nil
 }
 

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -13,6 +13,7 @@ import (
 
 	"log/slog"
 
+	"github.com/platform-engineering-labs/formae/internal/datastore"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
@@ -69,6 +70,7 @@ func NewChangeset(
 	targetUpdates []target_update.TargetUpdate,
 	commandID string,
 	command pkgmodel.Command,
+	ds datastore.Datastore,
 ) (Changeset, error) {
 	changeset := Changeset{
 		CommandID:      commandID,
@@ -79,6 +81,18 @@ func NewChangeset(
 	if err := changeset.DAG.Init(resourceUpdates, command); err != nil {
 		return Changeset{}, err
 	}
+
+	// Synthesize Resolve target ops for targets that a resource op references but
+	// that carry no real target update in this command. Such an unchanged target
+	// may still hold opaque $ref config that must be resolved before dependent
+	// ops dispatch it to the plugin. These synthetic ops are added as target
+	// updates so the shared target/resource edge-building wires them like a real
+	// create/update.
+	syntheticResolves, err := synthesizeResolveTargetUpdates(resourceUpdates, targetUpdates, ds)
+	if err != nil {
+		return Changeset{}, err
+	}
+	targetUpdates = append(targetUpdates, syntheticResolves...)
 
 	// Copy target updates into a local slice so the DAG owns its own memory.
 	// Without this, DAG nodes would point into the FormaCommand's TargetUpdates
@@ -127,6 +141,72 @@ func NewChangeset(
 	return changeset, nil
 }
 
+// synthesizeResolveTargetUpdates builds synthetic Resolve target ops for targets
+// that a resource op references but that are NOT already covered by a real
+// Create/Update/Replace/Delete target update in this command.
+//
+// An unchanged target may still hold opaque $ref config (e.g. a secret). Without a
+// real target update carrying resolved desired config, that config would be
+// dispatched to the plugin unresolved. For each such distinct target label, the
+// PERSISTED target row is loaded (a target with a real update already carries its
+// desired config, so it is never synthesized for), its config is scanned for
+// resolvable $refs using the same extractor that populates a target update's
+// RemainingResolvables, and — if any exist — a NewResolveTargetUpdate is appended.
+//
+// A nil datastore (unit tests that never reference persisted targets) or a target
+// that is not found is treated as "nothing to synthesize" and skipped.
+func synthesizeResolveTargetUpdates(
+	resourceUpdates []resource_update.ResourceUpdate,
+	targetUpdates []target_update.TargetUpdate,
+	ds datastore.Datastore,
+) ([]target_update.TargetUpdate, error) {
+	// Targets already covered by a real target update in this command must never be
+	// synthesized for — their update carries the desired (and re-resolved) config.
+	covered := make(map[string]bool)
+	for i := range targetUpdates {
+		covered[targetUpdates[i].Target.Label] = true
+	}
+
+	// Distinct candidate target labels referenced by a resource op, in first-seen
+	// order for a stable synthetic list.
+	seen := make(map[string]bool)
+	var candidates []string
+	consider := func(label string) {
+		if label == "" || covered[label] || seen[label] {
+			return
+		}
+		seen[label] = true
+		candidates = append(candidates, label)
+	}
+	for i := range resourceUpdates {
+		ru := &resourceUpdates[i]
+		consider(ru.DesiredState.Target)
+		consider(ru.ResourceTarget.Label)
+	}
+
+	if len(candidates) == 0 || ds == nil {
+		return nil, nil
+	}
+
+	var synthetic []target_update.TargetUpdate
+	for _, label := range candidates {
+		persisted, err := ds.LoadTarget(label)
+		if err != nil {
+			return nil, fmt.Errorf("synthesize resolve target %q: %w", label, err)
+		}
+		if persisted == nil {
+			continue
+		}
+		resolvables := resolver.ExtractResolvableURIsFromJSON(persisted.Config)
+		if len(resolvables) == 0 {
+			continue
+		}
+		synthetic = append(synthetic, target_update.NewResolveTargetUpdate(*persisted, resolvables))
+	}
+
+	return synthetic, nil
+}
+
 // createOperationURI creates a unique URI that includes the operation type
 func createOperationURI(baseURI pkgmodel.FormaeURI, operation resource_update.OperationType) pkgmodel.FormaeURI {
 	return pkgmodel.FormaeURI(fmt.Sprintf("%s/%s/%s", string(baseURI.KSUID()), string(baseURI.PropertyPath()), operation))
@@ -149,11 +229,12 @@ func (p *ExecutionDAG) buildOperationRelationships(allOps []resource_update.Reso
 //   - Delete:  resource deletes → target delete
 //   - Resolvables: target create/update → depends on resource creates it references
 //
-// For a target create/update node, every create/update resource op on that target
-// depends on it. A delete op on that target also depends on it, but only when the
-// target update re-resolves config ($ref → $value): the delete must dispatch with
+// For a target create/update/resolve node, every create/update resource op on that
+// target depends on it. A delete op on that target also depends on it, but only when
+// the target update re-resolves config ($ref → $value): the delete must dispatch with
 // the resolved config rather than the stale $ref-only snapshot. That delete edge is
-// gated on resolvables and skipped when it would close a cycle.
+// gated on resolvables and skipped when it would close a cycle. A synthetic Resolve
+// node is treated exactly like a create/update here.
 func (p *ExecutionDAG) buildTargetResourceEdges(targetUpdates []target_update.TargetUpdate) {
 	// Build resolvable-based dependency edges for target create/update operations.
 	// When a target config contains $ref to a resource property, the target node
@@ -164,7 +245,9 @@ func (p *ExecutionDAG) buildTargetResourceEdges(targetUpdates []target_update.Ta
 	// This ensures the target is persisted (and resolved, if it has resolvables) before
 	// the dependent op dispatches its config to the plugin.
 	for _, tu := range targetUpdates {
-		if tu.Operation == target_update.TargetOperationCreate || tu.Operation == target_update.TargetOperationUpdate {
+		if tu.Operation == target_update.TargetOperationCreate ||
+			tu.Operation == target_update.TargetOperationUpdate ||
+			tu.Operation == target_update.TargetOperationResolve {
 			targetNode := p.Nodes[tu.NodeURI()]
 			if targetNode == nil {
 				continue
@@ -527,7 +610,9 @@ func (p *ExecutionDAG) connectDeleteToCreate(allOps []resource_update.ResourceUp
 // buildTargetResolvableEdges links target nodes that have resolvables to the
 // resource nodes they depend on.
 //
-// For create/update: target waits for the resource it depends on (normal order).
+// For create/update/resolve: target waits for the resource it depends on (normal
+// order) — a synthetic Resolve node whose $ref points at a same-command source
+// resource waits for that resource's create/update just like a real update.
 // For delete: the resource delete waits for the target delete (reversed order),
 // ensuring resources on a dependent target are destroyed before the resource
 // that provides the target's config (e.g., Grafana dashboards deleted before

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -13,7 +13,6 @@ import (
 
 	"log/slog"
 
-	"github.com/platform-engineering-labs/formae/internal/datastore"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
@@ -65,12 +64,16 @@ type DAGNode struct {
 	Dependencies []*DAGNode
 }
 
+// NewChangeset builds the execution DAG from the given resource and target
+// updates. It is a pure graph-builder: any synthetic Resolve target ops the
+// command needs (for unchanged targets carrying opaque $ref config) are generated
+// in the Update-construction phase by target_update.SynthesizeResolveTargetUpdates
+// and passed in via targetUpdates, so this constructor needs no datastore.
 func NewChangeset(
 	resourceUpdates []resource_update.ResourceUpdate,
 	targetUpdates []target_update.TargetUpdate,
 	commandID string,
 	command pkgmodel.Command,
-	ds datastore.Datastore,
 ) (Changeset, error) {
 	changeset := Changeset{
 		CommandID:      commandID,
@@ -79,26 +82,6 @@ func NewChangeset(
 	}
 
 	if err := changeset.DAG.Init(resourceUpdates, command); err != nil {
-		return Changeset{}, err
-	}
-
-	// Synthesize Resolve target ops for targets that a resource op references but
-	// that carry no real target update in this command. Such an unchanged target
-	// may still hold opaque $ref config that must be resolved before dependent
-	// ops dispatch it to the plugin. These synthetic ops are added as target
-	// updates so the shared target/resource edge-building wires them like a real
-	// create/update.
-	syntheticResolves, err := synthesizeResolveTargetUpdates(resourceUpdates, targetUpdates, ds)
-	if err != nil {
-		return Changeset{}, err
-	}
-	targetUpdates = append(targetUpdates, syntheticResolves...)
-
-	// Reject a credential-from-credential chain: a target whose config opaquely
-	// $refs a secret whose OWN target also carries opaque $ref config cannot be
-	// resolved, because bootstrapping its credential would first require
-	// bootstrapping another.
-	if err := rejectTransitivelyOpaqueTargets(resourceUpdates, targetUpdates, ds); err != nil {
 		return Changeset{}, err
 	}
 
@@ -157,155 +140,6 @@ func NewChangeset(
 	}
 
 	return changeset, nil
-}
-
-// synthesizeResolveTargetUpdates builds synthetic Resolve target ops for targets
-// that a resource op references but that are NOT already covered by a real
-// Create/Update/Replace/Delete target update in this command.
-//
-// An unchanged target may still hold opaque $ref config (e.g. a secret). Without a
-// real target update carrying resolved desired config, that config would be
-// dispatched to the plugin unresolved. For each such distinct target label, the
-// PERSISTED target row is loaded (a target with a real update already carries its
-// desired config, so it is never synthesized for), its config is scanned for
-// resolvable $refs using the same extractor that populates a target update's
-// RemainingResolvables, and — if any exist — a NewResolveTargetUpdate is appended.
-//
-// A nil datastore (unit tests that never reference persisted targets) or a target
-// that is not found is treated as "nothing to synthesize" and skipped.
-func synthesizeResolveTargetUpdates(
-	resourceUpdates []resource_update.ResourceUpdate,
-	targetUpdates []target_update.TargetUpdate,
-	ds datastore.Datastore,
-) ([]target_update.TargetUpdate, error) {
-	// Targets already covered by a real target update in this command must never be
-	// synthesized for — their update carries the desired (and re-resolved) config.
-	covered := make(map[string]bool)
-	for i := range targetUpdates {
-		covered[targetUpdates[i].Target.Label] = true
-	}
-
-	// Distinct candidate target labels referenced by a resource op, in first-seen
-	// order for a stable synthetic list.
-	seen := make(map[string]bool)
-	var candidates []string
-	consider := func(label string) {
-		if label == "" || covered[label] || seen[label] {
-			return
-		}
-		seen[label] = true
-		candidates = append(candidates, label)
-	}
-	for i := range resourceUpdates {
-		ru := &resourceUpdates[i]
-		consider(ru.DesiredState.Target)
-		consider(ru.ResourceTarget.Label)
-	}
-
-	if len(candidates) == 0 || ds == nil {
-		return nil, nil
-	}
-
-	var synthetic []target_update.TargetUpdate
-	for _, label := range candidates {
-		persisted, err := ds.LoadTarget(label)
-		if err != nil {
-			return nil, fmt.Errorf("synthesize resolve target %q: %w", label, err)
-		}
-		if persisted == nil {
-			continue
-		}
-		resolvables := resolver.ExtractResolvableURIsFromJSON(persisted.Config)
-		if len(resolvables) == 0 {
-			continue
-		}
-		synthetic = append(synthetic, target_update.NewResolveTargetUpdate(*persisted, resolvables))
-	}
-
-	return synthetic, nil
-}
-
-// rejectTransitivelyOpaqueTargets rejects a target whose config opaquely $refs a
-// secret whose source resource lives on a target that ITSELF carries opaque $ref
-// config. Resolving such a target would require first bootstrapping a credential
-// from another credential that itself needs resolving — a chain that has no clear
-// starting point.
-//
-// For every target update in this command (real Create/Update ops AND synthetic
-// Resolve ops), each opaque $ref in the target config is followed to its source
-// resource (by KSUID). The source resource is looked up first among this command's
-// resource ops (a source being CREATED here is not yet persisted), then in the
-// datastore. The source's target config is then scanned: if it carries any opaque
-// $ref, the chain is rejected with an error naming both target labels and no secret
-// material.
-//
-// One hop is sufficient. A deeper chain (the source's target opaquely refs yet
-// another opaque target) is still rejected here, because the immediate hop this
-// guard inspects is already opaque. A nil datastore is treated as "nothing to
-// traverse" — such changesets never reference persisted secret sources.
-func rejectTransitivelyOpaqueTargets(
-	resourceUpdates []resource_update.ResourceUpdate,
-	targetUpdates []target_update.TargetUpdate,
-	ds datastore.Datastore,
-) error {
-	if ds == nil {
-		return nil
-	}
-
-	// Index in-command resource ops by KSUID so a secret source being created in
-	// this same command resolves to its target without a persisted row.
-	inCommandTargetByKsuid := make(map[string]string, len(resourceUpdates))
-	for i := range resourceUpdates {
-		ru := &resourceUpdates[i]
-		if k := ru.DesiredState.Ksuid; k != "" {
-			inCommandTargetByKsuid[k] = ru.DesiredState.Target
-		}
-	}
-
-	// sourceTargetLabel resolves a secret source KSUID to its target label, checking
-	// this command's resource ops before falling back to the persisted resource.
-	sourceTargetLabel := func(ksuid string) (string, error) {
-		if label, ok := inCommandTargetByKsuid[ksuid]; ok {
-			return label, nil
-		}
-		res, err := ds.LoadResourceById(ksuid)
-		if err != nil {
-			return "", fmt.Errorf("load secret source resource %q: %w", ksuid, err)
-		}
-		if res == nil {
-			return "", nil
-		}
-		return res.Target, nil
-	}
-
-	for i := range targetUpdates {
-		referencing := targetUpdates[i].Target.Label
-		opaqueRefs := resolver.ExtractOpaqueResolvableURIsFromJSON(targetUpdates[i].Target.Config)
-		for _, ref := range opaqueRefs {
-			sourceLabel, err := sourceTargetLabel(ref.KSUID())
-			if err != nil {
-				return err
-			}
-			if sourceLabel == "" || sourceLabel == referencing {
-				continue
-			}
-			sourceTarget, err := ds.LoadTarget(sourceLabel)
-			if err != nil {
-				return fmt.Errorf("load secret source target %q: %w", sourceLabel, err)
-			}
-			if sourceTarget == nil {
-				continue
-			}
-			if len(resolver.ExtractOpaqueResolvableURIsFromJSON(sourceTarget.Config)) > 0 {
-				return fmt.Errorf(
-					"cannot bootstrap a credential from a credential that itself requires resolution: "+
-						"target %q references a secret whose source lives on target %q, which itself carries opaque references",
-					referencing, sourceLabel)
-			}
-		}
-	}
-
-	return nil
 }
 
 // createOperationURI creates a unique URI that includes the operation type

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -94,6 +94,14 @@ func NewChangeset(
 	}
 	targetUpdates = append(targetUpdates, syntheticResolves...)
 
+	// Reject a credential-from-credential chain: a target whose config opaquely
+	// $refs a secret whose OWN target also carries opaque $ref config cannot be
+	// resolved, because bootstrapping its credential would first require
+	// bootstrapping another.
+	if err := rejectTransitivelyOpaqueTargets(resourceUpdates, targetUpdates, ds); err != nil {
+		return Changeset{}, err
+	}
+
 	// Copy target updates into a local slice so the DAG owns its own memory.
 	// Without this, DAG nodes would point into the FormaCommand's TargetUpdates
 	// backing array, which the FormaCommandPersister also mutates — violating
@@ -205,6 +213,89 @@ func synthesizeResolveTargetUpdates(
 	}
 
 	return synthetic, nil
+}
+
+// rejectTransitivelyOpaqueTargets rejects a target whose config opaquely $refs a
+// secret whose source resource lives on a target that ITSELF carries opaque $ref
+// config. Resolving such a target would require first bootstrapping a credential
+// from another credential that itself needs resolving — a chain that has no clear
+// starting point.
+//
+// For every target update in this command (real Create/Update ops AND synthetic
+// Resolve ops), each opaque $ref in the target config is followed to its source
+// resource (by KSUID). The source resource is looked up first among this command's
+// resource ops (a source being CREATED here is not yet persisted), then in the
+// datastore. The source's target config is then scanned: if it carries any opaque
+// $ref, the chain is rejected with an error naming both target labels and no secret
+// material.
+//
+// One hop is sufficient. A deeper chain (the source's target opaquely refs yet
+// another opaque target) is still rejected here, because the immediate hop this
+// guard inspects is already opaque. A nil datastore is treated as "nothing to
+// traverse" — such changesets never reference persisted secret sources.
+func rejectTransitivelyOpaqueTargets(
+	resourceUpdates []resource_update.ResourceUpdate,
+	targetUpdates []target_update.TargetUpdate,
+	ds datastore.Datastore,
+) error {
+	if ds == nil {
+		return nil
+	}
+
+	// Index in-command resource ops by KSUID so a secret source being created in
+	// this same command resolves to its target without a persisted row.
+	inCommandTargetByKsuid := make(map[string]string, len(resourceUpdates))
+	for i := range resourceUpdates {
+		ru := &resourceUpdates[i]
+		if k := ru.DesiredState.Ksuid; k != "" {
+			inCommandTargetByKsuid[k] = ru.DesiredState.Target
+		}
+	}
+
+	// sourceTargetLabel resolves a secret source KSUID to its target label, checking
+	// this command's resource ops before falling back to the persisted resource.
+	sourceTargetLabel := func(ksuid string) (string, error) {
+		if label, ok := inCommandTargetByKsuid[ksuid]; ok {
+			return label, nil
+		}
+		res, err := ds.LoadResourceById(ksuid)
+		if err != nil {
+			return "", fmt.Errorf("load secret source resource %q: %w", ksuid, err)
+		}
+		if res == nil {
+			return "", nil
+		}
+		return res.Target, nil
+	}
+
+	for i := range targetUpdates {
+		referencing := targetUpdates[i].Target.Label
+		opaqueRefs := resolver.ExtractOpaqueResolvableURIsFromJSON(targetUpdates[i].Target.Config)
+		for _, ref := range opaqueRefs {
+			sourceLabel, err := sourceTargetLabel(ref.KSUID())
+			if err != nil {
+				return err
+			}
+			if sourceLabel == "" || sourceLabel == referencing {
+				continue
+			}
+			sourceTarget, err := ds.LoadTarget(sourceLabel)
+			if err != nil {
+				return fmt.Errorf("load secret source target %q: %w", sourceLabel, err)
+			}
+			if sourceTarget == nil {
+				continue
+			}
+			if len(resolver.ExtractOpaqueResolvableURIsFromJSON(sourceTarget.Config)) > 0 {
+				return fmt.Errorf(
+					"cannot bootstrap a credential from a credential that itself requires resolution: "+
+						"target %q references a secret whose source lives on target %q, which itself carries opaque references",
+					referencing, sourceLabel)
+			}
+		}
+	}
+
+	return nil
 }
 
 // createOperationURI creates a unique URI that includes the operation type

--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -409,9 +409,12 @@ func targetUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, mess
 	// Notify the FormaCommandPersister about the target update completion.
 	// This is done here (not in the TargetUpdater) to avoid an import cycle
 	// between target_update and messages packages.
+	//
+	// Resolve ops are synthetic: they are not stored in command.TargetUpdates,
+	// so MarkTargetUpdateAsComplete must not be called for them.
 	node, exists := data.changeset.DAG.Nodes[message.NodeURI]
 	if exists {
-		if tu, ok := node.Update.(*target_update.TargetUpdate); ok {
+		if tu, ok := node.Update.(*target_update.TargetUpdate); ok && tu.Operation != target_update.TargetOperationResolve {
 			_, err := proc.Call(
 				gen.ProcessID{Name: gen.Atom("FormaCommandPersister"), Node: proc.Node().Name()},
 				messages.MarkTargetUpdateAsComplete{

--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -435,14 +435,31 @@ func targetUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, mess
 	// all downstream resource updates that reference this target. Without this,
 	// resource updaters would use the stale snapshot from generation time which
 	// still contains unresolved $ref objects.
+	//
+	// Fail closed if the resolved config cannot be converted to plugin format
+	// (e.g. it still carries a $hashed value that must never be sent to a
+	// provider). Propagating the unconverted document would leak $ref/$value
+	// metadata and secret material to the plugin, so instead the target finish
+	// is treated as a failure: the node is marked failed and the failure
+	// cascades to every dependent resource op, ensuring nothing malformed
+	// reaches a plugin. The conversion error is structural and carries no
+	// plaintext; message.ResolvedConfig is never logged.
 	if message.State == target_update.TargetUpdateStateSuccess && message.ResolvedConfig != nil {
 		if tu, ok := node.Update.(*target_update.TargetUpdate); ok {
 			// Convert the resolved config to plugin format: strip $ref/$value
 			// metadata so plugins receive plain values.
 			pluginConfig, err := resolver.ConvertToPluginFormat(message.ResolvedConfig)
 			if err != nil {
-				proc.Log().Error("Failed to convert target config to plugin format target=%s: %v", tu.Target.Label, err)
-				pluginConfig = message.ResolvedConfig
+				proc.Log().Error("Failed to convert target config to plugin format, failing dependent resource ops target=%s: %v", tu.Target.Label, err)
+				// Route through the failure branch of handleUpdateFinished so the
+				// node (still running here) is marked failed there and the failure
+				// cascades to dependent resource ops. Marking it failed now would
+				// make handleUpdateFinished treat it as already-completed and skip
+				// the cascade.
+				return handleUpdateFinished(from, state, data, updateFinishedEvent{
+					nodeURI:   message.NodeURI,
+					isSuccess: false,
+				}, proc)
 			}
 			data.changeset.DAG.propagateResolvedTargetConfig(tu.Target.Label, pluginConfig)
 		}

--- a/internal/metastructure/changeset/changeset_executor_test.go
+++ b/internal/metastructure/changeset/changeset_executor_test.go
@@ -428,3 +428,80 @@ func TestResolveNodeFinished_PropagatesConfigAndSkipsPersist(t *testing.T) {
 			"MarkTargetUpdateAsComplete must not be called for a synthetic Resolve op; got %+v", callEvent.Request)
 	}
 }
+
+// TestResolveNodeFinished_ConversionFailure_FailsDependentsClosed verifies that when a
+// resolved target config cannot be converted to plugin format (here it still carries a
+// $hashed value that must never be sent to a provider), the executor fails closed: the
+// unconverted document is NOT propagated to dependent resource ops, and those ops are
+// failed (removed from the DAG) so nothing malformed reaches a plugin.
+func TestResolveNodeFinished_ConversionFailure_FailsDependentsClosed(t *testing.T) {
+	const targetLabel = "consumer"
+	ksuid := util.NewID()
+
+	unresolved := json.RawMessage(`{"apiKey":{"$ref":"formae://secret#/token","$visibility":"Opaque"}}`)
+	// A resolved config carrying a $hashed value: ConvertToPluginFormat rejects it,
+	// because a stored hash can never be recovered to the live secret for a plugin.
+	hashedResolved := json.RawMessage(`{"apiKey":{"$value":"deadbeef","$hashed":true}}`)
+
+	resourceOp := resource_update.ResourceUpdate{
+		DesiredState:   pkgmodel.Resource{Label: "bucket", Type: "FakeAWS::S3::Bucket", Stack: "s", Ksuid: ksuid, Target: targetLabel},
+		Operation:      resource_update.OperationCreate,
+		State:          resource_update.ResourceUpdateStateNotStarted,
+		StackLabel:     "s",
+		ResourceTarget: pkgmodel.Target{Label: targetLabel, Namespace: "test", Config: unresolved},
+	}
+
+	resolveOp := target_update.NewResolveTargetUpdate(
+		pkgmodel.Target{Label: targetLabel, Namespace: "test", Config: unresolved},
+		[]pkgmodel.FormaeURI{pkgmodel.NewFormaeURI(util.NewID(), "")},
+	)
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{resourceOp},
+		[]target_update.TargetUpdate{resolveOp},
+		"cmd-resolve-fail-closed",
+		pkgmodel.CommandApply,
+		nil,
+	)
+	require.NoError(t, err)
+
+	resolveNodeURI := pkgmodel.FormaeURI("target://" + targetLabel + "/resolve")
+	resolveNode := cs.DAG.Nodes[resolveNodeURI]
+	require.NotNil(t, resolveNode, "resolve node must exist in DAG")
+	resolveNode.Update.MarkInProgress()
+
+	opURI := createOperationURI(pkgmodel.NewFormaeURI(ksuid, ""), resource_update.OperationCreate)
+	cs.trackedUpdates[string(opURI)] = true
+
+	// Capture the resource node before the handler runs so we can inspect its config after.
+	resourceNode := cs.DAG.Nodes[opURI]
+	require.NotNil(t, resourceNode)
+	ru := resourceNode.Update.(*resource_update.ResourceUpdate)
+
+	actor, err := unit.Spawn(t, NewChangesetExecutor, unit.WithArgs(gen.PID{}), unit.WithLogLevel(gen.LogLevelError))
+	require.NoError(t, err)
+	proc := actor.Process()
+
+	data := ChangesetData{changeset: cs, requestedBy: gen.PID{}}
+
+	finishedMsg := target_update.TargetUpdateFinished{
+		NodeURI:        resolveNodeURI,
+		State:          target_update.TargetUpdateStateSuccess,
+		ResolvedConfig: hashedResolved,
+	}
+
+	_, updatedData, _, _ := targetUpdateFinished(gen.PID{}, StateProcessing, data, finishedMsg, proc)
+
+	// The unconverted (hashed) config must NOT have been propagated onto the dependent op.
+	assert.NotContains(t, string(ru.ResourceTarget.Config), "$hashed",
+		"the unconverted hashed config must never be propagated to a dependent resource op")
+	assert.JSONEq(t, string(unresolved), string(ru.ResourceTarget.Config),
+		"the dependent op must retain its original config, not receive the unconverted document")
+
+	// The dependent resource op must be failed (removed from the DAG) so it is never
+	// dispatched to a plugin with malformed config.
+	assert.Nil(t, updatedData.changeset.DAG.Nodes[opURI],
+		"the dependent resource op must be failed and removed from the DAG (fail closed)")
+	assert.True(t, ru.IsFailed(),
+		"the dependent resource op must be marked failed when the target config conversion fails")
+}

--- a/internal/metastructure/changeset/changeset_executor_test.go
+++ b/internal/metastructure/changeset/changeset_executor_test.go
@@ -363,7 +363,7 @@ func TestResolveNodeFinished_PropagatesConfigAndSkipsPersist(t *testing.T) {
 		[]pkgmodel.FormaeURI{pkgmodel.NewFormaeURI(util.NewID(), "")},
 	)
 
-	cs, err := NewChangeset(
+	cs, err := buildChangesetForTest(
 		[]resource_update.ResourceUpdate{resourceOp},
 		[]target_update.TargetUpdate{resolveOp},
 		"cmd-resolve-propagation",
@@ -456,7 +456,7 @@ func TestResolveNodeFinished_ConversionFailure_FailsDependentsClosed(t *testing.
 		[]pkgmodel.FormaeURI{pkgmodel.NewFormaeURI(util.NewID(), "")},
 	)
 
-	cs, err := NewChangeset(
+	cs, err := buildChangesetForTest(
 		[]resource_update.ResourceUpdate{resourceOp},
 		[]target_update.TargetUpdate{resolveOp},
 		"cmd-resolve-fail-closed",

--- a/internal/metastructure/changeset/changeset_executor_test.go
+++ b/internal/metastructure/changeset/changeset_executor_test.go
@@ -7,6 +7,7 @@
 package changeset
 
 import (
+	"encoding/json"
 	"testing"
 
 	"ergo.services/ergo/gen"
@@ -15,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_persister"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
@@ -332,4 +334,97 @@ func newChangesetExecutorForTest(t *testing.T) (*unit.TestActor, gen.PID, error)
 	}
 
 	return executor, sender, nil
+}
+
+// TestResolveNodeFinished_PropagatesConfigAndSkipsPersist verifies that when
+// the executor receives TargetUpdateFinished for a synthetic Resolve op:
+//   - the resolved config is propagated onto every dependent resource op, and
+//   - MarkTargetUpdateAsComplete is NOT called (the Resolve op is synthetic and
+//     has no row in the command's TargetUpdates, so calling it would be incorrect).
+func TestResolveNodeFinished_PropagatesConfigAndSkipsPersist(t *testing.T) {
+	const targetLabel = "consumer"
+	ksuid := util.NewID()
+
+	unresolved := json.RawMessage(`{"apiKey":{"$ref":"formae://secret#/token","$visibility":"Opaque"}}`)
+	resolved := json.RawMessage(`{"apiKey":"resolved-credential"}`)
+
+	// Build a changeset: one Resolve op on 'consumer', one resource Create that
+	// depends on it (resource op references consumer's target label).
+	resourceOp := resource_update.ResourceUpdate{
+		DesiredState:   pkgmodel.Resource{Label: "bucket", Type: "FakeAWS::S3::Bucket", Stack: "s", Ksuid: ksuid, Target: targetLabel},
+		Operation:      resource_update.OperationCreate,
+		State:          resource_update.ResourceUpdateStateNotStarted,
+		StackLabel:     "s",
+		ResourceTarget: pkgmodel.Target{Label: targetLabel, Namespace: "test", Config: unresolved},
+	}
+
+	resolveOp := target_update.NewResolveTargetUpdate(
+		pkgmodel.Target{Label: targetLabel, Namespace: "test", Config: unresolved},
+		[]pkgmodel.FormaeURI{pkgmodel.NewFormaeURI(util.NewID(), "")},
+	)
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{resourceOp},
+		[]target_update.TargetUpdate{resolveOp},
+		"cmd-resolve-propagation",
+		pkgmodel.CommandApply,
+		nil, // datastore not needed: resolve op already provided explicitly
+	)
+	require.NoError(t, err)
+
+	// Mark the resolve node as running so the executor treats the completion
+	// message as valid (only running nodes are matched by the handler).
+	resolveNodeURI := pkgmodel.FormaeURI("target://" + targetLabel + "/resolve")
+	resolveNode := cs.DAG.Nodes[resolveNodeURI]
+	require.NotNil(t, resolveNode, "resolve node must exist in DAG")
+	resolveNode.Update.MarkInProgress()
+
+	// Pre-track the resource op so AvailableExecutableUpdates skips it during
+	// the resume() call that follows handleUpdateFinished. Without this, resume
+	// would call the RateLimiter actor — which does not exist in a unit test.
+	opURI := createOperationURI(pkgmodel.NewFormaeURI(ksuid, ""), resource_update.OperationCreate)
+	cs.trackedUpdates[string(opURI)] = true
+
+	// Obtain a TestProcess so we can inspect what proc.Call emits.
+	actor, err := unit.Spawn(t, NewChangesetExecutor, unit.WithArgs(gen.PID{}), unit.WithLogLevel(gen.LogLevelError))
+	require.NoError(t, err)
+	proc := actor.Process()
+
+	data := ChangesetData{
+		changeset:   cs,
+		requestedBy: gen.PID{},
+	}
+
+	finishedMsg := target_update.TargetUpdateFinished{
+		NodeURI:        resolveNodeURI,
+		State:          target_update.TargetUpdateStateSuccess,
+		ResolvedConfig: resolved,
+	}
+
+	// Call the handler directly. Before the fix, it calls MarkTargetUpdateAsComplete
+	// unconditionally, emitting a CallEvent. After the fix, no such CallEvent exists.
+	_, updatedData, _, _ := targetUpdateFinished(gen.PID{}, StateProcessing, data, finishedMsg, proc)
+
+	// ── Assert propagation ───────────────────────────────────────────────────
+	// Every resource op on the consumer target must have received the resolved
+	// config after the Resolve node finishes, so the op dispatches the plaintext
+	// credential to the plugin instead of the raw $ref object.
+	resourceNode := updatedData.changeset.DAG.Nodes[opURI]
+	require.NotNil(t, resourceNode, "resource node must exist in DAG after handler ran")
+	ru := resourceNode.Update.(*resource_update.ResourceUpdate)
+	assert.JSONEq(t, string(resolved), string(ru.ResourceTarget.Config),
+		"resource op must carry the resolved config after the Resolve node finishes")
+
+	// ── Assert no persist call ───────────────────────────────────────────────
+	// A Resolve op is synthetic: it has no row in command.TargetUpdates and
+	// must not trigger MarkTargetUpdateAsComplete.
+	for _, event := range actor.Events() {
+		callEvent, ok := event.(unit.CallEvent)
+		if !ok {
+			continue
+		}
+		_, isMarkComplete := callEvent.Request.(messages.MarkTargetUpdateAsComplete)
+		assert.Falsef(t, isMarkComplete,
+			"MarkTargetUpdateAsComplete must not be called for a synthetic Resolve op; got %+v", callEvent.Request)
+	}
 }

--- a/internal/metastructure/changeset/changeset_test.go
+++ b/internal/metastructure/changeset/changeset_test.go
@@ -3238,3 +3238,144 @@ func TestNewChangeset_TransitiveOpaqueSourceFoundInCommand(t *testing.T) {
 	assert.Contains(t, err.Error(), t1)
 	assert.Contains(t, err.Error(), t2)
 }
+
+// TestNewChangeset_MutuallyReferencingInCommandTargets_ReturnsCycleError covers two
+// NEW in-command targets whose configs reference secrets hosted on each other. The
+// transitive-opaque guard does not catch this — neither peer is persisted, so its
+// LoadTarget returns nil and the guard skips it — yet the target-resolvable edges form
+// a cycle (A.create → resource-on-B → B.create → resource-on-A → A.create). Without a
+// full-graph cycle check this hangs the executor; NewChangeset must return an error.
+func TestNewChangeset_MutuallyReferencingInCommandTargets_ReturnsCycleError(t *testing.T) {
+	const (
+		targetA = "target-a"
+		targetB = "target-b"
+	)
+	// The secret sources: a resource created on A, and a resource created on B.
+	resOnA := pkgmodel.NewFormaeURI(util.NewID(), "SecretString")
+	resOnB := pkgmodel.NewFormaeURI(util.NewID(), "SecretString")
+
+	// Both targets are NEW in-command creates: not persisted, so the transitive
+	// guard's LoadTarget of the peer returns nil and skips.
+	ds := &stubResolveDatastore{
+		targets:   map[string]*pkgmodel.Target{},
+		resources: map[string]*pkgmodel.Resource{},
+	}
+
+	resourceUpdates := []resource_update.ResourceUpdate{
+		{
+			// Source of the secret that target B references; lives on A.
+			DesiredState: pkgmodel.Resource{Label: "secret-on-a", Type: "AWS::SecretsManager::Secret", Stack: "s", Ksuid: resOnA.KSUID(), Target: targetA},
+			Operation:    resource_update.OperationCreate,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+		{
+			// Source of the secret that target A references; lives on B.
+			DesiredState: pkgmodel.Resource{Label: "secret-on-b", Type: "AWS::SecretsManager::Secret", Stack: "s", Ksuid: resOnB.KSUID(), Target: targetB},
+			Operation:    resource_update.OperationCreate,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+	}
+
+	// A's config refers to the secret hosted on B; B's config refers to the secret hosted on A.
+	targetUpdates := []target_update.TargetUpdate{
+		{
+			Target:               pkgmodel.Target{Label: targetA, Namespace: "AWS", Config: opaqueRefConfig(string(resOnB))},
+			Operation:            target_update.TargetOperationCreate,
+			State:                target_update.TargetUpdateStateNotStarted,
+			RemainingResolvables: []pkgmodel.FormaeURI{resOnB},
+		},
+		{
+			Target:               pkgmodel.Target{Label: targetB, Namespace: "AWS", Config: opaqueRefConfig(string(resOnA))},
+			Operation:            target_update.TargetOperationCreate,
+			State:                target_update.TargetUpdateStateNotStarted,
+			RemainingResolvables: []pkgmodel.FormaeURI{resOnA},
+		},
+	}
+
+	_, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-mutual-cycle", pkgmodel.CommandApply, ds)
+	require.Error(t, err, "mutually referencing in-command targets form a cycle and must be rejected, not hang")
+}
+
+// TestNewChangeset_SelfReferentialTarget_ReturnsCycleError covers a target whose config
+// references a secret hosted on a resource on the SAME target. The transitive-opaque
+// guard explicitly skips a self-reference, but the target-resolvable edges still form a
+// self-cycle (target.create → resource-on-target → target.create). NewChangeset must
+// return an error rather than let the executor hang.
+func TestNewChangeset_SelfReferentialTarget_ReturnsCycleError(t *testing.T) {
+	const targetLabel = "self-target"
+	secretOnSelf := pkgmodel.NewFormaeURI(util.NewID(), "SecretString")
+
+	ds := &stubResolveDatastore{
+		targets:   map[string]*pkgmodel.Target{},
+		resources: map[string]*pkgmodel.Resource{},
+	}
+
+	resourceUpdates := []resource_update.ResourceUpdate{
+		{
+			DesiredState: pkgmodel.Resource{Label: "secret", Type: "AWS::SecretsManager::Secret", Stack: "s", Ksuid: secretOnSelf.KSUID(), Target: targetLabel},
+			Operation:    resource_update.OperationCreate,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+	}
+
+	targetUpdates := []target_update.TargetUpdate{
+		{
+			Target:               pkgmodel.Target{Label: targetLabel, Namespace: "AWS", Config: opaqueRefConfig(string(secretOnSelf))},
+			Operation:            target_update.TargetOperationCreate,
+			State:                target_update.TargetUpdateStateNotStarted,
+			RemainingResolvables: []pkgmodel.FormaeURI{secretOnSelf},
+		},
+	}
+
+	_, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-self-cycle", pkgmodel.CommandApply, ds)
+	require.Error(t, err, "a self-referential target forms a self-cycle and must be rejected, not hang")
+}
+
+// TestNewChangeset_ValidTargetResolvableEdge_NoFalsePositive asserts the full-graph
+// cycle check does not reject a legitimate target-resolvable edge: target A resolves
+// from a resource hosted on target B, and B has no back-edge to A. This acyclic shape
+// must build without error.
+func TestNewChangeset_ValidTargetResolvableEdge_NoFalsePositive(t *testing.T) {
+	const (
+		targetA = "consumer"
+		targetB = "provider"
+	)
+	// The secret source lives on B; A's config references it. B references nothing back.
+	secretOnB := pkgmodel.NewFormaeURI(util.NewID(), "SecretString")
+
+	ds := &stubResolveDatastore{
+		targets:   map[string]*pkgmodel.Target{},
+		resources: map[string]*pkgmodel.Resource{},
+	}
+
+	resourceUpdates := []resource_update.ResourceUpdate{
+		{
+			DesiredState: pkgmodel.Resource{Label: "secret", Type: "AWS::SecretsManager::Secret", Stack: "s", Ksuid: secretOnB.KSUID(), Target: targetB},
+			Operation:    resource_update.OperationCreate,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+	}
+
+	targetUpdates := []target_update.TargetUpdate{
+		{
+			Target:               pkgmodel.Target{Label: targetA, Namespace: "AWS", Config: opaqueRefConfig(string(secretOnB))},
+			Operation:            target_update.TargetOperationCreate,
+			State:                target_update.TargetUpdateStateNotStarted,
+			RemainingResolvables: []pkgmodel.FormaeURI{secretOnB},
+		},
+		{
+			// B is a plain create with no resolvables — no back-edge to A.
+			Target:    pkgmodel.Target{Label: targetB, Namespace: "AWS", Config: json.RawMessage(`{"region":"us-east-1"}`)},
+			Operation: target_update.TargetOperationCreate,
+			State:     target_update.TargetUpdateStateNotStarted,
+		},
+	}
+
+	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-valid-resolvable", pkgmodel.CommandApply, ds)
+	require.NoError(t, err, "a valid acyclic target-resolvable edge must not be rejected")
+	assert.False(t, cs.DAG.HasCycles(), "the built graph must be acyclic")
+}

--- a/internal/metastructure/changeset/changeset_test.go
+++ b/internal/metastructure/changeset/changeset_test.go
@@ -112,7 +112,7 @@ func TestChangeset_ExecutionOrder_DeleteChainThenCreateChainWithParallelLeaves(t
 		},
 	}
 
-	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
+	changeset, err := buildChangesetForTest(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Print initial DAG state
@@ -272,7 +272,7 @@ func TestChangeset_RemoveNode_UnlinksAllDependentsWhenThreeOrMore(t *testing.T) 
 		},
 	}
 
-	changeset, err := NewChangeset(resourceUpdates, nil, "test-unlink-all", pkgmodel.CommandApply, nil)
+	changeset, err := buildChangesetForTest(resourceUpdates, nil, "test-unlink-all", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Step 1: Only VPC should be executable (no dependencies)
@@ -391,7 +391,7 @@ func TestChangeset_ExecutionOrder_IndependentCreateRunsParallelWithDeleteChain(t
 		},
 	}
 
-	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
+	changeset, err := buildChangesetForTest(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
 	assert.NoError(t, err)
 
 	// Get initial executable updates
@@ -549,7 +549,7 @@ func TestChangeset_ExecutionOrder_ExternalResolvableDoesNotBlock(t *testing.T) {
 		},
 	}
 
-	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
+	changeset, err := buildChangesetForTest(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
 	assert.NoError(t, err)
 
 	// Print initial DAG state for debugging
@@ -746,7 +746,7 @@ func TestChangeset_ExecutionOrder_MultipleUpstreamDependenciesBothMustComplete(t
 		},
 	}
 
-	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
+	changeset, err := buildChangesetForTest(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
 	assert.NoError(t, err)
 
 	// Get initial executable updates
@@ -918,7 +918,7 @@ func TestChangeset_Init_DifferentTypesSameLabelNoFalseReplace(t *testing.T) {
 			StackLabel: "test-stack",
 		},
 	}
-	changeset, err := NewChangeset(resourceUpdateInitial, nil, "test-command-1", pkgmodel.CommandApply, nil)
+	changeset, err := buildChangesetForTest(resourceUpdateInitial, nil, "test-command-1", pkgmodel.CommandApply, nil)
 	assert.NoError(t, err)
 
 	executables := changeset.GetExecutableUpdates("AWS", 100)
@@ -989,7 +989,7 @@ func TestChangeset_ExecutionOrder_DeleteChainReversesCreateDependencies(t *testi
 		},
 	}
 
-	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
+	changeset, err := buildChangesetForTest(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
 	assert.NoError(t, err)
 
 	executables := changeset.GetExecutableUpdates("AWS", 100)
@@ -1037,7 +1037,7 @@ func TestChangeset_FailureCascade_TransitiveDependentsAllFail(t *testing.T) {
 		RemainingResolvables: []pkgmodel.FormaeURI{subnetKsuid},
 	}
 
-	changeset, err := NewChangeset(
+	changeset, err := buildChangesetForTest(
 		[]resource_update.ResourceUpdate{vpcUpdate, subnetUpdate, instanceUpdate},
 		nil,
 		"test-recursive-cascade",
@@ -1105,7 +1105,7 @@ func TestChangeset_UpdateDAG_FailureCascadeRemovesNodes(t *testing.T) {
 		RemainingResolvables: []pkgmodel.FormaeURI{subnetKsuid},
 	}
 
-	changeset, err := NewChangeset(
+	changeset, err := buildChangesetForTest(
 		[]resource_update.ResourceUpdate{vpcUpdate, subnetUpdate, instanceUpdate},
 		nil,
 		"test-update-DAG-cascade",
@@ -1189,7 +1189,7 @@ func TestChangeset_GetExecutableUpdates_FiltersByNamespace(t *testing.T) {
 		},
 	}
 
-	changeset, err := NewChangeset(
+	changeset, err := buildChangesetForTest(
 		updates,
 		nil,
 		"test-max-n",
@@ -1249,7 +1249,7 @@ func TestChangeset_Init_CyclicDependenciesReturnError(t *testing.T) {
 		},
 	}
 
-	_, err := NewChangeset(
+	_, err := buildChangesetForTest(
 		resourceUpdates,
 		nil,
 		"test-cycle",
@@ -1286,7 +1286,7 @@ func TestChangeset_GetExecutableUpdates_RespectsMaxLimit(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	result := cs.GetExecutableUpdates("AWS", 1)
@@ -1316,7 +1316,7 @@ func TestChangeset_UpdateDAG_RejectedUpdateCascadesToDependents(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	exec := cs.GetExecutableUpdates("AWS", 10)
@@ -1344,7 +1344,7 @@ func TestChangeset_IsComplete_InProgressIsNotComplete(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	exec := cs.GetExecutableUpdates("AWS", 10)
@@ -1354,7 +1354,7 @@ func TestChangeset_IsComplete_InProgressIsNotComplete(t *testing.T) {
 }
 
 func TestChangeset_IsComplete_EmptyChangesetIsComplete(t *testing.T) {
-	cs, err := NewChangeset(nil, nil, "cmd-1", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(nil, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	assert.True(t, cs.IsComplete(), "empty changeset should be complete")
@@ -1380,7 +1380,7 @@ func TestChangeset_ExecutionOrder_DestroyChainCompletesInReverseOrder(t *testing
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Subnet delete first (reversed dependency order)
@@ -1426,7 +1426,7 @@ func TestChangeset_ExecutionOrder_UpdateOperationRespectsDependencies(t *testing
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// VPC update should be first (subnet depends on it)
@@ -1473,7 +1473,7 @@ func TestChangeset_AvailableExecutableUpdates_SkipsInProgressNodes(t *testing.T)
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Start one update (moves to InProgress)
@@ -1575,7 +1575,7 @@ func TestChangeset_Init_ReplaceOperationSplitsIntoDeleteAndCreateNodes(t *testin
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Replace should produce 2 DAG nodes: one delete, one create
@@ -1631,7 +1631,7 @@ func TestChangeset_ExecutionOrder_MixedResourceAndTargetUpdates(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-mixed", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-mixed", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Step 2: AvailableExecutableUpdates should only count resource updates (rate-limited), not targets
@@ -1708,7 +1708,7 @@ func TestChangeset_UpdateDAG_UnexpectedStateTreatedAsFailure(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, nil, "cmd-unexpected", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(resourceUpdates, nil, "cmd-unexpected", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Get the update to mark it in progress (so it's not "ready" and not "success" and not "failed")
@@ -1747,7 +1747,7 @@ func TestChangeset_IsComplete_AllFailedIsComplete(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, nil, "cmd-allfailed", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(resourceUpdates, nil, "cmd-allfailed", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Get both updates and fail them
@@ -1793,7 +1793,7 @@ func TestChangeset_FailureCascade_SkipsInProgressDependents(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, nil, "cmd-cascade-skip", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(resourceUpdates, nil, "cmd-cascade-skip", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Start the parent
@@ -1838,7 +1838,7 @@ func TestChangeset_AvailableExecutableUpdates_NonRateLimitedShowsZeroCount(t *te
 		},
 	}
 
-	cs, err := NewChangeset(nil, targetUpdates, "cmd-nonrl", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(nil, targetUpdates, "cmd-nonrl", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	available := cs.AvailableExecutableUpdates()
@@ -1857,7 +1857,7 @@ func TestChangeset_TargetReplace_SplitsIntoDeleteAndCreate(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(nil, targetUpdates, "cmd-1", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(nil, targetUpdates, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Should have 2 nodes: delete + create
@@ -1896,7 +1896,7 @@ func TestChangeset_TargetReplace_ResourceEdges(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-2", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-2", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// 4 nodes: resource delete, resource create, target delete, target create
@@ -1946,7 +1946,7 @@ func TestChangeset_SyncReadsDoNotCreateDependencyEdges(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-sync", pkgmodel.CommandSync, nil)
+	cs, err := buildChangesetForTest(updates, nil, "cmd-sync", pkgmodel.CommandSync, nil)
 	assert.NoError(t, err)
 
 	vpcNode := cs.DAG.Nodes[createOperationURI(vpcURI, resource_update.OperationRead)]
@@ -2003,7 +2003,7 @@ func TestChangeset_CrashRecovery_SuccessParentBlocksChildren(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(allUpdates, nil, "test-crash-bug", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(allUpdates, nil, "test-crash-bug", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// BUG: Subnet is blocked because VPC (Success) is in the pipeline as an
@@ -2041,7 +2041,7 @@ func TestChangeset_CrashRecovery_FilteredPendingUpdatesOnly(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(pendingOnly, nil, "test-crash-fix", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(pendingOnly, nil, "test-crash-fix", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// VPC URI is in RemainingResolvables but not in the changeset, so no
@@ -2071,7 +2071,7 @@ func TestChangeset_SyncReadFailureDoesNotCascade(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-sync", pkgmodel.CommandSync, nil)
+	cs, err := buildChangesetForTest(updates, nil, "cmd-sync", pkgmodel.CommandSync, nil)
 	require.NoError(t, err)
 
 	opURI := createOperationURI(vpcURI, resource_update.OperationRead)
@@ -2136,7 +2136,7 @@ func TestBuildDeleteDependencies_AttachesToInvertsEdgeDirection(t *testing.T) {
 			DesiredState: bResource,
 			Operation:    resource_update.OperationDelete,
 		}
-		cs, err := NewChangeset([]resource_update.ResourceUpdate{aDelete, bDelete}, nil, "c1", pkgmodel.CommandApply, nil)
+		cs, err := buildChangesetForTest([]resource_update.ResourceUpdate{aDelete, bDelete}, nil, "c1", pkgmodel.CommandApply, nil)
 		if err != nil {
 			t.Fatalf("NewChangeset: %v", err)
 		}
@@ -2190,7 +2190,7 @@ func TestBuildDeleteDependencies_MixedRefsOnOneResourceGetIndependentDirections(
 	bResource := pkgmodel.Resource{Ksuid: "B1", Label: "b", Type: "Test::B", Stack: "s", Properties: json.RawMessage(`{}`)}
 	cResource := pkgmodel.Resource{Ksuid: "C1", Label: "c", Type: "Test::C", Stack: "s", Properties: json.RawMessage(`{}`)}
 
-	cs, err := NewChangeset(
+	cs, err := buildChangesetForTest(
 		[]resource_update.ResourceUpdate{
 			{DesiredState: aResource, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{bURI, cURI}},
 			{DesiredState: bResource, Operation: resource_update.OperationDelete},
@@ -2230,7 +2230,7 @@ func TestBuildDeleteDependencies_MissingHintFallsBackToConstructionReverse(t *te
 	}
 	bResource := pkgmodel.Resource{Ksuid: "B1", Label: "b", Type: "Test::B", Stack: "s", Properties: json.RawMessage(`{}`)}
 
-	cs, err := NewChangeset(
+	cs, err := buildChangesetForTest(
 		[]resource_update.ResourceUpdate{
 			{DesiredState: aResource, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{bURI}},
 			{DesiredState: bResource, Operation: resource_update.OperationDelete},
@@ -2301,7 +2301,7 @@ func TestBuildDeleteDependencies_RuntimeDependency_AddsChildEdges(t *testing.T) 
 		Properties: json.RawMessage(`{"FileSystemId":"fs-abc"}`),
 	}
 
-	cs, err := NewChangeset([]resource_update.ResourceUpdate{
+	cs, err := buildChangesetForTest([]resource_update.ResourceUpdate{
 		{DesiredState: consumer, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
 		{DesiredState: producer, Operation: resource_update.OperationDelete},
 		{DesiredState: mtA, Operation: resource_update.OperationDelete},
@@ -2385,7 +2385,7 @@ func TestBuildDeleteDependencies_RuntimeDependency_InstanceSafe(t *testing.T) {
 		}
 	}
 
-	cs, err := NewChangeset([]resource_update.ResourceUpdate{
+	cs, err := buildChangesetForTest([]resource_update.ResourceUpdate{
 		{DesiredState: consumer, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{fs1URI}},
 		{DesiredState: fs1, Operation: resource_update.OperationDelete},
 		{DesiredState: fs2, Operation: resource_update.OperationDelete},
@@ -2446,7 +2446,7 @@ func TestBuildDeleteDependencies_RuntimeDependency_NoMatchingChildren_FallsBackT
 		Properties: json.RawMessage(`{"FileSystemId":"fs-abc"}`),
 	}
 
-	cs, err := NewChangeset([]resource_update.ResourceUpdate{
+	cs, err := buildChangesetForTest([]resource_update.ResourceUpdate{
 		{DesiredState: consumer, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
 		{DesiredState: producer, Operation: resource_update.OperationDelete},
 	}, nil, "rt3", pkgmodel.CommandApply, nil)
@@ -2533,7 +2533,7 @@ func TestBuildCreateUpdateDependencies_RuntimeDependency_AddsChildEdges(t *testi
 		Properties: json.RawMessage(`{"FileSystemId":{"$ref":"formae://PROD1#/FileSystemId","$value":""}}`),
 	}
 
-	cs, err := NewChangeset([]resource_update.ResourceUpdate{
+	cs, err := buildChangesetForTest([]resource_update.ResourceUpdate{
 		{DesiredState: consumer, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
 		{DesiredState: producer, Operation: resource_update.OperationCreate},
 		{DesiredState: mtA, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
@@ -2621,7 +2621,7 @@ func TestBuildCreateUpdateDependencies_RuntimeDependency_InstanceSafe(t *testing
 		}
 	}
 
-	cs, err := NewChangeset([]resource_update.ResourceUpdate{
+	cs, err := buildChangesetForTest([]resource_update.ResourceUpdate{
 		{DesiredState: consumer, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{fs1URI}},
 		{DesiredState: fs1, Operation: resource_update.OperationCreate},
 		{DesiredState: fs2, Operation: resource_update.OperationCreate},
@@ -2698,7 +2698,7 @@ func TestBuildCreateUpdateDependencies_RuntimeDependency_NoMatchingChildren_Fall
 		Properties: json.RawMessage(`{"OtherId":"other-1"}`),
 	}
 
-	cs, err := NewChangeset([]resource_update.ResourceUpdate{
+	cs, err := buildChangesetForTest([]resource_update.ResourceUpdate{
 		{DesiredState: consumer, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
 		{DesiredState: producer, Operation: resource_update.OperationCreate},
 		{DesiredState: unrelated, Operation: resource_update.OperationCreate},
@@ -2796,7 +2796,7 @@ func TestBuildDeleteDependencies_RuntimeDependency_MultipleRefsToSameProducer_Pr
 	// iteration — Go intentionally randomizes iteration order so one
 	// invocation could happen to pick the "good" ordering by luck.
 	for i := 0; i < 50; i++ {
-		cs, err := NewChangeset([]resource_update.ResourceUpdate{
+		cs, err := buildChangesetForTest([]resource_update.ResourceUpdate{
 			{DesiredState: consumer, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
 			{DesiredState: producer, Operation: resource_update.OperationDelete},
 			{DesiredState: mtA, Operation: resource_update.OperationDelete},
@@ -2862,7 +2862,7 @@ func TestBuildCreateUpdateDependencies_RuntimeDependency_MultipleRefsToSameProdu
 	}
 
 	for i := 0; i < 50; i++ {
-		cs, err := NewChangeset([]resource_update.ResourceUpdate{
+		cs, err := buildChangesetForTest([]resource_update.ResourceUpdate{
 			{DesiredState: consumer, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
 			{DesiredState: producer, Operation: resource_update.OperationCreate},
 			{DesiredState: mtA, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
@@ -2922,7 +2922,7 @@ func TestBuildCreateUpdateDependencies_RuntimeDependency_UpdateChild_StillLinks(
 
 	// mtA is in the changeset as Update, not Create — the hardcoded lookup
 	// would silently miss its node.
-	cs, err := NewChangeset([]resource_update.ResourceUpdate{
+	cs, err := buildChangesetForTest([]resource_update.ResourceUpdate{
 		{DesiredState: consumer, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
 		{DesiredState: producer, Operation: resource_update.OperationCreate},
 		{DesiredState: mtA, Operation: resource_update.OperationUpdate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
@@ -2996,7 +2996,7 @@ func TestNewChangeset_SynthesizesResolveNodeForUnchangedOpaqueTarget(t *testing.
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, nil, "cmd-synth", pkgmodel.CommandApply, ds)
+	cs, err := buildChangesetForTest(resourceUpdates, nil, "cmd-synth", pkgmodel.CommandApply, ds)
 	require.NoError(t, err)
 
 	resolveNode := cs.DAG.Nodes[pkgmodel.FormaeURI("target://"+targetLabel+"/resolve")]
@@ -3036,7 +3036,7 @@ func TestNewChangeset_NoSynthesisWhenTargetAlreadyHasUpdate(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-nodup", pkgmodel.CommandApply, ds)
+	cs, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-nodup", pkgmodel.CommandApply, ds)
 	require.NoError(t, err)
 
 	assert.Nil(t, cs.DAG.Nodes[pkgmodel.FormaeURI("target://"+targetLabel+"/resolve")],
@@ -3061,7 +3061,7 @@ func TestNewChangeset_NoSynthesisWhenTargetHasNoOpaqueRefs(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, nil, "cmd-norefs", pkgmodel.CommandApply, ds)
+	cs, err := buildChangesetForTest(resourceUpdates, nil, "cmd-norefs", pkgmodel.CommandApply, ds)
 	require.NoError(t, err)
 
 	assert.Nil(t, cs.DAG.Nodes[pkgmodel.FormaeURI("target://"+targetLabel+"/resolve")],
@@ -3096,7 +3096,7 @@ func TestNewChangeset_SyntheticResolveNodeIsDependencyOfEveryResourceOp(t *testi
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, nil, "cmd-dep", pkgmodel.CommandApply, ds)
+	cs, err := buildChangesetForTest(resourceUpdates, nil, "cmd-dep", pkgmodel.CommandApply, ds)
 	require.NoError(t, err)
 
 	resolveURI := pkgmodel.FormaeURI("target://" + targetLabel + "/resolve")
@@ -3150,7 +3150,7 @@ func TestNewChangeset_RejectsTransitivelyOpaqueTargetReference(t *testing.T) {
 		},
 	}
 
-	_, err := NewChangeset(resourceUpdates, nil, "cmd-transitive-opaque", pkgmodel.CommandApply, ds)
+	_, err := buildChangesetForTest(resourceUpdates, nil, "cmd-transitive-opaque", pkgmodel.CommandApply, ds)
 	require.Error(t, err, "resolving a target whose secret source's target is itself opaque must be rejected")
 	assert.Contains(t, err.Error(), t1, "error must name the referencing target")
 	assert.Contains(t, err.Error(), t2, "error must name the source resource's target")
@@ -3190,7 +3190,7 @@ func TestNewChangeset_AllowsOpaqueRefWhenSourceTargetIsPlain(t *testing.T) {
 		},
 	}
 
-	_, err := NewChangeset(resourceUpdates, nil, "cmd-plain-source-target", pkgmodel.CommandApply, ds)
+	_, err := buildChangesetForTest(resourceUpdates, nil, "cmd-plain-source-target", pkgmodel.CommandApply, ds)
 	require.NoError(t, err, "an opaque ref to a secret on a plain-config target is the normal single-hop case")
 }
 
@@ -3233,7 +3233,7 @@ func TestNewChangeset_TransitiveOpaqueSourceFoundInCommand(t *testing.T) {
 		},
 	}
 
-	_, err := NewChangeset(resourceUpdates, nil, "cmd-in-command-source", pkgmodel.CommandApply, ds)
+	_, err := buildChangesetForTest(resourceUpdates, nil, "cmd-in-command-source", pkgmodel.CommandApply, ds)
 	require.Error(t, err, "in-command secret source on an opaque target must also be rejected")
 	assert.Contains(t, err.Error(), t1)
 	assert.Contains(t, err.Error(), t2)
@@ -3294,7 +3294,7 @@ func TestNewChangeset_MutuallyReferencingInCommandTargets_ReturnsCycleError(t *t
 		},
 	}
 
-	_, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-mutual-cycle", pkgmodel.CommandApply, ds)
+	_, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-mutual-cycle", pkgmodel.CommandApply, ds)
 	require.Error(t, err, "mutually referencing in-command targets form a cycle and must be rejected, not hang")
 }
 
@@ -3330,7 +3330,7 @@ func TestNewChangeset_SelfReferentialTarget_ReturnsCycleError(t *testing.T) {
 		},
 	}
 
-	_, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-self-cycle", pkgmodel.CommandApply, ds)
+	_, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-self-cycle", pkgmodel.CommandApply, ds)
 	require.Error(t, err, "a self-referential target forms a self-cycle and must be rejected, not hang")
 }
 
@@ -3375,7 +3375,7 @@ func TestNewChangeset_ValidTargetResolvableEdge_NoFalsePositive(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-valid-resolvable", pkgmodel.CommandApply, ds)
+	cs, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-valid-resolvable", pkgmodel.CommandApply, ds)
 	require.NoError(t, err, "a valid acyclic target-resolvable edge must not be rejected")
 	assert.False(t, cs.DAG.HasCycles(), "the built graph must be acyclic")
 }

--- a/internal/metastructure/changeset/changeset_test.go
+++ b/internal/metastructure/changeset/changeset_test.go
@@ -2947,11 +2947,16 @@ func TestBuildCreateUpdateDependencies_RuntimeDependency_UpdateChild_StillLinks(
 // honest about what these tests actually depend on.
 type stubResolveDatastore struct {
 	datastore.Datastore
-	targets map[string]*pkgmodel.Target
+	targets   map[string]*pkgmodel.Target
+	resources map[string]*pkgmodel.Resource
 }
 
 func (s *stubResolveDatastore) LoadTarget(label string) (*pkgmodel.Target, error) {
 	return s.targets[label], nil
+}
+
+func (s *stubResolveDatastore) LoadResourceById(ksuid string) (*pkgmodel.Resource, error) {
+	return s.resources[ksuid], nil
 }
 
 // opaqueRefConfig is a target config carrying a single opaque $ref, mirroring an
@@ -3104,4 +3109,132 @@ func TestNewChangeset_SyntheticResolveNodeIsDependencyOfEveryResourceOp(t *testi
 
 	assert.True(t, hasDependencyOn(createNode, resolveURI), "create op must depend on the Resolve node")
 	assert.True(t, hasDependencyOn(updateNode, resolveURI), "update op must depend on the Resolve node")
+}
+
+// TestNewChangeset_RejectsTransitivelyOpaqueTargetReference asserts that resolving a
+// target whose config opaquely $refs a secret source, where that source's OWN target
+// also carries opaque $ref config, is rejected: bootstrapping a credential would
+// require first bootstrapping another credential. The error must name both target
+// labels and leak no plaintext secret material.
+func TestNewChangeset_RejectsTransitivelyOpaqueTargetReference(t *testing.T) {
+	const (
+		t1            = "consumer"
+		t2            = "secret-source-target"
+		secretValue   = "super-secret-plaintext"
+		outerRefKSUID = "sourceResourceKsuid00000001"
+	)
+
+	// T1's config opaquely refs a secret whose source resource lives on T2.
+	t1RefURI := pkgmodel.NewFormaeURI(outerRefKSUID, "SecretString")
+	// T2's OWN config also carries an opaque $ref (its credential itself needs resolving).
+	t2InnerRefURI := pkgmodel.NewFormaeURI(util.NewID(), "SecretString")
+
+	ds := &stubResolveDatastore{
+		targets: map[string]*pkgmodel.Target{
+			t1: {Label: t1, Namespace: "AWS", Config: opaqueRefConfig(string(t1RefURI))},
+			t2: {Label: t2, Namespace: "AWS", Config: opaqueRefConfig(string(t2InnerRefURI))},
+		},
+		// The source resource behind T1's ref lives on T2 (persisted, not in-command).
+		resources: map[string]*pkgmodel.Resource{
+			outerRefKSUID: {Label: "the-secret", Type: "AWS::SecretsManager::Secret", Ksuid: outerRefKSUID, Target: t2},
+		},
+	}
+
+	// A resource op on T1 triggers T1's synthetic Resolve op.
+	resourceUpdates := []resource_update.ResourceUpdate{
+		{
+			DesiredState: pkgmodel.Resource{Label: "bucket", Type: "AWS::S3::Bucket", Stack: "s", Ksuid: util.NewID(), Target: t1},
+			Operation:    resource_update.OperationCreate,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+	}
+
+	_, err := NewChangeset(resourceUpdates, nil, "cmd-transitive-opaque", pkgmodel.CommandApply, ds)
+	require.Error(t, err, "resolving a target whose secret source's target is itself opaque must be rejected")
+	assert.Contains(t, err.Error(), t1, "error must name the referencing target")
+	assert.Contains(t, err.Error(), t2, "error must name the source resource's target")
+	assert.NotContains(t, err.Error(), secretValue, "error must not leak the plaintext secret")
+	assert.NotContains(t, err.Error(), "$value", "error must not include any $value envelope")
+}
+
+// TestNewChangeset_AllowsOpaqueRefWhenSourceTargetIsPlain asserts the normal case:
+// T1 opaquely $refs a secret whose source resource lives on T2, and T2's own config
+// carries NO opaque $ref. This is a single-hop bootstrap and must be allowed.
+func TestNewChangeset_AllowsOpaqueRefWhenSourceTargetIsPlain(t *testing.T) {
+	const (
+		t1            = "consumer"
+		t2            = "secret-source-target"
+		outerRefKSUID = "sourceResourceKsuid00000002"
+	)
+
+	t1RefURI := pkgmodel.NewFormaeURI(outerRefKSUID, "SecretString")
+
+	ds := &stubResolveDatastore{
+		targets: map[string]*pkgmodel.Target{
+			t1: {Label: t1, Namespace: "AWS", Config: opaqueRefConfig(string(t1RefURI))},
+			// T2 carries plain config only: no opaque bootstrapping needed.
+			t2: {Label: t2, Namespace: "AWS", Config: json.RawMessage(`{"region":"us-east-1"}`)},
+		},
+		resources: map[string]*pkgmodel.Resource{
+			outerRefKSUID: {Label: "the-secret", Type: "AWS::SecretsManager::Secret", Ksuid: outerRefKSUID, Target: t2},
+		},
+	}
+
+	resourceUpdates := []resource_update.ResourceUpdate{
+		{
+			DesiredState: pkgmodel.Resource{Label: "bucket", Type: "AWS::S3::Bucket", Stack: "s", Ksuid: util.NewID(), Target: t1},
+			Operation:    resource_update.OperationCreate,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+	}
+
+	_, err := NewChangeset(resourceUpdates, nil, "cmd-plain-source-target", pkgmodel.CommandApply, ds)
+	require.NoError(t, err, "an opaque ref to a secret on a plain-config target is the normal single-hop case")
+}
+
+// TestNewChangeset_TransitiveOpaqueSourceFoundInCommand asserts the guard also
+// consults in-command resource ops for the secret source (a source being CREATED in
+// THIS command is not yet persisted), following it to its target and rejecting when
+// that target itself carries opaque config.
+func TestNewChangeset_TransitiveOpaqueSourceFoundInCommand(t *testing.T) {
+	const (
+		t1            = "consumer"
+		t2            = "secret-source-target"
+		outerRefKSUID = "sourceResourceKsuid00000003"
+	)
+
+	t1RefURI := pkgmodel.NewFormaeURI(outerRefKSUID, "SecretString")
+	t2InnerRefURI := pkgmodel.NewFormaeURI(util.NewID(), "SecretString")
+
+	ds := &stubResolveDatastore{
+		targets: map[string]*pkgmodel.Target{
+			t1: {Label: t1, Namespace: "AWS", Config: opaqueRefConfig(string(t1RefURI))},
+			t2: {Label: t2, Namespace: "AWS", Config: opaqueRefConfig(string(t2InnerRefURI))},
+		},
+		// No persisted resource — the source is created in-command below.
+		resources: map[string]*pkgmodel.Resource{},
+	}
+
+	resourceUpdates := []resource_update.ResourceUpdate{
+		{
+			DesiredState: pkgmodel.Resource{Label: "bucket", Type: "AWS::S3::Bucket", Stack: "s", Ksuid: util.NewID(), Target: t1},
+			Operation:    resource_update.OperationCreate,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+		{
+			// The secret source resource, created in this same command, lives on T2.
+			DesiredState: pkgmodel.Resource{Label: "the-secret", Type: "AWS::SecretsManager::Secret", Stack: "s", Ksuid: outerRefKSUID, Target: t2},
+			Operation:    resource_update.OperationCreate,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+	}
+
+	_, err := NewChangeset(resourceUpdates, nil, "cmd-in-command-source", pkgmodel.CommandApply, ds)
+	require.Error(t, err, "in-command secret source on an opaque target must also be rejected")
+	assert.Contains(t, err.Error(), t1)
+	assert.Contains(t, err.Error(), t2)
 }

--- a/internal/metastructure/changeset/changeset_test.go
+++ b/internal/metastructure/changeset/changeset_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/platform-engineering-labs/formae/internal/datastore"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
@@ -111,7 +112,7 @@ func TestChangeset_ExecutionOrder_DeleteChainThenCreateChainWithParallelLeaves(t
 		},
 	}
 
-	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply)
+	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Print initial DAG state
@@ -271,7 +272,7 @@ func TestChangeset_RemoveNode_UnlinksAllDependentsWhenThreeOrMore(t *testing.T) 
 		},
 	}
 
-	changeset, err := NewChangeset(resourceUpdates, nil, "test-unlink-all", pkgmodel.CommandApply)
+	changeset, err := NewChangeset(resourceUpdates, nil, "test-unlink-all", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Step 1: Only VPC should be executable (no dependencies)
@@ -390,7 +391,7 @@ func TestChangeset_ExecutionOrder_IndependentCreateRunsParallelWithDeleteChain(t
 		},
 	}
 
-	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply)
+	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
 	assert.NoError(t, err)
 
 	// Get initial executable updates
@@ -548,7 +549,7 @@ func TestChangeset_ExecutionOrder_ExternalResolvableDoesNotBlock(t *testing.T) {
 		},
 	}
 
-	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply)
+	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
 	assert.NoError(t, err)
 
 	// Print initial DAG state for debugging
@@ -745,7 +746,7 @@ func TestChangeset_ExecutionOrder_MultipleUpstreamDependenciesBothMustComplete(t
 		},
 	}
 
-	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply)
+	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
 	assert.NoError(t, err)
 
 	// Get initial executable updates
@@ -917,7 +918,7 @@ func TestChangeset_Init_DifferentTypesSameLabelNoFalseReplace(t *testing.T) {
 			StackLabel: "test-stack",
 		},
 	}
-	changeset, err := NewChangeset(resourceUpdateInitial, nil, "test-command-1", pkgmodel.CommandApply)
+	changeset, err := NewChangeset(resourceUpdateInitial, nil, "test-command-1", pkgmodel.CommandApply, nil)
 	assert.NoError(t, err)
 
 	executables := changeset.GetExecutableUpdates("AWS", 100)
@@ -988,7 +989,7 @@ func TestChangeset_ExecutionOrder_DeleteChainReversesCreateDependencies(t *testi
 		},
 	}
 
-	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply)
+	changeset, err := NewChangeset(resourceUpdates, nil, "test-command-1", pkgmodel.CommandApply, nil)
 	assert.NoError(t, err)
 
 	executables := changeset.GetExecutableUpdates("AWS", 100)
@@ -1041,6 +1042,7 @@ func TestChangeset_FailureCascade_TransitiveDependentsAllFail(t *testing.T) {
 		nil,
 		"test-recursive-cascade",
 		pkgmodel.CommandApply,
+		nil,
 	)
 	assert.NoError(t, err)
 
@@ -1108,6 +1110,7 @@ func TestChangeset_UpdateDAG_FailureCascadeRemovesNodes(t *testing.T) {
 		nil,
 		"test-update-DAG-cascade",
 		pkgmodel.CommandApply,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -1191,6 +1194,7 @@ func TestChangeset_GetExecutableUpdates_FiltersByNamespace(t *testing.T) {
 		nil,
 		"test-max-n",
 		pkgmodel.CommandApply,
+		nil,
 	)
 	assert.NoError(t, err)
 
@@ -1250,6 +1254,7 @@ func TestChangeset_Init_CyclicDependenciesReturnError(t *testing.T) {
 		nil,
 		"test-cycle",
 		pkgmodel.CommandApply,
+		nil,
 	)
 
 	assert.Error(t, err)
@@ -1281,7 +1286,7 @@ func TestChangeset_GetExecutableUpdates_RespectsMaxLimit(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply)
+	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	result := cs.GetExecutableUpdates("AWS", 1)
@@ -1311,7 +1316,7 @@ func TestChangeset_UpdateDAG_RejectedUpdateCascadesToDependents(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply)
+	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	exec := cs.GetExecutableUpdates("AWS", 10)
@@ -1339,7 +1344,7 @@ func TestChangeset_IsComplete_InProgressIsNotComplete(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply)
+	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	exec := cs.GetExecutableUpdates("AWS", 10)
@@ -1349,7 +1354,7 @@ func TestChangeset_IsComplete_InProgressIsNotComplete(t *testing.T) {
 }
 
 func TestChangeset_IsComplete_EmptyChangesetIsComplete(t *testing.T) {
-	cs, err := NewChangeset(nil, nil, "cmd-1", pkgmodel.CommandApply)
+	cs, err := NewChangeset(nil, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	assert.True(t, cs.IsComplete(), "empty changeset should be complete")
@@ -1375,7 +1380,7 @@ func TestChangeset_ExecutionOrder_DestroyChainCompletesInReverseOrder(t *testing
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply)
+	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Subnet delete first (reversed dependency order)
@@ -1421,7 +1426,7 @@ func TestChangeset_ExecutionOrder_UpdateOperationRespectsDependencies(t *testing
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply)
+	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// VPC update should be first (subnet depends on it)
@@ -1468,7 +1473,7 @@ func TestChangeset_AvailableExecutableUpdates_SkipsInProgressNodes(t *testing.T)
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply)
+	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Start one update (moves to InProgress)
@@ -1570,7 +1575,7 @@ func TestChangeset_Init_ReplaceOperationSplitsIntoDeleteAndCreateNodes(t *testin
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply)
+	cs, err := NewChangeset(updates, nil, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Replace should produce 2 DAG nodes: one delete, one create
@@ -1626,7 +1631,7 @@ func TestChangeset_ExecutionOrder_MixedResourceAndTargetUpdates(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-mixed", pkgmodel.CommandApply)
+	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-mixed", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Step 2: AvailableExecutableUpdates should only count resource updates (rate-limited), not targets
@@ -1703,7 +1708,7 @@ func TestChangeset_UpdateDAG_UnexpectedStateTreatedAsFailure(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, nil, "cmd-unexpected", pkgmodel.CommandApply)
+	cs, err := NewChangeset(resourceUpdates, nil, "cmd-unexpected", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Get the update to mark it in progress (so it's not "ready" and not "success" and not "failed")
@@ -1742,7 +1747,7 @@ func TestChangeset_IsComplete_AllFailedIsComplete(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, nil, "cmd-allfailed", pkgmodel.CommandApply)
+	cs, err := NewChangeset(resourceUpdates, nil, "cmd-allfailed", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Get both updates and fail them
@@ -1788,7 +1793,7 @@ func TestChangeset_FailureCascade_SkipsInProgressDependents(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, nil, "cmd-cascade-skip", pkgmodel.CommandApply)
+	cs, err := NewChangeset(resourceUpdates, nil, "cmd-cascade-skip", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Start the parent
@@ -1833,7 +1838,7 @@ func TestChangeset_AvailableExecutableUpdates_NonRateLimitedShowsZeroCount(t *te
 		},
 	}
 
-	cs, err := NewChangeset(nil, targetUpdates, "cmd-nonrl", pkgmodel.CommandApply)
+	cs, err := NewChangeset(nil, targetUpdates, "cmd-nonrl", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	available := cs.AvailableExecutableUpdates()
@@ -1852,7 +1857,7 @@ func TestChangeset_TargetReplace_SplitsIntoDeleteAndCreate(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(nil, targetUpdates, "cmd-1", pkgmodel.CommandApply)
+	cs, err := NewChangeset(nil, targetUpdates, "cmd-1", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// Should have 2 nodes: delete + create
@@ -1891,7 +1896,7 @@ func TestChangeset_TargetReplace_ResourceEdges(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-2", pkgmodel.CommandApply)
+	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-2", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// 4 nodes: resource delete, resource create, target delete, target create
@@ -1941,7 +1946,7 @@ func TestChangeset_SyncReadsDoNotCreateDependencyEdges(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-sync", pkgmodel.CommandSync)
+	cs, err := NewChangeset(updates, nil, "cmd-sync", pkgmodel.CommandSync, nil)
 	assert.NoError(t, err)
 
 	vpcNode := cs.DAG.Nodes[createOperationURI(vpcURI, resource_update.OperationRead)]
@@ -1998,7 +2003,7 @@ func TestChangeset_CrashRecovery_SuccessParentBlocksChildren(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(allUpdates, nil, "test-crash-bug", pkgmodel.CommandApply)
+	cs, err := NewChangeset(allUpdates, nil, "test-crash-bug", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// BUG: Subnet is blocked because VPC (Success) is in the pipeline as an
@@ -2036,7 +2041,7 @@ func TestChangeset_CrashRecovery_FilteredPendingUpdatesOnly(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(pendingOnly, nil, "test-crash-fix", pkgmodel.CommandApply)
+	cs, err := NewChangeset(pendingOnly, nil, "test-crash-fix", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// VPC URI is in RemainingResolvables but not in the changeset, so no
@@ -2066,7 +2071,7 @@ func TestChangeset_SyncReadFailureDoesNotCascade(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(updates, nil, "cmd-sync", pkgmodel.CommandSync)
+	cs, err := NewChangeset(updates, nil, "cmd-sync", pkgmodel.CommandSync, nil)
 	require.NoError(t, err)
 
 	opURI := createOperationURI(vpcURI, resource_update.OperationRead)
@@ -2131,7 +2136,7 @@ func TestBuildDeleteDependencies_AttachesToInvertsEdgeDirection(t *testing.T) {
 			DesiredState: bResource,
 			Operation:    resource_update.OperationDelete,
 		}
-		cs, err := NewChangeset([]resource_update.ResourceUpdate{aDelete, bDelete}, nil, "c1", pkgmodel.CommandApply)
+		cs, err := NewChangeset([]resource_update.ResourceUpdate{aDelete, bDelete}, nil, "c1", pkgmodel.CommandApply, nil)
 		if err != nil {
 			t.Fatalf("NewChangeset: %v", err)
 		}
@@ -2190,7 +2195,7 @@ func TestBuildDeleteDependencies_MixedRefsOnOneResourceGetIndependentDirections(
 			{DesiredState: aResource, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{bURI, cURI}},
 			{DesiredState: bResource, Operation: resource_update.OperationDelete},
 			{DesiredState: cResource, Operation: resource_update.OperationDelete},
-		}, nil, "c2", pkgmodel.CommandApply)
+		}, nil, "c2", pkgmodel.CommandApply, nil)
 	if err != nil {
 		t.Fatalf("NewChangeset: %v", err)
 	}
@@ -2229,7 +2234,7 @@ func TestBuildDeleteDependencies_MissingHintFallsBackToConstructionReverse(t *te
 		[]resource_update.ResourceUpdate{
 			{DesiredState: aResource, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{bURI}},
 			{DesiredState: bResource, Operation: resource_update.OperationDelete},
-		}, nil, "c3", pkgmodel.CommandApply)
+		}, nil, "c3", pkgmodel.CommandApply, nil)
 	if err != nil {
 		t.Fatalf("NewChangeset: %v", err)
 	}
@@ -2301,7 +2306,7 @@ func TestBuildDeleteDependencies_RuntimeDependency_AddsChildEdges(t *testing.T) 
 		{DesiredState: producer, Operation: resource_update.OperationDelete},
 		{DesiredState: mtA, Operation: resource_update.OperationDelete},
 		{DesiredState: mtB, Operation: resource_update.OperationDelete},
-	}, nil, "rt1", pkgmodel.CommandApply)
+	}, nil, "rt1", pkgmodel.CommandApply, nil)
 	if err != nil {
 		t.Fatalf("NewChangeset: %v", err)
 	}
@@ -2388,7 +2393,7 @@ func TestBuildDeleteDependencies_RuntimeDependency_InstanceSafe(t *testing.T) {
 		{DesiredState: mountTarget("MT1B", "mt1B", "fs-1"), Operation: resource_update.OperationDelete},
 		{DesiredState: mountTarget("MT2A", "mt2A", "fs-2"), Operation: resource_update.OperationDelete},
 		{DesiredState: mountTarget("MT2B", "mt2B", "fs-2"), Operation: resource_update.OperationDelete},
-	}, nil, "rt2", pkgmodel.CommandApply)
+	}, nil, "rt2", pkgmodel.CommandApply, nil)
 	if err != nil {
 		t.Fatalf("NewChangeset: %v", err)
 	}
@@ -2444,7 +2449,7 @@ func TestBuildDeleteDependencies_RuntimeDependency_NoMatchingChildren_FallsBackT
 	cs, err := NewChangeset([]resource_update.ResourceUpdate{
 		{DesiredState: consumer, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
 		{DesiredState: producer, Operation: resource_update.OperationDelete},
-	}, nil, "rt3", pkgmodel.CommandApply)
+	}, nil, "rt3", pkgmodel.CommandApply, nil)
 	if err != nil {
 		t.Fatalf("NewChangeset: %v", err)
 	}
@@ -2533,7 +2538,7 @@ func TestBuildCreateUpdateDependencies_RuntimeDependency_AddsChildEdges(t *testi
 		{DesiredState: producer, Operation: resource_update.OperationCreate},
 		{DesiredState: mtA, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
 		{DesiredState: mtB, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
-	}, nil, "rtc1", pkgmodel.CommandApply)
+	}, nil, "rtc1", pkgmodel.CommandApply, nil)
 	if err != nil {
 		t.Fatalf("NewChangeset: %v", err)
 	}
@@ -2624,7 +2629,7 @@ func TestBuildCreateUpdateDependencies_RuntimeDependency_InstanceSafe(t *testing
 		{DesiredState: mountTarget("MT1B", "mt1B", "FS1"), Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{fs1URI}},
 		{DesiredState: mountTarget("MT2A", "mt2A", "FS2"), Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{fs2URI}},
 		{DesiredState: mountTarget("MT2B", "mt2B", "FS2"), Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{fs2URI}},
-	}, nil, "rtc2", pkgmodel.CommandApply)
+	}, nil, "rtc2", pkgmodel.CommandApply, nil)
 	if err != nil {
 		t.Fatalf("NewChangeset: %v", err)
 	}
@@ -2697,7 +2702,7 @@ func TestBuildCreateUpdateDependencies_RuntimeDependency_NoMatchingChildren_Fall
 		{DesiredState: consumer, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
 		{DesiredState: producer, Operation: resource_update.OperationCreate},
 		{DesiredState: unrelated, Operation: resource_update.OperationCreate},
-	}, nil, "rtc3", pkgmodel.CommandApply)
+	}, nil, "rtc3", pkgmodel.CommandApply, nil)
 	if err != nil {
 		t.Fatalf("NewChangeset: %v", err)
 	}
@@ -2795,7 +2800,7 @@ func TestBuildDeleteDependencies_RuntimeDependency_MultipleRefsToSameProducer_Pr
 			{DesiredState: consumer, Operation: resource_update.OperationDelete, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
 			{DesiredState: producer, Operation: resource_update.OperationDelete},
 			{DesiredState: mtA, Operation: resource_update.OperationDelete},
-		}, nil, "rtmulti1", pkgmodel.CommandApply)
+		}, nil, "rtmulti1", pkgmodel.CommandApply, nil)
 		if err != nil {
 			t.Fatalf("iteration %d NewChangeset: %v", i, err)
 		}
@@ -2861,7 +2866,7 @@ func TestBuildCreateUpdateDependencies_RuntimeDependency_MultipleRefsToSameProdu
 			{DesiredState: consumer, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
 			{DesiredState: producer, Operation: resource_update.OperationCreate},
 			{DesiredState: mtA, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
-		}, nil, "rtcmulti1", pkgmodel.CommandApply)
+		}, nil, "rtcmulti1", pkgmodel.CommandApply, nil)
 		if err != nil {
 			t.Fatalf("iteration %d NewChangeset: %v", i, err)
 		}
@@ -2921,7 +2926,7 @@ func TestBuildCreateUpdateDependencies_RuntimeDependency_UpdateChild_StillLinks(
 		{DesiredState: consumer, Operation: resource_update.OperationCreate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
 		{DesiredState: producer, Operation: resource_update.OperationCreate},
 		{DesiredState: mtA, Operation: resource_update.OperationUpdate, RemainingResolvables: []pkgmodel.FormaeURI{producerURI}},
-	}, nil, "rtcupd1", pkgmodel.CommandApply)
+	}, nil, "rtcupd1", pkgmodel.CommandApply, nil)
 	if err != nil {
 		t.Fatalf("NewChangeset: %v", err)
 	}
@@ -2934,4 +2939,169 @@ func TestBuildCreateUpdateDependencies_RuntimeDependency_UpdateChild_StillLinks(
 	if !hasDependency(consNode, mtANode) {
 		t.Fatalf("consumer.create should depend on mountTargetA.update (runtimeDependency child edge must follow the child's actual operation, not a hardcoded Create)")
 	}
+}
+
+// stubResolveDatastore is a minimal datastore.Datastore used by the synthetic
+// Resolve-target tests. Only LoadTarget is exercised; every other method
+// inherits the embedded interface and panics if called, which keeps the stub
+// honest about what these tests actually depend on.
+type stubResolveDatastore struct {
+	datastore.Datastore
+	targets map[string]*pkgmodel.Target
+}
+
+func (s *stubResolveDatastore) LoadTarget(label string) (*pkgmodel.Target, error) {
+	return s.targets[label], nil
+}
+
+// opaqueRefConfig is a target config carrying a single opaque $ref, mirroring an
+// otherwise-unchanged target whose secret must be resolved before dependent
+// resource ops dispatch.
+func opaqueRefConfig(refURI string) json.RawMessage {
+	return json.RawMessage(`{"auth":{"$ref":"` + refURI + `","$visibility":"Opaque"}}`)
+}
+
+func hasDependencyOn(node *DAGNode, uri pkgmodel.FormaeURI) bool {
+	for _, dep := range node.Dependencies {
+		if dep.URI == uri {
+			return true
+		}
+	}
+	return false
+}
+
+// TestNewChangeset_SynthesizesResolveNodeForUnchangedOpaqueTarget asserts that a
+// resource op referencing a persisted target whose config carries an opaque $ref,
+// with NO real target update in the changeset, produces exactly one synthetic
+// Resolve node keyed target://<label>/resolve carrying the target's resolvables.
+func TestNewChangeset_SynthesizesResolveNodeForUnchangedOpaqueTarget(t *testing.T) {
+	const targetLabel = "aws-prod"
+	refURI := pkgmodel.NewFormaeURI(util.NewID(), "SecretString")
+
+	ds := &stubResolveDatastore{targets: map[string]*pkgmodel.Target{
+		targetLabel: {Label: targetLabel, Namespace: "AWS", Config: opaqueRefConfig(string(refURI))},
+	}}
+
+	resourceUpdates := []resource_update.ResourceUpdate{
+		{
+			DesiredState: pkgmodel.Resource{Label: "bucket", Type: "AWS::S3::Bucket", Stack: "s", Ksuid: util.NewID(), Target: targetLabel},
+			Operation:    resource_update.OperationCreate,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+	}
+
+	cs, err := NewChangeset(resourceUpdates, nil, "cmd-synth", pkgmodel.CommandApply, ds)
+	require.NoError(t, err)
+
+	resolveNode := cs.DAG.Nodes[pkgmodel.FormaeURI("target://"+targetLabel+"/resolve")]
+	require.NotNil(t, resolveNode, "expected a synthetic Resolve node for the unchanged opaque target")
+
+	tu, ok := resolveNode.Update.(*target_update.TargetUpdate)
+	require.True(t, ok)
+	assert.Equal(t, target_update.TargetOperationResolve, tu.Operation)
+	require.Len(t, tu.RemainingResolvables, 1)
+	assert.Equal(t, refURI, tu.RemainingResolvables[0])
+}
+
+// TestNewChangeset_NoSynthesisWhenTargetAlreadyHasUpdate asserts that a target
+// already covered by a real Create/Update target update never gets a duplicate
+// synthetic Resolve node.
+func TestNewChangeset_NoSynthesisWhenTargetAlreadyHasUpdate(t *testing.T) {
+	const targetLabel = "aws-prod"
+	refURI := pkgmodel.NewFormaeURI(util.NewID(), "SecretString")
+
+	ds := &stubResolveDatastore{targets: map[string]*pkgmodel.Target{
+		targetLabel: {Label: targetLabel, Namespace: "AWS", Config: opaqueRefConfig(string(refURI))},
+	}}
+
+	resourceUpdates := []resource_update.ResourceUpdate{
+		{
+			DesiredState: pkgmodel.Resource{Label: "bucket", Type: "AWS::S3::Bucket", Stack: "s", Ksuid: util.NewID(), Target: targetLabel},
+			Operation:    resource_update.OperationCreate,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+	}
+	targetUpdates := []target_update.TargetUpdate{
+		{
+			Target:    pkgmodel.Target{Label: targetLabel, Namespace: "AWS"},
+			Operation: target_update.TargetOperationUpdate,
+			State:     target_update.TargetUpdateStateNotStarted,
+		},
+	}
+
+	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-nodup", pkgmodel.CommandApply, ds)
+	require.NoError(t, err)
+
+	assert.Nil(t, cs.DAG.Nodes[pkgmodel.FormaeURI("target://"+targetLabel+"/resolve")],
+		"a target with a real update must not get a synthetic Resolve node")
+}
+
+// TestNewChangeset_NoSynthesisWhenTargetHasNoOpaqueRefs asserts that a persisted
+// target whose config carries no $ref produces no synthetic Resolve node.
+func TestNewChangeset_NoSynthesisWhenTargetHasNoOpaqueRefs(t *testing.T) {
+	const targetLabel = "aws-prod"
+
+	ds := &stubResolveDatastore{targets: map[string]*pkgmodel.Target{
+		targetLabel: {Label: targetLabel, Namespace: "AWS", Config: json.RawMessage(`{"region":"us-east-1"}`)},
+	}}
+
+	resourceUpdates := []resource_update.ResourceUpdate{
+		{
+			DesiredState: pkgmodel.Resource{Label: "bucket", Type: "AWS::S3::Bucket", Stack: "s", Ksuid: util.NewID(), Target: targetLabel},
+			Operation:    resource_update.OperationCreate,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+	}
+
+	cs, err := NewChangeset(resourceUpdates, nil, "cmd-norefs", pkgmodel.CommandApply, ds)
+	require.NoError(t, err)
+
+	assert.Nil(t, cs.DAG.Nodes[pkgmodel.FormaeURI("target://"+targetLabel+"/resolve")],
+		"a target with no $ref config must not get a synthetic Resolve node")
+}
+
+// TestNewChangeset_SyntheticResolveNodeIsDependencyOfEveryResourceOp asserts that
+// every resource op on the unchanged opaque target depends on the synthetic
+// Resolve node, so none dispatch before the target config is resolved.
+func TestNewChangeset_SyntheticResolveNodeIsDependencyOfEveryResourceOp(t *testing.T) {
+	const targetLabel = "aws-prod"
+	refURI := pkgmodel.NewFormaeURI(util.NewID(), "SecretString")
+
+	ds := &stubResolveDatastore{targets: map[string]*pkgmodel.Target{
+		targetLabel: {Label: targetLabel, Namespace: "AWS", Config: opaqueRefConfig(string(refURI))},
+	}}
+
+	createKsuid := util.NewID()
+	updateKsuid := util.NewID()
+	resourceUpdates := []resource_update.ResourceUpdate{
+		{
+			DesiredState: pkgmodel.Resource{Label: "bucket", Type: "AWS::S3::Bucket", Stack: "s", Ksuid: createKsuid, Target: targetLabel},
+			Operation:    resource_update.OperationCreate,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+		{
+			DesiredState: pkgmodel.Resource{Label: "queue", Type: "AWS::SQS::Queue", Stack: "s", Ksuid: updateKsuid, Target: targetLabel},
+			Operation:    resource_update.OperationUpdate,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+	}
+
+	cs, err := NewChangeset(resourceUpdates, nil, "cmd-dep", pkgmodel.CommandApply, ds)
+	require.NoError(t, err)
+
+	resolveURI := pkgmodel.FormaeURI("target://" + targetLabel + "/resolve")
+	require.NotNil(t, cs.DAG.Nodes[resolveURI])
+
+	createNode := cs.DAG.Nodes[createOperationURI(resourceUpdates[0].URI(), resource_update.OperationCreate)]
+	updateNode := cs.DAG.Nodes[createOperationURI(resourceUpdates[1].URI(), resource_update.OperationUpdate)]
+	require.NotNil(t, createNode)
+	require.NotNil(t, updateNode)
+
+	assert.True(t, hasDependencyOn(createNode, resolveURI), "create op must depend on the Resolve node")
+	assert.True(t, hasDependencyOn(updateNode, resolveURI), "update op must depend on the Resolve node")
 }

--- a/internal/metastructure/changeset/resolve_test_helper_test.go
+++ b/internal/metastructure/changeset/resolve_test_helper_test.go
@@ -1,0 +1,35 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package changeset
+
+import (
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// buildChangesetForTest mirrors the production Update-construction phase: it
+// generates any synthetic Resolve target ops (and runs the transitive-opaque
+// rejection) via target_update.SynthesizeResolveTargetUpdates, then builds the
+// (now ds-free) changeset. It keeps the old NewChangeset(rus, tus, id, cmd, ds)
+// call shape so the many existing tests port with a mechanical rename, and it
+// preserves their assertions: a reject error surfaces from the synthesis step,
+// a dependency-cycle error from NewChangeset.
+func buildChangesetForTest(
+	resourceUpdates []resource_update.ResourceUpdate,
+	targetUpdates []target_update.TargetUpdate,
+	commandID string,
+	command pkgmodel.Command,
+	ds target_update.TargetDatastore,
+) (Changeset, error) {
+	synth, err := target_update.SynthesizeResolveTargetUpdates(
+		resource_update.ReferencedTargetLabels(resourceUpdates),
+		resource_update.SourceTargetByKsuid(resourceUpdates),
+		targetUpdates, ds)
+	if err != nil {
+		return Changeset{}, err
+	}
+	return NewChangeset(resourceUpdates, append(targetUpdates, synth...), commandID, command)
+}

--- a/internal/metastructure/changeset/target_config_propagation_test.go
+++ b/internal/metastructure/changeset/target_config_propagation_test.go
@@ -66,7 +66,7 @@ func TestBuildTargetResourceEdges_MutableTargetUpdate_AllDependentOpsDependOnTar
 
 	targetUpdates := []target_update.TargetUpdate{mutableResolvableTargetUpdate(targetLabel)}
 
-	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-ordering", pkgmodel.CommandApply)
+	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-ordering", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	targetNode := cs.DAG.Nodes[pkgmodel.FormaeURI("target://"+targetLabel+"/update")]
@@ -106,7 +106,7 @@ func TestNewChangeset_ResourceReplaceOnResolvableTarget_RemainsAcyclic(t *testin
 	}
 	targetUpdates := []target_update.TargetUpdate{mutableResolvableTargetUpdate(targetLabel)}
 
-	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-replace-acyclic", pkgmodel.CommandApply)
+	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-replace-acyclic", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	assert.False(t, cs.DAG.HasCycles(),
@@ -147,7 +147,7 @@ func TestBuildTargetResourceEdges_CycleProneDeleteEdge_IsSkipped(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-cycle-guard", pkgmodel.CommandApply)
+	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-cycle-guard", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	deleteNode := dagNodeForOp(t, cs.DAG, pkgmodel.NewFormaeURI(k, ""), resource_update.OperationDelete)
@@ -218,7 +218,7 @@ func TestChangeset_MutableTargetUpdate_DeleteDispatchesResolvedConfigAfterTarget
 	}
 	targetUpdates := []target_update.TargetUpdate{mutableResolvableTargetUpdate(targetLabel)}
 
-	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-propagation", pkgmodel.CommandApply)
+	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-propagation", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// isGrafanaDelete identifies the grafana delete among scheduled updates. A

--- a/internal/metastructure/changeset/target_config_propagation_test.go
+++ b/internal/metastructure/changeset/target_config_propagation_test.go
@@ -66,7 +66,7 @@ func TestBuildTargetResourceEdges_MutableTargetUpdate_AllDependentOpsDependOnTar
 
 	targetUpdates := []target_update.TargetUpdate{mutableResolvableTargetUpdate(targetLabel)}
 
-	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-ordering", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-ordering", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	targetNode := cs.DAG.Nodes[pkgmodel.FormaeURI("target://"+targetLabel+"/update")]
@@ -106,7 +106,7 @@ func TestNewChangeset_ResourceReplaceOnResolvableTarget_RemainsAcyclic(t *testin
 	}
 	targetUpdates := []target_update.TargetUpdate{mutableResolvableTargetUpdate(targetLabel)}
 
-	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-replace-acyclic", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-replace-acyclic", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	assert.False(t, cs.DAG.HasCycles(),
@@ -149,7 +149,7 @@ func TestNewChangeset_TargetRefsResourceReplacedOnSameTarget_ReturnsCycleError(t
 		},
 	}
 
-	_, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-cycle-guard", pkgmodel.CommandApply, nil)
+	_, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-cycle-guard", pkgmodel.CommandApply, nil)
 	require.Error(t, err, "a target $ref to a resource replaced on the same target forms a cycle and must be rejected")
 }
 
@@ -213,7 +213,7 @@ func TestChangeset_MutableTargetUpdate_DeleteDispatchesResolvedConfigAfterTarget
 	}
 	targetUpdates := []target_update.TargetUpdate{mutableResolvableTargetUpdate(targetLabel)}
 
-	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-propagation", pkgmodel.CommandApply, nil)
+	cs, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-propagation", pkgmodel.CommandApply, nil)
 	require.NoError(t, err)
 
 	// isGrafanaDelete identifies the grafana delete among scheduled updates. A

--- a/internal/metastructure/changeset/target_config_propagation_test.go
+++ b/internal/metastructure/changeset/target_config_propagation_test.go
@@ -120,12 +120,14 @@ func TestNewChangeset_ResourceReplaceOnResolvableTarget_RemainsAcyclic(t *testin
 		"the replace's delete should wait for the target update when no cycle would result")
 }
 
-// TestBuildTargetResourceEdges_CycleProneDeleteEdge_IsSkipped covers the adversarial
-// shape the cycle-safety guard exists for: a target update whose $ref points at a
-// resource being replaced on that same target. There, target-update→create (resolvable)
-// and create→delete (replace) already exist, so adding delete→target-update would close
-// a cycle. The guard must skip that edge.
-func TestBuildTargetResourceEdges_CycleProneDeleteEdge_IsSkipped(t *testing.T) {
+// TestNewChangeset_TargetRefsResourceReplacedOnSameTarget_ReturnsCycleError covers a
+// target update whose $ref points at a resource being replaced on that SAME target. The
+// target update must wait for the resource's create to resolve its config (target→create),
+// while every resource create on the target must wait for the target to be persisted
+// (create→target). Those two edges form a genuine cycle that cannot be scheduled, so the
+// full-graph cycle check must reject the changeset with an error rather than let the
+// executor hang.
+func TestNewChangeset_TargetRefsResourceReplacedOnSameTarget_ReturnsCycleError(t *testing.T) {
 	const targetLabel = "grafana"
 	k := util.NewID()
 
@@ -147,15 +149,8 @@ func TestBuildTargetResourceEdges_CycleProneDeleteEdge_IsSkipped(t *testing.T) {
 		},
 	}
 
-	cs, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-cycle-guard", pkgmodel.CommandApply, nil)
-	require.NoError(t, err)
-
-	deleteNode := dagNodeForOp(t, cs.DAG, pkgmodel.NewFormaeURI(k, ""), resource_update.OperationDelete)
-	targetNode := cs.DAG.Nodes[pkgmodel.FormaeURI("target://"+targetLabel+"/update")]
-	require.NotNil(t, targetNode)
-
-	assert.False(t, hasDependency(deleteNode, targetNode),
-		"the cycle-prone delete→target-update edge must be skipped by the cycle-safety guard")
+	_, err := NewChangeset(resourceUpdates, targetUpdates, "cmd-cycle-guard", pkgmodel.CommandApply, nil)
+	require.Error(t, err, "a target $ref to a resource replaced on the same target forms a cycle and must be rejected")
 }
 
 // TestDependsOnTransitively_WalksDependencyChain locks the semantics of the

--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -717,6 +717,7 @@ func synchronizeResources(op ListOperation, namespace string, target pkgmodel.Ta
 	cs, err := changeset.NewChangeset(syncCommand.ResourceUpdates, nil, syncCommand.ID, pkgmodel.CommandSync, data.ds)
 	if err != nil {
 		slog.Error("failed to build changeset for discovery sync command", "commandID", syncCommand.ID, "error", err)
+		finalizeFailedSyncCommand(syncCommand, proc)
 		return "", fmt.Errorf("failed to build changeset: %w", err)
 	}
 
@@ -1039,4 +1040,31 @@ func injectResolvables(props string, op ListOperation) json.RawMessage {
 	}
 
 	return json.RawMessage(props)
+}
+
+// finalizeFailedSyncCommand marks all resource updates in the command as failed and then
+// finalizes the command itself, preventing persisted commands from being left in a
+// non-terminal pending state when changeset construction fails after storage.
+func finalizeFailedSyncCommand(cmd *forma_command.FormaCommand, proc gen.Process) {
+	refs := make([]forma_persister.ResourceUpdateRef, 0, len(cmd.ResourceUpdates))
+	for _, ru := range cmd.ResourceUpdates {
+		refs = append(refs, forma_persister.ResourceUpdateRef{
+			URI:       ru.URI(),
+			Operation: ru.Operation,
+		})
+	}
+	persister := actornames.FormaCommandPersister
+	if len(refs) > 0 {
+		if _, err := proc.Call(persister, forma_persister.MarkResourcesAsFailed{
+			CommandID:          cmd.ID,
+			Resources:          refs,
+			ResourceModifiedTs: time.Now(),
+		}); err != nil {
+			slog.Error("Discovery: failed to mark resources as failed for aborted command", "commandID", cmd.ID, "error", err)
+			return
+		}
+	}
+	if _, err := proc.Call(persister, forma_persister.FinalizeIncompleteCommand{CommandID: cmd.ID}); err != nil {
+		slog.Error("Discovery: failed to finalize aborted command", "commandID", cmd.ID, "error", err)
+	}
 }

--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -31,6 +31,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
@@ -714,7 +715,16 @@ func synchronizeResources(op ListOperation, namespace string, target pkgmodel.Ta
 
 	// Pass CommandSync so the DAG skips buildOperationRelationships — discovery
 	// sync reads are independent and one failed read must not cascade to others.
-	cs, err := changeset.NewChangeset(syncCommand.ResourceUpdates, nil, syncCommand.ID, pkgmodel.CommandSync, data.ds)
+	synth, err := target_update.SynthesizeResolveTargetUpdates(
+		resource_update.ReferencedTargetLabels(syncCommand.ResourceUpdates),
+		resource_update.SourceTargetByKsuid(syncCommand.ResourceUpdates),
+		nil, data.ds)
+	if err != nil {
+		slog.Error("failed to build changeset for discovery sync command", "commandID", syncCommand.ID, "error", err)
+		finalizeFailedSyncCommand(syncCommand, proc)
+		return "", fmt.Errorf("failed to build changeset: %w", err)
+	}
+	cs, err := changeset.NewChangeset(syncCommand.ResourceUpdates, synth, syncCommand.ID, pkgmodel.CommandSync)
 	if err != nil {
 		slog.Error("failed to build changeset for discovery sync command", "commandID", syncCommand.ID, "error", err)
 		finalizeFailedSyncCommand(syncCommand, proc)

--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -714,7 +714,11 @@ func synchronizeResources(op ListOperation, namespace string, target pkgmodel.Ta
 
 	// Pass CommandSync so the DAG skips buildOperationRelationships — discovery
 	// sync reads are independent and one failed read must not cascade to others.
-	cs, _ := changeset.NewChangeset(syncCommand.ResourceUpdates, nil, syncCommand.ID, pkgmodel.CommandSync, data.ds)
+	cs, err := changeset.NewChangeset(syncCommand.ResourceUpdates, nil, syncCommand.ID, pkgmodel.CommandSync, data.ds)
+	if err != nil {
+		slog.Error("failed to build changeset for discovery sync command", "commandID", syncCommand.ID, "error", err)
+		return "", fmt.Errorf("failed to build changeset: %w", err)
+	}
 
 	proc.Log().Debug("Ensuring ChangesetExecutor for sync command commandID=%s", syncCommand.ID)
 	_, err = proc.Call(

--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -714,7 +714,7 @@ func synchronizeResources(op ListOperation, namespace string, target pkgmodel.Ta
 
 	// Pass CommandSync so the DAG skips buildOperationRelationships — discovery
 	// sync reads are independent and one failed read must not cascade to others.
-	cs, _ := changeset.NewChangeset(syncCommand.ResourceUpdates, nil, syncCommand.ID, pkgmodel.CommandSync)
+	cs, _ := changeset.NewChangeset(syncCommand.ResourceUpdates, nil, syncCommand.ID, pkgmodel.CommandSync, data.ds)
 
 	proc.Log().Debug("Ensuring ChangesetExecutor for sync command commandID=%s", syncCommand.ID)
 	_, err = proc.Call(

--- a/internal/metastructure/discovery/synchronize_resources_error_test.go
+++ b/internal/metastructure/discovery/synchronize_resources_error_test.go
@@ -28,7 +28,7 @@ import (
 // error so tests can drive NewChangeset failure without full actor infrastructure.
 type stubSyncResourcesDatastore struct {
 	datastore.Datastore
-	targets     []*pkgmodel.Target
+	targets       []*pkgmodel.Target
 	loadTargetErr error
 }
 

--- a/internal/metastructure/discovery/synchronize_resources_error_test.go
+++ b/internal/metastructure/discovery/synchronize_resources_error_test.go
@@ -54,17 +54,27 @@ func (s *stubSyncResourcesDatastore) LoadTarget(label string) (*pkgmodel.Target,
 
 // persistCommandProcess is a gen.Process double that handles all actor calls
 // that synchronizeResources issues: StoreNewFormaCommand (before NewChangeset)
-// and EnsureChangesetExecutor (after). All other messages are delegated to the
-// embedded stubProcess.
+// and EnsureChangesetExecutor (after). It records MarkResourcesAsFailed and
+// FinalizeIncompleteCommand calls so tests can verify orphan-command cleanup.
+// All other messages are delegated to the embedded stubProcess.
 type persistCommandProcess struct {
 	*stubProcess
+
+	markFailedCalls    []forma_persister.MarkResourcesAsFailed
+	finalizeCalls      []forma_persister.FinalizeIncompleteCommand
 }
 
 func (p *persistCommandProcess) Call(_ any, message any) (any, error) {
-	switch message.(type) {
+	switch m := message.(type) {
 	case forma_persister.StoreNewFormaCommand:
 		return struct{}{}, nil
 	case changeset.EnsureChangesetExecutor:
+		return struct{}{}, nil
+	case forma_persister.MarkResourcesAsFailed:
+		p.markFailedCalls = append(p.markFailedCalls, m)
+		return struct{}{}, nil
+	case forma_persister.FinalizeIncompleteCommand:
+		p.finalizeCalls = append(p.finalizeCalls, m)
 		return struct{}{}, nil
 	default:
 		return p.stubProcess.Call(nil, message)
@@ -186,3 +196,51 @@ func TestSynchronizeResources_ReturnsCommandIDOnSuccess(t *testing.T) {
 
 // Ensure persistCommandProcess satisfies the gen.Process interface.
 var _ gen.Process = (*persistCommandProcess)(nil)
+
+// TestSynchronizeResources_FinalizesCommandOnNewChangesetError asserts that when
+// NewChangeset fails after the command has already been persisted, synchronizeResources
+// finalizes the stored command (marks all resources failed, then calls
+// FinalizeIncompleteCommand) so no command is left permanently pending.
+func TestSynchronizeResources_FinalizesCommandOnNewChangesetError(t *testing.T) {
+	const (
+		namespace    = "FakeAWS"
+		resourceType = "FakeAWS::S3::Bucket"
+		targetLabel  = "us-east-1"
+		nativeID     = "my-bucket"
+	)
+
+	loadTargetErr := errors.New("datastore read error")
+	ds := &stubSyncResourcesDatastore{
+		targets: []*pkgmodel.Target{
+			{Label: targetLabel, Namespace: namespace},
+		},
+		loadTargetErr: loadTargetErr,
+	}
+
+	data := newSyncResourcesData(ds, namespace, resourceType)
+	proc := &persistCommandProcess{stubProcess: &stubProcess{}}
+
+	op := ListOperation{
+		ResourceType: resourceType,
+		TargetLabel:  targetLabel,
+	}
+	target := pkgmodel.Target{Label: targetLabel, Namespace: namespace}
+	resources := []plugin.ListedResource{
+		{NativeID: nativeID, ResourceType: resourceType},
+	}
+
+	_, err := synchronizeResources(op, namespace, target, resources, data, proc)
+
+	require.Error(t, err, "synchronizeResources must propagate the NewChangeset error")
+
+	assert.NotEmpty(t, proc.markFailedCalls,
+		"MarkResourcesAsFailed must be called to terminalize resource updates before finalizing")
+	require.Len(t, proc.finalizeCalls, 1,
+		"FinalizeIncompleteCommand must be called exactly once to close out the orphaned command")
+
+	// The same command ID must be used throughout.
+	if len(proc.markFailedCalls) > 0 {
+		assert.Equal(t, proc.finalizeCalls[0].CommandID, proc.markFailedCalls[0].CommandID,
+			"MarkResourcesAsFailed and FinalizeIncompleteCommand must reference the same command")
+	}
+}

--- a/internal/metastructure/discovery/synchronize_resources_error_test.go
+++ b/internal/metastructure/discovery/synchronize_resources_error_test.go
@@ -1,0 +1,188 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package discovery
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/changeset"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_persister"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+)
+
+// stubSyncResourcesDatastore is a minimal datastore double for synchronizeResources
+// tests. LoadAllTargets returns a fixed list; LoadTarget injects the configured
+// error so tests can drive NewChangeset failure without full actor infrastructure.
+type stubSyncResourcesDatastore struct {
+	datastore.Datastore
+	targets     []*pkgmodel.Target
+	loadTargetErr error
+}
+
+func (s *stubSyncResourcesDatastore) LoadAllTargets() ([]*pkgmodel.Target, error) {
+	return s.targets, nil
+}
+
+func (s *stubSyncResourcesDatastore) LoadResourcesByStack(_ string) ([]*pkgmodel.Resource, error) {
+	return nil, nil
+}
+
+func (s *stubSyncResourcesDatastore) LoadTarget(label string) (*pkgmodel.Target, error) {
+	if s.loadTargetErr != nil {
+		return nil, s.loadTargetErr
+	}
+	for _, t := range s.targets {
+		if t.Label == label {
+			return t, nil
+		}
+	}
+	return nil, nil
+}
+
+// persistCommandProcess is a gen.Process double that handles all actor calls
+// that synchronizeResources issues: StoreNewFormaCommand (before NewChangeset)
+// and EnsureChangesetExecutor (after). All other messages are delegated to the
+// embedded stubProcess.
+type persistCommandProcess struct {
+	*stubProcess
+}
+
+func (p *persistCommandProcess) Call(_ any, message any) (any, error) {
+	switch message.(type) {
+	case forma_persister.StoreNewFormaCommand:
+		return struct{}{}, nil
+	case changeset.EnsureChangesetExecutor:
+		return struct{}{}, nil
+	default:
+		return p.stubProcess.Call(nil, message)
+	}
+}
+
+// newSyncResourcesData builds a DiscoveryData with a valid plugin schema cache
+// for the given namespace and resource type, ready to drive synchronizeResources
+// directly without a running actor system.
+func newSyncResourcesData(ds datastore.Datastore, namespace, resourceType string) DiscoveryData {
+	return DiscoveryData{
+		ds:           ds,
+		discoveryCfg: &pkgmodel.DiscoveryConfig{Enabled: true, Interval: 20 * time.Second},
+		serverCfg:    &pkgmodel.ServerConfig{},
+		targets:      map[string]pkgmodel.Target{},
+		resourceDescriptors: map[string]plugin.ResourceDescriptor{
+			resourceType: {Type: resourceType, Discoverable: true},
+		},
+		queuedListOperations:          map[string][]ListOperation{},
+		outstandingListOperations:     map[string]ListOperation{},
+		outstandingSyncCommands:       map[string]ListOperation{},
+		recentlyDiscoveredResourceIDs: map[string]struct{}{},
+		summary:                       map[string]int{},
+		typesWithChildrenQueued:       map[string]struct{}{},
+		nativeIDsByCommand:            map[string][]string{},
+		pluginInfoCache: map[string]*messages.PluginInfoResponse{
+			namespace: {
+				Found:     true,
+				Namespace: namespace,
+				ResourceSchemas: map[string]pkgmodel.Schema{
+					resourceType: {},
+				},
+			},
+		},
+	}
+}
+
+// TestSynchronizeResources_PropagatesNewChangesetError asserts that
+// synchronizeResources returns an error rather than proceeding with a zero-value
+// changeset when NewChangeset fails. The failure is injected via a datastore
+// stub that returns an error from LoadTarget, which triggers the
+// synthesizeResolveTargetUpdates path inside NewChangeset.
+func TestSynchronizeResources_PropagatesNewChangesetError(t *testing.T) {
+	const (
+		namespace    = "FakeAWS"
+		resourceType = "FakeAWS::S3::Bucket"
+		targetLabel  = "us-east-1"
+		nativeID     = "my-bucket"
+	)
+
+	// The datastore returns a valid target list so GenerateResourceUpdates
+	// succeeds, but then errors on LoadTarget so NewChangeset fails inside
+	// synthesizeResolveTargetUpdates.
+	loadTargetErr := errors.New("datastore read error")
+	ds := &stubSyncResourcesDatastore{
+		targets: []*pkgmodel.Target{
+			{Label: targetLabel, Namespace: namespace},
+		},
+		loadTargetErr: loadTargetErr,
+	}
+
+	data := newSyncResourcesData(ds, namespace, resourceType)
+	proc := &persistCommandProcess{stubProcess: &stubProcess{}}
+
+	op := ListOperation{
+		ResourceType: resourceType,
+		TargetLabel:  targetLabel,
+	}
+	target := pkgmodel.Target{Label: targetLabel, Namespace: namespace}
+	resources := []plugin.ListedResource{
+		{NativeID: nativeID, ResourceType: resourceType},
+	}
+
+	commandID, err := synchronizeResources(op, namespace, target, resources, data, proc)
+
+	require.Error(t, err, "synchronizeResources must propagate a NewChangeset failure, not silently proceed")
+	assert.Empty(t, commandID, "a failed synchronizeResources must return an empty command ID")
+	assert.ErrorContains(t, err, "failed to build changeset")
+}
+
+// TestSynchronizeResources_ReturnsCommandIDOnSuccess is a companion smoke-test:
+// synchronizeResources returns a non-empty command ID when NewChangeset succeeds
+// so we can distinguish the error path from a genuine no-op.
+func TestSynchronizeResources_ReturnsCommandIDOnSuccess(t *testing.T) {
+	const (
+		namespace    = "FakeAWS"
+		resourceType = "FakeAWS::S3::Bucket"
+		targetLabel  = "us-east-1"
+		nativeID     = "my-bucket"
+	)
+
+	// No loadTargetErr: NewChangeset will succeed (the target has no opaque refs
+	// so synthesizeResolveTargetUpdates produces nothing and returns nil error).
+	ds := &stubSyncResourcesDatastore{
+		targets: []*pkgmodel.Target{
+			{Label: targetLabel, Namespace: namespace},
+		},
+	}
+
+	data := newSyncResourcesData(ds, namespace, resourceType)
+	proc := &persistCommandProcess{stubProcess: &stubProcess{}}
+
+	op := ListOperation{
+		ResourceType: resourceType,
+		TargetLabel:  targetLabel,
+	}
+	target := pkgmodel.Target{Label: targetLabel, Namespace: namespace}
+	resources := []plugin.ListedResource{
+		{NativeID: nativeID, ResourceType: resourceType},
+	}
+
+	commandID, err := synchronizeResources(op, namespace, target, resources, data, proc)
+
+	// The process stub accepts but ignores the Start message sent to the
+	// ChangesetExecutor, so no further errors are expected.
+	require.NoError(t, err)
+	assert.NotEmpty(t, commandID, "synchronizeResources must return a non-empty command ID on success")
+}
+
+// Ensure persistCommandProcess satisfies the gen.Process interface.
+var _ gen.Process = (*persistCommandProcess)(nil)

--- a/internal/metastructure/discovery/synchronize_resources_error_test.go
+++ b/internal/metastructure/discovery/synchronize_resources_error_test.go
@@ -60,8 +60,8 @@ func (s *stubSyncResourcesDatastore) LoadTarget(label string) (*pkgmodel.Target,
 type persistCommandProcess struct {
 	*stubProcess
 
-	markFailedCalls    []forma_persister.MarkResourcesAsFailed
-	finalizeCalls      []forma_persister.FinalizeIncompleteCommand
+	markFailedCalls []forma_persister.MarkResourcesAsFailed
+	finalizeCalls   []forma_persister.FinalizeIncompleteCommand
 }
 
 func (p *persistCommandProcess) Call(_ any, message any) (any, error) {

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -350,7 +350,14 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 	// Create changeset early to catch validation errors before simulate
 	var cs changeset.Changeset
 	if len(fa.ResourceUpdates) > 0 || len(fa.TargetUpdates) > 0 {
-		cs, err = changeset.NewChangeset(fa.ResourceUpdates, fa.TargetUpdates, fa.ID, fa.Command, m.Datastore)
+		synth, synthErr := target_update.SynthesizeResolveTargetUpdates(
+			resource_update.ReferencedTargetLabels(fa.ResourceUpdates),
+			resource_update.SourceTargetByKsuid(fa.ResourceUpdates),
+			fa.TargetUpdates, m.Datastore)
+		if synthErr != nil {
+			return nil, synthErr
+		}
+		cs, err = changeset.NewChangeset(fa.ResourceUpdates, append(fa.TargetUpdates, synth...), fa.ID, fa.Command)
 		if err != nil {
 			return nil, err
 		}
@@ -811,7 +818,14 @@ func (m *Metastructure) DestroyForma(forma *pkgmodel.Forma, config *config.Forma
 	}
 
 	if len(fa.ResourceUpdates) > 0 || len(fa.TargetUpdates) > 0 {
-		cs, err := changeset.NewChangeset(fa.ResourceUpdates, fa.TargetUpdates, fa.ID, pkgmodel.CommandDestroy, m.Datastore)
+		synth, synthErr := target_update.SynthesizeResolveTargetUpdates(
+			resource_update.ReferencedTargetLabels(fa.ResourceUpdates),
+			resource_update.SourceTargetByKsuid(fa.ResourceUpdates),
+			fa.TargetUpdates, m.Datastore)
+		if synthErr != nil {
+			return nil, synthErr
+		}
+		cs, err := changeset.NewChangeset(fa.ResourceUpdates, append(fa.TargetUpdates, synth...), fa.ID, pkgmodel.CommandDestroy)
 		if err != nil {
 			return nil, err
 		}
@@ -1341,7 +1355,15 @@ func (m *Metastructure) ReRunIncompleteCommands() error {
 		// Build the changeset from only the pending (non-terminal) resource
 		// updates. Terminal resources are excluded so they don't create
 		// phantom dependency links in the new changeset's pipeline.
-		cs, err := changeset.NewChangeset(pendingUpdates, pendingTargetUpdates, fa.ID, pkgmodel.CommandApply, m.Datastore)
+		synth, synthErr := target_update.SynthesizeResolveTargetUpdates(
+			resource_update.ReferencedTargetLabels(pendingUpdates),
+			resource_update.SourceTargetByKsuid(pendingUpdates),
+			pendingTargetUpdates, m.Datastore)
+		if synthErr != nil {
+			slog.Error("Failed to build changeset for incomplete forma command, skipping", "commandID", fa.ID, "error", synthErr)
+			continue
+		}
+		cs, err := changeset.NewChangeset(pendingUpdates, append(pendingTargetUpdates, synth...), fa.ID, pkgmodel.CommandApply)
 		if err != nil {
 			slog.Error("Failed to build changeset for incomplete forma command, skipping", "commandID", fa.ID, "error", err)
 			continue

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -350,7 +350,7 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 	// Create changeset early to catch validation errors before simulate
 	var cs changeset.Changeset
 	if len(fa.ResourceUpdates) > 0 || len(fa.TargetUpdates) > 0 {
-		cs, err = changeset.NewChangeset(fa.ResourceUpdates, fa.TargetUpdates, fa.ID, fa.Command)
+		cs, err = changeset.NewChangeset(fa.ResourceUpdates, fa.TargetUpdates, fa.ID, fa.Command, m.Datastore)
 		if err != nil {
 			return nil, err
 		}
@@ -811,7 +811,7 @@ func (m *Metastructure) DestroyForma(forma *pkgmodel.Forma, config *config.Forma
 	}
 
 	if len(fa.ResourceUpdates) > 0 || len(fa.TargetUpdates) > 0 {
-		cs, err := changeset.NewChangeset(fa.ResourceUpdates, fa.TargetUpdates, fa.ID, pkgmodel.CommandDestroy)
+		cs, err := changeset.NewChangeset(fa.ResourceUpdates, fa.TargetUpdates, fa.ID, pkgmodel.CommandDestroy, m.Datastore)
 		if err != nil {
 			return nil, err
 		}
@@ -1341,7 +1341,7 @@ func (m *Metastructure) ReRunIncompleteCommands() error {
 		// Build the changeset from only the pending (non-terminal) resource
 		// updates. Terminal resources are excluded so they don't create
 		// phantom dependency links in the new changeset's pipeline.
-		cs, _ := changeset.NewChangeset(pendingUpdates, pendingTargetUpdates, fa.ID, pkgmodel.CommandApply)
+		cs, _ := changeset.NewChangeset(pendingUpdates, pendingTargetUpdates, fa.ID, pkgmodel.CommandApply, m.Datastore)
 
 		m.Node.Log().Debug("Starting ChangesetExecutor of changeset from incomplete forma command commandID=%s", fa.ID)
 		_, err = m.callActor(

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1341,7 +1341,11 @@ func (m *Metastructure) ReRunIncompleteCommands() error {
 		// Build the changeset from only the pending (non-terminal) resource
 		// updates. Terminal resources are excluded so they don't create
 		// phantom dependency links in the new changeset's pipeline.
-		cs, _ := changeset.NewChangeset(pendingUpdates, pendingTargetUpdates, fa.ID, pkgmodel.CommandApply, m.Datastore)
+		cs, err := changeset.NewChangeset(pendingUpdates, pendingTargetUpdates, fa.ID, pkgmodel.CommandApply, m.Datastore)
+		if err != nil {
+			slog.Error("Failed to build changeset for incomplete forma command, skipping", "commandID", fa.ID, "error", err)
+			continue
+		}
 
 		m.Node.Log().Debug("Starting ChangesetExecutor of changeset from incomplete forma command commandID=%s", fa.ID)
 		_, err = m.callActor(

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -218,6 +218,28 @@ func ExtractResolvableURIsFromJSON(data json.RawMessage) []pkgmodel.FormaeURI {
 	return resolver.getResolvableURIs()
 }
 
+// ExtractOpaqueResolvableURIsFromJSON extracts only the resolvable URIs whose $ref
+// carries an Opaque visibility (a secret credential), ignoring Clear cross-resource
+// references. Used to detect opaque target-config references that must be resolved
+// from a real secret source. Opacity is decided by the parsed Ref's ResolvedValue,
+// reusing pkgmodel.Value.IsOpaque rather than a hand-rolled $visibility string walk.
+func ExtractOpaqueResolvableURIsFromJSON(data json.RawMessage) []pkgmodel.FormaeURI {
+	if data == nil {
+		return nil
+	}
+	resolver := newPropertyResolver(data)
+	var uris []pkgmodel.FormaeURI
+	for uri, refs := range resolver.refs {
+		for i := range refs {
+			if refs[i].ResolvedValue.IsOpaque() {
+				uris = append(uris, uri)
+				break
+			}
+		}
+	}
+	return uris
+}
+
 // propertyParser parses JSON properties to identify references and values
 type propertyParser struct {
 	HasRef    bool

--- a/internal/metastructure/resource_update/resolve_inputs.go
+++ b/internal/metastructure/resource_update/resolve_inputs.go
@@ -1,0 +1,43 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package resource_update
+
+// ReferencedTargetLabels returns the distinct target labels referenced by the
+// given resource ops (a resource's DesiredState.Target and its ResourceTarget.Label),
+// skipping empty labels, in first-seen order for a stable result.
+//
+// This is the input the resolve-op synthesis needs to decide which unchanged
+// targets a command touches and may therefore have to resolve before dispatch.
+func ReferencedTargetLabels(resourceUpdates []ResourceUpdate) []string {
+	seen := make(map[string]bool)
+	var labels []string
+	consider := func(label string) {
+		if label == "" || seen[label] {
+			return
+		}
+		seen[label] = true
+		labels = append(labels, label)
+	}
+	for i := range resourceUpdates {
+		ru := &resourceUpdates[i]
+		consider(ru.DesiredState.Target)
+		consider(ru.ResourceTarget.Label)
+	}
+	return labels
+}
+
+// SourceTargetByKsuid indexes this command's resource ops by KSUID to their
+// target label, so a secret source being created in the same command resolves to
+// its target without a persisted row. Resources with an empty KSUID are skipped.
+func SourceTargetByKsuid(resourceUpdates []ResourceUpdate) map[string]string {
+	byKsuid := make(map[string]string, len(resourceUpdates))
+	for i := range resourceUpdates {
+		ru := &resourceUpdates[i]
+		if k := ru.DesiredState.Ksuid; k != "" {
+			byKsuid[k] = ru.DesiredState.Target
+		}
+	}
+	return byKsuid
+}

--- a/internal/metastructure/resource_update/resolve_inputs_test.go
+++ b/internal/metastructure/resource_update/resolve_inputs_test.go
@@ -1,0 +1,46 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func ru(target, resourceTargetLabel, ksuid string) ResourceUpdate {
+	return ResourceUpdate{
+		DesiredState:   pkgmodel.Resource{Target: target, Ksuid: ksuid},
+		ResourceTarget: pkgmodel.Target{Label: resourceTargetLabel},
+	}
+}
+
+func TestReferencedTargetLabels_DistinctFirstSeenOrder(t *testing.T) {
+	rus := []ResourceUpdate{
+		ru("a", "b", "k1"),
+		ru("a", "", "k2"),  // dup "a", empty resource-target skipped
+		ru("c", "b", "k3"), // "c" new, "b" already seen
+		ru("", "d", "k4"),  // empty desired-target skipped, "d" new
+	}
+	assert.Equal(t, []string{"a", "b", "c", "d"}, ReferencedTargetLabels(rus))
+}
+
+func TestReferencedTargetLabels_Empty(t *testing.T) {
+	assert.Nil(t, ReferencedTargetLabels(nil))
+}
+
+func TestSourceTargetByKsuid_MapsNonEmptyKsuids(t *testing.T) {
+	rus := []ResourceUpdate{
+		ru("target-a", "x", "k1"),
+		ru("target-b", "x", "k2"),
+		ru("target-c", "x", ""), // empty ksuid skipped
+	}
+	got := SourceTargetByKsuid(rus)
+	assert.Equal(t, map[string]string{"k1": "target-a", "k2": "target-b"}, got)
+}

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -933,7 +933,7 @@ func nextState(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.A
 		return StateFinishedSuccessfully, data, nil, nil
 	default:
 		// We should never reach this point, so if we do we exit the state machine with an error.
-		proc.Log().Error("ResourceUpdater reached an unexpected state state=%s data=%v", state, data)
+		proc.Log().Error("ResourceUpdater reached an unexpected state state=%s commandID=%s ksuid=%s operation=%s", state, data.commandID, data.originalResourceKsuidURI.KSUID(), data.resourceUpdate.Operation)
 		data.resourceUpdate.MarkAsFailed()
 		return StateFinishedWithError, data, nil, gen.TerminateReasonPanic
 	}
@@ -987,13 +987,13 @@ func doPluginOperation(resourceURI pkgmodel.FormaeURI, operation plugin.PluginOp
 }
 
 func pluginOperationMissingInAction(from gen.PID, state gen.Atom, data ResourceUpdateData, message PluginOperatorMissingInAction, proc gen.Process) (gen.Atom, ResourceUpdateData, []statemachine.Action, error) {
-	proc.Log().Error("Plugin operator is missing in action state=%s data=%v", state, data)
+	proc.Log().Error("Plugin operator is missing in action state=%s commandID=%s ksuid=%s operation=%s", state, data.commandID, data.originalResourceKsuidURI.KSUID(), data.resourceUpdate.Operation)
 	data.resourceUpdate.MarkAsFailed()
 	return StateFinishedWithError, data, nil, nil
 }
 
 func resolveCacheMissingInAction(from gen.PID, state gen.Atom, data ResourceUpdateData, message ResolveCacheMissingInAction, proc gen.Process) (gen.Atom, ResourceUpdateData, []statemachine.Action, error) {
-	proc.Log().Error("Resolve cache is missing in action state=%s data=%v", state, data)
+	proc.Log().Error("Resolve cache is missing in action state=%s commandID=%s ksuid=%s operation=%s", state, data.commandID, data.originalResourceKsuidURI.KSUID(), data.resourceUpdate.Operation)
 	data.resourceUpdate.MarkAsFailed()
 	return StateFinishedWithError, data, nil, nil
 }

--- a/internal/metastructure/resource_update/resource_updater_test.go
+++ b/internal/metastructure/resource_update/resource_updater_test.go
@@ -8,6 +8,7 @@ package resource_update
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -365,4 +366,95 @@ func TestHandleProgressUpdate_FilteredDiscoveryEmitsTargetHealth(t *testing.T) {
 	require.Len(t, healthMsgs, 1, "exactly one UpdateTargetHealth must be sent even on the filter path")
 	assert.Equal(t, targetLabel, healthMsgs[0].Observation.TargetLabel)
 	assert.Equal(t, pkgmodel.TargetHealthStateReachable, healthMsgs[0].Observation.State)
+}
+
+// capturingLog is a gen.Log that records all Error-level messages.
+type capturingLog struct {
+	gen.Log
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (l *capturingLog) Error(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.msgs = append(l.msgs, fmt.Sprintf(format, args...))
+}
+func (l *capturingLog) Trace(string, ...any)   {}
+func (l *capturingLog) Debug(string, ...any)   {}
+func (l *capturingLog) Info(string, ...any)    {}
+func (l *capturingLog) Warning(string, ...any) {}
+func (l *capturingLog) Panic(string, ...any)   {}
+
+func (l *capturingLog) all() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.msgs...)
+}
+
+// capturingProcess wraps stubUpdaterProcess but uses a capturingLog.
+type capturingProcess struct {
+	*stubUpdaterProcess
+	log *capturingLog
+}
+
+func (p *capturingProcess) Log() gen.Log { return p.log }
+
+// TestTimeoutHandlers_DoNotLogResolvedConfig asserts that the two timeout
+// handlers (plugin-operator missing, resolve-cache missing) log only safe
+// identifiers — command ID, KSUID, and operation — and never render the
+// ResourceUpdate data struct, which transitively contains ResourceTarget.Config
+// and may hold resolved plaintext credentials after target-config propagation.
+func TestTimeoutHandlers_DoNotLogResolvedConfig(t *testing.T) {
+	const knownPlaintext = "super-secret-plaintext-value"
+	commandID := "cmd-timeout-test"
+	ksuid := "3E3wKW8YqVCQEyfKjsGpbsoE8bl"
+
+	ru := &ResourceUpdate{
+		Operation: OperationCreate,
+		DesiredState: pkgmodel.Resource{
+			Label: "my-resource",
+			Ksuid: ksuid,
+		},
+		ResourceTarget: pkgmodel.Target{
+			Label:  "us-east-1",
+			Config: json.RawMessage(`{"password":"` + knownPlaintext + `"}`),
+		},
+	}
+
+	data := ResourceUpdateData{
+		resourceUpdate:           ru,
+		commandID:                commandID,
+		originalResourceKsuidURI: ru.DesiredState.URI(),
+	}
+
+	clog := &capturingLog{}
+	proc := &capturingProcess{
+		stubUpdaterProcess: &stubUpdaterProcess{},
+		log:                clog,
+	}
+
+	// pluginOperationMissingInAction handler
+	t.Run("PluginOperatorMissingInAction", func(t *testing.T) {
+		_, _, _, err := pluginOperationMissingInAction(gen.PID{}, gen.Atom("waiting_for_plugin"), data, PluginOperatorMissingInAction{}, proc)
+		require.NoError(t, err)
+		for _, msg := range clog.all() {
+			assert.NotContains(t, msg, knownPlaintext, "timeout log must not contain resolved credentials")
+			assert.NotContains(t, msg, "Config", "timeout log must not render Config field name (would expose struct)")
+		}
+		assert.NotEmpty(t, clog.all(), "a log message must have been emitted")
+	})
+
+	// resolveCacheMissingInAction handler
+	t.Run("ResolveCacheMissingInAction", func(t *testing.T) {
+		clog2 := &capturingLog{}
+		proc2 := &capturingProcess{stubUpdaterProcess: &stubUpdaterProcess{}, log: clog2}
+		_, _, _, err := resolveCacheMissingInAction(gen.PID{}, gen.Atom("resolving"), data, ResolveCacheMissingInAction{}, proc2)
+		require.NoError(t, err)
+		for _, msg := range clog2.all() {
+			assert.NotContains(t, msg, knownPlaintext, "timeout log must not contain resolved credentials")
+			assert.NotContains(t, msg, "Config", "timeout log must not render Config field name (would expose struct)")
+		}
+		assert.NotEmpty(t, clog2.all(), "a log message must have been emitted")
+	})
 }

--- a/internal/metastructure/stack_expirer.go
+++ b/internal/metastructure/stack_expirer.go
@@ -250,7 +250,7 @@ func prepareDestroyExpiredStack(ds datastore.Datastore, stackInfo datastore.Expi
 	)
 
 	// Create changeset
-	cs, err := changeset.NewChangeset(resourceUpdates, nil, destroyCommand.ID, pkgmodel.CommandDestroy)
+	cs, err := changeset.NewChangeset(resourceUpdates, nil, destroyCommand.ID, pkgmodel.CommandDestroy, ds)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create changeset: %w", err)
 	}

--- a/internal/metastructure/stack_expirer.go
+++ b/internal/metastructure/stack_expirer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_persister"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/stack_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
@@ -249,8 +250,15 @@ func prepareDestroyExpiredStack(ds datastore.Datastore, stackInfo datastore.Expi
 		forma_command.SourceStackExpirer,
 	)
 
-	// Create changeset
-	cs, err := changeset.NewChangeset(resourceUpdates, nil, destroyCommand.ID, pkgmodel.CommandDestroy, ds)
+	// Generate any synthetic Resolve target ops, then build the changeset.
+	synth, err := target_update.SynthesizeResolveTargetUpdates(
+		resource_update.ReferencedTargetLabels(resourceUpdates),
+		resource_update.SourceTargetByKsuid(resourceUpdates),
+		nil, ds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create changeset: %w", err)
+	}
+	cs, err := changeset.NewChangeset(resourceUpdates, synth, destroyCommand.ID, pkgmodel.CommandDestroy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create changeset: %w", err)
 	}

--- a/internal/metastructure/synchronizer.go
+++ b/internal/metastructure/synchronizer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_persister"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
@@ -331,7 +332,16 @@ func synchronizeAllResources(state gen.Atom, data SynchronizerData, proc gen.Pro
 		return state, data, nil, gen.TerminateReasonPanic
 	}
 
-	cs, err := changeset.NewChangeset(allResourceUpdates, nil, syncCommand.ID, pkgmodel.CommandSync, data.datastore)
+	synth, err := target_update.SynthesizeResolveTargetUpdates(
+		resource_update.ReferencedTargetLabels(allResourceUpdates),
+		resource_update.SourceTargetByKsuid(allResourceUpdates),
+		nil, data.datastore)
+	if err != nil {
+		proc.Log().Error("Synchronizer: failed to build changeset, skipping sync cycle commandID=%s: %v", syncCommand.ID, err)
+		finalizeFailedCommand(syncCommand, proc)
+		return StateIdle, data, rescheduleAction(data), nil
+	}
+	cs, err := changeset.NewChangeset(allResourceUpdates, synth, syncCommand.ID, pkgmodel.CommandSync)
 	if err != nil {
 		proc.Log().Error("Synchronizer: failed to build changeset, skipping sync cycle commandID=%s: %v", syncCommand.ID, err)
 		finalizeFailedCommand(syncCommand, proc)

--- a/internal/metastructure/synchronizer.go
+++ b/internal/metastructure/synchronizer.go
@@ -334,6 +334,7 @@ func synchronizeAllResources(state gen.Atom, data SynchronizerData, proc gen.Pro
 	cs, err := changeset.NewChangeset(allResourceUpdates, nil, syncCommand.ID, pkgmodel.CommandSync, data.datastore)
 	if err != nil {
 		proc.Log().Error("Synchronizer: failed to build changeset, skipping sync cycle commandID=%s: %v", syncCommand.ID, err)
+		finalizeFailedCommand(syncCommand, proc)
 		return StateIdle, data, rescheduleAction(data), nil
 	}
 
@@ -391,4 +392,31 @@ func findMatchFiltersForType(filters []pkgmodel.MatchFilter, resourceType string
 		}
 	}
 	return result
+}
+
+// finalizeFailedCommand marks all resource updates in the command as failed and then
+// finalizes the command itself, preventing persisted commands from being left in a
+// non-terminal pending state when changeset construction fails after storage.
+func finalizeFailedCommand(cmd *forma_command.FormaCommand, proc gen.Process) {
+	refs := make([]forma_persister.ResourceUpdateRef, 0, len(cmd.ResourceUpdates))
+	for _, ru := range cmd.ResourceUpdates {
+		refs = append(refs, forma_persister.ResourceUpdateRef{
+			URI:       ru.URI(),
+			Operation: ru.Operation,
+		})
+	}
+	persister := gen.ProcessID{Name: actornames.FormaCommandPersister, Node: proc.Node().Name()}
+	if len(refs) > 0 {
+		if _, err := proc.Call(persister, forma_persister.MarkResourcesAsFailed{
+			CommandID:          cmd.ID,
+			Resources:          refs,
+			ResourceModifiedTs: time.Now(),
+		}); err != nil {
+			proc.Log().Error("Synchronizer: failed to mark resources as failed for aborted command commandID=%s: %v", cmd.ID, err)
+			return
+		}
+	}
+	if _, err := proc.Call(persister, forma_persister.FinalizeIncompleteCommand{CommandID: cmd.ID}); err != nil {
+		proc.Log().Error("Synchronizer: failed to finalize aborted command commandID=%s: %v", cmd.ID, err)
+	}
 }

--- a/internal/metastructure/synchronizer.go
+++ b/internal/metastructure/synchronizer.go
@@ -332,7 +332,7 @@ func synchronizeAllResources(state gen.Atom, data SynchronizerData, proc gen.Pro
 	}
 
 	// Sync commands (READs) will never contain cycles so we can safely ignore the error here.
-	cs, _ := changeset.NewChangeset(allResourceUpdates, nil, syncCommand.ID, pkgmodel.CommandSync)
+	cs, _ := changeset.NewChangeset(allResourceUpdates, nil, syncCommand.ID, pkgmodel.CommandSync, data.datastore)
 
 	proc.Log().Debug("Ensuring ChangesetExecutor for sync command commandID=%s", syncCommand.ID)
 	_, err = proc.Call(

--- a/internal/metastructure/synchronizer.go
+++ b/internal/metastructure/synchronizer.go
@@ -331,8 +331,11 @@ func synchronizeAllResources(state gen.Atom, data SynchronizerData, proc gen.Pro
 		return state, data, nil, gen.TerminateReasonPanic
 	}
 
-	// Sync commands (READs) will never contain cycles so we can safely ignore the error here.
-	cs, _ := changeset.NewChangeset(allResourceUpdates, nil, syncCommand.ID, pkgmodel.CommandSync, data.datastore)
+	cs, err := changeset.NewChangeset(allResourceUpdates, nil, syncCommand.ID, pkgmodel.CommandSync, data.datastore)
+	if err != nil {
+		proc.Log().Error("Synchronizer: failed to build changeset, skipping sync cycle commandID=%s: %v", syncCommand.ID, err)
+		return StateIdle, data, rescheduleAction(data), nil
+	}
 
 	proc.Log().Debug("Ensuring ChangesetExecutor for sync command commandID=%s", syncCommand.ID)
 	_, err = proc.Call(

--- a/internal/metastructure/target_update/resolve_synthesis.go
+++ b/internal/metastructure/target_update/resolve_synthesis.go
@@ -1,0 +1,159 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package target_update
+
+import (
+	"fmt"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+)
+
+// SynthesizeResolveTargetUpdates builds synthetic Resolve target ops for targets
+// that a command references but that are NOT already covered by a real
+// Create/Update/Replace/Delete target update in this command.
+//
+// An unchanged target may still hold opaque $ref config (e.g. a secret). Without a
+// real target update carrying resolved desired config, that config would be
+// dispatched to the plugin unresolved. For each such distinct referenced target
+// label, the PERSISTED target row is loaded (a target with a real update already
+// carries its desired config, so it is never synthesized for), its config is
+// scanned for resolvable $refs using the same extractor that populates a target
+// update's RemainingResolvables, and — if any exist — a NewResolveTargetUpdate is
+// appended.
+//
+// It then rejects a credential-from-credential chain: a target whose config
+// opaquely $refs a secret whose OWN target also carries opaque $ref config cannot
+// be resolved, because bootstrapping its credential would first require
+// bootstrapping another.
+//
+// referencedLabels are the distinct target labels a resource op referenced (see
+// resource_update.ReferencedTargetLabels); sourceTargetByKsuid maps an in-command
+// resource KSUID to its target label (see resource_update.SourceTargetByKsuid), so
+// a secret source being created in this same command resolves to its target
+// without a persisted row. Passing these plain inputs keeps this package free of a
+// resource_update import.
+//
+// A nil datastore (unit tests that never reference persisted targets) or a target
+// that is not found is treated as "nothing to synthesize" and skipped.
+func SynthesizeResolveTargetUpdates(
+	referencedLabels []string,
+	sourceTargetByKsuid map[string]string,
+	existing []TargetUpdate,
+	ds TargetDatastore,
+) ([]TargetUpdate, error) {
+	// Targets already covered by a real target update in this command must never be
+	// synthesized for — their update carries the desired (and re-resolved) config.
+	covered := make(map[string]bool)
+	for i := range existing {
+		covered[existing[i].Target.Label] = true
+	}
+
+	var candidates []string
+	for _, label := range referencedLabels {
+		if label == "" || covered[label] {
+			continue
+		}
+		candidates = append(candidates, label)
+	}
+
+	if len(candidates) == 0 || ds == nil {
+		return nil, nil
+	}
+
+	var synthetic []TargetUpdate
+	for _, label := range candidates {
+		persisted, err := ds.LoadTarget(label)
+		if err != nil {
+			return nil, fmt.Errorf("synthesize resolve target %q: %w", label, err)
+		}
+		if persisted == nil {
+			continue
+		}
+		resolvables := resolver.ExtractResolvableURIsFromJSON(persisted.Config)
+		if len(resolvables) == 0 {
+			continue
+		}
+		synthetic = append(synthetic, NewResolveTargetUpdate(*persisted, resolvables))
+	}
+
+	if err := rejectTransitivelyOpaqueTargets(append(existing, synthetic...), sourceTargetByKsuid, ds); err != nil {
+		return nil, err
+	}
+
+	return synthetic, nil
+}
+
+// rejectTransitivelyOpaqueTargets rejects a target whose config opaquely $refs a
+// secret whose source resource lives on a target that ITSELF carries opaque $ref
+// config. Resolving such a target would require first bootstrapping a credential
+// from another credential that itself needs resolving — a chain that has no clear
+// starting point.
+//
+// For every target update in this command (real Create/Update ops AND synthetic
+// Resolve ops), each opaque $ref in the target config is followed to its source
+// resource (by KSUID). The source resource is looked up first among this command's
+// resource ops (a source being CREATED here is not yet persisted, via
+// sourceTargetByKsuid), then in the datastore. The source's target config is then
+// scanned: if it carries any opaque $ref, the chain is rejected with an error
+// naming both target labels and no secret material.
+//
+// One hop is sufficient. A deeper chain (the source's target opaquely refs yet
+// another opaque target) is still rejected here, because the immediate hop this
+// guard inspects is already opaque. A nil datastore is treated as "nothing to
+// traverse" — such changesets never reference persisted secret sources.
+func rejectTransitivelyOpaqueTargets(
+	targetUpdates []TargetUpdate,
+	sourceTargetByKsuid map[string]string,
+	ds TargetDatastore,
+) error {
+	if ds == nil {
+		return nil
+	}
+
+	// sourceTargetLabel resolves a secret source KSUID to its target label, checking
+	// this command's resource ops before falling back to the persisted resource.
+	sourceTargetLabel := func(ksuid string) (string, error) {
+		if label, ok := sourceTargetByKsuid[ksuid]; ok {
+			return label, nil
+		}
+		res, err := ds.LoadResourceById(ksuid)
+		if err != nil {
+			return "", fmt.Errorf("load secret source resource %q: %w", ksuid, err)
+		}
+		if res == nil {
+			return "", nil
+		}
+		return res.Target, nil
+	}
+
+	for i := range targetUpdates {
+		referencing := targetUpdates[i].Target.Label
+		opaqueRefs := resolver.ExtractOpaqueResolvableURIsFromJSON(targetUpdates[i].Target.Config)
+		for _, ref := range opaqueRefs {
+			sourceLabel, err := sourceTargetLabel(ref.KSUID())
+			if err != nil {
+				return err
+			}
+			if sourceLabel == "" || sourceLabel == referencing {
+				continue
+			}
+			sourceTarget, err := ds.LoadTarget(sourceLabel)
+			if err != nil {
+				return fmt.Errorf("load secret source target %q: %w", sourceLabel, err)
+			}
+			if sourceTarget == nil {
+				continue
+			}
+			if len(resolver.ExtractOpaqueResolvableURIsFromJSON(sourceTarget.Config)) > 0 {
+				return fmt.Errorf(
+					"cannot bootstrap a credential from a credential that itself requires resolution: "+
+						"target %q references a secret whose source lives on target %q, which itself carries opaque references",
+					referencing, sourceLabel)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/metastructure/target_update/revalidate_resolve.go
+++ b/internal/metastructure/target_update/revalidate_resolve.go
@@ -1,0 +1,71 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package target_update
+
+import (
+	"fmt"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// targetLoader is the minimal datastore surface revalidateResolveTarget needs:
+// it re-reads a persisted target by label. The full datastore.Datastore
+// satisfies it, and a narrow stub can be used in tests.
+type targetLoader interface {
+	LoadTarget(label string) (*pkgmodel.Target, error)
+}
+
+// revalidateResolveTarget closes the TOCTOU window between changeset build and
+// execute for a synthetic Resolve op.
+//
+// A Resolve TU is built (in NewChangeset) from a target's PERSISTED config at
+// build time and carries that config plus the target's revision as the embedded
+// Target.Version snapshot. Between build and execute a concurrent command can
+// update the same target — new config, bumped revision. If the Resolve op then
+// resolved the stale build-time config it could resolve the wrong (or a
+// no-longer-declared) credential.
+//
+// At execute time this re-reads the live persisted target. If its revision
+// differs from the snapshot the TU carries, it replaces the TU's config with the
+// current config and rebuilds RemainingResolvables from it, so resolution runs
+// against current state rather than the stale snapshot. If the target was deleted
+// between build and execute it returns an error instead of resolving a phantom.
+//
+// A SINGLE re-read is authoritative: target mutation is serialized through the
+// metastructure's ResourcePersister actor, so once this read returns within the
+// executing command there is no further concurrent mutation to chase — there is
+// no retry loop to bound.
+//
+// Only synthetic Resolve ops are re-validated; every other operation is returned
+// untouched, because a real create/update/delete TU already carries the desired
+// (and freshly re-resolved) config generated for this command.
+func revalidateResolveTarget(tu TargetUpdate, ds targetLoader) (TargetUpdate, error) {
+	if tu.Operation != TargetOperationResolve || ds == nil {
+		return tu, nil
+	}
+
+	label := tu.Target.Label
+	current, err := ds.LoadTarget(label)
+	if err != nil {
+		return tu, fmt.Errorf("re-validate resolve target %q: %w", label, err)
+	}
+	if current == nil {
+		return tu, fmt.Errorf("re-validate resolve target %q: target no longer exists", label)
+	}
+
+	if current.Version == tu.Target.Version {
+		// Revision unchanged: the snapshot config is still current, so resolve
+		// against it as-is with no wasted re-read of resolvables.
+		return tu, nil
+	}
+
+	// Revision advanced under us: rebuild against the current persisted config so
+	// resolution never runs against the stale snapshot.
+	tu.Target.Config = current.Config
+	tu.Target.Version = current.Version
+	tu.RemainingResolvables = resolver.ExtractResolvableURIsFromJSON(current.Config)
+	return tu, nil
+}

--- a/internal/metastructure/target_update/revalidate_resolve_test.go
+++ b/internal/metastructure/target_update/revalidate_resolve_test.go
@@ -1,0 +1,124 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package target_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// revalidateStubDatastore returns a preset target on LoadTarget, simulating the
+// live persisted row an executing Resolve op re-reads. Setting target to nil
+// simulates a target that was deleted between changeset build and execute.
+type revalidateStubDatastore struct {
+	target    *pkgmodel.Target
+	loadErr   error
+	loadCalls int
+}
+
+func (s *revalidateStubDatastore) LoadTarget(_ string) (*pkgmodel.Target, error) {
+	s.loadCalls++
+	return s.target, s.loadErr
+}
+
+// configA is the build-time (snapshot) config the Resolve TU carries; configB is
+// the current persisted config a concurrent command wrote before execute. They
+// reference distinct resolvables so a rebuild is observable.
+var (
+	configA = json.RawMessage(`{"secret":{"$ref":"formae://aaa111#/SecretString","$visibility":"Opaque"}}`)
+	configB = json.RawMessage(`{"secret":{"$ref":"formae://bbb222#/SecretString","$visibility":"Opaque"}}`)
+)
+
+func TestRevalidateResolveTarget_StaleRevision_RebuildsAgainstCurrentConfig(t *testing.T) {
+	// The Resolve TU was built from a target at Version=1 carrying configA. A
+	// concurrent command bumped the persisted target to Version=2 carrying configB.
+	// Re-validation must detect the changed revision and rebuild the TU so
+	// resolution runs against the CURRENT config (configB), never the stale one.
+	tu := NewResolveTargetUpdate(
+		pkgmodel.Target{Label: "consumer", Version: 1, Config: configA},
+		[]pkgmodel.FormaeURI{"formae://aaa111#/SecretString"},
+	)
+
+	ds := &revalidateStubDatastore{
+		target: &pkgmodel.Target{Label: "consumer", Version: 2, Config: configB},
+	}
+
+	revised, err := revalidateResolveTarget(tu, ds)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(configB), string(revised.Target.Config),
+		"config must be re-read from the current persisted target")
+	assert.Equal(t, 2, revised.Target.Version,
+		"snapshot version must advance to the current revision")
+	require.Len(t, revised.RemainingResolvables, 1)
+	assert.Equal(t, pkgmodel.FormaeURI("formae://bbb222#/SecretString"), revised.RemainingResolvables[0],
+		"resolvables must be rebuilt from the current config")
+	assert.Equal(t, 1, ds.loadCalls, "a single re-read suffices")
+}
+
+func TestRevalidateResolveTarget_UnchangedRevision_NoRebuild(t *testing.T) {
+	// When the persisted revision matches the snapshot, re-validation is a no-op:
+	// the TU keeps its snapshot config and resolvables untouched.
+	tu := NewResolveTargetUpdate(
+		pkgmodel.Target{Label: "consumer", Version: 5, Config: configA},
+		[]pkgmodel.FormaeURI{"formae://aaa111#/SecretString"},
+	)
+
+	ds := &revalidateStubDatastore{
+		target: &pkgmodel.Target{Label: "consumer", Version: 5, Config: configB},
+	}
+
+	revised, err := revalidateResolveTarget(tu, ds)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(configA), string(revised.Target.Config),
+		"unchanged revision must keep the snapshot config, not re-read")
+	assert.Equal(t, 5, revised.Target.Version)
+	require.Len(t, revised.RemainingResolvables, 1)
+	assert.Equal(t, pkgmodel.FormaeURI("formae://aaa111#/SecretString"), revised.RemainingResolvables[0],
+		"unchanged revision must keep the snapshot resolvables")
+}
+
+func TestRevalidateResolveTarget_TargetDeleted_SurfacesError(t *testing.T) {
+	// If the target the Resolve op targets was deleted between build and execute,
+	// re-validation must surface a clear error rather than resolve a phantom.
+	tu := NewResolveTargetUpdate(
+		pkgmodel.Target{Label: "consumer", Version: 1, Config: configA},
+		[]pkgmodel.FormaeURI{"formae://aaa111#/SecretString"},
+	)
+
+	ds := &revalidateStubDatastore{target: nil}
+
+	_, err := revalidateResolveTarget(tu, ds)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "consumer",
+		"error must name the target that no longer exists")
+}
+
+func TestRevalidateResolveTarget_NonResolveOp_Unchanged(t *testing.T) {
+	// Re-validation only applies to synthetic Resolve ops. A real create/update
+	// TU is returned untouched and never triggers a re-read.
+	tu := TargetUpdate{
+		Target:               pkgmodel.Target{Label: "consumer", Version: 1, Config: configA},
+		Operation:            TargetOperationUpdate,
+		RemainingResolvables: []pkgmodel.FormaeURI{"formae://aaa111#/SecretString"},
+	}
+
+	ds := &revalidateStubDatastore{
+		target: &pkgmodel.Target{Label: "consumer", Version: 99, Config: configB},
+	}
+
+	revised, err := revalidateResolveTarget(tu, ds)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(configA), string(revised.Target.Config))
+	assert.Equal(t, 0, ds.loadCalls, "non-Resolve ops must not re-read")
+}

--- a/internal/metastructure/target_update/target_update.go
+++ b/internal/metastructure/target_update/target_update.go
@@ -24,6 +24,7 @@ const (
 	TargetOperationUpdate  = types.OperationUpdate
 	TargetOperationDelete  = types.OperationDelete
 	TargetOperationReplace = types.OperationReplace
+	TargetOperationResolve = types.OperationResolve
 
 	TargetUpdateStateNotStarted = types.TargetUpdateStateNotStarted
 	TargetUpdateStateInProgress = types.TargetUpdateStateInProgress
@@ -68,8 +69,29 @@ func NewTargetUpdateForCascadeDelete(target *pkgmodel.Target, cascadeSource stri
 	}
 }
 
-// HasChange returns true if the discoverable field changed
+// NewResolveTargetUpdate creates a synthetic TargetUpdate that resolves opaque
+// $ref config values in-memory for an otherwise-unchanged target. The op is
+// never persisted and does not trigger discovery or cloud-side mutations.
+// ExistingTarget is nil because there is nothing to compare or persist.
+func NewResolveTargetUpdate(target pkgmodel.Target, resolvables []pkgmodel.FormaeURI) TargetUpdate {
+	now := util.TimeNow()
+	return TargetUpdate{
+		Target:               target,
+		ExistingTarget:       nil,
+		Operation:            TargetOperationResolve,
+		State:                TargetUpdateStateNotStarted,
+		StartTs:              now,
+		ModifiedTs:           now,
+		RemainingResolvables: resolvables,
+	}
+}
+
+// HasChange returns true if the discoverable field changed.
+// A Resolve op is synthetic and never persists anything, so it always returns false.
 func (tu *TargetUpdate) HasChange() bool {
+	if tu.Operation == TargetOperationResolve {
+		return false
+	}
 	if tu.ExistingTarget == nil {
 		return true
 	}

--- a/internal/metastructure/target_update/target_update_test.go
+++ b/internal/metastructure/target_update/target_update_test.go
@@ -269,3 +269,42 @@ func TestShouldTriggerDiscovery_Update_NilExistingTarget(t *testing.T) {
 
 	assert.True(t, ShouldTriggerDiscovery(&update))
 }
+
+func TestNewResolveTargetUpdate_OperationAndResolvables(t *testing.T) {
+	// NewResolveTargetUpdate must produce a TargetUpdate that carries
+	// TargetOperationResolve, preserves the supplied resolvables, has no
+	// ExistingTarget, and does not report a change or trigger discovery.
+	target := pkgmodel.Target{
+		Label:        "my-target",
+		Namespace:    "default",
+		Discoverable: true,
+		Version:      3,
+	}
+	resolvables := []pkgmodel.FormaeURI{
+		"formae://abc123#/Endpoint",
+		"formae://def456#/CertArn",
+	}
+
+	tu := NewResolveTargetUpdate(target, resolvables)
+
+	assert.Equal(t, TargetOperationResolve, tu.Operation)
+	assert.Equal(t, resolvables, tu.RemainingResolvables)
+	assert.Nil(t, tu.ExistingTarget)
+	assert.Equal(t, TargetUpdateStateNotStarted, tu.State)
+	assert.Equal(t, pkgmodel.FormaeURI("target://my-target/resolve"), tu.NodeURI())
+	assert.False(t, tu.HasChange(), "resolve op has no persistent change")
+	assert.False(t, ShouldTriggerDiscovery(&tu), "resolve op must not trigger discovery")
+}
+
+func TestNewResolveTargetUpdate_PreservesTargetVersion(t *testing.T) {
+	// The constructor must capture the target's Version so the FSM can
+	// compare it against the live row when it executes.
+	target := pkgmodel.Target{
+		Label:   "versioned-target",
+		Version: 7,
+	}
+
+	tu := NewResolveTargetUpdate(target, nil)
+
+	assert.Equal(t, 7, tu.Target.Version)
+}

--- a/internal/metastructure/target_update/target_updater.go
+++ b/internal/metastructure/target_update/target_updater.go
@@ -107,6 +107,12 @@ func handleStartTargetUpdate(from gen.PID, state gen.Atom, data TargetUpdaterDat
 // resolveTargetConfig pops the next resolvable and sends a ResolveValue request.
 func resolveTargetConfig(state gen.Atom, data TargetUpdaterData, proc gen.Process) (gen.Atom, TargetUpdaterData, []statemachine.Action, error) {
 	if len(data.targetUpdate.RemainingResolvables) == 0 {
+		// A Resolve op resolves config in-memory only: the target row is never
+		// written. Transition directly to success so the finished signal carries
+		// the resolved config without touching the datastore.
+		if data.targetUpdate.Operation == TargetOperationResolve {
+			return StateFinishedSuccessfully, data, nil, nil
+		}
 		return persistTarget(data, proc)
 	}
 

--- a/internal/metastructure/target_update/target_updater.go
+++ b/internal/metastructure/target_update/target_updater.go
@@ -225,14 +225,14 @@ func onTargetUpdaterStateChange(oldState gen.Atom, newState gen.Atom, data Targe
 		}
 
 		proc.Log().Debug("TargetUpdater: sending TargetUpdateFinished to requester state=%s target=%s", newState, data.targetUpdate.Target.Label)
-		err := proc.Send(
-			data.requestedBy,
-			TargetUpdateFinished{
-				NodeURI:        data.targetUpdate.NodeURI(),
-				State:          finalState,
-				ResolvedConfig: data.targetUpdate.Target.Config,
-			},
-		)
+		finished := TargetUpdateFinished{
+			NodeURI: data.targetUpdate.NodeURI(),
+			State:   finalState,
+		}
+		if finalState == TargetUpdateStateSuccess {
+			finished.ResolvedConfig = data.targetUpdate.Target.Config
+		}
+		err := proc.Send(data.requestedBy, finished)
 		if err != nil {
 			proc.Log().Error("TargetUpdater: failed to send TargetUpdateFinished to requester: %v", err)
 		}

--- a/internal/metastructure/target_update/target_updater.go
+++ b/internal/metastructure/target_update/target_updater.go
@@ -94,11 +94,13 @@ func resourcePersisterProcess(proc gen.Process) gen.ProcessID {
 }
 
 // handleStartTargetUpdate receives the initial message and enters the resolve loop or goes straight to persist.
+// A Resolve op is always routed through resolveTargetConfig regardless of resolvables count, because Resolve
+// ops must never call persistTarget — the resolve loop's drain path handles the zero-resolvables case directly.
 func handleStartTargetUpdate(from gen.PID, state gen.Atom, data TargetUpdaterData, message StartTargetUpdate, proc gen.Process) (gen.Atom, TargetUpdaterData, []statemachine.Action, error) {
 	data.targetUpdate = message.TargetUpdate
 	data.commandID = message.CommandID
 
-	if len(data.targetUpdate.RemainingResolvables) > 0 {
+	if len(data.targetUpdate.RemainingResolvables) > 0 || data.targetUpdate.Operation == TargetOperationResolve {
 		return resolveTargetConfig(state, data, proc)
 	}
 	return persistTarget(data, proc)

--- a/internal/metastructure/target_update/target_updater.go
+++ b/internal/metastructure/target_update/target_updater.go
@@ -55,6 +55,12 @@ type TargetUpdaterData struct {
 	targetUpdate TargetUpdate
 	commandID    string
 	requestedBy  gen.PID
+	// datastore re-reads the live persisted target so a synthetic Resolve op can
+	// close the TOCTOU window between changeset build and execute. It is read from
+	// the node environment (the same handle every other actor shares) rather than
+	// threaded through the supervisor, so it broadens no plumbing. May be nil in
+	// unit harnesses that never wire the environment; re-validation then no-ops.
+	datastore targetLoader
 }
 
 func NewTargetUpdater() gen.ProcessBehavior {
@@ -64,6 +70,19 @@ func NewTargetUpdater() gen.ProcessBehavior {
 func (t *TargetUpdater) Init(args ...any) (statemachine.StateMachineSpec[TargetUpdaterData], error) {
 	data := TargetUpdaterData{
 		requestedBy: args[0].(gen.PID),
+	}
+
+	// Read the shared datastore handle from the node environment so a synthetic
+	// Resolve op can re-validate the target's revision at execute time. It is
+	// asserted against the local targetLoader interface (not the concrete
+	// datastore.Datastore) to avoid an import cycle — target_update is imported by
+	// the datastore package. Absence is tolerated (some test harnesses run the FSM
+	// without an environment): re-validation then no-ops and the op resolves
+	// against its snapshot.
+	if env, ok := t.Env("Datastore"); ok {
+		if ds, ok := env.(targetLoader); ok {
+			data.datastore = ds
+		}
 	}
 
 	t.Log().Debug("TargetUpdater %s initialized", t.Name())
@@ -99,6 +118,19 @@ func resourcePersisterProcess(proc gen.Process) gen.ProcessID {
 func handleStartTargetUpdate(from gen.PID, state gen.Atom, data TargetUpdaterData, message StartTargetUpdate, proc gen.Process) (gen.Atom, TargetUpdaterData, []statemachine.Action, error) {
 	data.targetUpdate = message.TargetUpdate
 	data.commandID = message.CommandID
+
+	// A synthetic Resolve op carries the target's config and revision as they were
+	// at changeset build time. Before resolving, re-read the live persisted target:
+	// if a concurrent command bumped its revision, resolve against the current
+	// config instead of the stale snapshot; if the target was deleted, fail rather
+	// than resolve a phantom credential.
+	revised, err := revalidateResolveTarget(data.targetUpdate, data.datastore)
+	if err != nil {
+		proc.Log().Error("TargetUpdater: failed to re-validate resolve target target=%s: %v",
+			data.targetUpdate.Target.Label, err)
+		return StateFinishedWithError, data, nil, nil
+	}
+	data.targetUpdate = revised
 
 	if len(data.targetUpdate.RemainingResolvables) > 0 || data.targetUpdate.Operation == TargetOperationResolve {
 		return resolveTargetConfig(state, data, proc)

--- a/internal/metastructure/target_update/target_updater_test.go
+++ b/internal/metastructure/target_update/target_updater_test.go
@@ -1,0 +1,116 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package target_update
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// stubTargetUpdaterLog swallows all log output.
+type stubTargetUpdaterLog struct{ gen.Log }
+
+func (stubTargetUpdaterLog) Trace(string, ...any)   {}
+func (stubTargetUpdaterLog) Debug(string, ...any)   {}
+func (stubTargetUpdaterLog) Info(string, ...any)    {}
+func (stubTargetUpdaterLog) Warning(string, ...any) {}
+func (stubTargetUpdaterLog) Error(string, ...any)   {}
+func (stubTargetUpdaterLog) Panic(string, ...any)   {}
+
+// stubTargetUpdaterProcess is a gen.Process double for onTargetUpdaterStateChange
+// tests. It records every Send call so tests can inspect the messages sent to the
+// requester.
+type stubTargetUpdaterProcess struct {
+	gen.Process
+
+	mu    sync.Mutex
+	sends []any
+}
+
+func (p *stubTargetUpdaterProcess) Log() gen.Log { return stubTargetUpdaterLog{} }
+func (p *stubTargetUpdaterProcess) PID() gen.PID { return gen.PID{Node: "test-node", ID: 1} }
+func (p *stubTargetUpdaterProcess) Send(_ any, msg any) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.sends = append(p.sends, msg)
+	return nil
+}
+
+func (p *stubTargetUpdaterProcess) sentFinishedMessages() []TargetUpdateFinished {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var out []TargetUpdateFinished
+	for _, s := range p.sends {
+		if m, ok := s.(TargetUpdateFinished); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// TestOnTargetUpdaterStateChange_SuccessCarriesResolvedConfig asserts that a
+// successful Resolve op sends TargetUpdateFinished with the resolved config
+// populated so downstream resource ops can propagate it.
+func TestOnTargetUpdaterStateChange_SuccessCarriesResolvedConfig(t *testing.T) {
+	resolvedConfig := json.RawMessage(`{"endpoint":"https://cluster.example.com","token":"resolved-token"}`)
+
+	data := TargetUpdaterData{
+		targetUpdate: TargetUpdate{
+			Target: pkgmodel.Target{
+				Label:  "my-cluster",
+				Config: resolvedConfig,
+			},
+		},
+		requestedBy: gen.PID{Node: "test-node", ID: 99},
+	}
+
+	proc := &stubTargetUpdaterProcess{}
+	_, _, err := onTargetUpdaterStateChange(StateResolving, StateFinishedSuccessfully, data, proc)
+	require.NoError(t, err)
+
+	finished := proc.sentFinishedMessages()
+	require.Len(t, finished, 1, "exactly one TargetUpdateFinished must be sent on success")
+	assert.Equal(t, TargetUpdateStateSuccess, finished[0].State)
+	assert.Equal(t, resolvedConfig, finished[0].ResolvedConfig,
+		"ResolvedConfig must be populated on success so dependent resource ops receive credentials")
+}
+
+// TestOnTargetUpdaterStateChange_FailureOmitsResolvedConfig asserts that a
+// failed Resolve op sends TargetUpdateFinished with a nil ResolvedConfig.
+// On failure the config may be partially resolved (some $value placeholders
+// still present); sending it to downstream consumers would be misleading and
+// could expose intermediate plaintext unnecessarily.
+func TestOnTargetUpdaterStateChange_FailureOmitsResolvedConfig(t *testing.T) {
+	partialConfig := json.RawMessage(`{"endpoint":"https://cluster.example.com","token":{"$ref":"formae://abc#/Token"}}`)
+
+	data := TargetUpdaterData{
+		targetUpdate: TargetUpdate{
+			Target: pkgmodel.Target{
+				Label:  "my-cluster",
+				Config: partialConfig,
+			},
+		},
+		requestedBy: gen.PID{Node: "test-node", ID: 99},
+	}
+
+	proc := &stubTargetUpdaterProcess{}
+	_, _, err := onTargetUpdaterStateChange(StateResolving, StateFinishedWithError, data, proc)
+	require.NoError(t, err)
+
+	finished := proc.sentFinishedMessages()
+	require.Len(t, finished, 1, "exactly one TargetUpdateFinished must be sent on failure")
+	assert.Equal(t, TargetUpdateStateFailed, finished[0].State)
+	assert.Nil(t, finished[0].ResolvedConfig,
+		"ResolvedConfig must be nil on failure to avoid propagating partial or plaintext credentials")
+}

--- a/internal/metastructure/types/types.go
+++ b/internal/metastructure/types/types.go
@@ -36,6 +36,11 @@ const (
 
 	// Composite ops
 	OperationReplace OperationType = "replace" // delete + create
+
+	// OperationResolve is a synthetic op that resolves opaque $ref config values
+	// in-memory for an otherwise-unchanged target. It is never persisted and does
+	// not trigger discovery or cloud-side mutations.
+	OperationResolve OperationType = "resolve"
 )
 
 // ResourceUpdateState represents the current state of a resource update operation

--- a/internal/workflow_tests/local/apply_forma/target_config_resolve_test.go
+++ b/internal/workflow_tests/local/apply_forma/target_config_resolve_test.go
@@ -30,10 +30,8 @@ package workflow_tests_local
 //     {"$ref":…,"$visibility":"Opaque"} object still in TargetConfig instead of
 //     the plaintext credential.
 //
-// The test is skip-gated so it does not block the unit suite on the current tree.
-// Remove the t.Skip call once the synthetic Resolve op is wired up (slice 4,
-// Tasks 4/5). The assertions remain in place so the test goes GREEN as soon as
-// the fix lands.
+// The synthetic Resolve op (slice 4, Tasks 4/5) wires up the resolution so the
+// bucket Create receives the plaintext credential in its TargetConfig.
 
 import (
 	"encoding/json"
@@ -91,10 +89,6 @@ func findNthApplyCommand(cmds []*forma_command.FormaCommand, n int) *forma_comma
 }
 
 func TestTargetConfigResolve_UnchangedTargetWithOpaqueRef(t *testing.T) {
-	// Skip-gate: remove this line once the synthetic Resolve target op is wired up
-	// in the changeset executor (enabled by the synthetic Resolve op — slice 4 Task 4/5).
-	t.Skip("enabled by the synthetic Resolve op — slice 4 Task 4/5")
-
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		const plaintextSecret = "target-config-resolve-test-credential"
 

--- a/internal/workflow_tests/local/apply_forma/target_config_resolve_test.go
+++ b/internal/workflow_tests/local/apply_forma/target_config_resolve_test.go
@@ -30,7 +30,7 @@ package workflow_tests_local
 //     {"$ref":…,"$visibility":"Opaque"} object still in TargetConfig instead of
 //     the plaintext credential.
 //
-// The synthetic Resolve op (slice 4, Tasks 4/5) wires up the resolution so the
+// The synthetic Resolve op wires up the resolution so the
 // bucket Create receives the plaintext credential in its TargetConfig.
 
 import (

--- a/internal/workflow_tests/local/apply_forma/target_config_resolve_test.go
+++ b/internal/workflow_tests/local/apply_forma/target_config_resolve_test.go
@@ -1,0 +1,252 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+// TestTargetConfigResolve_UnchangedTargetWithOpaqueRef is the acceptance test for
+// the "synthetic Resolve target op" gap: when a target's Config carries an opaque
+// $ref and that target is NOT being created/updated in the changeset, the $ref must
+// be resolved before resource ops dispatch to the plugin.
+//
+// Variant built: two-command sequence (full variant).
+//
+//   - Apply 1: creates the secret resource (FakeAWS::SecretsManager::Secret) and
+//     the consumer target, whose Config carries an opaque $ref to the secret's
+//     SecretString. Because consumer IS new in apply 1, a TargetUpdate fires and
+//     propagateResolvedTargetConfig resolves the $ref for that command's resource
+//     ops. The stored Config retains the raw $ref; the resolved $value is stripped
+//     at the write boundary (StripOpaqueRefValues), so the DB holds only the pointer.
+//
+//   - Apply 2: creates a bucket resource (FakeAWS::S3::Bucket) on the consumer
+//     target. consumer is NOT listed in apply 2's Targets — GenerateTargetUpdates
+//     only processes declared targets and emits no TargetUpdate for consumer.
+//     consumer IS loaded from the DB into desiredTargetMap (so the resource
+//     reference resolves), but ConvertToPluginFormat cannot recover the resolved
+//     credential (no $value in the stored opaque config). Without the synthetic
+//     Resolve op, the bucket Create reaches the plugin with the raw
+//     {"$ref":…,"$visibility":"Opaque"} object still in TargetConfig instead of
+//     the plaintext credential.
+//
+// The test is skip-gated so it does not block the unit suite on the current tree.
+// Remove the t.Skip call once the synthetic Resolve op is wired up (slice 4,
+// Tasks 4/5). The assertions remain in place so the test goes GREEN as soon as
+// the fix lands.
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// targetConfigResolveCapture records the TargetConfig the plugin receives on
+// the bucket Create call in apply 2.
+type targetConfigResolveCapture struct {
+	mu     sync.Mutex
+	config json.RawMessage
+}
+
+func (c *targetConfigResolveCapture) set(cfg json.RawMessage) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cp := make(json.RawMessage, len(cfg))
+	copy(cp, cfg)
+	c.config = cp
+}
+
+func (c *targetConfigResolveCapture) get() json.RawMessage {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.config
+}
+
+// findNthApplyCommand returns the n-th (1-based) FormaCommand with Command ==
+// CommandApply, or nil if fewer than n apply commands exist.
+func findNthApplyCommand(cmds []*forma_command.FormaCommand, n int) *forma_command.FormaCommand {
+	count := 0
+	for _, c := range cmds {
+		if c.Command == pkgmodel.CommandApply {
+			count++
+			if count == n {
+				return c
+			}
+		}
+	}
+	return nil
+}
+
+func TestTargetConfigResolve_UnchangedTargetWithOpaqueRef(t *testing.T) {
+	// Skip-gate: remove this line once the synthetic Resolve target op is wired up
+	// in the changeset executor (enabled by the synthetic Resolve op — slice 4 Task 4/5).
+	t.Skip("enabled by the synthetic Resolve op — slice 4 Task 4/5")
+
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const plaintextSecret = "target-config-resolve-test-credential"
+
+		capture := &targetConfigResolveCapture{}
+
+		// Create override: capture TargetConfig only for the bucket Create in apply 2.
+		// For all other resource types (SecretsManager::Secret in apply 1) return nil
+		// so the default FakeAWS handler runs.
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(r *resource.CreateRequest) (*resource.CreateResult, error) {
+				if r.ResourceType == "FakeAWS::S3::Bucket" {
+					capture.set(r.TargetConfig)
+					// Synchronous success: keeps apply 2 deterministic (no Status poll).
+					return &resource.CreateResult{
+						ProgressResult: &resource.ProgressResult{
+							Operation:          resource.OperationCreate,
+							OperationStatus:    resource.OperationStatusSuccess,
+							RequestID:          "bucket-create-1",
+							NativeID:           "test-bucket-001",
+							ResourceProperties: r.Properties,
+						},
+					}, nil
+				}
+				// Fall through to the default FakeAWS handler.
+				return nil, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		secretKsuid := "2MiD2rA1SJbLMGZgTL0hCxjkjjv" // deterministic KSUID for the $ref
+		stackOne := "stack-secrets-" + util.NewID()
+		stackTwo := "stack-resources-" + util.NewID()
+
+		// ── Apply 1: create the secret and the consumer target ────────────────────
+		//
+		// consumer's Config has an opaque $ref to the secret's SecretString.
+		// Because consumer is a NEW target in this apply, a TargetUpdate fires.
+		// The changeset executor's propagateResolvedTargetConfig resolves the $ref
+		// for any resource ops in this command. The datastore strips the resolved
+		// $value before persisting (StripOpaqueRefValues), so the stored config
+		// retains only the raw $ref pointer (no $value).
+		applyOne := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: stackOne}},
+			Resources: []pkgmodel.Resource{{
+				Label:      "my-secret",
+				Type:       "FakeAWS::SecretsManager::Secret",
+				Stack:      stackOne,
+				Target:     "provider",
+				Ksuid:      secretKsuid,
+				Schema:     secretSchema(),
+				Properties: json.RawMessage(`{"Name":"my-secret","SecretString":"` + plaintextSecret + `"}`),
+			}},
+			Targets: []pkgmodel.Target{
+				{Label: "provider", Namespace: "test-namespace"},
+				{
+					Label:     "consumer",
+					Namespace: "test-namespace",
+					Config: json.RawMessage(fmt.Sprintf(`{
+						"apiKey": {"$ref": "formae://%s#/SecretString", "$visibility": "Opaque"}
+					}`, secretKsuid)),
+				},
+			},
+		}
+
+		_, err = m.ApplyForma(applyOne, defaultApplyConfig(), "test-client-id")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		firstApply := findNthApplyCommand(cmds, 1)
+		require.NotNil(t, firstApply, "first apply command must exist")
+		require.Equal(t, forma_command.CommandStateSuccess, firstApply.State,
+			"first apply (create secret + consumer target) must succeed")
+
+		// Verify the consumer target is stored with the raw $ref pointer and no
+		// resolved $value (StripOpaqueRefValues drops $value for opaque refs).
+		consumerTarget, err := m.Datastore.LoadTarget("consumer")
+		require.NoError(t, err)
+		require.NotNil(t, consumerTarget, "consumer target must have been persisted")
+		require.Contains(t, string(consumerTarget.Config), `"$ref"`,
+			"stored consumer config must retain the $ref pointer")
+		require.NotContains(t, string(consumerTarget.Config), plaintextSecret,
+			"stored consumer config must not contain the plaintext credential")
+
+		// ── Apply 2: new bucket on consumer, no TargetUpdate for consumer ─────────
+		//
+		// consumer is NOT listed in apply 2's Targets. GenerateTargetUpdates only
+		// iterates forma.Targets, so it emits no TargetUpdate for consumer.
+		// consumer IS in existingTargetMap (loaded from DB) and therefore in
+		// desiredTargetMap, but its Config has had only ConvertToPluginFormat applied
+		// (resource_update_generator.go lines 73-79). Because the stored opaque config
+		// has no $value, ConvertToPluginFormat cannot recover the credential and leaves
+		// the raw {"$ref":…,"$visibility":"Opaque"} object in place.
+		//
+		// Without the synthetic Resolve op, propagateResolvedTargetConfig never fires
+		// for consumer (no TargetUpdate), so the bucket Create dispatches with the
+		// unresolved $ref still in TargetConfig.
+		applyTwo := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: stackTwo}},
+			Resources: []pkgmodel.Resource{{
+				Label:  "r1",
+				Type:   "FakeAWS::S3::Bucket",
+				Stack:  stackTwo,
+				Target: "consumer",
+				Schema: pkgmodel.Schema{
+					Identifier: "BucketName",
+					Fields:     []string{"BucketName"},
+				},
+				Properties: json.RawMessage(`{"BucketName":"test-bucket-001"}`),
+			}},
+			// consumer is intentionally absent from Targets so no TargetUpdate fires.
+			// The system resolves the target from the datastore (existingTargetMap).
+			Targets: []pkgmodel.Target{},
+		}
+
+		_, err = m.ApplyForma(applyTwo, defaultApplyConfig(), "test-client-id")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err = m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		secondApply := findNthApplyCommand(cmds, 2)
+		require.NotNil(t, secondApply, "second apply command must exist")
+		require.Equal(t, forma_command.CommandStateSuccess, secondApply.State,
+			"second apply (create bucket on consumer) must succeed")
+
+		// ── Core assertion ────────────────────────────────────────────────────────
+		//
+		// The bucket Create override must have been called with a TargetConfig that
+		// carries the RESOLVED credential — not the raw {"$ref":…} object.
+		//
+		//   Before the fix: TargetConfig = {"apiKey":{"$ref":"formae://…","$visibility":"Opaque"}}
+		//   After the fix:  TargetConfig = {"apiKey":"target-config-resolve-test-credential"}
+		receivedConfig := capture.get()
+		require.NotNil(t, receivedConfig,
+			"FakeAWS::S3::Bucket Create override must have been called during apply 2")
+
+		assert.NotContains(t, string(receivedConfig), `"$ref"`,
+			"plugin Create must receive a resolved TargetConfig — the raw $ref object must not reach the plugin")
+
+		assert.Contains(t, string(receivedConfig), plaintextSecret,
+			"plugin Create must receive the resolved credential value in TargetConfig")
+	})
+}
+
+// defaultApplyConfig returns a standard reconcile FormaCommandConfig for tests.
+func defaultApplyConfig() *config.FormaCommandConfig {
+	return &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}
+}

--- a/internal/workflow_tests/local/changeset_executor_test.go
+++ b/internal/workflow_tests/local/changeset_executor_test.go
@@ -67,7 +67,7 @@ func TestChangesetExecutor_SingleResourceUpdate(t *testing.T) {
 		})
 
 		// Create changeset and start executor
-		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{resourceUpdate}, nil, commandID, pkgmodel.CommandApply)
+		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{resourceUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
 		assert.NoError(t, err)
 
 		// Ensure the changeset executor exists
@@ -166,7 +166,7 @@ func TestChangesetExecutor_DependentResources(t *testing.T) {
 		})
 
 		// Create changeset - it will automatically build the dependency pipeline
-		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{vpcUpdate, subnetUpdate}, nil, commandID, pkgmodel.CommandApply)
+		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{vpcUpdate, subnetUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
 		assert.NoError(t, err)
 
 		// Ensure the changeset executor exists
@@ -265,7 +265,7 @@ func TestChangesetExecutor_CascadeFailure(t *testing.T) {
 		})
 
 		// Create changeset - it will automatically build the dependency pipeline
-		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{vpcUpdate, subnetUpdate}, nil, commandID, pkgmodel.CommandApply)
+		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{vpcUpdate, subnetUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
 		assert.NoError(t, err)
 
 		// Ensure the changeset executor exists
@@ -363,7 +363,7 @@ func TestChangesetExecutor_SyncReadFailureDoesNotCascade(t *testing.T) {
 		})
 
 		cs, err := changeset.NewChangeset(
-			[]resource_update.ResourceUpdate{readUpdate}, nil, commandID, pkgmodel.CommandSync)
+			[]resource_update.ResourceUpdate{readUpdate}, nil, commandID, pkgmodel.CommandSync, m.Datastore)
 		assert.NoError(t, err)
 
 		_, err = testutil.Call(m.Node, "ChangesetSupervisor", changeset.EnsureChangesetExecutor{
@@ -425,7 +425,7 @@ func TestChangesetExecutor_HashesAllResourcesOnCompletion(t *testing.T) {
 		})
 
 		// Create changeset
-		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{resourceUpdate}, nil, commandID, pkgmodel.CommandApply)
+		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{resourceUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
 		assert.NoError(t, err)
 
 		// Ensure the changeset executor exists
@@ -494,7 +494,7 @@ func TestChangesetExecutor_HashesAllResourcesOnFailure(t *testing.T) {
 		})
 
 		// Create changeset
-		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{resourceUpdate}, nil, commandID, pkgmodel.CommandApply)
+		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{resourceUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
 		assert.NoError(t, err)
 
 		// Ensure the changeset executor exists
@@ -635,7 +635,7 @@ func TestChangesetExecutor_StuckOnReadFailureDuringUpdate(t *testing.T) {
 
 		// Create changeset from the updates
 		cs, err := changeset.NewChangeset(
-			[]resource_update.ResourceUpdate{resOK, resFail}, nil, commandID, pkgmodel.CommandApply)
+			[]resource_update.ResourceUpdate{resOK, resFail}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
 		assert.NoError(t, err)
 
 		// Ensure the changeset executor exists
@@ -717,6 +717,7 @@ func TestChangesetExecutor_MixedResourceAndTargetUpdates(t *testing.T) {
 			[]target_update.TargetUpdate{targetUp},
 			commandID,
 			pkgmodel.CommandApply,
+			m.Datastore,
 		)
 		require.NoError(t, err)
 

--- a/internal/workflow_tests/local/changeset_executor_test.go
+++ b/internal/workflow_tests/local/changeset_executor_test.go
@@ -67,7 +67,7 @@ func TestChangesetExecutor_SingleResourceUpdate(t *testing.T) {
 		})
 
 		// Create changeset and start executor
-		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{resourceUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
+		cs, err := buildChangesetWithResolves([]resource_update.ResourceUpdate{resourceUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
 		assert.NoError(t, err)
 
 		// Ensure the changeset executor exists
@@ -166,7 +166,7 @@ func TestChangesetExecutor_DependentResources(t *testing.T) {
 		})
 
 		// Create changeset - it will automatically build the dependency pipeline
-		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{vpcUpdate, subnetUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
+		cs, err := buildChangesetWithResolves([]resource_update.ResourceUpdate{vpcUpdate, subnetUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
 		assert.NoError(t, err)
 
 		// Ensure the changeset executor exists
@@ -265,7 +265,7 @@ func TestChangesetExecutor_CascadeFailure(t *testing.T) {
 		})
 
 		// Create changeset - it will automatically build the dependency pipeline
-		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{vpcUpdate, subnetUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
+		cs, err := buildChangesetWithResolves([]resource_update.ResourceUpdate{vpcUpdate, subnetUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
 		assert.NoError(t, err)
 
 		// Ensure the changeset executor exists
@@ -362,7 +362,7 @@ func TestChangesetExecutor_SyncReadFailureDoesNotCascade(t *testing.T) {
 			},
 		})
 
-		cs, err := changeset.NewChangeset(
+		cs, err := buildChangesetWithResolves(
 			[]resource_update.ResourceUpdate{readUpdate}, nil, commandID, pkgmodel.CommandSync, m.Datastore)
 		assert.NoError(t, err)
 
@@ -425,7 +425,7 @@ func TestChangesetExecutor_HashesAllResourcesOnCompletion(t *testing.T) {
 		})
 
 		// Create changeset
-		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{resourceUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
+		cs, err := buildChangesetWithResolves([]resource_update.ResourceUpdate{resourceUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
 		assert.NoError(t, err)
 
 		// Ensure the changeset executor exists
@@ -494,7 +494,7 @@ func TestChangesetExecutor_HashesAllResourcesOnFailure(t *testing.T) {
 		})
 
 		// Create changeset
-		cs, err := changeset.NewChangeset([]resource_update.ResourceUpdate{resourceUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
+		cs, err := buildChangesetWithResolves([]resource_update.ResourceUpdate{resourceUpdate}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
 		assert.NoError(t, err)
 
 		// Ensure the changeset executor exists
@@ -634,7 +634,7 @@ func TestChangesetExecutor_StuckOnReadFailureDuringUpdate(t *testing.T) {
 		})
 
 		// Create changeset from the updates
-		cs, err := changeset.NewChangeset(
+		cs, err := buildChangesetWithResolves(
 			[]resource_update.ResourceUpdate{resOK, resFail}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
 		assert.NoError(t, err)
 
@@ -712,7 +712,7 @@ func TestChangesetExecutor_MixedResourceAndTargetUpdates(t *testing.T) {
 		})
 
 		// Create changeset with both resource and target updates
-		cs, err := changeset.NewChangeset(
+		cs, err := buildChangesetWithResolves(
 			[]resource_update.ResourceUpdate{resourceUpdate},
 			[]target_update.TargetUpdate{targetUp},
 			commandID,

--- a/internal/workflow_tests/local/changeset_resolve_helper_test.go
+++ b/internal/workflow_tests/local/changeset_resolve_helper_test.go
@@ -1,0 +1,35 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"github.com/platform-engineering-labs/formae/internal/metastructure/changeset"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// buildChangesetWithResolves mirrors the production Update-construction phase:
+// generate synthetic Resolve target ops via target_update.SynthesizeResolveTargetUpdates,
+// then build the (ds-free) changeset. Keeps the old changeset.NewChangeset call
+// shape so existing tests port with a mechanical rename.
+func buildChangesetWithResolves(
+	resourceUpdates []resource_update.ResourceUpdate,
+	targetUpdates []target_update.TargetUpdate,
+	commandID string,
+	command pkgmodel.Command,
+	ds target_update.TargetDatastore,
+) (changeset.Changeset, error) {
+	synth, err := target_update.SynthesizeResolveTargetUpdates(
+		resource_update.ReferencedTargetLabels(resourceUpdates),
+		resource_update.SourceTargetByKsuid(resourceUpdates),
+		targetUpdates, ds)
+	if err != nil {
+		return changeset.Changeset{}, err
+	}
+	return changeset.NewChangeset(resourceUpdates, append(targetUpdates, synth...), commandID, command)
+}

--- a/internal/workflow_tests/local/target_updater_resolve_test.go
+++ b/internal/workflow_tests/local/target_updater_resolve_test.go
@@ -44,9 +44,9 @@ func spawnTargetUpdater(
 }
 
 // TestTargetUpdater_ResolveOp_EmptyResolvables_SkipsPersist verifies that a
-// Resolve op with zero resolvables never calls persistTarget — it must not write
-// the target row and must still reach TargetUpdateStateSuccess, carrying the
-// (unchanged) config in the finished signal.
+// Resolve op with zero resolvables never re-writes the target row — the row's
+// Version must be identical before and after the op — and must still reach
+// TargetUpdateStateSuccess, carrying the (unchanged) config in the finished signal.
 func TestTargetUpdater_ResolveOp_EmptyResolvables_SkipsPersist(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		m, def, err := test_helpers.NewTestMetastructure(t, nil)
@@ -57,15 +57,36 @@ func TestTargetUpdater_ResolveOp_EmptyResolvables_SkipsPersist(t *testing.T) {
 		helperPID, err := testutil.StartTestHelperActor(m.Node, received)
 		require.NoError(t, err)
 
-		// A Resolve TU with no resolvables: the config has no $ref fields to fill in.
+		// Persist the consumer target so revalidation (which re-reads the live row at
+		// execute time) can confirm it still exists. In production, synthesizeResolveTargetUpdates
+		// always operates on already-persisted targets; this mirrors that precondition.
 		consumerConfig := json.RawMessage(`{"region":"us-west-2"}`)
-		tu := target_update.NewResolveTargetUpdate(
-			pkgmodel.Target{
-				Label:     "empty-consumer",
-				Namespace: "FakeAWS",
-				Config:    consumerConfig,
+		_, err = testutil.Call(m.Node, "ResourcePersister", target_update.PersistTargetUpdates{
+			TargetUpdates: []target_update.TargetUpdate{
+				{
+					Target: pkgmodel.Target{
+						Label:     "empty-consumer",
+						Namespace: "FakeAWS",
+						Config:    consumerConfig,
+					},
+					Operation: target_update.TargetOperationCreate,
+					State:     target_update.TargetUpdateStateNotStarted,
+				},
 			},
-			[]pkgmodel.FormaeURI{}, // deliberately empty
+			CommandID: "empty-resolve-cmd",
+		})
+		require.NoError(t, err)
+
+		// Load the persisted target to capture its Version, then build the Resolve TU
+		// from it so the snapshot Version matches the live row (no stale-snapshot rebuild).
+		persistedConsumer, err := m.Datastore.LoadTarget("empty-consumer")
+		require.NoError(t, err)
+		require.NotNil(t, persistedConsumer)
+		versionBeforeOp := persistedConsumer.Version
+
+		tu := target_update.NewResolveTargetUpdate(
+			*persistedConsumer,
+			[]pkgmodel.FormaeURI{}, // deliberately empty — no resolvables to process
 		)
 
 		const commandID = "empty-resolve-cmd"
@@ -91,18 +112,21 @@ func TestTargetUpdater_ResolveOp_EmptyResolvables_SkipsPersist(t *testing.T) {
 			},
 		)
 
-		// (b) The target row must NOT have been written to the datastore.
+		// (b) The Resolve op must not re-write the target row: the Version must be
+		// identical to what was in place before the op ran.
 		consumerTarget, err := m.Datastore.LoadTarget("empty-consumer")
 		require.NoError(t, err)
-		assert.Nil(t, consumerTarget,
-			"Resolve op must not persist the target row even when resolvables are empty")
+		require.NotNil(t, consumerTarget,
+			"target row must still exist after a Resolve op")
+		assert.Equal(t, versionBeforeOp, consumerTarget.Version,
+			"Resolve op must not bump the target's Version — it must not write the target row")
 	})
 }
 
 // TestTargetUpdater_ResolveOp_SkipsPersistAndSignalsResolvedConfig verifies that
 // a Resolve op drives the full resolvable loop (mutating Target.Config), then
 // terminates with TargetUpdateStateSuccess and the resolved config — without
-// writing any target row to the datastore.
+// re-writing the target row to the datastore (Version must be unchanged).
 func TestTargetUpdater_ResolveOp_SkipsPersistAndSignalsResolvedConfig(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		// Plugin Read returns the resolved value so the ResolveCache can serve it.
@@ -189,18 +213,42 @@ func TestTargetUpdater_ResolveOp_SkipsPersistAndSignalsResolvedConfig(t *testing
 		// loop can request values.
 		require.NoError(t, spawnResolveCache(t, m.Node, "resolve-test-cmd"))
 
-		// Build the Resolve TU: unchanged target whose config has a $ref to the
-		// cluster's Endpoint. ExistingTarget is nil (Resolve ops are synthetic).
+		// Persist the consumer target so revalidation (which re-reads the live row at
+		// execute time) can confirm it still exists and its config is current.
+		// In production, synthesizeResolveTargetUpdates always operates on
+		// already-persisted targets; this mirrors that precondition.
 		resolvableURI := pkgmodel.NewFormaeURI(resourceKsuid, "Endpoint")
 		consumerConfig := json.RawMessage(`{
 			"endpoint": {"$ref": "` + string(resolvableURI) + `"}
 		}`)
-		tu := target_update.NewResolveTargetUpdate(
-			pkgmodel.Target{
-				Label:     "consumer",
-				Namespace: "FakeAWS",
-				Config:    consumerConfig,
+		_, err = testutil.Call(m.Node, "ResourcePersister", target_update.PersistTargetUpdates{
+			TargetUpdates: []target_update.TargetUpdate{
+				{
+					Target: pkgmodel.Target{
+						Label:     "consumer",
+						Namespace: "FakeAWS",
+						Config:    consumerConfig,
+					},
+					Operation: target_update.TargetOperationCreate,
+					State:     target_update.TargetUpdateStateNotStarted,
+				},
 			},
+			CommandID: "resolve-test-cmd",
+		})
+		require.NoError(t, err)
+
+		// Load the persisted consumer target to capture its Version, then build the
+		// Resolve TU from it so the snapshot Version matches the live row (revalidation
+		// sees an unchanged version and does not rebuild resolvables).
+		persistedConsumer, err := m.Datastore.LoadTarget("consumer")
+		require.NoError(t, err)
+		require.NotNil(t, persistedConsumer)
+		versionBeforeOp := persistedConsumer.Version
+
+		// Build the Resolve TU from the persisted target snapshot. The $ref in Config
+		// will be resolved in-memory during the op without touching the persisted row.
+		tu := target_update.NewResolveTargetUpdate(
+			*persistedConsumer,
 			[]pkgmodel.FormaeURI{resolvableURI},
 		)
 
@@ -240,10 +288,13 @@ func TestTargetUpdater_ResolveOp_SkipsPersistAndSignalsResolvedConfig(t *testing
 			},
 		)
 
-		// (b) The target row must NOT have been written — Resolve ops are never persisted.
+		// (b) The Resolve op must not re-write the target row: the Version must be
+		// identical to what was in place before the op ran.
 		consumerTarget, err := m.Datastore.LoadTarget("consumer")
 		require.NoError(t, err)
-		assert.Nil(t, consumerTarget,
-			"Resolve op must not persist the target row to the datastore")
+		require.NotNil(t, consumerTarget,
+			"target row must still exist after a Resolve op")
+		assert.Equal(t, versionBeforeOp, consumerTarget.Version,
+			"Resolve op must not bump the target's Version — it must not write the target row")
 	})
 }

--- a/internal/workflow_tests/local/target_updater_resolve_test.go
+++ b/internal/workflow_tests/local/target_updater_resolve_test.go
@@ -1,0 +1,193 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// spawnTargetUpdater spawns a TargetUpdater actor directly on the node,
+// registered under the canonical name for the given (label, operation, commandID)
+// tuple. from is the PID that will receive the TargetUpdateFinished message.
+func spawnTargetUpdater(
+	t *testing.T,
+	node gen.Node,
+	from gen.PID,
+	label string,
+	operation string,
+	commandID string,
+) error {
+	t.Helper()
+	name := actornames.TargetUpdater(label, operation, commandID)
+	_, err := node.SpawnRegister(name, target_update.NewTargetUpdater, gen.ProcessOptions{}, from)
+	return err
+}
+
+// TestTargetUpdater_ResolveOp_SkipsPersistAndSignalsResolvedConfig verifies that
+// a Resolve op drives the full resolvable loop (mutating Target.Config), then
+// terminates with TargetUpdateStateSuccess and the resolved config — without
+// writing any target row to the datastore.
+func TestTargetUpdater_ResolveOp_SkipsPersistAndSignalsResolvedConfig(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		// Plugin Read returns the resolved value so the ResolveCache can serve it.
+		resourceKsuid := util.NewID()
+		overrides := &plugin.ResourcePluginOverrides{
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{
+					ResourceType: "FakeAWS::S3::Bucket",
+					Properties:   `{"BucketName":"my-cluster","Endpoint":"https://my-cluster.example.com"}`,
+				}, nil
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		received := make(chan any, 1)
+		helperPID, err := testutil.StartTestHelperActor(m.Node, received)
+		require.NoError(t, err)
+
+		// Persist the provider target so the ResourcePersister can serve it
+		// (required for the ResolveCache to look up the resource's target config).
+		providerTarget := pkgmodel.Target{
+			Label:     "provider",
+			Namespace: "FakeAWS",
+			Config:    json.RawMessage(`{"region":"us-east-1"}`),
+		}
+		_, err = testutil.Call(m.Node, "ResourcePersister", target_update.PersistTargetUpdates{
+			TargetUpdates: []target_update.TargetUpdate{
+				{
+					Target:    providerTarget,
+					Operation: target_update.TargetOperationCreate,
+					State:     target_update.TargetUpdateStateNotStarted,
+				},
+			},
+			CommandID: "resolve-test-cmd",
+		})
+		require.NoError(t, err)
+
+		// Persist a resource so the ResolveCache can read the Endpoint property.
+		resourceUpdate := &resource_update.ResourceUpdate{
+			DesiredState: pkgmodel.Resource{
+				Label:    "cluster",
+				Type:     "FakeAWS::S3::Bucket",
+				Stack:    "infra",
+				Target:   "provider",
+				NativeID: "native-cluster",
+				Ksuid:    resourceKsuid,
+				Schema:   pkgmodel.Schema{Identifier: "BucketName", Portable: true},
+				Properties: json.RawMessage(
+					`{"BucketName":"my-cluster","Endpoint":"https://my-cluster.example.com"}`,
+				),
+			},
+			ResourceTarget: providerTarget,
+			State:          resource_update.ResourceUpdateStateSuccess,
+			Operation:      resource_update.OperationCreate,
+			ProgressResult: []plugin.TrackedProgress{
+				{
+					ProgressResult: resource.ProgressResult{
+						Operation:          resource.OperationCreate,
+						OperationStatus:    resource.OperationStatusSuccess,
+						RequestID:          "req-1",
+						NativeID:           "native-cluster",
+						ResourceProperties: json.RawMessage(`{"BucketName":"my-cluster","Endpoint":"https://my-cluster.example.com"}`),
+					},
+					ResourceType: "FakeAWS::S3::Bucket",
+					StartTs:      util.TimeNow(),
+					ModifiedTs:   util.TimeNow(),
+					Attempts:     1,
+				},
+			},
+			RemainingResolvables: []pkgmodel.FormaeURI{},
+			StackLabel:           "infra",
+			GroupID:              "resolve-test-group",
+		}
+		_, err = testutil.Call(m.Node, "ResourcePersister", resource_update.PersistResourceUpdate{
+			PluginOperation: resource.OperationCreate,
+			ResourceUpdate:  *resourceUpdate,
+		})
+		require.NoError(t, err)
+
+		// Spawn the ResolveCache for this command so the TargetUpdater's resolve
+		// loop can request values.
+		require.NoError(t, spawnResolveCache(t, m.Node, "resolve-test-cmd"))
+
+		// Build the Resolve TU: unchanged target whose config has a $ref to the
+		// cluster's Endpoint. ExistingTarget is nil (Resolve ops are synthetic).
+		resolvableURI := pkgmodel.NewFormaeURI(resourceKsuid, "Endpoint")
+		consumerConfig := json.RawMessage(`{
+			"endpoint": {"$ref": "` + string(resolvableURI) + `"}
+		}`)
+		tu := target_update.NewResolveTargetUpdate(
+			pkgmodel.Target{
+				Label:     "consumer",
+				Namespace: "FakeAWS",
+				Config:    consumerConfig,
+			},
+			[]pkgmodel.FormaeURI{resolvableURI},
+		)
+
+		const commandID = "resolve-test-cmd"
+
+		// Spawn the TargetUpdater with the TestHelperActor as requester.
+		require.NoError(t, spawnTargetUpdater(t, m.Node, helperPID,
+			tu.Target.Label, string(tu.Operation), commandID))
+
+		// Send StartTargetUpdate to kick off the FSM.
+		tuName := actornames.TargetUpdater(tu.Target.Label, string(tu.Operation), commandID)
+		err = testutil.Send(m.Node, tuName, target_update.StartTargetUpdate{
+			TargetUpdate: tu,
+			CommandID:    commandID,
+		})
+		require.NoError(t, err)
+
+		// (a) Finished signal carries success state and the resolved config.
+		testutil.ExpectMessageWithPredicate(t, received, 10*time.Second,
+			func(msg target_update.TargetUpdateFinished) bool {
+				assert.Equal(t, target_update.TargetUpdateStateSuccess, msg.State,
+					"Resolve op must finish successfully")
+
+				require.NotNil(t, msg.ResolvedConfig,
+					"Resolve op must propagate resolved config")
+
+				var cfg map[string]any
+				require.NoError(t, json.Unmarshal(msg.ResolvedConfig, &cfg))
+				endpointObj, ok := cfg["endpoint"].(map[string]any)
+				require.True(t, ok, "endpoint must be a $ref object in resolved config")
+				assert.Equal(t,
+					"https://my-cluster.example.com",
+					endpointObj["$value"],
+					"resolved config must carry the resolved $value",
+				)
+				return true
+			},
+		)
+
+		// (b) The target row must NOT have been written — Resolve ops are never persisted.
+		consumerTarget, err := m.Datastore.LoadTarget("consumer")
+		require.NoError(t, err)
+		assert.Nil(t, consumerTarget,
+			"Resolve op must not persist the target row to the datastore")
+	})
+}

--- a/internal/workflow_tests/local/target_updater_resolve_test.go
+++ b/internal/workflow_tests/local/target_updater_resolve_test.go
@@ -43,6 +43,62 @@ func spawnTargetUpdater(
 	return err
 }
 
+// TestTargetUpdater_ResolveOp_EmptyResolvables_SkipsPersist verifies that a
+// Resolve op with zero resolvables never calls persistTarget — it must not write
+// the target row and must still reach TargetUpdateStateSuccess, carrying the
+// (unchanged) config in the finished signal.
+func TestTargetUpdater_ResolveOp_EmptyResolvables_SkipsPersist(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, def, err := test_helpers.NewTestMetastructure(t, nil)
+		defer def()
+		require.NoError(t, err)
+
+		received := make(chan any, 1)
+		helperPID, err := testutil.StartTestHelperActor(m.Node, received)
+		require.NoError(t, err)
+
+		// A Resolve TU with no resolvables: the config has no $ref fields to fill in.
+		consumerConfig := json.RawMessage(`{"region":"us-west-2"}`)
+		tu := target_update.NewResolveTargetUpdate(
+			pkgmodel.Target{
+				Label:     "empty-consumer",
+				Namespace: "FakeAWS",
+				Config:    consumerConfig,
+			},
+			[]pkgmodel.FormaeURI{}, // deliberately empty
+		)
+
+		const commandID = "empty-resolve-cmd"
+
+		require.NoError(t, spawnTargetUpdater(t, m.Node, helperPID,
+			tu.Target.Label, string(tu.Operation), commandID))
+
+		tuName := actornames.TargetUpdater(tu.Target.Label, string(tu.Operation), commandID)
+		err = testutil.Send(m.Node, tuName, target_update.StartTargetUpdate{
+			TargetUpdate: tu,
+			CommandID:    commandID,
+		})
+		require.NoError(t, err)
+
+		// (a) The FSM must finish successfully and propagate the config.
+		testutil.ExpectMessageWithPredicate(t, received, 10*time.Second,
+			func(msg target_update.TargetUpdateFinished) bool {
+				assert.Equal(t, target_update.TargetUpdateStateSuccess, msg.State,
+					"Resolve op with empty resolvables must finish successfully")
+				require.NotNil(t, msg.ResolvedConfig,
+					"Resolve op must propagate config even when there are no resolvables")
+				return true
+			},
+		)
+
+		// (b) The target row must NOT have been written to the datastore.
+		consumerTarget, err := m.Datastore.LoadTarget("empty-consumer")
+		require.NoError(t, err)
+		assert.Nil(t, consumerTarget,
+			"Resolve op must not persist the target row even when resolvables are empty")
+	})
+}
+
 // TestTargetUpdater_ResolveOp_SkipsPersistAndSignalsResolvedConfig verifies that
 // a Resolve op drives the full resolvable loop (mutating Target.Config), then
 // terminates with TargetUpdateStateSuccess and the resolved config — without


### PR DESCRIPTION
## Summary

Resolves a gap where an **unchanged** target whose config references a secret (an opaque `$ref`) would dispatch that reference to a resource plugin **unresolved**. Resolved-config propagation previously ran only for targets being created/updated in the changeset, so a target referenced by a resource op but not itself changed carried its raw `{"$ref":…,"$visibility":"Opaque"}` object through to the plugin.

- **Synthetic `Resolve` target op.** `NewChangeset` now synthesizes a `Resolve` operation for every referenced-but-unchanged target that carries opaque `$ref` config, reads its persisted config, and wires the `Resolve` node as a dependency of the resource ops on that target. The `TargetUpdater` FSM resolves the config **in memory and never persists the target row**; the executor propagates the resolved config to dependent resource ops.

- **DAG hardening.**
  - Detects target-resolvable dependency cycles at build time — mutually- or self-referential credential bootstraps (target A's credential lives on B while B's lives on A, or a target hosting its own credential) — and returns a clear error instead of hanging the executor.
  - Re-validates the target revision at execute time, so a concurrent update landing between changeset build and execution is picked up rather than resolving a stale credential.
  - Rejects transitively-opaque target references (a credential that itself requires resolving another credential).
  - Surfaces the previously-discarded `NewChangeset` error in the sync, apply, and discovery callers, and finalizes the persisted command on a build error rather than leaving it pending.

- **Secret hygiene.** Resolved values are never persisted at rest; plaintext exists only in-flight to a plugin call. Timeout-path logs and failure actor messages no longer carry resolved config, and on a config-conversion failure the operation fails **closed** rather than dispatching an unconverted reference.

## Notes

- Stacks on #588.
- Known limitation: a narrow time-of-check/time-of-use window remains between the execute-time revision re-read and the dependent plugin dispatch. The revision re-check mitigates it; fully closing it via admission-time deconfliction on target-config credential changes is a tracked follow-up.
