### PR TITLE
feat(discovery): resolve target-config secrets before the List phase

### DIFF
--- a/internal/metastructure/changeset/resolve_cache.go
+++ b/internal/metastructure/changeset/resolve_cache.go
@@ -13,7 +13,6 @@ import (
 
 	"ergo.services/ergo/act"
 	"ergo.services/ergo/gen"
-	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
@@ -213,52 +212,7 @@ func (r *ResolveCache) continueResolve(retry resolveRetry) {
 
 // readViaPlugin spawns a PluginOperator and executes a single Read call.
 func (r *ResolveCache) readViaPlugin(retry resolveRetry) (*plugin.TrackedProgress, error) {
-	operationID := uuid.New().String()
-	spawnResult, err := r.Call(
-		gen.ProcessID{Name: actornames.PluginCoordinator, Node: r.Node().Name()},
-		messages.SpawnPluginOperator{
-			Namespace:   retry.loadResult.Resource.Namespace(),
-			ResourceURI: string(retry.ResourceURI.Stripped()),
-			Operation:   string(resource.OperationRead),
-			OperationID: operationID,
-			RequestedBy: r.PID(),
-		})
-	if err != nil {
-		return nil, fmt.Errorf("failed to spawn plugin operator: %w", err)
-	}
-	spawnRes, ok := spawnResult.(messages.SpawnPluginOperatorResult)
-	if !ok {
-		return nil, fmt.Errorf("unexpected result type from PluginCoordinator: %T", spawnResult)
-	}
-	if spawnRes.Error != "" {
-		return nil, fmt.Errorf("failed to spawn plugin operator: %s", spawnRes.Error)
-	}
-
-	// Use the same call budget as ResourceUpdater.doPluginOperation. The default
-	// Ergo Call timeout (5s) is too short for live AWS API reads, which routinely
-	// run longer than that — especially CloudControl GetResource immediately
-	// after a Create, when SDK credential resolution and the read itself stack up.
-	progressResult, err := r.CallWithTimeout(
-		spawnRes.PID,
-		plugin.ReadResource{
-			Namespace:         retry.loadResult.Resource.Namespace(),
-			ResourceType:      retry.loadResult.Resource.Type,
-			ResourceNamespace: retry.loadResult.Resource.Namespace(),
-			ExistingResource:  retry.loadResult.Resource,
-			Resource:          retry.loadResult.Resource,
-			NativeID:          retry.loadResult.Resource.NativeID,
-			TargetConfig:      retry.config,
-		},
-		resource_update.PluginOperationCallTimeout)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read resource: %w", err)
-	}
-
-	progress, ok := progressResult.(plugin.TrackedProgress)
-	if !ok {
-		return nil, fmt.Errorf("unexpected result type from plugin operator: %T", progressResult)
-	}
-	return &progress, nil
+	return resource_update.ReadResourceViaPlugin(r, retry.loadResult.Resource, retry.config)
 }
 
 func (r *ResolveCache) preserveRefMetadata(originalResource pkgmodel.Resource, pluginResult gjson.Result) gjson.Result {

--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -137,10 +137,22 @@ type DiscoveryData struct {
 	hasPendingResumeScan bool
 	// Cached plugin info per namespace, refreshed at start of each discovery cycle
 	pluginInfoCache map[string]*messages.PluginInfoResponse
+	// resolvedTargets tracks which targets have had their opaque $ref config
+	// successfully resolved this cycle. Keyed by target label.
+	resolvedTargets map[string]bool
+	// failedTargets tracks which targets failed opaque $ref resolution this
+	// cycle. Such targets are skipped for all remaining scan operations.
+	failedTargets map[string]bool
 }
 
 func (d *DiscoveryData) SetTargets(targets []*pkgmodel.Target) {
 	d.targets = make(map[string]pkgmodel.Target, len(targets))
+	if d.resolvedTargets == nil {
+		d.resolvedTargets = make(map[string]bool)
+	}
+	if d.failedTargets == nil {
+		d.failedTargets = make(map[string]bool)
+	}
 	for _, target := range targets {
 		// A reaped (or reap-pending) target is being — or has been —
 		// tombstoned by the reaper. Never sweep it: its resources are already
@@ -204,6 +216,8 @@ func (d *Discovery) Init(args ...any) (statemachine.StateMachineSpec[DiscoveryDa
 		pluginInfoCache:               make(map[string]*messages.PluginInfoResponse),
 		typesWithChildrenQueued:       make(map[string]struct{}),
 		nativeIDsByCommand:            make(map[string][]string),
+		resolvedTargets:               make(map[string]bool),
+		failedTargets:                 make(map[string]bool),
 	}
 
 	spec := statemachine.NewStateMachineSpec(StateIdle,
@@ -309,6 +323,8 @@ func discover(from gen.PID, state gen.Atom, data DiscoveryData, message Discover
 	data.pluginInfoCache = make(map[string]*messages.PluginInfoResponse)
 	data.typesWithChildrenQueued = make(map[string]struct{})
 	data.recentlyDiscoveredResourceIDs = make(map[string]struct{})
+	data.resolvedTargets = make(map[string]bool)
+	data.failedTargets = make(map[string]bool)
 	proc.Log().Debug("Starting resource discovery timestamp=%v", data.timeStarted)
 
 	allTargets, err := data.ds.LoadDiscoverableTargets()
@@ -386,6 +402,44 @@ func discover(from gen.PID, state gen.Atom, data DiscoveryData, message Discover
 	return StateDiscovering, data, nil, nil
 }
 
+// ensureTargetResolved guarantees that data.targets[label].Config holds the
+// ephemeral resolved form of the target's config (opaque $ref replaced by live
+// plaintext) before any List call reaches the plugin. Resolution is memoized
+// within the current discovery cycle via data.resolvedTargets / data.failedTargets
+// so each target is resolved at most once per cycle regardless of how many
+// resource types it scans.
+//
+// Returns the updated DiscoveryData and true on success; false when the target
+// failed resolution (it should be skipped for the remainder of this cycle).
+func ensureTargetResolved(data DiscoveryData, label string, proc gen.Process) (DiscoveryData, bool) {
+	if data.resolvedTargets == nil {
+		data.resolvedTargets = make(map[string]bool)
+	}
+	if data.failedTargets == nil {
+		data.failedTargets = make(map[string]bool)
+	}
+
+	if data.resolvedTargets[label] {
+		return data, true
+	}
+	if data.failedTargets[label] {
+		return data, false
+	}
+
+	resolved, err := resolveTargetConfigForList(proc, data.targets[label])
+	if err != nil {
+		proc.Log().Error("discovery: skipping target %s: could not resolve its config: %v", label, err)
+		data.failedTargets[label] = true
+		return data, false
+	}
+
+	t := data.targets[label]
+	t.Config = resolved
+	data.targets[label] = t
+	data.resolvedTargets[label] = true
+	return data, true
+}
+
 func resumeScanning(from gen.PID, state gen.Atom, data DiscoveryData, message ResumeScanning, proc gen.Process) (gen.Atom, DiscoveryData, []statemachine.Action, error) {
 	// The delayed message has arrived - clear the pending flag
 	data.hasPendingResumeScan = false
@@ -415,6 +469,11 @@ func resumeScanning(from gen.PID, state gen.Atom, data DiscoveryData, message Re
 		for range n {
 			nextOp := data.queuedListOperations[namespace][0]
 			data.queuedListOperations[namespace] = data.queuedListOperations[namespace][1:]
+			var ok bool
+			data, ok = ensureTargetResolved(data, nextOp.TargetLabel, proc)
+			if !ok {
+				continue
+			}
 			if err := scanTargetForResourceType(data.targets[nextOp.TargetLabel], nextOp, data, proc); err != nil {
 				// A failed scan of a single resource type must not crash the
 				// Discovery actor. Skip the resource type for this cycle and

--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -251,6 +251,14 @@ func (d *Discovery) Init(args ...any) (statemachine.StateMachineSpec[DiscoveryDa
 func onStateChange(oldState gen.Atom, newState gen.Atom, data DiscoveryData, proc gen.Process) (gen.Atom, DiscoveryData, error) {
 	if oldState == StateDiscovering && newState == StateIdle {
 		proc.Log().Debug("Discovery finished (duration=%s). The following resources have been discovered:\n%s", time.Since(data.timeStarted), renderSummary(data.summary))
+		if len(data.failedTargets) > 0 {
+			labels := make([]string, 0, len(data.failedTargets))
+			for label := range data.failedTargets {
+				labels = append(labels, label)
+			}
+			slices.Sort(labels)
+			proc.Log().Warning("discovery: %d target(s) skipped this cycle due to config resolution failure: %v", len(data.failedTargets), labels)
+		}
 	}
 	return newState, data, nil
 }
@@ -428,6 +436,10 @@ func ensureTargetResolved(data DiscoveryData, label string, proc gen.Process) (D
 
 	resolved, err := resolveTargetConfigForList(proc, data.targets[label])
 	if err != nil {
+		// Fail closed: a target whose credential source is missing or rotated is
+		// skipped for the remainder of this cycle so its ListResources call is
+		// never issued with a stale or unresolved credential. The target recovers
+		// automatically on the next discovery cycle once the source resolves.
 		proc.Log().Error("discovery: skipping target %s: could not resolve its config: %v", label, err)
 		data.failedTargets[label] = true
 		return data, false

--- a/internal/metastructure/discovery/resolve_target_config.go
+++ b/internal/metastructure/discovery/resolve_target_config.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"time"
 
 	"ergo.services/ergo/gen"
 	"github.com/tidwall/gjson"
@@ -22,10 +21,6 @@ import (
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
-
-// maxDiscoveryResolveAttempts is the maximum number of plugin Read attempts
-// made by readWithRetry before giving up on a single opaque reference.
-const maxDiscoveryResolveAttempts = 3
 
 // resolveTargetConfigForList returns an ephemeral copy of target.Config with
 // every opaque $ref replaced by its live plaintext value. When the config
@@ -77,7 +72,7 @@ func resolveTargetConfigForList(proc gen.Process, target pkgmodel.Target) (json.
 			srcCfg = cleanCfg
 		}
 
-		progress, err := readWithRetry(proc, loadResult.Resource, srcCfg)
+		progress, err := readSource(proc, loadResult.Resource, srcCfg)
 		if err != nil {
 			proc.Log().Error(
 				"failed to read resource for opaque ref resolution uri=%s target=%s: %v",
@@ -136,44 +131,18 @@ func resolveTargetConfigForList(proc gen.Process, target pkgmodel.Target) (json.
 	return plain, nil
 }
 
-// readWithRetry calls ReadResourceViaPlugin up to maxDiscoveryResolveAttempts
-// times. It retries with a short pause when the result is a recoverable
-// failure; on success, non-recoverable failure, or exhausted budget it returns.
-func readWithRetry(proc gen.Process, res pkgmodel.Resource, cfg json.RawMessage) (*plugin.TrackedProgress, error) {
-	for attempt := 1; attempt <= maxDiscoveryResolveAttempts; attempt++ {
-		progress, err := resource_update.ReadResourceViaPlugin(proc, res, cfg)
-		if err != nil {
-			return nil, err
-		}
-
-		if progress.OperationStatus == resource.OperationStatusFailure &&
-			resource.IsRecoverable(progress.ErrorCode) {
-			if attempt < maxDiscoveryResolveAttempts {
-				proc.Log().Info(
-					"readWithRetry: recoverable error, retrying errorCode=%s attempt=%d/%d",
-					progress.ErrorCode, attempt, maxDiscoveryResolveAttempts,
-				)
-				time.Sleep(75 * time.Millisecond)
-				continue
-			}
-			proc.Log().Error(
-				"readWithRetry: exhausted attempts errorCode=%s attempts=%d",
-				progress.ErrorCode, attempt,
-			)
-			return nil, fmt.Errorf(
-				"read failed after %d attempts: recoverable error %s",
-				attempt, progress.ErrorCode,
-			)
-		}
-
-		// Non-recoverable failure or success — return immediately.
-		if progress.OperationStatus == resource.OperationStatusFailure {
-			return nil, fmt.Errorf("read failed: non-recoverable error %s", progress.ErrorCode)
-		}
-
-		return progress, nil
+// readSource performs a single ReadResourceViaPlugin for opaque-ref resolution.
+// It does not retry and never sleeps: a recoverable failure is surfaced to the
+// caller, and discovery skips the target for this cycle and retries it on the
+// next cycle, so a transient failure is absorbed without blocking the discovery
+// actor.
+func readSource(proc gen.Process, res pkgmodel.Resource, cfg json.RawMessage) (*plugin.TrackedProgress, error) {
+	progress, err := resource_update.ReadResourceViaPlugin(proc, res, cfg)
+	if err != nil {
+		return nil, err
 	}
-
-	// Should not be reachable, but guard against the loop falling through.
-	return nil, fmt.Errorf("read failed: exhausted %d attempts", maxDiscoveryResolveAttempts)
+	if progress.OperationStatus == resource.OperationStatusFailure {
+		return nil, fmt.Errorf("read failed: error %s", progress.ErrorCode)
+	}
+	return progress, nil
 }

--- a/internal/metastructure/discovery/resolve_target_config.go
+++ b/internal/metastructure/discovery/resolve_target_config.go
@@ -1,0 +1,171 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package discovery
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"time"
+
+	"ergo.services/ergo/gen"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// maxDiscoveryResolveAttempts is the maximum number of plugin Read attempts
+// made by readWithRetry before giving up on a single opaque reference.
+const maxDiscoveryResolveAttempts = 3
+
+// resolveTargetConfigForList returns an ephemeral copy of target.Config with
+// every opaque $ref replaced by its live plaintext value. When the config
+// carries no opaque references it is returned unchanged. Any resolve failure
+// returns a redacted error that names the reference and target but never the
+// plaintext secret.
+func resolveTargetConfigForList(proc gen.Process, target pkgmodel.Target) (json.RawMessage, error) {
+	uris := resolver.ExtractOpaqueResolvableURIsFromJSON(target.Config)
+	if len(uris) == 0 {
+		return target.Config, nil
+	}
+
+	// Work on a copy so the caller's original config is never mutated.
+	cfg := bytes.Clone(target.Config)
+
+	for _, uri := range uris {
+		// Load the source resource from the persister.
+		rawResult, err := proc.Call(
+			gen.ProcessID{Name: actornames.ResourcePersister, Node: proc.Node().Name()},
+			messages.LoadResource{ResourceURI: uri.Stripped()},
+		)
+		if err != nil {
+			proc.Log().Error(
+				"failed to load resource for opaque ref resolution uri=%s target=%s: %v",
+				uri, target.Label, err,
+			)
+			return nil, fmt.Errorf(
+				"failed to resolve opaque reference %q for target %q: load error",
+				uri, target.Label,
+			)
+		}
+
+		loadResult, ok := rawResult.(messages.LoadResourceResult)
+		if !ok {
+			proc.Log().Error(
+				"unexpected result type from resource persister resultType=%v uri=%s target=%s",
+				reflect.TypeOf(rawResult), uri, target.Label,
+			)
+			return nil, fmt.Errorf(
+				"failed to resolve opaque reference %q for target %q: unexpected persister response",
+				uri, target.Label,
+			)
+		}
+
+		// Strip resolvable metadata from the source target's config before
+		// sending to the plugin — mirrors the pattern in resolve_cache.go.
+		srcCfg := loadResult.Target.Config
+		if cleanCfg, err := resolver.ConvertToPluginFormat(srcCfg); err == nil {
+			srcCfg = cleanCfg
+		}
+
+		progress, err := readWithRetry(proc, loadResult.Resource, srcCfg)
+		if err != nil {
+			proc.Log().Error(
+				"failed to read resource for opaque ref resolution uri=%s target=%s: %v",
+				uri, target.Label, err,
+			)
+			return nil, fmt.Errorf(
+				"failed to resolve opaque reference %q for target %q: read error",
+				uri, target.Label,
+			)
+		}
+
+		// Extract the property value from the read result.
+		parsed := gjson.ParseBytes([]byte(progress.ResourceProperties))
+		value := parsed.Get(uri.PropertyPath())
+		if !value.Exists() {
+			proc.Log().Error(
+				"opaque ref property not found in read result property=%s uri=%s target=%s",
+				uri.PropertyPath(), uri, target.Label,
+			)
+			return nil, fmt.Errorf(
+				"failed to resolve opaque reference %q for target %q: property %q absent from read result",
+				uri, target.Label, uri.PropertyPath(),
+			)
+		}
+
+		// Inject the resolved plaintext back into the working config copy.
+		cfg, err = resolver.ResolvePropertyReferences(uri, cfg, value.String())
+		if err != nil {
+			proc.Log().Error(
+				"failed to inject resolved value uri=%s target=%s configRedacted=%v: %v",
+				uri, target.Label, pkgmodel.RedactOpaqueForLog(cfg), err,
+			)
+			return nil, fmt.Errorf(
+				"failed to resolve opaque reference %q for target %q: inject error",
+				uri, target.Label,
+			)
+		}
+	}
+
+	// Strip the $ref/$value/$visibility wrappers so the returned config is
+	// plain JSON the plugin can unmarshal directly. A convert failure falls
+	// through and returns the partially-resolved (still-wrapped) config; the
+	// existing ConvertToPluginFormat guard in the scan path will handle it.
+	if plain, err := resolver.ConvertToPluginFormat(cfg); err == nil {
+		cfg = plain
+	}
+
+	return cfg, nil
+}
+
+// readWithRetry calls ReadResourceViaPlugin up to maxDiscoveryResolveAttempts
+// times. It retries with a short pause when the result is a recoverable
+// failure; on success, non-recoverable failure, or exhausted budget it returns.
+func readWithRetry(proc gen.Process, res pkgmodel.Resource, cfg json.RawMessage) (*plugin.TrackedProgress, error) {
+	for attempt := 1; attempt <= maxDiscoveryResolveAttempts; attempt++ {
+		progress, err := resource_update.ReadResourceViaPlugin(proc, res, cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		if progress.OperationStatus == resource.OperationStatusFailure &&
+			resource.IsRecoverable(progress.ErrorCode) {
+			if attempt < maxDiscoveryResolveAttempts {
+				proc.Log().Info(
+					"readWithRetry: recoverable error, retrying errorCode=%s attempt=%d/%d",
+					progress.ErrorCode, attempt, maxDiscoveryResolveAttempts,
+				)
+				time.Sleep(75 * time.Millisecond)
+				continue
+			}
+			proc.Log().Error(
+				"readWithRetry: exhausted attempts errorCode=%s attempts=%d",
+				progress.ErrorCode, attempt,
+			)
+			return nil, fmt.Errorf(
+				"read failed after %d attempts: recoverable error %s",
+				attempt, progress.ErrorCode,
+			)
+		}
+
+		// Non-recoverable failure or success — return immediately.
+		if progress.OperationStatus == resource.OperationStatusFailure {
+			return nil, fmt.Errorf("read failed: non-recoverable error %s", progress.ErrorCode)
+		}
+
+		return progress, nil
+	}
+
+	// Should not be reachable, but guard against the loop falling through.
+	return nil, fmt.Errorf("read failed: exhausted %d attempts", maxDiscoveryResolveAttempts)
+}

--- a/internal/metastructure/discovery/resolve_target_config.go
+++ b/internal/metastructure/discovery/resolve_target_config.go
@@ -118,14 +118,22 @@ func resolveTargetConfigForList(proc gen.Process, target pkgmodel.Target) (json.
 	}
 
 	// Strip the $ref/$value/$visibility wrappers so the returned config is
-	// plain JSON the plugin can unmarshal directly. A convert failure falls
-	// through and returns the partially-resolved (still-wrapped) config; the
-	// existing ConvertToPluginFormat guard in the scan path will handle it.
-	if plain, err := resolver.ConvertToPluginFormat(cfg); err == nil {
-		cfg = plain
+	// plain JSON the plugin can unmarshal directly. A failure here indicates
+	// an unresolvable envelope (e.g. a $hashed field whose plaintext is
+	// irrecoverable); surface it rather than returning the still-wrapped config.
+	plain, err := resolver.ConvertToPluginFormat(cfg)
+	if err != nil {
+		proc.Log().Error(
+			"failed to strip opaque wrappers from resolved target config target=%s configRedacted=%v: %v",
+			target.Label, pkgmodel.RedactOpaqueForLog(cfg), err,
+		)
+		return nil, fmt.Errorf(
+			"failed to prepare resolved config for target %q: convert error",
+			target.Label,
+		)
 	}
 
-	return cfg, nil
+	return plain, nil
 }
 
 // readWithRetry calls ReadResourceViaPlugin up to maxDiscoveryResolveAttempts

--- a/internal/metastructure/discovery/resolve_target_config_test.go
+++ b/internal/metastructure/discovery/resolve_target_config_test.go
@@ -425,3 +425,126 @@ var _ gen.Process = (*resolveStubProcess)(nil)
 
 // stubActorNamesSentinel verifies the expected actor name constant is accessible.
 var _ = actornames.ResourcePersister
+
+// buildDiscoveryDataWithTarget returns a DiscoveryData ready for
+// ensureTargetResolved tests: resolvedTargets/failedTargets are initialized and
+// the given target is registered.
+func buildDiscoveryDataWithTarget(label string, cfg json.RawMessage) DiscoveryData {
+	t := pkgmodel.Target{Label: label, Namespace: "FakeAWS", Config: cfg}
+	return DiscoveryData{
+		targets:         map[string]pkgmodel.Target{label: t},
+		resolvedTargets: make(map[string]bool),
+		failedTargets:   make(map[string]bool),
+	}
+}
+
+// TestEnsureTargetResolved_OpaqueRefResolvedOnce asserts that the first call
+// for a target with an opaque $ref invokes resolveTargetConfigForList (one
+// LoadResource call), stores the resolved config back into data.targets, and
+// marks the target resolved. A second call with the same data hits the
+// resolvedTargets cache and issues no further LoadResource calls.
+func TestEnsureTargetResolved_OpaqueRefResolvedOnce(t *testing.T) {
+	const label = "prod"
+	const ksuid = "35R2vyf6mT5wEs0mTWT5bp1Lf0E"
+	const prop = "SecretString"
+	const plaintext = "s3cr3t"
+
+	srcResource := buildSourceResource(ksuid)
+	srcTarget := pkgmodel.Target{
+		Label:     "us-east-1",
+		Namespace: "FakeAWS",
+		Config:    json.RawMessage(`{"Region":"us-east-1"}`),
+	}
+
+	proc := &resolveStubProcess{
+		loadResult: messages.LoadResourceResult{
+			Resource: srcResource,
+			Target:   srcTarget,
+		},
+		readResponses: []readResponse{
+			{
+				progress: &plugin.TrackedProgress{
+					ProgressResult: resource.ProgressResult{
+						OperationStatus:    resource.OperationStatusSuccess,
+						ResourceProperties: json.RawMessage(fmt.Sprintf(`{"%s":"%s"}`, prop, plaintext)),
+					},
+				},
+			},
+		},
+	}
+
+	cfg := buildOpaqueTargetConfig(ksuid, prop)
+	data := buildDiscoveryDataWithTarget(label, cfg)
+
+	// First call: should resolve the opaque $ref.
+	data, ok := ensureTargetResolved(data, label, proc)
+	require.True(t, ok, "first call must succeed")
+	assert.True(t, data.resolvedTargets[label], "target must be marked resolved")
+	assert.False(t, data.failedTargets[label], "target must not be marked failed")
+	resolvedCfg := string(data.targets[label].Config)
+	assert.Contains(t, resolvedCfg, plaintext, "resolved config must contain the plaintext")
+	assert.NotContains(t, resolvedCfg, `"$ref"`, "resolved config must not contain $ref")
+	loadCallsAfterFirst := len(proc.loadResourceCalls)
+	assert.Equal(t, 1, loadCallsAfterFirst, "exactly one LoadResource call on first resolve")
+
+	// Second call: must hit the cache, no additional LoadResource.
+	data, ok = ensureTargetResolved(data, label, proc)
+	require.True(t, ok, "second call must return true (cache hit)")
+	assert.Equal(t, loadCallsAfterFirst, len(proc.loadResourceCalls),
+		"second call must not issue another LoadResource (cache hit)")
+}
+
+// TestEnsureTargetResolved_FailedTargetNotRetried asserts that a target already
+// in failedTargets returns false immediately without calling resolveTargetConfigForList.
+func TestEnsureTargetResolved_FailedTargetNotRetried(t *testing.T) {
+	const label = "broken"
+	proc := &resolveStubProcess{}
+
+	cfg := json.RawMessage(`{"Region":"us-east-1"}`)
+	data := buildDiscoveryDataWithTarget(label, cfg)
+	data.failedTargets[label] = true
+
+	data, ok := ensureTargetResolved(data, label, proc)
+	require.False(t, ok, "a target already in failedTargets must return false")
+	assert.Empty(t, proc.loadResourceCalls,
+		"no LoadResource must be issued for a pre-failed target")
+}
+
+// TestEnsureTargetResolved_ResolveFailureMarksTargetFailed asserts that when
+// resolveTargetConfigForList returns an error the target is added to
+// failedTargets and the call returns false.
+func TestEnsureTargetResolved_ResolveFailureMarksTargetFailed(t *testing.T) {
+	const label = "prod"
+	const ksuid = "35R2vyf6mT5wEs0mTWT5bp1Lf0E"
+	const prop = "SecretString"
+
+	proc := &resolveStubProcess{
+		loadErr: fmt.Errorf("datastore unavailable"),
+	}
+
+	cfg := buildOpaqueTargetConfig(ksuid, prop)
+	data := buildDiscoveryDataWithTarget(label, cfg)
+
+	data, ok := ensureTargetResolved(data, label, proc)
+	require.False(t, ok, "a resolve failure must return false")
+	assert.True(t, data.failedTargets[label], "target must be marked failed after a resolve error")
+	assert.False(t, data.resolvedTargets[label], "target must not be marked resolved after a resolve error")
+}
+
+// TestEnsureTargetResolved_NoOpaqueRefPassthrough asserts that a target config
+// with no opaque refs is passed through unchanged and is immediately cached as
+// resolved without issuing any LoadResource or Read calls.
+func TestEnsureTargetResolved_NoOpaqueRefPassthrough(t *testing.T) {
+	const label = "plain"
+	proc := &resolveStubProcess{}
+
+	cfg := json.RawMessage(`{"Region":"us-east-1","AccountId":"123456789012"}`)
+	data := buildDiscoveryDataWithTarget(label, cfg)
+
+	data, ok := ensureTargetResolved(data, label, proc)
+	require.True(t, ok, "a target with no opaque refs must succeed")
+	assert.True(t, data.resolvedTargets[label])
+	assert.Empty(t, proc.loadResourceCalls, "no LoadResource for a plain config")
+	assert.Equal(t, string(cfg), string(data.targets[label].Config),
+		"plain config must be stored unchanged")
+}

--- a/internal/metastructure/discovery/resolve_target_config_test.go
+++ b/internal/metastructure/discovery/resolve_target_config_test.go
@@ -164,7 +164,8 @@ func TestResolveTargetConfigForList_OpaqueRefResolved(t *testing.T) {
 
 	// Exactly one LoadResource call was issued (for the opaque URI)
 	require.Len(t, proc.loadResourceCalls, 1)
-	assert.Equal(t, pkgmodel.FormaeURI(fmt.Sprintf("formae://%s#", ksuid)),
+	sourceURI := pkgmodel.FormaeURI(fmt.Sprintf("formae://%s#/%s", ksuid, prop))
+	assert.Equal(t, sourceURI.Stripped(),
 		proc.loadResourceCalls[0],
 		"LoadResource must be called with the stripped URI (no property path)")
 }
@@ -247,6 +248,8 @@ func TestResolveTargetConfigForList_NonRecoverableReadFailure(t *testing.T) {
 	// Error must NOT contain the plaintext or the raw $value
 	assert.NotContains(t, errMsg, plaintext,
 		"error must not leak the plaintext secret value")
+	assert.NotContains(t, errMsg, "$value",
+		"error must not include raw $ref envelope fields")
 }
 
 // TestResolveTargetConfigForList_RecoverableFailureThenSuccess asserts that a
@@ -331,9 +334,90 @@ func TestResolveTargetConfigForList_RecoverableFailureThenSuccess(t *testing.T) 
 
 		require.Error(t, err, "exhausting the retry budget must return an error")
 		assert.Nil(t, result, "result must be nil when budget is exhausted")
-		assert.LessOrEqual(t, proc.readAttempts, maxDiscoveryResolveAttempts,
-			"must not exceed the attempt budget")
+		assert.Equal(t, maxDiscoveryResolveAttempts, proc.readAttempts,
+			"must exhaust the full attempt budget on repeated recoverable failures")
 	})
+}
+
+// TestResolveTargetConfigForList_ConvertFailureDoesNotLeakEnvelope asserts that
+// when the final ConvertToPluginFormat step fails (e.g. a $hashed field remains
+// in the working config after all $ref URIs have been resolved), the function
+// returns an error and a nil result — never the still-wrapped envelope
+// containing $value.
+//
+// The trigger: the target config carries both an opaque $ref (which is
+// successfully resolved) AND a separately hashed field that has no $ref so it
+// is not in the opaque-URI list. ConvertToPluginFormat rejects the $hashed
+// marker, exercising the error surface introduced by this fix.
+func TestResolveTargetConfigForList_ConvertFailureDoesNotLeakEnvelope(t *testing.T) {
+	const ksuid = "35R2vyf6mT5wEs0mTWT5bp1Lf0E"
+	const prop = "SecretString"
+	const plaintext = "s3cr3t"
+	// hashedPlaintext is the value stored hashed in the target config; it must
+	// not appear in any error message.
+	const hashedPlaintext = "hashed-secret-value"
+
+	srcResource := buildSourceResource(ksuid)
+	srcTarget := pkgmodel.Target{
+		Label:     "us-east-1",
+		Namespace: "FakeAWS",
+		Config:    json.RawMessage(`{"Region":"us-east-1"}`),
+	}
+
+	proc := &resolveStubProcess{
+		loadResult: messages.LoadResourceResult{
+			Resource: srcResource,
+			Target:   srcTarget,
+		},
+		readResponses: []readResponse{
+			{
+				progress: &plugin.TrackedProgress{
+					ProgressResult: resource.ProgressResult{
+						OperationStatus:    resource.OperationStatusSuccess,
+						ResourceProperties: json.RawMessage(fmt.Sprintf(`{"%s":"%s"}`, prop, plaintext)),
+					},
+				},
+			},
+		},
+	}
+
+	// Target config has one resolvable $ref (SecretString) plus a hashed field
+	// (StoredHash) that carries no $ref — ExtractOpaqueResolvableURIsFromJSON
+	// will not include it in the URI list, so it survives to the final
+	// ConvertToPluginFormat call, which rejects the $hashed marker.
+	targetCfg := json.RawMessage(fmt.Sprintf(`{
+		"Region": "us-east-1",
+		"ApiKey": {
+			"$ref": "formae://%s#/%s",
+			"$value": "old-value",
+			"$visibility": "Opaque"
+		},
+		"StoredHash": {
+			"$value": %q,
+			"$visibility": "Opaque",
+			"$hashed": true
+		}
+	}`, ksuid, prop, hashedPlaintext))
+
+	target := pkgmodel.Target{
+		Label:  "prod",
+		Config: targetCfg,
+	}
+
+	result, err := resolveTargetConfigForList(proc, target)
+
+	require.Error(t, err, "a ConvertToPluginFormat failure must surface as an error")
+	assert.Nil(t, result, "result must be nil — envelope config must not be returned")
+
+	errMsg := err.Error()
+	assert.NotContains(t, errMsg, plaintext,
+		"error must not contain the plaintext resolved value")
+	assert.NotContains(t, errMsg, hashedPlaintext,
+		"error must not contain the hashed field's stored value")
+	assert.NotContains(t, errMsg, "$value",
+		"error must not include raw $ref envelope fields")
+	assert.Contains(t, errMsg, "prod",
+		"error must name the target label for operator action")
 }
 
 // Ensure resolveStubProcess satisfies gen.Process.

--- a/internal/metastructure/discovery/resolve_target_config_test.go
+++ b/internal/metastructure/discovery/resolve_target_config_test.go
@@ -10,13 +10,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"ergo.services/ergo/gen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/changeset"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
@@ -426,6 +429,45 @@ var _ gen.Process = (*resolveStubProcess)(nil)
 // stubActorNamesSentinel verifies the expected actor name constant is accessible.
 var _ = actornames.ResourcePersister
 
+// recordingLog is a gen.Log test double that records every formatted message
+// produced by any log method. Tests use it to assert that no log line on the
+// resolve-failure path contains a plaintext secret or a raw "$value" envelope.
+type recordingLog struct {
+	gen.Log
+	mu       sync.Mutex
+	messages []string
+}
+
+func (r *recordingLog) record(format string, args ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.messages = append(r.messages, fmt.Sprintf(format, args...))
+}
+
+func (r *recordingLog) Trace(format string, args ...any)   { r.record(format, args...) }
+func (r *recordingLog) Debug(format string, args ...any)   { r.record(format, args...) }
+func (r *recordingLog) Info(format string, args ...any)    { r.record(format, args...) }
+func (r *recordingLog) Warning(format string, args ...any) { r.record(format, args...) }
+func (r *recordingLog) Error(format string, args ...any)   { r.record(format, args...) }
+func (r *recordingLog) Panic(format string, args ...any)   { r.record(format, args...) }
+
+func (r *recordingLog) allMessages() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.messages))
+	copy(out, r.messages)
+	return out
+}
+
+// recordingProcess wraps resolveStubProcess but routes Log() to a recordingLog
+// so tests can assert on the content of log lines produced during resolution.
+type recordingProcess struct {
+	*resolveStubProcess
+	log *recordingLog
+}
+
+func (p *recordingProcess) Log() gen.Log { return p.log }
+
 // buildDiscoveryDataWithTarget returns a DiscoveryData ready for
 // ensureTargetResolved tests: resolvedTargets/failedTargets are initialized and
 // the given target is registered.
@@ -548,3 +590,190 @@ func TestEnsureTargetResolved_NoOpaqueRefPassthrough(t *testing.T) {
 	assert.Equal(t, string(cfg), string(data.targets[label].Config),
 		"plain config must be stored unchanged")
 }
+
+// TestEnsureTargetResolved_ResolveFailureLogsNoSecret asserts that when a
+// target's opaque reference cannot be resolved, none of the log lines produced
+// on that failure path contain the plaintext secret value or a raw "$value"
+// envelope field. This test runs at the ensureTargetResolved seam: it
+// exercises the full call chain (ensureTargetResolved → resolveTargetConfigForList)
+// with a recording log and a failing LoadResource stub, then scans every captured
+// message for the sentinel values.
+func TestEnsureTargetResolved_ResolveFailureLogsNoSecret(t *testing.T) {
+	const label = "prod"
+	const ksuid = "35R2vyf6mT5wEs0mTWT5bp1Lf0E"
+	const prop = "SecretString"
+	// plaintext is the value stored in the $value envelope; it must not leak
+	// into any log line on the failure path.
+	const plaintext = "super-secret-credential-value"
+
+	inner := &resolveStubProcess{
+		loadErr: fmt.Errorf("secret source unavailable"),
+	}
+	recLog := &recordingLog{}
+	proc := &recordingProcess{resolveStubProcess: inner, log: recLog}
+
+	// Build a config with the plaintext embedded in the $value envelope so any
+	// accidental serialisation of the raw config would contain the sentinel.
+	targetCfg := json.RawMessage(strings.ReplaceAll(
+		string(buildOpaqueTargetConfig(ksuid, prop)),
+		"old-value", plaintext,
+	))
+	data := buildDiscoveryDataWithTarget(label, targetCfg)
+
+	data, ok := ensureTargetResolved(data, label, proc)
+
+	require.False(t, ok, "resolve must fail when the source is unavailable")
+	assert.True(t, data.failedTargets[label], "failed target must be recorded")
+
+	for _, msg := range recLog.allMessages() {
+		assert.NotContains(t, msg, plaintext,
+			"log line must not contain the plaintext secret: %s", msg)
+		assert.NotContains(t, msg, "$value",
+			"log line must not include raw $ref envelope fields: %s", msg)
+	}
+}
+
+// resolveFailureProcess is a gen.Process double that makes resolveTargetConfigForList
+// fail (LoadResource returns an error) while also acting as a rate-limiter stub
+// for the resumeScanning outer loop. It records every SpawnPluginOperator request
+// so tests can assert that no ListResources is ever dispatched for the failed target.
+type resolveFailureProcess struct {
+	gen.Process
+	log           *recordingLog
+	loadErr       error
+	spawnRequests []messages.SpawnPluginOperator
+}
+
+func (p *resolveFailureProcess) Log() gen.Log            { return p.log }
+func (p *resolveFailureProcess) Node() gen.Node          { return stubNode{} }
+func (p *resolveFailureProcess) PID() gen.PID            { return gen.PID{Node: "test-node", ID: 1} }
+func (p *resolveFailureProcess) Send(_ any, _ any) error { return nil }
+
+func (p *resolveFailureProcess) Call(_ any, message any) (any, error) {
+	switch m := message.(type) {
+	case changeset.RequestTokens:
+		return changeset.TokensGranted{N: m.N}, nil
+	case messages.LoadResource:
+		if p.loadErr != nil {
+			return nil, p.loadErr
+		}
+		return nil, fmt.Errorf("resolveFailureProcess: no load result configured")
+	case messages.SpawnPluginOperator:
+		p.spawnRequests = append(p.spawnRequests, m)
+		return messages.SpawnPluginOperatorResult{}, nil
+	default:
+		return nil, fmt.Errorf("resolveFailureProcess: unexpected Call %T", message)
+	}
+}
+
+// TestResumeScanning_FailedResolveNeverDispatchesListResources asserts that
+// when a target's opaque config cannot be resolved, resumeScanning skips the
+// SpawnPluginOperator call entirely — no ListResources reaches the plugin —
+// and the discovery cycle still completes (returns StateIdle) rather than
+// hanging in StateDiscovering.
+func TestResumeScanning_FailedResolveNeverDispatchesListResources(t *testing.T) {
+	const namespace = "FakeAWS"
+	const targetLabel = "us-east-1"
+	const ksuid = "35R2vyf6mT5wEs0mTWT5bp1Lf0E"
+	const prop = "SecretString"
+	const plaintext = "top-secret-cred"
+
+	// Target has an opaque $ref that cannot be resolved.
+	opaqueConfig := json.RawMessage(strings.ReplaceAll(
+		string(buildOpaqueTargetConfig(ksuid, prop)),
+		"old-value", plaintext,
+	))
+
+	proc := &resolveFailureProcess{
+		log:     &recordingLog{},
+		loadErr: fmt.Errorf("secret manager unavailable"),
+	}
+
+	data := DiscoveryData{
+		discoveryCfg: &pkgmodel.DiscoveryConfig{Enabled: true, Interval: 20 * time.Second},
+		targets: map[string]pkgmodel.Target{
+			targetLabel: {Label: targetLabel, Namespace: namespace, Config: opaqueConfig},
+		},
+		resourceDescriptors: map[string]plugin.ResourceDescriptor{
+			"FakeAWS::S3::Bucket": {Type: "FakeAWS::S3::Bucket", Discoverable: true},
+		},
+		queuedListOperations: map[string][]ListOperation{
+			namespace: {
+				{ResourceType: "FakeAWS::S3::Bucket", TargetLabel: targetLabel},
+			},
+		},
+		outstandingListOperations: map[string]ListOperation{},
+		outstandingSyncCommands:   map[string]ListOperation{},
+		summary:                   map[string]int{},
+		resolvedTargets:           make(map[string]bool),
+		failedTargets:             make(map[string]bool),
+		typesWithChildrenQueued:   map[string]struct{}{},
+		nativeIDsByCommand:        map[string][]string{},
+	}
+
+	nextState, resultData, _, err := resumeScanning(gen.PID{}, StateDiscovering, data, ResumeScanning{}, proc)
+
+	require.NoError(t, err, "a resolve failure must not crash the actor")
+	assert.Empty(t, proc.spawnRequests,
+		"SpawnPluginOperator must not be called for a target whose config resolution failed")
+	assert.True(t, resultData.failedTargets[targetLabel],
+		"the target must be recorded in failedTargets")
+	assert.Equal(t, StateIdle, nextState,
+		"a cycle where all targets fail resolution must still return to Idle")
+
+	// Redaction invariant: no log line must contain the plaintext or a raw "$value".
+	for _, msg := range proc.log.allMessages() {
+		assert.NotContains(t, msg, plaintext,
+			"log line must not leak the plaintext credential: %s", msg)
+		assert.NotContains(t, msg, "$value",
+			"log line must not include raw $ref envelope fields: %s", msg)
+	}
+}
+
+// TestOnStateChange_WarnsAboutFailedTargets asserts that when transitioning
+// from StateDiscovering to StateIdle with at least one failed target, a warning
+// log line is produced that names the failed target label(s) and their count.
+// No config content is logged — only labels, which are safe to surface.
+func TestOnStateChange_WarnsAboutFailedTargets(t *testing.T) {
+	recLog := &recordingLog{}
+	proc := &onStateChangeProc{log: recLog}
+
+	data := DiscoveryData{
+		timeStarted: time.Now().Add(-5 * time.Second),
+		summary:     map[string]int{},
+		failedTargets: map[string]bool{
+			"prod-us-east-1": true,
+			"staging-eu":     true,
+		},
+	}
+
+	_, _, err := onStateChange(StateDiscovering, StateIdle, data, proc)
+	require.NoError(t, err)
+
+	msgs := recLog.allMessages()
+	found := false
+	for _, msg := range msgs {
+		if strings.Contains(msg, "2") && strings.Contains(msg, "prod-us-east-1") && strings.Contains(msg, "staging-eu") {
+			found = true
+		}
+	}
+	assert.True(t, found,
+		"completion warning must name the count and labels of all failed targets, got: %v", msgs)
+
+	// Labels are safe to log but config contents must not appear.
+	for _, msg := range msgs {
+		assert.NotContains(t, msg, "$value",
+			"completion log must not include raw $ref envelope fields: %s", msg)
+	}
+}
+
+// onStateChangeProc is a minimal gen.Process stub whose Log() returns the
+// recording logger used by TestOnStateChange_WarnsAboutFailedTargets.
+type onStateChangeProc struct {
+	gen.Process
+	log *recordingLog
+}
+
+func (p *onStateChangeProc) Log() gen.Log   { return p.log }
+func (p *onStateChangeProc) Node() gen.Node { return stubNode{} }
+func (p *onStateChangeProc) PID() gen.PID   { return gen.PID{Node: "test-node", ID: 3} }

--- a/internal/metastructure/discovery/resolve_target_config_test.go
+++ b/internal/metastructure/discovery/resolve_target_config_test.go
@@ -1,0 +1,343 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package discovery
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// resolveStubProcess is a gen.Process test double for resolveTargetConfigForList tests.
+// It records LoadResource calls and configures plugin Read outcomes.
+type resolveStubProcess struct {
+	gen.Process
+
+	loadResourceCalls []pkgmodel.FormaeURI
+	loadResult        messages.LoadResourceResult
+	loadErr           error
+
+	// readAttempts counts how many times the plugin read is attempted
+	readAttempts int
+	// readResponses is an ordered list of responses to return per attempt;
+	// the last one is repeated if exhausted.
+	readResponses []readResponse
+}
+
+type readResponse struct {
+	progress *plugin.TrackedProgress
+	err      error
+}
+
+func (p *resolveStubProcess) Log() gen.Log            { return stubLog{} }
+func (p *resolveStubProcess) Node() gen.Node          { return stubNode{} }
+func (p *resolveStubProcess) PID() gen.PID            { return gen.PID{Node: "test-node", ID: 2} }
+func (p *resolveStubProcess) Send(_ any, _ any) error { return nil }
+
+func (p *resolveStubProcess) Call(_ any, message any) (any, error) {
+	switch m := message.(type) {
+	case messages.LoadResource:
+		p.loadResourceCalls = append(p.loadResourceCalls, m.ResourceURI)
+		if p.loadErr != nil {
+			return nil, p.loadErr
+		}
+		return p.loadResult, nil
+	case messages.SpawnPluginOperator:
+		p.readAttempts++
+		idx := p.readAttempts - 1
+		if idx >= len(p.readResponses) {
+			idx = len(p.readResponses) - 1
+		}
+		resp := p.readResponses[idx]
+		if resp.err != nil {
+			return nil, resp.err
+		}
+		return messages.SpawnPluginOperatorResult{
+			PID: gen.PID{Node: "test-node", ID: 99},
+		}, nil
+	default:
+		return nil, fmt.Errorf("resolveStubProcess: unexpected Call message %T", message)
+	}
+}
+
+func (p *resolveStubProcess) CallWithTimeout(_ any, message any, _ int) (any, error) {
+	// This is called for the actual plugin.ReadResource after spawn
+	if _, ok := message.(plugin.ReadResource); ok {
+		idx := p.readAttempts - 1
+		if idx >= len(p.readResponses) {
+			idx = len(p.readResponses) - 1
+		}
+		resp := p.readResponses[idx]
+		if resp.err != nil {
+			return nil, resp.err
+		}
+		return *resp.progress, nil
+	}
+	return nil, fmt.Errorf("resolveStubProcess: unexpected CallWithTimeout message %T", message)
+}
+
+// buildOpaqueTargetConfig creates a target config with one opaque $ref pointing
+// to the given KSUID and property path.
+func buildOpaqueTargetConfig(ksuid, prop string) json.RawMessage {
+	return json.RawMessage(fmt.Sprintf(`{
+		"Region": "us-east-1",
+		"ApiKey": {
+			"$ref": "formae://%s#/%s",
+			"$value": "old-value",
+			"$visibility": "Opaque"
+		}
+	}`, ksuid, prop))
+}
+
+// buildSourceResource creates a minimal Resource that the stub LoadResource returns.
+func buildSourceResource(ksuid string) pkgmodel.Resource {
+	return pkgmodel.Resource{
+		Ksuid:    ksuid,
+		Label:    "my-secret",
+		Type:     "FakeAWS::SecretsManager::Secret",
+		Stack:    "default",
+		Target:   "us-east-1",
+		NativeID: "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret",
+	}
+}
+
+// TestResolveTargetConfigForList_OpaqueRefResolved asserts that when a target
+// config carries one opaque $ref, the returned config has the $ref replaced
+// by the resolved plaintext and contains no "$ref" substring.
+func TestResolveTargetConfigForList_OpaqueRefResolved(t *testing.T) {
+	const ksuid = "35R2vyf6mT5wEs0mTWT5bp1Lf0E"
+	const prop = "SecretString"
+	const plaintext = "s3cr3t"
+
+	srcResource := buildSourceResource(ksuid)
+	srcTarget := pkgmodel.Target{
+		Label:     "us-east-1",
+		Namespace: "FakeAWS",
+		Config:    json.RawMessage(`{"Region":"us-east-1"}`),
+	}
+
+	proc := &resolveStubProcess{
+		loadResult: messages.LoadResourceResult{
+			Resource: srcResource,
+			Target:   srcTarget,
+		},
+		readResponses: []readResponse{
+			{
+				progress: &plugin.TrackedProgress{
+					ProgressResult: resource.ProgressResult{
+						OperationStatus:    resource.OperationStatusSuccess,
+						ResourceProperties: json.RawMessage(fmt.Sprintf(`{"%s":"%s"}`, prop, plaintext)),
+					},
+				},
+			},
+		},
+	}
+
+	targetCfg := buildOpaqueTargetConfig(ksuid, prop)
+	target := pkgmodel.Target{
+		Label:  "prod",
+		Config: targetCfg,
+	}
+
+	result, err := resolveTargetConfigForList(proc, target)
+
+	require.NoError(t, err)
+	assert.NotContains(t, string(result), `"$ref"`,
+		"resolved config must not contain any $ref markers")
+	assert.Contains(t, string(result), plaintext,
+		"resolved config must contain the plaintext value")
+
+	// Exactly one LoadResource call was issued (for the opaque URI)
+	require.Len(t, proc.loadResourceCalls, 1)
+	assert.Equal(t, pkgmodel.FormaeURI(fmt.Sprintf("formae://%s#", ksuid)),
+		proc.loadResourceCalls[0],
+		"LoadResource must be called with the stripped URI (no property path)")
+}
+
+// TestResolveTargetConfigForList_NoOpaqueRefs asserts that a target config
+// with no opaque refs is returned byte-identical and no LoadResource or Read
+// is issued.
+func TestResolveTargetConfigForList_NoOpaqueRefs(t *testing.T) {
+	proc := &resolveStubProcess{}
+
+	cfg := json.RawMessage(`{"Region":"us-east-1","AccountId":"123456789012"}`)
+	target := pkgmodel.Target{
+		Label:  "prod",
+		Config: cfg,
+	}
+
+	result, err := resolveTargetConfigForList(proc, target)
+
+	require.NoError(t, err)
+	assert.Equal(t, string(cfg), string(result),
+		"config without opaque refs must be returned byte-identical")
+	assert.Empty(t, proc.loadResourceCalls,
+		"no LoadResource must be issued when there are no opaque refs")
+	assert.Zero(t, proc.readAttempts,
+		"no Read must be issued when there are no opaque refs")
+}
+
+// TestResolveTargetConfigForList_NonRecoverableReadFailure asserts that a
+// non-recoverable plugin Read failure returns an error that names the target
+// and reference but does NOT contain the plaintext or any raw $value.
+func TestResolveTargetConfigForList_NonRecoverableReadFailure(t *testing.T) {
+	const ksuid = "35R2vyf6mT5wEs0mTWT5bp1Lf0E"
+	const prop = "SecretString"
+	const plaintext = "top-secret-value"
+
+	srcResource := buildSourceResource(ksuid)
+	srcTarget := pkgmodel.Target{
+		Label:     "us-east-1",
+		Namespace: "FakeAWS",
+		Config:    json.RawMessage(`{"Region":"us-east-1"}`),
+	}
+
+	proc := &resolveStubProcess{
+		loadResult: messages.LoadResourceResult{
+			Resource: srcResource,
+			Target:   srcTarget,
+		},
+		readResponses: []readResponse{
+			{
+				progress: &plugin.TrackedProgress{
+					ProgressResult: resource.ProgressResult{
+						OperationStatus: resource.OperationStatusFailure,
+						// A non-recoverable error code
+						ErrorCode: resource.OperationErrorCodeNotFound,
+					},
+				},
+			},
+		},
+	}
+
+	targetCfg := buildOpaqueTargetConfig(ksuid, prop)
+	// Embed plaintext into the config $value so we can check it's not leaked
+	targetCfg = json.RawMessage(strings.ReplaceAll(string(targetCfg), "old-value", plaintext))
+	target := pkgmodel.Target{
+		Label:  "prod",
+		Config: targetCfg,
+	}
+
+	result, err := resolveTargetConfigForList(proc, target)
+
+	require.Error(t, err, "non-recoverable read failure must return an error")
+	assert.Nil(t, result, "result must be nil on failure")
+
+	// Error must name the target or reference for operator action
+	errMsg := err.Error()
+	assert.True(t,
+		strings.Contains(errMsg, "prod") || strings.Contains(errMsg, ksuid),
+		"error must name the target label or reference URI, got: %s", errMsg)
+
+	// Error must NOT contain the plaintext or the raw $value
+	assert.NotContains(t, errMsg, plaintext,
+		"error must not leak the plaintext secret value")
+}
+
+// TestResolveTargetConfigForList_RecoverableFailureThenSuccess asserts that a
+// recoverable failure followed by success within the attempt budget resolves
+// successfully, and that exceeding the budget returns an error.
+func TestResolveTargetConfigForList_RecoverableFailureThenSuccess(t *testing.T) {
+	const ksuid = "35R2vyf6mT5wEs0mTWT5bp1Lf0E"
+	const prop = "SecretString"
+	const plaintext = "s3cr3t"
+
+	srcResource := buildSourceResource(ksuid)
+	srcTarget := pkgmodel.Target{
+		Label:     "us-east-1",
+		Namespace: "FakeAWS",
+		Config:    json.RawMessage(`{"Region":"us-east-1"}`),
+	}
+
+	targetCfg := buildOpaqueTargetConfig(ksuid, prop)
+	target := pkgmodel.Target{
+		Label:  "prod",
+		Config: targetCfg,
+	}
+
+	t.Run("recoverable then success", func(t *testing.T) {
+		proc := &resolveStubProcess{
+			loadResult: messages.LoadResourceResult{
+				Resource: srcResource,
+				Target:   srcTarget,
+			},
+			readResponses: []readResponse{
+				{
+					progress: &plugin.TrackedProgress{
+						ProgressResult: resource.ProgressResult{
+							OperationStatus: resource.OperationStatusFailure,
+							ErrorCode:       resource.OperationErrorCodeServiceTimeout, // recoverable
+						},
+					},
+				},
+				{
+					progress: &plugin.TrackedProgress{
+						ProgressResult: resource.ProgressResult{
+							OperationStatus:    resource.OperationStatusSuccess,
+							ResourceProperties: json.RawMessage(fmt.Sprintf(`{"%s":"%s"}`, prop, plaintext)),
+						},
+					},
+				},
+			},
+		}
+
+		result, err := resolveTargetConfigForList(proc, target)
+
+		require.NoError(t, err, "retry after recoverable failure must succeed")
+		assert.Contains(t, string(result), plaintext,
+			"resolved config must contain the plaintext after retry")
+		assert.GreaterOrEqual(t, proc.readAttempts, 2,
+			"at least two read attempts must be made: one failure, one success")
+	})
+
+	t.Run("exhausts budget", func(t *testing.T) {
+		// Build a process where every attempt is a recoverable failure
+		recoverableResp := readResponse{
+			progress: &plugin.TrackedProgress{
+				ProgressResult: resource.ProgressResult{
+					OperationStatus: resource.OperationStatusFailure,
+					ErrorCode:       resource.OperationErrorCodeServiceTimeout,
+				},
+			},
+		}
+		responses := make([]readResponse, maxDiscoveryResolveAttempts+1)
+		for i := range responses {
+			responses[i] = recoverableResp
+		}
+		proc := &resolveStubProcess{
+			loadResult: messages.LoadResourceResult{
+				Resource: srcResource,
+				Target:   srcTarget,
+			},
+			readResponses: responses,
+		}
+
+		result, err := resolveTargetConfigForList(proc, target)
+
+		require.Error(t, err, "exhausting the retry budget must return an error")
+		assert.Nil(t, result, "result must be nil when budget is exhausted")
+		assert.LessOrEqual(t, proc.readAttempts, maxDiscoveryResolveAttempts,
+			"must not exceed the attempt budget")
+	})
+}
+
+// Ensure resolveStubProcess satisfies gen.Process.
+var _ gen.Process = (*resolveStubProcess)(nil)
+
+// stubActorNamesSentinel verifies the expected actor name constant is accessible.
+var _ = actornames.ResourcePersister

--- a/internal/metastructure/discovery/resolve_target_config_test.go
+++ b/internal/metastructure/discovery/resolve_target_config_test.go
@@ -255,13 +255,14 @@ func TestResolveTargetConfigForList_NonRecoverableReadFailure(t *testing.T) {
 		"error must not include raw $ref envelope fields")
 }
 
-// TestResolveTargetConfigForList_RecoverableFailureThenSuccess asserts that a
-// recoverable failure followed by success within the attempt budget resolves
-// successfully, and that exceeding the budget returns an error.
-func TestResolveTargetConfigForList_RecoverableFailureThenSuccess(t *testing.T) {
+// TestResolveTargetConfigForList_RecoverableReadFailureReturnsError asserts that
+// a recoverable read failure surfaces as an error after a single attempt.
+// resolveTargetConfigForList is single-shot and never sleeps: discovery skips the
+// target for this cycle and retries it on the next cycle, so retry does not
+// happen inside this call.
+func TestResolveTargetConfigForList_RecoverableReadFailureReturnsError(t *testing.T) {
 	const ksuid = "35R2vyf6mT5wEs0mTWT5bp1Lf0E"
 	const prop = "SecretString"
-	const plaintext = "s3cr3t"
 
 	srcResource := buildSourceResource(ksuid)
 	srcTarget := pkgmodel.Target{
@@ -269,77 +270,34 @@ func TestResolveTargetConfigForList_RecoverableFailureThenSuccess(t *testing.T) 
 		Namespace: "FakeAWS",
 		Config:    json.RawMessage(`{"Region":"us-east-1"}`),
 	}
-
-	targetCfg := buildOpaqueTargetConfig(ksuid, prop)
 	target := pkgmodel.Target{
 		Label:  "prod",
-		Config: targetCfg,
+		Config: buildOpaqueTargetConfig(ksuid, prop),
 	}
 
-	t.Run("recoverable then success", func(t *testing.T) {
-		proc := &resolveStubProcess{
-			loadResult: messages.LoadResourceResult{
-				Resource: srcResource,
-				Target:   srcTarget,
-			},
-			readResponses: []readResponse{
-				{
-					progress: &plugin.TrackedProgress{
-						ProgressResult: resource.ProgressResult{
-							OperationStatus: resource.OperationStatusFailure,
-							ErrorCode:       resource.OperationErrorCodeServiceTimeout, // recoverable
-						},
-					},
-				},
-				{
-					progress: &plugin.TrackedProgress{
-						ProgressResult: resource.ProgressResult{
-							OperationStatus:    resource.OperationStatusSuccess,
-							ResourceProperties: json.RawMessage(fmt.Sprintf(`{"%s":"%s"}`, prop, plaintext)),
-						},
+	proc := &resolveStubProcess{
+		loadResult: messages.LoadResourceResult{
+			Resource: srcResource,
+			Target:   srcTarget,
+		},
+		readResponses: []readResponse{
+			{
+				progress: &plugin.TrackedProgress{
+					ProgressResult: resource.ProgressResult{
+						OperationStatus: resource.OperationStatusFailure,
+						ErrorCode:       resource.OperationErrorCodeServiceTimeout, // recoverable
 					},
 				},
 			},
-		}
+		},
+	}
 
-		result, err := resolveTargetConfigForList(proc, target)
+	result, err := resolveTargetConfigForList(proc, target)
 
-		require.NoError(t, err, "retry after recoverable failure must succeed")
-		assert.Contains(t, string(result), plaintext,
-			"resolved config must contain the plaintext after retry")
-		assert.GreaterOrEqual(t, proc.readAttempts, 2,
-			"at least two read attempts must be made: one failure, one success")
-	})
-
-	t.Run("exhausts budget", func(t *testing.T) {
-		// Build a process where every attempt is a recoverable failure
-		recoverableResp := readResponse{
-			progress: &plugin.TrackedProgress{
-				ProgressResult: resource.ProgressResult{
-					OperationStatus: resource.OperationStatusFailure,
-					ErrorCode:       resource.OperationErrorCodeServiceTimeout,
-				},
-			},
-		}
-		responses := make([]readResponse, maxDiscoveryResolveAttempts+1)
-		for i := range responses {
-			responses[i] = recoverableResp
-		}
-		proc := &resolveStubProcess{
-			loadResult: messages.LoadResourceResult{
-				Resource: srcResource,
-				Target:   srcTarget,
-			},
-			readResponses: responses,
-		}
-
-		result, err := resolveTargetConfigForList(proc, target)
-
-		require.Error(t, err, "exhausting the retry budget must return an error")
-		assert.Nil(t, result, "result must be nil when budget is exhausted")
-		assert.Equal(t, maxDiscoveryResolveAttempts, proc.readAttempts,
-			"must exhaust the full attempt budget on repeated recoverable failures")
-	})
+	require.Error(t, err, "a recoverable read failure must surface as an error, not an in-call retry")
+	assert.Nil(t, result)
+	assert.Equal(t, 1, proc.readAttempts,
+		"resolveTargetConfigForList must read exactly once: retry is the discovery cycle's job")
 }
 
 // TestResolveTargetConfigForList_ConvertFailureDoesNotLeakEnvelope asserts that

--- a/internal/metastructure/resource_update/plugin_read.go
+++ b/internal/metastructure/resource_update/plugin_read.go
@@ -1,0 +1,72 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package resource_update
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"ergo.services/ergo/gen"
+	"github.com/google/uuid"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// ReadResourceViaPlugin spawns a PluginOperator for the given resource and
+// executes a single Read call, returning the plugin's progress result.
+// It is a pure dispatch helper — callers own caching, retry, and result
+// interpretation.
+func ReadResourceViaPlugin(proc gen.Process, res pkgmodel.Resource, targetConfig json.RawMessage) (*plugin.TrackedProgress, error) {
+	operationID := uuid.New().String()
+	spawnResult, err := proc.Call(
+		gen.ProcessID{Name: actornames.PluginCoordinator, Node: proc.Node().Name()},
+		messages.SpawnPluginOperator{
+			Namespace:   res.Namespace(),
+			ResourceURI: string(res.URI()),
+			Operation:   string(resource.OperationRead),
+			OperationID: operationID,
+			RequestedBy: proc.PID(),
+		})
+	if err != nil {
+		return nil, fmt.Errorf("failed to spawn plugin operator: %w", err)
+	}
+	spawnRes, ok := spawnResult.(messages.SpawnPluginOperatorResult)
+	if !ok {
+		return nil, fmt.Errorf("unexpected result type from PluginCoordinator: %T", spawnResult)
+	}
+	if spawnRes.Error != "" {
+		return nil, fmt.Errorf("failed to spawn plugin operator: %s", spawnRes.Error)
+	}
+
+	// Use the same call budget as ResourceUpdater.doPluginOperation. The default
+	// Ergo Call timeout (5s) is too short for live AWS API reads, which routinely
+	// run longer than that — especially CloudControl GetResource immediately
+	// after a Create, when SDK credential resolution and the read itself stack up.
+	progressResult, err := proc.CallWithTimeout(
+		spawnRes.PID,
+		plugin.ReadResource{
+			Namespace:         res.Namespace(),
+			ResourceType:      res.Type,
+			ResourceNamespace: res.Namespace(),
+			ExistingResource:  res,
+			Resource:          res,
+			NativeID:          res.NativeID,
+			TargetConfig:      targetConfig,
+		},
+		PluginOperationCallTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read resource: %w", err)
+	}
+
+	progress, ok := progressResult.(plugin.TrackedProgress)
+	if !ok {
+		return nil, fmt.Errorf("unexpected result type from plugin operator: %T", progressResult)
+	}
+	return &progress, nil
+}

--- a/internal/workflow_tests/local/discovery_resolve_test.go
+++ b/internal/workflow_tests/local/discovery_resolve_test.go
@@ -1,0 +1,207 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/discovery"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// discoveryListCapture records the TargetConfig the plugin receives on each
+// List call so the assertion can inspect what reached the plugin boundary.
+type discoveryListCapture struct {
+	mu      sync.Mutex
+	configs []json.RawMessage
+}
+
+func (c *discoveryListCapture) add(cfg json.RawMessage) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cp := make(json.RawMessage, len(cfg))
+	copy(cp, cfg)
+	c.configs = append(c.configs, cp)
+}
+
+func (c *discoveryListCapture) all() []json.RawMessage {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]json.RawMessage, len(c.configs))
+	copy(out, c.configs)
+	return out
+}
+
+// TestDiscoveryResolve_TargetConfigOpaqueRefIsResolvedBeforeList asserts that
+// when a discoverable target's Config carries an opaque $ref pointing to a
+// managed secret's field, the discovery List call to the plugin receives the
+// RESOLVED credential value — not the raw {"$ref":…} object stored at rest.
+//
+// Setup:
+//   - Apply 1 creates a FakeAWS::SecretsManager::Secret ("my-secret") and a
+//     consumer target ("discovery-target") marked Discoverable=true, whose
+//     Config carries an opaque $ref to the secret's SecretString.
+//   - The stored Config retains only the $ref pointer (StripOpaqueRefValues
+//     drops $value for opaque refs before the row is persisted).
+//   - A fake plugin is registered; its List override records every TargetConfig
+//     it receives, and its Read override returns the secret's value so the
+//     ResolveCache can serve it when the discovery path resolves the target.
+//   - Discovery is triggered; the recorded List TargetConfig is asserted to
+//     carry the resolved credential and to contain no "$ref" substring.
+func TestDiscoveryResolve_TargetConfigOpaqueRefIsResolvedBeforeList(t *testing.T) {
+	t.Skip("enabled by discovery List-phase target-config resolution")
+
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const plaintextSecret = "discovery-target-config-secret-value"
+
+		capture := &discoveryListCapture{}
+
+		// The List override records TargetConfig for every call so we can later
+		// assert every List invocation against this target received resolved creds.
+		// The Read override serves the secret's resolved value so the ResolveCache
+		// can populate it when the discovery path resolves the target's config.
+		overrides := &plugin.ResourcePluginOverrides{
+			List: func(req *resource.ListRequest) (*resource.ListResult, error) {
+				capture.add(req.TargetConfig)
+				// Return one discoverable resource so the test can confirm discovery ran.
+				if req.ResourceType == "FakeAWS::S3::Bucket" {
+					return &resource.ListResult{NativeIDs: []string{"discovered-bucket-1"}}, nil
+				}
+				return &resource.ListResult{NativeIDs: nil}, nil
+			},
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				switch req.ResourceType {
+				case "FakeAWS::SecretsManager::Secret":
+					// Return the secret's resolved value so reads by the ResolveCache succeed.
+					return &resource.ReadResult{
+						ResourceType: req.ResourceType,
+						Properties:   fmt.Sprintf(`{"Name":"my-secret","SecretString":%q}`, plaintextSecret),
+					}, nil
+				case "FakeAWS::S3::Bucket":
+					return &resource.ReadResult{
+						ResourceType: req.ResourceType,
+						Properties:   fmt.Sprintf(`{"BucketName":%q}`, req.NativeID),
+					}, nil
+				}
+				return nil, fmt.Errorf("unexpected resource type in Read: %s", req.ResourceType)
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		// Apply 1: create the managed secret and the discoverable consumer target
+		// whose Config carries an opaque $ref to the secret's SecretString.
+		// Because consumer IS new in this apply a TargetUpdate fires and
+		// propagateResolvedTargetConfig resolves the $ref for any resource ops.
+		// The datastore strips the resolved $value before persisting
+		// (StripOpaqueRefValues), so the stored config retains only the raw $ref.
+		secretKsuid := "2MiD2rA1SJbLMGZgTL0hCxjkjjw"
+		stack := "discovery-resolve-test-stack"
+
+		// secretManagerSchema mirrors the FakeAWS SecretsManager::Secret schema
+		// (see internal/testplugin/fakeaws/fake_aws.go): SecretString is Opaque so
+		// the system treats its resolved value as a credential that must be hashed
+		// at rest and resolved on-demand when consumed by another entity.
+		secretManagerSchema := pkgmodel.Schema{
+			Identifier: "Id",
+			Fields:     []string{"Name", "Description", "SecretString", "Tags"},
+			Hints: map[string]pkgmodel.FieldHint{
+				"SecretString": {Opaque: true},
+			},
+		}
+
+		applyOne := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: stack}},
+			Resources: []pkgmodel.Resource{{
+				Label:      "my-secret",
+				Type:       "FakeAWS::SecretsManager::Secret",
+				Stack:      stack,
+				Target:     "provider",
+				Ksuid:      secretKsuid,
+				Schema:     secretManagerSchema,
+				Properties: json.RawMessage(`{"Name":"my-secret","SecretString":"` + plaintextSecret + `"}`),
+			}},
+			Targets: []pkgmodel.Target{
+				{Label: "provider", Namespace: "FakeAWS"},
+				{
+					Label:     "discovery-target",
+					Namespace: "FakeAWS",
+					// The opaque $ref to the secret's SecretString field. This is the
+					// value that must be resolved before List reaches the plugin.
+					Config: json.RawMessage(fmt.Sprintf(`{
+						"apiKey": {"$ref": "formae://%s#/SecretString", "$visibility": "Opaque"}
+					}`, secretKsuid)),
+					Discoverable: true,
+				},
+			},
+		}
+
+		_, err = m.ApplyForma(applyOne, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "discovery-resolve-client")
+		require.NoError(t, err)
+
+		// Wait for the apply to complete before triggering discovery.
+		require.Eventually(t, func() bool {
+			cmds, loadErr := m.Datastore.LoadIncompleteFormaCommands()
+			return loadErr == nil && len(cmds) == 0
+		}, 10*time.Second, 100*time.Millisecond, "apply must reach a terminal state before discovery")
+
+		// Confirm the stored target config retains only the $ref pointer (no $value,
+		// no plaintext) — proving the setup is correct and the gap is real.
+		discoveryTarget, err := m.Datastore.LoadTarget("discovery-target")
+		require.NoError(t, err)
+		require.NotNil(t, discoveryTarget, "discovery-target must have been persisted by apply 1")
+		require.Contains(t, string(discoveryTarget.Config), "$ref",
+			"stored target config must retain the $ref pointer")
+		require.NotContains(t, string(discoveryTarget.Config), plaintextSecret,
+			"stored target config must not persist the resolved plaintext")
+
+		// Trigger discovery. The discovery path must resolve the opaque $ref in
+		// discovery-target's Config before passing TargetConfig to the plugin's List.
+		incoming := make(chan any, 1)
+		_, err = testutil.StartTestHelperActor(m.Node, incoming)
+		require.NoError(t, err)
+
+		err = testutil.Send(m.Node, "Discovery", discovery.Discover{})
+		require.NoError(t, err)
+
+		// Wait until the discovered bucket appears in the unmanaged stack — this
+		// confirms the List override was actually called.
+		require.Eventually(t, func() bool {
+			resources, loadErr := m.Datastore.LoadResourcesByStack("$unmanaged")
+			return loadErr == nil && len(resources) >= 1
+		}, 10*time.Second, 100*time.Millisecond, "discovery must persist the discovered resource")
+
+		// Core assertion: every List call against discovery-target must have
+		// received the RESOLVED credential — not the raw $ref object.
+		configs := capture.all()
+		require.NotEmpty(t, configs, "List override must have been called at least once")
+
+		for i, cfg := range configs {
+			cfgStr := string(cfg)
+			assert.NotContains(t, cfgStr, `"$ref"`,
+				"List call %d: TargetConfig must not contain a raw $ref — it must be resolved before reaching the plugin", i)
+			assert.True(t, strings.Contains(cfgStr, plaintextSecret),
+				"List call %d: TargetConfig must contain the resolved credential value", i)
+		}
+	})
+}

--- a/internal/workflow_tests/local/discovery_resolve_test.go
+++ b/internal/workflow_tests/local/discovery_resolve_test.go
@@ -7,7 +7,6 @@ package workflow_tests_local
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -115,6 +114,7 @@ func TestDiscoveryResolve_TargetConfigOpaqueRefIsResolvedBeforeList(t *testing.T
 		// propagateResolvedTargetConfig resolves the $ref for any resource ops.
 		// The datastore strips the resolved $value before persisting
 		// (StripOpaqueRefValues), so the stored config retains only the raw $ref.
+		// arbitrary stable KSUID for the test secret — must match the $ref below.
 		secretKsuid := "2MiD2rA1SJbLMGZgTL0hCxjkjjw"
 		stack := "discovery-resolve-test-stack"
 
@@ -177,10 +177,6 @@ func TestDiscoveryResolve_TargetConfigOpaqueRefIsResolvedBeforeList(t *testing.T
 
 		// Trigger discovery. The discovery path must resolve the opaque $ref in
 		// discovery-target's Config before passing TargetConfig to the plugin's List.
-		incoming := make(chan any, 1)
-		_, err = testutil.StartTestHelperActor(m.Node, incoming)
-		require.NoError(t, err)
-
 		err = testutil.Send(m.Node, "Discovery", discovery.Discover{})
 		require.NoError(t, err)
 
@@ -200,7 +196,7 @@ func TestDiscoveryResolve_TargetConfigOpaqueRefIsResolvedBeforeList(t *testing.T
 			cfgStr := string(cfg)
 			assert.NotContains(t, cfgStr, `"$ref"`,
 				"List call %d: TargetConfig must not contain a raw $ref — it must be resolved before reaching the plugin", i)
-			assert.True(t, strings.Contains(cfgStr, plaintextSecret),
+			assert.Contains(t, cfgStr, plaintextSecret,
 				"List call %d: TargetConfig must contain the resolved credential value", i)
 		}
 	})

--- a/internal/workflow_tests/local/discovery_resolve_test.go
+++ b/internal/workflow_tests/local/discovery_resolve_test.go
@@ -63,8 +63,6 @@ func (c *discoveryListCapture) all() []json.RawMessage {
 //   - Discovery is triggered; the recorded List TargetConfig is asserted to
 //     carry the resolved credential and to contain no "$ref" substring.
 func TestDiscoveryResolve_TargetConfigOpaqueRefIsResolvedBeforeList(t *testing.T) {
-	t.Skip("enabled by discovery List-phase target-config resolution")
-
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		const plaintextSecret = "discovery-target-config-secret-value"
 
@@ -174,6 +172,10 @@ func TestDiscoveryResolve_TargetConfigOpaqueRefIsResolvedBeforeList(t *testing.T
 			"stored target config must retain the $ref pointer")
 		require.NotContains(t, string(discoveryTarget.Config), plaintextSecret,
 			"stored target config must not persist the resolved plaintext")
+
+		// Start the test helper actor so testutil.Send can relay messages.
+		_, err = testutil.StartTestHelperActor(m.Node, make(chan any, 1))
+		require.NoError(t, err)
 
 		// Trigger discovery. The discovery path must resolve the opaque $ref in
 		// discovery-target's Config before passing TargetConfig to the plugin's List.

--- a/pkg/model/redact.go
+++ b/pkg/model/redact.go
@@ -4,7 +4,11 @@
 
 package model
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
 
 // RedactedForLog is substituted for the plaintext of an opaque value when it is
 // prepared for logging or other diagnostics.
@@ -21,6 +25,22 @@ const RedactedForLog = "<redacted>"
 func RedactOpaqueForLog(v any) any {
 	switch t := v.(type) {
 	case map[string]any:
+		// An embedded field ({"$embed": true, "$template": "...RS base64(env) US..."})
+		// hides opaque values base64-framed inside the $template string, where the
+		// generic walk below cannot reach them. Redact each span's $value in place.
+		if t["$embed"] == true {
+			if tmpl, ok := t["$template"].(string); ok {
+				out := make(map[string]any, len(t))
+				for k, val := range t {
+					if k == "$template" {
+						out[k] = redactEmbedTemplate(tmpl)
+						continue
+					}
+					out[k] = RedactOpaqueForLog(val)
+				}
+				return out
+			}
+		}
 		opaque := t["$visibility"] == VisibilityOpaque
 		out := make(map[string]any, len(t))
 		for k, val := range t {
@@ -52,4 +72,41 @@ func RedactOpaqueForLog(v any) any {
 	default:
 		return v
 	}
+}
+
+// redactEmbedTemplate redacts opaque $value fields carried inside the framed
+// spans of an $embed $template string, then re-frames each span so the template
+// stays structurally intact. If the template cannot be scanned (corrupt framing),
+// it fails closed: the whole template is replaced with RedactedForLog rather than
+// risk leaking an unparseable payload.
+func redactEmbedTemplate(tmpl string) string {
+	spans, err := ScanEmbedSpans(tmpl)
+	if err != nil {
+		return RedactedForLog
+	}
+	out := tmpl
+	// Splice back-to-front so earlier spans' byte offsets stay valid.
+	for i := len(spans) - 1; i >= 0; i-- {
+		sp := spans[i]
+		redacted := RedactOpaqueForLog(json.RawMessage(sp.EnvelopeJSON))
+		reJSON, err := marshalNoEscape(redacted)
+		if err != nil {
+			// Should not happen for a span we just decoded; fail closed.
+			reJSON = `"` + RedactedForLog + `"`
+		}
+		out = out[:sp.Start] + FrameEnvelope(reJSON) + out[sp.End:]
+	}
+	return out
+}
+
+// marshalNoEscape marshals v to JSON without escaping <, >, & so the redaction
+// marker stays human-readable (RedactedForLog contains angle brackets).
+func marshalNoEscape(v any) (string, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return "", err
+	}
+	return strings.TrimRight(buf.String(), "\n"), nil
 }

--- a/pkg/model/redact_test.go
+++ b/pkg/model/redact_test.go
@@ -7,6 +7,7 @@
 package model
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -90,6 +91,58 @@ func TestRedactOpaqueForLog_RedactsOpaqueInsideJSONRawMessage(t *testing.T) {
 
 	assert.NotContains(t, result, "super-secret", "plaintext secret must not leak into redacted output")
 	assert.Contains(t, result, RedactedForLog)
+}
+
+func TestRedactOpaqueForLog_RedactsOpaqueInsideEmbedTemplate(t *testing.T) {
+	// A secret interpolated into a string field is stored as an embed:
+	// {$embed:true, $template:"...<RS base64(envelope) US>..."} where the framed
+	// envelope carries the resolved plaintext in $value. The generic walk cannot
+	// see it (the value lives base64-framed inside a string), so the redactor
+	// must decode, redact, and re-frame each span.
+	const secret = "super-secret-embedded"
+	envelope := `{"$ref":"formae://res","$visibility":"Opaque","$value":"` + secret + `"}`
+	tmpl := "https://user:" + FrameEnvelope(envelope) + "@example.com"
+	in := map[string]any{
+		"url": map[string]any{"$embed": true, "$template": tmpl},
+	}
+
+	out := RedactOpaqueForLog(in).(map[string]any)
+
+	// The redacted template's span must no longer decode to the plaintext.
+	redactedTmpl := out["url"].(map[string]any)["$template"].(string)
+	spans, err := ScanEmbedSpans(redactedTmpl)
+	require.NoError(t, err)
+	require.Len(t, spans, 1)
+	assert.Contains(t, spans[0].EnvelopeJSON, RedactedForLog, "span $value must be redacted")
+	assert.NotContains(t, spans[0].EnvelopeJSON, secret, "plaintext must not survive in the span")
+
+	// No serialized form may leak, including the base64 frame of the plaintext
+	// envelope.
+	var buf strings.Builder
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	require.NoError(t, enc.Encode(out))
+	result := buf.String()
+	assert.NotContains(t, result, secret, "plaintext must not leak")
+	assert.NotContains(t, result, base64.StdEncoding.EncodeToString([]byte(envelope)),
+		"the base64 frame carrying the plaintext must not survive")
+
+	// Input must not be mutated.
+	assert.Equal(t, tmpl, in["url"].(map[string]any)["$template"].(string), "input must not be mutated")
+}
+
+func TestRedactOpaqueForLog_PreservesClearEmbedSpan(t *testing.T) {
+	// A non-opaque (Clear) embedded value must survive redaction unchanged.
+	envelope := `{"$ref":"formae://res","$visibility":"Clear","$value":"public-part"}`
+	tmpl := "prefix-" + FrameEnvelope(envelope) + "-suffix"
+	in := map[string]any{"field": map[string]any{"$embed": true, "$template": tmpl}}
+
+	out := RedactOpaqueForLog(in).(map[string]any)
+	redactedTmpl := out["field"].(map[string]any)["$template"].(string)
+	spans, err := ScanEmbedSpans(redactedTmpl)
+	require.NoError(t, err)
+	require.Len(t, spans, 1)
+	assert.Contains(t, spans[0].EnvelopeJSON, "public-part", "clear embedded value must be preserved")
 }
 
 func TestRedactOpaqueForLog_UnparseableByteSlicePassedThrough(t *testing.T) {


### PR DESCRIPTION
## Discovery List-phase secret resolution

Resolve a discovery target's own config **before** the plugin `ListResources` call, so a target whose config references a managed secret via an opaque `$ref` is discoverable.

### Problem
Discovery passed target config to `ListResources` via `ConvertToPluginFormat`, which leaves an unresolved opaque `$ref` in place — so an unresolved credential reached `List` and could not be used. Target-config secrets were therefore apply-only and silently undiscoverable. The List phase runs pre-changeset, so the synthetic Resolve op (which lives inside `NewChangeset`, used by the post-List import changeset) does not cover it.

### Approach
The discovery List phase is sequential (one `List` per (type, target), not cancellable), so this adds a **synchronous, once-per-target** resolve — no fan-out machinery:

- `resource_update.ReadResourceViaPlugin` — a small plugin-Read dispatch helper extracted from `ResolveCache.readViaPlugin` (behavior-preserving) and shared by both the apply path and discovery.
- `resolveTargetConfigForList` — for each opaque `$ref` in a target's config: read the source secret via the plugin (bounded retry on recoverable errors), inject the value with `ResolvePropertyReferences` (honouring `.at()`/`.json()`), and return a plugin-ready resolved copy. No opaque refs → returned unchanged with no read.
- `ensureTargetResolved` — memoizes the resolved config once per target into in-memory discovery state and feeds it to every `List` op for that target.

### Guarantees
- **Reference-don't-store:** the resolved (plaintext) config is ephemeral — in-memory only, for the `List` dispatch; it is never written to the datastore. The persisted target row keeps its `$ref`.
- **Plaintext only in-flight:** the resolved credential reaches only the plugin `List` call.
- **No plaintext in logs/errors:** every failure path redacts (via `RedactOpaqueForLog`); errors name only the reference URI and target label.
- **Per-target failure surfacing:** a target whose config cannot be resolved (e.g. a missing/rotated source secret) is fail-closed for the cycle — its `List` is never dispatched with an unresolved or stale credential — and is surfaced in the discovery completion summary rather than silently omitted. It self-heals on the next cycle once the source resolves.

### Testing
- Workflow acceptance test: a discoverable target with an opaque `$ref` config → discovery → the plugin's `List` receives the resolved credential (no `$ref`); the persisted target still stores a bare `$ref`.
- Unit tests for once-per-target resolution, resolve-failure fail-closed + redaction, no-`List`-on-failure, and the completion-summary warning.
- Full `internal/metastructure/...` and `internal/workflow_tests/...` green.

### Known follow-ups (non-blocking)
- The source target's read-context config is converted with the guarded `ConvertToPluginFormat` (mirroring the existing resolve path); `ConvertExistingStateForRead` would be marginally cleaner for read-only identity context.
- Two test-assertion tightenings.

Stacked on the previous change in this series.
