### PR TITLE
fix(patch): make the executed patch agree with the plan on reference-fed fields

### DIFF
--- a/internal/metastructure/patch/drift_test.go
+++ b/internal/metastructure/patch/drift_test.go
@@ -24,3 +24,36 @@ func TestDriftPatch(t *testing.T) {
 	assert.Equal(t, "/Value", ops[0]["path"])
 	assert.Equal(t, "/api/v2", ops[0]["value"])
 }
+
+// The applied baseline is formae's own bookkeeping inside a reference
+// envelope, not cloud state. A drift report describes what changed in the
+// cloud, so the baseline must not appear in it — including when absorbing the
+// drift drops the baseline and would otherwise render as a removal.
+func TestDriftPatch_OmitsTheAppliedBaseline(t *testing.T) {
+	old := json.RawMessage(`{"TargetKeyId":{"$ref":"formae://abc#/Arn","$value":"key-old","$applied":"arn:aws:kms:::key/key-old"}}`)
+	cur := json.RawMessage(`{"TargetKeyId":{"$ref":"formae://abc#/Arn","$value":"key-new"}}`)
+
+	p, err := DriftPatch(old, cur)
+	require.NoError(t, err)
+	assert.NotContains(t, string(p), "$applied", "the applied baseline is not cloud state")
+
+	var ops []map[string]any
+	require.NoError(t, json.Unmarshal(p, &ops))
+	require.Len(t, ops, 1, "only the observed value changed")
+	assert.Equal(t, "replace", ops[0]["op"])
+	assert.Equal(t, "/TargetKeyId/$value", ops[0]["path"])
+	assert.Equal(t, "key-new", ops[0]["value"])
+}
+
+// A drift report on a resource whose reference did not change at all is empty,
+// even though the stored side carries a baseline the read side never has.
+func TestDriftPatch_UnchangedReferenceWithBaseline_IsEmpty(t *testing.T) {
+	old := json.RawMessage(`{"TargetKeyId":{"$ref":"formae://abc#/Arn","$value":"key-1","$applied":"arn:aws:kms:::key/key-1"}}`)
+	cur := json.RawMessage(`{"TargetKeyId":{"$ref":"formae://abc#/Arn","$value":"key-1"}}`)
+
+	p, err := DriftPatch(old, cur)
+	require.NoError(t, err)
+	var ops []map[string]any
+	require.NoError(t, json.Unmarshal(p, &ops))
+	assert.Empty(t, ops)
+}

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -30,8 +30,8 @@ var defaultIgnoredFields = []jsonpatch.Path{}
 //     these immutable properties changed: …") and are never sent to plugins.
 //
 // The two slices are disjoint. Either can be nil.
-func GeneratePatch(document []byte, patch []byte, storedEnvelopes []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, error) {
-	return generatePatch(document, patch, storedEnvelopes, properties, schema, mode)
+func GeneratePatch(document []byte, patch []byte, storedEnvelopes []byte, desiredEnvelopes []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, error) {
+	return generatePatch(document, patch, storedEnvelopes, desiredEnvelopes, properties, schema, mode)
 }
 
 func collectionSemanticsFromFieldHints(hints map[string]pkgmodel.FieldHint) jsonpatch.Collections {
@@ -66,8 +66,8 @@ func entitySetProviderDefaultsFromHints(hints map[string]pkgmodel.FieldHint) map
 	return result
 }
 
-func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, error) {
-	flattenedDocument, flattenedPatch, err := flattenAndResolveRefs(document, patch, storedEnvelopes, properties)
+func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desiredEnvelopes []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, error) {
+	flattenedDocument, flattenedPatch, err := flattenAndResolveRefs(document, patch, storedEnvelopes, desiredEnvelopes, properties)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to flatten and resolve refs: %w", err)
 	}
@@ -951,22 +951,63 @@ func storedAppliedEnvelope(storedNode any) map[string]any {
 	return storedMap
 }
 
