### PR TITLE
feat(destroy): resolve target-config secrets on delete + dependency-aware secret deletion

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -140,7 +140,7 @@ func (c *Client) ApplyForma(forma *pkgmodel.Forma, mode pkgmodel.FormaApplyMode,
 	}
 }
 
-func (c *Client) DestroyForma(forma *pkgmodel.Forma, simulate bool, clientID string) (*apimodel.SubmitCommandResponse, error) {
+func (c *Client) DestroyForma(forma *pkgmodel.Forma, simulate bool, onDependents string, clientID string) (*apimodel.SubmitCommandResponse, error) {
 	var status apimodel.SubmitCommandResponse
 
 	formaJSON, err := json.Marshal(&forma)
@@ -157,8 +157,9 @@ func (c *Client) DestroyForma(forma *pkgmodel.Forma, simulate bool, clientID str
 		SetContentType("multipart/form-data").
 		SetHeader("Client-ID", clientID).
 		SetFormData(map[string]string{
-			"command":  "destroy",
-			"simulate": fmt.Sprintf("%t", simulate),
+			"command":       "destroy",
+			"simulate":      fmt.Sprintf("%t", simulate),
+			"on-dependents": onDependents,
 		}).
 		SetFileReader(formFieldName, clientFileName, formaBuffer).
 		Post(c.endpoint + "/api/v1/commands")
@@ -179,16 +180,17 @@ func (c *Client) DestroyForma(forma *pkgmodel.Forma, simulate bool, clientID str
 	}
 }
 
-func (c *Client) DestroyByQuery(query string, simulate bool, clientID string) (*apimodel.SubmitCommandResponse, error) {
+func (c *Client) DestroyByQuery(query string, simulate bool, onDependents string, clientID string) (*apimodel.SubmitCommandResponse, error) {
 	var status apimodel.SubmitCommandResponse
 	resp, err := c.resty.R().
 		SetResult(&status).
 		SetContentType("multipart/form-data").
 		SetHeader("Client-ID", clientID).
 		SetFormData(map[string]string{
-			"command":  "destroy",
-			"query":    query,
-			"simulate": fmt.Sprintf("%t", simulate),
+			"command":       "destroy",
+			"query":         query,
+			"simulate":      fmt.Sprintf("%t", simulate),
+			"on-dependents": onDependents,
 		}).
 		Post(c.endpoint + "/api/v1/commands")
 	if err != nil {
@@ -319,6 +321,13 @@ func (c *Client) parseSubmitCommandErrorResponse(body io.ReadCloser) (*apimodel.
 		var errResp apimodel.ErrorResponse[apimodel.TargetReapedError]
 		if err := json.Unmarshal(bodyBytes, &errResp); err != nil {
 			return nil, fmt.Errorf("failed to parse TargetReaped error: %w", err)
+		}
+		return nil, &errResp
+
+	case apimodel.TargetHasDependents:
+		var errResp apimodel.ErrorResponse[apimodel.FormaTargetHasDependentsError]
+		if err := json.Unmarshal(bodyBytes, &errResp); err != nil {
+			return nil, fmt.Errorf("failed to parse TargetHasDependents error: %w", err)
 		}
 		return nil, &errResp
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -331,6 +331,13 @@ func (c *Client) parseSubmitCommandErrorResponse(body io.ReadCloser) (*apimodel.
 		}
 		return nil, &errResp
 
+	case apimodel.ResourceHasDependents:
+		var errResp apimodel.ErrorResponse[apimodel.FormaResourceHasDependentsError]
+		if err := json.Unmarshal(bodyBytes, &errResp); err != nil {
+			return nil, fmt.Errorf("failed to parse ResourceHasDependents error: %w", err)
+		}
+		return nil, &errResp
+
 	case apimodel.RequiredFieldMissingOnCreate:
 		var errResp apimodel.ErrorResponse[apimodel.RequiredFieldMissingOnCreateError]
 		if err := json.Unmarshal(bodyBytes, &errResp); err != nil {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -5,10 +5,42 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"testing"
 
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// TestParseSubmitCommandErrorResponse_ResourceHasDependents asserts the client
+// decodes a 409 ResourceHasDependents body into a typed
+// FormaResourceHasDependentsError (so the CLI renders it) rather than falling
+// through to "unknown error type".
+func TestParseSubmitCommandErrorResponse_ResourceHasDependents(t *testing.T) {
+	body, err := json.Marshal(apimodel.ErrorResponse[apimodel.FormaResourceHasDependentsError]{
+		ErrorType: apimodel.ResourceHasDependents,
+		Data: apimodel.FormaResourceHasDependentsError{
+			Dependents: []apimodel.ResourceDependent{
+				{ResourceLabel: "child-subnet", ResourceType: "FakeAWS::EC2::Subnet", Stack: "consumer-stack", CascadeSource: "parent-vpc"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	c := &Client{}
+	_, perr := c.parseSubmitCommandErrorResponse(io.NopCloser(bytes.NewReader(body)))
+	require.Error(t, perr)
+
+	var got *apimodel.ErrorResponse[apimodel.FormaResourceHasDependentsError]
+	require.ErrorAs(t, perr, &got, "must decode into a typed FormaResourceHasDependentsError")
+	require.Len(t, got.Data.Dependents, 1)
+	assert.Equal(t, "child-subnet", got.Data.Dependents[0].ResourceLabel)
+	assert.Equal(t, "consumer-stack", got.Data.Dependents[0].Stack)
+	assert.Equal(t, "parent-vpc", got.Data.Dependents[0].CascadeSource)
+}
 
 func TestFormatEndpointStandardPort(t *testing.T) {
 	want := "http://localhost:49684"

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -811,6 +811,11 @@ func mapError(c echo.Context, err error) error {
 		return apiError(c, http.StatusConflict, apimodel.TargetHasDependents, targetHasDependentsError)
 	}
 
+	var resourceHasDependentsError apimodel.FormaResourceHasDependentsError
+	if errors.As(err, &resourceHasDependentsError) {
+		return apiError(c, http.StatusConflict, apimodel.ResourceHasDependents, resourceHasDependentsError)
+	}
+
 	var requiredFieldMissingError apimodel.RequiredFieldMissingOnCreateError
 	if errors.As(err, &requiredFieldMissingError) {
 		return apiError(c, http.StatusBadRequest, apimodel.RequiredFieldMissingOnCreate, requiredFieldMissingError)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -278,6 +278,7 @@ func (s *Server) configureEcho() *echo.Echo {
 // @Param simulate formData boolean false "If true, simulates command execution without actual changes to the infrastructure (defaults to false)."
 // @Param force formData boolean false "Only applies to the apply command in reconcile mode. If true, any changes made to the infrastructure since the last reconcile, either by patches or outside of Formae, will be overwritten."
 // @Param query formData string false "Only applies to destroy commands. A query string to select the resources to be destroyed."
+// @Param on-dependents formData string false "Only applies to destroy commands. Behavior when a delete would cascade onto dependent targets: abort (default) or cascade."
 // @Param file formData file false "A valid Forma file."
 // @Success 200 {object} apimodel.SubmitCommandResponse "OK: No changes required, or simulation result returned."
 // @Success 202 {object} apimodel.SubmitCommandResponse "Accepted: The command is validated, stored, and queued for execution."
@@ -320,10 +321,14 @@ func (s *Server) SubmitFormaCommand(c echo.Context) error {
 		}
 	case "destroy":
 		var err error
+		// on-dependents governs whether a destroy that cascades onto dependent
+		// targets aborts (default) or proceeds. Empty is treated as "abort" by the
+		// metastructure.
+		onDependents := c.FormValue("on-dependents")
 		query := c.FormValue("query")
 		if query != "" {
 			// If query is provided, use it
-			response, err = s.metastructure.DestroyByQuery(query, &config.FormaCommandConfig{Simulate: simulate}, clientID)
+			response, err = s.metastructure.DestroyByQuery(query, &config.FormaCommandConfig{Simulate: simulate, OnDependents: onDependents}, clientID)
 		} else {
 			// Otherwise, expect a Forma file
 			if !hasFormaFile(c) {
@@ -333,7 +338,7 @@ func (s *Server) SubmitFormaCommand(c echo.Context) error {
 			if getFormaErr != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, getFormaErr.Error())
 			}
-			response, err = s.metastructure.DestroyForma(forma, &config.FormaCommandConfig{Simulate: simulate}, clientID)
+			response, err = s.metastructure.DestroyForma(forma, &config.FormaCommandConfig{Simulate: simulate, OnDependents: onDependents}, clientID)
 		}
 		if err != nil {
 			return mapError(c, err)
@@ -799,6 +804,11 @@ func mapError(c echo.Context, err error) error {
 	var targetReapedError apimodel.TargetReapedError
 	if errors.As(err, &targetReapedError) {
 		return apiError(c, http.StatusConflict, apimodel.TargetReaped, targetReapedError)
+	}
+
+	var targetHasDependentsError apimodel.FormaTargetHasDependentsError
+	if errors.As(err, &targetHasDependentsError) {
+		return apiError(c, http.StatusConflict, apimodel.TargetHasDependents, targetHasDependentsError)
 	}
 
 	var requiredFieldMissingError apimodel.RequiredFieldMissingOnCreateError

--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -251,7 +251,7 @@ func (a *App) Apply(path string, props map[string]string, mode pkgmodel.FormaApp
 	return resp, nags, nil
 }
 
-func (a *App) Destroy(path string, query string, props map[string]string, simulate bool) (*apimodel.SubmitCommandResponse, []string, error) {
+func (a *App) Destroy(path string, query string, props map[string]string, simulate bool, onDependents string) (*apimodel.SubmitCommandResponse, []string, error) {
 	auth, net, err := a.getAuthAndNetHandlers()
 	if err != nil {
 		return nil, nil, err
@@ -285,12 +285,12 @@ func (a *App) Destroy(path string, query string, props map[string]string, simula
 			)
 		}
 
-		resp, err = client.DestroyForma(forma, simulate, clientID)
+		resp, err = client.DestroyForma(forma, simulate, onDependents, clientID)
 		if err != nil {
 			return nil, nil, err
 		}
 	} else {
-		resp, err = client.DestroyByQuery(query, simulate, clientID)
+		resp, err = client.DestroyByQuery(query, simulate, onDependents, clientID)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/cli/destroy/destroy.go
+++ b/internal/cli/destroy/destroy.go
@@ -69,7 +69,7 @@ var (
 	}
 
 	destroyFn = func(a *app.App, opts *DestroyOptions, simulate bool) (*apimodel.SubmitCommandResponse, []string, error) {
-		return a.Destroy(opts.FormaFile, opts.Query, opts.Properties, simulate)
+		return a.Destroy(opts.FormaFile, opts.Query, opts.Properties, simulate, string(opts.OnDependents))
 	}
 )
 
@@ -268,7 +268,12 @@ func runDestroyInteractive(a *app.App, opts *DestroyOptions) error {
 		return nil
 	}
 
-	// Confirmed: run the real destroy.
+	// Confirmed: run the real destroy. If the simulation showed cascade deletes,
+	// the interactive confirmation serves as the user's opt-in — elevate to cascade
+	// so the server gate does not reject with a dependents conflict.
+	if hasCascadeDeletes(&res.Simulation.Command) {
+		opts.OnDependents = OnDependentsCascade
+	}
 	realRes, _, err := destroyFn(a, opts, false)
 	if err != nil {
 		msg, renderErr := errfmt.Render(err)
@@ -399,6 +404,12 @@ func runDestroyLegacy(app *app.App, opts *DestroyOptions) error {
 			th := app.Theme()
 			fmt.Print(lipgloss.NewStyle().Foreground(th.Palette.Error).Render("\nCommand aborted") + "\n")
 			return nil
+		}
+		// The interactive confirmation serves as the user's opt-in for cascade
+		// deletes — elevate so the server gate does not reject with a dependents
+		// conflict when the simulation showed cascades.
+		if hasCascades {
+			opts.OnDependents = OnDependentsCascade
 		}
 	}
 

--- a/internal/cli/destroy/destroy_confirm_test.go
+++ b/internal/cli/destroy/destroy_confirm_test.go
@@ -7,6 +7,7 @@
 package destroy
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -140,4 +141,49 @@ func TestDestroyLegacy_TTY_Declined_Aborts(t *testing.T) {
 	err := runDestroyLegacy(a, opts)
 	require.NoError(t, err)
 	assert.Equal(t, 1, destroyCallCount, "only simulate call — real destroy not submitted after decline")
+}
+
+// TestDestroyLegacy_TTY_Confirmed_Cascade_ElevatesOnDependents asserts that when
+// the legacy path's simulation shows cascade deletes and the user confirms via
+// the interactive prompt, the real destroy call receives OnDependentsCascade —
+// not the default abort. Without this elevation the server gate returns 409
+// even after an explicit interactive confirmation.
+func TestDestroyLegacy_TTY_Confirmed_Cascade_ElevatesOnDependents(t *testing.T) {
+	stubDestroyConfirmSeams(t)
+	origLaunchWatch := launchWatch
+	origLegacyWidth := legacyWidth
+	t.Cleanup(func() {
+		launchWatch = origLaunchWatch
+		legacyWidth = origLegacyWidth
+	})
+
+	legacyWidth = func(w io.Writer) int { return 100 }
+	launchWatch = func(a *app.App, commandID string) (bool, error) { return true, nil }
+
+	var realOnDependents OnDependents
+	destroyFn = func(a *app.App, opts *DestroyOptions, simulate bool) (*apimodel.SubmitCommandResponse, []string, error) {
+		if simulate {
+			return &apimodel.SubmitCommandResponse{Simulation: cascadeSimulation()}, nil, nil
+		}
+		realOnDependents = opts.OnDependents
+		return &apimodel.SubmitCommandResponse{CommandID: "legacy-cascade-cmd"}, nil, nil
+	}
+
+	isInteractive = func() bool { return true }
+	runConfirm = func(_ *theme.Theme, _, _ string) (bool, error) {
+		return true, nil // user confirmed
+	}
+
+	a := newTestApp()
+	opts := &DestroyOptions{
+		OutputConsumer: printer.ConsumerHuman,
+		FormaFile:      "forma.pkl",
+		OnDependents:   OnDependentsAbort,
+		Yes:            false,
+	}
+
+	err := runDestroyLegacy(a, opts)
+	require.NoError(t, err)
+	assert.Equal(t, OnDependentsCascade, realOnDependents,
+		"legacy interactive confirm with cascades must pass OnDependentsCascade to the real destroy call")
 }

--- a/internal/cli/destroy/destroy_e2e_test.go
+++ b/internal/cli/destroy/destroy_e2e_test.go
@@ -133,7 +133,7 @@ func TestDestroyTUI_EndToEnd(t *testing.T) {
 	var postedSimulateFlags []bool
 	destroyFn = func(a *app.App, opts *DestroyOptions, simulate bool) (*apimodel.SubmitCommandResponse, []string, error) {
 		postedSimulateFlags = append(postedSimulateFlags, simulate)
-		resp, err := client.DestroyByQuery(opts.Query, simulate, "e2e-client")
+		resp, err := client.DestroyByQuery(opts.Query, simulate, string(opts.OnDependents), "e2e-client")
 		return resp, nil, err
 	}
 
@@ -226,7 +226,7 @@ func TestDestroyTUI_EndToEnd_CascadeAbort(t *testing.T) {
 	postCount := 0
 	destroyFn = func(a *app.App, opts *DestroyOptions, simulate bool) (*apimodel.SubmitCommandResponse, []string, error) {
 		postCount++
-		resp, err := client.DestroyByQuery(opts.Query, simulate, "e2e-client")
+		resp, err := client.DestroyByQuery(opts.Query, simulate, string(opts.OnDependents), "e2e-client")
 		return resp, nil, err
 	}
 

--- a/internal/cli/destroy/destroy_tui_test.go
+++ b/internal/cli/destroy/destroy_tui_test.go
@@ -594,3 +594,45 @@ func TestDestroy_TTY_Confirmed_EarlyDetach_PrintsAsyncNotice(t *testing.T) {
 	assert.Contains(t, out, "Still running asynchronously on the agent. Check its status with:")
 	assert.Contains(t, out, "formae status command --query='id:detached-cmd-2'")
 }
+
+// TestDestroy_Interactive_Cascades_ElevatesOnDependents asserts that when the
+// interactive path's simulation shows cascade deletes and the user confirms via
+// the simview, the real destroy call receives OnDependentsCascade — not the
+// default abort. Without this elevation the server gate returns 409 on cascade
+// destroys even after an explicit confirmation.
+func TestDestroy_Interactive_Cascades_ElevatesOnDependents(t *testing.T) {
+	stubSeams(t)
+
+	isTerminal = func(w io.Writer) bool { return true }
+
+	var realOnDependents OnDependents
+	destroyFn = func(a *app.App, opts *DestroyOptions, simulate bool) (*apimodel.SubmitCommandResponse, []string, error) {
+		if simulate {
+			return &apimodel.SubmitCommandResponse{Simulation: cascadeSimulation()}, nil, nil
+		}
+		realOnDependents = opts.OnDependents
+		return &apimodel.SubmitCommandResponse{CommandID: "elevated-cascade-cmd"}, nil, nil
+	}
+
+	launchSimView = func(th *theme.Theme, sim *apimodel.Simulation, opts simview.Options) (simview.Decision, error) {
+		return simview.DecisionConfirmed, nil
+	}
+
+	launchWatch = func(a *app.App, commandID string) (bool, error) { return true, nil }
+
+	a := newTestApp()
+	opts := &DestroyOptions{
+		OutputConsumer: printer.ConsumerHuman,
+		FormaFile:      "forma.pkl",
+		OnDependents:   OnDependentsAbort,
+		Yes:            false,
+	}
+
+	_ = captureStdout(t, func() {
+		err := runDestroyForHumans(a, opts)
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, OnDependentsCascade, realOnDependents,
+		"interactive confirm with cascades must pass OnDependentsCascade to the real destroy call")
+}

--- a/internal/cli/tui/errfmt/errfmt.go
+++ b/internal/cli/tui/errfmt/errfmt.go
@@ -152,6 +152,10 @@ func (r *renderer) render(err error) (string, error) {
 		msg = r.renderTargetHasDependents(&errResp.Data)
 	}
 
+	if errResp, ok := err.(*apimodel.ErrorResponse[apimodel.FormaResourceHasDependentsError]); ok {
+		msg = r.renderResourceHasDependents(&errResp.Data)
+	}
+
 	if errResp, ok := err.(*apimodel.ErrorResponse[apimodel.PluginNotFoundError]); ok {
 		msg = r.errorf("plugin '%s' not found\n", errResp.Data.Name)
 	}
@@ -361,6 +365,28 @@ func (r *renderer) renderTargetHasDependents(data *apimodel.FormaTargetHasDepend
 	message += r.warning("A target's config references a resource being deleted. Removing it would leave the\n"+
 		"dependent target unresolvable.\n\n") +
 		"To proceed and tear the dependent target(s) and their resources down too, re-run with\n" +
+		"--on-dependents=cascade.\n"
+	return message
+}
+
+// renderResourceHasDependents formats FormaResourceHasDependentsError: a destroy
+// that would cascade-delete dependent resources (a resource whose CreateOnly field
+// references one being deleted), possibly across stacks.
+func (r *renderer) renderResourceHasDependents(data *apimodel.FormaResourceHasDependentsError) string {
+	var message string
+	if len(data.Dependents) == 1 {
+		d := data.Dependents[0]
+		message = r.errorf("deleting '%s' would cascade-delete dependent resource '%s'.\n\n", d.CascadeSource, d.ResourceLabel)
+	} else {
+		message = r.error("this delete would cascade-delete the following dependent resources:\n\n")
+		for _, d := range data.Dependents {
+			message += fmt.Sprintf("  - %s (%s, stack %s; referenced by %s)\n", d.ResourceLabel, d.ResourceType, d.Stack, d.CascadeSource)
+		}
+		message += "\n"
+	}
+	message += r.warning("Another resource references a resource being deleted on a create-only field, so\n"+
+		"it would be torn down too.\n\n") +
+		"To proceed and tear the dependent resource(s) down as well, re-run with\n" +
 		"--on-dependents=cascade.\n"
 	return message
 }

--- a/internal/cli/tui/errfmt/errfmt.go
+++ b/internal/cli/tui/errfmt/errfmt.go
@@ -148,6 +148,10 @@ func (r *renderer) render(err error) (string, error) {
 		msg = r.renderTargetReaped(&errResp.Data)
 	}
 
+	if errResp, ok := err.(*apimodel.ErrorResponse[apimodel.FormaTargetHasDependentsError]); ok {
+		msg = r.renderTargetHasDependents(&errResp.Data)
+	}
+
 	if errResp, ok := err.(*apimodel.ErrorResponse[apimodel.PluginNotFoundError]); ok {
 		msg = r.errorf("plugin '%s' not found\n", errResp.Data.Name)
 	}
@@ -337,6 +341,27 @@ func (r *renderer) renderTargetReaped(data *apimodel.TargetReapedError) string {
 		"to it without re-declaring it would silently resurrect it.\n\n") +
 		"To recover it, re-declare the target in your forma file (its 'targets' block) and\n" +
 		"apply again — this mints a fresh incarnation and brings the target back under management.\n"
+	return message
+}
+
+// renderTargetHasDependents formats FormaTargetHasDependentsError: a destroy that
+// would cascade onto targets whose config references a resource being deleted.
+func (r *renderer) renderTargetHasDependents(data *apimodel.FormaTargetHasDependentsError) string {
+	var message string
+	if len(data.Dependents) == 1 {
+		d := data.Dependents[0]
+		message = r.errorf("deleting '%s' would cascade-delete dependent target '%s' and its resources.\n\n", d.CascadeSource, d.TargetLabel)
+	} else {
+		message = r.error("this delete would cascade-delete the following dependent targets and their resources:\n\n")
+		for _, d := range data.Dependents {
+			message += fmt.Sprintf("  - %s (referenced by %s)\n", d.TargetLabel, d.CascadeSource)
+		}
+		message += "\n"
+	}
+	message += r.warning("A target's config references a resource being deleted. Removing it would leave the\n"+
+		"dependent target unresolvable.\n\n") +
+		"To proceed and tear the dependent target(s) and their resources down too, re-run with\n" +
+		"--on-dependents=cascade.\n"
 	return message
 }
 

--- a/internal/metastructure/changeset/changeset_test.go
+++ b/internal/metastructure/changeset/changeset_test.go
@@ -2966,6 +2966,19 @@ func opaqueRefConfig(refURI string) json.RawMessage {
 	return json.RawMessage(`{"auth":{"$ref":"` + refURI + `","$visibility":"Opaque"}}`)
 }
 
+// jsonCredConfig mirrors how a Grafana target's basic-auth credentials persist
+// when sourced from a JSON secret via secret.res.secretValue.json("<key>"): a
+// $ref to the secret's value property plus a $json extraction path. Crucially the
+// envelope's $visibility is "Clear" — opacity is derived from the source secret's
+// FieldHint at resolve time, not stamped on the envelope — even though the
+// resolved value is a credential the plugin needs to authenticate.
+func jsonCredConfig(refURI string) json.RawMessage {
+	return json.RawMessage(`{` +
+		`"username":{"$ref":"` + refURI + `","$json":"username","$visibility":"Clear"},` +
+		`"password":{"$ref":"` + refURI + `","$json":"password","$visibility":"Clear"}` +
+		`}`)
+}
+
 func hasDependencyOn(node *DAGNode, uri pkgmodel.FormaeURI) bool {
 	for _, dep := range node.Dependencies {
 		if dep.URI == uri {
@@ -3378,4 +3391,286 @@ func TestNewChangeset_ValidTargetResolvableEdge_NoFalsePositive(t *testing.T) {
 	cs, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-valid-resolvable", pkgmodel.CommandApply, ds)
 	require.NoError(t, err, "a valid acyclic target-resolvable edge must not be rejected")
 	assert.False(t, cs.DAG.HasCycles(), "the built graph must be acyclic")
+}
+
+// TestNewChangeset_SynthesizesResolveForDeleteOnlyOpaqueTarget asserts that a target
+// carrying opaque $ref config gets a synthetic Resolve node even when the only target
+// update for that target is a Delete op. A Delete TU does not carry re-resolved config,
+// so resource-delete ops on that target must still get a Resolve dependency or they
+// dispatch with an unresolved credential.
+func TestNewChangeset_SynthesizesResolveForDeleteOnlyOpaqueTarget(t *testing.T) {
+	const targetLabel = "t1"
+	refURI := pkgmodel.NewFormaeURI(util.NewID(), "SecretString")
+
+	ds := &stubResolveDatastore{targets: map[string]*pkgmodel.Target{
+		targetLabel: {Label: targetLabel, Namespace: "AWS", Config: opaqueRefConfig(string(refURI))},
+	}}
+
+	deleteKsuid := util.NewID()
+	resourceUpdates := []resource_update.ResourceUpdate{
+		{
+			PriorState:   pkgmodel.Resource{Label: "res", Type: "AWS::S3::Bucket", Stack: "s", Ksuid: deleteKsuid, Target: targetLabel},
+			DesiredState: pkgmodel.Resource{Label: "res", Type: "AWS::S3::Bucket", Stack: "s", Ksuid: deleteKsuid, Target: targetLabel},
+			Operation:    resource_update.OperationDelete,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+	}
+
+	// The only TU for t1 is a Delete — it must NOT suppress Resolve synthesis.
+	targetUpdates := []target_update.TargetUpdate{
+		{
+			Target:    pkgmodel.Target{Label: targetLabel, Namespace: "AWS"},
+			Operation: target_update.TargetOperationDelete,
+			State:     target_update.TargetUpdateStateNotStarted,
+		},
+	}
+
+	cs, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-delete-resolve", pkgmodel.CommandApply, ds)
+	require.NoError(t, err)
+
+	resolveURI := pkgmodel.FormaeURI("target://" + targetLabel + "/resolve")
+	resolveNode := cs.DAG.Nodes[resolveURI]
+	require.NotNil(t, resolveNode, "expected a synthetic Resolve node for the delete-only opaque target")
+
+	tu, ok := resolveNode.Update.(*target_update.TargetUpdate)
+	require.True(t, ok)
+	assert.Equal(t, target_update.TargetOperationResolve, tu.Operation)
+	require.Len(t, tu.RemainingResolvables, 1)
+	assert.Equal(t, refURI, tu.RemainingResolvables[0])
+
+	deleteNode := dagNodeForOp(t, cs.DAG, pkgmodel.NewFormaeURI(deleteKsuid, ""), resource_update.OperationDelete)
+	assert.True(t, hasDependencyOn(deleteNode, resolveURI),
+		"resource-delete must depend on the Resolve node so it dispatches with resolved config")
+}
+
+// TestNewChangeset_SynthesizesResolveForCascadeDeletedOpaqueTarget asserts that a
+// target cascade-deleted because its $ref source resource is torn down in the same
+// command DOES get a synthetic Resolve node. The cascade orders the source-secret
+// delete AFTER the target delete, so the secret is still present when the target
+// resolves — the resource deletes on that target must dispatch with the resolved
+// credential, exactly like a plain delete.
+//
+// It also asserts the DAG ordering holds and is acyclic:
+//
+//	Resolve(target) → resource-delete → target-delete → secret-delete
+func TestNewChangeset_SynthesizesResolveForCascadeDeletedOpaqueTarget(t *testing.T) {
+	const targetLabel = "consumer"
+	// The secret source resource lives on some other target; the cascade target's
+	// config $refs it. Deleting the secret is what triggers the cascade.
+	secretKsuid := util.NewID()
+	refURI := pkgmodel.NewFormaeURI(secretKsuid, "SecretString")
+
+	ds := &stubResolveDatastore{targets: map[string]*pkgmodel.Target{
+		targetLabel: {Label: targetLabel, Namespace: "AWS", Config: opaqueRefConfig(string(refURI))},
+	}}
+
+	// A resource-delete on the cascade target (the deployment being torn down).
+	deploymentKsuid := util.NewID()
+	// The source secret's own delete op — it must run LAST (after the target delete).
+	resourceUpdates := []resource_update.ResourceUpdate{
+		{
+			PriorState:   pkgmodel.Resource{Label: "deployment", Type: "AWS::S3::Bucket", Stack: "consumer-stack", Ksuid: deploymentKsuid, Target: targetLabel},
+			DesiredState: pkgmodel.Resource{Label: "deployment", Type: "AWS::S3::Bucket", Stack: "consumer-stack", Ksuid: deploymentKsuid, Target: targetLabel},
+			Operation:    resource_update.OperationDelete,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "consumer-stack",
+		},
+		{
+			PriorState:   pkgmodel.Resource{Label: "secret", Type: "AWS::SecretsManager::Secret", Stack: "s", Ksuid: secretKsuid, Target: "provider"},
+			DesiredState: pkgmodel.Resource{Label: "secret", Type: "AWS::SecretsManager::Secret", Stack: "s", Ksuid: secretKsuid, Target: "provider"},
+			Operation:    resource_update.OperationDelete,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+	}
+
+	// A cascade Delete TU: the target's $ref source is being deleted in this command.
+	// ExistingTarget carries the opaque $ref config so the reversed delete edge and the
+	// synthetic Resolve can both find the resolvable.
+	targetUpdates := []target_update.TargetUpdate{
+		target_update.NewTargetUpdateForCascadeDelete(
+			&pkgmodel.Target{Label: targetLabel, Namespace: "AWS", Config: opaqueRefConfig(string(refURI))},
+			"secret",
+		),
+	}
+
+	cs, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-cascade-resolve", pkgmodel.CommandApply, ds)
+	require.NoError(t, err)
+
+	// A synthetic Resolve node must exist for the cascade target.
+	resolveURI := pkgmodel.FormaeURI("target://" + targetLabel + "/resolve")
+	resolveNode := cs.DAG.Nodes[resolveURI]
+	require.NotNil(t, resolveNode, "a cascade-deleted opaque target must get a synthetic Resolve node")
+
+	tu, ok := resolveNode.Update.(*target_update.TargetUpdate)
+	require.True(t, ok)
+	assert.Equal(t, target_update.TargetOperationResolve, tu.Operation)
+	require.Len(t, tu.RemainingResolvables, 1)
+	assert.Equal(t, refURI, tu.RemainingResolvables[0])
+
+	// The deployment resource-delete depends on the Resolve node.
+	deploymentDelete := dagNodeForOp(t, cs.DAG, pkgmodel.NewFormaeURI(deploymentKsuid, ""), resource_update.OperationDelete)
+	assert.True(t, hasDependencyOn(deploymentDelete, resolveURI),
+		"resource-delete on the cascade target must depend on the Resolve node")
+
+	// The source secret-delete depends on the cascade target-delete (reversed edge),
+	// so the secret is still present at Resolve time.
+	targetDeleteURI := pkgmodel.FormaeURI("target://" + targetLabel + "/delete")
+	secretDelete := dagNodeForOp(t, cs.DAG, pkgmodel.NewFormaeURI(secretKsuid, ""), resource_update.OperationDelete)
+	assert.True(t, hasDependencyOn(secretDelete, targetDeleteURI),
+		"source secret-delete must wait for the cascade target-delete so the secret is present at Resolve time")
+
+	assert.False(t, cs.DAG.HasCycles(), "the cascade delete graph must be acyclic")
+}
+
+// TestNewChangeset_SynthesizesResolveForCascadeDeletedJSONCredTarget asserts the
+// headline case for the delete path: a cascade-deleted target whose
+// credentials come from a JSON secret via .json() (persisted as $ref+$json with
+// $visibility "Clear") must still get a synthetic Resolve, and its resource-delete
+// ops must depend on that Resolve — otherwise the plugin dispatches the teardown
+// with unresolved credentials and the real cloud resource is orphaned. This is the
+// same shape as the opaque-$ref cascade test, but with .json()-derived Clear
+// credentials rather than a directly-opaque $ref.
+func TestNewChangeset_SynthesizesResolveForCascadeDeletedJSONCredTarget(t *testing.T) {
+	const targetLabel = "consumer"
+	secretKsuid := util.NewID()
+	refURI := pkgmodel.NewFormaeURI(secretKsuid, "SecretString")
+
+	// The source secret resource: its SecretString property is opaque at rest, so
+	// the .json() credential refs deriving from it are really secrets even though
+	// their consumer-side envelopes are Clear.
+	ds := &stubResolveDatastore{
+		targets: map[string]*pkgmodel.Target{
+			targetLabel: {Label: targetLabel, Namespace: "GRAFANA", Config: jsonCredConfig(string(refURI))},
+		},
+		resources: map[string]*pkgmodel.Resource{
+			secretKsuid: {
+				Label: "secret", Type: "AWS::SecretsManager::Secret", Ksuid: secretKsuid, Target: "provider",
+				Properties: json.RawMessage(`{"SecretString":{"$value":"deadbeef","$visibility":"Opaque","$hashed":true,"$strategy":"Update"}}`),
+			},
+		},
+	}
+
+	// A resource-delete on the cascade target (the folder being torn down), plus
+	// the source secret's own delete op (must run last).
+	folderKsuid := util.NewID()
+	resourceUpdates := []resource_update.ResourceUpdate{
+		{
+			PriorState:   pkgmodel.Resource{Label: "folder", Type: "GRAFANA::Core::Folder", Stack: "consumer-stack", Ksuid: folderKsuid, Target: targetLabel},
+			DesiredState: pkgmodel.Resource{Label: "folder", Type: "GRAFANA::Core::Folder", Stack: "consumer-stack", Ksuid: folderKsuid, Target: targetLabel},
+			Operation:    resource_update.OperationDelete,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "consumer-stack",
+		},
+		{
+			PriorState:   pkgmodel.Resource{Label: "secret", Type: "AWS::SecretsManager::Secret", Stack: "s", Ksuid: secretKsuid, Target: "provider"},
+			DesiredState: pkgmodel.Resource{Label: "secret", Type: "AWS::SecretsManager::Secret", Stack: "s", Ksuid: secretKsuid, Target: "provider"},
+			Operation:    resource_update.OperationDelete,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+	}
+
+	targetUpdates := []target_update.TargetUpdate{
+		target_update.NewTargetUpdateForCascadeDelete(
+			&pkgmodel.Target{Label: targetLabel, Namespace: "GRAFANA", Config: jsonCredConfig(string(refURI))},
+			"secret",
+		),
+	}
+
+	cs, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-cascade-jsoncred", pkgmodel.CommandApply, ds)
+	require.NoError(t, err)
+
+	// The cascade target must get a synthetic Resolve carrying its credential ref,
+	// so the folder-delete can dispatch with resolved credentials.
+	resolveURI := pkgmodel.FormaeURI("target://" + targetLabel + "/resolve")
+	resolveNode := cs.DAG.Nodes[resolveURI]
+	require.NotNil(t, resolveNode, "a cascade-deleted target whose creds come via .json() must get a synthetic Resolve node")
+
+	tu, ok := resolveNode.Update.(*target_update.TargetUpdate)
+	require.True(t, ok)
+	assert.Equal(t, target_update.TargetOperationResolve, tu.Operation)
+	require.NotEmpty(t, tu.RemainingResolvables, "the synthetic Resolve must carry the credential resolvable")
+	assert.Contains(t, tu.RemainingResolvables, refURI)
+
+	// The folder resource-delete depends on the Resolve so it dispatches with creds.
+	folderDelete := dagNodeForOp(t, cs.DAG, pkgmodel.NewFormaeURI(folderKsuid, ""), resource_update.OperationDelete)
+	assert.True(t, hasDependencyOn(folderDelete, resolveURI),
+		"resource-delete on the cascade target must depend on the Resolve node")
+
+	assert.False(t, cs.DAG.HasCycles(), "the cascade delete graph must be acyclic")
+}
+
+// TestNewChangeset_CascadeDeleteOpaqueTargetWithNonOpaqueRef_SyntheticResolveOpaqueOnly asserts
+// that when a cascade-deleted target carries BOTH an opaque $ref AND a non-opaque
+// cross-resource $ref whose source is being deleted in the same command, the synthetic
+// Resolve node for that target includes ONLY the opaque resolvable. Including the
+// non-opaque ref would attempt to read a vanishing source; the non-opaque ref carries
+// its stored value in the resource's NativeID and does not need in-flight resolution.
+func TestNewChangeset_CascadeDeleteOpaqueTargetWithNonOpaqueRef_SyntheticResolveOpaqueOnly(t *testing.T) {
+	const targetLabel = "consumer"
+
+	// The opaque ref: a secret credential still present at Resolve time (deleted after the target).
+	secretKsuid := util.NewID()
+	opaqueRef := pkgmodel.NewFormaeURI(secretKsuid, "SecretString")
+
+	// The non-opaque ref: a cross-resource ref whose source is being deleted in the same command.
+	vanishingKsuid := util.NewID()
+	nonOpaqueRef := pkgmodel.NewFormaeURI(vanishingKsuid, "Arn")
+
+	// Mixed config: both an opaque and a non-opaque $ref.
+	mixedConfig := json.RawMessage(`{
+		"auth":   {"$ref":"` + string(opaqueRef) + `","$visibility":"Opaque"},
+		"roleArn":{"$ref":"` + string(nonOpaqueRef) + `","$value":"arn:aws:iam::123:role/r"}
+	}`)
+
+	ds := &stubResolveDatastore{targets: map[string]*pkgmodel.Target{
+		targetLabel: {Label: targetLabel, Namespace: "AWS", Config: mixedConfig},
+	}}
+
+	deploymentKsuid := util.NewID()
+	resourceUpdates := []resource_update.ResourceUpdate{
+		{
+			PriorState:   pkgmodel.Resource{Label: "deployment", Type: "AWS::S3::Bucket", Stack: "s", Ksuid: deploymentKsuid, Target: targetLabel},
+			DesiredState: pkgmodel.Resource{Label: "deployment", Type: "AWS::S3::Bucket", Stack: "s", Ksuid: deploymentKsuid, Target: targetLabel},
+			Operation:    resource_update.OperationDelete,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+		{
+			// The vanishing non-opaque source being deleted in this command.
+			PriorState:   pkgmodel.Resource{Label: "role", Type: "AWS::IAM::Role", Stack: "s", Ksuid: vanishingKsuid, Target: "provider"},
+			DesiredState: pkgmodel.Resource{Label: "role", Type: "AWS::IAM::Role", Stack: "s", Ksuid: vanishingKsuid, Target: "provider"},
+			Operation:    resource_update.OperationDelete,
+			State:        resource_update.ResourceUpdateStateNotStarted,
+			StackLabel:   "s",
+		},
+	}
+
+	// Cascade Delete: the target's opaque $ref source is being torn down.
+	targetUpdates := []target_update.TargetUpdate{
+		target_update.NewTargetUpdateForCascadeDelete(
+			&pkgmodel.Target{Label: targetLabel, Namespace: "AWS", Config: mixedConfig},
+			"secret",
+		),
+	}
+
+	cs, err := buildChangesetForTest(resourceUpdates, targetUpdates, "cmd-mixed-visibility", pkgmodel.CommandApply, ds)
+	require.NoError(t, err)
+
+	resolveURI := pkgmodel.FormaeURI("target://" + targetLabel + "/resolve")
+	resolveNode := cs.DAG.Nodes[resolveURI]
+	require.NotNil(t, resolveNode, "a cascade-deleted target with an opaque $ref must get a synthetic Resolve node")
+
+	tu, ok := resolveNode.Update.(*target_update.TargetUpdate)
+	require.True(t, ok)
+	assert.Equal(t, target_update.TargetOperationResolve, tu.Operation)
+
+	// The synthetic Resolve must carry ONLY the opaque resolvable, not the
+	// non-opaque one whose source is being deleted in this command.
+	require.Len(t, tu.RemainingResolvables, 1,
+		"only the opaque resolvable must be included; the non-opaque vanishing source must be excluded")
+	assert.Equal(t, opaqueRef, tu.RemainingResolvables[0],
+		"the single resolvable must be the opaque $ref, not the non-opaque one")
 }

--- a/internal/metastructure/config/config.go
+++ b/internal/metastructure/config/config.go
@@ -12,4 +12,9 @@ type FormaCommandConfig struct {
 	Mode     pkgmodel.FormaApplyMode `mapstructure:"mode" default:"reconcile" description:"forma apply mode (reconcile | patch)"`
 	Force    bool                    `mapstructure:"force" default:"false" description:"overwrite any changes since the last reconcile without warning"`
 	Simulate bool                    `mapstructure:"simulate" default:"false" description:"simulate the forma command rather than make actual changes"`
+	// OnDependents governs a destroy that cascades onto dependents (e.g. a target
+	// whose config references a secret being deleted): "abort" (default) rejects
+	// the command naming the dependents; "cascade" deletes them too. Empty is
+	// treated as "abort".
+	OnDependents string `mapstructure:"on-dependents" default:"abort" description:"destroy behavior when dependents exist (abort | cascade)"`
 }

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1941,11 +1941,28 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 		// into resourceUpdates by the generator. Gate them server-side too, so a
 		// non-CLI caller cannot tear down dependents without on-dependents=cascade;
 		// the CLI still surfaces them via simulation and elevates on confirmation.
+		//
+		// Exclude the resource's own target being torn down: a resource deleted
+		// because its target is destroyed in this same command (the generator also
+		// marks that IsCascade, with CascadeSource = the target) is the expected
+		// consequence of an explicit target destroy, not a surprising dependency
+		// cascade, so it must not require opt-in.
 		if !formaCommandConfig.Simulate && formaCommandConfig.OnDependents != "cascade" {
+			targetsBeingDeleted := make(map[string]bool)
+			for i := range targetUpdates {
+				if targetUpdates[i].Operation == target_update.TargetOperationDelete {
+					targetsBeingDeleted[targetUpdates[i].Target.Label] = true
+				}
+			}
+			for i := range cascadeTargetUpdates {
+				targetsBeingDeleted[cascadeTargetUpdates[i].Target.Label] = true
+			}
+
 			var resourceDependents []apimodel.ResourceDependent
 			for i := range resourceUpdates {
 				ru := &resourceUpdates[i]
-				if ru.IsCascade && ru.Operation == resource_update.OperationDelete {
+				if ru.IsCascade && ru.Operation == resource_update.OperationDelete &&
+					!targetsBeingDeleted[ru.DesiredState.Target] {
 					resourceDependents = append(resourceDependents, apimodel.ResourceDependent{
 						ResourceLabel: ru.DesiredState.Label,
 						ResourceType:  ru.DesiredState.Type,

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1915,6 +1915,25 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 		if err != nil {
 			return nil, fmt.Errorf("failed to find cascade target deletes: %w", err)
 		}
+
+		// Default to abort: deleting a resource that a target's config references
+		// (e.g. a secret) would cascade-delete that target and its resources. Unless
+		// the command carries on-dependents=cascade, reject it and name the
+		// dependents — mirroring the resource/stack cascade-abort default. Simulation
+		// still surfaces the cascades so the client can show them and prompt the user.
+		if len(cascadeTargetUpdates) > 0 &&
+			!formaCommandConfig.Simulate &&
+			formaCommandConfig.OnDependents != "cascade" {
+			dependents := make([]apimodel.TargetDependent, 0, len(cascadeTargetUpdates))
+			for _, tu := range cascadeTargetUpdates {
+				dependents = append(dependents, apimodel.TargetDependent{
+					TargetLabel:   tu.Target.Label,
+					CascadeSource: tu.CascadeSource,
+				})
+			}
+			return nil, apimodel.FormaTargetHasDependentsError{Dependents: dependents}
+		}
+
 		targetUpdates = append(targetUpdates, cascadeTargetUpdates...)
 		resourceUpdates = append(resourceUpdates, cascadeResourceUpdates...)
 	}

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1934,6 +1934,31 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 			return nil, apimodel.FormaTargetHasDependentsError{Dependents: dependents}
 		}
 
+		// Same default-abort for resource-to-resource cascades: deleting a resource
+		// whose CreateOnly field another resource references cascade-deletes that
+		// dependent (possibly in another stack — findCascadeDeletes matches by ref
+		// URI across all managed stacks). These IsCascade deletes are already folded
+		// into resourceUpdates by the generator. Gate them server-side too, so a
+		// non-CLI caller cannot tear down dependents without on-dependents=cascade;
+		// the CLI still surfaces them via simulation and elevates on confirmation.
+		if !formaCommandConfig.Simulate && formaCommandConfig.OnDependents != "cascade" {
+			var resourceDependents []apimodel.ResourceDependent
+			for i := range resourceUpdates {
+				ru := &resourceUpdates[i]
+				if ru.IsCascade && ru.Operation == resource_update.OperationDelete {
+					resourceDependents = append(resourceDependents, apimodel.ResourceDependent{
+						ResourceLabel: ru.DesiredState.Label,
+						ResourceType:  ru.DesiredState.Type,
+						Stack:         ru.DesiredState.Stack,
+						CascadeSource: ru.CascadeSource,
+					})
+				}
+			}
+			if len(resourceDependents) > 0 {
+				return nil, apimodel.FormaResourceHasDependentsError{Dependents: resourceDependents}
+			}
+		}
+
 		targetUpdates = append(targetUpdates, cascadeTargetUpdates...)
 		resourceUpdates = append(resourceUpdates, cascadeResourceUpdates...)
 	}

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -240,6 +240,61 @@ func ExtractOpaqueResolvableURIsFromJSON(data json.RawMessage) []pkgmodel.Formae
 	return uris
 }
 
+// isSourcePropertyOpaque reports whether propertyName on a source resource is an
+// opaque value — a secret stored hashed-at-rest with Opaque visibility. Used to
+// decide, from the SOURCE side, whether an otherwise Clear consumer ref is really
+// a credential. It checks Properties first then ReadOnlyProperties, mirroring
+// Resource property precedence: an opaque value (e.g. a plugin-generated token)
+// may be persisted in either collection.
+func isSourcePropertyOpaque(source *pkgmodel.Resource, propertyName string) bool {
+	if source == nil || propertyName == "" {
+		return false
+	}
+	if gjson.GetBytes(source.Properties, propertyName).Get("$visibility").String() == pkgmodel.VisibilityOpaque {
+		return true
+	}
+	return gjson.GetBytes(source.ReadOnlyProperties, propertyName).Get("$visibility").String() == pkgmodel.VisibilityOpaque
+}
+
+// ExtractSourceOpaqueResolvableURIsFromJSON returns the resolvable URIs in data
+// that resolve a SECRET: either the ref envelope itself is Opaque, or — crucially —
+// the ref's SOURCE property is opaque even though the consumer envelope is Clear.
+// The latter is how .json()-derived credentials (secret.res.secretValue.json("k"))
+// look at rest: their envelope is Clear because opacity is derived from the source
+// secret's FieldHint, not stamped on the consumer envelope. Non-opaque
+// cross-resource refs (whose source property is a plain value) are excluded, so a
+// cascade delete still avoids resolving a vanishing cross-resource source.
+// loadResource loads a resource by KSUID; a nil source contributes nothing.
+func ExtractSourceOpaqueResolvableURIsFromJSON(data json.RawMessage, loadResource func(ksuid string) (*pkgmodel.Resource, error)) ([]pkgmodel.FormaeURI, error) {
+	if data == nil {
+		return nil, nil
+	}
+	resolver := newPropertyResolver(data)
+	var uris []pkgmodel.FormaeURI
+	for uri, refs := range resolver.refs {
+		for i := range refs {
+			if refs[i].ResolvedValue.IsOpaque() {
+				uris = append(uris, uri)
+				break
+			}
+			src, err := loadResource(refs[i].ResourceURI.KSUID())
+			if err != nil {
+				return nil, err
+			}
+			// A source that cannot be loaded (nil) is treated as non-opaque. In a
+			// same-command cascade this is safe: DAG ordering keeps a credential
+			// source present until the Resolve and its dependent deletes complete,
+			// so it loads here. A genuinely dangling source (data inconsistency)
+			// would fall through as non-opaque — a narrow accepted residual.
+			if src != nil && isSourcePropertyOpaque(src, refs[i].SourcePropertyName) {
+				uris = append(uris, uri)
+				break
+			}
+		}
+	}
+	return uris, nil
+}
+
 // propertyParser parses JSON properties to identify references and values
 type propertyParser struct {
 	HasRef    bool

--- a/internal/metastructure/resolver/resolver_test.go
+++ b/internal/metastructure/resolver/resolver_test.go
@@ -1591,3 +1591,57 @@ func TestToPluginFormat_ErrorsOnHashedValue(t *testing.T) {
 	assert.Contains(t, msg, "hashed", "explains the value is stored hashed")
 	assert.Contains(t, msg, "re-supply", "tells the user how to proceed")
 }
+
+// TestExtractSourceOpaqueResolvableURIsFromJSON covers deriving credential-ness
+// from the SOURCE property rather than the consumer envelope, including the
+// ReadOnlyProperties fallback (a plugin may expose a generated credential there).
+func TestExtractSourceOpaqueResolvableURIsFromJSON(t *testing.T) {
+	secretKsuid := util.NewID()
+	roKsuid := util.NewID()
+	plainKsuid := util.NewID()
+
+	secretURI := pkgmodel.NewFormaeURI(secretKsuid, "SecretString")
+	roURI := pkgmodel.NewFormaeURI(roKsuid, "Token")
+	plainURI := pkgmodel.NewFormaeURI(plainKsuid, "Arn")
+
+	sources := map[string]*pkgmodel.Resource{
+		secretKsuid: {Ksuid: secretKsuid, Properties: json.RawMessage(`{"SecretString":{"$value":"h","$visibility":"Opaque","$hashed":true}}`)},
+		roKsuid:     {Ksuid: roKsuid, ReadOnlyProperties: json.RawMessage(`{"Token":{"$value":"h","$visibility":"Opaque","$hashed":true}}`)},
+		plainKsuid:  {Ksuid: plainKsuid, ReadOnlyProperties: json.RawMessage(`{"Arn":"arn:aws:iam::123:role/r"}`)},
+	}
+	load := func(ksuid string) (*pkgmodel.Resource, error) { return sources[ksuid], nil }
+
+	// A Clear .json() cred whose opaque source lives in Properties is a credential.
+	got, err := ExtractSourceOpaqueResolvableURIsFromJSON(
+		json.RawMessage(`{"password":{"$ref":"`+string(secretURI)+`","$json":"password","$visibility":"Clear"}}`), load)
+	require.NoError(t, err)
+	assert.Equal(t, []pkgmodel.FormaeURI{secretURI}, got)
+
+	// A Clear cred whose opaque source lives in ReadOnlyProperties is a credential.
+	got, err = ExtractSourceOpaqueResolvableURIsFromJSON(
+		json.RawMessage(`{"token":{"$ref":"`+string(roURI)+`","$visibility":"Clear"}}`), load)
+	require.NoError(t, err)
+	assert.Equal(t, []pkgmodel.FormaeURI{roURI}, got)
+
+	// A Clear cross-resource ref to a plain (non-opaque) source is excluded.
+	got, err = ExtractSourceOpaqueResolvableURIsFromJSON(
+		json.RawMessage(`{"roleArn":{"$ref":"`+string(plainURI)+`","$visibility":"Clear"}}`), load)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	// An envelope-Opaque ref is a credential without ever loading the source.
+	loadFail := func(string) (*pkgmodel.Resource, error) {
+		return nil, fmt.Errorf("source must not be loaded for an envelope-opaque ref")
+	}
+	got, err = ExtractSourceOpaqueResolvableURIsFromJSON(
+		json.RawMessage(`{"auth":{"$ref":"`+string(secretURI)+`","$visibility":"Opaque"}}`), loadFail)
+	require.NoError(t, err)
+	assert.Equal(t, []pkgmodel.FormaeURI{secretURI}, got)
+
+	// An unloadable (missing) source is not classified as a credential.
+	missingURI := pkgmodel.NewFormaeURI(util.NewID(), "SecretString")
+	got, err = ExtractSourceOpaqueResolvableURIsFromJSON(
+		json.RawMessage(`{"password":{"$ref":"`+string(missingURI)+`","$visibility":"Clear"}}`), load)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/internal/metastructure/target_update/resolve_synthesis.go
+++ b/internal/metastructure/target_update/resolve_synthesis.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
 // SynthesizeResolveTargetUpdates builds synthetic Resolve target ops for targets
@@ -43,11 +44,43 @@ func SynthesizeResolveTargetUpdates(
 	existing []TargetUpdate,
 	ds TargetDatastore,
 ) ([]TargetUpdate, error) {
-	// Targets already covered by a real target update in this command must never be
-	// synthesized for — their update carries the desired (and re-resolved) config.
+	// A target is covered (needs no synthetic Resolve) only when an update already
+	// carries re-resolved config:
+	//   - Create/Update/Replace/Resolve carry freshly re-resolved config, so they cover.
+	//   - A plain Delete does NOT carry resolved config, yet resource ops tearing down
+	//     on that target still need the current secret value, so it stays uncovered.
+	//   - A cascade Delete tears down its config's $ref source in the same command. For
+	//     a plain cross-resource $ref that is fine (the delete works off the stored
+	//     snapshot / NativeID), so it stays covered. But when the cascade target carries
+	//     an OPAQUE $ref (a secret the plugin needs to authenticate teardown) it is
+	//     un-covered: the changeset orders the secret delete AFTER the target delete, so
+	//     the secret is still present at Resolve time, and only its opaque refs resolve.
 	covered := make(map[string]bool)
+	cascadeOpaqueUncovered := make(map[string]bool)
 	for i := range existing {
-		covered[existing[i].Target.Label] = true
+		switch existing[i].Operation {
+		case TargetOperationCreate,
+			TargetOperationUpdate,
+			TargetOperationReplace,
+			TargetOperationResolve:
+			covered[existing[i].Target.Label] = true
+		case TargetOperationDelete:
+			if existing[i].IsCascade {
+				var hasOpaque bool
+				if existing[i].ExistingTarget != nil && ds != nil {
+					opaqueURIs, err := resolver.ExtractSourceOpaqueResolvableURIsFromJSON(existing[i].ExistingTarget.Config, ds.LoadResourceById)
+					if err != nil {
+						return nil, fmt.Errorf("detect opaque refs for cascade target %q: %w", existing[i].Target.Label, err)
+					}
+					hasOpaque = len(opaqueURIs) > 0
+				}
+				if !hasOpaque {
+					covered[existing[i].Target.Label] = true
+				} else {
+					cascadeOpaqueUncovered[existing[i].Target.Label] = true
+				}
+			}
+		}
 	}
 
 	var candidates []string
@@ -71,11 +104,28 @@ func SynthesizeResolveTargetUpdates(
 		if persisted == nil {
 			continue
 		}
-		resolvables := resolver.ExtractResolvableURIsFromJSON(persisted.Config)
+		// For a cascade-opaque uncovered target, resolve ONLY its opaque $refs: its
+		// non-opaque cross-resource $refs point at sources being deleted in this same
+		// command, so reading a vanishing source would fail. On the delete path those
+		// non-opaque refs carry their stored value via NativeID and need no resolution.
+		var resolvables []pkgmodel.FormaeURI
+		opaqueOnly := cascadeOpaqueUncovered[label]
+		if opaqueOnly {
+			resolvables, err = resolver.ExtractSourceOpaqueResolvableURIsFromJSON(persisted.Config, ds.LoadResourceById)
+			if err != nil {
+				return nil, fmt.Errorf("extract opaque resolvables for cascade target %q: %w", label, err)
+			}
+		} else {
+			resolvables = resolver.ExtractResolvableURIsFromJSON(persisted.Config)
+		}
 		if len(resolvables) == 0 {
 			continue
 		}
-		synthetic = append(synthetic, NewResolveTargetUpdate(*persisted, resolvables))
+		resolveTU := NewResolveTargetUpdate(*persisted, resolvables)
+		// Preserve the opaque-only selection so execute-time revalidation keeps
+		// excluding vanishing non-opaque refs if the config advances under us.
+		resolveTU.OpaqueOnly = opaqueOnly
+		synthetic = append(synthetic, resolveTU)
 	}
 
 	if err := rejectTransitivelyOpaqueTargets(append(existing, synthetic...), sourceTargetByKsuid, ds); err != nil {

--- a/internal/metastructure/target_update/revalidate_resolve.go
+++ b/internal/metastructure/target_update/revalidate_resolve.go
@@ -12,10 +12,12 @@ import (
 )
 
 // targetLoader is the minimal datastore surface revalidateResolveTarget needs:
-// it re-reads a persisted target by label. The full datastore.Datastore
-// satisfies it, and a narrow stub can be used in tests.
+// it re-reads a persisted target by label, and (for an opaque-only Resolve) a
+// source resource by KSUID to preserve source-derived credential opacity. The
+// full datastore.Datastore satisfies it, and a narrow stub can be used in tests.
 type targetLoader interface {
 	LoadTarget(label string) (*pkgmodel.Target, error)
+	LoadResourceById(ksuid string) (*pkgmodel.Resource, error)
 }
 
 // revalidateResolveTarget closes the TOCTOU window between changeset build and
@@ -63,9 +65,20 @@ func revalidateResolveTarget(tu TargetUpdate, ds targetLoader) (TargetUpdate, er
 	}
 
 	// Revision advanced under us: rebuild against the current persisted config so
-	// resolution never runs against the stale snapshot.
+	// resolution never runs against the stale snapshot. Preserve the op's
+	// selection policy — an opaque-only Resolve (cascade-deleted secret-backed
+	// target) must keep excluding non-opaque cross-resource refs whose sources are
+	// being deleted in the same command; the full extractor would re-include them.
 	tu.Target.Config = current.Config
 	tu.Target.Version = current.Version
-	tu.RemainingResolvables = resolver.ExtractResolvableURIsFromJSON(current.Config)
+	if tu.OpaqueOnly {
+		opaqueURIs, err := resolver.ExtractSourceOpaqueResolvableURIsFromJSON(current.Config, ds.LoadResourceById)
+		if err != nil {
+			return tu, fmt.Errorf("re-validate resolve target %q: %w", label, err)
+		}
+		tu.RemainingResolvables = opaqueURIs
+	} else {
+		tu.RemainingResolvables = resolver.ExtractResolvableURIsFromJSON(current.Config)
+	}
 	return tu, nil
 }

--- a/internal/metastructure/target_update/revalidate_resolve_test.go
+++ b/internal/metastructure/target_update/revalidate_resolve_test.go
@@ -23,11 +23,16 @@ type revalidateStubDatastore struct {
 	target    *pkgmodel.Target
 	loadErr   error
 	loadCalls int
+	resources map[string]*pkgmodel.Resource
 }
 
 func (s *revalidateStubDatastore) LoadTarget(_ string) (*pkgmodel.Target, error) {
 	s.loadCalls++
 	return s.target, s.loadErr
+}
+
+func (s *revalidateStubDatastore) LoadResourceById(ksuid string) (*pkgmodel.Resource, error) {
+	return s.resources[ksuid], nil
 }
 
 // configA is the build-time (snapshot) config the Resolve TU carries; configB is
@@ -36,6 +41,9 @@ func (s *revalidateStubDatastore) LoadTarget(_ string) (*pkgmodel.Target, error)
 var (
 	configA = json.RawMessage(`{"secret":{"$ref":"formae://aaa111#/SecretString","$visibility":"Opaque"}}`)
 	configB = json.RawMessage(`{"secret":{"$ref":"formae://bbb222#/SecretString","$visibility":"Opaque"}}`)
+	// configMixed carries one opaque credential $ref and one non-opaque
+	// cross-resource $ref, both current (post-revision-bump).
+	configMixed = json.RawMessage(`{"cred":{"$ref":"formae://sec111#/SecretString","$visibility":"Opaque"},"peer":{"$ref":"formae://res222#/Id"}}`)
 )
 
 func TestRevalidateResolveTarget_StaleRevision_RebuildsAgainstCurrentConfig(t *testing.T) {
@@ -63,6 +71,51 @@ func TestRevalidateResolveTarget_StaleRevision_RebuildsAgainstCurrentConfig(t *t
 	assert.Equal(t, pkgmodel.FormaeURI("formae://bbb222#/SecretString"), revised.RemainingResolvables[0],
 		"resolvables must be rebuilt from the current config")
 	assert.Equal(t, 1, ds.loadCalls, "a single re-read suffices")
+}
+
+func TestRevalidateResolveTarget_OpaqueOnly_StaleRevision_RebuildsOpaqueOnly(t *testing.T) {
+	// An opaque-only synthetic Resolve (a cascade-deleted secret-backed target)
+	// whose revision advanced under a concurrent command must rebuild against the
+	// current config using only its OPAQUE refs. Its non-opaque cross-resource
+	// refs point at sources being deleted in the same command; re-including them
+	// would attempt to resolve a vanishing value and fail the cascade teardown.
+	tu := NewResolveTargetUpdate(
+		pkgmodel.Target{Label: "consumer", Version: 1, Config: configA},
+		[]pkgmodel.FormaeURI{"formae://aaa111#/SecretString"},
+	)
+	tu.OpaqueOnly = true
+
+	ds := &revalidateStubDatastore{
+		target: &pkgmodel.Target{Label: "consumer", Version: 2, Config: configMixed},
+	}
+
+	revised, err := revalidateResolveTarget(tu, ds)
+	require.NoError(t, err)
+
+	require.Len(t, revised.RemainingResolvables, 1,
+		"opaque-only rebuild must exclude the non-opaque cross-resource ref")
+	assert.Equal(t, pkgmodel.FormaeURI("formae://sec111#/SecretString"), revised.RemainingResolvables[0],
+		"only the opaque credential ref survives the opaque-only rebuild")
+}
+
+func TestRevalidateResolveTarget_FullSelection_StaleRevision_RebuildsAllRefs(t *testing.T) {
+	// A default (non-opaque-only) synthetic Resolve rebuilds with EVERY ref in the
+	// current config, opaque and non-opaque alike — the OpaqueOnly flag is the only
+	// thing that narrows the selection.
+	tu := NewResolveTargetUpdate(
+		pkgmodel.Target{Label: "consumer", Version: 1, Config: configA},
+		[]pkgmodel.FormaeURI{"formae://aaa111#/SecretString"},
+	)
+
+	ds := &revalidateStubDatastore{
+		target: &pkgmodel.Target{Label: "consumer", Version: 2, Config: configMixed},
+	}
+
+	revised, err := revalidateResolveTarget(tu, ds)
+	require.NoError(t, err)
+
+	require.Len(t, revised.RemainingResolvables, 2,
+		"the default selection rebuilds with both the opaque and non-opaque refs")
 }
 
 func TestRevalidateResolveTarget_UnchangedRevision_NoRebuild(t *testing.T) {

--- a/internal/metastructure/target_update/target_update.go
+++ b/internal/metastructure/target_update/target_update.go
@@ -46,6 +46,12 @@ type TargetUpdate struct {
 	RemainingResolvables []pkgmodel.FormaeURI `json:"RemainingResolvables,omitempty"`
 	IsCascade            bool                 `json:"IsCascade,omitempty"`     // True if this delete is triggered by cascade
 	CascadeSource        string               `json:"CascadeSource,omitempty"` // Label of resource that triggered the cascade
+	// OpaqueOnly marks a synthetic Resolve that must resolve only opaque
+	// (credential) refs. Its non-opaque cross-resource refs point at sources
+	// being deleted in the same command, so they must not be resolved. The flag
+	// is preserved so execute-time revalidation keeps the opaque-only selection
+	// when it rebuilds resolvables against a concurrently-advanced config.
+	OpaqueOnly bool `json:"OpaqueOnly,omitempty"`
 }
 
 // NewTargetUpdateForCascadeDelete creates a cascade delete TargetUpdate for a target

--- a/internal/workflow_tests/local/apply_forma/target_config_resolve_destroy_test.go
+++ b/internal/workflow_tests/local/apply_forma/target_config_resolve_destroy_test.go
@@ -1,0 +1,197 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+// TestTargetConfigResolve_DestroyResolvesSecretBackedTarget is the acceptance test for
+// the delete-path gap in synthetic Resolve synthesis: when a resource is destroyed on a
+// target whose Config carries an opaque $ref, the resource-delete op must receive the
+// resolved credential — not the raw $ref pointer — in its TargetConfig.
+//
+// Sequence:
+//
+//   - Apply: creates a secret, the consumer target (config $ref-ing the secret), and a
+//     bucket resource on consumer. The stored consumer config retains only the raw $ref
+//     pointer (StripOpaqueRefValues removes $value at the write boundary).
+//
+//   - Destroy: tears down the bucket, the consumer target, and the secret. Before the
+//     fix, the consumer target's Delete TU marked it as "covered", suppressing the
+//     synthetic Resolve op — so the bucket Delete received the unresolved $ref. After
+//     the fix, the synthetic Resolve is synthesized even when a Delete TU exists, and
+//     the bucket Delete dispatches with the plaintext credential.
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// destroyTargetConfigCapture records the TargetConfig received on the bucket Delete call.
+type destroyTargetConfigCapture struct {
+	mu     sync.Mutex
+	config json.RawMessage
+}
+
+func (c *destroyTargetConfigCapture) set(cfg json.RawMessage) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cp := make(json.RawMessage, len(cfg))
+	copy(cp, cfg)
+	c.config = cp
+}
+
+func (c *destroyTargetConfigCapture) get() json.RawMessage {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.config
+}
+
+func TestTargetConfigResolve_DestroyResolvesSecretBackedTarget(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const plaintextSecret = "destroy-resolve-test-credential"
+
+		capture := &destroyTargetConfigCapture{}
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(r *resource.CreateRequest) (*resource.CreateResult, error) {
+				if r.ResourceType == "FakeAWS::S3::Bucket" {
+					return &resource.CreateResult{
+						ProgressResult: &resource.ProgressResult{
+							Operation:          resource.OperationCreate,
+							OperationStatus:    resource.OperationStatusSuccess,
+							RequestID:          "bucket-create-destroy-1",
+							NativeID:           "test-bucket-destroy-001",
+							ResourceProperties: r.Properties,
+						},
+					}, nil
+				}
+				return nil, nil
+			},
+			Delete: func(r *resource.DeleteRequest) (*resource.DeleteResult, error) {
+				if r.ResourceType == "FakeAWS::S3::Bucket" {
+					capture.set(r.TargetConfig)
+				}
+				return &resource.DeleteResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationDelete,
+						OperationStatus: resource.OperationStatusSuccess,
+						RequestID:       "delete-1",
+						NativeID:        r.NativeID,
+					},
+				}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		secretKsuid := "3NjE3sB2TKcMNHahUM1iDykljkw" // deterministic KSUID for the $ref
+		stackSecrets := "stack-destroy-secrets-" + util.NewID()
+		stackResources := "stack-destroy-resources-" + util.NewID()
+
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{
+				{Label: stackSecrets},
+				{Label: stackResources},
+			},
+			Resources: []pkgmodel.Resource{
+				{
+					Label:      "my-secret",
+					Type:       "FakeAWS::SecretsManager::Secret",
+					Stack:      stackSecrets,
+					Target:     "provider",
+					Ksuid:      secretKsuid,
+					Schema:     secretSchema(),
+					Properties: json.RawMessage(`{"Name":"my-secret","SecretString":"` + plaintextSecret + `"}`),
+				},
+				{
+					Label:  "my-bucket",
+					Type:   "FakeAWS::S3::Bucket",
+					Stack:  stackResources,
+					Target: "consumer",
+					Schema: pkgmodel.Schema{
+						Identifier: "BucketName",
+						Fields:     []string{"BucketName"},
+					},
+					Properties: json.RawMessage(`{"BucketName":"test-destroy-bucket-001"}`),
+				},
+			},
+			Targets: []pkgmodel.Target{
+				{Label: "provider", Namespace: "test-namespace"},
+				{
+					Label:     "consumer",
+					Namespace: "test-namespace",
+					Config: json.RawMessage(fmt.Sprintf(`{
+						"apiKey": {"$ref": "formae://%s#/SecretString", "$visibility": "Opaque"}
+					}`, secretKsuid)),
+				},
+			},
+		}
+
+		// ── Apply: stand up all three pieces ──────────────────────────────────────
+		_, err = m.ApplyForma(forma, defaultApplyConfig(), "test-client-id")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		applyCmd := findNthApplyCommand(cmds, 1)
+		require.NotNil(t, applyCmd, "apply command must exist")
+		require.Equal(t, forma_command.CommandStateSuccess, applyCmd.State,
+			"apply must succeed before the destroy can be tested")
+
+		// Confirm stored consumer config retains only the $ref pointer.
+		consumerTarget, err := m.Datastore.LoadTarget("consumer")
+		require.NoError(t, err)
+		require.NotNil(t, consumerTarget)
+		require.Contains(t, string(consumerTarget.Config), `"$ref"`)
+		require.NotContains(t, string(consumerTarget.Config), plaintextSecret)
+
+		// ── Destroy: tear down all three pieces ───────────────────────────────────
+		//
+		// consumer is included explicitly so it gets a Delete TargetUpdate in the
+		// destroy command. Before the fix that Delete TU marked consumer "covered",
+		// suppressing the synthetic Resolve — so the bucket Delete received the raw
+		// $ref. After the fix the synthetic Resolve is always synthesized when the
+		// persisted config carries opaque refs, regardless of the Delete TU.
+		_, err = m.DestroyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		destroyCmd := findDestroyCommand(t, m)
+		require.Equal(t, forma_command.CommandStateSuccess, destroyCmd.State,
+			"destroy must complete successfully — a hang here indicates unresolved credentials")
+
+		// ── Core assertion ────────────────────────────────────────────────────────
+		//
+		// The bucket Delete must have been called with the resolved credential,
+		// not the raw {"$ref":…,"$visibility":"Opaque"} envelope.
+		receivedConfig := capture.get()
+		require.NotNil(t, receivedConfig,
+			"FakeAWS::S3::Bucket Delete override must have been called during destroy")
+
+		assert.NotContains(t, string(receivedConfig), `"$ref"`,
+			"plugin Delete must receive a resolved TargetConfig — the raw $ref must not reach the plugin")
+		assert.Contains(t, string(receivedConfig), plaintextSecret,
+			"plugin Delete must receive the resolved credential value in TargetConfig")
+	})
+}

--- a/internal/workflow_tests/local/cascade_delete_test.go
+++ b/internal/workflow_tests/local/cascade_delete_test.go
@@ -303,9 +303,12 @@ func TestDestroyWithCascade_CascadeDeletesDependentTargetAndResources(t *testing
 		require.NoError(t, err)
 		require.Len(t, consumerResources, 1, "Should have the deployment resource")
 
-		// Step 5: Actually destroy forma A (not simulate)
+		// Step 5: Actually destroy forma A (not simulate). The consumer target's
+		// config references the cluster being deleted, so this cascades — opt in
+		// with on-dependents=cascade (the default is to abort).
 		_, err = m.DestroyForma(providerForma, &config.FormaCommandConfig{
-			Mode: pkgmodel.FormaApplyModeReconcile,
+			Mode:         pkgmodel.FormaApplyModeReconcile,
+			OnDependents: "cascade",
 		}, "test")
 		require.NoError(t, err)
 
@@ -331,5 +334,90 @@ func TestDestroyWithCascade_CascadeDeletesDependentTargetAndResources(t *testing
 		consumerResources, err = m.Datastore.LoadResourcesByStack("consumer-stack")
 		require.NoError(t, err)
 		assert.Empty(t, consumerResources, "Deployment resource should be deleted")
+	})
+}
+
+// TestDestroyWithCascade_TargetDependentsAbortByDefault asserts that destroying a
+// resource whose deletion would cascade-delete a target (because the target's config
+// references it) is REJECTED by default with a FormaTargetHasDependentsError naming
+// the dependent target, and PROCEEDS only when on-dependents=cascade is set.
+func TestDestroyWithCascade_TargetDependentsAbortByDefault(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		overrides := &plugin.ResourcePluginOverrides{}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err, "Failed to create metastructure")
+
+		// Apply forma A — provider target + cluster resource.
+		providerForma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "provider-stack"}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label:      "cluster",
+					Type:       "FakeAWS::S3::Bucket",
+					Properties: json.RawMessage(`{"BucketName":"my-cluster"}`),
+					Stack:      "provider-stack",
+					Target:     "provider",
+				},
+			},
+			Targets: []pkgmodel.Target{{Label: "provider"}},
+		}
+
+		_, err = m.ApplyForma(providerForma, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test")
+		require.NoError(t, err)
+
+		assert.Eventually(t, func() bool {
+			fas, err := m.Datastore.LoadFormaCommands()
+			if err != nil || len(fas) == 0 {
+				return false
+			}
+			return fas[0].State == forma_command.CommandStateSuccess
+		}, 5*time.Second, 100*time.Millisecond, "Provider forma should be applied")
+
+		clusterResources, err := m.Datastore.LoadResourcesByStack("provider-stack")
+		require.NoError(t, err)
+		require.Len(t, clusterResources, 1)
+		clusterKsuid := clusterResources[0].Ksuid
+
+		// A "consumer" target whose config $refs the cluster being deleted.
+		consumerConfig := fmt.Sprintf(`{"endpoint":{"$ref":"formae://%s#/BucketName","$value":"my-cluster"}}`, clusterKsuid)
+		_, err = m.Datastore.CreateTarget(&pkgmodel.Target{
+			Label:  "consumer",
+			Config: json.RawMessage(consumerConfig),
+		})
+		require.NoError(t, err)
+
+		// Default (abort): the destroy is rejected with a dependents error naming the
+		// consumer target, and no command is executed.
+		_, err = m.DestroyForma(providerForma, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test")
+		require.Error(t, err, "default destroy must abort when a dependent target exists")
+
+		var depErr apimodel.FormaTargetHasDependentsError
+		require.ErrorAs(t, err, &depErr, "error must be a FormaTargetHasDependentsError")
+		require.Len(t, depErr.Dependents, 1)
+		assert.Equal(t, "consumer", depErr.Dependents[0].TargetLabel)
+		assert.Equal(t, "cluster", depErr.Dependents[0].CascadeSource)
+
+		// The consumer target and cluster must still be intact — nothing ran.
+		consumerTarget, err := m.Datastore.LoadTarget("consumer")
+		require.NoError(t, err)
+		require.NotNil(t, consumerTarget, "consumer target must still exist after an aborted destroy")
+
+		// With on-dependents=cascade, the destroy proceeds and tears the consumer down.
+		_, err = m.DestroyForma(providerForma, &config.FormaCommandConfig{
+			Mode:         pkgmodel.FormaApplyModeReconcile,
+			OnDependents: "cascade",
+		}, "test")
+		require.NoError(t, err, "on-dependents=cascade must be accepted")
+
+		assert.Eventually(t, func() bool {
+			ct, err := m.Datastore.LoadTarget("consumer")
+			return err == nil && ct == nil
+		}, 10*time.Second, 100*time.Millisecond, "consumer target should be cascade-deleted")
 	})
 }

--- a/internal/workflow_tests/local/cascade_delete_test.go
+++ b/internal/workflow_tests/local/cascade_delete_test.go
@@ -421,3 +421,87 @@ func TestDestroyWithCascade_TargetDependentsAbortByDefault(t *testing.T) {
 		}, 10*time.Second, 100*time.Millisecond, "consumer target should be cascade-deleted")
 	})
 }
+
+// TestDestroyWithCascade_ResourceDependentsAbortByDefault asserts that destroying a
+// resource whose deletion would cascade-delete a dependent resource IN ANOTHER STACK
+// (the dependent references it on a CreateOnly field) is REJECTED by default with a
+// FormaResourceHasDependentsError naming the cross-stack dependent, and PROCEEDS only
+// when on-dependents=cascade is set — mirroring the target-cascade default.
+func TestDestroyWithCascade_ResourceDependentsAbortByDefault(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		overrides := &plugin.ResourcePluginOverrides{}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err, "Failed to create metastructure")
+
+		// Apply a provider VPC in provider-stack.
+		providerForma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "provider-stack"}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label:      "parent-vpc",
+					Type:       "FakeAWS::EC2::VPC",
+					Properties: json.RawMessage(`{"CidrBlock":"10.0.0.0/16"}`),
+					Stack:      "provider-stack",
+					Target:     "shared-target",
+				},
+			},
+			Targets: []pkgmodel.Target{{Label: "shared-target"}},
+		}
+		_, err = m.ApplyForma(providerForma, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test")
+		require.NoError(t, err)
+
+		assert.Eventually(t, func() bool {
+			fas, err := m.Datastore.LoadFormaCommands()
+			return err == nil && len(fas) > 0 && fas[0].State == forma_command.CommandStateSuccess
+		}, 5*time.Second, 100*time.Millisecond, "provider VPC should be applied")
+
+		parentResources, err := m.Datastore.LoadResourcesByStack("provider-stack")
+		require.NoError(t, err)
+		require.Len(t, parentResources, 1)
+		parentKsuid := parentResources[0].Ksuid
+
+		// A dependent subnet in a DIFFERENT stack, referencing the VPC's VpcId on the
+		// CreateOnly VpcId field, so deleting the VPC cascade-deletes the subnet.
+		childProperties := fmt.Sprintf(`{"VpcId":{"$ref":"formae://%s#/VpcId","$value":"vpc-123"},"CidrBlock":"10.0.1.0/24"}`, parentKsuid)
+		_, err = m.Datastore.StoreResource(&pkgmodel.Resource{
+			NativeID:   "subnet-child-native",
+			Label:      "child-subnet",
+			Type:       "FakeAWS::EC2::Subnet",
+			Properties: json.RawMessage(childProperties),
+			Stack:      "consumer-stack",
+			Target:     "shared-target",
+			Managed:    true,
+		}, "seed-cmd")
+		require.NoError(t, err)
+
+		// Default (abort): the destroy is rejected with a dependents error naming the
+		// cross-stack dependent, and nothing runs.
+		_, err = m.DestroyForma(providerForma, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test")
+		require.Error(t, err, "default destroy must abort when a dependent resource exists")
+
+		var depErr apimodel.FormaResourceHasDependentsError
+		require.ErrorAs(t, err, &depErr, "error must be a FormaResourceHasDependentsError")
+		require.Len(t, depErr.Dependents, 1)
+		assert.Equal(t, "child-subnet", depErr.Dependents[0].ResourceLabel)
+		assert.Equal(t, "consumer-stack", depErr.Dependents[0].Stack)
+		assert.Equal(t, "parent-vpc", depErr.Dependents[0].CascadeSource)
+
+		// The dependent must still exist — nothing ran.
+		remaining, err := m.Datastore.LoadResourcesByStack("consumer-stack")
+		require.NoError(t, err)
+		require.Len(t, remaining, 1, "cross-stack dependent must survive an aborted destroy")
+
+		// With on-dependents=cascade, the destroy proceeds.
+		_, err = m.DestroyForma(providerForma, &config.FormaCommandConfig{
+			Mode:         pkgmodel.FormaApplyModeReconcile,
+			OnDependents: "cascade",
+		}, "test")
+		require.NoError(t, err, "on-dependents=cascade must be accepted")
+	})
+}

--- a/pkg/api/model/errors.go
+++ b/pkg/api/model/errors.go
@@ -34,6 +34,7 @@ const (
 	PluginDependencyConflict     APIError = "PluginDependencyConflict"
 	PluginRepositoryUnreachable  APIError = "PluginRepositoryUnreachable"
 	PluginSignatureInvalid       APIError = "PluginSignatureInvalid"
+	TargetHasDependents          APIError = "TargetHasDependents"
 )
 
 type ErrorResponse[T any] struct {
@@ -217,6 +218,34 @@ type TargetHasResourcesError struct {
 
 func (e TargetHasResourcesError) Error() string {
 	return fmt.Sprintf("target %s cannot be deleted: has %d deployed resources", e.TargetLabel, e.ResourceCount)
+}
+
+// TargetDependent names a target whose config references a resource being
+// deleted, along with the source resource that triggers the cascade.
+type TargetDependent struct {
+	TargetLabel   string `json:"TargetLabel"`
+	CascadeSource string `json:"CascadeSource"`
+}
+
+// FormaTargetHasDependentsError is returned when a destroy would cascade onto one
+// or more targets whose config references a resource being deleted (e.g. a secret),
+// but the command was not run with on-dependents=cascade. The default is to abort
+// so the user does not unknowingly tear down dependent targets and their resources.
+type FormaTargetHasDependentsError struct {
+	Dependents []TargetDependent `json:"Dependents"`
+}
+
+func (e FormaTargetHasDependentsError) Error() string {
+	if len(e.Dependents) == 1 {
+		return fmt.Sprintf("deleting %q would cascade-delete dependent target %q; re-run with --on-dependents=cascade to proceed",
+			e.Dependents[0].CascadeSource, e.Dependents[0].TargetLabel)
+	}
+	labels := make([]string, len(e.Dependents))
+	for i, d := range e.Dependents {
+		labels[i] = d.TargetLabel
+	}
+	return fmt.Sprintf("this delete would cascade-delete %d dependent target(s) %v; re-run with --on-dependents=cascade to proceed",
+		len(e.Dependents), labels)
 }
 
 type PluginNotFoundError struct {

--- a/pkg/api/model/errors.go
+++ b/pkg/api/model/errors.go
@@ -35,6 +35,7 @@ const (
 	PluginRepositoryUnreachable  APIError = "PluginRepositoryUnreachable"
 	PluginSignatureInvalid       APIError = "PluginSignatureInvalid"
 	TargetHasDependents          APIError = "TargetHasDependents"
+	ResourceHasDependents        APIError = "ResourceHasDependents"
 )
 
 type ErrorResponse[T any] struct {
@@ -245,6 +246,38 @@ func (e FormaTargetHasDependentsError) Error() string {
 		labels[i] = d.TargetLabel
 	}
 	return fmt.Sprintf("this delete would cascade-delete %d dependent target(s) %v; re-run with --on-dependents=cascade to proceed",
+		len(e.Dependents), labels)
+}
+
+// ResourceDependent names a resource whose config references (on a CreateOnly
+// field) a resource being deleted, along with the source resource that triggers
+// the cascade. The dependent may live in a different stack.
+type ResourceDependent struct {
+	ResourceLabel string `json:"ResourceLabel"`
+	ResourceType  string `json:"ResourceType"`
+	Stack         string `json:"Stack"`
+	CascadeSource string `json:"CascadeSource"`
+}
+
+// FormaResourceHasDependentsError is returned when a destroy would cascade-delete
+// one or more dependent resources (a resource whose CreateOnly field references a
+// resource being deleted, possibly across stacks) but the command was not run with
+// on-dependents=cascade. The default is to abort so the user does not unknowingly
+// tear down dependent resources, mirroring the target-cascade default.
+type FormaResourceHasDependentsError struct {
+	Dependents []ResourceDependent `json:"Dependents"`
+}
+
+func (e FormaResourceHasDependentsError) Error() string {
+	if len(e.Dependents) == 1 {
+		return fmt.Sprintf("deleting %q would cascade-delete dependent resource %q; re-run with --on-dependents=cascade to proceed",
+			e.Dependents[0].CascadeSource, e.Dependents[0].ResourceLabel)
+	}
+	labels := make([]string, len(e.Dependents))
+	for i, d := range e.Dependents {
+		labels[i] = d.ResourceLabel
+	}
+	return fmt.Sprintf("this delete would cascade-delete %d dependent resource(s) %v; re-run with --on-dependents=cascade to proceed",
 		len(e.Dependents), labels)
 }
 

--- a/tests/blackbox/executor.go
+++ b/tests/blackbox/executor.go
@@ -130,7 +130,7 @@ func (h *TestHarness) ResetAgentState(t *testing.T) {
 			h.dumpRawResourceRows(t, forma.Resources, seen)
 		}
 
-		resp, err := h.client.DestroyForma(forma, false, clientID)
+		resp, err := h.client.DestroyForma(forma, false, "abort", clientID)
 		if err != nil {
 			t.Logf("ResetAgentState: destroy returned: %v (attempt %d)", err, attempt+1)
 			time.Sleep(500 * time.Millisecond)
@@ -1228,7 +1228,7 @@ func (h *TestHarness) executeDestroyDefault(t *testing.T, op *Operation, model *
 		}
 	}
 
-	resp, err := h.client.DestroyForma(forma, false, clientID)
+	resp, err := h.client.DestroyForma(forma, false, "abort", clientID)
 	if err != nil {
 		if len(programmedSeqs) > 0 {
 			h.UnprogramResponses(t, programmedSeqs)
@@ -1280,7 +1280,7 @@ func (h *TestHarness) executeDestroyAbort(t *testing.T, op *Operation, model *St
 
 	if hasDependents {
 		// Simulate to check whether the agent would create cascade deletes.
-		simResp, err := h.client.DestroyForma(forma, true, clientID)
+		simResp, err := h.client.DestroyForma(forma, true, "abort", clientID)
 		if err != nil {
 			t.Logf("[op %d] Destroy (abort) stack=%s resources %v → simulate error: %v", op.SequenceNum, stackLabel, existingIDs, err)
 			return
@@ -1309,7 +1309,7 @@ func (h *TestHarness) executeDestroyAbort(t *testing.T, op *Operation, model *St
 		}
 	}
 
-	resp, err := h.client.DestroyForma(forma, false, clientID)
+	resp, err := h.client.DestroyForma(forma, false, "abort", clientID)
 	if err != nil {
 		if len(programmedSeqs) > 0 {
 			h.UnprogramResponses(t, programmedSeqs)
@@ -1361,7 +1361,7 @@ func (h *TestHarness) executeDestroyCascade(t *testing.T, op *Operation, model *
 		}
 	}
 
-	resp, err := h.client.DestroyForma(forma, false, clientID)
+	resp, err := h.client.DestroyForma(forma, false, "cascade", clientID)
 	if err != nil {
 		if len(programmedSeqs) > 0 {
 			h.UnprogramResponses(t, programmedSeqs)


### PR DESCRIPTION
## Resolve target-config secrets on the delete path + dependency-aware secret deletion

Target-config secret credentials (a target whose auth is sourced from a managed secret via an opaque `$ref`) were resolved on create/update but **not on delete**, so tearing down a resource on such a target couldn't authenticate — apply worked, destroy hung then failed. This resolves them for resource-delete ops and adds the dependency-aware cascade model for deleting a secret a target references.

### Plain delete (target explicit in the destroy forma)
`synthesizeResolveTargetUpdates` no longer treats a plain Delete target as "covered", so a target referenced by resource-delete ops with opaque `$ref` config gets a synthetic Resolve — its resource-deletes dispatch with resolved credentials. Ordering `Resolve → resource-deletes → target-delete → secret-delete` (reversed edge), acyclic.

### Cascade (delete just a secret that a target uses)
Mirrors the existing `onDependents` behavior: **default = abort** (409 `FormaTargetHasDependentsError` with a "re-run with `--on-dependents=cascade`" hint); with `--on-dependents=cascade` (or an interactive confirmation, which is the opt-in) the dependent target is deleted too and its config is **resolved** so its resources tear down, ordering resources → target → secret. Cascade targets un-cover (resolve) only when config carries an **opaque** `$ref` (a secret whose value isn't stored); non-opaque cross-resource refs stay covered (value is in the stored snapshot). The synthetic Resolve for an un-covered target carries only the opaque resolvables.

### Wiring + tests
`onDependents` threaded API server → client → CLI (default abort); 409 round-trips through `errfmt`. Verified end-to-end by a Grafana e2e demo (a target whose username/password come from one AWS JSON secret via `.json()`; apply + plain-destroy pass with no `GRAFANA_AUTH` env). Reviewed by opus (whole-branch) + Codex; both confirm the engine/ordering; the fix wave closed a property-suite compile break, the interactive-cascade opt-in gap, and a mixed-visibility Resolve edge.

**Depends on `formae@0.89.0` schema (the secret base types).** Part of RFC-110 Part 1. Stacked on #595.
