### PR TITLE
fix(conformance): simulate the extract re-apply and bound harness CLI calls

### DIFF
--- a/pkg/plugin-conformance-tests/README.md
+++ b/pkg/plugin-conformance-tests/README.md
@@ -83,10 +83,12 @@ lifecycle and asserts that:
 3. `formae inventory` reports the resource with the properties from the base
    Pkl file.
 4. If the resource type is extractable, `formae extract` round-trips back to
-   an equivalent Pkl declaration, and patch-applying that declaration succeeds
-   and leaves the resource unchanged — same `Label`, `Stack`, `NativeID` and
-   properties. Resources carrying an opaque secret skip the re-apply, because
-   extract emits a hashed envelope for those fields rather than the authored
+   an equivalent Pkl declaration, and a simulated patch-mode apply of that
+   declaration plans zero changes. A faithful extract describes state that
+   already exists, so the simulation must come back empty; a lossy one diffs,
+   and the failure names the operations the re-apply would have performed.
+   Resources carrying an opaque secret skip the re-apply, because extract
+   emits a hashed envelope for those fields rather than the authored
    plaintext.
 5. A forced sync leaves the resource untouched (idempotency).
 6. If `-update.pkl` exists, patch-mode apply updates the resource without
@@ -122,6 +124,7 @@ exercised.
 | `FORMAE_TEST_TESTDATA_DIR` | Override the testdata directory. Relative paths resolve against the plugin directory. |
 | `FORMAE_TEST_EXTRA_DISCOVERY_TYPES` | Extra resource types (comma-separated) to add to the discovery scan, beyond those declared in test data. |
 | `FORMAE_TEST_KEEP_TEMP` | Set truthy (e.g. `true`, `1`) to keep each test's temp directory even when the test passes. Failing tests keep theirs regardless. |
+| `FORMAE_TEST_CLI_TIMEOUT` | Bound, in minutes, for a single formae CLI invocation (default 5). A CLI process that never exits fails the test with a diagnostic instead of stalling until the go-test deadline. |
 | `FORMAE_BINARY` | Absolute path to a specific `formae` binary. Skips the channel-aware resolver. |
 | `FORMAE_VERSION` | Pin a specific formae version. The resolver searches stable then dev channels for an exact match. |
 | `FORMAE_TEST_RUN_ID` | Set by the harness for each run; available to Pkl fixtures for unique resource naming. |