-// storedAppliedElementByValue finds the stored array element whose applied
-// baseline equals want. Ambiguity (zero or multiple matches) returns nil, so
-// an element with no unique counterpart keeps its existing behavior.
-func storedAppliedElementByValue(storedArr []any, want any) map[string]any {
-	var match map[string]any
-	for _, elem := range storedArr {
-		m := storedAppliedEnvelope(elem)
-		if m == nil || !reflect.DeepEqual(m["$applied"], want) {
-			continue
-		}
-		if match != nil {
-			return nil
-		}
-		match = m
+// storedEchoForResolvedRef reports the echo to compare against when the desired
+// side no longer carries a reference envelope.
+//
+// The executor resolves references before calling a provider and re-derives the
+// patch from the resolved properties, so on that path the desired value arrives
+// as the resolved value alone. The unconverted desired properties still hold the
+// envelope it came from, which is what establishes that the value IS a resolved
+// reference rather than a literal the user wrote: matching on the value alone
+// cannot tell those apart, and suppressing a literal would silently drop the
+// user's edit.
+//
+// It returns the stored echo when the desired envelope names the same reference
+// as the stored one and resolves to what the last write applied. Opaque
+// envelopes and envelopes with no recorded baseline are excluded.
+func storedEchoForResolvedRef(desiredNode, storedNode, modNode any) (any, bool) {
+	desiredEnv, ok := desiredNode.(map[string]any)
+	if !ok || desiredEnv["$visibility"] == pkgmodel.VisibilityOpaque {
+		return nil, false
 	}
-	return match
+	desiredRef, ok := desiredEnv["$ref"].(string)
+	if !ok || desiredRef == "" {
+		return nil, false
+	}
+	desiredValue, resolved := desiredEnv["$value"]
+	if !resolved || desiredValue == nil {
+		return nil, false
+	}
+	// A desired side that still carries its envelope is handled by the
+	// structured path, which resolves it fresh.
+	if modEnv, isEnv := modNode.(map[string]any); isEnv {
+		if _, hasRef := modEnv["$ref"]; hasRef {
+			return nil, false
+		}
+	}
+	storedEnv := storedAppliedEnvelope(storedNode)
+	if storedEnv == nil || storedEnv["$ref"] != desiredRef {
+		return nil, false
+	}
+	if !reflect.DeepEqual(storedEnv["$applied"], desiredValue) {
+		return nil, false
+	}
+	return storedEnv["$value"], true
+}
+
+// storedEchoForResolvedRefInArray applies storedEchoForResolvedRef to one array
+// element, locating the stored counterpart by the reference the desired element
+// names rather than by position: the provider may return elements in any order.
+func storedEchoForResolvedRefInArray(desiredElem any, storedArr []any, modElem any) (any, bool) {
+	desiredEnv, ok := desiredElem.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	storedElem := storedRefElementByURI(storedArr, desiredEnv["$ref"])
+	if storedElem == nil {
+		return nil, false
+	}
+	return storedEchoForResolvedRef(desiredElem, storedElem, modElem)
 }
 
 // storedRefElementByURI finds the stored array element whose $ref equals uri.
@@ -988,8 +1029,15 @@ func storedRefElementByURI(storedArr []any, uri any) map[string]any {
 }
 
 // resolveRefs uses properties to resolve references in the patch document
-func resolveRefs(current, mod, stored map[string]any, resolvableProperties resolver.ResolvableProperties) error {
+func resolveRefs(current, mod, stored, desired map[string]any, resolvableProperties resolver.ResolvableProperties) error {
 	for k, v := range mod {
+		// A reference the executor already resolved: the desired side holds the
+		// resolved value alone, and the envelope it came from lives in the
+		// unconverted desired properties.
+		if echo, ok := storedEchoForResolvedRef(desired[k], stored[k], v); ok {
+			mod[k] = echo
+			continue
+		}
 		switch modVal := v.(type) {
 		case map[string]any:
 			if ref, hasRef := modVal["$ref"]; hasRef {
@@ -1045,7 +1093,13 @@ func resolveRefs(current, mod, stored map[string]any, resolvableProperties resol
 			} else {
 				storedNested = map[string]any{}
 			}
-			if err := resolveRefs(currNested, modVal, storedNested, resolvableProperties); err != nil {
+			var desiredNested map[string]any
+			if d, ok := desired[k].(map[string]any); ok {
+				desiredNested = d
+			} else {
+				desiredNested = map[string]any{}
+			}
+			if err := resolveRefs(currNested, modVal, storedNested, desiredNested, resolvableProperties); err != nil {
 				return err
 			}
 		case []any:
@@ -1058,6 +1112,13 @@ func resolveRefs(current, mod, stored map[string]any, resolvableProperties resol
 				if s, ok := stored[k].([]any); ok {
 					storedArr = s
 				}
+			}
+			// The unconverted desired properties are the same document in the
+			// same order, so desired elements are matched by index; stored
+			// elements are a different document and are matched by reference.
+			var desiredArr []any
+			if d, ok := desired[k].([]any); ok {
+				desiredArr = d
 			}
 			for i, elem := range modVal {
 				var currElem any
@@ -1086,7 +1147,11 @@ func resolveRefs(current, mod, stored map[string]any, resolvableProperties resol
 						storedElem := storedArr[i]
 						wrappedStored = map[string]any{k: storedElem}
 					}
-					if err := resolveRefs(wrappedCurrent, wrappedElem, wrappedStored, resolvableProperties); err != nil {
+					var wrappedDesired map[string]any
+					if len(desiredArr) > i {
+						wrappedDesired = map[string]any{k: desiredArr[i]}
+					}
+					if err := resolveRefs(wrappedCurrent, wrappedElem, wrappedStored, wrappedDesired, resolvableProperties); err != nil {
 						return err
 					}
 					if resolvedElem, ok := wrappedElem[k].(map[string]any); ok {
@@ -1094,22 +1159,17 @@ func resolveRefs(current, mod, stored map[string]any, resolvableProperties resol
 					}
 					continue
 				}
-				// An already-resolved element: compare it against the applied
-				// baselines rather than by position, since a resolved element
-				// carries nothing that ties it to one stored slot.
-				if counterpart := storedAppliedElementByValue(storedArr, elem); counterpart != nil {
-					modVal[i] = counterpart["$value"]
+				// An already-resolved element. The unconverted desired array is
+				// the same document in the same order, so its element at this
+				// index names the reference this value came from; the stored
+				// counterpart is then found by that reference.
+				var desiredElem any
+				if len(desiredArr) > i {
+					desiredElem = desiredArr[i]
 				}
-			}
-		default:
-			// An already-resolved reference: the desired side holds the value
-			// the reference resolves to, with no envelope left to match. When
-			// it equals what the last write applied, the reference is unchanged
-			// and the diff must compare within the observed domain, exactly as
-			// it does for a structured reference.
-			if counterpart := storedAppliedEnvelope(stored[k]); counterpart != nil &&
-				reflect.DeepEqual(modVal, counterpart["$applied"]) {
-				mod[k] = counterpart["$value"]
+				if echo, ok := storedEchoForResolvedRefInArray(desiredElem, storedArr, elem); ok {
+					modVal[i] = echo
+				}
 			}
 		}
 	}
@@ -1233,7 +1293,7 @@ func normalizeToFlattenedKeys(m map[string]any) {
 	}
 }
 
-func flattenAndResolveRefs(document []byte, patch []byte, storedEnvelopes []byte, resolvableProperties resolver.ResolvableProperties) ([]byte, []byte, error) {
+func flattenAndResolveRefs(document []byte, patch []byte, storedEnvelopes []byte, desiredEnvelopes []byte, resolvableProperties resolver.ResolvableProperties) ([]byte, []byte, error) {
 	var current, mod map[string]any
 	if err := json.Unmarshal(document, &current); err != nil {
 		return nil, nil, err
@@ -1247,7 +1307,13 @@ func flattenAndResolveRefs(document []byte, patch []byte, storedEnvelopes []byte
 			return nil, nil, err
 		}
 	}
-	if err := resolveRefs(current, mod, stored, resolvableProperties); err != nil {
+	var desired map[string]any
+	if len(desiredEnvelopes) > 0 {
+		if err := json.Unmarshal(desiredEnvelopes, &desired); err != nil {
+			return nil, nil, err
+		}
+	}
+	if err := resolveRefs(current, mod, stored, desired, resolvableProperties); err != nil {
 		return nil, nil, err
 	}
 	flattenRefs(current)

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -984,21 +984,25 @@ func resolvedDesiredEnvelope(desiredNode, modNode any) (map[string]any, bool) {
 // current one is available it is the authority: trusting the cached value would
 // let a reference that now points somewhere else compare as unchanged and drop
 // the update, or miss a replacement on an immutable field.
-func freshResolution(env map[string]any, current any, resolvableProperties resolver.ResolvableProperties) (any, string, bool) {
+func freshResolution(env map[string]any, current any, resolvableProperties resolver.ResolvableProperties) (any, string, bool, error) {
 	ref, _ := env["$ref"].(string)
 	uri := pkgmodel.FormaeURI(ref)
 	val, found := resolvableProperties.Get(uri.KSUID(), uri.PropertyPath())
 	if !found {
-		return nil, "", false
+		return nil, "", false, nil
 	}
 	if jsonPath, ok := env["$json"].(string); ok && jsonPath != "" {
 		extracted, err := resolver.ExtractJSONPath(val, jsonPath)
 		if err != nil {
-			return nil, "", false
+			// A source that resolves but cannot be read through its path is a
+			// broken reference, not a missing one. Surfacing it matches the
+			// structured path; falling back to the recorded value would leave
+			// the resource on its old value with nothing reported.
+			return nil, "", false, err
 		}
 		val = extracted
 	}
-	return normalizeResolvedValue(val, current), val, true
+	return normalizeResolvedValue(val, current), val, true, nil
 }
 
 // substituteResolvedRef decides what the desired side should carry for a
@@ -1010,33 +1014,37 @@ func freshResolution(env map[string]any, current any, resolvableProperties resol
 // and the reference is not rewritten in the provider's own spelling. Otherwise
 // the desired side carries the current resolution, so a genuine repoint is
 // planned (and, on an immutable field, still forces a replacement).
-func substituteResolvedRef(desiredNode, storedNode, modNode, currentNode any, resolvableProperties resolver.ResolvableProperties) (any, bool) {
+func substituteResolvedRef(desiredNode, storedNode, modNode, currentNode any, resolvableProperties resolver.ResolvableProperties) (any, bool, error) {
 	desiredEnv, ok := resolvedDesiredEnvelope(desiredNode, modNode)
 	if !ok {
-		return nil, false
+		return nil, false, nil
 	}
 	storedEnv := storedAppliedEnvelope(storedNode)
 	sameRef := storedEnv != nil && storedEnv["$ref"] == desiredEnv["$ref"]
 
 	effective := desiredEnv["$value"]
 	matchesApplied := sameRef && reflect.DeepEqual(storedEnv["$applied"], effective)
-	if native, raw, found := freshResolution(desiredEnv, currentNode, resolvableProperties); found {
+	native, raw, found, err := freshResolution(desiredEnv, currentNode, resolvableProperties)
+	if err != nil {
+		return nil, false, err
+	}
+	if found {
 		effective = native
 		matchesApplied = sameRef && appliedMatches(raw, storedEnv["$applied"])
 	}
 	if matchesApplied {
-		return storedEnv["$value"], true
+		return storedEnv["$value"], true, nil
 	}
-	return effective, true
+	return effective, true, nil
 }
 
 // substituteResolvedRefInArray applies substituteResolvedRef to one array
 // element, locating the stored counterpart by the reference the desired element
 // names rather than by position: the provider may return elements in any order.
-func substituteResolvedRefInArray(desiredElem any, storedArr []any, modElem, currentElem any, resolvableProperties resolver.ResolvableProperties) (any, bool) {
+func substituteResolvedRefInArray(desiredElem any, storedArr []any, modElem, currentElem any, resolvableProperties resolver.ResolvableProperties) (any, bool, error) {
 	desiredEnv, ok := desiredElem.(map[string]any)
 	if !ok {
-		return nil, false
+		return nil, false, nil
 	}
 	var storedElem any
 	if match := storedRefElementByURI(storedArr, desiredEnv["$ref"]); match != nil {
@@ -1069,7 +1077,11 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 		// A reference the executor already resolved: the desired side holds the
 		// resolved value alone, and the envelope it came from lives in the
 		// unconverted desired properties.
-		if value, handled := substituteResolvedRef(desired[k], stored[k], v, current[k], resolvableProperties); handled {
+		value, handled, err := substituteResolvedRef(desired[k], stored[k], v, current[k], resolvableProperties)
+		if err != nil {
+			return err
+		}
+		if handled {
 			mod[k] = value
 			continue
 		}
@@ -1202,7 +1214,11 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 				if len(desiredArr) > i {
 					desiredElem = desiredArr[i]
 				}
-				if value, handled := substituteResolvedRefInArray(desiredElem, storedArr, elem, currElem, resolvableProperties); handled {
+				value, handled, err := substituteResolvedRefInArray(desiredElem, storedArr, elem, currElem, resolvableProperties)
+				if err != nil {
+					return err
+				}
+				if handled {
 					modVal[i] = value
 				}
 			}

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -1201,9 +1201,11 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 					if err := resolveRefs(wrappedCurrent, wrappedElem, wrappedStored, wrappedDesired, resolvableProperties); err != nil {
 						return err
 					}
-					if resolvedElem, ok := wrappedElem[k].(map[string]any); ok {
-						modVal[i] = resolvedElem
-					}
+					// Copy back whatever the recursion produced, not only a map:
+					// a reference whose recorded value was an object can resolve
+					// to a scalar or a list now, and dropping that would leave
+					// the stale object in place.
+					modVal[i] = wrappedElem[k]
 					continue
 				}
 				// An already-resolved element. The unconverted desired array is

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -924,6 +924,51 @@ func appliedMatches(fresh string, applied any) bool {
 	return reflect.DeepEqual(parsed, applied)
 }
 
+// storedAppliedEnvelope returns the stored node as a provenance-carrying
+// envelope: a reference envelope that records what the last write applied and
+// still holds the value the provider echoed for it. Opaque envelopes are
+// excluded, matching the rest of the provenance rules.
+//
+// This is the counterpart lookup for a desired side that is no longer
+// structured. The executor resolves references before calling a provider and
+// re-derives the patch from the resolved properties, so on that path the
+// desired value arrives as the bare resolved scalar with no envelope to match
+// a reference URI against; the applied baseline is what identifies it.
+func storedAppliedEnvelope(storedNode any) map[string]any {
+	storedMap, ok := storedNode.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if storedMap["$ref"] == nil && storedMap["$res"] == nil {
+		return nil
+	}
+	if storedMap["$visibility"] == pkgmodel.VisibilityOpaque {
+		return nil
+	}
+	if storedMap["$applied"] == nil || storedMap["$value"] == nil {
+		return nil
+	}
+	return storedMap
+}
+
+// storedAppliedElementByValue finds the stored array element whose applied
+// baseline equals want. Ambiguity (zero or multiple matches) returns nil, so
+// an element with no unique counterpart keeps its existing behavior.
+func storedAppliedElementByValue(storedArr []any, want any) map[string]any {
+	var match map[string]any
+	for _, elem := range storedArr {
+		m := storedAppliedEnvelope(elem)
+		if m == nil || !reflect.DeepEqual(m["$applied"], want) {
+			continue
+		}
+		if match != nil {
+			return nil
+		}
+		match = m
+	}
+	return match
+}
+
 // storedRefElementByURI finds the stored array element whose $ref equals uri.
 // Ambiguity (zero or multiple matches) returns nil: with no unique
 // counterpart the element gets no provenance treatment.
@@ -1047,7 +1092,24 @@ func resolveRefs(current, mod, stored map[string]any, resolvableProperties resol
 					if resolvedElem, ok := wrappedElem[k].(map[string]any); ok {
 						modVal[i] = resolvedElem
 					}
+					continue
 				}
+				// An already-resolved element: compare it against the applied
+				// baselines rather than by position, since a resolved element
+				// carries nothing that ties it to one stored slot.
+				if counterpart := storedAppliedElementByValue(storedArr, elem); counterpart != nil {
+					modVal[i] = counterpart["$value"]
+				}
+			}
+		default:
+			// An already-resolved reference: the desired side holds the value
+			// the reference resolves to, with no envelope left to match. When
+			// it equals what the last write applied, the reference is unchanged
+			// and the diff must compare within the observed domain, exactly as
+			// it does for a structured reference.
+			if counterpart := storedAppliedEnvelope(stored[k]); counterpart != nil &&
+				reflect.DeepEqual(modVal, counterpart["$applied"]) {
+				mod[k] = counterpart["$value"]
 			}
 		}
 	}

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -951,31 +951,21 @@ func storedAppliedEnvelope(storedNode any) map[string]any {
 	return storedMap
 }
 
-// storedEchoForResolvedRef reports the echo to compare against when the desired
-// side no longer carries a reference envelope.
-//
-// The executor resolves references before calling a provider and re-derives the
-// patch from the resolved properties, so on that path the desired value arrives
-// as the resolved value alone. The unconverted desired properties still hold the
-// envelope it came from, which is what establishes that the value IS a resolved
-// reference rather than a literal the user wrote: matching on the value alone
-// cannot tell those apart, and suppressing a literal would silently drop the
-// user's edit.
-//
-// It returns the stored echo when the desired envelope names the same reference
-// as the stored one and resolves to what the last write applied. Opaque
-// envelopes and envelopes with no recorded baseline are excluded.
-func storedEchoForResolvedRef(desiredNode, storedNode, modNode any) (any, bool) {
+// resolvedDesiredEnvelope returns the desired-side envelope for a value that has
+// already been resolved: the converted desired document holds the resolved value
+// alone, while the unconverted desired properties still hold the envelope it came
+// from. That envelope is what establishes the value IS a resolved reference
+// rather than a literal the user wrote in its place, which matching on the value
+// alone cannot tell apart.
+func resolvedDesiredEnvelope(desiredNode, modNode any) (map[string]any, bool) {
 	desiredEnv, ok := desiredNode.(map[string]any)
 	if !ok || desiredEnv["$visibility"] == pkgmodel.VisibilityOpaque {
 		return nil, false
 	}
-	desiredRef, ok := desiredEnv["$ref"].(string)
-	if !ok || desiredRef == "" {
+	if ref, ok := desiredEnv["$ref"].(string); !ok || ref == "" {
 		return nil, false
 	}
-	desiredValue, resolved := desiredEnv["$value"]
-	if !resolved || desiredValue == nil {
+	if value, resolved := desiredEnv["$value"]; !resolved || value == nil {
 		return nil, false
 	}
 	// A desired side that still carries its envelope is handled by the
@@ -985,29 +975,74 @@ func storedEchoForResolvedRef(desiredNode, storedNode, modNode any) (any, bool) 
 			return nil, false
 		}
 	}
-	storedEnv := storedAppliedEnvelope(storedNode)
-	if storedEnv == nil || storedEnv["$ref"] != desiredRef {
-		return nil, false
-	}
-	if !reflect.DeepEqual(storedEnv["$applied"], desiredValue) {
-		return nil, false
-	}
-	return storedEnv["$value"], true
+	return desiredEnv, true
 }
 
-// storedEchoForResolvedRefInArray applies storedEchoForResolvedRef to one array
+// freshResolution returns what a reference resolves to now, both normalized to
+// the live value's JSON shape and as the raw resolved text. A cached $value on
+// the desired envelope is only a record of an earlier resolution, so whenever a
+// current one is available it is the authority: trusting the cached value would
+// let a reference that now points somewhere else compare as unchanged and drop
+// the update, or miss a replacement on an immutable field.
+func freshResolution(env map[string]any, current any, resolvableProperties resolver.ResolvableProperties) (any, string, bool) {
+	ref, _ := env["$ref"].(string)
+	uri := pkgmodel.FormaeURI(ref)
+	val, found := resolvableProperties.Get(uri.KSUID(), uri.PropertyPath())
+	if !found {
+		return nil, "", false
+	}
+	if jsonPath, ok := env["$json"].(string); ok && jsonPath != "" {
+		extracted, err := resolver.ExtractJSONPath(val, jsonPath)
+		if err != nil {
+			return nil, "", false
+		}
+		val = extracted
+	}
+	return normalizeResolvedValue(val, current), val, true
+}
+
+// substituteResolvedRef decides what the desired side should carry for a
+// reference that has already been resolved. It reports whether it handled the
+// node at all.
+//
+// When the reference still resolves to what the last write applied, the desired
+// side takes the stored echo so the comparison stays within the observed domain
+// and the reference is not rewritten in the provider's own spelling. Otherwise
+// the desired side carries the current resolution, so a genuine repoint is
+// planned (and, on an immutable field, still forces a replacement).
+func substituteResolvedRef(desiredNode, storedNode, modNode, currentNode any, resolvableProperties resolver.ResolvableProperties) (any, bool) {
+	desiredEnv, ok := resolvedDesiredEnvelope(desiredNode, modNode)
+	if !ok {
+		return nil, false
+	}
+	storedEnv := storedAppliedEnvelope(storedNode)
+	sameRef := storedEnv != nil && storedEnv["$ref"] == desiredEnv["$ref"]
+
+	effective := desiredEnv["$value"]
+	matchesApplied := sameRef && reflect.DeepEqual(storedEnv["$applied"], effective)
+	if native, raw, found := freshResolution(desiredEnv, currentNode, resolvableProperties); found {
+		effective = native
+		matchesApplied = sameRef && appliedMatches(raw, storedEnv["$applied"])
+	}
+	if matchesApplied {
+		return storedEnv["$value"], true
+	}
+	return effective, true
+}
+
+// substituteResolvedRefInArray applies substituteResolvedRef to one array
 // element, locating the stored counterpart by the reference the desired element
 // names rather than by position: the provider may return elements in any order.
-func storedEchoForResolvedRefInArray(desiredElem any, storedArr []any, modElem any) (any, bool) {
+func substituteResolvedRefInArray(desiredElem any, storedArr []any, modElem, currentElem any, resolvableProperties resolver.ResolvableProperties) (any, bool) {
 	desiredEnv, ok := desiredElem.(map[string]any)
 	if !ok {
 		return nil, false
 	}
-	storedElem := storedRefElementByURI(storedArr, desiredEnv["$ref"])
-	if storedElem == nil {
-		return nil, false
+	var storedElem any
+	if match := storedRefElementByURI(storedArr, desiredEnv["$ref"]); match != nil {
+		storedElem = match
 	}
-	return storedEchoForResolvedRef(desiredElem, storedElem, modElem)
+	return substituteResolvedRef(desiredElem, storedElem, modElem, currentElem, resolvableProperties)
 }
 
 // storedRefElementByURI finds the stored array element whose $ref equals uri.
@@ -1034,8 +1069,8 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 		// A reference the executor already resolved: the desired side holds the
 		// resolved value alone, and the envelope it came from lives in the
 		// unconverted desired properties.
-		if echo, ok := storedEchoForResolvedRef(desired[k], stored[k], v); ok {
-			mod[k] = echo
+		if value, handled := substituteResolvedRef(desired[k], stored[k], v, current[k], resolvableProperties); handled {
+			mod[k] = value
 			continue
 		}
 		switch modVal := v.(type) {
@@ -1167,8 +1202,8 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 				if len(desiredArr) > i {
 					desiredElem = desiredArr[i]
 				}
-				if echo, ok := storedEchoForResolvedRefInArray(desiredElem, storedArr, elem); ok {
-					modVal[i] = echo
+				if value, handled := substituteResolvedRefInArray(desiredElem, storedArr, elem, currElem, resolvableProperties); handled {
+					modVal[i] = value
 				}
 			}
 		}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -3326,3 +3326,98 @@ func TestGeneratePatch_ResolvedArrayRefsAmbiguousStored_FailsClosed(t *testing.T
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
 	assert.NotEmpty(t, ops, "ambiguous counterparts must not silently compare equal")
 }
+
+// A $value on the desired envelope records an earlier resolution. When the
+// reference resolves to something else now, that current resolution is what
+// gets planned: trusting the cached value would compare a moved reference as
+// unchanged and drop the update entirely.
+func TestGeneratePatch_ResolvedRefWithStaleValue_PlansFreshResolution(t *testing.T) {
+	ksuid := util.NewID()
+	appliedArn := "arn:aws:kms:us-east-1:111122223333:key/47110862-aaaa"
+	freshArn := "arn:aws:kms:us-east-1:111122223333:key/99887766-bbbb"
+	document := []byte(`{"TargetKeyId": "47110862-aaaa"}`)
+	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": "47110862-aaaa", "$applied": %q}}`, ksuid, appliedArn)
+	// The desired envelope still carries the previously applied resolution.
+	desired := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": %q}}`, ksuid, appliedArn)
+	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, appliedArn)
+	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "Arn", freshArn)
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	require.Len(t, ops, 1, "a reference that resolves somewhere new must be planned")
+	assert.Equal(t, freshArn, ops[0].Value, "the plan must carry the current resolution, not the cached one")
+}
+
+// The same on an immutable field must still force a replacement.
+func TestGeneratePatch_CreateOnlyResolvedRefWithStaleValue_PlansReplacement(t *testing.T) {
+	ksuid := util.NewID()
+	appliedArn := "arn:aws:lambda:us-east-1:111122223333:function:fn-v1"
+	freshArn := "arn:aws:lambda:us-east-1:111122223333:function:fn-v2"
+	document := []byte(`{"TargetFunctionArn": "fn-v1"}`)
+	stored := fmt.Appendf(nil, `{"TargetFunctionArn": {"$ref": "formae://%s#/Arn", "$value": "fn-v1", "$applied": %q}}`, ksuid, appliedArn)
+	desired := fmt.Appendf(nil, `{"TargetFunctionArn": {"$ref": "formae://%s#/Arn", "$value": %q}}`, ksuid, appliedArn)
+	patch := fmt.Appendf(nil, `{"TargetFunctionArn": %q}`, appliedArn)
+	schema := pkgmodel.Schema{
+		Fields: []string{"TargetFunctionArn"},
+		Hints:  map[string]pkgmodel.FieldHint{"TargetFunctionArn": {CreateOnly: true}},
+	}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "Arn", freshArn)
+
+	_, createOnlyPatch, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.NotEmpty(t, createOnlyPatch, "a moved reference on an immutable field must still force a replacement")
+	assert.Contains(t, string(createOnlyPatch), freshArn)
+}
+
+// A resolution matching the baseline stays suppressed even when it arrives from
+// a fresh lookup rather than the envelope's cached value.
+func TestGeneratePatch_ResolvedRefFreshlyMatchingApplied_NoPatch(t *testing.T) {
+	ksuid := util.NewID()
+	arn := "arn:aws:kms:us-east-1:111122223333:key/47110862-aaaa"
+	document := []byte(`{"TargetKeyId": "47110862-aaaa"}`)
+	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": "47110862-aaaa", "$applied": %q}}`, ksuid, arn)
+	desired := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": %q}}`, ksuid, arn)
+	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
+	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "Arn", arn)
+
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, createOnlyPatch)
+	assert.Nil(t, patchDoc, "an unchanged reference stays suppressed under fresh resolution")
+}
+
+// An array element whose reference moved is written with its current
+// resolution while its unchanged sibling stays suppressed.
+func TestGeneratePatch_ResolvedArrayRefWithStaleValue_PlansFreshResolution(t *testing.T) {
+	ksuid := util.NewID()
+	arnA := "arn:aws:sns:us-east-1:111122223333:topic-a"
+	arnB := "arn:aws:sns:us-east-1:111122223333:topic-b"
+	arnBMoved := "arn:aws:sns:us-east-1:111122223333:topic-b2"
+	document := []byte(`{"Topics": ["name-a", "name-b"]}`)
+	stored := fmt.Appendf(nil, `{"Topics": [
+		{"$ref": "formae://%s#/ArnA", "$value": "name-a", "$applied": %q},
+		{"$ref": "formae://%s#/ArnB", "$value": "name-b", "$applied": %q}
+	]}`, ksuid, arnA, ksuid, arnB)
+	desired := fmt.Appendf(nil, `{"Topics": [
+		{"$ref": "formae://%s#/ArnA", "$value": %q},
+		{"$ref": "formae://%s#/ArnB", "$value": %q}
+	]}`, ksuid, arnA, ksuid, arnB)
+	patch := fmt.Appendf(nil, `{"Topics": [%q, %q]}`, arnA, arnB)
+	schema := pkgmodel.Schema{Fields: []string{"Topics"}}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "ArnA", arnA)
+	props.Add(ksuid, "ArnB", arnBMoved)
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.NotNil(t, patchDoc, "a moved array reference must be planned")
+	assert.Contains(t, string(patchDoc), arnBMoved, "the moved element carries its current resolution")
+	assert.NotContains(t, string(patchDoc), arnA, "the unchanged element is not rewritten")
+}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -359,7 +359,7 @@ func TestGeneratePatch(t *testing.T) {
 	resProps := resolver.NewResolvableProperties()
 	resProps.Add(resourceKsuid, "id", "def")
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, resProps, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, resProps, schema, pkgmodel.FormaApplyModePatch)
 
 	assert.NoError(t, err)
 	// val2 is createOnly and changed → a non-empty createOnlyPatch is returned
@@ -431,7 +431,7 @@ func TestGeneratePatch_NestedCreateOnlyTriggersReplacement(t *testing.T) {
 		},
 	}
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	require.NotEmpty(t, createOnlyPatch, "nested createOnly change must produce a non-empty createOnlyPatch")
 
@@ -482,7 +482,7 @@ func TestGeneratePatch_ShouldResolveRefs(t *testing.T) {
 	props.Add(resourceKsuid, "other-id", "def")
 	props.Add(resourceKsuid, "notha-id", "ghi")
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	assert.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -519,7 +519,7 @@ func TestGeneratePatch_ListResolvableMatchingLiveValue_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "ValidationRecords.0.Values", `["_7a296.acm-validations.aws"]`)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "an unchanged list-valued resolvable must reconcile to a no-op")
@@ -543,7 +543,7 @@ func TestGeneratePatch_MultiValueListResolvableMatchingLiveValue_NoPatch(t *test
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "Values", `["10.0.0.1","10.0.0.2"]`)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc)
@@ -567,7 +567,7 @@ func TestGeneratePatch_ListResolvableGenuineChange_EmitsReplace(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "ValidationRecords.0.Values", `["new.acm-validations.aws"]`)
 
-	patchDoc, _, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "a genuine list change must still emit a patch")
 
@@ -598,7 +598,7 @@ func TestGeneratePatch_ObjectResolvableMatchingLiveValue_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "Endpoints", `{"host":"db.internal","port":5432,"tls":true,"aliases":["a","b"],"fallback":null}`)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc)
@@ -624,7 +624,7 @@ func TestGeneratePatch_JsonStringScalarResolvable_StaysString_NoPatch(t *testing
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "PolicyDocument", `{"Version":"2012-10-17"}`)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "a JSON-string scalar must not be reparsed into a native structure")
@@ -650,7 +650,7 @@ func TestGeneratePatch_ArrayElementObjectResolvableMatchingLiveValue_NoPatch(t *
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "Endpoints.0", `{"host":"db.internal","port":5432}`)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "an unchanged array of object-valued resolvables must reconcile to a no-op")
@@ -676,7 +676,7 @@ func TestGeneratePatch_StringNullResolvableAgainstArray_StaysString(t *testing.T
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "Polymorphic", "null")
 
-	patchDoc, _, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc)
 	assert.Contains(t, string(patchDoc), `"value":"null"`, "the literal string \"null\" must not be rewritten to JSON null")
@@ -695,7 +695,7 @@ func TestResolveRefs_UnresolvedForwardRefLeftIntact(t *testing.T) {
 		"ResourceRecords": map[string]any{"$ref": uri},
 	}
 
-	err := resolveRefs(current, mod, nil, resolver.NewResolvableProperties())
+	err := resolveRefs(current, mod, nil, nil, resolver.NewResolvableProperties())
 	require.NoError(t, err)
 
 	ref, ok := mod["ResourceRecords"].(map[string]any)
@@ -723,7 +723,7 @@ func TestResolveRefs_JSONPathAppliedOnUpdatePath(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "SecretString", `{"db":{"password":"the-secret"}}`)
 
-	err := resolveRefs(current, mod, nil, props)
+	err := resolveRefs(current, mod, nil, nil, props)
 	require.NoError(t, err)
 
 	envelope, ok := mod["Password"].(map[string]any)
@@ -833,7 +833,7 @@ func TestGeneratePatch_MixedNestedAndFlattenedStructures(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 
 	assert.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
@@ -919,7 +919,7 @@ func TestGeneratePatch_RequiredOnUpdateFieldsGenerateAddOperation(t *testing.T) 
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -987,7 +987,7 @@ func TestGeneratePatch_WriteOnlyCreateOnlyFieldsNoPhantomReplacement(t *testing.
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "writeOnly+createOnly field should NOT trigger replacement")
 	assert.Nil(t, patchDoc, "No patch should be generated when only writeOnly+createOnly fields differ")
@@ -1027,7 +1027,7 @@ func TestGeneratePatch_WriteOnlyFieldUnchanged_NoAddOperation(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "writeOnly-only field unchanged should not force an add op")
@@ -1069,7 +1069,7 @@ func TestGeneratePatch_AddTagsWhileRetainingExisting(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1134,7 +1134,7 @@ func TestGeneratePatch_HasProviderDefaultFieldsNotRemoved(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1177,7 +1177,7 @@ func TestGeneratePatch_HasProviderDefaultFieldsOverridden(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1370,7 +1370,7 @@ func TestGeneratePatch_ReconcileRemovesOOBTagsWhenDesiredIsEmptyArray(t *testing
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1396,7 +1396,7 @@ func TestGeneratePatch_ReconcileRemovesOOBTagsWhenDesiredIsNull(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	require.NotNil(t, patchDoc, "expected a patch to handle the OOB tag, got nil")
@@ -1436,7 +1436,7 @@ func TestGeneratePatch_AbsentDesiredVsEmptyActualArray_NoPatch(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "expected no patch ops when desired is absent and actual is empty array")
@@ -1539,7 +1539,7 @@ func TestGeneratePatch_OuterWithOnlyNestedEmpties_NoSpuriousSuppression(t *testi
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "expected nil patch; pinning current jsonpatch behavior for {Outer:{}}-vs-{} so any future change surfaces here, not as silent drift")
 }
@@ -1565,7 +1565,7 @@ func TestGeneratePatch_AbsentDesiredVsEmptyActualArray_PatchMode_NoPatch(t *test
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "expected no patch ops in Patch mode either")
 }
@@ -1598,7 +1598,7 @@ func TestGeneratePatch_AbsentDesiredVsEmptyActual_EntitySetField_NotAWSSpecific_
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc)
 }
@@ -1745,7 +1745,7 @@ func TestGeneratePatch_ProviderDefaultInsideArray_NoPatch(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "Expected no patch when only difference is provider default Cpu inside array")
 }
@@ -1782,7 +1782,7 @@ func TestGeneratePatch_AtomicField_SingleReplace(t *testing.T) {
 		},
 	}
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1808,7 +1808,7 @@ func TestGeneratePatch_AtomicField_NoDiffNoPatch(t *testing.T) {
 		},
 	}
 
-	patchDoc, createOnlyPatch, err := generatePatch(doc, doc, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, err := generatePatch(doc, doc, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Empty(t, patchDoc, "Expected no patch when atomic field is identical")
@@ -1838,7 +1838,7 @@ func TestGeneratePatch_EmptyArrayOnCreateOnlyField_NoPatch(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "Empty arrays on createOnly fields should not trigger replacement")
 	assert.Empty(t, patchDoc, "Expected no patch when only difference is empty arrays on createOnly fields")
@@ -1863,7 +1863,7 @@ func TestGeneratePatch_NonEmptyArrayOnCreateOnlyField_TriggersReplacement(t *tes
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.NotEmpty(t, createOnlyPatch, "Non-empty change to createOnly field should trigger replacement")
 	assert.NotEmpty(t, patchDoc)
@@ -1889,7 +1889,7 @@ func TestGeneratePatch_EmptyArrayOnNonCreateOnlyField_NoPatch(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "Expected no patch when only difference is empty arrays on non-createOnly fields")
 }
@@ -1913,7 +1913,7 @@ func TestGeneratePatch_ReplaceNonEmptyArrayPreserved(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.NotEmpty(t, patchDoc, "Expected patch when user clears a collection via replace")
 }
@@ -2052,7 +2052,7 @@ func TestGeneratePatch_EntitySetProviderDefaults_PatchMode(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Empty(t, patchDoc, "Expected no patch when user-specified attribute matches actual")
@@ -2089,7 +2089,7 @@ func TestGeneratePatch_EntitySetProviderDefaults_WithUserChange(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	require.NotEmpty(t, patchDoc)
@@ -2139,7 +2139,7 @@ func TestGeneratePatch_ProviderDefaultInsideArray_SingleElement_NoReplace(t *tes
 	}
 
 	patchDoc, createOnlyPatch, err := generatePatch(
-		document, patch, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2179,7 +2179,7 @@ func TestGeneratePatch_ProviderDefaultInsideArray_MixedElements_NoReplace(t *tes
 	}
 
 	patchDoc, createOnlyPatch, err := generatePatch(
-		document, patch, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2236,7 +2236,7 @@ func TestGeneratePatch_ProviderDefaultInsideNestedArray_PortMappingHostPort_Mixe
 	}
 
 	patchDoc, createOnlyPatch, err := generatePatch(
-		document, patch, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2292,7 +2292,7 @@ func TestGeneratePatch_ProviderDefaultInsideNestedArray_PortMappingHostPort(t *t
 	}
 
 	patchDoc, createOnlyPatch, err := generatePatch(
-		document, patch, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2335,7 +2335,7 @@ func TestGeneratePatch_UserChangedFieldInsideArray_StillReplaces(t *testing.T) {
 	}
 
 	_, createOnlyPatch, err := generatePatch(
-		document, patch, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2365,7 +2365,7 @@ func TestGeneratePatch_TopLevelProviderDefaultOverride_StillDiffs(t *testing.T) 
 	}
 
 	patchDoc, _, err := generatePatch(
-		document, patch, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2403,7 +2403,7 @@ func TestGeneratePatch_EntitySetProviderDefaults_ReconcileMode(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "Expected no patch when only provider-default elements differ in reconcile mode")
 }
@@ -2462,7 +2462,7 @@ func TestGeneratePatch_NestedListOrderingInsideArrayElement_NoReplace(t *testing
 	}
 
 	patchDoc, createOnlyPatch, err := generatePatch(
-		document, patch, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2512,7 +2512,7 @@ func TestGeneratePatch_NestedPortMappingsOrderInsideArrayElement_NoReplace(t *te
 	}
 
 	patchDoc, createOnlyPatch, err := generatePatch(
-		document, patch, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2553,7 +2553,7 @@ func TestGeneratePatch_NestedListContentChange_StillReplaces(t *testing.T) {
 	}
 
 	_, createOnlyPatch, err := generatePatch(
-		document, patch, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2587,7 +2587,7 @@ func TestGeneratePatch_HasProviderDefault_PlainListing_OmittedDesired(t *testing
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "user omitted hasProviderDefault Listing — strip pass must suppress remove ops for runtime-registered entries")
 }
@@ -2606,7 +2606,7 @@ func TestGeneratePatch_HasProviderDefault_NullDesired_Defensive(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc)
 }
@@ -2640,7 +2640,7 @@ func TestGeneratePatch_HasProviderDefault_PlainListing_PR269Rendering(t *testing
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 
 	// Document the bug shape: explicit empty Listing in patch + runtime entry
@@ -2695,7 +2695,7 @@ func TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserOmits_PostRevert(t 
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "characterization: with hasProviderDefault on an EntitySet, OOB-added entries are NOT removed when user omits — see test docstring for the open question")
 }
@@ -2732,7 +2732,7 @@ func TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserDeclaresOne(t *test
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "characterization: with hasProviderDefault on an EntitySet, OOB-added entries are tolerated even when user declares others")
 }
@@ -2765,7 +2765,7 @@ func TestGeneratePatch_AtomicNestedArrayProducesReplace(t *testing.T) {
 		},
 	}
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -2798,7 +2798,7 @@ func TestGeneratePatch_BundledUpdate_DropsSerializationOnlyHintedOp(t *testing.T
 	document := []byte(`{"folderUid":"a","configJson":"{\"x\":1,\"y\":2}"}`)
 	patch := []byte(`{"folderUid":"b","configJson":"{\n  \"y\": 2,\n  \"x\": 1\n}"}`)
 
-	mutable, _, err := GeneratePatch(document, patch, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2816,7 +2816,7 @@ func TestGeneratePatch_GenuineHintedChange_KeepsOp(t *testing.T) {
 	document := []byte(`{"configJson":"{\"x\":1}"}`)
 	patch := []byte(`{"configJson":"{\"x\":2}"}`)
 
-	mutable, _, err := GeneratePatch(document, patch, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2830,7 +2830,7 @@ func TestGeneratePatch_FallbackKeepsOpOnInvalidJSON(t *testing.T) {
 	document := []byte(`{"configJson":"{\"x\":1}"}`)
 	patch := []byte(`{"configJson":"not json"}`)
 
-	mutable, _, err := GeneratePatch(document, patch, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2843,7 +2843,7 @@ func TestGeneratePatch_CreateOnlyHinted_SerializationOnly_NoReplacement(t *testi
 	schema := pkgmodel.Schema{Fields: []string{"configJson"}, Hints: map[string]pkgmodel.FieldHint{"configJson": {Format: "json", CreateOnly: true}}}
 	document := []byte(`{"configJson":"{\"x\":1,\"y\":2}"}`)
 	patch := []byte(`{"configJson":"{\"y\":2,\"x\":1}"}`)
-	mutable, createOnly, err := GeneratePatch(document, patch, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, createOnly, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2860,7 +2860,7 @@ func TestGeneratePatch_ArrayPathNeverDropped(t *testing.T) {
 	schema := pkgmodel.Schema{Fields: []string{"tags"}, Hints: map[string]pkgmodel.FieldHint{"tags": {Format: "json"}}}
 	document := []byte(`{"tags":["a","b"]}`)
 	patch := []byte(`{"tags":["a","c"]}`)
-	mutable, _, err := GeneratePatch(document, patch, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2883,7 +2883,7 @@ func TestGeneratePatch_RefResolutionMatchesApplied_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "an unchanged reference must reconcile to a no-op regardless of echo form")
@@ -2904,7 +2904,7 @@ func TestGeneratePatch_CreateOnlyRefMatchesApplied_NoReplacement(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "unchanged createOnly reference must not trigger replacement")
 	var ops []jsonpatch.JsonPatchOperation
@@ -2926,7 +2926,7 @@ func TestGeneratePatch_RefResolutionDiffersFromApplied_PlansUpdate(t *testing.T)
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", newArn)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	var ops []jsonpatch.JsonPatchOperation
@@ -2948,7 +2948,7 @@ func TestGeneratePatch_AppliedWithoutStoredEcho_FallsBackToFresh(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, _, err := generatePatch(document, patch, stored, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -2967,7 +2967,7 @@ func TestFlattenAndResolveRefs_UnresolvableRefWithApplied_UsesStoredEcho(t *test
 	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": %q, "$applied": %q}}`, ksuid, echoVal, appliedVal)
 	patch := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn"}}`, ksuid)
 
-	_, flatPatch, err := flattenAndResolveRefs(document, patch, stored, resolver.NewResolvableProperties())
+	_, flatPatch, err := flattenAndResolveRefs(document, patch, stored, nil, resolver.NewResolvableProperties())
 	require.NoError(t, err)
 
 	var flatMap map[string]any
@@ -2984,7 +2984,7 @@ func TestFlattenAndResolveRefs_UnresolvableRefWithoutApplied_FlattenToEmpty(t *t
 	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": %q}}`, ksuid, echoVal)
 	patch := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn"}}`, ksuid)
 
-	_, flatPatch, err := flattenAndResolveRefs(document, patch, stored, resolver.NewResolvableProperties())
+	_, flatPatch, err := flattenAndResolveRefs(document, patch, stored, nil, resolver.NewResolvableProperties())
 	require.NoError(t, err)
 
 	var flatMap map[string]any
@@ -3004,7 +3004,7 @@ func TestFlattenAndResolveRefs_UnresolvableRefAppliedWithoutStoredEcho_FlattensT
 	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$applied": %q}}`, ksuid, appliedVal)
 	patch := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn"}}`, ksuid)
 
-	_, flatPatch, err := flattenAndResolveRefs(document, patch, stored, resolver.NewResolvableProperties())
+	_, flatPatch, err := flattenAndResolveRefs(document, patch, stored, nil, resolver.NewResolvableProperties())
 	require.NoError(t, err)
 
 	var flatMap map[string]any
@@ -3026,7 +3026,7 @@ func TestGeneratePatch_LegacyRowWithoutApplied_KeepsFreshVsEcho(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, _, err := generatePatch(document, patch, stored, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3044,7 +3044,7 @@ func TestGeneratePatch_OpaqueRefIgnoresApplied(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Value", "sent")
 
-	patchDoc, _, err := generatePatch(document, patch, stored, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3064,7 +3064,7 @@ func TestGeneratePatch_NumericRefMatchesApplied_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Port", "443")
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "numeric ref matching $applied must reconcile to no-op")
@@ -3082,7 +3082,7 @@ func TestGeneratePatch_NumericRefDiffersFromApplied_PlansUpdate(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Port", "8443")
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	var ops []jsonpatch.JsonPatchOperation
@@ -3111,7 +3111,7 @@ func TestGeneratePatch_ArrayRefCounterpartMatchedByURI_NotIndex(t *testing.T) {
 	props.Add(ksuid, "ArnA", arnA)
 	props.Add(ksuid, "ArnB", arnB)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "reordered echoes of unchanged references must reconcile to a no-op")
@@ -3135,44 +3135,45 @@ func TestGeneratePatch_ArrayRefDuplicateURIs_FailsClosed(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "ArnA", arn)
 
-	patchDoc, _, err := generatePatch(document, patch, stored, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
 	assert.NotEmpty(t, ops, "ambiguous counterparts must not silently equal")
 }
 
-// The executor re-resolves references before calling a provider and re-derives
-// the patch from the resolved properties, so by then the desired side carries
-// the resolved value as a bare scalar rather than an envelope. A scalar that
-// equals what the last write applied is still an unchanged reference and must
-// not be rewritten.
-func TestGeneratePatch_FlattenedRefMatchingApplied_NoPatch(t *testing.T) {
+// The executor resolves references before calling a provider and re-derives the
+// patch from the resolved properties, so on that path the desired side holds the
+// resolved value alone. The envelope it came from still exists in the
+// unconverted desired properties, and a reference that resolves to what the last
+// write applied must not be rewritten.
+func TestGeneratePatch_ResolvedRefMatchingApplied_NoPatch(t *testing.T) {
 	ksuid := util.NewID()
 	arn := "arn:aws:kms:us-east-1:111122223333:key/47110862-aaaa"
 	document := []byte(`{"TargetKeyId": "47110862-aaaa"}`)
 	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": "47110862-aaaa", "$applied": %q}}`, ksuid, arn)
+	desired := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": %q}}`, ksuid, arn)
 	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
 	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "a resolved reference matching the applied baseline must not be rewritten")
 }
 
-// A resolved scalar that differs from the applied baseline is a genuine
-// repoint and must still be written.
-func TestGeneratePatch_FlattenedRefDifferingFromApplied_PlansUpdate(t *testing.T) {
+// A resolved reference pointing somewhere new is a genuine repoint.
+func TestGeneratePatch_ResolvedRefDifferingFromApplied_PlansUpdate(t *testing.T) {
 	ksuid := util.NewID()
 	oldArn := "arn:aws:kms:us-east-1:111122223333:key/47110862-aaaa"
 	newArn := "arn:aws:kms:us-east-1:111122223333:key/99887766-bbbb"
 	document := []byte(`{"TargetKeyId": "47110862-aaaa"}`)
 	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": "47110862-aaaa", "$applied": %q}}`, ksuid, oldArn)
+	desired := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": %q}}`, ksuid, newArn)
 	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, newArn)
 	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3180,15 +3181,56 @@ func TestGeneratePatch_FlattenedRefDifferingFromApplied_PlansUpdate(t *testing.T
 	assert.Equal(t, newArn, ops[0].Value)
 }
 
-// Opaque envelopes stay outside the provenance rules on this path too.
-func TestGeneratePatch_FlattenedOpaqueRefIgnoresApplied(t *testing.T) {
+// A user who replaces a reference with a literal is making a real edit, even
+// when the literal happens to equal what the reference last applied. The value
+// alone cannot distinguish the two, so the desired side must still carry the
+// envelope for the reference rule to apply.
+func TestGeneratePatch_LiteralReplacingRefMatchingApplied_PlansUpdate(t *testing.T) {
+	ksuid := util.NewID()
+	arn := "arn:aws:kms:us-east-1:111122223333:key/47110862-aaaa"
+	document := []byte(`{"TargetKeyId": "47110862-aaaa"}`)
+	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": "47110862-aaaa", "$applied": %q}}`, ksuid, arn)
+	desired := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
+	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
+	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	require.Len(t, ops, 1, "de-referencing a field is a user edit and must be planned")
+	assert.Equal(t, arn, ops[0].Value)
+}
+
+// A reference naming a different resource than the stored one is a repoint even
+// if the two resolve to equal values.
+func TestGeneratePatch_ResolvedRefWithDifferentURI_PlansUpdate(t *testing.T) {
+	storedKsuid := util.NewID()
+	desiredKsuid := util.NewID()
+	arn := "arn:aws:kms:us-east-1:111122223333:key/47110862-aaaa"
+	document := []byte(`{"TargetKeyId": "47110862-aaaa"}`)
+	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": "47110862-aaaa", "$applied": %q}}`, storedKsuid, arn)
+	desired := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": %q}}`, desiredKsuid, arn)
+	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
+	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	require.Len(t, ops, 1, "a reference to a different resource must be planned")
+}
+
+// Opaque envelopes stay outside the reference rules on this path too.
+func TestGeneratePatch_ResolvedOpaqueRefIgnoresApplied(t *testing.T) {
 	ksuid := util.NewID()
 	document := []byte(`{"Secret": "echoed"}`)
 	stored := fmt.Appendf(nil, `{"Secret": {"$ref": "formae://%s#/Value", "$value": "echoed", "$applied": "sent", "$visibility": "Opaque"}}`, ksuid)
+	desired := fmt.Appendf(nil, `{"Secret": {"$ref": "formae://%s#/Value", "$value": "sent", "$visibility": "Opaque"}}`, ksuid)
 	patch := []byte(`{"Secret": "sent"}`)
 	schema := pkgmodel.Schema{Fields: []string{"Secret"}}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3196,9 +3238,24 @@ func TestGeneratePatch_FlattenedOpaqueRefIgnoresApplied(t *testing.T) {
 	assert.Equal(t, "sent", ops[0].Value)
 }
 
-// Resolved array elements carry no reference URI, so their stored counterpart
-// is located by the applied baseline itself. Provider ordering must not matter.
-func TestGeneratePatch_FlattenedArrayRefsMatchingApplied_NoPatch(t *testing.T) {
+// A resolved reference whose value is structured (a list or object) follows the
+// same rule as a scalar one.
+func TestGeneratePatch_ResolvedStructuredRefMatchingApplied_NoPatch(t *testing.T) {
+	ksuid := util.NewID()
+	document := []byte(`{"Hosts": ["echo-a", "echo-b"]}`)
+	stored := fmt.Appendf(nil, `{"Hosts": {"$ref": "formae://%s#/Names", "$value": ["echo-a", "echo-b"], "$applied": ["a", "b"]}}`, ksuid)
+	desired := fmt.Appendf(nil, `{"Hosts": {"$ref": "formae://%s#/Names", "$value": ["a", "b"]}}`, ksuid)
+	patch := []byte(`{"Hosts": ["a", "b"]}`)
+	schema := pkgmodel.Schema{Fields: []string{"Hosts"}}
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Nil(t, patchDoc, "a structured resolution matching its baseline must not be rewritten")
+}
+
+// Stored arrays are persisted in provider order, so a resolved element's stored
+// counterpart is located by the reference the desired element names.
+func TestGeneratePatch_ResolvedArrayRefsMatchingApplied_NoPatch(t *testing.T) {
 	ksuid := util.NewID()
 	arnA := "arn:aws:sns:us-east-1:111122223333:topic-a"
 	arnB := "arn:aws:sns:us-east-1:111122223333:topic-b"
@@ -3207,18 +3264,48 @@ func TestGeneratePatch_FlattenedArrayRefsMatchingApplied_NoPatch(t *testing.T) {
 		{"$ref": "formae://%s#/ArnB", "$value": "name-b", "$applied": %q},
 		{"$ref": "formae://%s#/ArnA", "$value": "name-a", "$applied": %q}
 	]}`, ksuid, arnB, ksuid, arnA)
+	desired := fmt.Appendf(nil, `{"Topics": [
+		{"$ref": "formae://%s#/ArnA", "$value": %q},
+		{"$ref": "formae://%s#/ArnB", "$value": %q}
+	]}`, ksuid, arnA, ksuid, arnB)
 	patch := fmt.Appendf(nil, `{"Topics": [%q, %q]}`, arnA, arnB)
 	schema := pkgmodel.Schema{Fields: []string{"Topics"}}
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "resolved array references matching their baselines must not be rewritten")
 }
 
-// Two stored elements sharing one applied baseline give no unique counterpart,
-// so the elements keep their pre-provenance behavior.
-func TestGeneratePatch_FlattenedArrayRefsAmbiguousApplied_FailsClosed(t *testing.T) {
+// One element repointed and one unchanged: only the repointed element is
+// written, and it is written with the value the reference resolves to.
+func TestGeneratePatch_ResolvedArrayRefPartiallyRepointed_PlansOnlyTheChange(t *testing.T) {
+	ksuid := util.NewID()
+	arnA := "arn:aws:sns:us-east-1:111122223333:topic-a"
+	arnB := "arn:aws:sns:us-east-1:111122223333:topic-b"
+	arnC := "arn:aws:sns:us-east-1:111122223333:topic-c"
+	document := []byte(`{"Topics": ["name-a", "name-b"]}`)
+	stored := fmt.Appendf(nil, `{"Topics": [
+		{"$ref": "formae://%s#/ArnA", "$value": "name-a", "$applied": %q},
+		{"$ref": "formae://%s#/ArnB", "$value": "name-b", "$applied": %q}
+	]}`, ksuid, arnA, ksuid, arnB)
+	desired := fmt.Appendf(nil, `{"Topics": [
+		{"$ref": "formae://%s#/ArnA", "$value": %q},
+		{"$ref": "formae://%s#/ArnB", "$value": %q}
+	]}`, ksuid, arnA, ksuid, arnC)
+	patch := fmt.Appendf(nil, `{"Topics": [%q, %q]}`, arnA, arnC)
+	schema := pkgmodel.Schema{Fields: []string{"Topics"}}
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.NotNil(t, patchDoc)
+	assert.Contains(t, string(patchDoc), arnC, "the repointed element must be written")
+	assert.NotContains(t, string(patchDoc), arnA, "the unchanged element must not be rewritten")
+}
+
+// Two stored elements naming one reference give no unique counterpart, so the
+// elements keep their pre-existing behavior.
+func TestGeneratePatch_ResolvedArrayRefsAmbiguousStored_FailsClosed(t *testing.T) {
 	ksuid := util.NewID()
 	arn := "arn:aws:sns:us-east-1:111122223333:topic-a"
 	document := []byte(`{"Topics": ["name-a", "name-a"]}`)
@@ -3226,10 +3313,14 @@ func TestGeneratePatch_FlattenedArrayRefsAmbiguousApplied_FailsClosed(t *testing
 		{"$ref": "formae://%s#/ArnA", "$value": "name-a", "$applied": %q},
 		{"$ref": "formae://%s#/ArnA", "$value": "name-a", "$applied": %q}
 	]}`, ksuid, arn, ksuid, arn)
+	desired := fmt.Appendf(nil, `{"Topics": [
+		{"$ref": "formae://%s#/ArnA", "$value": %q},
+		{"$ref": "formae://%s#/ArnA", "$value": %q}
+	]}`, ksuid, arn, ksuid, arn)
 	patch := fmt.Appendf(nil, `{"Topics": [%q, %q]}`, arn, arn)
 	schema := pkgmodel.Schema{Fields: []string{"Topics"}}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -3421,3 +3421,77 @@ func TestGeneratePatch_ResolvedArrayRefWithStaleValue_PlansFreshResolution(t *te
 	assert.Contains(t, string(patchDoc), arnBMoved, "the moved element carries its current resolution")
 	assert.NotContains(t, string(patchDoc), arnA, "the unchanged element is not rewritten")
 }
+
+// A reference whose source resolves but cannot be read through its path is
+// broken, not absent. Falling back to the value recorded on the envelope would
+// compare as unchanged and leave the resource on its old value with nothing
+// reported, so the failure is surfaced instead.
+func TestGeneratePatch_ResolvedRefWithUnreadableJSONPath_Fails(t *testing.T) {
+	ksuid := util.NewID()
+	applied := "10.0.0.1"
+	document := []byte(`{"Endpoint": "10.0.0.1"}`)
+	stored := fmt.Appendf(nil, `{"Endpoint": {"$ref": "formae://%s#/Config", "$json": "address", "$value": "10.0.0.1", "$applied": %q}}`, ksuid, applied)
+	desired := fmt.Appendf(nil, `{"Endpoint": {"$ref": "formae://%s#/Config", "$json": "address", "$value": %q}}`, ksuid, applied)
+	patch := fmt.Appendf(nil, `{"Endpoint": %q}`, applied)
+	schema := pkgmodel.Schema{Fields: []string{"Endpoint"}}
+	props := resolver.NewResolvableProperties()
+	// The source resolves, but no longer carries the path the reference reads.
+	props.Add(ksuid, "Config", `{"host":"10.0.0.2"}`)
+
+	_, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.Error(t, err, "a reference that cannot be read through its path must not be treated as unchanged")
+	assert.Contains(t, err.Error(), "address")
+}
+
+// The same on an immutable field, where silently comparing as unchanged would
+// also swallow the replacement.
+func TestGeneratePatch_CreateOnlyResolvedRefWithUnreadableJSONPath_Fails(t *testing.T) {
+	ksuid := util.NewID()
+	applied := "fn-v1"
+	document := []byte(`{"TargetFunctionArn": "fn-v1"}`)
+	stored := fmt.Appendf(nil, `{"TargetFunctionArn": {"$ref": "formae://%s#/Config", "$json": "arn", "$value": "fn-v1", "$applied": %q}}`, ksuid, applied)
+	desired := fmt.Appendf(nil, `{"TargetFunctionArn": {"$ref": "formae://%s#/Config", "$json": "arn", "$value": %q}}`, ksuid, applied)
+	patch := fmt.Appendf(nil, `{"TargetFunctionArn": %q}`, applied)
+	schema := pkgmodel.Schema{
+		Fields: []string{"TargetFunctionArn"},
+		Hints:  map[string]pkgmodel.FieldHint{"TargetFunctionArn": {CreateOnly: true}},
+	}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "Config", `{"name":"fn-v2"}`)
+
+	_, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.Error(t, err, "an unreadable reference on an immutable field must not silently suppress the replacement")
+}
+
+// The array path surfaces the same failure.
+func TestGeneratePatch_ResolvedArrayRefWithUnreadableJSONPath_Fails(t *testing.T) {
+	ksuid := util.NewID()
+	applied := "10.0.0.1"
+	document := []byte(`{"Endpoints": ["10.0.0.1"]}`)
+	stored := fmt.Appendf(nil, `{"Endpoints": [{"$ref": "formae://%s#/Config", "$json": "address", "$value": "10.0.0.1", "$applied": %q}]}`, ksuid, applied)
+	desired := fmt.Appendf(nil, `{"Endpoints": [{"$ref": "formae://%s#/Config", "$json": "address", "$value": %q}]}`, ksuid, applied)
+	patch := fmt.Appendf(nil, `{"Endpoints": [%q]}`, applied)
+	schema := pkgmodel.Schema{Fields: []string{"Endpoints"}}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "Config", `{"host":"10.0.0.2"}`)
+
+	_, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.Error(t, err, "an unreadable array reference must not be treated as unchanged")
+}
+
+// A reference whose source is not resolvable at all is a different situation:
+// nothing is broken, the value simply is not available yet, so the recorded
+// resolution still stands and the reference is not rewritten.
+func TestGeneratePatch_ResolvedRefWithUnresolvableSource_UsesRecordedValue(t *testing.T) {
+	ksuid := util.NewID()
+	applied := "10.0.0.1"
+	document := []byte(`{"Endpoint": "echo-10.0.0.1"}`)
+	stored := fmt.Appendf(nil, `{"Endpoint": {"$ref": "formae://%s#/Config", "$json": "address", "$value": "echo-10.0.0.1", "$applied": %q}}`, ksuid, applied)
+	desired := fmt.Appendf(nil, `{"Endpoint": {"$ref": "formae://%s#/Config", "$json": "address", "$value": %q}}`, ksuid, applied)
+	patch := fmt.Appendf(nil, `{"Endpoint": %q}`, applied)
+	schema := pkgmodel.Schema{Fields: []string{"Endpoint"}}
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Nil(t, patchDoc, "an unavailable source leaves the recorded resolution standing")
+}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -3141,3 +3141,97 @@ func TestGeneratePatch_ArrayRefDuplicateURIs_FailsClosed(t *testing.T) {
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
 	assert.NotEmpty(t, ops, "ambiguous counterparts must not silently equal")
 }
+
+// The executor re-resolves references before calling a provider and re-derives
+// the patch from the resolved properties, so by then the desired side carries
+// the resolved value as a bare scalar rather than an envelope. A scalar that
+// equals what the last write applied is still an unchanged reference and must
+// not be rewritten.
+func TestGeneratePatch_FlattenedRefMatchingApplied_NoPatch(t *testing.T) {
+	ksuid := util.NewID()
+	arn := "arn:aws:kms:us-east-1:111122223333:key/47110862-aaaa"
+	document := []byte(`{"TargetKeyId": "47110862-aaaa"}`)
+	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": "47110862-aaaa", "$applied": %q}}`, ksuid, arn)
+	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
+	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
+
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, createOnlyPatch)
+	assert.Nil(t, patchDoc, "a resolved reference matching the applied baseline must not be rewritten")
+}
+
+// A resolved scalar that differs from the applied baseline is a genuine
+// repoint and must still be written.
+func TestGeneratePatch_FlattenedRefDifferingFromApplied_PlansUpdate(t *testing.T) {
+	ksuid := util.NewID()
+	oldArn := "arn:aws:kms:us-east-1:111122223333:key/47110862-aaaa"
+	newArn := "arn:aws:kms:us-east-1:111122223333:key/99887766-bbbb"
+	document := []byte(`{"TargetKeyId": "47110862-aaaa"}`)
+	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": "47110862-aaaa", "$applied": %q}}`, ksuid, oldArn)
+	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, newArn)
+	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
+
+	patchDoc, _, err := generatePatch(document, patch, stored, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	require.Len(t, ops, 1)
+	assert.Equal(t, newArn, ops[0].Value)
+}
+
+// Opaque envelopes stay outside the provenance rules on this path too.
+func TestGeneratePatch_FlattenedOpaqueRefIgnoresApplied(t *testing.T) {
+	ksuid := util.NewID()
+	document := []byte(`{"Secret": "echoed"}`)
+	stored := fmt.Appendf(nil, `{"Secret": {"$ref": "formae://%s#/Value", "$value": "echoed", "$applied": "sent", "$visibility": "Opaque"}}`, ksuid)
+	patch := []byte(`{"Secret": "sent"}`)
+	schema := pkgmodel.Schema{Fields: []string{"Secret"}}
+
+	patchDoc, _, err := generatePatch(document, patch, stored, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	require.Len(t, ops, 1, "opaque envelopes keep their existing behavior")
+	assert.Equal(t, "sent", ops[0].Value)
+}
+
+// Resolved array elements carry no reference URI, so their stored counterpart
+// is located by the applied baseline itself. Provider ordering must not matter.
+func TestGeneratePatch_FlattenedArrayRefsMatchingApplied_NoPatch(t *testing.T) {
+	ksuid := util.NewID()
+	arnA := "arn:aws:sns:us-east-1:111122223333:topic-a"
+	arnB := "arn:aws:sns:us-east-1:111122223333:topic-b"
+	document := []byte(`{"Topics": ["name-b", "name-a"]}`)
+	stored := fmt.Appendf(nil, `{"Topics": [
+		{"$ref": "formae://%s#/ArnB", "$value": "name-b", "$applied": %q},
+		{"$ref": "formae://%s#/ArnA", "$value": "name-a", "$applied": %q}
+	]}`, ksuid, arnB, ksuid, arnA)
+	patch := fmt.Appendf(nil, `{"Topics": [%q, %q]}`, arnA, arnB)
+	schema := pkgmodel.Schema{Fields: []string{"Topics"}}
+
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, createOnlyPatch)
+	assert.Nil(t, patchDoc, "resolved array references matching their baselines must not be rewritten")
+}
+
+// Two stored elements sharing one applied baseline give no unique counterpart,
+// so the elements keep their pre-provenance behavior.
+func TestGeneratePatch_FlattenedArrayRefsAmbiguousApplied_FailsClosed(t *testing.T) {
+	ksuid := util.NewID()
+	arn := "arn:aws:sns:us-east-1:111122223333:topic-a"
+	document := []byte(`{"Topics": ["name-a", "name-a"]}`)
+	stored := fmt.Appendf(nil, `{"Topics": [
+		{"$ref": "formae://%s#/ArnA", "$value": "name-a", "$applied": %q},
+		{"$ref": "formae://%s#/ArnA", "$value": "name-a", "$applied": %q}
+	]}`, ksuid, arn, ksuid, arn)
+	patch := fmt.Appendf(nil, `{"Topics": [%q, %q]}`, arn, arn)
+	schema := pkgmodel.Schema{Fields: []string{"Topics"}}
+
+	patchDoc, _, err := generatePatch(document, patch, stored, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	assert.NotEmpty(t, ops, "ambiguous counterparts must not silently compare equal")
+}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -3495,3 +3495,59 @@ func TestGeneratePatch_ResolvedRefWithUnresolvableSource_UsesRecordedValue(t *te
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "an unavailable source leaves the recorded resolution standing")
 }
+
+// An array element's reference whose recorded value was an object can resolve
+// to a scalar now. The current resolution has to survive back into the desired
+// side; keeping the recorded object would compare as unchanged and drop the
+// update.
+func TestGeneratePatch_ResolvedArrayRefChangingShape_PlansFreshResolution(t *testing.T) {
+	ksuid := util.NewID()
+	document := []byte(`{"Backends": [{"host":"h1"}]}`)
+	stored := fmt.Appendf(nil, `{"Backends": [{"$ref": "formae://%s#/Cfg", "$value": {"host":"h1"}, "$applied": {"host":"h1"}}]}`, ksuid)
+	desired := fmt.Appendf(nil, `{"Backends": [{"$ref": "formae://%s#/Cfg", "$value": {"host":"h1"}}]}`, ksuid)
+	patch := []byte(`{"Backends": [{"host":"h1"}]}`)
+	schema := pkgmodel.Schema{Fields: []string{"Backends"}}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "Cfg", "h2")
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.NotNil(t, patchDoc, "a reference resolving to a new shape must be planned")
+	assert.Contains(t, string(patchDoc), "h2", "the plan must carry the current resolution")
+}
+
+// The same on an immutable field must still force a replacement.
+func TestGeneratePatch_CreateOnlyResolvedArrayRefChangingShape_PlansReplacement(t *testing.T) {
+	ksuid := util.NewID()
+	document := []byte(`{"Backends": [{"host":"h1"}]}`)
+	stored := fmt.Appendf(nil, `{"Backends": [{"$ref": "formae://%s#/Cfg", "$value": {"host":"h1"}, "$applied": {"host":"h1"}}]}`, ksuid)
+	desired := fmt.Appendf(nil, `{"Backends": [{"$ref": "formae://%s#/Cfg", "$value": {"host":"h1"}}]}`, ksuid)
+	patch := []byte(`{"Backends": [{"host":"h1"}]}`)
+	schema := pkgmodel.Schema{
+		Fields: []string{"Backends"},
+		Hints:  map[string]pkgmodel.FieldHint{"Backends": {CreateOnly: true}},
+	}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "Cfg", "h2")
+
+	_, createOnlyPatch, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.NotEmpty(t, createOnlyPatch, "a shape-changing reference on an immutable field must still force a replacement")
+}
+
+// An object-valued array reference that still resolves to its recorded value
+// stays suppressed, so the write-back does not reintroduce churn.
+func TestGeneratePatch_ResolvedArrayRefObjectMatchingApplied_NoPatch(t *testing.T) {
+	ksuid := util.NewID()
+	document := []byte(`{"Backends": [{"host":"echo-h1"}]}`)
+	stored := fmt.Appendf(nil, `{"Backends": [{"$ref": "formae://%s#/Cfg", "$value": {"host":"echo-h1"}, "$applied": {"host":"h1"}}]}`, ksuid)
+	desired := fmt.Appendf(nil, `{"Backends": [{"$ref": "formae://%s#/Cfg", "$value": {"host":"h1"}}]}`, ksuid)
+	patch := []byte(`{"Backends": [{"host":"h1"}]}`)
+	schema := pkgmodel.Schema{Fields: []string{"Backends"}}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "Cfg", `{"host":"h1"}`)
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Nil(t, patchDoc, "an unchanged object-valued reference must not be rewritten")
+}

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -177,6 +177,7 @@ func (ru *ResourceUpdate) regeneratePatchDocument() (json.RawMessage, error) {
 		existingPluginProps,
 		newPluginProps,
 		existingForPatch,
+		desiredForPatch,
 		resolver.NewResolvableProperties(),
 		ru.DesiredState.Schema,
 		pkgmodel.FormaApplyModePatch,

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -89,6 +89,7 @@ func NewResourceUpdateForExisting(
 			existingPluginProps,
 			newPluginProps,
 			existingForPatch,
+			desiredForPatch,
 			resolvableProperties,
 			newResource.Schema,
 			mode,

--- a/internal/workflow_tests/local/apply_forma/cascade_replace_cross_form_test.go
+++ b/internal/workflow_tests/local/apply_forma/cascade_replace_cross_form_test.go
@@ -38,6 +38,12 @@ import (
 // referenced resource is replaced: the planner reaches it through the
 // dependency pass rather than its own diff, and the executor re-resolves the
 // reference after the replacement completes.
+//
+// This guards behavior that already holds: the dependency pass is what keeps
+// the repointing correct once a dependent's own diff falls silent. It is here
+// because nothing else pins that interaction, and a change to either half
+// would otherwise strand dependents pointing at a resource that no longer
+// exists.
 func TestApplyForma_ParentReplace_CrossFormRef_DependentIsRepointed(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		// The parent's identity as the cloud reports it; flipped between the

--- a/internal/workflow_tests/local/apply_forma/cascade_replace_cross_form_test.go
+++ b/internal/workflow_tests/local/apply_forma/cascade_replace_cross_form_test.go
@@ -1,0 +1,250 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// TestApplyForma_ParentReplace_CrossFormRef_DependentIsRepointed covers a
+// dependent whose provider echoes the reference in a DIFFERENT FORM than the
+// one the reference resolves to (an identifier spelled as an ARN on read but
+// as a bare name on write). That combination is what puts an applied-baseline
+// marker on the dependent's stored envelope, and it is the case where the
+// dependent's own property diff compares equal and therefore plans nothing.
+//
+// The dependent must still be repointed within the same apply when the
+// referenced resource is replaced: the planner reaches it through the
+// dependency pass rather than its own diff, and the executor re-resolves the
+// reference after the replacement completes.
+func TestApplyForma_ParentReplace_CrossFormRef_DependentIsRepointed(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		// The parent's identity as the cloud reports it; flipped between the
+		// two applies so the executor's re-resolution observes the new one.
+		var parentName atomic.Value
+		parentName.Store("parent-v1")
+
+		// The form the provider echoes for the dependent's reference field.
+		// It never equals the form the reference resolves to, which is the
+		// whole point of this fixture.
+		echoForm := func(name string) string { return "arn:fake:parent/" + name }
+
+		var consumerUpdatePatch atomic.Value
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				props := json.RawMessage(fmt.Sprintf(`{"Name":"%s","Value":"hello"}`,
+					parentName.Load().(string)))
+				if req.ResourceType == "FakeAWS::Formed::Consumer" {
+					// The provider reports the reference in its own spelling,
+					// which is never the spelling the reference resolves to.
+					props = json.RawMessage(fmt.Sprintf(`{"Name":"consumer-1","ParentRef":"%s"}`,
+						echoForm(parentName.Load().(string))))
+				}
+				return &resource.CreateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:          resource.OperationCreate,
+						OperationStatus:    resource.OperationStatusSuccess,
+						NativeID:           req.Label,
+						ResourceProperties: props,
+					},
+				}, nil
+			},
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				switch req.ResourceType {
+				case "FakeAWS::Formed::Parent":
+					name := parentName.Load().(string)
+					return &resource.ReadResult{
+						ResourceType: req.ResourceType,
+						Properties:   fmt.Sprintf(`{"Name":"%s","Value":"hello"}`, name),
+					}, nil
+				case "FakeAWS::Formed::Consumer":
+					// Pre-update cloud state: the dependent still carries the
+					// echoed form of the OLD parent identity, because its own
+					// Update has not fired yet.
+					return &resource.ReadResult{
+						ResourceType: req.ResourceType,
+						Properties: fmt.Sprintf(`{"Name":"consumer-1","ParentRef":"%s"}`,
+							echoForm("parent-v1")),
+					}, nil
+				}
+				return nil, nil
+			},
+			Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				if req.ResourceType == "FakeAWS::Formed::Consumer" && req.PatchDocument != nil {
+					consumerUpdatePatch.Store(*req.PatchDocument)
+				}
+				return &resource.UpdateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationUpdate,
+						OperationStatus: resource.OperationStatusSuccess,
+						RequestID:       "update-req-1",
+						NativeID:        req.NativeID,
+					},
+				}, nil
+			},
+		}
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		parentSchema := pkgmodel.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "Value"},
+			Hints: map[string]pkgmodel.FieldHint{
+				"Name": {CreateOnly: true},
+			},
+		}
+		consumerSchema := pkgmodel.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "ParentRef"},
+			Hints: map[string]pkgmodel.FieldHint{
+				"Name":      {CreateOnly: true},
+				"ParentRef": {CreateOnly: false},
+			},
+		}
+
+		consumerProperties := json.RawMessage(`{
+			"Name": "consumer-1",
+			"ParentRef": {
+				"$res": true,
+				"$label": "parent",
+				"$type": "FakeAWS::Formed::Parent",
+				"$stack": "test-stack",
+				"$property": "Name"
+			}
+		}`)
+
+		formaFor := func(parentValue string) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+				Resources: []pkgmodel.Resource{
+					{
+						Label:      "parent",
+						Type:       "FakeAWS::Formed::Parent",
+						Properties: json.RawMessage(fmt.Sprintf(`{"Name":"%s","Value":"hello"}`, parentValue)),
+						Stack:      "test-stack",
+						Target:     "test-target",
+						Managed:    true,
+						Schema:     parentSchema,
+					},
+					{
+						Label:      "consumer",
+						Type:       "FakeAWS::Formed::Consumer",
+						Properties: consumerProperties,
+						Stack:      "test-stack",
+						Target:     "test-target",
+						Managed:    true,
+						Schema:     consumerSchema,
+					},
+				},
+				Targets: []pkgmodel.Target{{Label: "test-target"}},
+			}
+		}
+
+		_, err = m.ApplyForma(formaFor("parent-v1"), &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test")
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			fas, _ := m.Datastore.LoadFormaCommands()
+			if len(fas) == 0 {
+				return false
+			}
+			return fas[0].State == forma_command.CommandStateSuccess || fas[0].State == forma_command.CommandStateFailed
+		}, 10*time.Second, 100*time.Millisecond, "v1 should reach terminal state")
+		fas, _ := m.Datastore.LoadFormaCommands()
+		require.Equal(t, forma_command.CommandStateSuccess, fas[0].State, "v1 apply should succeed")
+
+		// Guard the fixture itself: the dependent's stored envelope must hold
+		// the echoed form as its value and the written form as its applied
+		// baseline. Without both, the scenario under test is not set up and
+		// the assertions below would pass for the wrong reason.
+		stored, err := m.Datastore.LoadResourcesByStack("test-stack")
+		require.NoError(t, err)
+		var consumerStored *pkgmodel.Resource
+		for _, r := range stored {
+			if r.Label == "consumer" {
+				consumerStored = r
+			}
+		}
+		require.NotNil(t, consumerStored, "consumer must be stored after v1")
+		envelope := gjson.GetBytes(consumerStored.Properties, "ParentRef")
+		require.Equal(t, echoForm("parent-v1"), envelope.Get("$value").String(),
+			"fixture guard: stored value must be the echoed form")
+		require.Equal(t, "parent-v1", envelope.Get("$applied").String(),
+			"fixture guard: stored envelope must carry the written form as its applied baseline")
+
+		// v2: the parent's CreateOnly identity changes, forcing a replacement.
+		parentName.Store("parent-v2")
+
+		_, err = m.ApplyForma(formaFor("parent-v2"), &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test")
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			fas, _ := m.Datastore.LoadFormaCommands()
+			if len(fas) < 2 {
+				return false
+			}
+			return fas[0].State == forma_command.CommandStateSuccess || fas[0].State == forma_command.CommandStateFailed
+		}, 30*time.Second, 100*time.Millisecond, "v2 should reach terminal state")
+		fas, _ = m.Datastore.LoadFormaCommands()
+		require.Equal(t, forma_command.CommandStateSuccess, fas[0].State, "v2 apply should succeed end-to-end")
+
+		var parentOps, consumerOps []resource_update.OperationType
+		var consumerRU *resource_update.ResourceUpdate
+		for i, ru := range fas[0].ResourceUpdates {
+			switch ru.DesiredState.Label {
+			case "parent":
+				parentOps = append(parentOps, ru.Operation)
+			case "consumer":
+				consumerOps = append(consumerOps, ru.Operation)
+				consumerRU = &fas[0].ResourceUpdates[i]
+			}
+		}
+		assert.Len(t, parentOps, 2, "parent should be replaced (delete + create)")
+		assert.Contains(t, parentOps, resource_update.OperationDelete)
+		assert.Contains(t, parentOps, resource_update.OperationCreate)
+		require.Len(t, consumerOps, 1, "dependent must be repointed within the same apply")
+		assert.Equal(t, resource_update.OperationUpdate, consumerOps[0])
+		// The dependent's own property diff compares equal here (its reference
+		// resolves to the same value it last applied), so the update it gets
+		// must come from the dependency pass. Asserting the provenance of the
+		// update keeps this test honest: without the flag, a dependent that
+		// planned an update for some unrelated reason would satisfy the count
+		// above and hide a genuine repointing failure.
+		require.NotNil(t, consumerRU)
+		assert.True(t, consumerRU.IsCascade,
+			"the dependent's update must come from the dependency pass, not its own diff")
+		assert.Equal(t, "parent", consumerRU.CascadeSource)
+
+		patch := consumerUpdatePatch.Load()
+		require.NotNil(t, patch, "the provider must receive an Update for the dependent")
+		assert.Contains(t, fmt.Sprintf("%s", patch), "parent-v2",
+			"the patch handed to the provider must carry the replaced parent's new identity")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/reference_provenance_execution_test.go
+++ b/internal/workflow_tests/local/apply_forma/reference_provenance_execution_test.go
@@ -1,0 +1,197 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// TestApplyForma_UnchangedReference_IsAbsentFromTheExecutedPatch pins the
+// patch a provider actually receives when an unrelated field changes on a
+// resource that also carries a reference the provider echoes in a different
+// spelling.
+//
+// The reference is unchanged, so it must appear in neither the simulated
+// plan nor the executed patch. The executed patch is the load-bearing half:
+// the executor re-resolves every reference before the provider call and
+// re-derives the patch from the resolved properties, which is a separate
+// code path from the one the plan is built on.
+func TestApplyForma_UnchangedReference_IsAbsentFromTheExecutedPatch(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		echoForm := func(name string) string { return "arn:fake:parent/" + name }
+
+		var consumerUpdatePatch atomic.Value
+		var consumerNote atomic.Value
+		consumerNote.Store("note-v1")
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				props := json.RawMessage(`{"Name":"parent-v1","Value":"hello"}`)
+				if req.ResourceType == "FakeAWS::Noted::Consumer" {
+					props = json.RawMessage(fmt.Sprintf(
+						`{"Name":"consumer-1","Note":"%s","ParentRef":"%s"}`,
+						consumerNote.Load().(string), echoForm("parent-v1")))
+				}
+				return &resource.CreateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:          resource.OperationCreate,
+						OperationStatus:    resource.OperationStatusSuccess,
+						NativeID:           req.Label,
+						ResourceProperties: props,
+					},
+				}, nil
+			},
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				switch req.ResourceType {
+				case "FakeAWS::Noted::Parent":
+					return &resource.ReadResult{
+						ResourceType: req.ResourceType,
+						Properties:   `{"Name":"parent-v1","Value":"hello"}`,
+					}, nil
+				case "FakeAWS::Noted::Consumer":
+					return &resource.ReadResult{
+						ResourceType: req.ResourceType,
+						Properties: fmt.Sprintf(`{"Name":"consumer-1","Note":"%s","ParentRef":"%s"}`,
+							consumerNote.Load().(string), echoForm("parent-v1")),
+					}, nil
+				}
+				return nil, nil
+			},
+			Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				if req.ResourceType == "FakeAWS::Noted::Consumer" && req.PatchDocument != nil {
+					consumerUpdatePatch.Store(fmt.Sprintf("%s", *req.PatchDocument))
+				}
+				return &resource.UpdateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationUpdate,
+						OperationStatus: resource.OperationStatusSuccess,
+						RequestID:       "update-req-1",
+						NativeID:        req.NativeID,
+					},
+				}, nil
+			},
+		}
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		parentSchema := pkgmodel.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "Value"},
+			Hints:      map[string]pkgmodel.FieldHint{"Name": {CreateOnly: true}},
+		}
+		consumerSchema := pkgmodel.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "Note", "ParentRef"},
+			Hints: map[string]pkgmodel.FieldHint{
+				"Name":      {CreateOnly: true},
+				"ParentRef": {CreateOnly: false},
+			},
+		}
+
+		formaFor := func(note string) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+				Resources: []pkgmodel.Resource{
+					{
+						Label:      "parent",
+						Type:       "FakeAWS::Noted::Parent",
+						Properties: json.RawMessage(`{"Name":"parent-v1","Value":"hello"}`),
+						Stack:      "test-stack",
+						Target:     "test-target",
+						Managed:    true,
+						Schema:     parentSchema,
+					},
+					{
+						Label: "consumer",
+						Type:  "FakeAWS::Noted::Consumer",
+						Properties: json.RawMessage(fmt.Sprintf(`{
+							"Name": "consumer-1",
+							"Note": "%s",
+							"ParentRef": {
+								"$res": true,
+								"$label": "parent",
+								"$type": "FakeAWS::Noted::Parent",
+								"$stack": "test-stack",
+								"$property": "Name"
+							}
+						}`, note)),
+						Stack:   "test-stack",
+						Target:  "test-target",
+						Managed: true,
+						Schema:  consumerSchema,
+					},
+				},
+				Targets: []pkgmodel.Target{{Label: "test-target"}},
+			}
+		}
+
+		_, err = m.ApplyForma(formaFor("note-v1"), &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test")
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			fas, _ := m.Datastore.LoadFormaCommands()
+			return len(fas) > 0 && (fas[0].State == forma_command.CommandStateSuccess || fas[0].State == forma_command.CommandStateFailed)
+		}, 10*time.Second, 100*time.Millisecond, "v1 should reach terminal state")
+		fas, _ := m.Datastore.LoadFormaCommands()
+		require.Equal(t, forma_command.CommandStateSuccess, fas[0].State, "v1 apply should succeed")
+
+		// Change only the unrelated field. The reference still resolves to
+		// the same parent identity it was applied with.
+		consumerNote.Store("note-v1") // the cloud still reports the pre-update note
+		v2 := formaFor("note-v2")
+
+		simResp, err := m.ApplyForma(v2, &config.FormaCommandConfig{
+			Mode:     pkgmodel.FormaApplyModeReconcile,
+			Simulate: true,
+		}, "test")
+		require.NoError(t, err)
+		require.True(t, simResp.Simulation.ChangesRequired, "changing the note should produce a change")
+		var plannedPatch string
+		for _, ru := range simResp.Simulation.Command.ResourceUpdates {
+			if ru.ResourceLabel == "consumer" {
+				plannedPatch = string(ru.PatchDocument)
+			}
+		}
+		require.Contains(t, plannedPatch, "/Note", "the plan should carry the changed field")
+		require.NotContains(t, plannedPatch, "/ParentRef",
+			"the plan must not touch a reference that still resolves to what was applied")
+
+		_, err = m.ApplyForma(v2, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test")
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			fas, _ := m.Datastore.LoadFormaCommands()
+			return len(fas) >= 2 && (fas[0].State == forma_command.CommandStateSuccess || fas[0].State == forma_command.CommandStateFailed)
+		}, 30*time.Second, 100*time.Millisecond, "v2 should reach terminal state")
+		fas, _ = m.Datastore.LoadFormaCommands()
+		require.Equal(t, forma_command.CommandStateSuccess, fas[0].State, "v2 apply should succeed")
+
+		executed := consumerUpdatePatch.Load()
+		require.NotNil(t, executed, "the provider must receive the consumer's update")
+		assert.Contains(t, executed.(string), "/Note", "the executed patch should carry the changed field")
+		assert.NotContains(t, executed.(string), "/ParentRef",
+			"the executed patch must match the plan: an unchanged reference is not rewritten")
+	})
+}


