### PR TITLE
fix(patch): keep the provider's read spelling out of the patch it receives

### DIFF
--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -1035,7 +1035,14 @@ func substituteResolvedRef(desiredNode, storedNode, modNode, currentNode any, re
 	// The value formae would write is returned either way. When the reference is
 	// unchanged the caller aligns the comparison side instead of rewriting this
 	// one, so an operation covering this path still carries the written form.
-	return resolvedRefDecision{Value: effective, Echo: storedEnv["$value"], Matched: matchesApplied}, true, nil
+	//
+	// For an unchanged reference that value is the record itself, which keeps
+	// the JSON type that was written: a resolution arrives as text, so a number
+	// or boolean would otherwise be written back as a string.
+	if matchesApplied {
+		return resolvedRefDecision{Value: storedEnv["$applied"], Echo: storedEnv["$value"], Matched: true}, true, nil
+	}
+	return resolvedRefDecision{Value: effective, Echo: storedEnv["$value"], Matched: false}, true, nil
 }
 
 // resolvedRefDecision carries what the desired side should hold for an
@@ -1199,14 +1206,20 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 					native := normalizeResolvedValue(resolved, current[k])
 					modVal["$value"] = native
 					if counterpart != nil {
-						if applied, hasApplied := counterpart["$applied"]; hasApplied && appliedMatches(resolved, applied) && counterpart["$value"] != nil {
+						if applied, hasApplied := counterpart["$applied"]; hasApplied && applied != nil && appliedMatches(resolved, applied) && counterpart["$value"] != nil {
+							// Carry the recorded value itself rather than the
+							// freshly resolved text. Resolution yields text, while
+							// the record keeps the JSON type that was written, so
+							// a number or boolean would otherwise be written back
+							// as a string.
+							modVal["$value"] = applied
 							// The reference still resolves to what the last write
 							// sent, so it is unchanged. Align the comparison side
 							// rather than the desired side: the desired side is
 							// where operation values come from, and rewriting it
 							// to the provider's spelling would send that spelling
 							// back inside any operation covering this path.
-							alignComparisonValue(current, k, counterpart["$value"], native)
+							alignComparisonValue(current, k, counterpart["$value"], applied)
 						}
 					}
 				} else if counterpart != nil {

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -1014,10 +1014,10 @@ func freshResolution(env map[string]any, current any, resolvableProperties resol
 // and the reference is not rewritten in the provider's own spelling. Otherwise
 // the desired side carries the current resolution, so a genuine repoint is
 // planned (and, on an immutable field, still forces a replacement).
-func substituteResolvedRef(desiredNode, storedNode, modNode, currentNode any, resolvableProperties resolver.ResolvableProperties) (any, bool, error) {
+func substituteResolvedRef(desiredNode, storedNode, modNode, currentNode any, resolvableProperties resolver.ResolvableProperties) (any, bool, bool, error) {
 	desiredEnv, ok := resolvedDesiredEnvelope(desiredNode, modNode)
 	if !ok {
-		return nil, false, nil
+		return nil, false, false, nil
 	}
 	storedEnv := storedAppliedEnvelope(storedNode)
 	sameRef := storedEnv != nil && storedEnv["$ref"] == desiredEnv["$ref"]
@@ -1026,25 +1026,73 @@ func substituteResolvedRef(desiredNode, storedNode, modNode, currentNode any, re
 	matchesApplied := sameRef && reflect.DeepEqual(storedEnv["$applied"], effective)
 	native, raw, found, err := freshResolution(desiredEnv, currentNode, resolvableProperties)
 	if err != nil {
-		return nil, false, err
+		return nil, false, false, err
 	}
 	if found {
 		effective = native
 		matchesApplied = sameRef && appliedMatches(raw, storedEnv["$applied"])
 	}
-	if matchesApplied {
-		return storedEnv["$value"], true, nil
+	// The value formae would write is returned either way. When the reference is
+	// unchanged the caller aligns the comparison side instead of rewriting this
+	// one, so an operation covering this path still carries the written form.
+	return effective, matchesApplied, true, nil
+}
+
+// desiredEnvRef reports the reference a desired array element names, if any.
+func desiredEnvRef(desiredElem any) any {
+	env, ok := desiredElem.(map[string]any)
+	if !ok {
+		return nil
 	}
-	return effective, true, nil
+	return env["$ref"]
+}
+
+// alignComparisonElement rewrites the actual-state array element the provider
+// reported for an unchanged reference. The element is found by the echo recorded
+// with the reference rather than by position; with no unique match the element is
+// left alone and the comparison keeps its previous behavior.
+func alignComparisonElement(currentArr []any, echo, value any) {
+	if echo == nil {
+		return
+	}
+	match := -1
+	for i, elem := range currentArr {
+		if !reflect.DeepEqual(elem, echo) {
+			continue
+		}
+		if match >= 0 {
+			return
+		}
+		match = i
+	}
+	if match >= 0 {
+		currentArr[match] = value
+	}
+}
+
+// alignComparisonValue records, on the actual-state side of the diff, the value
+// an unchanged reference resolves to, so the two sides compare equal without
+// the desired side being rewritten into the provider's spelling.
+//
+// It only rewrites a path the provider actually reported: inventing one would
+// turn an addition into a no-op.
+func alignComparisonValue(current map[string]any, key string, value any) {
+	if current == nil {
+		return
+	}
+	if _, reported := current[key]; !reported {
+		return
+	}
+	current[key] = value
 }
 
 // substituteResolvedRefInArray applies substituteResolvedRef to one array
 // element, locating the stored counterpart by the reference the desired element
 // names rather than by position: the provider may return elements in any order.
-func substituteResolvedRefInArray(desiredElem any, storedArr []any, modElem, currentElem any, resolvableProperties resolver.ResolvableProperties) (any, bool, error) {
+func substituteResolvedRefInArray(desiredElem any, storedArr []any, modElem, currentElem any, resolvableProperties resolver.ResolvableProperties) (any, bool, bool, error) {
 	desiredEnv, ok := desiredElem.(map[string]any)
 	if !ok {
-		return nil, false, nil
+		return nil, false, false, nil
 	}
 	var storedElem any
 	if match := storedRefElementByURI(storedArr, desiredEnv["$ref"]); match != nil {
@@ -1077,12 +1125,15 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 		// A reference the executor already resolved: the desired side holds the
 		// resolved value alone, and the envelope it came from lives in the
 		// unconverted desired properties.
-		value, handled, err := substituteResolvedRef(desired[k], stored[k], v, current[k], resolvableProperties)
+		value, matched, handled, err := substituteResolvedRef(desired[k], stored[k], v, current[k], resolvableProperties)
 		if err != nil {
 			return err
 		}
 		if handled {
 			mod[k] = value
+			if matched {
+				alignComparisonValue(current, k, value)
+			}
 			continue
 		}
 		switch modVal := v.(type) {
@@ -1104,17 +1155,18 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 						}
 						resolved = extracted
 					}
+					native := normalizeResolvedValue(resolved, current[k])
+					modVal["$value"] = native
 					if counterpart != nil {
 						if applied, hasApplied := counterpart["$applied"]; hasApplied && appliedMatches(resolved, applied) && counterpart["$value"] != nil {
-							// The reference still resolves to what the last write sent;
-							// flatten to the stored echo so the diff compares within the
-							// observed domain and sees no change.
-							modVal["$value"] = counterpart["$value"]
-						} else {
-							modVal["$value"] = normalizeResolvedValue(resolved, current[k])
+							// The reference still resolves to what the last write
+							// sent, so it is unchanged. Align the comparison side
+							// rather than the desired side: the desired side is
+							// where operation values come from, and rewriting it
+							// to the provider's spelling would send that spelling
+							// back inside any operation covering this path.
+							alignComparisonValue(current, k, native)
 						}
-					} else {
-						modVal["$value"] = normalizeResolvedValue(resolved, current[k])
 					}
 				} else if counterpart != nil {
 					if _, hasApplied := counterpart["$applied"]; hasApplied && counterpart["$value"] != nil {
@@ -1206,6 +1258,21 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 					// to a scalar or a list now, and dropping that would leave
 					// the stale object in place.
 					modVal[i] = wrappedElem[k]
+					// The recursion aligns the comparison side inside a wrapper
+					// keyed by position. Re-apply it to the element the provider
+					// actually reported for this reference, found by the echo
+					// recorded with it, since positions need not correspond.
+					if aligned, ok := wrappedCurrent[k]; ok && !reflect.DeepEqual(aligned, currElem) {
+						// A converted element carries no reference of its own, so
+						// fall back to the one the desired element names.
+						ref := elemMap["$ref"]
+						if ref == nil && len(desiredArr) > i {
+							ref = desiredEnvRef(desiredArr[i])
+						}
+						if storedElem := storedRefElementByURI(storedArr, ref); storedElem != nil {
+							alignComparisonElement(currArr, storedElem["$value"], aligned)
+						}
+					}
 					continue
 				}
 				// An already-resolved element. The unconverted desired array is
@@ -1216,12 +1283,20 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 				if len(desiredArr) > i {
 					desiredElem = desiredArr[i]
 				}
-				value, handled, err := substituteResolvedRefInArray(desiredElem, storedArr, elem, currElem, resolvableProperties)
+				value, matched, handled, err := substituteResolvedRefInArray(desiredElem, storedArr, elem, currElem, resolvableProperties)
 				if err != nil {
 					return err
 				}
 				if handled {
 					modVal[i] = value
+					if matched {
+						// Locate the element the provider reported for this
+						// reference by the echo recorded alongside it, since the
+						// provider may return elements in any order.
+						if storedElem := storedRefElementByURI(storedArr, desiredEnvRef(desiredElem)); storedElem != nil {
+							alignComparisonElement(currArr, storedElem["$value"], value)
+						}
+					}
 				}
 			}
 		}

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -1210,11 +1210,15 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 						}
 					}
 				} else if counterpart != nil {
-					if _, hasApplied := counterpart["$applied"]; hasApplied && counterpart["$value"] != nil {
+					if applied, hasApplied := counterpart["$applied"]; hasApplied && applied != nil && counterpart["$value"] != nil {
 						if _, hasVal := modVal["$value"]; !hasVal {
-							// No resolution available but a prior write attests this exact
-							// reference; treat the gap as transient, not as a change.
-							modVal["$value"] = counterpart["$value"]
+							// No resolution available, but a prior write attests
+							// this exact reference, so the gap is transient rather
+							// than a change. Carry the value that write sent: the
+							// desired side is what operations are built from, and
+							// the provider's spelling must never be written back.
+							modVal["$value"] = applied
+							alignComparisonValue(current, k, counterpart["$value"], applied)
 						}
 					}
 				}

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -1014,10 +1014,10 @@ func freshResolution(env map[string]any, current any, resolvableProperties resol
 // and the reference is not rewritten in the provider's own spelling. Otherwise
 // the desired side carries the current resolution, so a genuine repoint is
 // planned (and, on an immutable field, still forces a replacement).
-func substituteResolvedRef(desiredNode, storedNode, modNode, currentNode any, resolvableProperties resolver.ResolvableProperties) (any, bool, bool, error) {
+func substituteResolvedRef(desiredNode, storedNode, modNode, currentNode any, resolvableProperties resolver.ResolvableProperties) (resolvedRefDecision, bool, error) {
 	desiredEnv, ok := resolvedDesiredEnvelope(desiredNode, modNode)
 	if !ok {
-		return nil, false, false, nil
+		return resolvedRefDecision{}, false, nil
 	}
 	storedEnv := storedAppliedEnvelope(storedNode)
 	sameRef := storedEnv != nil && storedEnv["$ref"] == desiredEnv["$ref"]
@@ -1026,7 +1026,7 @@ func substituteResolvedRef(desiredNode, storedNode, modNode, currentNode any, re
 	matchesApplied := sameRef && reflect.DeepEqual(storedEnv["$applied"], effective)
 	native, raw, found, err := freshResolution(desiredEnv, currentNode, resolvableProperties)
 	if err != nil {
-		return nil, false, false, err
+		return resolvedRefDecision{}, false, err
 	}
 	if found {
 		effective = native
@@ -1035,7 +1035,16 @@ func substituteResolvedRef(desiredNode, storedNode, modNode, currentNode any, re
 	// The value formae would write is returned either way. When the reference is
 	// unchanged the caller aligns the comparison side instead of rewriting this
 	// one, so an operation covering this path still carries the written form.
-	return effective, matchesApplied, true, nil
+	return resolvedRefDecision{Value: effective, Echo: storedEnv["$value"], Matched: matchesApplied}, true, nil
+}
+
+// resolvedRefDecision carries what the desired side should hold for an
+// already-resolved reference, the provider spelling recorded with it, and
+// whether it still resolves to what the last write applied.
+type resolvedRefDecision struct {
+	Value   any
+	Echo    any
+	Matched bool
 }
 
 // desiredEnvRef reports the reference a desired array element names, if any.
@@ -1045,6 +1054,31 @@ func desiredEnvRef(desiredElem any) any {
 		return nil
 	}
 	return env["$ref"]
+}
+
+// alignComparisonElementForRef aligns the actual-state element for one array
+// reference, when that reference still resolves to what the last write applied.
+func alignComparisonElementForRef(currentArr []any, storedElem map[string]any, desiredElem any) {
+	if storedElem == nil || storedElem["$applied"] == nil || storedElem["$value"] == nil {
+		return
+	}
+	// An element still carrying its envelope holds the resolution under $value;
+	// an already-converted element IS the resolution, which may itself be an
+	// object and must not be mistaken for an envelope.
+	resolved := desiredElem
+	if env, isEnv := desiredElem.(map[string]any); isEnv {
+		if _, isEnvelope := env["$ref"]; isEnvelope {
+			value, hasValue := env["$value"]
+			if !hasValue {
+				return
+			}
+			resolved = value
+		}
+	}
+	if !reflect.DeepEqual(storedElem["$applied"], resolved) {
+		return
+	}
+	alignComparisonElement(currentArr, storedElem["$value"], resolved)
 }
 
 // alignComparisonElement rewrites the actual-state array element the provider
@@ -1076,11 +1110,18 @@ func alignComparisonElement(currentArr []any, echo, value any) {
 //
 // It only rewrites a path the provider actually reported: inventing one would
 // turn an addition into a no-op.
-func alignComparisonValue(current map[string]any, key string, value any) {
+func alignComparisonValue(current map[string]any, key string, echo, value any) {
 	if current == nil {
 		return
 	}
-	if _, reported := current[key]; !reported {
+	reported, exists := current[key]
+	if !exists {
+		return
+	}
+	// Only align a value that still matches what the provider echoed when the
+	// reference was written. A live value that has moved since is drift, and
+	// overwriting it here would compare it away and leave it unrepaired.
+	if !reflect.DeepEqual(reported, echo) {
 		return
 	}
 	current[key] = value
@@ -1089,10 +1130,10 @@ func alignComparisonValue(current map[string]any, key string, value any) {
 // substituteResolvedRefInArray applies substituteResolvedRef to one array
 // element, locating the stored counterpart by the reference the desired element
 // names rather than by position: the provider may return elements in any order.
-func substituteResolvedRefInArray(desiredElem any, storedArr []any, modElem, currentElem any, resolvableProperties resolver.ResolvableProperties) (any, bool, bool, error) {
+func substituteResolvedRefInArray(desiredElem any, storedArr []any, modElem, currentElem any, resolvableProperties resolver.ResolvableProperties) (resolvedRefDecision, bool, error) {
 	desiredEnv, ok := desiredElem.(map[string]any)
 	if !ok {
-		return nil, false, false, nil
+		return resolvedRefDecision{}, false, nil
 	}
 	var storedElem any
 	if match := storedRefElementByURI(storedArr, desiredEnv["$ref"]); match != nil {
@@ -1125,14 +1166,14 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 		// A reference the executor already resolved: the desired side holds the
 		// resolved value alone, and the envelope it came from lives in the
 		// unconverted desired properties.
-		value, matched, handled, err := substituteResolvedRef(desired[k], stored[k], v, current[k], resolvableProperties)
+		decision, handled, err := substituteResolvedRef(desired[k], stored[k], v, current[k], resolvableProperties)
 		if err != nil {
 			return err
 		}
 		if handled {
-			mod[k] = value
-			if matched {
-				alignComparisonValue(current, k, value)
+			mod[k] = decision.Value
+			if decision.Matched {
+				alignComparisonValue(current, k, decision.Echo, decision.Value)
 			}
 			continue
 		}
@@ -1165,7 +1206,7 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 							// where operation values come from, and rewriting it
 							// to the provider's spelling would send that spelling
 							// back inside any operation covering this path.
-							alignComparisonValue(current, k, native)
+							alignComparisonValue(current, k, counterpart["$value"], native)
 						}
 					}
 				} else if counterpart != nil {
@@ -1258,21 +1299,19 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 					// to a scalar or a list now, and dropping that would leave
 					// the stale object in place.
 					modVal[i] = wrappedElem[k]
-					// The recursion aligns the comparison side inside a wrapper
-					// keyed by position. Re-apply it to the element the provider
-					// actually reported for this reference, found by the echo
-					// recorded with it, since positions need not correspond.
-					if aligned, ok := wrappedCurrent[k]; ok && !reflect.DeepEqual(aligned, currElem) {
-						// A converted element carries no reference of its own, so
-						// fall back to the one the desired element names.
-						ref := elemMap["$ref"]
-						if ref == nil && len(desiredArr) > i {
-							ref = desiredEnvRef(desiredArr[i])
-						}
-						if storedElem := storedRefElementByURI(storedArr, ref); storedElem != nil {
-							alignComparisonElement(currArr, storedElem["$value"], aligned)
-						}
+					// Alignment for an element happens here rather than in the
+					// recursion: the recursion only sees a wrapper keyed by
+					// position, while the provider may report elements in any
+					// order, so the element to align is found by the echo
+					// recorded with the reference.
+					//
+					// A converted element carries no reference of its own, so
+					// fall back to the one the desired element names.
+					ref := elemMap["$ref"]
+					if ref == nil && len(desiredArr) > i {
+						ref = desiredEnvRef(desiredArr[i])
 					}
+					alignComparisonElementForRef(currArr, storedRefElementByURI(storedArr, ref), wrappedElem[k])
 					continue
 				}
 				// An already-resolved element. The unconverted desired array is
@@ -1283,18 +1322,18 @@ func resolveRefs(current, mod, stored, desired map[string]any, resolvablePropert
 				if len(desiredArr) > i {
 					desiredElem = desiredArr[i]
 				}
-				value, matched, handled, err := substituteResolvedRefInArray(desiredElem, storedArr, elem, currElem, resolvableProperties)
+				decision, handled, err := substituteResolvedRefInArray(desiredElem, storedArr, elem, currElem, resolvableProperties)
 				if err != nil {
 					return err
 				}
 				if handled {
-					modVal[i] = value
-					if matched {
+					modVal[i] = decision.Value
+					if decision.Matched {
 						// Locate the element the provider reported for this
 						// reference by the echo recorded alongside it, since the
 						// provider may return elements in any order.
 						if storedElem := storedRefElementByURI(storedArr, desiredEnvRef(desiredElem)); storedElem != nil {
-							alignComparisonElement(currArr, storedElem["$value"], value)
+							alignComparisonElement(currArr, storedElem["$value"], decision.Value)
 						}
 					}
 				}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -2959,7 +2959,7 @@ func TestGeneratePatch_AppliedWithoutStoredEcho_FallsBackToFresh(t *testing.T) {
 // An unresolvable reference (no fresh resolution) with an $applied-carrying
 // stored counterpart flattens to the stored echo value, preserving the last
 // known state across a transient resolution gap.
-func TestFlattenAndResolveRefs_UnresolvableRefWithApplied_UsesStoredEcho(t *testing.T) {
+func TestFlattenAndResolveRefs_UnresolvableRefWithApplied_UsesWrittenForm(t *testing.T) {
 	ksuid := util.NewID()
 	echoVal := "47110862-aaaa"
 	appliedVal := "arn:aws:kms:us-east-1:111122223333:key/47110862-aaaa"
@@ -2967,12 +2967,21 @@ func TestFlattenAndResolveRefs_UnresolvableRefWithApplied_UsesStoredEcho(t *test
 	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": %q, "$applied": %q}}`, ksuid, echoVal, appliedVal)
 	patch := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn"}}`, ksuid)
 
-	_, flatPatch, err := flattenAndResolveRefs(document, patch, stored, nil, resolver.NewResolvableProperties())
+	flatDocument, flatPatch, err := flattenAndResolveRefs(document, patch, stored, nil, resolver.NewResolvableProperties())
 	require.NoError(t, err)
 
 	var flatMap map[string]any
 	require.NoError(t, json.Unmarshal(flatPatch, &flatMap))
-	assert.Equal(t, echoVal, flatMap["TargetKeyId"], "unresolvable ref with $applied must flatten to stored echo")
+	assert.Equal(t, appliedVal, flatMap["TargetKeyId"],
+		"an unresolvable reference carries the value its last write sent, which is what an operation would have to write")
+
+	// The two sides still agree, so nothing is planned for the reference: the
+	// actual-state side is what absorbs the difference in spelling.
+	var flatDoc map[string]any
+	require.NoError(t, json.Unmarshal(flatDocument, &flatDoc))
+	assert.Equal(t, appliedVal, flatDoc["TargetKeyId"],
+		"the actual-state side is aligned instead, so the reference compares equal")
+	_ = echoVal
 }
 
 // An unresolvable reference without $applied flattens to empty string, the
@@ -3743,4 +3752,71 @@ func TestGeneratePatch_ArrayRefWithDriftedLiveElement_PlansRepair(t *testing.T) 
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "a drifted array element must be repaired")
 	assert.Contains(t, string(patchDoc), arnB, "the repair carries the written form")
+}
+
+// A reference that cannot be resolved right now still has a last-written form
+// recorded with it. When a sibling change makes the diff emit the whole object,
+// that operation must carry the written form, never the provider's spelling.
+func TestGeneratePatch_AtomicObjectWithUnresolvableRef_EmitsWriteForm(t *testing.T) {
+	ksuid := util.NewID()
+	arn := "arn:aws:sns:us-east-1:111122223333:topic-a"
+	document := []byte(`{"Cfg": {"Note": "a", "Ref": "name-a"}}`)
+	stored := fmt.Appendf(nil, `{"Cfg": {"Note": "a", "Ref": {"$ref": "formae://%s#/Arn", "$value": "name-a", "$applied": %q}}}`, ksuid, arn)
+	desired := fmt.Appendf(nil, `{"Cfg": {"Note": "b", "Ref": {"$ref": "formae://%s#/Arn"}}}`, ksuid)
+	patch := desired
+	schema := pkgmodel.Schema{
+		Fields: []string{"Cfg"},
+		Hints:  map[string]pkgmodel.FieldHint{"Cfg": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic}},
+	}
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.NotNil(t, patchDoc, "the sibling change must be planned")
+	assert.Contains(t, string(patchDoc), arn, "the emitted object must carry the last written form")
+	assert.NotContains(t, string(patchDoc), "name-a", "the provider's read form must not be sent back as a write")
+}
+
+// The same for an ordered list whose references cannot be resolved right now.
+func TestGeneratePatch_OrderedArrayUnresolvableRefsReordered_EmitWriteForm(t *testing.T) {
+	ksuid := util.NewID()
+	arnA := "arn:aws:sns:us-east-1:111122223333:topic-a"
+	arnB := "arn:aws:sns:us-east-1:111122223333:topic-b"
+	document := []byte(`{"Topics": ["name-a", "name-b"]}`)
+	stored := fmt.Appendf(nil, `{"Topics": [
+		{"$ref": "formae://%s#/ArnA", "$value": "name-a", "$applied": %q},
+		{"$ref": "formae://%s#/ArnB", "$value": "name-b", "$applied": %q}
+	]}`, ksuid, arnA, ksuid, arnB)
+	desired := fmt.Appendf(nil, `{"Topics": [
+		{"$ref": "formae://%s#/ArnB"},
+		{"$ref": "formae://%s#/ArnA"}
+	]}`, ksuid, ksuid)
+	patch := desired
+	schema := pkgmodel.Schema{
+		Fields: []string{"Topics"},
+		Hints:  map[string]pkgmodel.FieldHint{"Topics": {UpdateMethod: pkgmodel.FieldUpdateMethodArray}},
+	}
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.NotNil(t, patchDoc, "reordering an ordered list is a change")
+	assert.NotContains(t, string(patchDoc), "name-a", "the provider's read form must not be sent back as a write")
+	assert.NotContains(t, string(patchDoc), "name-b", "the provider's read form must not be sent back as a write")
+	assert.Contains(t, string(patchDoc), arnA)
+	assert.Contains(t, string(patchDoc), arnB)
+}
+
+// An unresolvable reference that has not otherwise changed still produces
+// nothing, so carrying the written form does not reintroduce churn.
+func TestGeneratePatch_UnresolvableRefUnchanged_NoPatch(t *testing.T) {
+	ksuid := util.NewID()
+	arn := "arn:aws:kms:us-east-1:111122223333:key/47110862-aaaa"
+	document := []byte(`{"TargetKeyId": "47110862-aaaa"}`)
+	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": "47110862-aaaa", "$applied": %q}}`, ksuid, arn)
+	desired := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn"}}`, ksuid)
+	patch := desired
+	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Nil(t, patchDoc, "an unchanged reference must still reconcile to a no-op")
 }

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -3820,3 +3820,95 @@ func TestGeneratePatch_UnresolvableRefUnchanged_NoPatch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "an unchanged reference must still reconcile to a no-op")
 }
+
+// A reference to a numeric property: resolution yields text, while the record
+// keeps the number that was written. An unchanged reference must neither be
+// rewritten nor have its type changed.
+func TestGeneratePatch_NumericArrayRefsUnchanged_NoPatch(t *testing.T) {
+	ksuid := util.NewID()
+	document := []byte(`{"Ports": [443, 8080]}`)
+	stored := fmt.Appendf(nil, `{"Ports": [
+		{"$ref": "formae://%s#/PortA", "$value": 443, "$applied": 443},
+		{"$ref": "formae://%s#/PortB", "$value": 8080, "$applied": 8080}
+	]}`, ksuid, ksuid)
+	desired := fmt.Appendf(nil, `{"Ports": [
+		{"$ref": "formae://%s#/PortA"},
+		{"$ref": "formae://%s#/PortB"}
+	]}`, ksuid, ksuid)
+	patch := desired
+	schema := pkgmodel.Schema{Fields: []string{"Ports"}}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "PortA", "443")
+	props.Add(ksuid, "PortB", "8080")
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Nil(t, patchDoc, "unchanged numeric references must not be rewritten")
+}
+
+// The same list under ordered semantics, where a reorder emits an operation per
+// position: the emitted values must stay numbers.
+func TestGeneratePatch_NumericOrderedArrayRefsReordered_EmitNumbers(t *testing.T) {
+	ksuid := util.NewID()
+	document := []byte(`{"Ports": [443, 8080]}`)
+	stored := fmt.Appendf(nil, `{"Ports": [
+		{"$ref": "formae://%s#/PortA", "$value": 443, "$applied": 443},
+		{"$ref": "formae://%s#/PortB", "$value": 8080, "$applied": 8080}
+	]}`, ksuid, ksuid)
+	desired := fmt.Appendf(nil, `{"Ports": [
+		{"$ref": "formae://%s#/PortB"},
+		{"$ref": "formae://%s#/PortA"}
+	]}`, ksuid, ksuid)
+	patch := desired
+	schema := pkgmodel.Schema{
+		Fields: []string{"Ports"},
+		Hints:  map[string]pkgmodel.FieldHint{"Ports": {UpdateMethod: pkgmodel.FieldUpdateMethodArray}},
+	}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "PortA", "443")
+	props.Add(ksuid, "PortB", "8080")
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.NotNil(t, patchDoc, "reordering an ordered list is a change")
+	assert.NotContains(t, string(patchDoc), `"443"`, "a numeric reference must not be written back as text")
+	assert.NotContains(t, string(patchDoc), `"8080"`, "a numeric reference must not be written back as text")
+}
+
+// A boolean-valued reference behaves the same way.
+func TestGeneratePatch_BooleanRefUnchanged_NoPatch(t *testing.T) {
+	ksuid := util.NewID()
+	document := []byte(`{"Enabled": true}`)
+	stored := fmt.Appendf(nil, `{"Enabled": {"$ref": "formae://%s#/Flag", "$value": true, "$applied": true}}`, ksuid)
+	desired := fmt.Appendf(nil, `{"Enabled": {"$ref": "formae://%s#/Flag"}}`, ksuid)
+	patch := desired
+	schema := pkgmodel.Schema{Fields: []string{"Enabled"}}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "Flag", "true")
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Nil(t, patchDoc, "an unchanged boolean reference must not be rewritten")
+}
+
+// A numeric reference inside an Atomic-hinted object, where a sibling change
+// forces the whole object to be emitted.
+func TestGeneratePatch_AtomicObjectWithNumericRef_EmitsNumber(t *testing.T) {
+	ksuid := util.NewID()
+	document := []byte(`{"Cfg": {"Note": "a", "Port": 443}}`)
+	stored := fmt.Appendf(nil, `{"Cfg": {"Note": "a", "Port": {"$ref": "formae://%s#/PortA", "$value": 443, "$applied": 443}}}`, ksuid)
+	desired := fmt.Appendf(nil, `{"Cfg": {"Note": "b", "Port": {"$ref": "formae://%s#/PortA"}}}`, ksuid)
+	patch := desired
+	schema := pkgmodel.Schema{
+		Fields: []string{"Cfg"},
+		Hints:  map[string]pkgmodel.FieldHint{"Cfg": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic}},
+	}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "PortA", "443")
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.NotNil(t, patchDoc, "the sibling change must be planned")
+	assert.Contains(t, string(patchDoc), "443")
+	assert.NotContains(t, string(patchDoc), `"443"`, "a numeric reference must not be written back as text")
+}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -3551,3 +3551,106 @@ func TestGeneratePatch_ResolvedArrayRefObjectMatchingApplied_NoPatch(t *testing.
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "an unchanged object-valued reference must not be rewritten")
 }
+
+// An unchanged reference sitting inside an Atomic-hinted object: a change to a
+// sibling makes the diff emit the whole object, and the emitted value must
+// carry the reference the way formae writes it, not the way the provider
+// reports it.
+func TestGeneratePatch_AtomicObjectWithUnchangedRef_EmitsWriteForm(t *testing.T) {
+	ksuid := util.NewID()
+	arn := "arn:aws:sns:us-east-1:111122223333:topic-a"
+	document := []byte(`{"Cfg": {"Note": "a", "Ref": "name-a"}}`)
+	stored := fmt.Appendf(nil, `{"Cfg": {"Note": "a", "Ref": {"$ref": "formae://%s#/Arn", "$value": "name-a", "$applied": %q}}}`, ksuid, arn)
+	desired := fmt.Appendf(nil, `{"Cfg": {"Note": "b", "Ref": {"$ref": "formae://%s#/Arn"}}}`, ksuid)
+	patch := fmt.Appendf(nil, `{"Cfg": {"Note": "b", "Ref": {"$ref": "formae://%s#/Arn"}}}`, ksuid)
+	schema := pkgmodel.Schema{
+		Fields: []string{"Cfg"},
+		Hints:  map[string]pkgmodel.FieldHint{"Cfg": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic}},
+	}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "Arn", arn)
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.NotNil(t, patchDoc, "the sibling change must be planned")
+	assert.Contains(t, string(patchDoc), arn,
+		"the emitted object must carry the reference in the form formae writes")
+	assert.NotContains(t, string(patchDoc), "name-a",
+		"the provider's read form must not be sent back as a write")
+}
+
+// An ordered list of references compares position by position, so reordering
+// emits an operation per position. Those operations must carry the references
+// the way formae writes them.
+func TestGeneratePatch_OrderedArrayReorderedRefs_EmitWriteForm(t *testing.T) {
+	ksuid := util.NewID()
+	arnA := "arn:aws:sns:us-east-1:111122223333:topic-a"
+	arnB := "arn:aws:sns:us-east-1:111122223333:topic-b"
+	document := []byte(`{"Topics": ["name-a", "name-b"]}`)
+	stored := fmt.Appendf(nil, `{"Topics": [
+		{"$ref": "formae://%s#/ArnA", "$value": "name-a", "$applied": %q},
+		{"$ref": "formae://%s#/ArnB", "$value": "name-b", "$applied": %q}
+	]}`, ksuid, arnA, ksuid, arnB)
+	desired := fmt.Appendf(nil, `{"Topics": [
+		{"$ref": "formae://%s#/ArnB"},
+		{"$ref": "formae://%s#/ArnA"}
+	]}`, ksuid, ksuid)
+	patch := desired
+	schema := pkgmodel.Schema{
+		Fields: []string{"Topics"},
+		Hints:  map[string]pkgmodel.FieldHint{"Topics": {UpdateMethod: pkgmodel.FieldUpdateMethodArray}},
+	}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "ArnA", arnA)
+	props.Add(ksuid, "ArnB", arnB)
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.NotNil(t, patchDoc, "reordering an ordered list is a change")
+	assert.Contains(t, string(patchDoc), arnA)
+	assert.Contains(t, string(patchDoc), arnB)
+	assert.NotContains(t, string(patchDoc), "name-a", "the provider's read form must not be sent back as a write")
+	assert.NotContains(t, string(patchDoc), "name-b", "the provider's read form must not be sent back as a write")
+}
+
+// The same guarantee on the execution path, where the desired side arrives with
+// its references already resolved.
+func TestGeneratePatch_AtomicObjectWithResolvedRef_EmitsWriteForm(t *testing.T) {
+	ksuid := util.NewID()
+	arn := "arn:aws:sns:us-east-1:111122223333:topic-a"
+	document := []byte(`{"Cfg": {"Note": "a", "Ref": "name-a"}}`)
+	stored := fmt.Appendf(nil, `{"Cfg": {"Note": "a", "Ref": {"$ref": "formae://%s#/Arn", "$value": "name-a", "$applied": %q}}}`, ksuid, arn)
+	desired := fmt.Appendf(nil, `{"Cfg": {"Note": "b", "Ref": {"$ref": "formae://%s#/Arn", "$value": %q}}}`, ksuid, arn)
+	patch := fmt.Appendf(nil, `{"Cfg": {"Note": "b", "Ref": %q}}`, arn)
+	schema := pkgmodel.Schema{
+		Fields: []string{"Cfg"},
+		Hints:  map[string]pkgmodel.FieldHint{"Cfg": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic}},
+	}
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.NotNil(t, patchDoc, "the sibling change must be planned")
+	assert.Contains(t, string(patchDoc), arn)
+	assert.NotContains(t, string(patchDoc), "name-a")
+}
+
+// An unchanged reference on its own still produces nothing, which is what makes
+// aligning the comparison side rather than the desired side safe.
+func TestGeneratePatch_AtomicObjectFullyUnchanged_NoPatch(t *testing.T) {
+	ksuid := util.NewID()
+	arn := "arn:aws:sns:us-east-1:111122223333:topic-a"
+	document := []byte(`{"Cfg": {"Note": "a", "Ref": "name-a"}}`)
+	stored := fmt.Appendf(nil, `{"Cfg": {"Note": "a", "Ref": {"$ref": "formae://%s#/Arn", "$value": "name-a", "$applied": %q}}}`, ksuid, arn)
+	desired := fmt.Appendf(nil, `{"Cfg": {"Note": "a", "Ref": {"$ref": "formae://%s#/Arn"}}}`, ksuid)
+	patch := desired
+	schema := pkgmodel.Schema{
+		Fields: []string{"Cfg"},
+		Hints:  map[string]pkgmodel.FieldHint{"Cfg": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic}},
+	}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "Arn", arn)
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Nil(t, patchDoc, "an unchanged atomic object must still reconcile to a no-op")
+}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -3654,3 +3654,93 @@ func TestGeneratePatch_AtomicObjectFullyUnchanged_NoPatch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "an unchanged atomic object must still reconcile to a no-op")
 }
