### PR TITLE
fix(secrets): map-secret support + target-config-secret resolution hardening

### DIFF
--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -207,6 +207,21 @@ func (p *ExecutionDAG) buildTargetResourceEdges(targetUpdates []target_update.Ta
 					if reResolvesConfig && !dependsOnTransitively(targetNode, node.URI) {
 						node.LinkWith(targetNode)
 					}
+				case resource_update.OperationRead:
+					// A read on a target whose config is being resolved — the
+					// synthetic Resolve op, e.g. a sync/OOB read of a resource on a
+					// secret-authed target — must wait for that Resolve so it
+					// dispatches the resolved credential instead of the raw opaque
+					// $ref (which the plugin cannot authenticate with, hanging or
+					// failing the read). Only the Resolve op warrants this edge: a
+					// plain target create/update already carries a usable config, and
+					// sync reads are otherwise deliberately edge-free (independent of
+					// one another) to avoid one failing read cascading a whole
+					// subtree. Guard against a cycle exactly as deletes do.
+					if tu.Operation == target_update.TargetOperationResolve &&
+						reResolvesConfig && !dependsOnTransitively(targetNode, node.URI) {
+						node.LinkWith(targetNode)
+					}
 				}
 			}
 		}

--- a/internal/metastructure/changeset/resolve_cache.go
+++ b/internal/metastructure/changeset/resolve_cache.go
@@ -7,8 +7,10 @@ package changeset
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"ergo.services/ergo/act"
@@ -17,7 +19,6 @@ import (
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
-	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
@@ -107,7 +108,7 @@ func (r *ResolveCache) startResolve(from gen.PID, resourceURI pkgmodel.FormaeURI
 	// Check if the resource is already in the cache
 	if json, ok := r.cache[resourceURI.Stripped()]; ok {
 		r.Log().Debug("Cache hit for resource URI uri=%v", resourceURI)
-		value := json.Get(resourceURI.PropertyPath())
+		value := resolvedValueAt(json, resourceURI.PropertyPath())
 		if !value.Exists() {
 			r.Log().Error("Unable to resolve property in cached properties property=%s resourceURI=%v", resourceURI.PropertyPath(), resourceURI)
 			_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI, Reason: resolveMissReason(resourceURI, nil)})
@@ -136,30 +137,69 @@ func (r *ResolveCache) startResolve(from gen.PID, resourceURI pkgmodel.FormaeURI
 		return
 	}
 
-	// The persisted target config may contain resolvable metadata ($ref/$value
-	// wrappers) that plugins cannot parse.  Strip these to produce clean JSON
-	// the plugin can unmarshal.
-	targetConfig := loadResourceResult.Target.Config
-	if cleanConfig, err := resolver.ConvertToPluginFormat(targetConfig); err == nil {
-		targetConfig = cleanConfig
-	}
-
-	// Execute the first attempt inline (no delay).
+	// Execute the first attempt inline (no delay). Both the source target's
+	// config resolution and the Read happen in continueResolve, so a recoverable
+	// failure in EITHER reschedules via SendAfter on one non-blocking budget.
 	retry := resolveRetry{
 		From:        from,
 		ResourceURI: resourceURI,
 		Attempt:     1,
 		loadResult:  loadResourceResult,
-		config:      targetConfig,
 	}
 	r.continueResolve(retry)
 }
 
-// continueResolve executes a single read attempt and either resolves, schedules
-// a retry via SendAfter, or sends a failure back to the original requester.
+// strategy is the retry strategy for a resolve read: exponential-for-throttling,
+// and the single source of truth the caller's timeout budget is derived from.
+// It uses the command-global RetryConfig the actor reads at startup. Honoring a
+// per-plugin retry override for the source namespace is a known gap: it would
+// need the cache to query the coordinator for that namespace's config, plus a
+// per-namespace timeout budget (a resource can reference secrets across several
+// plugins), so it is deferred.
+func (r *ResolveCache) strategy() resource.RetryStrategy {
+	return resource.RetryStrategy{MaxRetries: r.maxRetries, BaseDelay: r.retryDelay}
+}
+
+// scheduleRetry reschedules a resolve attempt without blocking the actor loop.
+func (r *ResolveCache) scheduleRetry(retry resolveRetry, after time.Duration) {
+	if _, err := r.SendAfter(r.PID(), retry, after); err != nil {
+		r.Log().Error("Failed to schedule resolve retry: %v", err)
+		_ = r.Send(retry.From, messages.FailedToResolveValue{ResourceURI: retry.ResourceURI})
+	}
+}
+
+// continueResolve resolves the source target's config (single-shot) and executes
+// a read attempt; on a recoverable failure in either it schedules a retry via
+// SendAfter (non-blocking), otherwise it resolves or reports failure.
 func (r *ResolveCache) continueResolve(retry resolveRetry) {
 	resourceURI := retry.ResourceURI
 	from := retry.From
+
+	// Resolve the source target's opaque config (single-shot) before the Read.
+	// When the target authenticates from a secret, its persisted config carries a
+	// bare opaque $ref with no $value at rest (reference-don't-store), and
+	// ConvertToPluginFormat only strips metadata — it does not read the source. A
+	// recoverable failure here reschedules the whole resolve via SendAfter, on the
+	// same non-blocking budget as the Read below.
+	if retry.config == nil {
+		targetConfig, err := resource_update.ResolveOpaqueTargetConfig(r, retry.loadResult.Target)
+		if err != nil {
+			var rec *resource_update.RecoverableResolveError
+			if errors.As(err, &rec) {
+				if dec := r.strategy().Decide(retry.Attempt, rec.Code); dec.Retry {
+					r.Log().Info("ResolveCache: recoverable target-config resolve error, retrying errorCode=%s resourceURI=%v attempt=%d",
+						rec.Code, resourceURI, retry.Attempt)
+					retry.Attempt++
+					r.scheduleRetry(retry, dec.After)
+					return
+				}
+			}
+			r.Log().Error("Failed to resolve target config for resolve-read resourceURI=%v: %v", resourceURI, err)
+			_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI, Reason: err.Error()})
+			return
+		}
+		retry.config = targetConfig
+	}
 
 	progress, err := r.readViaPlugin(retry)
 	if err != nil {
@@ -168,16 +208,14 @@ func (r *ResolveCache) continueResolve(retry resolveRetry) {
 		return
 	}
 
-	// Retry on recoverable errors via SendAfter (non-blocking).
+	// Retry on recoverable read errors via SendAfter (non-blocking), sharing the
+	// same attempt budget as the config resolution above.
 	if progress.OperationStatus == resource.OperationStatusFailure && resource.IsRecoverable(progress.ErrorCode) {
-		if retry.Attempt < r.maxRetries {
+		if dec := r.strategy().Decide(retry.Attempt, progress.ErrorCode); dec.Retry {
 			r.Log().Info("ResolveCache: recoverable error, retrying errorCode=%s resourceURI=%v attempt=%d maxRetries=%d",
 				progress.ErrorCode, resourceURI, retry.Attempt, r.maxRetries)
 			retry.Attempt++
-			if _, err := r.SendAfter(r.PID(), retry, r.retryDelay); err != nil {
-				r.Log().Error("Failed to schedule resolve retry: %v", err)
-				_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI})
-			}
+			r.scheduleRetry(retry, dec.After)
 			return
 		}
 		r.Log().Error("ResolveCache: exhausted retries errorCode=%s resourceURI=%v attempts=%d",
@@ -200,7 +238,7 @@ func (r *ResolveCache) continueResolve(retry resolveRetry) {
 
 	r.cache[resourceURI.Stripped()] = enhancedParsed
 	r.Log().Debug("Cached resolved properties uri=%v", resourceURI)
-	value := enhancedParsed.Get(resourceURI.PropertyPath())
+	value := resolvedValueAt(enhancedParsed, resourceURI.PropertyPath())
 	if !value.Exists() {
 		r.Log().Error("Unable to resolve property in cached properties property=%s resourceURI=%v", resourceURI.PropertyPath(), resourceURI)
 		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI, Reason: resolveMissReason(resourceURI, &retry.loadResult.Resource)})
@@ -268,4 +306,38 @@ func (r *ResolveCache) preserveRefMetadata(originalResource pkgmodel.Resource, p
 func hasOpaqueValues(props json.RawMessage) bool {
 	return bytes.Contains(props, []byte(`"$visibility"`)) &&
 		bytes.Contains(props, []byte(`"Opaque"`))
+}
+
+// resolvedValueAt extracts the resolved value for propertyPath from cached
+// plugin properties. preserveRefMetadata wraps an opaque field as
+// {"$value": <fieldValue>, "$visibility": "Opaque"}, so a scalar secret whose
+// path IS the field name resolves directly. A ref into a MAP-shaped opaque
+// secret selects a key (e.g. "decodedData.username") that lives beneath the
+// wrapper at "<field>.$value.<subpath>"; when the direct lookup misses, descend
+// into the opaque parent's $value and re-wrap the leaf in the same envelope
+// shape so downstream handling is identical for scalar and map secrets.
+func resolvedValueAt(props gjson.Result, propertyPath string) gjson.Result {
+	if v := props.Get(propertyPath); v.Exists() {
+		return v
+	}
+	root, subpath, nested := strings.Cut(propertyPath, ".")
+	if !nested {
+		return gjson.Result{}
+	}
+	parent := props.Get(root)
+	if parent.Get("$visibility").String() != pkgmodel.VisibilityOpaque {
+		return gjson.Result{}
+	}
+	leaf := parent.Get("$value." + subpath)
+	if !leaf.Exists() {
+		return gjson.Result{}
+	}
+	wrapped, err := json.Marshal(map[string]any{
+		"$value":      leaf.Value(),
+		"$visibility": pkgmodel.VisibilityOpaque,
+	})
+	if err != nil {
+		return gjson.Result{}
+	}
+	return gjson.ParseBytes(wrapped)
 }

--- a/internal/metastructure/changeset/resolve_cache_test.go
+++ b/internal/metastructure/changeset/resolve_cache_test.go
@@ -55,3 +55,25 @@ func TestPreserveRefMetadata_NoOpaqueFields_ReturnsUnchanged(t *testing.T) {
 	assert.Equal(t, "plain-value", out.Get("Name").String())
 	assert.False(t, out.Get("Name.$visibility").Exists())
 }
+
+func TestResolvedValueAt_MapSecretSubPath(t *testing.T) {
+	// preserveRefMetadata wraps an opaque field as {$value:<v>,$visibility:Opaque}.
+	// A ref selecting a key of a MAP-shaped opaque secret lives beneath the wrapper
+	// at "<field>.$value.<key>"; resolvedValueAt must descend into the envelope and
+	// re-wrap the leaf in the same shape a scalar secret produces.
+	wrapped := gjson.Parse(`{"decodedData":{"$value":{"username":"admin","password":"p"},"$visibility":"Opaque"}}`)
+
+	v := resolvedValueAt(wrapped, "decodedData.username")
+	assert.True(t, v.Exists())
+	assert.Equal(t, "admin", v.Get("$value").String())
+	assert.Equal(t, "Opaque", v.Get("$visibility").String())
+
+	// A scalar secret whose path IS the field name resolves to its envelope directly.
+	scalar := gjson.Parse(`{"SecretString":{"$value":"s","$visibility":"Opaque"}}`)
+	sv := resolvedValueAt(scalar, "SecretString")
+	assert.True(t, sv.Exists())
+	assert.Equal(t, "s", sv.Get("$value").String())
+
+	// A missing key does not resolve.
+	assert.False(t, resolvedValueAt(wrapped, "decodedData.nope").Exists())
+}

--- a/internal/metastructure/discovery/resolve_target_config.go
+++ b/internal/metastructure/discovery/resolve_target_config.go
@@ -5,144 +5,19 @@
 package discovery
 
 import (
-	"bytes"
 	"encoding/json"
-	"fmt"
-	"reflect"
 
 	"ergo.services/ergo/gen"
-	"github.com/tidwall/gjson"
 
-	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
-	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
-	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
-	"github.com/platform-engineering-labs/formae/pkg/plugin"
-	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
 // resolveTargetConfigForList returns an ephemeral copy of target.Config with
-// every opaque $ref replaced by its live plaintext value. When the config
-// carries no opaque references it is returned unchanged. Any resolve failure
-// returns a redacted error that names the reference and target but never the
-// plaintext secret.
+// every opaque $ref replaced by its live plaintext value, so the List call
+// authenticates. It delegates to the shared resolver used by every plugin-call
+// path that loads a persisted target config (see
+// resource_update.ResolveOpaqueTargetConfig).
 func resolveTargetConfigForList(proc gen.Process, target pkgmodel.Target) (json.RawMessage, error) {
-	uris := resolver.ExtractOpaqueResolvableURIsFromJSON(target.Config)
-	if len(uris) == 0 {
-		return target.Config, nil
-	}
-
-	// Work on a copy so the caller's original config is never mutated.
-	cfg := bytes.Clone(target.Config)
-
-	for _, uri := range uris {
-		// Load the source resource from the persister.
-		rawResult, err := proc.Call(
-			gen.ProcessID{Name: actornames.ResourcePersister, Node: proc.Node().Name()},
-			messages.LoadResource{ResourceURI: uri.Stripped()},
-		)
-		if err != nil {
-			proc.Log().Error(
-				"failed to load resource for opaque ref resolution uri=%s target=%s: %v",
-				uri, target.Label, err,
-			)
-			return nil, fmt.Errorf(
-				"failed to resolve opaque reference %q for target %q: load error",
-				uri, target.Label,
-			)
-		}
-
-		loadResult, ok := rawResult.(messages.LoadResourceResult)
-		if !ok {
-			proc.Log().Error(
-				"unexpected result type from resource persister resultType=%v uri=%s target=%s",
-				reflect.TypeOf(rawResult), uri, target.Label,
-			)
-			return nil, fmt.Errorf(
-				"failed to resolve opaque reference %q for target %q: unexpected persister response",
-				uri, target.Label,
-			)
-		}
-
-		// Strip resolvable metadata from the source target's config before
-		// sending to the plugin — mirrors the pattern in resolve_cache.go.
-		srcCfg := loadResult.Target.Config
-		if cleanCfg, err := resolver.ConvertToPluginFormat(srcCfg); err == nil {
-			srcCfg = cleanCfg
-		}
-
-		progress, err := readSource(proc, loadResult.Resource, srcCfg)
-		if err != nil {
-			proc.Log().Error(
-				"failed to read resource for opaque ref resolution uri=%s target=%s: %v",
-				uri, target.Label, err,
-			)
-			return nil, fmt.Errorf(
-				"failed to resolve opaque reference %q for target %q: read error",
-				uri, target.Label,
-			)
-		}
-
-		// Extract the property value from the read result.
-		parsed := gjson.ParseBytes([]byte(progress.ResourceProperties))
-		value := parsed.Get(uri.PropertyPath())
-		if !value.Exists() {
-			proc.Log().Error(
-				"opaque ref property not found in read result property=%s uri=%s target=%s",
-				uri.PropertyPath(), uri, target.Label,
-			)
-			return nil, fmt.Errorf(
-				"failed to resolve opaque reference %q for target %q: property %q absent from read result",
-				uri, target.Label, uri.PropertyPath(),
-			)
-		}
-
-		// Inject the resolved plaintext back into the working config copy.
-		cfg, err = resolver.ResolvePropertyReferences(uri, cfg, value.String())
-		if err != nil {
-			proc.Log().Error(
-				"failed to inject resolved value uri=%s target=%s configRedacted=%v: %v",
-				uri, target.Label, pkgmodel.RedactOpaqueForLog(cfg), err,
-			)
-			return nil, fmt.Errorf(
-				"failed to resolve opaque reference %q for target %q: inject error",
-				uri, target.Label,
-			)
-		}
-	}
-
-	// Strip the $ref/$value/$visibility wrappers so the returned config is
-	// plain JSON the plugin can unmarshal directly. A failure here indicates
-	// an unresolvable envelope (e.g. a $hashed field whose plaintext is
-	// irrecoverable); surface it rather than returning the still-wrapped config.
-	plain, err := resolver.ConvertToPluginFormat(cfg)
-	if err != nil {
-		proc.Log().Error(
-			"failed to strip opaque wrappers from resolved target config target=%s configRedacted=%v: %v",
-			target.Label, pkgmodel.RedactOpaqueForLog(cfg), err,
-		)
-		return nil, fmt.Errorf(
-			"failed to prepare resolved config for target %q: convert error",
-			target.Label,
-		)
-	}
-
-	return plain, nil
-}
-
-// readSource performs a single ReadResourceViaPlugin for opaque-ref resolution.
-// It does not retry and never sleeps: a recoverable failure is surfaced to the
-// caller, and discovery skips the target for this cycle and retries it on the
-// next cycle, so a transient failure is absorbed without blocking the discovery
-// actor.
-func readSource(proc gen.Process, res pkgmodel.Resource, cfg json.RawMessage) (*plugin.TrackedProgress, error) {
-	progress, err := resource_update.ReadResourceViaPlugin(proc, res, cfg)
-	if err != nil {
-		return nil, err
-	}
-	if progress.OperationStatus == resource.OperationStatusFailure {
-		return nil, fmt.Errorf("read failed: error %s", progress.ErrorCode)
-	}
-	return progress, nil
+	return resource_update.ResolveOpaqueTargetConfig(proc, target)
 }

--- a/internal/metastructure/discovery/resolve_target_config_test.go
+++ b/internal/metastructure/discovery/resolve_target_config_test.go
@@ -8,6 +8,7 @@ package discovery
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -21,6 +22,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/changeset"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
@@ -255,14 +257,13 @@ func TestResolveTargetConfigForList_NonRecoverableReadFailure(t *testing.T) {
 		"error must not include raw $ref envelope fields")
 }
 
-// TestResolveTargetConfigForList_RecoverableReadFailureReturnsError asserts that
-// a recoverable read failure surfaces as an error after a single attempt.
-// resolveTargetConfigForList is single-shot and never sleeps: discovery skips the
-// target for this cycle and retries it on the next cycle, so retry does not
-// happen inside this call.
-func TestResolveTargetConfigForList_RecoverableReadFailureReturnsError(t *testing.T) {
+// TestResolveTargetConfigForList_RecoverableFailureThenSuccess asserts that a
+// recoverable failure followed by success within the attempt budget resolves
+// successfully, and that exceeding the budget returns an error.
+func TestResolveTargetConfigForList_RecoverableFailureIsSingleShot(t *testing.T) {
 	const ksuid = "35R2vyf6mT5wEs0mTWT5bp1Lf0E"
 	const prop = "SecretString"
+	const plaintext = "s3cr3t"
 
 	srcResource := buildSourceResource(ksuid)
 	srcTarget := pkgmodel.Target{
@@ -270,34 +271,67 @@ func TestResolveTargetConfigForList_RecoverableReadFailureReturnsError(t *testin
 		Namespace: "FakeAWS",
 		Config:    json.RawMessage(`{"Region":"us-east-1"}`),
 	}
+
+	targetCfg := buildOpaqueTargetConfig(ksuid, prop)
 	target := pkgmodel.Target{
 		Label:  "prod",
-		Config: buildOpaqueTargetConfig(ksuid, prop),
+		Config: targetCfg,
 	}
 
-	proc := &resolveStubProcess{
-		loadResult: messages.LoadResourceResult{
-			Resource: srcResource,
-			Target:   srcTarget,
-		},
-		readResponses: []readResponse{
-			{
-				progress: &plugin.TrackedProgress{
-					ProgressResult: resource.ProgressResult{
-						OperationStatus: resource.OperationStatusFailure,
-						ErrorCode:       resource.OperationErrorCodeServiceTimeout, // recoverable
+	t.Run("recoverable failure is single-shot and typed", func(t *testing.T) {
+		proc := &resolveStubProcess{
+			loadResult: messages.LoadResourceResult{
+				Resource: srcResource,
+				Target:   srcTarget,
+			},
+			readResponses: []readResponse{
+				{
+					progress: &plugin.TrackedProgress{
+						ProgressResult: resource.ProgressResult{
+							OperationStatus: resource.OperationStatusFailure,
+							ErrorCode:       resource.OperationErrorCodeServiceTimeout, // recoverable
+						},
 					},
 				},
 			},
-		},
-	}
+		}
 
-	result, err := resolveTargetConfigForList(proc, target)
+		result, err := resolveTargetConfigForList(proc, target)
 
-	require.Error(t, err, "a recoverable read failure must surface as an error, not an in-call retry")
-	assert.Nil(t, result)
-	assert.Equal(t, 1, proc.readAttempts,
-		"resolveTargetConfigForList must read exactly once: retry is the discovery cycle's job")
+		require.Error(t, err, "a recoverable read failure must surface as an error")
+		assert.Nil(t, result)
+		var rec *resource_update.RecoverableResolveError
+		require.True(t, errors.As(err, &rec),
+			"a recoverable failure must surface as *RecoverableResolveError so the caller can reschedule")
+		assert.Equal(t, resource.OperationErrorCodeServiceTimeout, rec.Code)
+		assert.Equal(t, 1, proc.readAttempts,
+			"resolution is single-shot: exactly one read, no in-place retry")
+	})
+
+	t.Run("success resolves in one read", func(t *testing.T) {
+		proc := &resolveStubProcess{
+			loadResult: messages.LoadResourceResult{
+				Resource: srcResource,
+				Target:   srcTarget,
+			},
+			readResponses: []readResponse{
+				{
+					progress: &plugin.TrackedProgress{
+						ProgressResult: resource.ProgressResult{
+							OperationStatus:    resource.OperationStatusSuccess,
+							ResourceProperties: json.RawMessage(fmt.Sprintf(`{"%s":"%s"}`, prop, plaintext)),
+						},
+					},
+				},
+			},
+		}
+
+		result, err := resolveTargetConfigForList(proc, target)
+
+		require.NoError(t, err)
+		assert.Contains(t, string(result), plaintext)
+		assert.Equal(t, 1, proc.readAttempts)
+	})
 }
 
 // TestResolveTargetConfigForList_ConvertFailureDoesNotLeakEnvelope asserts that

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -250,10 +251,24 @@ func isSourcePropertyOpaque(source *pkgmodel.Resource, propertyName string) bool
 	if source == nil || propertyName == "" {
 		return false
 	}
-	if gjson.GetBytes(source.Properties, propertyName).Get("$visibility").String() == pkgmodel.VisibilityOpaque {
-		return true
+	// Check the property path itself and its top-level field. A ref into a
+	// MAP-shaped opaque secret (e.g. "decodedData.password", produced by
+	// secret.res.secretValue.at("password")) is opaque by virtue of its opaque
+	// parent field: the field is stored as a single hashed envelope with no
+	// per-key sub-structure, so the leaf path has no $visibility of its own.
+	candidates := []string{propertyName}
+	if root, _, found := strings.Cut(propertyName, "."); found {
+		candidates = append(candidates, root)
 	}
-	return gjson.GetBytes(source.ReadOnlyProperties, propertyName).Get("$visibility").String() == pkgmodel.VisibilityOpaque
+	for _, p := range candidates {
+		if gjson.GetBytes(source.Properties, p).Get("$visibility").String() == pkgmodel.VisibilityOpaque {
+			return true
+		}
+		if gjson.GetBytes(source.ReadOnlyProperties, p).Get("$visibility").String() == pkgmodel.VisibilityOpaque {
+			return true
+		}
+	}
+	return false
 }
 
 // ExtractSourceOpaqueResolvableURIsFromJSON returns the resolvable URIs in data

--- a/internal/metastructure/resolver/resolver_test.go
+++ b/internal/metastructure/resolver/resolver_test.go
@@ -1629,6 +1629,22 @@ func TestExtractSourceOpaqueResolvableURIsFromJSON(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, got)
 
+	// A map-shaped secret (Kubernetes-style): the opaque value is a single field
+	// `decodedData` stored as one hashed envelope, and a ref selects a key with
+	// .at("password"), so its source property path is "decodedData.password".
+	// The ref is a credential by virtue of its opaque PARENT field, even though
+	// the leaf path has no envelope of its own.
+	mapKsuid := util.NewID()
+	mapURI := pkgmodel.NewFormaeURI(mapKsuid, "decodedData.password")
+	sources[mapKsuid] = &pkgmodel.Resource{
+		Ksuid:      mapKsuid,
+		Properties: json.RawMessage(`{"decodedData":{"$value":"h","$visibility":"Opaque","$hashed":true}}`),
+	}
+	got, err = ExtractSourceOpaqueResolvableURIsFromJSON(
+		json.RawMessage(`{"password":{"$ref":"`+string(mapURI)+`","$visibility":"Clear"}}`), load)
+	require.NoError(t, err)
+	assert.Equal(t, []pkgmodel.FormaeURI{mapURI}, got)
+
 	// An envelope-Opaque ref is a credential without ever loading the source.
 	loadFail := func(string) (*pkgmodel.Resource, error) {
 		return nil, fmt.Errorf("source must not be loaded for an envelope-opaque ref")

--- a/internal/metastructure/resource_update/resolve_target_config.go
+++ b/internal/metastructure/resource_update/resolve_target_config.go
@@ -52,11 +52,14 @@ func ResolveOpaqueTargetConfig(proc gen.Process, target pkgmodel.Target) (json.R
 	uris := resolver.ExtractOpaqueResolvableURIsFromJSON(target.Config)
 	if len(uris) == 0 {
 		// No opaque refs: still strip any cached $value/metadata so the plugin
-		// receives plain JSON, mirroring the resolved path's final conversion.
-		if plain, err := resolver.ConvertToPluginFormat(target.Config); err == nil {
-			return plain, nil
+		// receives plain JSON, mirroring the resolved path's final conversion. Fail
+		// closed on a conversion error (e.g. an irrecoverable $hashed field) rather
+		// than leaking the raw envelope to the plugin.
+		plain, err := resolver.ConvertToPluginFormat(target.Config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare config for target %q: convert error", target.Label)
 		}
-		return target.Config, nil
+		return plain, nil
 	}
 
 	// Work on a copy so the caller's original config is never mutated.

--- a/internal/metastructure/resource_update/resolve_target_config.go
+++ b/internal/metastructure/resource_update/resolve_target_config.go
@@ -1,0 +1,179 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package resource_update
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"ergo.services/ergo/gen"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// RecoverableResolveError marks a target-config resolution failure whose
+// underlying plugin Read returned a recoverable error code. Resolution is
+// single-shot and never blocks; a caller running on an actor loop should detect
+// this (errors.As) and reschedule the resolve non-blockingly rather than fail.
+type RecoverableResolveError struct {
+	Code resource.OperationErrorCode
+}
+
+func (e *RecoverableResolveError) Error() string {
+	return fmt.Sprintf("recoverable resolve read error: %s", e.Code)
+}
+
+// ResolveOpaqueTargetConfig returns an ephemeral copy of target.Config with
+// every opaque $ref replaced by its live plaintext value, ready to hand to a
+// plugin call. When the config carries no opaque references it is returned
+// unchanged (after stripping any cached metadata).
+//
+// This is the single resolution routine for every plugin-call path that loads a
+// PERSISTED target config and must authenticate a plugin operation: at rest an
+// opaque secret-sourced credential is a bare $ref with no $value (reference-
+// don't-store), and resolver.ConvertToPluginFormat only strips metadata — it
+// does NOT read the source. So any such path (discovery List, the resolve-read
+// path in ResolveCache, ...) must call this first; the primary apply/changeset
+// path instead resolves via a synthetic Resolve target op and propagation.
+//
+// Any resolve failure returns a redacted error that names the reference and
+// target but never the plaintext secret.
+func ResolveOpaqueTargetConfig(proc gen.Process, target pkgmodel.Target) (json.RawMessage, error) {
+	uris := resolver.ExtractOpaqueResolvableURIsFromJSON(target.Config)
+	if len(uris) == 0 {
+		// No opaque refs: still strip any cached $value/metadata so the plugin
+		// receives plain JSON, mirroring the resolved path's final conversion.
+		if plain, err := resolver.ConvertToPluginFormat(target.Config); err == nil {
+			return plain, nil
+		}
+		return target.Config, nil
+	}
+
+	// Work on a copy so the caller's original config is never mutated.
+	cfg := bytes.Clone(target.Config)
+
+	for _, uri := range uris {
+		// Load the source resource from the persister.
+		rawResult, err := proc.Call(
+			gen.ProcessID{Name: actornames.ResourcePersister, Node: proc.Node().Name()},
+			messages.LoadResource{ResourceURI: uri.Stripped()},
+		)
+		if err != nil {
+			proc.Log().Error(
+				"failed to load resource for opaque ref resolution uri=%s target=%s: %v",
+				uri, target.Label, err,
+			)
+			return nil, fmt.Errorf(
+				"failed to resolve opaque reference %q for target %q: load error",
+				uri, target.Label,
+			)
+		}
+
+		loadResult, ok := rawResult.(messages.LoadResourceResult)
+		if !ok {
+			proc.Log().Error(
+				"unexpected result type from resource persister resultType=%v uri=%s target=%s",
+				reflect.TypeOf(rawResult), uri, target.Label,
+			)
+			return nil, fmt.Errorf(
+				"failed to resolve opaque reference %q for target %q: unexpected persister response",
+				uri, target.Label,
+			)
+		}
+
+		// Strip resolvable metadata from the source target's config before
+		// sending to the plugin. The source of a credential is itself a managed
+		// resource (e.g. a secret) whose own target auth is a plain/bootstrap
+		// credential, not another opaque ref (transitive-opaque is rejected at
+		// admission), so a metadata strip is sufficient here.
+		srcCfg := loadResult.Target.Config
+		if cleanCfg, err := resolver.ConvertToPluginFormat(srcCfg); err == nil {
+			srcCfg = cleanCfg
+		}
+
+		progress, err := readSource(proc, loadResult.Resource, srcCfg)
+		if err != nil {
+			proc.Log().Error(
+				"failed to read resource for opaque ref resolution uri=%s target=%s: %v",
+				uri, target.Label, err,
+			)
+			// Wrap with %w so a caller on an actor loop can detect a
+			// RecoverableResolveError and reschedule non-blockingly.
+			return nil, fmt.Errorf(
+				"failed to resolve opaque reference %q for target %q: %w",
+				uri, target.Label, err,
+			)
+		}
+
+		// Extract the property value from the read result.
+		parsed := gjson.ParseBytes([]byte(progress.ResourceProperties))
+		value := parsed.Get(uri.PropertyPath())
+		if !value.Exists() {
+			proc.Log().Error(
+				"opaque ref property not found in read result property=%s uri=%s target=%s",
+				uri.PropertyPath(), uri, target.Label,
+			)
+			return nil, fmt.Errorf(
+				"failed to resolve opaque reference %q for target %q: property %q absent from read result",
+				uri, target.Label, uri.PropertyPath(),
+			)
+		}
+
+		// Inject the resolved plaintext back into the working config copy.
+		cfg, err = resolver.ResolvePropertyReferences(uri, cfg, value.String())
+		if err != nil {
+			proc.Log().Error(
+				"failed to inject resolved value uri=%s target=%s configRedacted=%v: %v",
+				uri, target.Label, pkgmodel.RedactOpaqueForLog(cfg), err,
+			)
+			return nil, fmt.Errorf(
+				"failed to resolve opaque reference %q for target %q: inject error",
+				uri, target.Label,
+			)
+		}
+	}
+
+	// Strip the $ref/$value/$visibility wrappers so the returned config is plain
+	// JSON the plugin can unmarshal directly.
+	plain, err := resolver.ConvertToPluginFormat(cfg)
+	if err != nil {
+		proc.Log().Error(
+			"failed to strip opaque wrappers from resolved target config target=%s configRedacted=%v: %v",
+			target.Label, pkgmodel.RedactOpaqueForLog(cfg), err,
+		)
+		return nil, fmt.Errorf(
+			"failed to prepare resolved config for target %q: convert error",
+			target.Label,
+		)
+	}
+
+	return plain, nil
+}
+
+// readSource performs a SINGLE plugin Read of a credential source resource. It
+// never retries and never blocks: a recoverable failure is surfaced as a
+// *RecoverableResolveError so the actor-loop caller can reschedule the whole
+// resolve via SendAfter. A non-recoverable failure is a plain terminal error.
+func readSource(proc gen.Process, res pkgmodel.Resource, cfg json.RawMessage) (*plugin.TrackedProgress, error) {
+	progress, err := ReadResourceViaPlugin(proc, res, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if progress.OperationStatus == resource.OperationStatusFailure {
+		if resource.IsRecoverable(progress.ErrorCode) {
+			return nil, &RecoverableResolveError{Code: progress.ErrorCode}
+		}
+		return nil, fmt.Errorf("read failed: non-recoverable error %s", progress.ErrorCode)
+	}
+	return progress, nil
+}

--- a/internal/metastructure/resource_update/resolve_target_config_test.go
+++ b/internal/metastructure/resource_update/resolve_target_config_test.go
@@ -1,0 +1,45 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// TestResolveOpaqueTargetConfig_NoOpaqueRefsPassthrough asserts that a config
+// with no opaque references needs no source read (a nil process is safe) and is
+// returned as plain plugin JSON with any cached resolvable metadata stripped.
+// The opaque-resolving paths are covered end-to-end via the discovery wiring
+// tests, which drive this same routine through resolveTargetConfigForList.
+func TestResolveOpaqueTargetConfig_NoOpaqueRefsPassthrough(t *testing.T) {
+	// A plain config plus a NON-opaque ($visibility Clear) resolvable carrying a
+	// cached $value: no opaque ref, so no plugin read; the $value is used and the
+	// $ref wrapper stripped.
+	target := pkgmodel.Target{
+		Label: "t1",
+		Config: json.RawMessage(`{
+			"Region": "us-east-1",
+			"Url": {"$ref": "formae://abc#/status.url", "$value": "http://svc", "$visibility": "Clear"}
+		}`),
+	}
+
+	// No opaque refs → the routine must not touch the process.
+	out, err := ResolveOpaqueTargetConfig(nil, target)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, "us-east-1", got["Region"])
+	assert.Equal(t, "http://svc", got["Url"], "non-opaque ref collapses to its cached value")
+	assert.NotContains(t, string(out), "$ref", "resolvable wrappers stripped for the plugin")
+}

--- a/internal/metastructure/resource_update/resolve_timeout_test.go
+++ b/internal/metastructure/resource_update/resolve_timeout_test.go
@@ -1,0 +1,71 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"testing"
+	"time"
+
+	"ergo.services/actor/statemachine"
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// TestResolveTimeoutTimeout_CoversExponentialBackoff asserts the resolve
+// timeout envelope is derived from RetryStrategy.MaxTotalDelay and, for a large
+// MaxRetries, strictly exceeds the old flat (MaxRetries-1)*RetryDelay estimate,
+// so ResolveCache's exponential-backoff retries cannot trip the timeout.
+func TestResolveTimeoutTimeout_CoversExponentialBackoff(t *testing.T) {
+	cfg := pkgmodel.RetryConfig{MaxRetries: 8, RetryDelay: 1 * time.Second}
+
+	perAttempt := time.Duration(PluginOperationCallTimeout) * time.Second
+	strategy := resource.RetryStrategy{MaxRetries: cfg.MaxRetries, BaseDelay: cfg.RetryDelay}
+	want := time.Duration(cfg.MaxRetries)*perAttempt + strategy.MaxTotalDelay() + 30*time.Second
+	assert.Equal(t, want, resolvingTimeout(cfg))
+
+	flatEstimate := time.Duration(cfg.MaxRetries)*perAttempt +
+		time.Duration(cfg.MaxRetries-1)*cfg.RetryDelay + 30*time.Second
+	assert.Greater(t, resolvingTimeout(cfg), flatEstimate,
+		"budget-aware timeout must exceed the old flat estimate")
+}
+
+// TestResolve_SchedulesBudgetAwareTimeout drives the resolve state handler in
+// isolation with a stub process (the ergo-unit direct-handler pattern) and
+// asserts it schedules a ResolveTimedOut StateTimeout whose duration
+// is the budget-aware envelope for the actor's RetryConfig.
+func TestResolve_SchedulesBudgetAwareTimeout(t *testing.T) {
+	cfg := pkgmodel.RetryConfig{MaxRetries: 8, RetryDelay: 1 * time.Second}
+	data := ResourceUpdateData{
+		resourceUpdate: &ResourceUpdate{
+			Operation:            OperationUpdate,
+			DesiredState:         pkgmodel.Resource{Label: "r", Ksuid: "3E3wKW8YqVCQEyfKjsGpbsoE8bl"},
+			RemainingResolvables: []pkgmodel.FormaeURI{"formae://src#/SecretString"},
+		},
+		commandID:   "cmd",
+		retryConfig: cfg,
+	}
+
+	_, _, actions, err := resolve(gen.Atom("resolving"), data, &stubUpdaterProcess{})
+	require.NoError(t, err)
+
+	var found bool
+	var dur time.Duration
+	for _, a := range actions {
+		if st, ok := a.(statemachine.StateTimeout); ok {
+			if _, isTimeout := st.Message.(ResolveTimedOut); isTimeout {
+				found, dur = true, st.Duration
+			}
+		}
+	}
+	require.True(t, found, "resolve must schedule a ResolveTimedOut timeout")
+	assert.Equal(t, resolvingTimeout(cfg), dur,
+		"the scheduled timeout must be the budget-aware envelope")
+}

--- a/internal/metastructure/resource_update/resolve_timeout_test.go
+++ b/internal/metastructure/resource_update/resolve_timeout_test.go
@@ -28,8 +28,16 @@ func TestResolveTimeoutTimeout_CoversExponentialBackoff(t *testing.T) {
 
 	perAttempt := time.Duration(PluginOperationCallTimeout) * time.Second
 	strategy := resource.RetryStrategy{MaxRetries: cfg.MaxRetries, BaseDelay: cfg.RetryDelay}
-	want := time.Duration(cfg.MaxRetries)*perAttempt + strategy.MaxTotalDelay() + 30*time.Second
+	// The retry loop performs MaxRetries+1 reads (the initial read plus MaxRetries
+	// retries), so the envelope must budget one read per attempt, not per retry.
+	want := time.Duration(cfg.MaxRetries+1)*perAttempt + strategy.MaxTotalDelay() + 30*time.Second
 	assert.Equal(t, want, resolvingTimeout(cfg))
+
+	// Invariant: the envelope must cover every attempt plus the full backoff
+	// budget, or it can fire mid-retry.
+	assert.GreaterOrEqual(t, resolvingTimeout(cfg),
+		time.Duration(cfg.MaxRetries+1)*perAttempt+strategy.MaxTotalDelay(),
+		"timeout must cover MaxRetries+1 attempts plus the backoff budget")
 
 	flatEstimate := time.Duration(cfg.MaxRetries)*perAttempt +
 		time.Duration(cfg.MaxRetries-1)*cfg.RetryDelay + 30*time.Second

--- a/internal/metastructure/resource_update/resource_update_generator_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_test.go
@@ -1404,9 +1404,9 @@ func TestAppendCascadeUpdatesIfAbsent_MarksExistingUpdate(t *testing.T) {
 			IsCascade:    false,
 		}
 		cascade := ResourceUpdate{
-			DesiredState: pkgmodel.Resource{Label: "dependent", Type: "T", Stack: "s", Ksuid: dependentURI.KSUID()},
-			Operation:    OperationUpdate,
-			IsCascade:    true,
+			DesiredState:  pkgmodel.Resource{Label: "dependent", Type: "T", Stack: "s", Ksuid: dependentURI.KSUID()},
+			Operation:     OperationUpdate,
+			IsCascade:     true,
 			CascadeSource: sourceLabel,
 		}
 

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -154,7 +154,7 @@ type StartResourceUpdate struct {
 
 type PluginOperatorMissingInAction struct{}
 
-type ResolveCacheMissingInAction struct{}
+type ResolveTimedOut struct{}
 
 type Shutdown struct{}
 
@@ -251,7 +251,7 @@ func (r *ResourceUpdater) Init(args ...any) (statemachine.StateMachineSpec[Resou
 		statemachine.WithStateMessageHandler(StateUpdating, pluginOperationMissingInAction),
 		statemachine.WithStateMessageHandler(StateUpdating, shutdown),
 		statemachine.WithStateMessageHandler(StateResolving, resourceResolved),
-		statemachine.WithStateMessageHandler(StateResolving, resolveCacheMissingInAction),
+		statemachine.WithStateMessageHandler(StateResolving, resolveTimedOut),
 		statemachine.WithStateMessageHandler(StateResolving, resourceFailedToResolve),
 		statemachine.WithStateMessageHandler(StateResolving, shutdown),
 		statemachine.WithStateMessageHandler(StateSynchronizing, handleProgressUpdate),
@@ -468,6 +468,20 @@ func delete(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 	return handleProgressUpdate(gen.PID{}, state, data, *result, proc)
 }
 
+// resolvingTimeout sizes the ResolveCache timeout to outlive the cache's
+// worst-case resolve wall time: MaxRetries reads (each up to the plugin call
+// timeout) plus the exponential backoff budget the ResolveCache schedules with
+// (RetryStrategy.MaxTotalDelay), plus a margin. The backoff term is derived from
+// the same RetryStrategy the cache retries with, so a tuned or exponential
+// policy cannot make the two drift: a flat MaxRetries*RetryDelay estimate would
+// under-cover exponential throttling backoff and trip this timeout mid-retry.
+func resolvingTimeout(cfg pkgmodel.RetryConfig) time.Duration {
+	const resolveCacheMargin = 30 * time.Second
+	perAttempt := time.Duration(PluginOperationCallTimeout) * time.Second
+	strategy := resource.RetryStrategy{MaxRetries: cfg.MaxRetries, BaseDelay: cfg.RetryDelay}
+	return time.Duration(cfg.MaxRetries)*perAttempt + strategy.MaxTotalDelay() + resolveCacheMargin
+}
+
 func resolve(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom, ResourceUpdateData, []statemachine.Action, error) {
 	if len(data.resourceUpdate.RemainingResolvables) == 0 {
 		return nextState(state, data, proc)
@@ -488,19 +502,9 @@ func resolve(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Ato
 		return StateResolving, data, nil, fmt.Errorf("failed to send ResolveValue message to resolve cache: %w", err)
 	}
 
-	// The watchdog must outlive ResolveCache's worst-case wall time per property:
-	// each plugin Call takes up to PluginOperationCallTimeout, retried up to
-	// MaxRetries times with RetryDelay spacing for recoverable errors. Derive
-	// the envelope from the same RetryConfig that ResolveCache itself reads, so
-	// the two cannot drift if the policy is tuned.
-	perAttempt := time.Duration(PluginOperationCallTimeout) * time.Second
-	const resolveCacheMargin = 30 * time.Second
-	resolveCacheTimeout := time.Duration(data.retryConfig.MaxRetries)*perAttempt +
-		time.Duration(data.retryConfig.MaxRetries-1)*data.retryConfig.RetryDelay +
-		resolveCacheMargin
 	timeout := statemachine.StateTimeout{
-		Duration: resolveCacheTimeout,
-		Message:  ResolveCacheMissingInAction{},
+		Duration: resolvingTimeout(data.retryConfig),
+		Message:  ResolveTimedOut{},
 	}
 
 	return StateResolving, data, []statemachine.Action{timeout}, nil
@@ -989,7 +993,7 @@ func pluginOperationMissingInAction(from gen.PID, state gen.Atom, data ResourceU
 	return StateFinishedWithError, data, nil, nil
 }
 
-func resolveCacheMissingInAction(from gen.PID, state gen.Atom, data ResourceUpdateData, message ResolveCacheMissingInAction, proc gen.Process) (gen.Atom, ResourceUpdateData, []statemachine.Action, error) {
+func resolveTimedOut(from gen.PID, state gen.Atom, data ResourceUpdateData, message ResolveTimedOut, proc gen.Process) (gen.Atom, ResourceUpdateData, []statemachine.Action, error) {
 	proc.Log().Error("Resolve cache is missing in action state=%s commandID=%s ksuid=%s operation=%s", state, data.commandID, data.originalResourceKsuidURI.KSUID(), data.resourceUpdate.Operation)
 	data.resourceUpdate.MarkAsFailed()
 	return StateFinishedWithError, data, nil, nil

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -469,17 +469,18 @@ func delete(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 }
 
 // resolvingTimeout sizes the ResolveCache timeout to outlive the cache's
-// worst-case resolve wall time: MaxRetries reads (each up to the plugin call
-// timeout) plus the exponential backoff budget the ResolveCache schedules with
-// (RetryStrategy.MaxTotalDelay), plus a margin. The backoff term is derived from
-// the same RetryStrategy the cache retries with, so a tuned or exponential
-// policy cannot make the two drift: a flat MaxRetries*RetryDelay estimate would
-// under-cover exponential throttling backoff and trip this timeout mid-retry.
+// worst-case resolve wall time: MaxRetries+1 reads (the initial read plus
+// MaxRetries retries, each up to the plugin call timeout) plus the exponential
+// backoff budget the ResolveCache schedules with (RetryStrategy.MaxTotalDelay),
+// plus a margin. The backoff term is derived from the same RetryStrategy the
+// cache retries with, so a tuned or exponential policy cannot make the two
+// drift: a flat MaxRetries*RetryDelay estimate would under-cover exponential
+// throttling backoff and trip this timeout mid-retry.
 func resolvingTimeout(cfg pkgmodel.RetryConfig) time.Duration {
 	const resolveCacheMargin = 30 * time.Second
 	perAttempt := time.Duration(PluginOperationCallTimeout) * time.Second
 	strategy := resource.RetryStrategy{MaxRetries: cfg.MaxRetries, BaseDelay: cfg.RetryDelay}
-	return time.Duration(cfg.MaxRetries)*perAttempt + strategy.MaxTotalDelay() + resolveCacheMargin
+	return time.Duration(cfg.MaxRetries+1)*perAttempt + strategy.MaxTotalDelay() + resolveCacheMargin
 }
 
 func resolve(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom, ResourceUpdateData, []statemachine.Action, error) {

--- a/internal/metastructure/resource_update/resource_updater_test.go
+++ b/internal/metastructure/resource_update/resource_updater_test.go
@@ -445,11 +445,11 @@ func TestTimeoutHandlers_DoNotLogResolvedConfig(t *testing.T) {
 		assert.NotEmpty(t, clog.all(), "a log message must have been emitted")
 	})
 
-	// resolveCacheMissingInAction handler
-	t.Run("ResolveCacheMissingInAction", func(t *testing.T) {
+	// resolveTimedOut handler
+	t.Run("ResolveTimedOut", func(t *testing.T) {
 		clog2 := &capturingLog{}
 		proc2 := &capturingProcess{stubUpdaterProcess: &stubUpdaterProcess{}, log: clog2}
-		_, _, _, err := resolveCacheMissingInAction(gen.PID{}, gen.Atom("resolving"), data, ResolveCacheMissingInAction{}, proc2)
+		_, _, _, err := resolveTimedOut(gen.PID{}, gen.Atom("resolving"), data, ResolveTimedOut{}, proc2)
 		require.NoError(t, err)
 		for _, msg := range clog2.all() {
 			assert.NotContains(t, msg, knownPlaintext, "timeout log must not contain resolved credentials")

--- a/internal/metastructure/resource_update/target_health_classifier_test.go
+++ b/internal/metastructure/resource_update/target_health_classifier_test.go
@@ -74,7 +74,7 @@ func TestTargetHealthObservation(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name:   "non-terminal in-progress → no observation",
+			name: "non-terminal in-progress → no observation",
 			tp: &plugin.TrackedProgress{
 				ProgressResult: resource.ProgressResult{
 					OperationStatus: resource.OperationStatusInProgress,

--- a/internal/metastructure/target_update/classify_config_change.go
+++ b/internal/metastructure/target_update/classify_config_change.go
@@ -118,14 +118,63 @@ func stripResolvableValuesRaw(raw json.RawMessage) json.RawMessage {
 	return out
 }
 
-// stripResolvableValues recursively removes $value from any object that
-// contains a $ref key. This ensures that a resolved config (with cached
-// $value) compares equal to an unresolved config (only $ref).
+// stripDerivedRefMetadataRaw returns a copy of raw with only the DERIVED
+// metadata ($visibility, $strategy) stripped from every $ref object, leaving
+// $ref, $json, and any cached $value intact. Used where a stale $value must
+// still surface (a dangling ref) but derived metadata — which the forma never
+// authors and which flips Opaque↔Clear for secret-sourced credentials — must
+// never count as a change.
+func stripDerivedRefMetadataRaw(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return raw
+	}
+	stripDerivedRefMetadata(v)
+	out, err := json.Marshal(v)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// stripDerivedRefMetadata recursively removes $visibility and $strategy (but not
+// $value) from any object that contains a $ref key.
+func stripDerivedRefMetadata(v any) {
+	switch val := v.(type) {
+	case map[string]any:
+		if _, hasRef := val["$ref"]; hasRef {
+			delete(val, "$visibility")
+			delete(val, "$strategy")
+		}
+		for _, child := range val {
+			stripDerivedRefMetadata(child)
+		}
+	case []any:
+		for _, item := range val {
+			stripDerivedRefMetadata(item)
+		}
+	}
+}
+
+// stripResolvableValues recursively removes derived metadata from any object
+// that contains a $ref key, leaving only the reference's semantic identity
+// ($ref path and $json). $value is a cached resolution; $visibility and
+// $strategy are derived from the source property (a secret-sourced credential
+// persists $visibility:"Opaque" so reference-don't-store strips its $value,
+// while the forma renders the same ref $visibility:"Clear"). Dropping all three
+// ensures a resolved / opacity-stamped stored config compares equal to the
+// authored $ref, so an idempotent re-apply of a target with secret-sourced
+// config does not spuriously classify a createOnly credential as changed.
 func stripResolvableValues(v any) {
 	switch val := v.(type) {
 	case map[string]any:
 		if _, hasRef := val["$ref"]; hasRef {
 			delete(val, "$value")
+			delete(val, "$visibility")
+			delete(val, "$strategy")
 		}
 		for _, child := range val {
 			stripResolvableValues(child)

--- a/internal/metastructure/target_update/classify_config_change_test.go
+++ b/internal/metastructure/target_update/classify_config_change_test.go
@@ -173,6 +173,26 @@ func TestClassifyConfigChange_ResolvableDifferentRef_IsImmutable(t *testing.T) {
 	assert.Equal(t, ConfigImmutableChange, result)
 }
 
+func TestClassifyConfigChange_ResolvableVisibilityIgnored(t *testing.T) {
+	// A target-config secret credential persists with $visibility:"Opaque" (so
+	// reference-don't-store strips its $value), but the forma renders the same
+	// ref with $visibility:"Clear" — opacity is derived from the source property,
+	// not stamped on the envelope. This derived metadata must not count as a
+	// change: otherwise an idempotent re-apply classifies the createOnly
+	// credential as an immutable change and forces a spurious target replace.
+	existing := json.RawMessage(`{"Password":{"$ref":"formae://abc#/decodedData.admin-password","$visibility":"Opaque"},"Username":"admin"}`)
+	new := json.RawMessage(`{"Password":{"$ref":"formae://abc#/decodedData.admin-password","$visibility":"Clear"},"Username":"admin"}`)
+	schema := pkgmodel.ConfigSchema{
+		Hints: map[string]pkgmodel.ConfigFieldHint{
+			"Password": {CreateOnly: true},
+			"Username": {CreateOnly: true},
+		},
+	}
+
+	result := ClassifyConfigChange(existing, new, schema)
+	assert.Equal(t, ConfigNoChange, result)
+}
+
 func TestClassifyConfigChange_FieldRemoved(t *testing.T) {
 	existing := json.RawMessage(`{"Region":"us-east-1","Profile":"prod"}`)
 	new := json.RawMessage(`{"Region":"us-east-1"}`)

--- a/internal/metastructure/target_update/resolve_timeout_test.go
+++ b/internal/metastructure/target_update/resolve_timeout_test.go
@@ -1,0 +1,57 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package target_update
+
+import (
+	"testing"
+	"time"
+
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// timeoutEnvProcess is a gen.Process double that serves a RetryConfig from its
+// environment, so resolvingTimeout can be exercised in isolation.
+type timeoutEnvProcess struct {
+	gen.Process
+	env map[gen.Env]any
+}
+
+func (p *timeoutEnvProcess) Env(name gen.Env) (any, bool) {
+	v, ok := p.env[name]
+	return v, ok
+}
+
+// TestResolveTimeoutTimeout_CoversExponentialBackoff asserts the TargetUpdater
+// resolve timeout is derived from RetryStrategy.MaxTotalDelay and, for a large
+// MaxRetries, strictly exceeds the old flat (MaxRetries-1)*RetryDelay estimate,
+// so exponential-backoff resolve retries cannot trip the timeout.
+func TestResolveTimeoutTimeout_CoversExponentialBackoff(t *testing.T) {
+	cfg := pkgmodel.RetryConfig{MaxRetries: 8, RetryDelay: 1 * time.Second}
+	proc := &timeoutEnvProcess{env: map[gen.Env]any{"RetryConfig": cfg}}
+
+	const perAttempt = 60 * time.Second
+	strategy := resource.RetryStrategy{MaxRetries: cfg.MaxRetries, BaseDelay: cfg.RetryDelay}
+	want := time.Duration(cfg.MaxRetries)*perAttempt + strategy.MaxTotalDelay() + 30*time.Second
+	assert.Equal(t, want, resolvingTimeout(proc))
+
+	flatEstimate := time.Duration(cfg.MaxRetries)*perAttempt +
+		time.Duration(cfg.MaxRetries-1)*cfg.RetryDelay + 30*time.Second
+	assert.Greater(t, resolvingTimeout(proc), flatEstimate,
+		"budget-aware timeout must exceed the old flat estimate")
+}
+
+// TestResolveTimeoutTimeout_NoEnvFallback asserts that without a RetryConfig in
+// the environment (a bare unit harness) the timeout falls back to a fixed,
+// generous default rather than a zero-length timeout.
+func TestResolveTimeoutTimeout_NoEnvFallback(t *testing.T) {
+	proc := &timeoutEnvProcess{env: map[gen.Env]any{}}
+	assert.Equal(t, 60*time.Second+30*time.Second, resolvingTimeout(proc))
+}

--- a/internal/metastructure/target_update/resolve_timeout_test.go
+++ b/internal/metastructure/target_update/resolve_timeout_test.go
@@ -39,8 +39,16 @@ func TestResolveTimeoutTimeout_CoversExponentialBackoff(t *testing.T) {
 
 	const perAttempt = 60 * time.Second
 	strategy := resource.RetryStrategy{MaxRetries: cfg.MaxRetries, BaseDelay: cfg.RetryDelay}
-	want := time.Duration(cfg.MaxRetries)*perAttempt + strategy.MaxTotalDelay() + 30*time.Second
+	// The retry loop performs MaxRetries+1 reads (the initial read plus MaxRetries
+	// retries), so the envelope must budget one read per attempt, not per retry.
+	want := time.Duration(cfg.MaxRetries+1)*perAttempt + strategy.MaxTotalDelay() + 30*time.Second
 	assert.Equal(t, want, resolvingTimeout(proc))
+
+	// Invariant: the envelope must cover every attempt plus the full backoff
+	// budget, or it can fire mid-retry.
+	assert.GreaterOrEqual(t, resolvingTimeout(proc),
+		time.Duration(cfg.MaxRetries+1)*perAttempt+strategy.MaxTotalDelay(),
+		"timeout must cover MaxRetries+1 attempts plus the backoff budget")
 
 	flatEstimate := time.Duration(cfg.MaxRetries)*perAttempt +
 		time.Duration(cfg.MaxRetries-1)*cfg.RetryDelay + 30*time.Second

--- a/internal/metastructure/target_update/target_update_generator.go
+++ b/internal/metastructure/target_update/target_update_generator.go
@@ -148,7 +148,7 @@ func (tp *TargetUpdateGenerator) determineTargetUpdate(target pkgmodel.Target, c
 
 		// Determine which configs to compare. When the new config contains
 		// $ref resolvables, resolve them first so we compare actual values.
-		existingResolved, newResolved, allRefsResolved, err := tp.resolvedConfigs(existing.Config, target.Config, resolvables)
+		existingResolved, newResolved, _, anyRefDangling, err := tp.resolvedConfigs(existing.Config, target.Config, resolvables)
 		if err != nil {
 			return TargetUpdate{}, false, fmt.Errorf("failed to resolve target configs: %w", err)
 		}
@@ -171,15 +171,22 @@ func (tp *TargetUpdateGenerator) determineTargetUpdate(target pkgmodel.Target, c
 			// - The raw config format changed (e.g., plain value ↔ $ref wrapper)
 			// - The discoverable flag changed
 			// - The ConfigSchema changed (e.g., plugin annotations updated)
-			// Only strip cached $value entries when refs were successfully
-			// resolved. If resolution failed, a stale cached $value paired
-			// with a dangling $ref must still surface as an update so the
-			// failure isn't silently absorbed.
-			existingForRaw := existing.Config
-			desiredForRaw := target.Config
-			if allRefsResolved {
-				existingForRaw = stripResolvableValuesRaw(existingForRaw)
-				desiredForRaw = stripResolvableValuesRaw(desiredForRaw)
+			//
+			// Two configs with the same $refs are the same config: strip the
+			// cached $value and the derived $visibility/$strategy so identity
+			// alone drives the comparison. The one exception is a DANGLING ref
+			// (its source is gone): keep its stale cached $value so it surfaces
+			// as an update rather than being silently fed to a plugin. A ref that
+			// merely exposes no readable value (an opaque hash, an unsynced
+			// status) is not dangling and must not trigger a spurious update on
+			// every re-apply.
+			var existingForRaw, desiredForRaw json.RawMessage
+			if anyRefDangling {
+				existingForRaw = stripDerivedRefMetadataRaw(existing.Config)
+				desiredForRaw = stripDerivedRefMetadataRaw(target.Config)
+			} else {
+				existingForRaw = stripResolvableValuesRaw(existing.Config)
+				desiredForRaw = stripResolvableValuesRaw(target.Config)
 			}
 			if !util.JsonEqualRaw(existingForRaw, desiredForRaw) {
 				operation = TargetOperationUpdate
@@ -272,54 +279,78 @@ func configSchemasEqual(a, b pkgmodel.ConfigSchema) bool {
 // field-level comparison. Both configs are stripped of $ref metadata so that
 // ClassifyConfigChange compares plain values. When the new config contains
 // $ref resolvables, they are resolved from the DB first.
-func (tp *TargetUpdateGenerator) resolvedConfigs(existingConfig, newConfig json.RawMessage, resolvables []pkgmodel.FormaeURI) (json.RawMessage, json.RawMessage, bool, error) {
+// resolvedConfigs resolves the $refs in newConfig against the datastore and
+// returns both configs with $ref metadata stripped for comparison. The third
+// return reports whether ALL refs resolved to a value; the fourth reports
+// whether any ref is DANGLING — its source resource could not be loaded at all,
+// as opposed to loading fine but exposing no readable value at the path (e.g. an
+// opaque credential stored as a hash, or a status field not yet synced). A
+// dangling ref means a stale cached $value must surface as an update; a
+// present-but-unresolvable ref does not, because the reference identity is
+// unchanged.
+func (tp *TargetUpdateGenerator) resolvedConfigs(existingConfig, newConfig json.RawMessage, resolvables []pkgmodel.FormaeURI) (json.RawMessage, json.RawMessage, bool, bool, error) {
 	if len(resolvables) == 0 {
 		// No resolvables in new config, but existing config may still have
 		// $ref metadata from a previous apply. Strip it for comparison.
 		existingValues, err := resolver.ConvertToPluginFormat(existingConfig)
 		if err != nil {
-			return existingConfig, newConfig, true, nil
+			return existingConfig, newConfig, true, false, nil
 		}
-		return existingValues, newConfig, true, nil
+		return existingValues, newConfig, true, false, nil
 	}
 
 	// Resolve $ref values from DB for comparison
 	resolvedConfig := make([]byte, len(newConfig))
 	copy(resolvedConfig, newConfig)
 
+	allResolved := true
+	anyDangling := false
 	for _, uri := range resolvables {
 		ksuid := uri.KSUID()
 		propertyPath := uri.PropertyPath()
 
 		resource, err := tp.datastore.LoadResourceById(ksuid)
 		if err != nil || resource == nil {
-			slog.Debug("Cannot resolve $ref from DB, treating as config change",
+			// The source resource is gone — a genuinely dangling ref.
+			slog.Debug("Cannot load $ref source from DB, treating as dangling",
 				"uri", uri, "error", err)
-			return existingConfig, newConfig, false, nil
+			anyDangling = true
+			allResolved = false
+			continue
 		}
 
 		strVal, ok := resource.GetProperty(propertyPath)
 		if !ok {
-			slog.Debug("Referenced property not found in resource, treating as config change",
+			// The source is present but exposes no readable value at this path
+			// (e.g. an opaque credential hashed at rest, or an unsynced status
+			// field). The reference is valid, so this is not a change — compare
+			// by $ref identity rather than treating it as dangling.
+			slog.Debug("Referenced property not readable, comparing by ref identity",
 				"uri", uri, "propertyPath", propertyPath)
-			return existingConfig, newConfig, false, nil
+			allResolved = false
+			continue
 		}
 
 		resolvedConfig, err = resolver.ResolvePropertyReferences(uri, resolvedConfig, strVal)
 		if err != nil {
-			return existingConfig, newConfig, false, nil
+			allResolved = false
+			continue
 		}
+	}
+
+	if !allResolved {
+		return existingConfig, newConfig, false, anyDangling, nil
 	}
 
 	// Strip $ref metadata from both sides so ClassifyConfigChange sees plain values
 	existingValues, err := resolver.ConvertToPluginFormat(existingConfig)
 	if err != nil {
-		return existingConfig, json.RawMessage(resolvedConfig), true, nil
+		return existingConfig, json.RawMessage(resolvedConfig), true, false, nil
 	}
 	newValues, err := resolver.ConvertToPluginFormat(resolvedConfig)
 	if err != nil {
-		return existingConfig, json.RawMessage(resolvedConfig), true, nil
+		return existingConfig, json.RawMessage(resolvedConfig), true, false, nil
 	}
 
-	return existingValues, newValues, true, nil
+	return existingValues, newValues, true, false, nil
 }

--- a/internal/metastructure/target_update/target_update_generator_test.go
+++ b/internal/metastructure/target_update/target_update_generator_test.go
@@ -1177,6 +1177,43 @@ func TestGenerateTargetUpdates_RefWithCachedValue_UnresolvableRef(t *testing.T) 
 	assert.Equal(t, TargetOperationUpdate, updates[0].Operation)
 }
 
+// A target credential sourced from a secret persists $visibility:"Opaque" (so
+// reference-don't-store drops its $value) while the forma renders the same ref
+// $visibility:"Clear". The source resource is PRESENT but exposes no readable
+// value at the ref path (the secret value is a single hash at rest). Unlike a
+// dangling ref, this must not produce an update on every re-apply.
+func TestGenerateTargetUpdates_OpaqueCredRef_PresentButUnreadable_NoChange(t *testing.T) {
+	mockDS := &mockTargetDatastore{
+		targets: map[string]*pkgmodel.Target{
+			"grafana-target": {
+				Label:     "grafana-target",
+				Namespace: "GRAFANA",
+				Config:    json.RawMessage(`{"Type":"Grafana","Username":"admin","Password":{"$ref":"formae://sec1#/decodedData.admin-password","$visibility":"Opaque"}}`),
+			},
+		},
+		resources: map[string]*pkgmodel.Resource{
+			"sec1": {
+				Ksuid: "sec1",
+				// decodedData is one hashed envelope; the sub-key is not readable.
+				Properties: json.RawMessage(`{"decodedData":{"$value":"deadbeef","$visibility":"Opaque","$hashed":true}}`),
+			},
+		},
+	}
+	generator := NewTargetUpdateGenerator(mockDS)
+
+	targets := []pkgmodel.Target{
+		{
+			Label:     "grafana-target",
+			Namespace: "GRAFANA",
+			Config:    json.RawMessage(`{"Type":"Grafana","Username":"admin","Password":{"$ref":"formae://sec1#/decodedData.admin-password","$visibility":"Clear"}}`),
+		},
+	}
+
+	updates, err := generator.GenerateTargetUpdates(targets, pkgmodel.CommandApply, false)
+	require.NoError(t, err)
+	assert.Empty(t, updates, "an opaque credential ref (present source, unreadable hashed value, Opaque->Clear) must be idempotent, not update every re-apply")
+}
+
 // Mirrors a real K8s target Config shape: $refs are nested under Auth, alongside
 // plain scalar fields. Existing Config has $ref+$value pairs (resolved at apply);
 // desired Config has $ref only. Same resolved values, same shape → no update.

--- a/internal/metastructure/target_update/target_updater.go
+++ b/internal/metastructure/target_update/target_updater.go
@@ -14,6 +14,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
 const (
@@ -47,8 +48,8 @@ type TargetUpdateFinished struct {
 // Shutdown is sent to terminate the TargetUpdater process.
 type Shutdown struct{}
 
-// ResolveCacheMissingInAction is a timeout message for the resolve loop.
-type ResolveCacheMissingInAction struct{}
+// ResolveTimedOut is a timeout message for the resolve loop.
+type ResolveTimedOut struct{}
 
 // TargetUpdaterData holds the FSM's internal state.
 type TargetUpdaterData struct {
@@ -139,6 +140,28 @@ func handleStartTargetUpdate(from gen.PID, state gen.Atom, data TargetUpdaterDat
 }
 
 // resolveTargetConfig pops the next resolvable and sends a ResolveValue request.
+// resolvingTimeout sizes the ResolveCache timeout to outlive the cache's
+// worst-case retry wall time: MaxRetries reads (each up to the plugin call
+// timeout) plus the exponential backoff budget. It derives the backoff envelope
+// from the same RetryConfig the ResolveCache reads, so a tuned policy cannot
+// cause the two to drift and trip this timeout mid-retry.
+func resolvingTimeout(proc gen.Process) time.Duration {
+	// perAttempt mirrors resource_update.PluginOperationCallTimeout (60s). It is
+	// duplicated as a local const because target_update must not import
+	// resource_update (which imports target_update).
+	const perAttempt = 60 * time.Second
+	const margin = 30 * time.Second
+
+	env, _ := proc.Env("RetryConfig")
+	cfg, ok := env.(pkgmodel.RetryConfig)
+	if !ok {
+		// No environment (unit harness): a fixed, generous default.
+		return perAttempt + margin
+	}
+	strategy := resource.RetryStrategy{MaxRetries: cfg.MaxRetries, BaseDelay: cfg.RetryDelay}
+	return time.Duration(cfg.MaxRetries)*perAttempt + strategy.MaxTotalDelay() + margin
+}
+
 func resolveTargetConfig(state gen.Atom, data TargetUpdaterData, proc gen.Process) (gen.Atom, TargetUpdaterData, []statemachine.Action, error) {
 	if len(data.targetUpdate.RemainingResolvables) == 0 {
 		// A Resolve op resolves config in-memory only: the target row is never
@@ -168,8 +191,8 @@ func resolveTargetConfig(state gen.Atom, data TargetUpdaterData, proc gen.Proces
 	}
 
 	timeout := statemachine.StateTimeout{
-		Duration: 30 * time.Second,
-		Message:  ResolveCacheMissingInAction{},
+		Duration: resolvingTimeout(proc),
+		Message:  ResolveTimedOut{},
 	}
 
 	return StateResolving, data, []statemachine.Action{timeout}, nil
@@ -193,7 +216,7 @@ func targetFailedToResolve(from gen.PID, state gen.Atom, data TargetUpdaterData,
 }
 
 // targetResolveCacheTimeout handles the timeout when the resolve cache doesn't respond.
-func targetResolveCacheTimeout(from gen.PID, state gen.Atom, data TargetUpdaterData, message ResolveCacheMissingInAction, proc gen.Process) (gen.Atom, TargetUpdaterData, []statemachine.Action, error) {
+func targetResolveCacheTimeout(from gen.PID, state gen.Atom, data TargetUpdaterData, message ResolveTimedOut, proc gen.Process) (gen.Atom, TargetUpdaterData, []statemachine.Action, error) {
 	proc.Log().Error("TargetUpdater: resolve cache timeout target=%s", data.targetUpdate.Target.Label)
 	return StateFinishedWithError, data, nil, nil
 }

--- a/internal/metastructure/target_update/target_updater.go
+++ b/internal/metastructure/target_update/target_updater.go
@@ -141,10 +141,11 @@ func handleStartTargetUpdate(from gen.PID, state gen.Atom, data TargetUpdaterDat
 
 // resolveTargetConfig pops the next resolvable and sends a ResolveValue request.
 // resolvingTimeout sizes the ResolveCache timeout to outlive the cache's
-// worst-case retry wall time: MaxRetries reads (each up to the plugin call
-// timeout) plus the exponential backoff budget. It derives the backoff envelope
-// from the same RetryConfig the ResolveCache reads, so a tuned policy cannot
-// cause the two to drift and trip this timeout mid-retry.
+// worst-case retry wall time: MaxRetries+1 reads (the initial read plus
+// MaxRetries retries, each up to the plugin call timeout) plus the exponential
+// backoff budget. It derives the backoff envelope from the same RetryConfig the
+// ResolveCache reads, so a tuned policy cannot cause the two to drift and trip
+// this timeout mid-retry.
 func resolvingTimeout(proc gen.Process) time.Duration {
 	// perAttempt mirrors resource_update.PluginOperationCallTimeout (60s). It is
 	// duplicated as a local const because target_update must not import
@@ -159,7 +160,7 @@ func resolvingTimeout(proc gen.Process) time.Duration {
 		return perAttempt + margin
 	}
 	strategy := resource.RetryStrategy{MaxRetries: cfg.MaxRetries, BaseDelay: cfg.RetryDelay}
-	return time.Duration(cfg.MaxRetries)*perAttempt + strategy.MaxTotalDelay() + margin
+	return time.Duration(cfg.MaxRetries+1)*perAttempt + strategy.MaxTotalDelay() + margin
 }
 
 func resolveTargetConfig(state gen.Atom, data TargetUpdaterData, proc gen.Process) (gen.Atom, TargetUpdaterData, []statemachine.Action, error) {

--- a/internal/metastructure/transformations/persist_value_transformer.go
+++ b/internal/metastructure/transformations/persist_value_transformer.go
@@ -162,7 +162,14 @@ func (pv *PersistValueTransformer) processProps(m map[string]any, opaqueFields m
 // (wrapping it into a hashed opaque envelope) or an existing envelope map.
 func (pv *PersistValueTransformer) hashOpaqueField(v any) (map[string]any, bool) {
 	if m, ok := v.(map[string]any); ok {
-		return pv.hashEnvelope(m)
+		// An existing opaque envelope carries $value — hash it in place. A raw map
+		// WITHOUT $value is itself the secret value (a map-shaped secret field, e.g.
+		// K8S decodedData); fall through so the whole map is hashed into one opaque
+		// envelope rather than being mistaken for an envelope, which would leave the
+		// plaintext keys beside a nil $value.
+		if _, isEnvelope := m["$value"]; isEnvelope {
+			return pv.hashEnvelope(m)
+		}
 	}
 	// Bare scalar (e.g. an opaque field supplied as a plain string literal, RDS
 	// MasterUserPassword): wrap + hash into a CANONICAL formae.Value envelope. It

--- a/internal/metastructure/transformations/persist_value_transformer.go
+++ b/internal/metastructure/transformations/persist_value_transformer.go
@@ -162,12 +162,16 @@ func (pv *PersistValueTransformer) processProps(m map[string]any, opaqueFields m
 // (wrapping it into a hashed opaque envelope) or an existing envelope map.
 func (pv *PersistValueTransformer) hashOpaqueField(v any) (map[string]any, bool) {
 	if m, ok := v.(map[string]any); ok {
-		// An existing opaque envelope carries $value — hash it in place. A raw map
-		// WITHOUT $value is itself the secret value (a map-shaped secret field, e.g.
-		// K8S decodedData); fall through so the whole map is hashed into one opaque
-		// envelope rather than being mistaken for an envelope, which would leave the
-		// plaintext keys beside a nil $value.
-		if _, isEnvelope := m["$value"]; isEnvelope {
+		// A formae opaque envelope carries BOTH $value and $visibility — hash it in
+		// place. A raw map is itself the secret value (a map-shaped secret field,
+		// e.g. K8S decodedData), even when one of its keys happens to be named
+		// "$value": without $visibility it is not an envelope. Fall through so the
+		// whole map is hashed into one opaque envelope rather than being mistaken for
+		// an envelope, which would hash only the "$value" key and leave sibling
+		// plaintext keys at rest.
+		_, hasValue := m["$value"]
+		_, hasVisibility := m["$visibility"]
+		if hasValue && hasVisibility {
 			return pv.hashEnvelope(m)
 		}
 	}

--- a/internal/metastructure/transformations/persist_value_transformer_test.go
+++ b/internal/metastructure/transformations/persist_value_transformer_test.go
@@ -315,6 +315,31 @@ func TestApplyToResource_HashesMapValuedSchemaOpaqueField(t *testing.T) {
 	assert.NotContains(t, dd["$value"].(string), "s3cr3t")
 }
 
+func TestApplyToResource_MapSecretWithValueKeyIsNotMistakenForEnvelope(t *testing.T) {
+	// A map-shaped secret whose keys happen to include one literally named "$value"
+	// but NO $visibility is not a formae envelope — it is the secret value. It must
+	// be hashed as a whole, not hashed-in-place (which would digest only the
+	// "$value" key and leave sibling plaintext at rest).
+	r := &pkgmodel.Resource{
+		Schema:     schemaWithOpaque("decodedData"),
+		Properties: json.RawMessage(`{"decodedData":{"password":"s3cr3t","$value":"not-an-envelope"}}`),
+	}
+	out, err := NewPersistValueTransformer().ApplyToResource(r)
+	require.NoError(t, err)
+
+	var props map[string]any
+	require.NoError(t, json.Unmarshal(out.Properties, &props))
+	dd := props["decodedData"].(map[string]any)
+	assert.Equal(t, "Opaque", dd["$visibility"])
+	assert.Equal(t, true, dd["$hashed"])
+	assert.Len(t, dd["$value"].(string), 64, "the whole map is hashed into one digest")
+	_, hasPass := dd["password"]
+	assert.False(t, hasPass, "sibling plaintext key must not survive at rest")
+	assert.NotContains(t, dd["$value"].(string), "s3cr3t")
+	assert.NotContains(t, dd["$value"].(string), "not-an-envelope",
+		"the coincidental $value key must be hashed, not surfaced as plaintext")
+}
+
 func TestApplyToResource_IdempotentAndSkipsClear(t *testing.T) {
 	r := &pkgmodel.Resource{
 		Schema:     schemaWithOpaque("SecretString"),

--- a/internal/metastructure/transformations/persist_value_transformer_test.go
+++ b/internal/metastructure/transformations/persist_value_transformer_test.go
@@ -287,6 +287,34 @@ func TestApplyToResource_HashesEnvelopedOpaque(t *testing.T) {
 	assert.Len(t, sv["$value"].(string), 64)
 }
 
+func TestApplyToResource_HashesMapValuedSchemaOpaqueField(t *testing.T) {
+	// A map-shaped secret field (e.g. K8S decodedData) is itself the secret value.
+	// It must be hashed into ONE opaque envelope, never left with plaintext keys
+	// beside a nil $value.
+	r := &pkgmodel.Resource{
+		Schema:     schemaWithOpaque("decodedData"),
+		Properties: json.RawMessage(`{"Name":"n","decodedData":{"username":"admin","password":"s3cr3t"}}`),
+	}
+	out, err := NewPersistValueTransformer().ApplyToResource(r)
+	require.NoError(t, err)
+
+	var props map[string]any
+	require.NoError(t, json.Unmarshal(out.Properties, &props))
+	assert.Equal(t, "n", props["Name"], "non-secret field untouched")
+
+	dd := props["decodedData"].(map[string]any)
+	assert.Equal(t, "Opaque", dd["$visibility"])
+	assert.Equal(t, true, dd["$hashed"])
+	assert.Equal(t, "Update", dd["$strategy"])
+	assert.Len(t, dd["$value"].(string), 64, "the whole map is hashed into one digest")
+	_, hasUser := dd["username"]
+	_, hasPass := dd["password"]
+	assert.False(t, hasUser, "plaintext username key must not survive at rest")
+	assert.False(t, hasPass, "plaintext password key must not survive at rest")
+	assert.NotContains(t, dd["$value"].(string), "admin")
+	assert.NotContains(t, dd["$value"].(string), "s3cr3t")
+}
+
 func TestApplyToResource_IdempotentAndSkipsClear(t *testing.T) {
 	r := &pkgmodel.Resource{
 		Schema:     schemaWithOpaque("SecretString"),

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -448,19 +448,22 @@ open class ScalarSecretResolvable extends Resolvable {
 /// consumer field, so the mistake is a PKL eval-time type error. Only .at(key)
 /// produces a Resolvable.
 class SecretMapAccessor {
+    local _self = this
     hidden label: String?
     hidden type: String(matches(Regex(#"^.*::.*$"#)))?
     hidden stack: String?
     hidden valueProperty: String
     hidden visibility: "Clear"|"Opaque" = "Clear"
     /// Access a value by key in the resolved map. Colons and dots are escaped for
-    /// gjson, matching MappingResolvable.at.
+    /// gjson, matching MappingResolvable.at. The leaf's label/type/stack/visibility
+    /// are captured from the accessor (via `_self`) rather than `this`, which inside
+    /// the `new {}` binds to the leaf being constructed and would self-reference.
     function at(key: String): SecretValueResolvable = new {
-        label = this.label
-        type = this.type
-        stack = this.stack
-        property = valueProperty + "." + key.replaceAll(":", "\\:").replaceAll(".", "\\.")
-        visibility = this.visibility
+        label = _self.label
+        type = _self.type
+        stack = _self.stack
+        property = _self.valueProperty + "." + key.replaceAll(":", "\\:").replaceAll(".", "\\.")
+        visibility = _self.visibility
     }
 }
 

--- a/internal/schema/pkl/schema/tests/secret_resolvable_test.pkl
+++ b/internal/schema/pkl/schema/tests/secret_resolvable_test.pkl
@@ -39,6 +39,12 @@ facts {
     mapSecret.secretValue.at("h:1").$property == "data.h\\:1"
     mapSecret.secretValue.at("token") is formae.SecretValueResolvable
   }
+  ["map .at(key) leaf carries the accessor's label/type/stack (full-render, no self-reference)"] {
+    mapSecret.secretValue.at("token").$label == "kv"
+    mapSecret.secretValue.at("token").$type == "Test::Secret"
+    mapSecret.secretValue.at("token").$stack == "default"
+    mapSecret.secretValue.at("token").$res == true
+  }
   ["json(path) renders $json and is chainable after at()"] {
     scalar.secretValue.json("a.b").$json == "a.b"
     scalar.secretValue.json("a.b") is formae.SecretValueResolvable

--- a/internal/workflow_tests/local/sync_target_config_resolve_test.go
+++ b/internal/workflow_tests/local/sync_target_config_resolve_test.go
@@ -1,0 +1,213 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// syncReadCapture records the TargetConfig the plugin receives on each Read of
+// the resource that lives on the secret-authed target, so the assertion can
+// inspect what reached the plugin boundary during a sync cycle.
+type syncReadCapture struct {
+	mu      sync.Mutex
+	configs []json.RawMessage
+}
+
+func (c *syncReadCapture) add(cfg json.RawMessage) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cp := make(json.RawMessage, len(cfg))
+	copy(cp, cfg)
+	c.configs = append(c.configs, cp)
+}
+
+func (c *syncReadCapture) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.configs = nil
+}
+
+func (c *syncReadCapture) all() []json.RawMessage {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]json.RawMessage, len(c.configs))
+	copy(out, c.configs)
+	return out
+}
+
+// TestSyncResolve_TargetConfigOpaqueRefIsResolvedBeforeRead asserts that when a
+// managed resource lives on a target whose Config carries an opaque $ref to a
+// managed secret (reference-don't-store: no $value at rest), a background SYNC
+// resolves that target's config live and the plugin Read receives the RESOLVED
+// credential — not the stripped/unresolved config.
+//
+// This is the sync-path analogue of
+// TestDiscoveryResolve_TargetConfigOpaqueRefIsResolvedBeforeList. It guards the
+// gap where sync resource ops are OperationRead, which the changeset
+// edge-builders did not wire to the synthetic target Resolve node — so the Read
+// dispatched with unresolved credentials (with a real provider that hangs the
+// Read forever; with a fake plugin it simply receives a credential-less config).
+//
+// Setup:
+//   - Apply 1 creates a FakeAWS::SecretsManager::Secret ("my-secret") and a
+//     consumer target ("consumer") whose Config carries an opaque $ref to the
+//     secret's SecretString, plus a managed FakeAWS::S3::Bucket ("r1") on that
+//     consumer target.
+//   - The stored consumer Config retains only the $ref pointer (no $value).
+//   - A fake plugin captures the TargetConfig every Read of "r1" receives, and
+//     serves the secret's value so the ResolveCache can resolve the target.
+//   - ForceSync is triggered; the recorded Read TargetConfig for "r1" must carry
+//     the resolved credential.
+func TestSyncResolve_TargetConfigOpaqueRefIsResolvedBeforeRead(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const plaintextSecret = "sync-target-config-secret-value"
+		const bucketNative = "r1-native"
+		const secretNative = "my-secret-native"
+
+		capture := &syncReadCapture{}
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				nid := bucketNative
+				if req.ResourceType == "FakeAWS::SecretsManager::Secret" {
+					nid = secretNative
+				}
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          req.Label,
+					NativeID:           nid,
+					ResourceProperties: req.Properties,
+				}}, nil
+			},
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				switch req.ResourceType {
+				case "FakeAWS::SecretsManager::Secret":
+					// Serve the secret so the ResolveCache can resolve the target $ref.
+					return &resource.ReadResult{
+						ResourceType: req.ResourceType,
+						Properties:   fmt.Sprintf(`{"Name":"my-secret","SecretString":%q}`, plaintextSecret),
+					}, nil
+				case "FakeAWS::S3::Bucket":
+					// r1 lives on the secret-authed target: record the config that
+					// reached the plugin on this Read, then return its live state.
+					capture.add(req.TargetConfig)
+					return &resource.ReadResult{
+						ResourceType: req.ResourceType,
+						Properties:   fmt.Sprintf(`{"BucketName":%q}`, req.NativeID),
+					}, nil
+				}
+				return nil, fmt.Errorf("unexpected resource type in Read: %s", req.ResourceType)
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false // manual sync control
+		cfg.Agent.Retry.MaxRetries = 0
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		secretKsuid := "2MiD2rA1SJbLMGZgTL0hCxjkjjw"
+		stack := "sync-resolve-test-stack"
+
+		secretManagerSchema := pkgmodel.Schema{
+			Identifier: "Id",
+			Fields:     []string{"Name", "Description", "SecretString", "Tags"},
+			Hints: map[string]pkgmodel.FieldHint{
+				"SecretString": {Opaque: true},
+			},
+		}
+		bucketSchema := pkgmodel.Schema{
+			Identifier: "BucketName",
+			Fields:     []string{"BucketName"},
+		}
+
+		applyOne := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: stack}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label:      "my-secret",
+					Type:       "FakeAWS::SecretsManager::Secret",
+					Stack:      stack,
+					Target:     "provider",
+					Ksuid:      secretKsuid,
+					Schema:     secretManagerSchema,
+					Properties: json.RawMessage(`{"Name":"my-secret","SecretString":"` + plaintextSecret + `"}`),
+				},
+				{
+					Label:      "r1",
+					Type:       "FakeAWS::S3::Bucket",
+					Stack:      stack,
+					Target:     "consumer",
+					Schema:     bucketSchema,
+					Properties: json.RawMessage(`{"BucketName":"` + bucketNative + `"}`),
+				},
+			},
+			Targets: []pkgmodel.Target{
+				{Label: "provider", Namespace: "FakeAWS"},
+				{
+					Label:     "consumer",
+					Namespace: "FakeAWS",
+					Config: json.RawMessage(fmt.Sprintf(`{
+						"apiKey": {"$ref": "formae://%s#/SecretString", "$visibility": "Opaque"}
+					}`, secretKsuid)),
+				},
+			},
+		}
+
+		_, err = m.ApplyForma(applyOne, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "sync-resolve-client")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		// The stored consumer config must retain only the $ref pointer (no plaintext).
+		consumerTarget, err := m.Datastore.LoadTarget("consumer")
+		require.NoError(t, err)
+		require.NotNil(t, consumerTarget, "consumer target must have been persisted by apply 1")
+		require.Contains(t, string(consumerTarget.Config), "$ref",
+			"stored consumer config must retain the $ref pointer")
+		require.NotContains(t, string(consumerTarget.Config), plaintextSecret,
+			"stored consumer config must not persist the resolved plaintext")
+
+		// Isolate the sync cycle's reads from any apply-time reads.
+		capture.reset()
+
+		// Force a sync. The sync Read of r1 (on the secret-authed consumer target)
+		// must resolve the target's opaque $ref config live before dispatching.
+		require.NoError(t, m.ForceSync())
+		require.Eventually(t, func() bool {
+			return len(capture.all()) > 0
+		}, 15*time.Second, 50*time.Millisecond, "sync must read r1 on the secret-authed target")
+
+		// Core assertion: every sync Read of r1 received the RESOLVED credential —
+		// not a stripped/unresolved config.
+		configs := capture.all()
+		require.NotEmpty(t, configs, "sync Read of r1 must have been called at least once")
+		for i, c := range configs {
+			cfgStr := string(c)
+			assert.Contains(t, cfgStr, plaintextSecret,
+				"sync Read %d: TargetConfig must contain the resolved credential (not a stripped/unresolved $ref)", i)
+			assert.NotContains(t, cfgStr, `"$ref"`,
+				"sync Read %d: TargetConfig must not contain a raw $ref — it must be resolved before reaching the plugin", i)
+		}
+	})
+}

--- a/pkg/plugin/plugin_operator.go
+++ b/pkg/plugin/plugin_operator.go
@@ -733,27 +733,6 @@ func resume(from gen.PID, state gen.Atom, data PluginUpdateData, operation Resum
 	return handlePluginResult(data, operation.Request, proc, result.ProgressResult)
 }
 
-// calculateExponentialBackoff returns a delay that doubles with each attempt.
-// For throttling errors, this prevents the "thundering herd" problem where
-// all throttled operations retry simultaneously after a fixed delay.
-// Formula: baseDelay * 2^(attempt-1), capped at 30 seconds.
-func calculateExponentialBackoff(attempt int, baseDelay time.Duration) time.Duration {
-	const maxBackoff = 30 * time.Second
-
-	if attempt <= 1 {
-		return baseDelay
-	}
-
-	// Calculate 2^(attempt-1)
-	multiplier := 1 << (attempt - 1) // 1, 2, 4, 8, ...
-	backoff := baseDelay * time.Duration(multiplier)
-
-	if backoff > maxBackoff {
-		return maxBackoff
-	}
-	return backoff
-}
-
 // isThrottlingError checks if an error is a throttling/rate limit error.
 // This checks for common throttling indicators in error messages since
 // the AWS SDK wraps errors when retries are exhausted.
@@ -798,7 +777,7 @@ func handlePluginResult(data PluginUpdateData, operation StatusCheck, proc gen.P
 			// Use exponential backoff for throttling errors to avoid thundering herd
 			retryDelay := data.config.RetryDelay
 			if progress.ErrorCode == resource.OperationErrorCodeThrottling {
-				retryDelay = calculateExponentialBackoff(data.attempts, data.config.RetryDelay)
+				retryDelay = resource.RetryStrategy{BaseDelay: data.config.RetryDelay}.Backoff(data.attempts)
 				proc.Log().Debug("PluginOperator: %T throttled, backing off for %v before retry (%d/%d)", operation, retryDelay, data.attempts, maxAttempts)
 			} else {
 				proc.Log().Info("PluginOperator: %T operation failed with recoverable error code %s. Status message: %s. Retrying (%d/%d)", operation, progress.ErrorCode, progress.StatusMessage, data.attempts, maxAttempts)
@@ -884,7 +863,7 @@ func list(from gen.PID, state gen.Atom, data PluginUpdateData, operation ListRes
 
 			// Check if this is a throttling error worth retrying
 			if isThrottlingError(err) && attempt < maxListAttempts {
-				backoff := calculateExponentialBackoff(attempt, data.config.RetryDelay)
+				backoff := resource.RetryStrategy{BaseDelay: data.config.RetryDelay}.Backoff(attempt)
 				proc.Log().Debug("PluginOperator: list %s throttled, backing off for %v before retry (%d/%d)",
 					operation.ResourceType, backoff, attempt, maxListAttempts)
 				time.Sleep(backoff)

--- a/pkg/plugin/resource/retry.go
+++ b/pkg/plugin/resource/retry.go
@@ -1,0 +1,88 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package resource
+
+import "time"
+
+// DefaultMaxBackoff caps a single exponential-backoff delay. It matches the
+// historical cap in the plugin operator's throttling backoff.
+const DefaultMaxBackoff = 30 * time.Second
+
+// RetryStrategy is a pure, actor-agnostic description of how a recoverable
+// plugin operation should be retried. It performs no I/O, no sleeping, and holds
+// no actor state: callers ask it for a decision and then schedule their own
+// (non-blocking) reschedule. It is the single source of truth for both the
+// per-attempt backoff and the total retry budget, so a waiting actor's watchdog
+// (derived from MaxTotalDelay) can never drift from the actual backoff.
+type RetryStrategy struct {
+	// MaxRetries is the number of retries allowed after the first attempt.
+	MaxRetries int
+	// BaseDelay is the delay before the first retry and the flat delay used for
+	// recoverable non-throttling errors.
+	BaseDelay time.Duration
+	// MaxBackoff caps a single exponential backoff delay. Zero means
+	// DefaultMaxBackoff.
+	MaxBackoff time.Duration
+}
+
+// RetryDecision is the result of RetryStrategy.Decide.
+type RetryDecision struct {
+	Retry bool
+	After time.Duration
+}
+
+func (s RetryStrategy) maxBackoff() time.Duration {
+	if s.MaxBackoff <= 0 {
+		return DefaultMaxBackoff
+	}
+	return s.MaxBackoff
+}
+
+// Backoff returns the delay before the retry that follows a given attempt.
+// attempt is 1-based (attempt 1 = the first try just failed). It reproduces the
+// historical calculateExponentialBackoff exactly: attempt <= 1 returns BaseDelay;
+// otherwise BaseDelay * 2^(attempt-1), capped at MaxBackoff.
+func (s RetryStrategy) Backoff(attempt int) time.Duration {
+	if attempt <= 1 {
+		return s.BaseDelay
+	}
+	shift := attempt - 1
+	// Guard against overflow of the shift and of the multiplication.
+	if shift >= 62 {
+		return s.maxBackoff()
+	}
+	backoff := s.BaseDelay * time.Duration(int64(1)<<uint(shift))
+	if backoff <= 0 || backoff > s.maxBackoff() {
+		return s.maxBackoff()
+	}
+	return backoff
+}
+
+// Decide reports whether an operation that has just failed on its `attempt`-th
+// try (1-based) with error code `code` should retry, and after how long.
+// Throttling uses exponential Backoff; other recoverable codes use the flat
+// BaseDelay. It gives up on a non-recoverable code or once attempt reaches
+// MaxRetries.
+func (s RetryStrategy) Decide(attempt int, code OperationErrorCode) RetryDecision {
+	if !IsRecoverable(code) || attempt > s.MaxRetries {
+		return RetryDecision{Retry: false}
+	}
+	if code == OperationErrorCodeThrottling {
+		return RetryDecision{Retry: true, After: s.Backoff(attempt)}
+	}
+	return RetryDecision{Retry: true, After: s.BaseDelay}
+}
+
+// MaxTotalDelay is the worst-case total time spent backing off across all
+// retries (the exponential/throttling path, which dominates the flat path). A
+// watchdog that waits on a retrying operation must cover at least this budget on
+// top of the per-attempt operation timeouts, or it will fire mid-retry.
+func (s RetryStrategy) MaxTotalDelay() time.Duration {
+	var total time.Duration
+	for attempt := 1; attempt <= s.MaxRetries; attempt++ {
+		total += s.Backoff(attempt)
+	}
+	return total
+}

--- a/pkg/plugin/resource/retry_test.go
+++ b/pkg/plugin/resource/retry_test.go
@@ -1,0 +1,82 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryStrategy_Backoff(t *testing.T) {
+	s := RetryStrategy{MaxRetries: 10, BaseDelay: time.Second, MaxBackoff: 30 * time.Second}
+	// attempt<=1 => BaseDelay; then 2^(attempt-1)*BaseDelay, capped at MaxBackoff.
+	assert.Equal(t, time.Second, s.Backoff(1))
+	assert.Equal(t, 2*time.Second, s.Backoff(2))
+	assert.Equal(t, 4*time.Second, s.Backoff(3))
+	assert.Equal(t, 8*time.Second, s.Backoff(4))
+	assert.Equal(t, 16*time.Second, s.Backoff(5))
+	assert.Equal(t, 30*time.Second, s.Backoff(6), "32s exceeds cap -> 30s")
+	assert.Equal(t, 30*time.Second, s.Backoff(50), "large attempt saturates at cap")
+}
+
+func TestRetryStrategy_Backoff_ZeroMaxBackoffUsesDefault(t *testing.T) {
+	s := RetryStrategy{MaxRetries: 10, BaseDelay: time.Second}
+	assert.Equal(t, DefaultMaxBackoff, s.Backoff(10))
+}
+
+func TestRetryStrategy_Decide_NonRecoverable(t *testing.T) {
+	s := RetryStrategy{MaxRetries: 5, BaseDelay: time.Second}
+	d := s.Decide(1, OperationErrorCodeInvalidRequest)
+	assert.False(t, d.Retry)
+}
+
+func TestRetryStrategy_Decide_ExhaustedAttempts(t *testing.T) {
+	s := RetryStrategy{MaxRetries: 3, BaseDelay: time.Second}
+	assert.True(t, s.Decide(3, OperationErrorCodeThrottling).Retry)
+	assert.False(t, s.Decide(4, OperationErrorCodeThrottling).Retry, "attempt beyond MaxRetries gives up")
+}
+
+func TestRetryStrategy_Decide_ThrottlingIsExponential(t *testing.T) {
+	s := RetryStrategy{MaxRetries: 5, BaseDelay: time.Second}
+	assert.Equal(t, time.Second, s.Decide(1, OperationErrorCodeThrottling).After)
+	assert.Equal(t, 2*time.Second, s.Decide(2, OperationErrorCodeThrottling).After)
+	assert.Equal(t, 4*time.Second, s.Decide(3, OperationErrorCodeThrottling).After)
+}
+
+func TestRetryStrategy_Decide_OtherRecoverableIsFlat(t *testing.T) {
+	s := RetryStrategy{MaxRetries: 5, BaseDelay: time.Second}
+	assert.Equal(t, time.Second, s.Decide(1, OperationErrorCodeThrottling).After)
+	// NetworkFailure is recoverable but not throttling -> flat BaseDelay each time.
+	assert.Equal(t, time.Second, s.Decide(3, OperationErrorCodeNetworkFailure).After)
+}
+
+func TestRetryStrategy_MaxTotalDelay(t *testing.T) {
+	// MaxRetries=4, base 1s: 1 + 2 + 4 + 8 = 15s.
+	s := RetryStrategy{MaxRetries: 4, BaseDelay: time.Second, MaxBackoff: 30 * time.Second}
+	assert.Equal(t, 15*time.Second, s.MaxTotalDelay())
+
+	// With saturation: MaxRetries=8: 1+2+4+8+16+30+30+30 = 121s.
+	s8 := RetryStrategy{MaxRetries: 8, BaseDelay: time.Second, MaxBackoff: 30 * time.Second}
+	assert.Equal(t, 121*time.Second, s8.MaxTotalDelay())
+
+	assert.Equal(t, time.Duration(0), RetryStrategy{MaxRetries: 0, BaseDelay: time.Second}.MaxTotalDelay())
+}
+
+func TestRetryStrategy_MaxTotalDelay_ExceedsFlatEstimate(t *testing.T) {
+	// A resolve watchdog must be sized off MaxTotalDelay, not a flat
+	// (MaxRetries-1)*BaseDelay estimate: under exponential-for-throttling backoff
+	// the real budget is far larger, so a flat-sized watchdog would fire
+	// mid-retry and crash the waiting actor. This guards that MaxTotalDelay
+	// captures the (larger) exponential budget the watchdog derives from.
+	s := RetryStrategy{MaxRetries: 8, BaseDelay: time.Second, MaxBackoff: 30 * time.Second}
+	flatEstimate := time.Duration(s.MaxRetries-1) * s.BaseDelay // the old assumption: 7s
+	assert.Greater(t, s.MaxTotalDelay(), flatEstimate,
+		"exponential budget must exceed the flat estimate the old watchdog used")
+	assert.Equal(t, 121*time.Second, s.MaxTotalDelay())
+}


### PR DESCRIPTION
Stacks on the delete-path/cascade PR. These six fixes are RFC-110 secret-resolution bugs surfaced by the first end-to-end exercise of a **map-shaped** secret and of an idempotent **re-apply** of a target that sources a credential from a secret (a Kubernetes Secret supplying a Grafana target's basic auth, with no `GRAFANA_AUTH`). Each is independent, root-caused, and covered by a test.

## Map-shaped secret support

- **`fix(schema): capture accessor fields in SecretMapAccessor.at`** — `secret.res.secretValue.at(key)` stack-overflowed when the resulting leaf was rendered: it read `label`/`type`/`stack` from `this`, which inside `new {}` binds to the leaf being constructed. Capture the accessor via `local _self = this` (matching `ScalarSecretResolvable`).
- **`fix(resolver): treat a ref into an opaque map field as a credential`** — `isSourcePropertyOpaque` looked up only the leaf path (`decodedData.password`), which sits beneath the field's single hashed envelope, so a map-secret credential was misclassified as a plain cross-resource ref. Also check the top-level field.
- **`fix(persist): hash a map-shaped opaque secret field as one value`** — a raw map on an opaque field was mistaken for a `{$value}` envelope, leaving the plaintext keys beside a nil `$value` (a leak at rest). Only route a map to the envelope path when it carries `$value`; otherwise hash the whole map.
- **`fix(resolver): resolve a ref into a map-shaped opaque secret`** — resolving a map sub-key after `preserveRefMetadata` wrapped the field failed; descend into the opaque parent's `$value` and re-wrap the leaf in the scalar envelope shape.

## Target-config-secret resolution across plugin-call paths

- **`fix(target): ignore derived ref metadata when classifying config change`** — a secret-sourced credential persists `$visibility:"Opaque"` (so reference-don't-store strips `$value`) while the forma renders the same ref `$visibility:"Clear"`. The config-change classifier compared this derived metadata, so every idempotent re-apply saw the `createOnly` credential as changed and forced a spurious target replace. Strip `$visibility`/`$strategy` alongside `$value`; a ref's identity is its path + `$json`.
- **`fix(resolve): re-resolve opaque target creds on the resolve-read path`** — a resource resolvable (e.g. a dashboard's `folderUid = folder.res.uid`) triggers a live plugin Read via `ResolveCache`, which used the persisted target config whose credential is a bare opaque `$ref` with no value at rest, and never re-resolved it — so the Read ran unauthenticated. Extract discovery's resolver into a shared `resource_update.ResolveOpaqueTargetConfig` used by both the discovery List path and the resolve-read path, so every plugin-call path that loads a persisted target config resolves credentials the same way the apply path already does.

## Verification

Unit tests per fix; verified live end-to-end against a Kubernetes cluster + Grafana: a native Secret supplies a Grafana target's `username`/`password` via `secret.res.secretValue.at(...)` with **no `GRAFANA_AUTH`**; the target's Folder, DataSources, and Dashboards are created; the Secret's decoded value is hashed at rest; and **a repeat reconcile is idempotent** — no target replace, no failures.