### PR TITLE
test(conformance): fix two sync-wait defects behind recurring conformance flakes

### DIFF
--- a/pkg/plugin-conformance-tests/discovery_wait_test.go
+++ b/pkg/plugin-conformance-tests/discovery_wait_test.go
@@ -34,7 +34,8 @@ func TestWaitForResource(t *testing.T) {
 
 		err := waitForResource(clk, t.Logf, 100*time.Second,
 			backoffConfig{initial: 10 * time.Second, max: 60 * time.Second},
-			2*time.Second, trigger, check)
+			2*time.Second, waitDescription{trigger: "discovery", condition: "appear in inventory"},
+			trigger, check)
 		if err != nil {
 			t.Fatalf("expected success, got error: %v", err)
 		}
@@ -54,7 +55,8 @@ func TestWaitForResource(t *testing.T) {
 
 		_ = waitForResource(clk, t.Logf, 200*time.Second,
 			backoffConfig{initial: 10 * time.Second, max: 60 * time.Second},
-			5*time.Second, trigger, check)
+			5*time.Second, waitDescription{trigger: "discovery", condition: "appear in inventory"},
+			trigger, check)
 
 		want := []time.Duration{0, 10, 30, 70, 130, 190}
 		for i := range want {
@@ -78,7 +80,8 @@ func TestWaitForResource(t *testing.T) {
 
 		err := waitForResource(clk, t.Logf, 20*time.Second,
 			backoffConfig{initial: 10 * time.Second, max: 60 * time.Second},
-			5*time.Second, trigger, check)
+			5*time.Second, waitDescription{trigger: "discovery", condition: "appear in inventory"},
+			trigger, check)
 		if err == nil {
 			t.Fatal("expected timeout error, got nil")
 		}
@@ -101,7 +104,8 @@ func TestWaitForResource(t *testing.T) {
 
 		err := waitForResource(clk, t.Logf, 20*time.Second,
 			backoffConfig{initial: 10 * time.Second, max: 60 * time.Second},
-			5*time.Second, trigger, check)
+			5*time.Second, waitDescription{trigger: "discovery", condition: "appear in inventory"},
+			trigger, check)
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -127,7 +131,8 @@ func TestWaitForResource(t *testing.T) {
 
 		err := waitForResource(clk, t.Logf, 100*time.Second,
 			backoffConfig{initial: 10 * time.Second, max: 60 * time.Second},
-			2*time.Second, trigger, check)
+			2*time.Second, waitDescription{trigger: "discovery", condition: "appear in inventory"},
+			trigger, check)
 		if err != nil {
 			t.Fatalf("a transient first-trigger error must not abort the wait, got: %v", err)
 		}
@@ -143,7 +148,8 @@ func TestWaitForResource(t *testing.T) {
 		// 9s deadline — below the ~one-poll-interval scan grace, so it is skipped.
 		err := waitForResource(clk, t.Logf, 9*time.Second,
 			backoffConfig{initial: 8 * time.Second, max: 60 * time.Second},
-			2*time.Second, trigger, check)
+			2*time.Second, waitDescription{trigger: "discovery", condition: "appear in inventory"},
+			trigger, check)
 		if err == nil {
 			t.Fatal("expected timeout error, got nil")
 		}
@@ -179,6 +185,76 @@ func TestGetDiscoveryRetriggerBackoff(t *testing.T) {
 			}
 			if got.max != discoveryRetriggerCap {
 				t.Errorf("max = %v, want %v", got.max, discoveryRetriggerCap)
+			}
+		})
+	}
+}
+
+// The out-of-band delete wait re-uses the same loop as the discovery wait. Its
+// distinguishing requirement is that it must re-trigger sync: a single sync can
+// land inside the cloud provider's propagation window for the delete, read the
+// resource as still present, and cache that. Polling the inventory alone after
+// that point can never observe the tombstone.
+func TestWaitForResource_RemovalRetriggersSync(t *testing.T) {
+	t.Run("resource leaves inventory only after a later sync", func(t *testing.T) {
+		clk := &fakeClock{now: clockBase}
+		syncs := 0
+		trigger := func() error { syncs++; return nil }
+		// Sync #1 races the delete and still sees the resource; only the second
+		// sync observes it gone.
+		stillPresent := func() (bool, error) { return syncs >= 2, nil }
+
+		err := waitForResource(clk, t.Logf, 100*time.Second,
+			backoffConfig{initial: 10 * time.Second, max: 60 * time.Second},
+			2*time.Second, waitDescription{trigger: "sync", condition: "leave inventory"},
+			trigger, stillPresent)
+		if err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+		if syncs < 2 {
+			t.Errorf("expected at least 2 sync triggers, got %d", syncs)
+		}
+	})
+
+	t.Run("timeout message names the sync trigger and the removal condition", func(t *testing.T) {
+		clk := &fakeClock{now: clockBase}
+		trigger := func() error { return nil }
+		neverRemoved := func() (bool, error) { return false, nil }
+
+		err := waitForResource(clk, t.Logf, 20*time.Second,
+			backoffConfig{initial: 5 * time.Second, max: 10 * time.Second},
+			2*time.Second, waitDescription{trigger: "sync", condition: "leave inventory"},
+			trigger, neverRemoved)
+		if err == nil {
+			t.Fatal("expected a timeout error")
+		}
+		if !strings.Contains(err.Error(), "leave inventory") {
+			t.Errorf("error should name the removal condition, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "sync") {
+			t.Errorf("error should name the sync trigger, got: %v", err)
+		}
+	})
+}
+
+func TestGetOOBSyncRetriggerBackoff(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset uses default", "", oobSyncRetriggerDefault},
+		{"seconds are honoured", "12", 12 * time.Second},
+		{"clamped up to the floor", "1", oobSyncRetriggerFloor},
+		{"clamped down to the cap", "9999", oobSyncRetriggerCap},
+		{"non-numeric falls back", "soon", oobSyncRetriggerDefault},
+		{"zero falls back", "0", oobSyncRetriggerDefault},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("FORMAE_TEST_OOB_SYNC_RETRIGGER_INTERVAL", tt.env)
+			if got := getOOBSyncRetriggerBackoff().initial; got != tt.want {
+				t.Errorf("initial = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/plugin-conformance-tests/harness.go
+++ b/pkg/plugin-conformance-tests/harness.go
@@ -1206,12 +1206,24 @@ type backoffConfig struct {
 // than a misleading not-found timeout. No re-trigger is issued once the time
 // remaining before the deadline drops below the poll interval (the scan grace),
 // since a scan started that late has almost no chance of completing in time.
+// waitDescription supplies the nouns waitForResource uses in its log lines and
+// error messages, so one loop can serve both the discovery wait ("discovery" /
+// "appear in inventory") and the out-of-band delete wait ("sync" / "leave
+// inventory") without either reporting the other's vocabulary.
+type waitDescription struct {
+	// trigger names what re-triggering does, e.g. "discovery" or "sync".
+	trigger string
+	// condition names what the check waits for, e.g. "leave inventory".
+	condition string
+}
+
 func waitForResource(
 	clk clock,
 	logf func(format string, args ...any),
 	timeout time.Duration,
 	backoff backoffConfig,
 	pollInterval time.Duration,
+	desc waitDescription,
 	trigger func() error,
 	check func() (bool, error),
 ) error {
@@ -1240,7 +1252,7 @@ func waitForResource(
 				attempts++
 				if err := trigger(); err != nil {
 					lastTriggerErr = err
-					logf("discovery trigger attempt %d failed (continuing): %v", attempts, err)
+					logf("%s trigger attempt %d failed (continuing): %v", desc.trigger, attempts, err)
 				} else {
 					successes++
 				}
@@ -1257,9 +1269,9 @@ func waitForResource(
 
 		found, err := check()
 		if err != nil {
-			logf("discovery inventory check failed (will retry): %v", err)
+			logf("%s inventory check failed (will retry): %v", desc.trigger, err)
 		} else if found {
-			logf("resource discovered after %d trigger attempt(s) in %v", attempts, clk.Now().Sub(start))
+			logf("resource observed to %s after %d %s trigger attempt(s) in %v", desc.condition, attempts, desc.trigger, clk.Now().Sub(start))
 			return nil
 		}
 
@@ -1267,9 +1279,9 @@ func waitForResource(
 	}
 
 	if attempts > 0 && successes == 0 {
-		return fmt.Errorf("could not trigger discovery: all %d trigger attempt(s) failed; last error: %v", attempts, lastTriggerErr)
+		return fmt.Errorf("could not trigger %s: all %d trigger attempt(s) failed; last error: %v", desc.trigger, attempts, lastTriggerErr)
 	}
-	msg := fmt.Sprintf("timeout after %v: resource did not appear in inventory (%d discovery trigger attempt(s))", timeout, attempts)
+	msg := fmt.Sprintf("timeout after %v: resource did not %s (%d %s trigger attempt(s))", timeout, desc.condition, attempts, desc.trigger)
 	if lastTriggerErr != nil {
 		msg += fmt.Sprintf("; last trigger error: %v", lastTriggerErr)
 	}
@@ -1292,6 +1304,7 @@ func (h *TestHarness) WaitForResourceDiscovered(resourceType, nativeID string, t
 		timeout,
 		backoff,
 		discoveryPollInterval,
+		waitDescription{trigger: "discovery", condition: "appear in inventory"},
 		h.TriggerDiscovery,
 		func() (bool, error) {
 			inventory, err := h.Inventory(fmt.Sprintf("type: %s managed: false", resourceType))
@@ -2145,43 +2158,45 @@ func (h *TestHarness) DeleteResourceOOB(resourceType, nativeID string, target *p
 	return h.DeleteUnmanagedResource(resourceType, nativeID, target)
 }
 
-// WaitForResourceRemovedFromInventory polls the inventory until the specified resource
-// is no longer present. This is used to verify that sync correctly tombstones resources
-// that were deleted out-of-band.
+// WaitForResourceRemovedFromInventory waits for a resource deleted out-of-band
+// to be tombstoned: it re-triggers sync on a backoff schedule while polling the
+// inventory for the given type + nativeID, until the resource is gone or the
+// timeout elapses.
+//
+// The re-trigger is the point. A single sync can start inside the cloud
+// provider's propagation window for the delete, read the resource as still
+// present, and persist that. Polling the inventory alone after that point can
+// never observe the tombstone, because nothing goes back out to the cloud, so
+// the wait burns its whole budget on state that is frozen and stale. Re-syncing
+// across the window is what makes eventual consistency tolerable here, exactly
+// as re-scanning does for WaitForResourceDiscovered.
 func (h *TestHarness) WaitForResourceRemovedFromInventory(resourceType, nativeID string, timeout time.Duration) error {
-	h.t.Logf("Waiting for resource to be removed from inventory: type=%s, nativeID=%s", resourceType, nativeID)
+	backoff := getOOBSyncRetriggerBackoff()
+	h.t.Logf("Waiting for resource to be removed from inventory: type=%s, nativeID=%s (timeout=%v, base re-trigger=%v)", resourceType, nativeID, timeout, backoff.initial)
 
-	deadline := time.Now().Add(timeout)
-	pollInterval := 2 * time.Second
-
-	for time.Now().Before(deadline) {
-		inventory, err := h.Inventory(fmt.Sprintf("type: %s", resourceType))
-		if err != nil {
-			h.t.Logf("Inventory query failed (will retry): %v", err)
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		found := false
-		for _, res := range inventory.Resources {
-			if resNativeID, ok := res["NativeID"].(string); ok {
-				if resNativeID == nativeID {
-					found = true
-					break
+	return waitForResource(
+		realClock{},
+		h.t.Logf,
+		timeout,
+		backoff,
+		oobSyncPollInterval,
+		waitDescription{trigger: "sync", condition: "leave inventory"},
+		h.Sync,
+		func() (bool, error) {
+			inventory, err := h.Inventory(fmt.Sprintf("type: %s", resourceType))
+			if err != nil {
+				return false, err
+			}
+			for _, res := range inventory.Resources {
+				if resNativeID, ok := res["NativeID"].(string); ok && resNativeID == nativeID {
+					h.t.Logf("Resource still in inventory, polling...")
+					return false, nil
 				}
 			}
-		}
-
-		if !found {
 			h.t.Logf("Resource removed from inventory: NativeID=%s", nativeID)
-			return nil
-		}
-
-		h.t.Logf("Resource still in inventory, polling...")
-		time.Sleep(pollInterval)
-	}
-
-	return fmt.Errorf("timeout waiting for resource %s (type: %s) to be removed from inventory after %v", nativeID, resourceType, timeout)
+			return true, nil
+		},
+	)
 }
 
 // pluginNameToPascalCase converts a hyphenated plugin name to PascalCase

--- a/pkg/plugin-conformance-tests/runner.go
+++ b/pkg/plugin-conformance-tests/runner.go
@@ -212,6 +212,30 @@ func getDiscoveryTimeout() time.Duration {
 	return 2 * time.Minute // Default timeout
 }
 
+// defaultSyncTimeout bounds the wait for a forced synchronization to report
+// completion.
+//
+// It has to clear the plugin-side retry budget, not just a typical sync. A
+// healthy sync settles in a few seconds, but plugins absorb recoverable
+// CloudControl errors with their own exponential backoff. The AWS plugin,
+// for instance, budgets ten attempts over a 1s..30s backoff, roughly three
+// minutes. Under the shared-account throttling the conformance matrix
+// generates, a sync that is still retrying is making progress, not hanging.
+// A shorter wait here turns that into a spurious failure on a random test
+// each run, so the default sits above the retry budget with headroom.
+const defaultSyncTimeout = 5 * time.Minute
+
+// getSyncTimeout returns the timeout duration for waiting on synchronization.
+// It reads from the FORMAE_TEST_SYNC_TIMEOUT environment variable (in minutes).
+func getSyncTimeout() time.Duration {
+	if val := os.Getenv("FORMAE_TEST_SYNC_TIMEOUT"); val != "" {
+		if minutes, err := strconv.Atoi(val); err == nil && minutes > 0 {
+			return time.Duration(minutes) * time.Minute
+		}
+	}
+	return defaultSyncTimeout
+}
+
 const (
 	// discoveryPollInterval is how often the discovery wait loop reads the local
 	// inventory while waiting for a scan to surface the resource.
@@ -1439,7 +1463,7 @@ func runCRUDTest(t *testing.T, tc TestCase, rc *ResultCollector) {
 
 	// === Step 8: Wait for synchronization to complete ===
 	t.Log("Step 8: Waiting for synchronization to complete...")
-	if err := harness.WaitForSyncCompletion(60 * time.Second); err != nil {
+	if err := harness.WaitForSyncCompletion(getSyncTimeout()); err != nil {
 		rc.CRUDFatalf(t, idx, PhaseSync, "Synchronization should complete successfully: %v", err)
 	}
 

--- a/pkg/plugin-conformance-tests/runner.go
+++ b/pkg/plugin-conformance-tests/runner.go
@@ -287,6 +287,45 @@ func getOOBDeleteTimeout() time.Duration {
 	return 2 * time.Minute // Default timeout
 }
 
+const (
+	// oobSyncPollInterval is how often the OOB-delete wait loop re-reads the
+	// local inventory between sync re-triggers.
+	oobSyncPollInterval = 2 * time.Second
+	// oobSyncRetriggerDefault is the default interval before the first sync
+	// re-trigger in the OOB-delete wait; it then backs off toward the cap.
+	oobSyncRetriggerDefault = 10 * time.Second
+	// oobSyncRetriggerCap is the ceiling for the re-trigger interval.
+	oobSyncRetriggerCap = 30 * time.Second
+	// oobSyncRetriggerFloor is the minimum re-trigger interval. Sync walks every
+	// managed resource, and the conformance matrix runs ~150 jobs against one
+	// shared cloud account, so the floor caps re-trigger pressure and cannot be
+	// configured away.
+	oobSyncRetriggerFloor = 5 * time.Second
+)
+
+// getOOBSyncRetriggerBackoff returns the capped exponential backoff schedule for
+// re-triggering sync in the OOB-delete wait loop. The base interval is read from
+// FORMAE_TEST_OOB_SYNC_RETRIGGER_INTERVAL (in seconds); empty, non-numeric, or
+// non-positive values fall back to the default, and the value is clamped into
+// [floor, cap] - up to the floor so the rate-limit guarantee holds, and down to
+// the cap so an oversized base interval cannot push the first re-trigger past
+// the timeout and suppress retries entirely.
+func getOOBSyncRetriggerBackoff() backoffConfig {
+	initial := oobSyncRetriggerDefault
+	if val := os.Getenv("FORMAE_TEST_OOB_SYNC_RETRIGGER_INTERVAL"); val != "" {
+		if secs, err := strconv.Atoi(val); err == nil && secs > 0 {
+			initial = time.Duration(secs) * time.Second
+			if initial < oobSyncRetriggerFloor {
+				initial = oobSyncRetriggerFloor
+			}
+			if initial > oobSyncRetriggerCap {
+				initial = oobSyncRetriggerCap
+			}
+		}
+	}
+	return backoffConfig{initial: initial, max: oobSyncRetriggerCap}
+}
+
 // RunCRUDTests discovers test cases from the testdata directory and runs
 // the standard CRUD lifecycle test for each resource type.
 //

--- a/pkg/plugin-conformance-tests/runner_test.go
+++ b/pkg/plugin-conformance-tests/runner_test.go
@@ -7,6 +7,7 @@ package conformance
 import (
 	"os"
 	"testing"
+	"time"
 
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
@@ -1332,4 +1333,39 @@ func TestFindMainResourceNativeID(t *testing.T) {
 			t.Fatal("expected error when no resource matches type")
 		}
 	})
+}
+
+func TestGetSyncTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset falls back to default", "", defaultSyncTimeout},
+		{"minutes are honoured", "7", 7 * time.Minute},
+		{"non-numeric falls back to default", "soon", defaultSyncTimeout},
+		{"zero falls back to default", "0", defaultSyncTimeout},
+		{"negative falls back to default", "-3", defaultSyncTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("FORMAE_TEST_SYNC_TIMEOUT", tt.env)
+			if got := getSyncTimeout(); got != tt.want {
+				t.Errorf("getSyncTimeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// The plugin-side retry budget (exponential backoff over recoverable
+// CloudControl errors) can legitimately keep a single read in flight for
+// minutes. If the harness gives up first it reports a failure for a sync that
+// was still making progress, so the default must leave room for that budget.
+func TestSyncTimeoutDefaultExceedsPluginRetryBudget(t *testing.T) {
+	const observedPluginRetryBudget = 3 * time.Minute
+	if defaultSyncTimeout <= observedPluginRetryBudget {
+		t.Errorf("defaultSyncTimeout = %v, must exceed the plugin retry budget of %v",
+			defaultSyncTimeout, observedPluginRetryBudget)
+	}
 }


### PR DESCRIPTION
## Summary

Two independent defects in the conformance harness's sync waits, both found by tracing AWS plugin nightly failures to root cause. Each was producing failures on a *different random resource type* per run, which reads as flake but is not.

### 1. The CRUD sync wait was shorter than the plugin's own retry budget

Step 8 waited a hardcoded 60s for a forced synchronization to complete. Measured against the nightly matrix:

- A healthy sync finishes in **0-3s** (sampled across six passing jobs), so 60s was never about normal latency.
- Under shared-account throttling the plugin enters its own backoff loop: ten attempts over a 1s..30s backoff, roughly **three minutes**. Log evidence from a failing run shows `ccx: retrying read on recoverable error ... resource_type=AWS::IAM::User` immediately before the sync window.
- Each retry emits a progress update, which reschedules the agent's 40s `PluginOperatorMissingInAction` watchdog, so nothing else capped the wait. The state machine was still `synchronizing` and still posting progress 26s before the harness gave up.

So the harness aborted syncs that were legitimately still working. Adds `FORMAE_TEST_SYNC_TIMEOUT` (minutes, mirroring `FORMAE_TEST_DISCOVERY_TIMEOUT`) and lifts the default to 5 minutes, above the plugin retry budget with headroom. A regression test pins that relationship so the two numbers cannot silently drift back into conflict.

### 2. The out-of-band delete wait never re-triggered sync

`WaitForResourceRemovedFromInventory` fired a single sync and then polled only the local inventory. If that one sync started inside the cloud provider's propagation window for the delete, it read the resource as still present and persisted that, and nothing ever went back out to the cloud again.

Observed on `ec2-networkaclentry`:

```
Step 22  OOB delete via plugin → success
Step 23  harness.Sync()   (fire-and-forget)
04:37:38 Starting resource synchronization
         └─ entry read SUCCEEDED and persisted   ← ~2s after delete, AWS still returns rule 100
04:37:40 Synchronization finished duration=1.927s
04:37:40 ← last cloud read anywhere in the job
04:37:40–04:39:39  "Resource still in inventory, polling..." ×60, no sync ever again
```

Zero throttling lines in that job, and the plugin's `Read` correctly returns `NotFound` when no rule matches, so this is purely the harness freezing a stale observation. **Raising `FORMAE_TEST_OOB_DELETE_TIMEOUT` would not have helped at all** - with no further sync, a longer wait just polls the same static inventory.

Fix reuses the discovery wait loop, which already re-triggers on a backoff for exactly this reason, and adds `FORMAE_TEST_OOB_SYNC_RETRIGGER_INTERVAL` with the same floor/cap clamping so re-trigger pressure on the shared account stays bounded.

## Notes for review

- `waitForResource` gains a `waitDescription` parameter so its log lines and errors name the actual trigger and condition rather than always saying "discovery". The six existing call sites in `discovery_wait_test.go` are updated mechanically; behaviour is unchanged for the discovery path and its tests still pass.
- `summary.go` is listed by `gofmt -l`, but that predates this branch (it fails on `origin/main` too) and is untouched here.