+
+// A reference that still resolves to what was applied, on a field whose live
+// value has since moved out of band, is drift: the live value no longer matches
+// the spelling the provider reported when the reference was written, and the
+// repair must still be planned.
+func TestGeneratePatch_UnchangedRefWithDriftedLiveValue_PlansRepair(t *testing.T) {
+	ksuid := util.NewID()
+	arn := "arn:aws:kms:us-east-1:111122223333:key/47110862-aaaa"
+	document := []byte(`{"TargetKeyId": "somebody-else-set-this"}`)
+	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": "47110862-aaaa", "$applied": %q}}`, ksuid, arn)
+	desired := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn"}}`, ksuid)
+	patch := desired
+	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "Arn", arn)
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	require.Len(t, ops, 1, "drift on a reference-fed field must still be repaired")
+	assert.Equal(t, arn, ops[0].Value)
+}
+
+// The same on an immutable field, where swallowing the drift would also swallow
+// the replacement it requires.
+func TestGeneratePatch_CreateOnlyUnchangedRefWithDriftedLiveValue_PlansReplacement(t *testing.T) {
+	ksuid := util.NewID()
+	arn := "arn:aws:lambda:us-east-1:111122223333:function:fn"
+	document := []byte(`{"TargetFunctionArn": "somebody-else-set-this"}`)
+	stored := fmt.Appendf(nil, `{"TargetFunctionArn": {"$ref": "formae://%s#/Arn", "$value": "fn", "$applied": %q}}`, ksuid, arn)
+	desired := fmt.Appendf(nil, `{"TargetFunctionArn": {"$ref": "formae://%s#/Arn"}}`, ksuid)
+	patch := desired
+	schema := pkgmodel.Schema{
+		Fields: []string{"TargetFunctionArn"},
+		Hints:  map[string]pkgmodel.FieldHint{"TargetFunctionArn": {CreateOnly: true}},
+	}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "Arn", arn)
+
+	_, createOnlyPatch, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.NotEmpty(t, createOnlyPatch, "drift on an immutable reference-fed field must still force a replacement")
+}
+
+// The execution path, where the desired side arrives already resolved, must
+// surface drift too.
+func TestGeneratePatch_ResolvedRefWithDriftedLiveValue_PlansRepair(t *testing.T) {
+	ksuid := util.NewID()
+	arn := "arn:aws:kms:us-east-1:111122223333:key/47110862-aaaa"
+	document := []byte(`{"TargetKeyId": "somebody-else-set-this"}`)
+	stored := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": "47110862-aaaa", "$applied": %q}}`, ksuid, arn)
+	desired := fmt.Appendf(nil, `{"TargetKeyId": {"$ref": "formae://%s#/Arn", "$value": %q}}`, ksuid, arn)
+	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
+	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	require.Len(t, ops, 1, "drift must be repaired on the execution path too")
+	assert.Equal(t, arn, ops[0].Value)
+}
+
+// An array element that drifted out of band is repaired while its unchanged
+// siblings stay suppressed.
+func TestGeneratePatch_ArrayRefWithDriftedLiveElement_PlansRepair(t *testing.T) {
+	ksuid := util.NewID()
+	arnA := "arn:aws:sns:us-east-1:111122223333:topic-a"
+	arnB := "arn:aws:sns:us-east-1:111122223333:topic-b"
+	document := []byte(`{"Topics": ["name-a", "somebody-else-set-this"]}`)
+	stored := fmt.Appendf(nil, `{"Topics": [
+		{"$ref": "formae://%s#/ArnA", "$value": "name-a", "$applied": %q},
+		{"$ref": "formae://%s#/ArnB", "$value": "name-b", "$applied": %q}
+	]}`, ksuid, arnA, ksuid, arnB)
+	desired := fmt.Appendf(nil, `{"Topics": [
+		{"$ref": "formae://%s#/ArnA"},
+		{"$ref": "formae://%s#/ArnB"}
+	]}`, ksuid, ksuid)
+	patch := desired
+	schema := pkgmodel.Schema{Fields: []string{"Topics"}}
+	props := resolver.NewResolvableProperties()
+	props.Add(ksuid, "ArnA", arnA)
+	props.Add(ksuid, "ArnB", arnB)
+
+	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.NotNil(t, patchDoc, "a drifted array element must be repaired")
+	assert.Contains(t, string(patchDoc), arnB, "the repair carries the written form")
+}


