### PR TITLE
feat(auth): login verbs, typed error codes, and subject fields in the plugin SDK

### DIFF
--- a/internal/auth/auth_plugin_handle_test.go
+++ b/internal/auth/auth_plugin_handle_test.go
@@ -20,6 +20,7 @@ import (
 
 // mockAuthPlugin implements pkgauth.AuthPlugin for testing.
 type mockAuthPlugin struct {
+	pkgauth.UnimplementedAuthPlugin
 	validResponse bool
 }
 

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -20,6 +20,7 @@ import (
 
 // testMiddlewarePlugin is a configurable mock for middleware tests.
 type testMiddlewarePlugin struct {
+	pkgauth.UnimplementedAuthPlugin
 	validResponse bool
 	callCount     int
 }

--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -689,7 +689,7 @@ func (a *App) getAuthAndNetHandlers() (http.Header, *http.Client, error) {
 			a.authClient = client
 		}
 
-		resp, err := a.authClient.GetAuthHeader()
+		resp, err := a.authClient.GetAuthHeader(false)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get auth header: %w", err)
 		}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -9,12 +9,30 @@ import (
 	"time"
 )
 
+// ErrorCode identifies a category of auth plugin error, letting callers
+// branch on failure kind without parsing the human-readable Error string.
+type ErrorCode string
+
+const (
+	// ErrorCodeUnsupported indicates the plugin does not implement this verb.
+	ErrorCodeUnsupported ErrorCode = "unsupported"
+	// ErrorCodeNotLoggedIn indicates there is no active session.
+	ErrorCodeNotLoggedIn ErrorCode = "not_logged_in"
+	// ErrorCodeSessionExpired indicates a previously active session has expired.
+	ErrorCodeSessionExpired ErrorCode = "session_expired"
+	// ErrorCodeIssuerUnreachable indicates the plugin could not reach its identity issuer.
+	ErrorCodeIssuerUnreachable ErrorCode = "issuer_unreachable"
+)
+
 // AuthPlugin is the interface that auth plugin binaries must implement.
 // Method signatures are net/rpc compatible (two args: request pointer, response pointer; returns error).
 type AuthPlugin interface {
 	Init(req *InitRequest, resp *InitResponse) error
 	Validate(req *ValidateRequest, resp *ValidateResponse) error
 	GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error
+	LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error
+	LoginWait(req *LoginWaitRequest, resp *LoginWaitResponse) error
+	Logout(req *LogoutRequest, resp *LogoutResponse) error
 }
 
 // InitRequest is sent once at startup to configure the plugin.
@@ -36,14 +54,63 @@ type ValidateRequest struct {
 type ValidateResponse struct {
 	Valid    bool
 	Error    string
-	CacheKey string
+	CacheKey string // retained for SOURCE compatibility with existing plugins; the host never reads it
 	CacheTTL time.Duration
+
+	Subject     string // verified stable subject id; empty when the plugin has no notion of one
+	SubjectName string // display hint only; never used for authorization
+	ErrorCode   ErrorCode
 }
 
 // GetAuthHeaderRequest requests auth headers for outgoing requests (CLI side).
-type GetAuthHeaderRequest struct{}
+type GetAuthHeaderRequest struct {
+	ForceRefresh bool // skip freshness checks and refresh the credential now
+}
 
 // GetAuthHeaderResponse contains the headers to attach to outgoing requests.
 type GetAuthHeaderResponse struct {
-	Headers map[string][]string
+	Headers   map[string][]string
+	Error     string
+	ErrorCode ErrorCode
+}
+
+// LoginStartRequest begins an interactive login flow.
+type LoginStartRequest struct {
+	Mode  string // "browser" | "device"
+	Force bool
+}
+
+// LoginStartResponse describes how the caller should carry out (or skip) the login flow.
+type LoginStartResponse struct {
+	Status           string // "started" | "already_authenticated"
+	Method           string // echoes Mode when Status=="started"
+	BrowserURL       string
+	VerificationURI  string
+	UserCode         string
+	SessionID        string
+	ExpiresInSeconds int
+	Subject          string // set when Status=="already_authenticated"
+	SubjectName      string
+	Error            string
+	ErrorCode        ErrorCode
+}
+
+// LoginWaitRequest polls for completion of a login flow started by LoginStart.
+type LoginWaitRequest struct{ SessionID string }
+
+// LoginWaitResponse reports the outcome of a login flow.
+type LoginWaitResponse struct {
+	Subject     string
+	SubjectName string
+	Error       string
+	ErrorCode   ErrorCode
+}
+
+// LogoutRequest ends the current session.
+type LogoutRequest struct{}
+
+// LogoutResponse is the plugin's response to Logout.
+type LogoutResponse struct {
+	Error     string
+	ErrorCode ErrorCode
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -29,6 +29,9 @@ const (
 type AuthPlugin interface {
 	Init(req *InitRequest, resp *InitResponse) error
 	Validate(req *ValidateRequest, resp *ValidateResponse) error
+	// GetAuthHeader: to fail closed on every host version, return a non-nil
+	// error rather than relying on GetAuthHeaderResponse's typed fields,
+	// which a host built against an earlier SDK cannot read.
 	GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error
 	LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error
 	LoginWait(req *LoginWaitRequest, resp *LoginWaitResponse) error
@@ -68,6 +71,14 @@ type GetAuthHeaderRequest struct {
 }
 
 // GetAuthHeaderResponse contains the headers to attach to outgoing requests.
+//
+// Error and ErrorCode were added in SDK 0.3.0. A host built against an
+// earlier SDK decodes only Headers and cannot observe either field, so a
+// nil error paired with empty Headers reads as successful authentication.
+// A plugin that must fail closed regardless of host version returns a
+// non-nil Go error from GetAuthHeader instead; these typed fields are
+// additive information for hosts new enough to read them, not a
+// substitute for that error.
 type GetAuthHeaderResponse struct {
 	Headers   map[string][]string
 	Error     string

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -28,6 +28,10 @@ const (
 // Method signatures are net/rpc compatible (two args: request pointer, response pointer; returns error).
 type AuthPlugin interface {
 	Init(req *InitRequest, resp *InitResponse) error
+	// Validate: return nil with Valid: false to deny a credential. Reserve a
+	// non-nil error for the plugin being genuinely unable to answer: the
+	// host maps any error from this call to plugin-unavailable, not to a
+	// rejected credential.
 	Validate(req *ValidateRequest, resp *ValidateResponse) error
 	// GetAuthHeader: to fail closed on every host version, return a non-nil
 	// error rather than relying on GetAuthHeaderResponse's typed fields,
@@ -60,9 +64,9 @@ type ValidateResponse struct {
 	CacheKey string // retained for SOURCE compatibility with existing plugins; the host never reads it
 	CacheTTL time.Duration
 
-	Subject     string // verified stable subject id; empty when the plugin has no notion of one
-	SubjectName string // display hint only; never used for authorization
-	ErrorCode   ErrorCode
+	Subject     string    // verified stable subject id; empty when the plugin has no notion of one
+	SubjectName string    // display hint only; never used for authorization
+	ErrorCode   ErrorCode // reserved; not currently surfaced to clients, so put the rejection reason on the plugin's stderr
 }
 
 // GetAuthHeaderRequest requests auth headers for outgoing requests (CLI side).
@@ -80,7 +84,7 @@ type GetAuthHeaderRequest struct {
 // additive information for hosts new enough to read them, not a
 // substitute for that error.
 type GetAuthHeaderResponse struct {
-	Headers   map[string][]string
+	Headers   map[string][]string // the client attaches only the canonical "Authorization" header; return the credential under that exact key
 	Error     string
 	ErrorCode ErrorCode
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -14,9 +14,10 @@ import (
 
 // fakePlugin is a test double implementing the AuthPlugin interface.
 type fakePlugin struct {
-	initCalled    bool
-	receivedCfg   json.RawMessage
-	validateUsers map[string]string // username -> password (plaintext for testing)
+	initCalled       bool
+	receivedCfg      json.RawMessage
+	validateUsers    map[string]string // username -> password (plaintext for testing)
+	lastForceRefresh bool
 }
 
 func (f *fakePlugin) Init(req *InitRequest, resp *InitResponse) error {
@@ -40,9 +41,26 @@ func (f *fakePlugin) Validate(req *ValidateRequest, resp *ValidateResponse) erro
 }
 
 func (f *fakePlugin) GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error {
+	f.lastForceRefresh = req.ForceRefresh
 	resp.Headers = map[string][]string{
 		"X-Api-Key": {"secret-key"},
 	}
+	return nil
+}
+
+func (f *fakePlugin) LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error {
+	resp.Status = "started"
+	resp.SessionID = "s-1"
+	return nil
+}
+
+func (f *fakePlugin) LoginWait(req *LoginWaitRequest, resp *LoginWaitResponse) error {
+	resp.Subject = "11111111-1111-4111-8111-111111111111"
+	resp.SubjectName = "dpanders"
+	return nil
+}
+
+func (f *fakePlugin) Logout(req *LogoutRequest, resp *LogoutResponse) error {
 	return nil
 }
 
@@ -144,7 +162,7 @@ func TestServerAndClient_GetAuthHeader(t *testing.T) {
 	defer client.Close()
 
 	var resp GetAuthHeaderResponse
-	err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp)
+	err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{ForceRefresh: true}, &resp)
 	if err != nil {
 		t.Fatalf("GetAuthHeader call failed: %v", err)
 	}
@@ -152,5 +170,75 @@ func TestServerAndClient_GetAuthHeader(t *testing.T) {
 	keys := resp.Headers["X-Api-Key"]
 	if len(keys) != 1 || keys[0] != "secret-key" {
 		t.Fatalf("expected X-Api-Key header with 'secret-key', got %v", resp.Headers)
+	}
+
+	if !plugin.lastForceRefresh {
+		t.Fatal("expected ForceRefresh to round-trip to the plugin")
+	}
+}
+
+func TestServerAndClient_LoginStart(t *testing.T) {
+	plugin := &fakePlugin{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	var resp LoginStartResponse
+	err := client.Call("AuthPlugin.LoginStart", &LoginStartRequest{Mode: "browser"}, &resp)
+	if err != nil {
+		t.Fatalf("LoginStart call failed: %v", err)
+	}
+	if resp.Status != "started" {
+		t.Fatalf("expected Status 'started', got %q", resp.Status)
+	}
+	if resp.SessionID != "s-1" {
+		t.Fatalf("expected SessionID 's-1', got %q", resp.SessionID)
+	}
+}
+
+func TestServerAndClient_LoginWait(t *testing.T) {
+	plugin := &fakePlugin{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	var resp LoginWaitResponse
+	err := client.Call("AuthPlugin.LoginWait", &LoginWaitRequest{SessionID: "s-1"}, &resp)
+	if err != nil {
+		t.Fatalf("LoginWait call failed: %v", err)
+	}
+	if resp.Subject != "11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("expected Subject '11111111-1111-4111-8111-111111111111', got %q", resp.Subject)
+	}
+	if resp.SubjectName != "dpanders" {
+		t.Fatalf("expected SubjectName 'dpanders', got %q", resp.SubjectName)
+	}
+}
+
+func TestServerAndClient_Logout(t *testing.T) {
+	plugin := &fakePlugin{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	var resp LogoutResponse
+	err := client.Call("AuthPlugin.Logout", &LogoutRequest{}, &resp)
+	if err != nil {
+		t.Fatalf("Logout call failed: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("expected no error, got %q", resp.Error)
+	}
+	if resp.ErrorCode != "" {
+		t.Fatalf("expected no error code, got %q", resp.ErrorCode)
 	}
 }

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/rpc"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -110,12 +111,74 @@ func (c *Client) Validate(req *ValidateRequest) (*ValidateResponse, error) {
 }
 
 // GetAuthHeader requests auth headers from the plugin for outgoing requests.
-func (c *Client) GetAuthHeader() (*GetAuthHeaderResponse, error) {
+// forceRefresh asks the plugin to skip freshness checks and refresh the
+// credential now.
+func (c *Client) GetAuthHeader(forceRefresh bool) (*GetAuthHeaderResponse, error) {
 	var resp GetAuthHeaderResponse
-	if err := c.rpcClient.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp); err != nil {
-		return nil, fmt.Errorf("auth client: get auth header: %w", err)
+	if err := c.call("GetAuthHeader", &GetAuthHeaderRequest{ForceRefresh: forceRefresh}, &resp); err != nil {
+		return nil, err
 	}
 	return &resp, nil
+}
+
+// LoginStart begins an interactive login flow on the plugin.
+func (c *Client) LoginStart(req *LoginStartRequest) (*LoginStartResponse, error) {
+	var resp LoginStartResponse
+	if err := c.call("LoginStart", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// LoginWait polls the plugin for completion of a login flow started by
+// LoginStart. It carries no client-side timeout: the plugin owns the bound
+// on how long the flow may take.
+func (c *Client) LoginWait(req *LoginWaitRequest) (*LoginWaitResponse, error) {
+	var resp LoginWaitResponse
+	if err := c.call("LoginWait", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Logout ends the current session on the plugin.
+func (c *Client) Logout() (*LogoutResponse, error) {
+	var resp LogoutResponse
+	if err := c.call("Logout", &LogoutRequest{}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// errorCoded is implemented by response types that carry an ErrorCode field,
+// letting call set it uniformly when a verb turns out to be unsupported.
+type errorCoded interface {
+	setUnsupported()
+}
+
+func (r *GetAuthHeaderResponse) setUnsupported() { r.ErrorCode = ErrorCodeUnsupported }
+func (r *LoginStartResponse) setUnsupported()    { r.ErrorCode = ErrorCodeUnsupported }
+func (r *LoginWaitResponse) setUnsupported()     { r.ErrorCode = ErrorCodeUnsupported }
+func (r *LogoutResponse) setUnsupported()        { r.ErrorCode = ErrorCodeUnsupported }
+
+// methodNotFoundPrefix is the text net/rpc prefixes to the error it returns
+// when the server has no registered method for the requested name.
+const methodNotFoundPrefix = "rpc: can't find method"
+
+// call invokes an AuthPlugin RPC method and translates net/rpc's
+// method-not-found transport error into the typed unsupported contract, so
+// an old already-built plugin binary that lacks a verb is indistinguishable
+// from a new one that declines it.
+func (c *Client) call(method string, req any, resp errorCoded) error {
+	err := c.rpcClient.Call("AuthPlugin."+method, req, resp)
+	if err == nil {
+		return nil
+	}
+	if strings.HasPrefix(err.Error(), methodNotFoundPrefix) {
+		resp.setUnsupported()
+		return nil
+	}
+	return fmt.Errorf("auth client: %s: %w", method, err)
 }
 
 // Close shuts down the RPC client, closes the connection, and kills the subprocess.

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/rpc"
 	"os/exec"
-	"strings"
 	"time"
 )
 
@@ -161,20 +160,26 @@ func (r *LoginStartResponse) setUnsupported()    { r.ErrorCode = ErrorCodeUnsupp
 func (r *LoginWaitResponse) setUnsupported()     { r.ErrorCode = ErrorCodeUnsupported }
 func (r *LogoutResponse) setUnsupported()        { r.ErrorCode = ErrorCodeUnsupported }
 
-// methodNotFoundPrefix is the text net/rpc prefixes to the error it returns
-// when the server has no registered method for the requested name.
-const methodNotFoundPrefix = "rpc: can't find method"
-
 // call invokes an AuthPlugin RPC method and translates net/rpc's
 // method-not-found transport error into the typed unsupported contract, so
 // an old already-built plugin binary that lacks a verb is indistinguishable
 // from a new one that declines it.
+//
+// The match is against the exact canonical error text net/rpc's server
+// produces for the specific method being called ("rpc: can't find method " +
+// serviceMethod), not a bare prefix. net/rpc surfaces both its own dispatch
+// failures and errors returned by an invoked method through the same
+// unstructured error channel, so a registered method that fails with an
+// error string that happens to start with that same prefix (e.g. a plugin
+// propagating a downstream RPC failure verbatim) must NOT be mistaken for an
+// absent method.
 func (c *Client) call(method string, req any, resp errorCoded) error {
-	err := c.rpcClient.Call("AuthPlugin."+method, req, resp)
+	serviceMethod := "AuthPlugin." + method
+	err := c.rpcClient.Call(serviceMethod, req, resp)
 	if err == nil {
 		return nil
 	}
-	if strings.HasPrefix(err.Error(), methodNotFoundPrefix) {
+	if err.Error() == "rpc: can't find method "+serviceMethod {
 		resp.setUnsupported()
 		return nil
 	}

--- a/pkg/auth/client_test.go
+++ b/pkg/auth/client_test.go
@@ -5,6 +5,7 @@
 package auth
 
 import (
+	"errors"
 	"net/rpc"
 	"testing"
 	"time"
@@ -253,6 +254,44 @@ func TestClient_UnsupportedVerbTranslation(t *testing.T) {
 				t.Fatalf("expected ErrorCode %q, got %q", tc.wantCode, code)
 			}
 		})
+	}
+}
+
+// confusingErrorPlugin implements the full AuthPlugin interface, but its
+// LoginStart method itself fails, returning an error whose text happens to
+// share the "rpc: can't find method" prefix net/rpc uses for its own
+// method-not-found error — for a different service and method than the one
+// invoked, as could occur when a plugin propagates a downstream RPC failure
+// verbatim (e.g. its own call to an issuer's RPC surface).
+type confusingErrorPlugin struct {
+	UnimplementedAuthPlugin
+}
+
+func (confusingErrorPlugin) Init(req *InitRequest, resp *InitResponse) error {
+	return nil
+}
+
+func (confusingErrorPlugin) LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error {
+	return errors.New("rpc: can't find method Issuer.Refresh")
+}
+
+// TestClient_Call_DoesNotMisclassifyDownstreamError exercises a method that
+// IS registered but whose own implementation fails with an error string that
+// happens to start with the same text net/rpc uses for a genuinely absent
+// method. call must surface this as a real, non-nil error rather than
+// translating it into ErrorCodeUnsupported.
+func TestClient_Call_DoesNotMisclassifyDownstreamError(t *testing.T) {
+	plugin := &confusingErrorPlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	var resp LoginStartResponse
+	err := client.call("LoginStart", &LoginStartRequest{Mode: "browser"}, &resp)
+	if err == nil {
+		t.Fatal("expected a non-nil error, got nil")
+	}
+	if resp.ErrorCode == ErrorCodeUnsupported {
+		t.Fatal("expected the downstream error not to be misclassified as ErrorCodeUnsupported")
 	}
 }
 

--- a/pkg/auth/client_test.go
+++ b/pkg/auth/client_test.go
@@ -71,7 +71,7 @@ func TestClient_GetAuthHeader(t *testing.T) {
 	client := newTestClient(t, plugin)
 	defer client.Close()
 
-	resp, err := client.GetAuthHeader()
+	resp, err := client.GetAuthHeader(false)
 	if err != nil {
 		t.Fatalf("GetAuthHeader failed: %v", err)
 	}
@@ -79,6 +79,180 @@ func TestClient_GetAuthHeader(t *testing.T) {
 	keys := resp.Headers["X-Api-Key"]
 	if len(keys) != 1 || keys[0] != "secret-key" {
 		t.Fatalf("expected X-Api-Key='secret-key', got %v", resp.Headers)
+	}
+}
+
+func TestClient_GetAuthHeader_ForceRefresh(t *testing.T) {
+	plugin := &fakePlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	if _, err := client.GetAuthHeader(true); err != nil {
+		t.Fatalf("GetAuthHeader failed: %v", err)
+	}
+
+	if !plugin.lastForceRefresh {
+		t.Fatal("expected ForceRefresh=true to transmit to the plugin")
+	}
+}
+
+func TestClient_LoginStart(t *testing.T) {
+	plugin := &fakePlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	resp, err := client.LoginStart(&LoginStartRequest{Mode: "browser"})
+	if err != nil {
+		t.Fatalf("LoginStart failed: %v", err)
+	}
+	if resp.Status != "started" {
+		t.Fatalf("expected Status 'started', got %q", resp.Status)
+	}
+	if resp.SessionID != "s-1" {
+		t.Fatalf("expected SessionID 's-1', got %q", resp.SessionID)
+	}
+}
+
+func TestClient_LoginWait(t *testing.T) {
+	plugin := &fakePlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	resp, err := client.LoginWait(&LoginWaitRequest{SessionID: "s-1"})
+	if err != nil {
+		t.Fatalf("LoginWait failed: %v", err)
+	}
+	if resp.Subject != "11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("expected Subject '11111111-1111-4111-8111-111111111111', got %q", resp.Subject)
+	}
+	if resp.SubjectName != "dpanders" {
+		t.Fatalf("expected SubjectName 'dpanders', got %q", resp.SubjectName)
+	}
+}
+
+func TestClient_Logout(t *testing.T) {
+	plugin := &fakePlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	resp, err := client.Logout()
+	if err != nil {
+		t.Fatalf("Logout failed: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("expected no error, got %q", resp.Error)
+	}
+	if resp.ErrorCode != "" {
+		t.Fatalf("expected no error code, got %q", resp.ErrorCode)
+	}
+}
+
+// legacyAuthPlugin implements only the pre-login-verb surface (Init,
+// Validate, GetAuthHeader), modelling an already-built plugin binary that
+// predates the LoginStart/LoginWait/Logout verbs.
+type legacyAuthPlugin struct{}
+
+func (legacyAuthPlugin) Init(req *InitRequest, resp *InitResponse) error {
+	return nil
+}
+
+func (legacyAuthPlugin) Validate(req *ValidateRequest, resp *ValidateResponse) error {
+	resp.Valid = true
+	return nil
+}
+
+func (legacyAuthPlugin) GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error {
+	resp.Headers = map[string][]string{"X-Api-Key": {"legacy-key"}}
+	return nil
+}
+
+// newLegacyTestClient wires a Client to an RPC server that registers only
+// the given legacy-shaped plugin, bypassing Serve (which requires the full
+// AuthPlugin interface) so the server genuinely lacks the login verbs.
+func newLegacyTestClient(t *testing.T, plugin any) *Client {
+	t.Helper()
+
+	clientConn, serverConn := pipeConn()
+
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("AuthPlugin", plugin); err != nil {
+		t.Fatalf("RegisterName: %v", err)
+	}
+	go srv.ServeConn(serverConn)
+
+	rpcClient := rpc.NewClient(clientConn)
+
+	return &Client{
+		rpcClient: rpcClient,
+		conn:      clientConn,
+	}
+}
+
+func TestClient_UnsupportedVerbTranslation(t *testing.T) {
+	client := newLegacyTestClient(t, &legacyAuthPlugin{})
+	defer client.Close()
+
+	cases := []struct {
+		name     string
+		call     func() (ErrorCode, error)
+		wantCode ErrorCode
+	}{
+		{
+			name: "GetAuthHeader",
+			call: func() (ErrorCode, error) {
+				resp, err := client.GetAuthHeader(false)
+				if err != nil {
+					return "", err
+				}
+				return resp.ErrorCode, nil
+			},
+			wantCode: "",
+		},
+		{
+			name: "LoginStart",
+			call: func() (ErrorCode, error) {
+				resp, err := client.LoginStart(&LoginStartRequest{Mode: "browser"})
+				if err != nil {
+					return "", err
+				}
+				return resp.ErrorCode, nil
+			},
+			wantCode: ErrorCodeUnsupported,
+		},
+		{
+			name: "LoginWait",
+			call: func() (ErrorCode, error) {
+				resp, err := client.LoginWait(&LoginWaitRequest{SessionID: "s-1"})
+				if err != nil {
+					return "", err
+				}
+				return resp.ErrorCode, nil
+			},
+			wantCode: ErrorCodeUnsupported,
+		},
+		{
+			name: "Logout",
+			call: func() (ErrorCode, error) {
+				resp, err := client.Logout()
+				if err != nil {
+					return "", err
+				}
+				return resp.ErrorCode, nil
+			},
+			wantCode: ErrorCodeUnsupported,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, err := tc.call()
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if code != tc.wantCode {
+				t.Fatalf("expected ErrorCode %q, got %q", tc.wantCode, code)
+			}
+		})
 	}
 }
 

--- a/pkg/auth/unimplemented.go
+++ b/pkg/auth/unimplemented.go
@@ -1,0 +1,44 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package auth
+
+// UnimplementedAuthPlugin can be embedded in an AuthPlugin implementation to
+// satisfy verbs the plugin does not support. Every stub returns a nil error
+// with ErrorCode set to ErrorCodeUnsupported, letting existing plugins adopt
+// the widened AuthPlugin interface without implementing every verb.
+//
+// Init is deliberately absent: every plugin implements it.
+type UnimplementedAuthPlugin struct{}
+
+// Validate reports the request as unsupported.
+func (UnimplementedAuthPlugin) Validate(req *ValidateRequest, resp *ValidateResponse) error {
+	resp.Valid = false
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}
+
+// GetAuthHeader reports the verb as unsupported.
+func (UnimplementedAuthPlugin) GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error {
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}
+
+// LoginStart reports the verb as unsupported.
+func (UnimplementedAuthPlugin) LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error {
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}
+
+// LoginWait reports the verb as unsupported.
+func (UnimplementedAuthPlugin) LoginWait(req *LoginWaitRequest, resp *LoginWaitResponse) error {
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}
+
+// Logout reports the verb as unsupported.
+func (UnimplementedAuthPlugin) Logout(req *LogoutRequest, resp *LogoutResponse) error {
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}

--- a/pkg/auth/unimplemented.go
+++ b/pkg/auth/unimplemented.go
@@ -4,10 +4,19 @@
 
 package auth
 
+import "errors"
+
 // UnimplementedAuthPlugin can be embedded in an AuthPlugin implementation to
-// satisfy verbs the plugin does not support. Every stub returns a nil error
+// satisfy verbs the plugin does not support. Most stubs return a nil error
 // with ErrorCode set to ErrorCodeUnsupported, letting existing plugins adopt
 // the widened AuthPlugin interface without implementing every verb.
+//
+// GetAuthHeader is the exception: it returns a Go error instead. A host
+// built against the pre-widening GetAuthHeaderResponse (Headers only, no
+// Error or ErrorCode) cannot observe those fields, so a nil-error response
+// with empty Headers reads as successful, unauthenticated access. Signaling
+// through the RPC error instead makes an agent-only plugin fail closed on
+// every host version, old or new.
 //
 // Init is deliberately absent: every plugin implements it.
 type UnimplementedAuthPlugin struct{}
@@ -19,10 +28,12 @@ func (UnimplementedAuthPlugin) Validate(req *ValidateRequest, resp *ValidateResp
 	return nil
 }
 
-// GetAuthHeader reports the verb as unsupported.
+// GetAuthHeader returns an RPC error rather than a typed response field: a
+// host running against the older GetAuthHeaderResponse shape (Headers only)
+// cannot see ErrorCode, and a nil error there is indistinguishable from a
+// successful, empty-headers response.
 func (UnimplementedAuthPlugin) GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error {
-	resp.ErrorCode = ErrorCodeUnsupported
-	return nil
+	return errors.New("auth plugin does not support GetAuthHeader")
 }
 
 // LoginStart reports the verb as unsupported.

--- a/pkg/auth/unimplemented_test.go
+++ b/pkg/auth/unimplemented_test.go
@@ -1,0 +1,105 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package auth
+
+import (
+	"net/rpc"
+	"testing"
+)
+
+// onlyInit embeds UnimplementedAuthPlugin and implements only Init itself,
+// showing that the embed alone satisfies the widened AuthPlugin interface.
+type onlyInit struct {
+	UnimplementedAuthPlugin
+}
+
+func (o *onlyInit) Init(req *InitRequest, resp *InitResponse) error {
+	return nil
+}
+
+var _ AuthPlugin = (*onlyInit)(nil)
+
+func TestUnimplementedAuthPlugin_StubsReturnUnsupported(t *testing.T) {
+	plugin := &onlyInit{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "Validate",
+			run: func(t *testing.T) {
+				var resp ValidateResponse
+				if err := client.Call("AuthPlugin.Validate", &ValidateRequest{}, &resp); err != nil {
+					t.Fatalf("Validate call failed: %v", err)
+				}
+				if resp.Valid {
+					t.Fatal("expected Valid=false")
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+		{
+			name: "GetAuthHeader",
+			run: func(t *testing.T) {
+				var resp GetAuthHeaderResponse
+				if err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp); err != nil {
+					t.Fatalf("GetAuthHeader call failed: %v", err)
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+		{
+			name: "LoginStart",
+			run: func(t *testing.T) {
+				var resp LoginStartResponse
+				if err := client.Call("AuthPlugin.LoginStart", &LoginStartRequest{}, &resp); err != nil {
+					t.Fatalf("LoginStart call failed: %v", err)
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+		{
+			name: "LoginWait",
+			run: func(t *testing.T) {
+				var resp LoginWaitResponse
+				if err := client.Call("AuthPlugin.LoginWait", &LoginWaitRequest{}, &resp); err != nil {
+					t.Fatalf("LoginWait call failed: %v", err)
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+		{
+			name: "Logout",
+			run: func(t *testing.T) {
+				var resp LogoutResponse
+				if err := client.Call("AuthPlugin.Logout", &LogoutRequest{}, &resp); err != nil {
+					t.Fatalf("Logout call failed: %v", err)
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.run)
+	}
+}

--- a/pkg/auth/unimplemented_test.go
+++ b/pkg/auth/unimplemented_test.go
@@ -21,6 +21,12 @@ func (o *onlyInit) Init(req *InitRequest, resp *InitResponse) error {
 
 var _ AuthPlugin = (*onlyInit)(nil)
 
+// TestUnimplementedAuthPlugin_StubsReturnUnsupported covers the four verbs
+// that report "unsupported" through the response's ErrorCode field with a
+// nil RPC error: Validate, LoginStart, LoginWait, Logout. These verbs did
+// not exist (or, for Validate, already fail closed via Valid=false) on
+// hosts predating the widened interface, so a typed field in the response
+// is safe.
 func TestUnimplementedAuthPlugin_StubsReturnUnsupported(t *testing.T) {
 	plugin := &onlyInit{}
 	clientConn, serverConn := pipeConn()
@@ -43,18 +49,6 @@ func TestUnimplementedAuthPlugin_StubsReturnUnsupported(t *testing.T) {
 				}
 				if resp.Valid {
 					t.Fatal("expected Valid=false")
-				}
-				if resp.ErrorCode != ErrorCodeUnsupported {
-					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
-				}
-			},
-		},
-		{
-			name: "GetAuthHeader",
-			run: func(t *testing.T) {
-				var resp GetAuthHeaderResponse
-				if err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp); err != nil {
-					t.Fatalf("GetAuthHeader call failed: %v", err)
 				}
 				if resp.ErrorCode != ErrorCodeUnsupported {
 					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
@@ -101,5 +95,28 @@ func TestUnimplementedAuthPlugin_StubsReturnUnsupported(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, tt.run)
+	}
+}
+
+// TestUnimplementedAuthPlugin_GetAuthHeaderFailsClosed exercises the one
+// stub that must signal unsupported through the RPC error channel instead
+// of a response field: a host built against the pre-widening
+// GetAuthHeaderResponse (Headers only) cannot see ErrorCode, so a nil-error
+// response with empty Headers would read as successful, unauthenticated
+// access. The call must come back with a non-nil error over the real
+// net/rpc round trip, not merely from the Go method in isolation.
+func TestUnimplementedAuthPlugin_GetAuthHeaderFailsClosed(t *testing.T) {
+	plugin := &onlyInit{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	var resp GetAuthHeaderResponse
+	err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp)
+	if err == nil {
+		t.Fatal("expected a non-nil error from GetAuthHeader")
 	}
 }

--- a/pkg/auth/version.go
+++ b/pkg/auth/version.go
@@ -10,4 +10,4 @@ const MinFormaeVersion = "0.84.0"
 
 // SDKVersion is the version of this auth SDK package.
 // Used in compatibility error messages to tell plugin authors which version to upgrade to.
-const SDKVersion = "0.2.1"
+const SDKVersion = "0.3.0"


### PR DESCRIPTION
Revises the `pkg/auth` plugin SDK so it can express interactive credential acquisition and typed failures. This is PR 1 of 4 in a stack; it changes the SDK surface only, and no host behaviour depends on the new fields yet.

**Stack:** **A (this PR)** → B (host verdict cache + middleware) → C (command attribution + migrations) → D (CLI `login`/`logout` + 401 retry). The SDK submodule is tagged `pkg/auth/v0.3.0` only after D merges, so the released SDK matches what core actually ships.

## What changes

**The interface grows three verbs.** `LoginStart` / `LoginWait` / `Logout`. Login is two calls rather than one because net/rpc is request/response and the CLI has to render the thing the user acts on — a URL to open, a device code to type — *before* the flow completes. `LoginStart` returns what to render plus a session id; `LoginWait` blocks until the flow finishes and returns the identity. There is deliberately no `Refresh` verb: silent refresh is `GetAuthHeader`'s private business, and the CLI never invokes it.

**Typed error codes replace error-string parsing.** net/rpc flattens Go errors to strings, so responses now carry an `ErrorCode` alongside the existing `Error` text, with a closed enum: `unsupported`, `not_logged_in`, `session_expired`, `issuer_unreachable`. Unknown codes are expected to degrade to generic handling, so an older host against a newer plugin does not break.

**`UnimplementedAuthPlugin` keeps interface growth from breaking existing plugins.** Adding methods to `AuthPlugin` would otherwise fail the compile-time assertion every plugin makes. Embedding the base is the whole migration. `Init` is deliberately absent from it — every plugin implements that one.

**Old plugin binaries degrade identically to new ones that decline.** An already-built binary answers an unknown verb with a net/rpc transport error, not a typed response, so the client translates that into the same `unsupported` code. The match is against the exact canonical text for the method being called, so a registered method that propagates a similarly-worded error of its own is still surfaced as a real failure rather than silently swallowed.

**Attribution fields.** `ValidateResponse` gains `Subject` (the verified subject id, authoritative) and `SubjectName` (a display hint, never used for authorization). Nothing reads them yet; PR B widens the host cache to carry them and PR C records them on command rows.

**`GetAuthHeaderRequest.ForceRefresh`.** The recovery path for a client whose clock jumped backwards — a stale token then looks fresh and nothing would ever refresh it — and for a token signed by a just-revoked key. PR D adds the retry that sets it.

## The version-skew constraint, and a residual worth knowing about

`GetAuthHeaderResponse` previously contained only `Headers`. A host built against the earlier SDK decodes only that field and discards `Error` and `ErrorCode`, so a plugin that reports failure by setting a typed code and returning a nil error is read by that host as empty headers plus no error — that is, as successful authentication, and the request goes out unauthenticated. net/rpc discards the reply body entirely when a method returns a non-nil error, so a plugin cannot signal both ways in one call.

`UnimplementedAuthPlugin.GetAuthHeader` therefore returns a non-nil Go error rather than a typed code, so a plugin that does not implement the client side fails closed on every host version. The other four stubs keep the nil-plus-code convention: an older host never calls the three login verbs, and `Validate`'s `Valid: false` already fails closed. That asymmetry is documented on the public types, since this SDK version ships as an immutable module tag.

The residual: a plugin that *does* implement `GetAuthHeader` and reports a typed failure can still read as success on a pre-0.3.0 host. There is no client-side version floor to prevent it — `FilterCompatiblePlugins` is applied when the agent loads plugins, not when the CLI does. Nothing shipping today can hit this, since the only auth plugin in existence reads its credential from config and cannot fail this way. The convention for plugins that can fail is a deliberate open decision for the first such plugin rather than something settled here.

## Also in this PR

`ValidateResponse.CacheKey` is retained and documented as unread by the host. It stays for source compatibility with plugins that set it today; the middleware computes its own key and always has.

`SDKVersion` moves to `0.3.0`. `MinFormaeVersion` is unchanged — this is not a wire-breaking protocol change, and raising the SDK-wide floor would make a newly built agent reject every published plugin.

## Testing

Both new SDK surfaces are exercised over the real net/rpc harness rather than asserted on struct literals. The unsupported-verb translation is proven against a server that genuinely does not register the method, and its false-positive counterpart against a server whose registered method returns a similarly-worded error. The in-repo mocks that implement `AuthPlugin` are updated in the same commit as the widening, so every commit in this branch builds and tests green in isolation.

`make test-unit` green repo-wide.
