### PR TITLE
feat(cli): render full resource-update lists in the sim and live views

### DIFF
--- a/internal/cli/tui/simview/model.go
+++ b/internal/cli/tui/simview/model.go
@@ -60,8 +60,7 @@ const (
 type navLineKind int
 
 const (
-	navRow      navLineKind = iota
-	navShowMore navLineKind = iota
+	navRow navLineKind = iota
 )
 
 // navLine is one cursor position in the flat navigable list.
@@ -69,7 +68,6 @@ type navLine struct {
 	kind    navLineKind
 	rowKind rowKind
 	rowKey  string
-	rowIdx  int
 }
 
 // simviewChromeLines is the total fixed lines consumed by header + summary + footer.
@@ -94,7 +92,6 @@ type Model struct {
 	cmd      apimodel.Command // stored for footer delegation to components.PromptForOperations
 	groups   []simGroup
 	cursor   int
-	visible  map[rowKind]int
 	sortHi   map[rowKind]int
 	sortCol  map[rowKind]int
 	sortDir  map[rowKind]components.SortDirection
@@ -126,12 +123,6 @@ func New(th *theme.Theme, sim *apimodel.Simulation, opts Options) Model {
 		cmd:    sim.Command,
 		groups: groups,
 		cursor: 0,
-		visible: map[rowKind]int{
-			kindTarget:   10,
-			kindStack:    10,
-			kindPolicy:   10,
-			kindResource: 10,
-		},
 		sortHi: map[rowKind]int{
 			kindTarget:   colOp,
 			kindStack:    colOp,
@@ -321,9 +312,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.Enter) || msg.Type == tea.KeySpace:
 			if m.cursor >= 0 && m.cursor < total {
 				line := nav[m.cursor]
-				if line.kind == navShowMore {
-					m.visible[line.rowKind] += 10
-				} else if line.kind == navRow {
+				if line.kind == navRow {
 					// Toggle card expansion by row key.
 					if m.expanded[line.rowKey] {
 						delete(m.expanded, line.rowKey)
@@ -473,20 +462,11 @@ func (m Model) headerRight() string {
 func (m Model) navLines() []navLine {
 	var lines []navLine
 	for _, g := range m.groups {
-		lim := m.visible[g.kind]
-		shown, remaining := simVisibleRows(g, lim)
-		for i, r := range shown {
+		for _, r := range g.rows {
 			lines = append(lines, navLine{
 				kind:    navRow,
 				rowKind: g.kind,
 				rowKey:  r.key,
-				rowIdx:  i,
-			})
-		}
-		if remaining > 0 {
-			lines = append(lines, navLine{
-				kind:    navShowMore,
-				rowKind: g.kind,
 			})
 		}
 	}
@@ -730,17 +710,6 @@ func wrapText(text string, maxWidth int) string {
 		lines = append(lines, line)
 	}
 	return strings.Join(lines, "\n")
-}
-
-// simVisibleRows returns the visible slice and remaining count for a group.
-func simVisibleRows(g simGroup, limit int) ([]simRow, int) {
-	n := len(g.rows)
-	if limit > n {
-		limit = n
-	}
-	rows := make([]simRow, limit)
-	copy(rows, g.rows[:limit])
-	return rows, n - limit
 }
 
 // validSimSortCols returns the valid sort column indexes for a rowKind.

--- a/internal/cli/tui/simview/model_test.go
+++ b/internal/cli/tui/simview/model_test.go
@@ -119,38 +119,28 @@ func TestSimView_HeaderShowsMode(t *testing.T) {
 	assert.Equal(t, "destroy", New(th, sim, Options{Kind: KindDestroy, Mode: "reconcile"}).headerCommand())
 }
 
-// TestSimView_PaginationShowsMore navigates to the "show more" row in the
-// Resources group and presses enter; asserts that 10 more rows become visible.
-func TestSimView_PaginationShowsMore(t *testing.T) {
+// TestSimView_ShowsAllRowsNoTruncation asserts that every resource row is
+// navigable with no pagination cap: the number of resource rows in the flat nav
+// list equals the total resource rows in the group, and no show-more affordance
+// is produced.
+func TestSimView_ShowsAllRowsNoTruncation(t *testing.T) {
 	m := makeModel(100, 40)
 
-	// Resources group has 12 rows → first 10 shown + show-more.
-	// Nav list: targets(3) + stack(1) + policies(4) + resources(10) + show-more = 19 navigable entries.
-	// Navigate to show-more of resources group.
-	nav := m.navLines()
-	showMoreIdx := -1
-	for i, n := range nav {
-		if n.kind == navShowMore && n.rowKind == kindResource {
-			showMoreIdx = i
-			break
+	var totalResourceRows int
+	for _, g := range m.groups {
+		if g.kind == kindResource {
+			totalResourceRows = len(g.rows)
 		}
 	}
-	require.GreaterOrEqual(t, showMoreIdx, 0, "show-more row for resources must exist")
+	require.Greater(t, totalResourceRows, 10, "fixture must have >10 resource rows to exercise the previously-truncated case")
 
-	// Navigate cursor to show-more
-	for m.cursor < showMoreIdx {
-		var mm tea.Model
-		mm, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
-		m = mm.(Model)
+	navResourceRows := 0
+	for _, n := range m.navLines() {
+		if n.rowKind == kindResource {
+			navResourceRows++
+		}
 	}
-	assert.Equal(t, showMoreIdx, m.cursor, "cursor should be on show-more")
-
-	// Press enter to expand
-	var mm tea.Model
-	mm, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	m = mm.(Model)
-
-	assert.Equal(t, 20, m.visible[kindResource], "visible[resource] should expand by 10 to 20")
+	assert.Equal(t, totalResourceRows, navResourceRows, "all resource rows must be navigable (no truncation)")
 }
 
 // TestSimView_SortByColumn presses → then s and asserts the Resources group

--- a/internal/cli/tui/simview/render.go
+++ b/internal/cli/tui/simview/render.go
@@ -42,9 +42,13 @@ func (m Model) renderSummaryCounts() string {
 // plus the line index of the cursor row (for scroll-to-cursor).
 func (m Model) renderBody() (string, int) {
 	var body strings.Builder
-	nav := m.navLines()
 	cursorLine := 0
 	lineCount := 0
+	// navIdx is a running index into the flat nav list. Rendering visits groups
+	// and rows in the exact order navLines builds them (one nav entry per row),
+	// so a counter incremented per row matches the nav index without an O(n)
+	// lookup per row.
+	navIdx := 0
 
 	// Destroy cascade warning banner: shown at the top of the viewport when
 	// KindDestroy and any resource row has cascade=true.
@@ -75,8 +79,7 @@ func (m Model) renderBody() (string, int) {
 	}
 
 	for _, g := range m.groups {
-		lim := m.visible[g.kind]
-		shown, remaining := simVisibleRows(g, lim)
+		shown := g.rows
 		opW, labelW, typeW, stackW := groupLayout(g.kind, m.width)
 
 		// Blank line + section header
@@ -89,8 +92,7 @@ func (m Model) renderBody() (string, int) {
 		lineCount++
 
 		// Rows
-		for i, r := range shown {
-			navIdx := findNavIndex(nav, g.kind, r.key, i)
+		for _, r := range shown {
 			isCursor := navIdx == m.cursor
 			if isCursor {
 				cursorLine = lineCount
@@ -108,23 +110,7 @@ func (m Model) renderBody() (string, int) {
 					lineCount++
 				}
 			}
-		}
-
-		// Show-more row
-		if remaining > 0 {
-			smNavIdx := findShowMoreNavIndex(nav, g.kind)
-			isCursor := smNavIdx == m.cursor
-			if isCursor {
-				cursorLine = lineCount
-			}
-			moreText := fmt.Sprintf("      ↓ show 10 more (%d remaining)", remaining)
-			p := m.th.Palette
-			if isCursor {
-				body.WriteString(lipgloss.NewStyle().Foreground(p.PrimaryAccent).Bold(true).Render(moreText) + "\n")
-			} else {
-				body.WriteString(lipgloss.NewStyle().Foreground(p.TextSubtle).Render(moreText) + "\n")
-			}
-			lineCount++
+			navIdx++
 		}
 	}
 
@@ -392,24 +378,4 @@ func (m Model) renderRow(r simRow, kind rowKind, opW, labelW, typeW, stackW int,
 	}
 
 	return result
-}
-
-// findNavIndex returns the nav list index for a specific row in a group.
-func findNavIndex(nav []navLine, kind rowKind, key string, rowIdx int) int {
-	for i, n := range nav {
-		if n.kind == navRow && n.rowKind == kind && n.rowKey == key && n.rowIdx == rowIdx {
-			return i
-		}
-	}
-	return -1
-}
-
-// findShowMoreNavIndex returns the nav index for a show-more row in a group.
-func findShowMoreNavIndex(nav []navLine, kind rowKind) int {
-	for i, n := range nav {
-		if n.kind == navShowMore && n.rowKind == kind {
-			return i
-		}
-	}
-	return -1
 }

--- a/internal/cli/tui/statuswatch/detailmodel.go
+++ b/internal/cli/tui/statuswatch/detailmodel.go
@@ -24,13 +24,8 @@ import (
 type navigableLineKind int
 
 const (
-	navRow      navigableLineKind = iota // a summary or card row
-	navShowMore                          // a "show N more" row
+	navRow navigableLineKind = iota // a summary or card row
 )
-
-// detailPageSize is how many rows per group are shown before a "show N more"
-// row, and how many each activation reveals.
-const detailPageSize = 20
 
 // detailChromeLines is the detail view's non-viewport height: a plain two-line
 // header + the pinned command row + separator + the two-line footer. It is
@@ -43,7 +38,6 @@ type navigableLine struct {
 	kind      navigableLineKind
 	groupKind updateKind // which group this line belongs to
 	rowKey    string     // updateRow.key (for navRow only)
-	rowIdx    int        // index into the group's visible rows slice (for navRow only)
 }
 
 type detailModel struct {
@@ -54,7 +48,6 @@ type detailModel struct {
 	cursor     int                // index into the flat navigable lines list
 	expanded   map[string]bool    // keyed by updateRow.key
 	detailMode bool               // 'd': every row renders as card
-	visible    map[updateKind]int // pagination limit per group (starts at 10)
 	sortHi     map[updateKind]int // column highlighted by →←
 	sortCol    map[updateKind]int // active sort column per group
 	sortDir    map[updateKind]components.SortDirection
@@ -87,8 +80,7 @@ type detailModel struct {
 func newDetailModel(th *theme.Theme, width, height int) detailModel {
 	vp := viewport.New(width, max(height-detailChromeLines, 1)) // placeholder; resized on SetCommand/View
 	return detailModel{
-		th:      th,
-		visible: map[updateKind]int{kindTarget: detailPageSize, kindStack: detailPageSize, kindPolicy: detailPageSize, kindResource: detailPageSize},
+		th: th,
 		// Default the sort to the Label column (not the empty status column) so the
 		// ▲/▼ arrow appears on a real, labeled header instead of a lone glyph.
 		sortHi:  map[updateKind]int{kindTarget: detailColLabel, kindStack: detailColLabel, kindPolicy: detailColLabel, kindResource: detailColLabel},
@@ -192,20 +184,11 @@ func (d detailModel) ApplyTheme(t *theme.Theme) detailModel {
 func (d detailModel) navLines() []navigableLine {
 	var lines []navigableLine
 	for _, g := range d.groups {
-		lim := d.visible[g.kind]
-		shown, remaining := visibleRows(g, lim)
-		for i, r := range shown {
+		for _, r := range g.rows {
 			lines = append(lines, navigableLine{
 				kind:      navRow,
 				groupKind: g.kind,
 				rowKey:    r.key,
-				rowIdx:    i,
-			})
-		}
-		if remaining > 0 {
-			lines = append(lines, navigableLine{
-				kind:      navShowMore,
-				groupKind: g.kind,
 			})
 		}
 	}
@@ -329,15 +312,11 @@ func (d detailModel) Update(msg tea.KeyMsg, keys tui.KeyMap) (detailModel, bool)
 	case key.Matches(msg, keys.Enter) || msg.Type == tea.KeySpace:
 		if d.cursor >= 0 && d.cursor < total {
 			line := nav[d.cursor]
-			if line.kind == navShowMore {
-				d.visible[line.groupKind] += detailPageSize
+			// Toggle expansion for this row key
+			if d.expanded[line.rowKey] {
+				delete(d.expanded, line.rowKey)
 			} else {
-				// Toggle expansion for this row key
-				if d.expanded[line.rowKey] {
-					delete(d.expanded, line.rowKey)
-				} else {
-					d.expanded[line.rowKey] = true
-				}
+				d.expanded[line.rowKey] = true
 			}
 		}
 
@@ -376,14 +355,16 @@ func (d detailModel) View(height int, showQueryBar bool) string {
 
 	// Build scrollable body
 	var body strings.Builder
-	nav := d.navLines()
 	cursorLine := 0 // line index within body where cursor is
 
 	lineCount := 0 // running count of lines emitted to body
+	// navIdx is a running index into the flat nav list. Rendering visits groups
+	// and rows in the same order navLines builds them (one nav entry per row), so
+	// a per-row counter matches the nav index without an O(n) lookup per row.
+	navIdx := 0
 
 	for _, g := range d.groups {
-		lim := d.visible[g.kind]
-		shown, remaining := visibleRows(g, lim)
+		shown := g.rows
 
 		labelW, typeW, stackW := groupLayout(g.kind, w)
 
@@ -398,9 +379,7 @@ func (d detailModel) View(height int, showQueryBar bool) string {
 		lineCount++
 
 		// Rows
-		for i, r := range shown {
-			// Find this row's nav index
-			navIdx := d.findNavIndex(nav, g.kind, r.key, i)
+		for _, r := range shown {
 			isCursor := navIdx == d.cursor
 			if isCursor {
 				cursorLine = lineCount
@@ -422,27 +401,7 @@ func (d detailModel) View(height int, showQueryBar bool) string {
 				rowLines := strings.Count(rowStr, "\n")
 				lineCount += rowLines
 			}
-		}
-
-		// Show-more row
-		if remaining > 0 {
-			showMoreNavIdx := d.findShowMoreNavIndex(nav, g.kind)
-			isCursor := showMoreNavIdx == d.cursor
-			if isCursor {
-				cursorLine = lineCount
-			}
-			moreText := fmt.Sprintf("      ↓ show %d more (%d remaining)", min(detailPageSize, remaining), remaining)
-			if isCursor {
-				body.WriteString(lipgloss.NewStyle().
-					Foreground(p.PrimaryAccent).
-					Bold(true).
-					Render(moreText) + "\n")
-			} else {
-				body.WriteString(lipgloss.NewStyle().
-					Foreground(p.TextSubtle).
-					Render(moreText) + "\n")
-			}
-			lineCount++
+			navIdx++
 		}
 	}
 
@@ -495,26 +454,6 @@ func detailFooterHints(singleCommand bool) []components.KeyHint {
 		hints = append(hints, components.KeyHint{Key: "esc", Desc: "back"})
 	}
 	return append(hints, components.KeyHint{Key: "q", Desc: "quit"})
-}
-
-// findNavIndex finds the nav cursor index for a specific row in a group.
-func (d detailModel) findNavIndex(nav []navigableLine, kind updateKind, key string, rowIdx int) int {
-	for i, n := range nav {
-		if n.kind == navRow && n.groupKind == kind && n.rowKey == key && n.rowIdx == rowIdx {
-			return i
-		}
-	}
-	return -1
-}
-
-// findShowMoreNavIndex finds the nav cursor index for a show-more row.
-func (d detailModel) findShowMoreNavIndex(nav []navigableLine, kind updateKind) int {
-	for i, n := range nav {
-		if n.kind == navShowMore && n.groupKind == kind {
-			return i
-		}
-	}
-	return -1
 }
 
 // renderGroupColHeader renders the column header row for a group.

--- a/internal/cli/tui/statuswatch/detailmodel_test.go
+++ b/internal/cli/tui/statuswatch/detailmodel_test.go
@@ -113,7 +113,7 @@ func TestDetailModel_SummaryRowsAndSecondLines(t *testing.T) {
 		"a failed resource with no error of its own is explained as a dependency failure")
 }
 
-func TestDetailModel_ShowMoreRow(t *testing.T) {
+func TestDetailModel_ShowsAllRowsNoTruncation(t *testing.T) {
 	th := theme.New("formae")
 	dm := newDetailModel(th, 100, 40)
 
@@ -134,19 +134,19 @@ func TestDetailModel_ShowMoreRow(t *testing.T) {
 	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
 	dm = dm.SetCommand(c, r, "◉", now, nil)
 
-	v := plain(dm.View(40, false))
-	// 25 resources, page size 20 → 20 shown, 5 remaining.
-	assert.Contains(t, v, "show 5 more (5 remaining)")
-
-	// cursor to show-more row (row index 20, after 20 visible rows)
-	// navigate down 20 times from 0
-	keys := defaultKeyMap()
-	for i := 0; i < 20; i++ {
-		dm, _ = dm.Update(tea.KeyMsg{Type: tea.KeyDown}, keys)
+	// All 25 resource rows are navigable — no pagination cap.
+	navResourceRows := 0
+	for _, n := range dm.navLines() {
+		if n.groupKind == kindResource {
+			navResourceRows++
+		}
 	}
-	// Now cursor should be on the show-more row — press enter
-	dm, _ = dm.Update(tea.KeyMsg{Type: tea.KeyEnter}, keys)
-	assert.Equal(t, 40, dm.visible[kindResource], "visible should expand by 20 to 40")
+	assert.Equal(t, 25, navResourceRows, "all resource rows must be navigable (no truncation)")
+
+	// No show-more affordance is rendered.
+	v := plain(dm.View(40, false))
+	assert.NotContains(t, v, "↓ show", "no show-more row should be rendered")
+	assert.NotContains(t, v, "remaining)", "no show-more remaining-count should be rendered")
 }
 
 func TestDetailModel_ExpandCardByKey(t *testing.T) {
@@ -420,7 +420,7 @@ func TestSetCommand_ClampsCursorWhenListShrinks(t *testing.T) {
 	th := theme.New("formae")
 	dm := newDetailModel(th, 100, 40)
 
-	// Build a command with 25 resource updates so visibleRows returns 20 + show-more.
+	// Build a command with 25 resource updates; all render (no truncation).
 	c12 := apimodel.Command{
 		CommandID: "cmd-shrink",
 		State:     "InProgress",
@@ -438,11 +438,11 @@ func TestSetCommand_ClampsCursorWhenListShrinks(t *testing.T) {
 	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
 	dm = dm.SetCommand(c12, r12, "◉", now, nil)
 
-	// Navigate cursor to the last navigable line (show-more row, index 10).
+	// Navigate cursor to the last navigable line.
 	nav12 := dm.navLines()
 	dm.cursor = len(nav12) - 1
-	require.Equal(t, 21, len(nav12), "expect 20 rows + 1 show-more = 21 nav entries")
-	require.Equal(t, 20, dm.cursor)
+	require.Equal(t, 25, len(nav12), "expect all 25 rows as nav entries (no truncation)")
+	require.Equal(t, 24, dm.cursor)
 
 	// Now refresh with a 2-resource command — list shrinks drastically.
 	c2 := apimodel.Command{

--- a/internal/cli/tui/statuswatch/detailview.go
+++ b/internal/cli/tui/statuswatch/detailview.go
@@ -203,16 +203,6 @@ func marshalRefLabels(m map[string]string) json.RawMessage {
 	return b
 }
 
-func visibleRows(g group, limit int) ([]updateRow, int) {
-	n := len(g.rows)
-	if limit > n {
-		limit = n
-	}
-	rows := make([]updateRow, limit)
-	copy(rows, g.rows[:limit])
-	return rows, n - limit
-}
-
 func validSortCols(kind updateKind) []int {
 	switch kind {
 	case kindPolicy:

--- a/internal/cli/tui/statuswatch/detailview_test.go
+++ b/internal/cli/tui/statuswatch/detailview_test.go
@@ -5,7 +5,6 @@
 package statuswatch
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -79,24 +78,6 @@ func TestBuildGroups_KeysDistinguishSameLabelAcrossStacks(t *testing.T) {
 	assert.Contains(t, rows[1].key, "web")
 }
 
-func TestVisibleRows_Pagination(t *testing.T) {
-	g := group{kind: kindResource, title: "Resources"}
-	for i := 0; i < 25; i++ {
-		g.rows = append(g.rows, updateRow{label: fmt.Sprintf("r-%02d", i)})
-	}
-	shown, remaining := visibleRows(g, 10)
-	assert.Len(t, shown, 10)
-	assert.Equal(t, 15, remaining)
-
-	shown, remaining = visibleRows(g, 20)
-	assert.Len(t, shown, 20)
-	assert.Equal(t, 5, remaining)
-
-	shown, remaining = visibleRows(g, 99)
-	assert.Len(t, shown, 25)
-	assert.Zero(t, remaining)
-}
-
 func TestSortGroup_ByLabelAndTime(t *testing.T) {
 	rows := []updateRow{
 		{label: "b", duration: 2 * time.Second},
@@ -113,12 +94,4 @@ func TestValidSortCols_PerKind(t *testing.T) {
 	assert.NotContains(t, validSortCols(kindTarget), detailColStack)
 	assert.Contains(t, validSortCols(kindResource), detailColType)
 	assert.Contains(t, validSortCols(kindPolicy), detailColStack)
-}
-
-func TestVisibleRows_ReturnsCopy(t *testing.T) {
-	g := group{rows: []updateRow{{key: "a"}, {key: "b"}, {key: "c"}}}
-	rows, remaining := visibleRows(g, 2)
-	assert.Equal(t, 1, remaining)
-	rows[0].key = "mutated"
-	assert.Equal(t, "a", g.rows[0].key, "returned slice must not alias the group's backing array")
 }


### PR DESCRIPTION
## Summary

- The apply/destroy simulation preview (simview) and the live progress view (statuswatch) capped each row group at 10 (preview) / 20 (live) rows behind a "show N more" pager. On plans that touch many resources this hid most of the changeset behind repeated manual activations.
- Both views already scroll their viewport, so the cap added friction without protecting layout. This renders every row in every group (resources, targets, stacks, policies) and removes the pagination mechanism entirely — the per-group visible limits, the show-more nav rows, and their key handling.
- Rendering now tracks a running index into the flat nav list instead of scanning it once per row, so a redraw stays linear in the number of rows rather than becoming quadratic now that the list is unbounded.