### PR DESCRIPTION
## Summary

Investigating the reported "dependents of a resource replaced in the same apply are not repointed until the next reconcile" turned up something different: that does not happen. The dependency pass already plans an update for the dependent when its own diff falls silent, and the executor re-resolves the reference after the replacement completes. What is real is a disagreement between the plan and the patch the provider actually receives.

**The plan and the executed patch disagreed on reference-fed fields.** Changing an unrelated field on a resource that also carries a reference produced a plan of `[/Note]` but handed the provider `[/Note, /ParentRef]`. The executor resolves references before calling a provider and re-derives the patch from the resolved properties; that conversion flattens the now-resolved envelope to a bare value, leaving nothing for the reference comparison to match, so the reference was rewritten with the resolution spelling over the provider's echoed spelling on every update. This is the same class of write the applied-baseline comparison was added to eliminate, surviving on the execution path only.

The fix threads the unconverted desired properties into patch generation alongside the stored ones. A resolved value is treated as an unchanged reference only when the desired side still carries the envelope it came from, that envelope names the same reference as the stored one, and it resolves to what the last write applied. All three conditions matter: matching on the value alone cannot distinguish a resolved reference from a user replacing the reference with a literal equal to what was last applied, and suppressing the latter would silently drop that edit and leave the stored envelope, and its dependency edge, in place.