--- a/pkg/plugin-conformance-tests/harness.go
+++ b/pkg/plugin-conformance-tests/harness.go
@@ -60,6 +60,7 @@ type resolvablePath struct {
 type TestHarness struct {
 	t                       *testing.T
 	formaeBinary            string
+	cliTimeout              time.Duration // bound for a single CLI invocation; 0 means getCLIInvocationTimeout()
 	agentCmd                *exec.Cmd
 	agentCtx                context.Context
 	agentCancel             context.CancelFunc
@@ -833,6 +834,38 @@ func (h *TestHarness) GetTempDir() string {
 	return h.tempDir
 }
 
+// runCLI runs one formae CLI invocation with the given arguments, bounded by
+// the harness CLI timeout so a CLI process that never exits surfaces as an
+// error rather than blocking the suite until the go-test deadline. Stdout and
+// stderr are captured separately so stderr (ANSI codes, warnings) cannot
+// corrupt output a caller parses.
+func (h *TestHarness) runCLI(args ...string) (string, string, error) {
+	timeout := h.cliTimeout
+	if timeout <= 0 {
+		timeout = getCLIInvocationTimeout()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, h.formaeBinary, args...)
+	h.setCommandEnv(cmd)
+
+	// Without a WaitDelay, a child the CLI spawned (pkl, a shell) that outlives
+	// it holds the stdout/stderr pipes open and Wait blocks on them even after
+	// the deadline killed the CLI itself.
+	cmd.WaitDelay = time.Second
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		err = fmt.Errorf("formae %s timed out after %s", args[0], timeout)
+	}
+	return stdout.String(), stderr.String(), err
+}
+
 // Apply runs `formae apply` with the given PKL file in reconcile mode and returns the command ID
 func (h *TestHarness) Apply(pklFile string) (string, error) {
 	return h.ApplyWithMode(pklFile, "reconcile")
@@ -842,8 +875,7 @@ func (h *TestHarness) Apply(pklFile string) (string, error) {
 func (h *TestHarness) ApplyWithMode(pklFile string, mode string) (string, error) {
 	h.t.Logf("Running formae apply with %s (mode: %s)", pklFile, mode)
 
-	cmd := exec.Command(
-		h.formaeBinary,
+	stdout, stderr, err := h.runCLI(
 		"apply",
 		pklFile,
 		"--config", h.configFile,
@@ -851,76 +883,91 @@ func (h *TestHarness) ApplyWithMode(pklFile string, mode string) (string, error)
 		"--output-consumer", "machine",
 		"--output-schema", "json",
 	)
-	h.setCommandEnv(cmd)
-
-	// Capture stdout and stderr separately to prevent stderr (ANSI codes, warnings)
-	// from corrupting the JSON output that we need to parse
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
 	if err != nil {
-		return "", fmt.Errorf("apply command failed: %w\nStderr: %s\nStdout: %s", err, stderr.String(), stdout.String())
+		return "", fmt.Errorf("apply command failed: %w\nStderr: %s\nStdout: %s", err, stderr, stdout)
 	}
 
 	// Log stderr if there was any output (for debugging purposes)
-	if stderr.Len() > 0 {
-		h.t.Logf("Apply stderr (ignored for parsing): %s", stderr.String())
+	if stderr != "" {
+		h.t.Logf("Apply stderr (ignored for parsing): %s", stderr)
 	}
 
 	// Parse JSON response from stdout only
 	var response model.SubmitCommandResponse
-	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
-		return "", fmt.Errorf("failed to parse apply response: %w\nStdout: %s", err, stdout.String())
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		return "", fmt.Errorf("failed to parse apply response: %w\nStdout: %s", err, stdout)
 	}
 
 	if response.CommandID == "" {
-		return "", fmt.Errorf("no command ID in response: %s", stdout.String())
+		return "", fmt.Errorf("no command ID in response: %s", stdout)
 	}
 
 	h.t.Logf("Apply command submitted, CommandID: %s", response.CommandID)
 	return response.CommandID, nil
 }
 
+// SimulateApply runs `formae apply --simulate` with the given PKL file and
+// mode, and returns the agent's simulation of the changes the apply would
+// perform. Nothing is submitted and no state is mutated; a forma that matches
+// current state comes back with ChangesRequired = false.
+func (h *TestHarness) SimulateApply(pklFile string, mode string) (*model.Simulation, error) {
+	h.t.Logf("Running formae apply --simulate with %s (mode: %s)", pklFile, mode)
+
+	stdout, stderr, err := h.runCLI(
+		"apply",
+		pklFile,
+		"--config", h.configFile,
+		"--mode", mode,
+		"--simulate",
+		"--output-consumer", "machine",
+		"--output-schema", "json",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("simulate command failed: %w\nStderr: %s\nStdout: %s", err, stderr, stdout)
+	}
+
+	// Log stderr if there was any output (for debugging purposes)
+	if stderr != "" {
+		h.t.Logf("Simulate stderr (ignored for parsing): %s", stderr)
+	}
+
+	// Parse JSON response from stdout only
+	var simulation model.Simulation
+	if err := json.Unmarshal([]byte(stdout), &simulation); err != nil {
+		return nil, fmt.Errorf("failed to parse simulate response: %w\nStdout: %s", err, stdout)
+	}
+
+	return &simulation, nil
+}
+
 // Destroy runs `formae destroy` with the given PKL file and returns the command ID
 func (h *TestHarness) Destroy(pklFile string) (string, error) {
 	h.t.Logf("Running formae destroy with %s", pklFile)
 
-	cmd := exec.Command(
-		h.formaeBinary,
+	stdout, stderr, err := h.runCLI(
 		"destroy",
 		pklFile,
 		"--config", h.configFile,
 		"--output-consumer", "machine",
 		"--output-schema", "json",
 	)
-	h.setCommandEnv(cmd)
-
-	// Capture stdout and stderr separately to prevent stderr (ANSI codes, warnings)
-	// from corrupting the JSON output that we need to parse
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
 	if err != nil {
-		return "", fmt.Errorf("destroy command failed: %w\nStderr: %s\nStdout: %s", err, stderr.String(), stdout.String())
+		return "", fmt.Errorf("destroy command failed: %w\nStderr: %s\nStdout: %s", err, stderr, stdout)
 	}
 
 	// Log stderr if there was any output (for debugging purposes)
-	if stderr.Len() > 0 {
-		h.t.Logf("Destroy stderr (ignored for parsing): %s", stderr.String())
+	if stderr != "" {
+		h.t.Logf("Destroy stderr (ignored for parsing): %s", stderr)
 	}
 
 	// Parse JSON response from stdout only
 	var response model.SubmitCommandResponse
-	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
-		return "", fmt.Errorf("failed to parse destroy response: %w\nStdout: %s", err, stdout.String())
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		return "", fmt.Errorf("failed to parse destroy response: %w\nStdout: %s", err, stdout)
 	}
 
 	if response.CommandID == "" {
-		return "", fmt.Errorf("no command ID in response: %s", stdout.String())
+		return "", fmt.Errorf("no command ID in response: %s", stdout)
 	}
 
 	h.t.Logf("Destroy command submitted, CommandID: %s", response.CommandID)
@@ -931,33 +978,23 @@ func (h *TestHarness) Destroy(pklFile string) (string, error) {
 func (h *TestHarness) Eval(pklFile string) (string, error) {
 	h.t.Logf("Running formae eval with %s", pklFile)
 
-	cmd := exec.Command(
-		h.formaeBinary,
+	stdout, stderr, err := h.runCLI(
 		"eval",
 		pklFile,
 		"--config", h.configFile,
 		"--output-consumer", "machine",
 		"--output-schema", "json",
 	)
-	h.setCommandEnv(cmd)
-
-	// Capture stdout and stderr separately to prevent stderr (warnings, etc.)
-	// from corrupting the JSON output that we need to parse
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
 	if err != nil {
-		return "", fmt.Errorf("eval command failed: %w\nStderr: %s\nStdout: %s", err, stderr.String(), stdout.String())
+		return "", fmt.Errorf("eval command failed: %w\nStderr: %s\nStdout: %s", err, stderr, stdout)
 	}
 
 	// Log stderr if there was any output (for debugging purposes)
-	if stderr.Len() > 0 {
-		h.t.Logf("Eval stderr (ignored for parsing): %s", stderr.String())
+	if stderr != "" {
+		h.t.Logf("Eval stderr (ignored for parsing): %s", stderr)
 	}
 
-	return stdout.String(), nil
+	return stdout, nil
 }
 
 // Extract runs `formae extract` with the given query and output file.
@@ -977,30 +1014,20 @@ func (h *TestHarness) Eval(pklFile string) (string, error) {
 func (h *TestHarness) Extract(query string, outputFile string) error {
 	h.t.Logf("Running formae extract with query '%s' to %s", query, outputFile)
 
-	cmd := exec.Command(
-		h.formaeBinary,
+	stdout, stderr, err := h.runCLI(
 		"extract",
 		"--config", h.configFile,
 		"--schema-location", "local",
 		"--query", query,
 		outputFile,
 	)
-	h.setCommandEnv(cmd)
-
-	// Capture stdout and stderr separately to prevent stderr (ANSI codes, warnings)
-	// from corrupting the output
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("extract command failed: %w\nStderr: %s\nStdout: %s", err, stderr.String(), stdout.String())
+		return fmt.Errorf("extract command failed: %w\nStderr: %s\nStdout: %s", err, stderr, stdout)
 	}
 
 	// Log stderr if there was any output (for debugging purposes)
-	if stderr.Len() > 0 {
-		h.t.Logf("Extract stderr (ignored): %s", stderr.String())
+	if stderr != "" {
+		h.t.Logf("Extract stderr (ignored): %s", stderr)
 	}
 
 	h.t.Logf("Extract completed successfully")
@@ -1017,8 +1044,7 @@ type InventoryResponse struct {
 func (h *TestHarness) Inventory(query string) (*InventoryResponse, error) {
 	h.t.Logf("Running formae inventory with query: %s", query)
 
-	cmd := exec.Command(
-		h.formaeBinary,
+	stdout, stderr, err := h.runCLI(
 		"inventory",
 		"resources", // Need to specify the subcommand
 		"--config", h.configFile,
@@ -1026,27 +1052,19 @@ func (h *TestHarness) Inventory(query string) (*InventoryResponse, error) {
 		"--output-consumer", "machine",
 		"--output-schema", "json",
 	)
-
-	// Capture stdout and stderr separately to prevent stderr (ANSI codes, warnings)
-	// from corrupting the JSON output that we need to parse
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
 	if err != nil {
-		return nil, fmt.Errorf("inventory command failed: %w\nStderr: %s\nStdout: %s", err, stderr.String(), stdout.String())
+		return nil, fmt.Errorf("inventory command failed: %w\nStderr: %s\nStdout: %s", err, stderr, stdout)
 	}
 
 	// Log stderr if there was any output (for debugging purposes)
-	if stderr.Len() > 0 {
-		h.t.Logf("Inventory stderr (ignored for parsing): %s", stderr.String())
+	if stderr != "" {
+		h.t.Logf("Inventory stderr (ignored for parsing): %s", stderr)
 	}
 
 	// Parse JSON response from stdout only
 	var response InventoryResponse
-	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
-		return nil, fmt.Errorf("failed to parse inventory response: %w\nStdout: %s", err, stdout.String())
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		return nil, fmt.Errorf("failed to parse inventory response: %w\nStdout: %s", err, stdout)
 	}
 
 	h.t.Logf("Inventory returned %d resource(s)", len(response.Resources))
@@ -2193,8 +2211,7 @@ func (h *TestHarness) PollStatus(commandID string, timeout time.Duration) (strin
 
 // GetStatus gets the current status of a command
 func (h *TestHarness) GetStatus(commandID string) (string, error) {
-	cmd := exec.Command(
-		h.formaeBinary,
+	stdout, stderr, err := h.runCLI(
 		"status",
 		"command",
 		"--config", h.configFile,
@@ -2202,22 +2219,14 @@ func (h *TestHarness) GetStatus(commandID string) (string, error) {
 		"--output-consumer", "machine",
 		"--output-schema", "json",
 	)
-
-	// Capture stdout and stderr separately to prevent stderr (ANSI codes, warnings)
-	// from corrupting the JSON output that we need to parse
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
 	if err != nil {
-		return "", fmt.Errorf("status command failed: %w\nStderr: %s\nStdout: %s", err, stderr.String(), stdout.String())
+		return "", fmt.Errorf("status command failed: %w\nStderr: %s\nStdout: %s", err, stderr, stdout)
 	}
 
 	// Parse JSON response from stdout only
 	var response model.ListCommandStatusResponse
-	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
-		return "", fmt.Errorf("failed to parse status response: %w\nStdout: %s", err, stdout.String())
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		return "", fmt.Errorf("failed to parse status response: %w\nStdout: %s", err, stdout)
 	}
 
 	if len(response.Commands) == 0 {

--- a/pkg/plugin-conformance-tests/harness_test.go
+++ b/pkg/plugin-conformance-tests/harness_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 )
 
@@ -409,6 +410,117 @@ func TestTempDirRetention(t *testing.T) {
 				if !strings.Contains(out, s) {
 					t.Errorf("child output does not contain %q\n%s", s, out)
 				}
+			}
+		})
+	}
+}
+
+// stubFormaeBinary writes an executable shell script standing in for the
+// formae CLI. It records its argv (one arg per line) to argsFile when that
+// path is non-empty, then runs the given body.
+func stubFormaeBinary(t *testing.T, argsFile, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "formae")
+	script := "#!/bin/sh\n"
+	if argsFile != "" {
+		script += fmt.Sprintf("printf '%%s\\n' \"$@\" > %q\n", argsFile)
+	}
+	script += body + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write stub formae binary: %v", err)
+	}
+	return path
+}
+
+func TestSimulateApplyParsesSimulation(t *testing.T) {
+	argsFile := filepath.Join(t.TempDir(), "args")
+	stdout := `{"ChangesRequired":true,"Command":{"CommandId":"cmd-1","Command":"Apply","State":"Simulated"}}`
+	h := &TestHarness{
+		t:            t,
+		formaeBinary: stubFormaeBinary(t, argsFile, "printf '%s' '"+stdout+"'"),
+		configFile:   "/tmp/config.pkl",
+	}
+
+	sim, err := h.SimulateApply("/tmp/extracted.pkl", "patch")
+	if err != nil {
+		t.Fatalf("SimulateApply() error = %v", err)
+	}
+	if !sim.ChangesRequired {
+		t.Error("SimulateApply() should parse ChangesRequired = true")
+	}
+
+	raw, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("stub did not record its args: %v", err)
+	}
+	args := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	for _, want := range [][]string{
+		{"apply", "/tmp/extracted.pkl"},
+		{"--mode", "patch"},
+		{"--simulate"},
+		{"--output-consumer", "machine"},
+		{"--output-schema", "json"},
+	} {
+		if !containsSubsequence(args, want) {
+			t.Errorf("CLI args %v should contain %v in order", args, want)
+		}
+	}
+}
+
+// containsSubsequence reports whether want appears in args as a contiguous run.
+func containsSubsequence(args, want []string) bool {
+	for i := 0; i+len(want) <= len(args); i++ {
+		matched := true
+		for j, w := range want {
+			if args[i+j] != w {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCLIInvocationsAreBounded pins that every formae CLI invocation the
+// harness makes carries a deadline: a CLI process that never exits must
+// surface as an error instead of blocking the suite until the go-test
+// deadline.
+func TestCLIInvocationsAreBounded(t *testing.T) {
+	h := &TestHarness{
+		t:            t,
+		formaeBinary: stubFormaeBinary(t, "", "sleep 60"),
+		configFile:   "/tmp/config.pkl",
+		cliTimeout:   100 * time.Millisecond,
+	}
+
+	invocations := map[string]func() error{
+		"ApplyWithMode": func() error { _, err := h.ApplyWithMode("/tmp/x.pkl", "patch"); return err },
+		"SimulateApply": func() error { _, err := h.SimulateApply("/tmp/x.pkl", "patch"); return err },
+		"Destroy":       func() error { _, err := h.Destroy("/tmp/x.pkl"); return err },
+		"Eval":          func() error { _, err := h.Eval("/tmp/x.pkl"); return err },
+		"Extract":       func() error { return h.Extract("type:NS::Storage::Bucket", "/tmp/out.pkl") },
+		"Inventory":     func() error { _, err := h.Inventory("type: NS::Storage::Bucket"); return err },
+		"GetStatus":     func() error { _, err := h.GetStatus("cmd-1"); return err },
+	}
+
+	for name, invoke := range invocations {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			start := time.Now()
+			err := invoke()
+			elapsed := time.Since(start)
+			if err == nil {
+				t.Fatal("a CLI invocation that never exits should return an error")
+			}
+			if elapsed > 10*time.Second {
+				t.Fatalf("invocation took %s, want it bounded by the CLI timeout", elapsed)
+			}
+			if !strings.Contains(err.Error(), "timed out") {
+				t.Errorf("error %q should say the invocation timed out", err)
 			}
 		})
 	}

--- a/pkg/plugin-conformance-tests/runner.go
+++ b/pkg/plugin-conformance-tests/runner.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/platform-engineering-labs/formae/pkg/api/model"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
@@ -198,6 +199,22 @@ func getOperationTimeout() time.Duration {
 		}
 	}
 	return 5 * time.Minute // Default timeout
+}
+
+// getCLIInvocationTimeout returns the bound for a single formae CLI
+// invocation. Every CLI call the harness makes either submits work and
+// returns or reads state, so none runs legitimately for minutes; the bound
+// exists so a CLI process that never exits surfaces as a test failure with a
+// diagnostic instead of a silent stall until the go-test deadline.
+// It reads from the FORMAE_TEST_CLI_TIMEOUT environment variable (in minutes).
+// Default is 5 minutes.
+func getCLIInvocationTimeout() time.Duration {
+	if val := os.Getenv("FORMAE_TEST_CLI_TIMEOUT"); val != "" {
+		if minutes, err := strconv.Atoi(val); err == nil && minutes > 0 {
+			return time.Duration(minutes) * time.Minute
+		}
+	}
+	return 5 * time.Minute
 }
 
 // getDiscoveryTimeout returns the timeout duration for discovery inventory polling.
@@ -1340,32 +1357,27 @@ func compareProperties(r testReporter, expectedProperties map[string]any, actual
 // Narrowing it keeps the sub-step unit-testable with a fake, mirroring the
 // testReporter seam used by the comparison helpers.
 type reapplyHarness interface {
-	ApplyWithMode(pklFile string, mode string) (string, error)
-	PollStatus(commandID string, timeout time.Duration) (string, error)
-	Inventory(query string) (*InventoryResponse, error)
-	Destroy(pklFile string) (string, error)
+	SimulateApply(pklFile string, mode string) (*model.Simulation, error)
 }
 
-// verifyExtractReapply applies the forma that `formae extract` just produced and
-// asserts it feeds back in: the apply succeeds, exactly one resource of the type
-// remains, its identity triplet is unchanged, and its properties still match. A
-// faithful extract makes this a zero-operation apply; a lossy one diffs, which is
-// what drives the plugin's handler and surfaces rejections that evaluating the
-// extracted file alone cannot catch.
+// verifyExtractReapply simulates a patch-mode apply of the forma that
+// `formae extract` just produced and asserts the agent plans no changes. A
+// faithful extract describes state that already exists, so the simulation must
+// come back empty; a lossy one diffs, and the planned operations name exactly
+// what the re-apply would touch. Simulating rather than applying asserts the
+// round-trip property directly, keeps the resource pristine for the phases
+// that follow, and avoids waiting on a command the agent never stores for
+// zero-change applies.
 //
-// Reporting is non-fatal so the lifecycle still reaches Destroy. Every check
-// returns immediately on failure, so no check runs on the output of a failed one.
-// Returns whether the round trip passed.
+// Reporting is non-fatal so the lifecycle still reaches Destroy. Returns
+// whether the round trip passed.
 func (rc *ResultCollector) verifyExtractReapply(
 	t *testing.T,
 	idx int,
 	harness reapplyHarness,
 	extractFile string,
-	resourceType string,
 	extractedResource map[string]any,
 	createdResource map[string]any,
-	expectedProperties map[string]any,
-	providerDefaults map[string]providerDefault,
 ) bool {
 	// Secret fields are hashed at rest, so extract emits an opaque envelope rather
 	// than the authored plaintext. Re-applying that would either be refused as a
@@ -1377,94 +1389,44 @@ func (rc *ResultCollector) verifyExtractReapply(
 		return true
 	}
 
-	t.Log("Re-applying extracted forma in patch mode...")
-	reapplyCommandID, err := harness.ApplyWithMode(extractFile, "patch")
+	t.Log("Simulating a patch-mode apply of the extracted forma...")
+	simulation, err := harness.SimulateApply(extractFile, "patch")
 	if err != nil {
-		rc.CRUDErrorf(t, idx, PhaseExtract, "Re-apply of extracted forma failed: %v", err)
+		rc.CRUDErrorf(t, idx, PhaseExtract, "Simulated re-apply of extracted forma failed: %v", err)
 		return false
 	}
-	if reapplyCommandID == "" {
-		rc.CRUDErrorf(t, idx, PhaseExtract, "Re-apply of extracted forma should return a command ID")
+	if simulation == nil {
+		rc.CRUDErrorf(t, idx, PhaseExtract, "Simulated re-apply of extracted forma should return a simulation")
 		return false
 	}
-
-	// A command that was submitted may have created resources before it failed or
-	// timed out, so these paths clean up too — not just the identity anomalies below.
-	reapplyStatus, err := harness.PollStatus(reapplyCommandID, getOperationTimeout())
-	if err != nil {
-		rc.CRUDErrorf(t, idx, PhaseExtract, "Re-apply command should complete successfully: %v", err)
-		destroyExtractedForma(t, harness, extractFile)
-		return false
-	}
-	if reapplyStatus != "Success" {
-		rc.CRUDErrorf(t, idx, PhaseExtract, "Re-apply command should reach Success state, got: %s", reapplyStatus)
-		destroyExtractedForma(t, harness, extractFile)
+	if simulation.ChangesRequired {
+		rc.CRUDErrorf(t, idx, PhaseExtract,
+			"Re-applying the extracted forma should be a zero-operation apply, but the agent plans changes: %s",
+			describePlannedChanges(&simulation.Command))
 		return false
 	}
 
-	inventoryAfterReapply, err := harness.Inventory(fmt.Sprintf("type: %s", resourceType))
-	if err != nil {
-		rc.CRUDErrorf(t, idx, PhaseExtract, "Inventory command failed after re-apply: %v", err)
-		destroyExtractedForma(t, harness, extractFile)
-		return false
-	}
-	if inventoryAfterReapply == nil {
-		rc.CRUDErrorf(t, idx, PhaseExtract, "Inventory should return a response after re-apply")
-		destroyExtractedForma(t, harness, extractFile)
-		return false
-	}
-	if len(inventoryAfterReapply.Resources) != 1 {
-		rc.CRUDErrorf(t, idx, PhaseExtract, "Inventory should contain exactly 1 resource after re-apply, got %d", len(inventoryAfterReapply.Resources))
-		destroyExtractedForma(t, harness, extractFile)
-		return false
-	}
-
-	// An unchanged NativeID means the re-apply did not silently replace the
-	// resource; an unchanged Label and Stack mean the extract did not fabricate a
-	// second identity triplet, which would leave a resource the fixture-driven
-	// Destroy step never reclaims.
-	resourceAfterReapply := inventoryAfterReapply.Resources[0]
-	for _, field := range []string{"Label", "Stack", "NativeID"} {
-		actualValue, ok := resourceAfterReapply[field].(string)
-		if !ok {
-			rc.CRUDErrorf(t, idx, PhaseExtract, "Resource should have a string %s after re-apply, got: %v", field, resourceAfterReapply[field])
-			destroyExtractedForma(t, harness, extractFile)
-			return false
-		}
-		expectedValue, _ := createdResource[field].(string)
-		if actualValue != expectedValue {
-			rc.CRUDErrorf(t, idx, PhaseExtract, "Re-apply of extracted forma should not change %s: expected %s, got %s", field, expectedValue, actualValue)
-			destroyExtractedForma(t, harness, extractFile)
-			return false
-		}
-	}
-
-	if !rc.compareCRUDProperties(t, idx, PhaseExtract, expectedProperties, resourceAfterReapply, "after extract re-apply", providerDefaults) {
-		return false
-	}
-
-	t.Log("Extract re-apply validation completed!")
+	t.Log("Extract re-apply simulation confirmed a zero-operation apply!")
 	return true
 }
 
-// destroyExtractedForma makes a best-effort attempt to destroy whatever the
-// extracted forma names, so anything the re-apply created under an identity the
-// fixture does not name is not leaked. Runs inline rather than through the
-// harness cleanup registry, because the extract step removes the file's temp
-// directory before registered cleanups unwind. Errors are logged and ignored.
-func destroyExtractedForma(t *testing.T, harness reapplyHarness, extractFile string) {
-	t.Log("Re-apply did not complete cleanly; destroying the extracted forma to avoid leaking a resource...")
-	destroyCommandID, err := harness.Destroy(extractFile)
-	if err != nil {
-		t.Logf("Best-effort destroy of extracted forma failed: %v", err)
-		return
+// describePlannedChanges renders the operations a simulation would perform, so
+// a failed round trip names exactly what the re-apply would touch.
+func describePlannedChanges(cmd *model.Command) string {
+	var ops []string
+	for _, ru := range cmd.ResourceUpdates {
+		ops = append(ops, fmt.Sprintf("%s %s (%s)", ru.Operation, ru.ResourceLabel, ru.ResourceType))
 	}
-	status, err := harness.PollStatus(destroyCommandID, getOperationTimeout())
-	if err != nil {
-		t.Logf("Best-effort destroy of extracted forma did not complete: %v", err)
-		return
+	for _, tu := range cmd.TargetUpdates {
+		ops = append(ops, fmt.Sprintf("%s target %s", tu.Operation, tu.TargetLabel))
 	}
-	t.Logf("Best-effort destroy of extracted forma finished with status: %s", status)
+	for _, su := range cmd.StackUpdates {
+		ops = append(ops, fmt.Sprintf("%s stack %s", su.Operation, su.StackLabel))
+	}
+	if len(ops) == 0 {
+		return "(the simulation reported changes but listed no operations)"
+	}
+	return strings.Join(ops, "; ")
 }
 
 // runCRUDTest runs the full CRUD lifecycle for a single test case.
@@ -1641,8 +1603,8 @@ func runCRUDTest(t *testing.T, tc TestCase, rc *ResultCollector) {
 		// known-bad properties would mutate the resource for no extra signal.
 		if !rc.compareCRUDProperties(t, idx, PhaseExtract, expectedProperties, extractedResource, "after extract", providerDefaults) {
 			allPropertiesMatched = false
-		} else if rc.verifyExtractReapply(t, idx, harness, extractFile, actualResourceType,
-			extractedResource, actualResource, expectedProperties, providerDefaults) {
+		} else if rc.verifyExtractReapply(t, idx, harness, extractFile,
+			extractedResource, actualResource) {
 			rc.SetCRUDPhase(idx, PhaseExtract, StepPassed)
 		} else {
 			allPropertiesMatched = false

--- a/pkg/plugin-conformance-tests/runner.go
+++ b/pkg/plugin-conformance-tests/runner.go
@@ -1412,6 +1412,12 @@ func (rc *ResultCollector) verifyExtractReapply(
 
 // describePlannedChanges renders the operations a simulation would perform, so
 // a failed round trip names exactly what the re-apply would touch.
+//
+// Only fields present in the released pkg/api/model module may be used here:
+// plugin repos build this SDK as a dependency, where the local replace on
+// ../api/model does not apply. Command.StackUpdates, for instance, is not in
+// the released module; a stack-only plan still fails the round trip through
+// ChangesRequired and falls back to the no-operations text below.
 func describePlannedChanges(cmd *model.Command) string {
 	var ops []string
 	for _, ru := range cmd.ResourceUpdates {
@@ -1419,9 +1425,6 @@ func describePlannedChanges(cmd *model.Command) string {
 	}
 	for _, tu := range cmd.TargetUpdates {
 		ops = append(ops, fmt.Sprintf("%s target %s", tu.Operation, tu.TargetLabel))
-	}
-	for _, su := range cmd.StackUpdates {
-		ops = append(ops, fmt.Sprintf("%s stack %s", su.Operation, su.StackLabel))
 	}
 	if len(ops) == 0 {
 		return "(the simulation reported changes but listed no operations)"

--- a/pkg/plugin-conformance-tests/runner_test.go
+++ b/pkg/plugin-conformance-tests/runner_test.go
@@ -8,9 +8,11 @@ import (
 	"errors"
 	"os"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/platform-engineering-labs/formae/pkg/api/model"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
@@ -631,32 +633,13 @@ func TestContainsOpaqueValue(t *testing.T) {
 type fakeReapplyHarness struct {
 	calls []string
 
-	applyCommandID string
-	applyErr       error
-	pollStatus     string
-	pollErr        error
-	inventory      *InventoryResponse
-	inventoryErr   error
+	simulation  *model.Simulation
+	simulateErr error
 }
 
-func (f *fakeReapplyHarness) ApplyWithMode(pklFile string, mode string) (string, error) {
-	f.calls = append(f.calls, "ApplyWithMode:"+mode)
-	return f.applyCommandID, f.applyErr
-}
-
-func (f *fakeReapplyHarness) PollStatus(commandID string, timeout time.Duration) (string, error) {
-	f.calls = append(f.calls, "PollStatus")
-	return f.pollStatus, f.pollErr
-}
-
-func (f *fakeReapplyHarness) Inventory(query string) (*InventoryResponse, error) {
-	f.calls = append(f.calls, "Inventory")
-	return f.inventory, f.inventoryErr
-}
-
-func (f *fakeReapplyHarness) Destroy(pklFile string) (string, error) {
-	f.calls = append(f.calls, "Destroy")
-	return "cmd-destroy", nil
+func (f *fakeReapplyHarness) SimulateApply(pklFile string, mode string) (*model.Simulation, error) {
+	f.calls = append(f.calls, "SimulateApply:"+mode)
+	return f.simulation, f.simulateErr
 }
 
 // reapplyResource builds an inventory-shaped resource with the given identity.
@@ -675,10 +658,6 @@ func TestVerifyExtractReapply(t *testing.T) {
 	created := reapplyResource("my-bucket", "default", "bucket-1", properties)
 	extracted := reapplyResource("my-bucket", "default", "bucket-1", properties)
 
-	inventoryWith := func(resources ...map[string]any) *InventoryResponse {
-		return &InventoryResponse{Resources: resources}
-	}
-
 	tests := []struct {
 		name          string
 		harness       *fakeReapplyHarness
@@ -686,149 +665,40 @@ func TestVerifyExtractReapply(t *testing.T) {
 		created       map[string]any
 		expectedPass  bool
 		expectedCalls []string
+		expectedError string
 	}{
 		{
-			name: "faithful extract re-applies cleanly",
-			harness: &fakeReapplyHarness{
-				applyCommandID: "cmd-1",
-				pollStatus:     "Success",
-				inventory:      inventoryWith(reapplyResource("my-bucket", "default", "bucket-1", properties)),
-			},
+			name:          "faithful extract simulates to a zero-operation apply",
+			harness:       &fakeReapplyHarness{simulation: &model.Simulation{ChangesRequired: false}},
 			expectedPass:  true,
-			expectedCalls: []string{"ApplyWithMode:patch", "PollStatus", "Inventory"},
+			expectedCalls: []string{"SimulateApply:patch"},
 		},
 		{
-			name:          "apply returns an error",
-			harness:       &fakeReapplyHarness{applyErr: errors.New("provider rejected the request")},
+			name:          "simulate returns an error",
+			harness:       &fakeReapplyHarness{simulateErr: errors.New("agent unreachable")},
 			expectedPass:  false,
-			expectedCalls: []string{"ApplyWithMode:patch"},
+			expectedCalls: []string{"SimulateApply:patch"},
+			expectedError: "agent unreachable",
 		},
 		{
-			name:          "apply returns an empty command id",
-			harness:       &fakeReapplyHarness{applyCommandID: ""},
+			name:          "simulate returns no simulation",
+			harness:       &fakeReapplyHarness{},
 			expectedPass:  false,
-			expectedCalls: []string{"ApplyWithMode:patch"},
+			expectedCalls: []string{"SimulateApply:patch"},
 		},
 		{
-			name:          "poll returns an error",
-			harness:       &fakeReapplyHarness{applyCommandID: "cmd-1", pollErr: errors.New("timed out")},
+			name: "lossy extract plans a change",
+			harness: &fakeReapplyHarness{simulation: &model.Simulation{
+				ChangesRequired: true,
+				Command: model.Command{ResourceUpdates: []model.ResourceUpdate{{
+					Operation:     model.OperationUpdate,
+					ResourceLabel: "my-bucket",
+					ResourceType:  "NS::Storage::Bucket",
+				}}},
+			}},
 			expectedPass:  false,
-			expectedCalls: []string{"ApplyWithMode:patch", "PollStatus", "Destroy", "PollStatus"},
-		},
-		{
-			name:          "poll reaches a non-success terminal state",
-			harness:       &fakeReapplyHarness{applyCommandID: "cmd-1", pollStatus: "Failed"},
-			expectedPass:  false,
-			expectedCalls: []string{"ApplyWithMode:patch", "PollStatus", "Destroy", "PollStatus"},
-		},
-		{
-			name: "inventory returns an error",
-			harness: &fakeReapplyHarness{
-				applyCommandID: "cmd-1",
-				pollStatus:     "Success",
-				inventoryErr:   errors.New("inventory unavailable"),
-			},
-			expectedPass:  false,
-			expectedCalls: []string{"ApplyWithMode:patch", "PollStatus", "Inventory", "Destroy", "PollStatus"},
-		},
-		{
-			name: "inventory returns no response",
-			harness: &fakeReapplyHarness{
-				applyCommandID: "cmd-1",
-				pollStatus:     "Success",
-				inventory:      nil,
-			},
-			expectedPass:  false,
-			expectedCalls: []string{"ApplyWithMode:patch", "PollStatus", "Inventory", "Destroy", "PollStatus"},
-		},
-		{
-			name: "inventory returns no resources",
-			harness: &fakeReapplyHarness{
-				applyCommandID: "cmd-1",
-				pollStatus:     "Success",
-				inventory:      inventoryWith(),
-			},
-			expectedPass:  false,
-			expectedCalls: []string{"ApplyWithMode:patch", "PollStatus", "Inventory", "Destroy", "PollStatus"},
-		},
-		{
-			name: "inventory returns two resources",
-			harness: &fakeReapplyHarness{
-				applyCommandID: "cmd-1",
-				pollStatus:     "Success",
-				inventory: inventoryWith(
-					reapplyResource("my-bucket", "default", "bucket-1", properties),
-					reapplyResource("my-bucket-copy", "default", "bucket-2", properties),
-				),
-			},
-			expectedPass:  false,
-			expectedCalls: []string{"ApplyWithMode:patch", "PollStatus", "Inventory", "Destroy", "PollStatus"},
-		},
-		{
-			name: "native id is missing",
-			harness: &fakeReapplyHarness{
-				applyCommandID: "cmd-1",
-				pollStatus:     "Success",
-				inventory: inventoryWith(map[string]any{
-					"Label": "my-bucket", "Stack": "default", "Properties": properties,
-				}),
-			},
-			expectedPass:  false,
-			expectedCalls: []string{"ApplyWithMode:patch", "PollStatus", "Inventory", "Destroy", "PollStatus"},
-		},
-		{
-			name: "native id is not a string",
-			harness: &fakeReapplyHarness{
-				applyCommandID: "cmd-1",
-				pollStatus:     "Success",
-				inventory: inventoryWith(map[string]any{
-					"Label": "my-bucket", "Stack": "default", "NativeID": 42, "Properties": properties,
-				}),
-			},
-			expectedPass:  false,
-			expectedCalls: []string{"ApplyWithMode:patch", "PollStatus", "Inventory", "Destroy", "PollStatus"},
-		},
-		{
-			name: "native id changed",
-			harness: &fakeReapplyHarness{
-				applyCommandID: "cmd-1",
-				pollStatus:     "Success",
-				inventory:      inventoryWith(reapplyResource("my-bucket", "default", "bucket-2", properties)),
-			},
-			expectedPass:  false,
-			expectedCalls: []string{"ApplyWithMode:patch", "PollStatus", "Inventory", "Destroy", "PollStatus"},
-		},
-		{
-			name: "label changed",
-			harness: &fakeReapplyHarness{
-				applyCommandID: "cmd-1",
-				pollStatus:     "Success",
-				inventory:      inventoryWith(reapplyResource("my-bucket-2", "default", "bucket-1", properties)),
-			},
-			expectedPass:  false,
-			expectedCalls: []string{"ApplyWithMode:patch", "PollStatus", "Inventory", "Destroy", "PollStatus"},
-		},
-		{
-			name: "stack changed",
-			harness: &fakeReapplyHarness{
-				applyCommandID: "cmd-1",
-				pollStatus:     "Success",
-				inventory:      inventoryWith(reapplyResource("my-bucket", "other", "bucket-1", properties)),
-			},
-			expectedPass:  false,
-			expectedCalls: []string{"ApplyWithMode:patch", "PollStatus", "Inventory", "Destroy", "PollStatus"},
-		},
-		{
-			name: "properties changed by the re-apply",
-			harness: &fakeReapplyHarness{
-				applyCommandID: "cmd-1",
-				pollStatus:     "Success",
-				inventory: inventoryWith(reapplyResource("my-bucket", "default", "bucket-1", map[string]any{
-					"BucketName": "a-different-bucket",
-				})),
-			},
-			expectedPass:  false,
-			expectedCalls: []string{"ApplyWithMode:patch", "PollStatus", "Inventory"},
+			expectedCalls: []string{"SimulateApply:patch"},
+			expectedError: "update my-bucket (NS::Storage::Bucket)",
 		},
 		{
 			name:          "skipped when the extracted properties carry an opaque secret",
@@ -861,8 +731,8 @@ func TestVerifyExtractReapply(t *testing.T) {
 			idx := rc.NewCRUDResult("NS::Storage::Bucket")
 			fakeT := &testing.T{}
 
-			passed := rc.verifyExtractReapply(fakeT, idx, tt.harness, "/tmp/extracted.pkl", "NS::Storage::Bucket",
-				extractedResource, createdResource, properties, map[string]providerDefault{})
+			passed := rc.verifyExtractReapply(fakeT, idx, tt.harness, "/tmp/extracted.pkl",
+				extractedResource, createdResource)
 
 			if passed != tt.expectedPass {
 				t.Errorf("verifyExtractReapply() = %v, want %v", passed, tt.expectedPass)
@@ -875,6 +745,17 @@ func TestVerifyExtractReapply(t *testing.T) {
 			defer rc.mu.Unlock()
 			phase := rc.crudResults[idx].Phases[int(PhaseExtract)]
 			errCount := len(rc.crudResults[idx].Errors)
+			if tt.expectedError != "" {
+				found := false
+				for _, e := range rc.crudResults[idx].Errors {
+					if strings.Contains(e.Msg, tt.expectedError) {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("recorded errors %v should contain %q", rc.crudResults[idx].Errors, tt.expectedError)
+				}
+			}
 			if tt.expectedPass {
 				if phase == StepFailed {
 					t.Error("Extract phase should not be failed when the re-apply passes")


### PR DESCRIPTION
## Summary

The CRUD Extract phase's re-apply sub-step stalled every conformance fixture. It submitted a real patch-mode apply of the extracted forma and then polled for the command to complete. A faithful extract describes state that already exists, so that apply is a zero-change apply, and the agent returns a command id for those without storing a command row. The harness then polled a command that would never exist for the full per-command timeout (`FORMAE_TEST_TIMEOUT`, which plugin CI commonly sets to 60 minutes), turning every fixture into a silent multi-hour stall. The sub-step's assertion was also weaker than its stated intent: it checked only that the apply succeeded and one resource remained, so a lossy extract that successfully mutated the resource still passed.

Two changes:

- **`verifyExtractReapply` now simulates instead of applying.** It runs `formae apply --simulate --mode patch` on the extracted forma and asserts the simulation plans zero changes. This asserts the round-trip property directly, mutates no provider state mid-suite (the phases after Extract run against a pristine resource), removes the best-effort destroy cleanup paths, and no longer waits on a command that cannot exist. A failure names the operations the re-apply would have performed, e.g. `update my-bucket (NS::Storage::Bucket)`. The opaque-secret skip is unchanged.
- **Every formae CLI invocation the harness makes is now bounded.** `ApplyWithMode`, `SimulateApply`, `Destroy`, `Eval`, `Extract`, `Inventory` and `GetStatus` previously used bare `exec.Command` with no deadline, so a CLI process that never exits would stall the suite until the go-test deadline with zero diagnostics (go test buffers subtest output until the test completes). They now share a `runCLI` helper bounded by `FORMAE_TEST_CLI_TIMEOUT` (minutes, default 5), with a `WaitDelay` so a lingering child process cannot hold the stdout pipe open past the deadline.

Not covered here: the three one-shot `exec.Command` calls in `setup.go` (`pkl project resolve`, `pkl eval`, `formae --version`) are still unbounded, and the agent still returns a command id for zero-change applies that `formae status command` can never find; both are candidates for follow-ups.