### PR TITLE
fix(conformance): retry formae version resolution across a release publish window

### DIFF
--- a/pkg/plugin-conformance-tests/runner.go
+++ b/pkg/plugin-conformance-tests/runner.go
@@ -1421,7 +1421,13 @@ func (rc *ResultCollector) verifyExtractReapply(
 func describePlannedChanges(cmd *model.Command) string {
 	var ops []string
 	for _, ru := range cmd.ResourceUpdates {
-		ops = append(ops, fmt.Sprintf("%s %s (%s)", ru.Operation, ru.ResourceLabel, ru.ResourceType))
+		op := fmt.Sprintf("%s %s (%s)", ru.Operation, ru.ResourceLabel, ru.ResourceType)
+		// The patch document names the exact properties that diff, which is
+		// the difference between "some property is lossy" and a fixable report.
+		if len(ru.PatchDocument) > 0 {
+			op += " patch: " + string(ru.PatchDocument)
+		}
+		ops = append(ops, op)
 	}
 	for _, tu := range cmd.TargetUpdates {
 		ops = append(ops, fmt.Sprintf("%s target %s", tu.Operation, tu.TargetLabel))

--- a/pkg/plugin-conformance-tests/runner_test.go
+++ b/pkg/plugin-conformance-tests/runner_test.go
@@ -701,6 +701,21 @@ func TestVerifyExtractReapply(t *testing.T) {
 			expectedError: "update my-bucket (NS::Storage::Bucket)",
 		},
 		{
+			name: "lossy extract failure names the diffing properties",
+			harness: &fakeReapplyHarness{simulation: &model.Simulation{
+				ChangesRequired: true,
+				Command: model.Command{ResourceUpdates: []model.ResourceUpdate{{
+					Operation:     model.OperationUpdate,
+					ResourceLabel: "my-alias",
+					ResourceType:  "NS::KMS::Alias",
+					PatchDocument: []byte(`[{"op":"replace","path":"/TargetKeyId","value":"abc123"}]`),
+				}}},
+			}},
+			expectedPass:  false,
+			expectedCalls: []string{"SimulateApply:patch"},
+			expectedError: `update my-alias (NS::KMS::Alias) patch: [{"op":"replace","path":"/TargetKeyId","value":"abc123"}]`,
+		},
+		{
 			name:          "skipped when the extracted properties carry an opaque secret",
 			harness:       &fakeReapplyHarness{},
 			extracted:     reapplyResource("my-db", "default", "db-1", map[string]any{"Password": map[string]any{"$visibility": pkgmodel.VisibilityOpaque}}),

--- a/pkg/plugin-conformance-tests/setup.go
+++ b/pkg/plugin-conformance-tests/setup.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/platform-engineering-labs/orbital/mgr"
 	"github.com/platform-engineering-labs/orbital/opm/records"
@@ -219,22 +220,29 @@ func selectFormaeCandidate(t *testing.T, queryChannel func(channel string) (*rec
 			cleanup()
 			t.Fatalf("failed to parse FORMAE_VERSION %q: %v", version, err)
 		}
-		for _, channel := range []string{"stable", "dev"} {
-			available, err := queryChannel(channel)
-			if err != nil {
-				cleanup()
-				t.Fatalf("failed to query available formae versions (%s channel): %v", channel, err)
+		candidate, channel, err := retryResolve(func() (*records.Package, string, error) {
+			for _, channel := range []string{"stable", "dev"} {
+				available, err := queryChannel(channel)
+				if err != nil {
+					return nil, "", fmt.Errorf("failed to query available formae versions (%s channel): %w", channel, err)
+				}
+				if found, candidate := available.HasVersion(want); found {
+					return candidate, channel, nil
+				}
 			}
-			if found, candidate := available.HasVersion(want); found {
-				return candidate, channel
-			}
+			return nil, "", fmt.Errorf("formae version %s not found in the stable or dev channel", version)
+		}, resolveAttempts, time.Sleep)
+		if err != nil {
+			cleanup()
+			t.Fatalf("%v", err)
 		}
-		cleanup()
-		t.Fatalf("formae version %s not found in the stable or dev channel", version)
+		return candidate, channel
 	}
 
 	minVersion := readMinFormaeVersion(t, cleanup)
-	candidate, channel, err := resolveFormaeCandidate(queryChannel, minVersion)
+	candidate, channel, err := retryResolve(func() (*records.Package, string, error) {
+		return resolveFormaeCandidate(queryChannel, minVersion)
+	}, resolveAttempts, time.Sleep)
 	if err != nil {
 		cleanup()
 		t.Fatalf("%v", err)
@@ -261,6 +269,35 @@ func readMinFormaeVersion(t *testing.T, cleanup func()) *ops.Version {
 		t.Fatalf("failed to parse minFormaeVersion %q from formae-plugin.pkl: %v", raw, err)
 	}
 	return v
+}
+
+// A release publish rewrites a channel's package index, and a resolver that
+// reads during that window sees an error ("no available packages for: formae")
+// or a partial listing. Both are transient, so resolution retries across a
+// window that outlasts a publish before giving up.
+const (
+	resolveAttempts   = 6
+	resolveRetryDelay = 20 * time.Second
+)
+
+// retryResolve runs resolve until it succeeds, sleeping between attempts,
+// and returns the last error once attempts are exhausted.
+func retryResolve(resolve func() (*records.Package, string, error), attempts int, sleep func(time.Duration)) (*records.Package, string, error) {
+	var (
+		pkg     *records.Package
+		channel string
+		err     error
+	)
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			sleep(resolveRetryDelay)
+		}
+		pkg, channel, err = resolve()
+		if err == nil {
+			return pkg, channel, nil
+		}
+	}
+	return nil, "", err
 }
 
 // resolveFormaeCandidate picks the formae package to install by preferring the

--- a/pkg/plugin-conformance-tests/setup_test.go
+++ b/pkg/plugin-conformance-tests/setup_test.go
@@ -5,7 +5,9 @@
 package conformance
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -128,6 +130,71 @@ func TestResolveFormaeCandidate(t *testing.T) {
 		_, _, err := resolveFormaeCandidate(query, min)
 		if err == nil {
 			t.Fatal("expected an error when no channel has a release >= 0.86.0, got nil")
+		}
+	})
+}
+
+func TestRetryResolve(t *testing.T) {
+	pkg := pkgAt(t, "0.89.0")
+
+	t.Run("returns immediately on success without sleeping", func(t *testing.T) {
+		var sleeps []time.Duration
+		got, channel, err := retryResolve(func() (*records.Package, string, error) {
+			return pkg, "dev", nil
+		}, 6, func(d time.Duration) { sleeps = append(sleeps, d) })
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != pkg || channel != "dev" {
+			t.Errorf("retryResolve() = (%v, %q), want the resolved package on dev", got, channel)
+		}
+		if len(sleeps) != 0 {
+			t.Errorf("slept %d times on immediate success, want 0", len(sleeps))
+		}
+	})
+
+	t.Run("retries through transient failures until the channel recovers", func(t *testing.T) {
+		var sleeps []time.Duration
+		calls := 0
+		got, channel, err := retryResolve(func() (*records.Package, string, error) {
+			calls++
+			if calls < 3 {
+				return nil, "", errors.New("querying dev channel for formae versions: no available packages for: formae")
+			}
+			return pkg, "dev", nil
+		}, 6, func(d time.Duration) { sleeps = append(sleeps, d) })
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != pkg || channel != "dev" {
+			t.Errorf("retryResolve() = (%v, %q), want the resolved package on dev", got, channel)
+		}
+		if calls != 3 {
+			t.Errorf("resolve called %d times, want 3", calls)
+		}
+		if len(sleeps) != 2 {
+			t.Errorf("slept %d times, want 2 (one before each retry)", len(sleeps))
+		}
+	})
+
+	t.Run("gives up with the last error once attempts are exhausted", func(t *testing.T) {
+		var sleeps []time.Duration
+		calls := 0
+		_, _, err := retryResolve(func() (*records.Package, string, error) {
+			calls++
+			return nil, "", fmt.Errorf("attempt %d failed", calls)
+		}, 4, func(d time.Duration) { sleeps = append(sleeps, d) })
+		if err == nil {
+			t.Fatal("expected an error after exhausting attempts")
+		}
+		if calls != 4 {
+			t.Errorf("resolve called %d times, want 4", calls)
+		}
+		if len(sleeps) != 3 {
+			t.Errorf("slept %d times, want 3", len(sleeps))
+		}
+		if !strings.Contains(err.Error(), "attempt 4 failed") {
+			t.Errorf("error %q should be the last attempt's error", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

A release publish rewrites a channel's package index. A conformance job that resolves its formae binary during that window gets a transient error from the channel query (`no available packages for: formae`) or a partial listing, and the job fails in seconds before testing anything. Observed in a formae-plugin-aws CI run whose `codebuild-image-build` job resolved exactly while a dev release was publishing.

Resolution now retries up to 6 attempts spaced 20 seconds apart (a window that outlasts a publish), on both resolution paths: the `FORMAE_VERSION`-pinned lookup and the `minFormaeVersion` floor-based candidate selection. The retry helper takes an injectable sleep and is unit-tested for immediate success, recovery after transient failures, and exhaustion returning the last error.

A resolver that exhausts the window still fails with the underlying error, so a genuinely empty channel remains a loud failure.