### PR TITLE
fix(target-update): compare a hashed-at-rest credential ref by identity

### DIFF
--- a/internal/metastructure/target_update/target_update_generator.go
+++ b/internal/metastructure/target_update/target_update_generator.go
@@ -10,6 +10,8 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/platform-engineering-labs/formae/internal/metastructure/reaping"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
@@ -261,6 +263,19 @@ func (tp *TargetUpdateGenerator) resolveTargetReaping(target *pkgmodel.Target) e
 	return nil
 }
 
+// isHashedAtRest reports whether a property value read from the datastore is an
+// opaque envelope whose $value is a SHA-256 digest rather than the plaintext.
+// Only a top-level envelope counts: a container that merely holds a hashed value
+// somewhere inside still has clear fields whose change must be detected, so it
+// is resolved normally.
+func isHashedAtRest(raw string) bool {
+	parsed := gjson.Parse(raw)
+	if !parsed.IsObject() {
+		return false
+	}
+	return parsed.Get("$hashed").Bool()
+}
+
 // configSchemasEqual returns true if two ConfigSchemas have identical hints.
 func configSchemasEqual(a, b pkgmodel.ConfigSchema) bool {
 	if len(a.Hints) != len(b.Hints) {
@@ -322,10 +337,27 @@ func (tp *TargetUpdateGenerator) resolvedConfigs(existingConfig, newConfig json.
 		strVal, ok := resource.GetProperty(propertyPath)
 		if !ok {
 			// The source is present but exposes no readable value at this path
-			// (e.g. an opaque credential hashed at rest, or an unsynced status
-			// field). The reference is valid, so this is not a change — compare
-			// by $ref identity rather than treating it as dangling.
+			// (e.g. an opaque credential nested inside a hashed envelope, or an
+			// unsynced status field). The reference is valid, so this is not a
+			// change — compare by $ref identity rather than treating it as
+			// dangling.
 			slog.Debug("Referenced property not readable, comparing by ref identity",
+				"uri", uri, "propertyPath", propertyPath)
+			allResolved = false
+			continue
+		}
+
+		if isHashedAtRest(strVal) {
+			// The property IS readable, but what it holds is a digest, not the
+			// value: an opaque field is persisted as a whole hashed envelope, so
+			// GetProperty hands back that envelope's raw JSON. Resolving it would
+			// compare the desired side's digest against a stored side that carries
+			// no $value at all (reference-don't-store strips it), so a target with
+			// a secret-sourced credential would report a change on every re-apply.
+			// A digest can never participate in a value comparison, so fall back to
+			// $ref identity — the same treatment as an unreadable property, and
+			// explicitly NOT dangling.
+			slog.Debug("Referenced property is hashed at rest, comparing by ref identity",
 				"uri", uri, "propertyPath", propertyPath)
 			allResolved = false
 			continue

--- a/internal/metastructure/target_update/target_update_generator_test.go
+++ b/internal/metastructure/target_update/target_update_generator_test.go
@@ -8,6 +8,7 @@ package target_update
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1177,25 +1178,104 @@ func TestGenerateTargetUpdates_RefWithCachedValue_UnresolvableRef(t *testing.T) 
 	assert.Equal(t, TargetOperationUpdate, updates[0].Operation)
 }
 
-// A target credential sourced from a secret persists $visibility:"Opaque" (so
-// reference-don't-store drops its $value) while the forma renders the same ref
-// $visibility:"Clear". The source resource is PRESENT but exposes no readable
-// value at the ref path (the secret value is a single hash at rest). Unlike a
-// dangling ref, this must not produce an update on every re-apply.
-func TestGenerateTargetUpdates_OpaqueCredRef_PresentButUnreadable_NoChange(t *testing.T) {
+// Every shape an opaque credential can take at rest must survive an identical
+// re-apply without producing a target update. Held fixed across the cases: the
+// stored config carries the opacity-stamped $ref with no $value (reference-
+// don't-store), while the re-rendered forma carries the same $ref stamped
+// Clear. What varies is how the source resource holds the secret, which decides
+// whether the $ref reads back a value at all — a whole map-shaped secret hashed
+// into a single envelope exposes nothing at a sub-key, whereas a property
+// hashed in place reads back as an envelope whose $value is a digest. A digest
+// can never compare equal to the stored side's bare $ref, so any shape that
+// feeds one into the comparison reports a change on every apply.
+func TestGenerateTargetUpdates_OpaqueCredRef_IdempotentAcrossAtRestShapes(t *testing.T) {
+	const digest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	tests := []struct {
+		name        string
+		refPath     string
+		sourceProps string
+	}{
+		{
+			name:        "sub-key of a map-shaped secret hashed whole",
+			refPath:     "decodedData.admin-password",
+			sourceProps: `{"decodedData":{"$value":"` + digest + `","$visibility":"Opaque","$strategy":"Update","$hashed":true}}`,
+		},
+		{
+			name:        "top-level opaque property hashed in place",
+			refPath:     "SecretString",
+			sourceProps: `{"SecretString":{"$value":"` + digest + `","$visibility":"Opaque","$strategy":"Update","$hashed":true}}`,
+		},
+		{
+			name:        "nested opaque property hashed in place",
+			refPath:     "settings.password",
+			sourceProps: `{"settings":{"password":{"$value":"` + digest + `","$visibility":"Opaque","$strategy":"Update","$hashed":true}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stored := fmt.Sprintf(
+				`{"Type":"Grafana","Username":"admin","Password":{"$ref":"formae://sec1#/%s","$strategy":"Update","$visibility":"Opaque"}}`, tt.refPath)
+			desired := fmt.Sprintf(
+				`{"Type":"Grafana","Username":"admin","Password":{"$ref":"formae://sec1#/%s","$visibility":"Clear"}}`, tt.refPath)
+
+			mockDS := &mockTargetDatastore{
+				targets: map[string]*pkgmodel.Target{
+					"grafana-target": {
+						Label:     "grafana-target",
+						Namespace: "GRAFANA",
+						Config:    json.RawMessage(stored),
+					},
+				},
+				resources: map[string]*pkgmodel.Resource{
+					"sec1": {Ksuid: "sec1", Properties: json.RawMessage(tt.sourceProps)},
+				},
+			}
+			generator := NewTargetUpdateGenerator(mockDS)
+
+			targets := []pkgmodel.Target{
+				{Label: "grafana-target", Namespace: "GRAFANA", Config: json.RawMessage(desired)},
+			}
+
+			updates, err := generator.GenerateTargetUpdates(targets, pkgmodel.CommandApply, false)
+			require.NoError(t, err)
+			assert.Empty(t, updates, "an opaque credential ref must be idempotent, not update on every re-apply")
+		})
+	}
+}
+
+// The full target-config shape a secret-backed target actually persists: the
+// opaque credential sits nested inside an Auth object, and a SIBLING clear $ref
+// carries the cached $value a successful apply wrote. The sibling matters — it
+// is the field whose cached $value has no counterpart in a freshly rendered
+// forma, so it is what a comparison falling through to raw configs would trip
+// over. An identical re-declare of the whole config must still be a no-op.
+func TestGenerateTargetUpdates_SecretSourcedCredRef_HashedEnvelopeAtRest_NoChange(t *testing.T) {
 	mockDS := &mockTargetDatastore{
 		targets: map[string]*pkgmodel.Target{
 			"grafana-target": {
 				Label:     "grafana-target",
 				Namespace: "GRAFANA",
-				Config:    json.RawMessage(`{"Type":"Grafana","Username":"admin","Password":{"$ref":"formae://sec1#/decodedData.admin-password","$visibility":"Opaque"}}`),
+				Config: json.RawMessage(`{
+					"Url":{"$ref":"formae://svc1#/Endpoint","$value":"http://lb.example.com:80"},
+					"Auth":{"Type":"Token","Token":{"$ref":"formae://sec1#/SecretString","$strategy":"Update","$visibility":"Opaque"}}
+				}`),
+				ConfigSchema: pkgmodel.ConfigSchema{
+					Hints: map[string]pkgmodel.ConfigFieldHint{
+						"Auth": {CreateOnly: false},
+					},
+				},
 			},
 		},
 		resources: map[string]*pkgmodel.Resource{
+			"svc1": {
+				Ksuid:              "svc1",
+				ReadOnlyProperties: json.RawMessage(`{"Endpoint":"http://lb.example.com:80"}`),
+			},
 			"sec1": {
-				Ksuid: "sec1",
-				// decodedData is one hashed envelope; the sub-key is not readable.
-				Properties: json.RawMessage(`{"decodedData":{"$value":"deadbeef","$visibility":"Opaque","$hashed":true}}`),
+				Ksuid:      "sec1",
+				Properties: json.RawMessage(`{"SecretString":{"$value":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","$visibility":"Opaque","$strategy":"Update","$hashed":true}}`),
 			},
 		},
 	}
@@ -1205,13 +1285,97 @@ func TestGenerateTargetUpdates_OpaqueCredRef_PresentButUnreadable_NoChange(t *te
 		{
 			Label:     "grafana-target",
 			Namespace: "GRAFANA",
-			Config:    json.RawMessage(`{"Type":"Grafana","Username":"admin","Password":{"$ref":"formae://sec1#/decodedData.admin-password","$visibility":"Clear"}}`),
+			Config: json.RawMessage(`{
+				"Url":{"$ref":"formae://svc1#/Endpoint"},
+				"Auth":{"Type":"Token","Token":{"$ref":"formae://sec1#/SecretString"}}
+			}`),
+			ConfigSchema: pkgmodel.ConfigSchema{
+				Hints: map[string]pkgmodel.ConfigFieldHint{
+					"Auth": {CreateOnly: false},
+				},
+			},
 		},
 	}
 
 	updates, err := generator.GenerateTargetUpdates(targets, pkgmodel.CommandApply, false)
 	require.NoError(t, err)
-	assert.Empty(t, updates, "an opaque credential ref (present source, unreadable hashed value, Opaque->Clear) must be idempotent, not update every re-apply")
+	assert.Empty(t, updates, "a ref to a hashed-at-rest opaque property must compare by ref identity, not update every re-apply")
+}
+
+// Falling back to ref identity for a hashed-at-rest credential must not swallow
+// a real change elsewhere in the config: a mutable plain field that differs, and
+// a credential ref repointed at a different secret, both still produce an update.
+func TestGenerateTargetUpdates_SecretSourcedCredRef_RealChangeStillDetected(t *testing.T) {
+	storedConfig := `{
+		"OrgId":"1",
+		"Auth":{"Type":"Token","Token":{"$ref":"formae://sec1#/SecretString","$strategy":"Update","$visibility":"Opaque"}}
+	}`
+	newDS := func() *mockTargetDatastore {
+		return &mockTargetDatastore{
+			targets: map[string]*pkgmodel.Target{
+				"grafana-target": {
+					Label:     "grafana-target",
+					Namespace: "GRAFANA",
+					Config:    json.RawMessage(storedConfig),
+					ConfigSchema: pkgmodel.ConfigSchema{
+						Hints: map[string]pkgmodel.ConfigFieldHint{
+							"Auth":  {CreateOnly: false},
+							"OrgId": {CreateOnly: false},
+						},
+					},
+				},
+			},
+			resources: map[string]*pkgmodel.Resource{
+				"sec1": {
+					Ksuid:      "sec1",
+					Properties: json.RawMessage(`{"SecretString":{"$value":"aaaa","$visibility":"Opaque","$strategy":"Update","$hashed":true}}`),
+				},
+				"sec2": {
+					Ksuid:      "sec2",
+					Properties: json.RawMessage(`{"SecretString":{"$value":"bbbb","$visibility":"Opaque","$strategy":"Update","$hashed":true}}`),
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		newConfig string
+	}{
+		{
+			name:      "plain field changed",
+			newConfig: `{"OrgId":"2","Auth":{"Type":"Token","Token":{"$ref":"formae://sec1#/SecretString"}}}`,
+		},
+		{
+			name:      "credential repointed at another secret",
+			newConfig: `{"OrgId":"1","Auth":{"Type":"Token","Token":{"$ref":"formae://sec2#/SecretString"}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			generator := NewTargetUpdateGenerator(newDS())
+
+			targets := []pkgmodel.Target{
+				{
+					Label:     "grafana-target",
+					Namespace: "GRAFANA",
+					Config:    json.RawMessage(tt.newConfig),
+					ConfigSchema: pkgmodel.ConfigSchema{
+						Hints: map[string]pkgmodel.ConfigFieldHint{
+							"Auth":  {CreateOnly: false},
+							"OrgId": {CreateOnly: false},
+						},
+					},
+				},
+			}
+
+			updates, err := generator.GenerateTargetUpdates(targets, pkgmodel.CommandApply, false)
+			require.NoError(t, err)
+			require.Len(t, updates, 1)
+			assert.Equal(t, TargetOperationUpdate, updates[0].Operation)
+		})
+	}
 }
 
 // Mirrors a real K8s target Config shape: $refs are nested under Auth, alongside


### PR DESCRIPTION
## Summary

A target whose config references a secret reported a target `update` on every re-apply, even immediately after a successful one. The change set was otherwise empty, so the stack never simulated clean and an auto-reconcile policy would re-issue the update every interval. The update was benign (an update, not a replace, with no bound resources touched), which is why this is a correctness-of-signal fix rather than an availability one.

An opaque credential is persisted as a whole hashed envelope, so `GetProperty` hands back that envelope's raw JSON rather than reporting the property as unreadable. The comparison path in `resolvedConfigs` therefore treated the ref as resolvable, extracted the stored SHA-256 digest, and compared it against a stored side that carries no `$value` at all, since reference-don't-store strips it for an opaque ref. A digest and a bare `$ref` can never compare equal, so the credential's field read as changed on every apply. Because that field's hint is not createOnly, it classified as a mutable change and became an `update`.

A digest can never participate in a value comparison. A readable property holding a top-level hashed envelope is now treated exactly like a present-but-unreadable one: comparison falls back to `$ref` identity, and the ref is explicitly not marked dangling. The check deliberately matches only a top-level envelope, because a container that merely holds a hashed value somewhere inside still has clear fields whose changes must be detected, including immutable ones that have to escalate to a replace.

Scope is limited to the datastore-backed comparison path, which is the only place in the tree that resolves a ref against the datastore for comparison. Apply-time resolution runs through the resolve cache, which does a live plugin read, so the value that reaches a plugin was never the digest.

## Test coverage

The existing idempotence test covered a single at-rest shape, a ref into a sub-key of a map-shaped secret hashed whole. That shape is genuinely unreadable, so it passed both before and after this change and was blind to the failure. It is widened into a table over the shapes a secret actually takes at rest, two of which (a top-level and a nested property hashed in place) reproduce the bug and fail without the fix. A separate case pins that the ref-identity fallback does not swallow real changes: a changed plain field and a credential repointed at a different secret both still produce an update.

Fixes PLA-436.