### PR DESCRIPTION
## Summary

An unchanged cross-resource reference is made to compare equal so it is not rewritten on every reconcile. That was done by writing the provider's echoed value onto the desired side of the diff, which is also where jsonpatch takes operation values from. Wherever the diff emits a whole node rather than a single field, an Atomic-hinted object or an ordered list, the resulting operation carried the reference the way the provider reports it rather than the way formae writes it. A provider that accepts only one spelling on write could reject the update or store the wrong value.

The rule is now one sentence: the desired side always carries a value formae would write, and the actual-state side is aligned to it where the provider's echo still stands.

Concretely:

- The desired side carries the fresh resolution when the reference has moved, and the value recorded from the last write when it has not. Nothing puts a read spelling there, so no emitted operation can carry one.
- Alignment happens on the actual-state side, and only where the live value still matches the echo recorded with the reference. A value that has moved out of band is drift, stays visible, and is still repaired. On an immutable field it still forces a replacement.
- A path the provider did not report is never invented, since that would turn an addition into a no-op.
- Array elements are located by the recorded echo rather than by position, because the provider may return them in any order, and ambiguity fails closed.
- An unchanged reference carries the recorded value itself, which preserves the JSON type that was written. Resolution yields text, so a numeric or boolean reference was previously written back as a string, and inside an array that mismatch also skipped alignment entirely and left an unchanged list emitting operations on every reconcile.

## Tests

Coverage for the write form on Atomic objects and ordered lists, with and without a fresh resolution available; drift preservation on scalars, arrays, the execution path and immutable fields; numeric and boolean references across plain, ordered and Atomic shapes; and suppression still holding for unchanged references. Each behavioral test was checked to fail without the corresponding change.

One existing expectation changed deliberately: an unresolvable reference used to flatten to the provider's echo and now flattens to the value the last write sent. Suppression is unaffected, and the value carried is one that could actually be written.

## Review

Cross-model adversarial review ran four times against this branch and found three defects, each fixed with tests that fail without the fix: alignment erasing genuine drift, including the replacement it should force on an immutable field; the unresolvable-reference fallback still placing a read spelling on the desired side; and numeric or boolean references bypassing alignment and being written back as text. The final pass reports no material findings.