Applying the rule before the value's shape is inspected also covers list- and object-valued resolutions, which diverged between plan and execution the same way. Inside arrays, desired elements are matched by index (the same document, same order) while stored elements are matched by reference, since the provider may return them in any order; ambiguity fails closed.

## Tests

- Two workflow tests covering the end-to-end paths: one pinning that a dependent is repointed within the same apply when the resource it references is replaced (asserting the update comes from the dependency pass, so it cannot pass for the wrong reason), and one asserting the executed patch matches the plan.
- Patch-level tests for each rule, including the de-reference case and a reference pointing at a different resource. I verified the discriminating tests fail without the production change, and that the two guard tests fail under a value-only comparison.
- Two drift tests characterize an existing property: the applied baseline never appears in drift output. They pass without any production change and are labeled as such.

## Follow-up filed

The echo substituted for comparison rides along inside coarse-grained operations on Array-hinted and Atomic-hinted fields, so a provider can receive the read spelling instead of the write spelling. That predates this branch (it came in with the applied-baseline comparison) and is tracked separately.

## Review rounds

Cross-model adversarial review ran four times against this branch and found three distinct defects, each now fixed with tests that fail without the fix:

1. A resolution recorded on the desired envelope outranked a current one, so a reference that had moved could compare as unchanged: the update was dropped, and on an immutable field the replacement went with it.
2. A reference whose source resolves but whose `$json` path no longer reads was reported as unavailable and fell back to the recorded value. It now fails, matching the path for a not-yet-resolved reference; the fallback is kept only when nothing resolves at all.
3. An array element whose recorded value was an object had a shape-changing resolution dropped by a write-back that only copied structured results.

## Known limitation, tracked separately

Where the diff emits at a coarser granularity than a single field (an Atomic-hinted object, an ordered Array-hinted list), the value substituted for comparison rides along inside the emitted operation, so a provider can receive the reference in its read spelling. That already happens on main through the planning path; this branch extends it to the execution path as a consequence of making the two agree. It needs a reference on an Atomic-hinted or ordered-Array-hinted field, which no conformance fixture currently has.

The reviewer's assessment is that this is not separable from substituting into the desired document, since that value serves both comparison and emission. The follow-up is filed and is next in the queue: the plan is to try substituting into the comparison side instead, which leaves emitted values untouched, and to fall back to separate comparison and emission documents if that does not hold.