### PR TITLE
fix(metastructure): treat JSON map keys as literals in property merge paths

### DIFF
--- a/internal/metastructure/resource_update/merge_dotted_keys_test.go
+++ b/internal/metastructure/resource_update/merge_dotted_keys_test.go
@@ -1,0 +1,88 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// Map keys are literal JSON keys, not gjson path expressions. A key containing
+// dots (e.g. the ubiquitous "app.kubernetes.io/name" Kubernetes label) must
+// survive the merge as a single key, not be exploded into nested objects.
+func TestMerge_DottedMapKeysStayLiteral(t *testing.T) {
+	user := json.RawMessage(`{"spec":{"template":{"metadata":{"labels":{"app.kubernetes.io/name":"nginx"}}}}}`)
+	plugin := json.RawMessage(`{"spec":{"template":{"metadata":{"labels":{"app.kubernetes.io/name":"nginx"}}}}}`)
+
+	merged, err := mergeRefsPreservingUserRefs(user, plugin, pkgmodel.Schema{}, false)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(merged, &out))
+	labels := out["spec"].(map[string]any)["template"].(map[string]any)["metadata"].(map[string]any)["labels"].(map[string]any)
+
+	assert.Equal(t, "nginx", labels["app.kubernetes.io/name"])
+	assert.NotContains(t, labels, "app",
+		"dotted key must not be split into a nested object tree")
+}
+
+// When the plugin response omits a user-provided field whose key contains dots,
+// the kept user value must land under the literal key.
+func TestMerge_DottedMapKeyKeptFromUserAtLiteralKey(t *testing.T) {
+	user := json.RawMessage(`{"labels":{"app.kubernetes.io/instance":"web"}}`)
+	plugin := json.RawMessage(`{"labels":{}}`)
+
+	merged, err := mergeRefsPreservingUserRefs(user, plugin, pkgmodel.Schema{}, false)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(merged, &out))
+	labels := out["labels"].(map[string]any)
+
+	assert.Equal(t, "web", labels["app.kubernetes.io/instance"])
+	assert.NotContains(t, labels, "app")
+}
+
+// Array element matching compares a user element's fields against the plugin
+// element's. A field whose key contains dots must be looked up as a literal
+// key; otherwise a matching element is declared non-matching and its $ref
+// envelope collapses to the plugin's plain scalar, losing the resolvable link.
+func TestMerge_ArrayElementMatchingWithDottedKeys(t *testing.T) {
+	user := json.RawMessage(`{"rules":[{"app.kubernetes.io/name":"nginx","target":{"$ref":"formae://x#/id","$value":"same"}}]}`)
+	plugin := json.RawMessage(`{"rules":[{"app.kubernetes.io/name":"nginx","target":"same"}]}`)
+
+	merged, err := mergeRefsPreservingUserRefs(user, plugin, pkgmodel.Schema{}, false)
+	require.NoError(t, err)
+
+	target := gjson.GetBytes(merged, "rules.0.target")
+	require.True(t, target.IsObject(),
+		"element must match on its dotted key so the $ref envelope is preserved")
+	assert.Equal(t, "formae://x#/id", target.Get("$ref").String())
+}
+
+// Keys containing gjson/sjson wildcard characters must also be treated as
+// literal keys.
+func TestMerge_WildcardCharactersInMapKeysStayLiteral(t *testing.T) {
+	user := json.RawMessage(`{"data":{"glob*key":"a","which?key":"b"}}`)
+	plugin := json.RawMessage(`{"data":{}}`)
+
+	merged, err := mergeRefsPreservingUserRefs(user, plugin, pkgmodel.Schema{}, false)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(merged, &out))
+	data := out["data"].(map[string]any)
+
+	assert.Equal(t, "a", data["glob*key"])
+	assert.Equal(t, "b", data["which?key"])
+}

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/patch"
@@ -605,7 +606,7 @@ func (m *propertyMerger) mergeObject(path string, userVal, pluginVal gjson.Resul
 	// Not a $ref or $embed object - recursively merge each field
 	userVal.ForEach(func(key, val gjson.Result) bool {
 		childPath := m.buildChildPath(path, key.String())
-		pluginChildVal := pluginVal.Get(key.String())
+		pluginChildVal := pluginVal.Get(escapePathKey(key.String()))
 		m.mergeValue(childPath, val, pluginChildVal)
 		return true
 	})
@@ -990,7 +991,7 @@ func (m *propertyMerger) concreteFieldsMatchPlugin(userElem, pluginElem gjson.Re
 		if m.isUnresolvedRef(userVal) {
 			return true // ignore unresolved-$ref fields
 		}
-		pluginVal := pluginElem.Get(key.String())
+		pluginVal := pluginElem.Get(escapePathKey(key.String()))
 		if !pluginVal.Exists() || !m.valuesMatch(userVal, pluginVal) {
 			allMatch = false
 			return false
@@ -1023,7 +1024,7 @@ func (m *propertyMerger) userElementMatchesPlugin(userElem, pluginElem gjson.Res
 	allFieldsMatch := true
 	userElem.ForEach(func(key, userVal gjson.Result) bool {
 		keyStr := key.String()
-		pluginVal := pluginElem.Get(keyStr)
+		pluginVal := pluginElem.Get(escapePathKey(keyStr))
 
 		// If plugin doesn't have this field, it's not a match
 		if !pluginVal.Exists() {
@@ -1094,12 +1095,23 @@ func (m *propertyMerger) mergePrimitive(path string, userVal gjson.Result) {
 	}
 }
 
-// buildChildPath constructs a JSON path for a child field
+// buildChildPath constructs a JSON path for a child field. The field name is a
+// literal JSON key, so path-special characters in it must be escaped — K8s
+// label/annotation keys like "app.kubernetes.io/name" would otherwise be
+// interpreted as nested paths and exploded into object trees on write.
 func (m *propertyMerger) buildChildPath(parentPath, fieldName string) string {
+	escaped := escapePathKey(fieldName)
 	if parentPath == "" {
-		return fieldName
+		return escaped
 	}
-	return parentPath + "." + fieldName
+	return parentPath + "." + escaped
+}
+
+// escapePathKey escapes a literal JSON key for use in a gjson/sjson path.
+var pathKeyEscaper = strings.NewReplacer(`\`, `\\`, `.`, `\.`, `*`, `\*`, `?`, `\?`, `:`, `\:`)
+
+func escapePathKey(key string) string {
+	return pathKeyEscaper.Replace(key)
 }
 
 // cleanPath removes leading dot from a path if present


### PR DESCRIPTION
## Summary

- `propertyMerger` (the desired-state/plugin-read merge behind `mergeRefsPreservingUserRefs`) built gjson/sjson paths by joining raw JSON keys with dots. Keys containing path-special characters were interpreted as nested paths on write, so a key like `app.kubernetes.io/name` was exploded into `{"app": {"kubernetes": {"io/name": ...}}}` alongside the correct literal key in the merged properties.
- Since virtually every Kubernetes workload labels its pod template with `app.kubernetes.io/*` keys, this corrupted the stored properties of any such resource: the phantom nested object surfaced as an unexpected property in after-create comparison and broke extract rendering. This is what has kept the formae-plugin-kubernetes nightly chart-conformance jobs red since mid-July: the corruption was previously masked because pod template metadata used `ObjectMeta`, whose `labels` field carries `hasProviderDefault = true`, and the switch to `PodTemplateMetadata` (no such hint) exposed it.
- The same raw-key-as-path defect affected array element matching (`userElementMatchesPlugin` / `concreteFieldsMatchPlugin`): a dotted key in a user element failed to find its counterpart in the plugin element, so identical elements were declared non-matching. That collapsed a `$ref` envelope on a sibling field into the plugin's plain scalar, losing the resolvable link in stored state.
- Fix: escape gjson/sjson path-special characters (`\` `.` `*` `?` `:`) when building child paths and when looking up a plugin's sibling or element value, so map keys round-trip as literals. Regression tests cover dotted keys surviving the merge, dotted keys kept from the user side landing under the literal key, array element matching on a dotted key, and wildcard characters in keys.

Validated with the new unit tests (each red before the fix, green after) and a full `-tags=unit` run across the repo.