### PR TITLE
feat(agent): carry the authenticated subject through the auth cache and request context

### DIFF
--- a/internal/auth/auth_plugin_handle_test.go
+++ b/internal/auth/auth_plugin_handle_test.go
@@ -20,6 +20,7 @@ import (
 
 // mockAuthPlugin implements pkgauth.AuthPlugin for testing.
 type mockAuthPlugin struct {
+	pkgauth.UnimplementedAuthPlugin
 	validResponse bool
 }
 

--- a/internal/auth/cache.go
+++ b/internal/auth/cache.go
@@ -11,6 +11,14 @@ import (
 
 const defaultReapInterval = 60 * time.Second
 
+// Verdict is a cached auth validation result: whether the request is
+// allowed, and the subject attribution that goes with that answer.
+type Verdict struct {
+	Valid       bool
+	Subject     string
+	SubjectName string
+}
+
 // AuthCache is a TTL-based cache for auth validation results.
 // Keyed by a hash of the Authorization header to avoid repeated RPC calls
 // for the same credentials. A background reaper removes expired entries
@@ -22,7 +30,7 @@ type AuthCache struct {
 }
 
 type cacheEntry struct {
-	valid     bool
+	verdict   Verdict
 	expiresAt time.Time
 }
 
@@ -35,24 +43,24 @@ func NewAuthCache() *AuthCache {
 	return c
 }
 
-// Get returns the cached validation result for the given key.
-// Returns (valid, true) on cache hit, (false, false) on miss or expiry.
-func (c *AuthCache) Get(key string) (valid bool, found bool) {
+// Get returns the cached verdict for the given key.
+// Returns (verdict, true) on cache hit, (Verdict{}, false) on miss or expiry.
+func (c *AuthCache) Get(key string) (Verdict, bool) {
 	c.mu.RLock()
 	entry, ok := c.entries[key]
 	c.mu.RUnlock()
 
 	if !ok || time.Now().After(entry.expiresAt) {
-		return false, false
+		return Verdict{}, false
 	}
-	return entry.valid, true
+	return entry.verdict, true
 }
 
-// Set stores a validation result with the given TTL.
-func (c *AuthCache) Set(key string, valid bool, ttl time.Duration) {
+// Set stores a verdict with the given TTL.
+func (c *AuthCache) Set(key string, v Verdict, ttl time.Duration) {
 	c.mu.Lock()
 	c.entries[key] = &cacheEntry{
-		valid:     valid,
+		verdict:   v,
 		expiresAt: time.Now().Add(ttl),
 	}
 	c.mu.Unlock()

--- a/internal/auth/cache_test.go
+++ b/internal/auth/cache_test.go
@@ -23,14 +23,14 @@ func TestAuthCache_SetAndGet(t *testing.T) {
 	cache := NewAuthCache()
 	defer cache.Stop()
 
-	cache.Set("key1", true, time.Minute)
+	cache.Set("key1", Verdict{Valid: true, Subject: "s", SubjectName: "Sam"}, time.Minute)
 
-	valid, found := cache.Get("key1")
+	v, found := cache.Get("key1")
 	if !found {
 		t.Fatal("expected cache hit")
 	}
-	if !valid {
-		t.Fatal("expected valid=true")
+	if v.Valid != true || v.Subject != "s" || v.SubjectName != "Sam" {
+		t.Fatalf("expected Verdict{Valid:true, Subject:%q, SubjectName:%q} to round-trip, got %+v", "s", "Sam", v)
 	}
 }
 
@@ -38,14 +38,14 @@ func TestAuthCache_SetInvalidAndGet(t *testing.T) {
 	cache := NewAuthCache()
 	defer cache.Stop()
 
-	cache.Set("key1", false, time.Minute)
+	cache.Set("key1", Verdict{Valid: false}, time.Minute)
 
-	valid, found := cache.Get("key1")
+	v, found := cache.Get("key1")
 	if !found {
 		t.Fatal("expected cache hit")
 	}
-	if valid {
-		t.Fatal("expected valid=false")
+	if v.Valid {
+		t.Fatal("expected Valid=false")
 	}
 }
 
@@ -53,7 +53,7 @@ func TestAuthCache_Expiry(t *testing.T) {
 	cache := NewAuthCache()
 	defer cache.Stop()
 
-	cache.Set("key1", true, 10*time.Millisecond)
+	cache.Set("key1", Verdict{Valid: true}, 10*time.Millisecond)
 
 	time.Sleep(20 * time.Millisecond)
 
@@ -67,15 +67,15 @@ func TestAuthCache_OverwriteEntry(t *testing.T) {
 	cache := NewAuthCache()
 	defer cache.Stop()
 
-	cache.Set("key1", true, time.Minute)
-	cache.Set("key1", false, time.Minute)
+	cache.Set("key1", Verdict{Valid: true}, time.Minute)
+	cache.Set("key1", Verdict{Valid: false}, time.Minute)
 
-	valid, found := cache.Get("key1")
+	v, found := cache.Get("key1")
 	if !found {
 		t.Fatal("expected cache hit")
 	}
-	if valid {
-		t.Fatal("expected valid=false after overwrite")
+	if v.Valid {
+		t.Fatal("expected Valid=false after overwrite")
 	}
 }
 
@@ -83,17 +83,17 @@ func TestAuthCache_IndependentKeys(t *testing.T) {
 	cache := NewAuthCache()
 	defer cache.Stop()
 
-	cache.Set("alice", true, time.Minute)
-	cache.Set("bob", false, time.Minute)
+	cache.Set("alice", Verdict{Valid: true, Subject: "alice"}, time.Minute)
+	cache.Set("bob", Verdict{Valid: false}, time.Minute)
 
-	aliceValid, found := cache.Get("alice")
-	if !found || !aliceValid {
-		t.Fatal("expected alice=valid")
+	alice, found := cache.Get("alice")
+	if !found || !alice.Valid || alice.Subject != "alice" {
+		t.Fatalf("expected alice=valid with Subject=alice, got %+v (found=%v)", alice, found)
 	}
 
-	bobValid, found := cache.Get("bob")
-	if !found || bobValid {
-		t.Fatal("expected bob=invalid")
+	bob, found := cache.Get("bob")
+	if !found || bob.Valid {
+		t.Fatalf("expected bob=invalid, got %+v (found=%v)", bob, found)
 	}
 }
 
@@ -101,8 +101,8 @@ func TestAuthCache_ReapExpired(t *testing.T) {
 	cache := NewAuthCache()
 	defer cache.Stop()
 
-	cache.Set("expired", true, 10*time.Millisecond)
-	cache.Set("alive", true, time.Minute)
+	cache.Set("expired", Verdict{Valid: true}, 10*time.Millisecond)
+	cache.Set("alive", Verdict{Valid: true}, time.Minute)
 
 	time.Sleep(20 * time.Millisecond)
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -45,7 +45,7 @@ func NewAuthMiddleware(handle *AuthPluginHandle, cache *AuthCache) echo.Middlewa
 				}
 			}
 
-			headers := map[string][]string(c.Request().Header)
+			headers := authRelevantHeaders(map[string][]string(c.Request().Header))
 			cacheKey := computeCacheKey(headers)
 
 			if v, found := cache.Get(cacheKey); found {
@@ -83,7 +83,8 @@ func NewAuthMiddleware(handle *AuthPluginHandle, cache *AuthCache) echo.Middlewa
 
 // nonAuthHeaders are headers known to be volatile or unrelated to authentication.
 // Excluding them prevents per-request variance (User-Agent, X-Request-Id, etc.)
-// from defeating the auth cache.
+// from defeating the auth cache. This is the same exclusion set that gates
+// what the auth plugin is allowed to see; see authRelevantHeaders.
 var nonAuthHeaders = map[string]bool{
 	"accept":           true,
 	"accept-encoding":  true,
@@ -99,8 +100,27 @@ var nonAuthHeaders = map[string]bool{
 	"x-request-id":     true,
 }
 
-// computeCacheKey derives a cache key from auth-relevant request headers by
-// hashing their sorted key-value pairs, excluding known volatile headers.
+// authRelevantHeaders returns the subset of headers not excluded by
+// nonAuthHeaders. It is the single source of truth for what enters both the
+// plugin's Validate call and computeCacheKey: the middleware filters once
+// and feeds the same map to each, so the plugin can never see a header the
+// cache key doesn't already cover, and the two can never drift apart. That
+// alignment is what makes a cached verdict trustworthy: it cannot outlive a
+// change in anything the plugin was able to authenticate on, because the
+// plugin was never able to authenticate on anything outside the cache key.
+func authRelevantHeaders(headers map[string][]string) map[string][]string {
+	filtered := make(map[string][]string, len(headers))
+	for k, v := range headers {
+		if !nonAuthHeaders[strings.ToLower(k)] {
+			filtered[k] = v
+		}
+	}
+	return filtered
+}
+
+// computeCacheKey derives a cache key from headers by hashing their sorted
+// key-value pairs. Callers pass authRelevantHeaders' output, not raw
+// request headers, so the key only ever reflects auth-relevant headers.
 //
 // The encoding is unambiguously decodable: each header contributes its
 // length-prefixed key, then a fixed-width big-endian uint64 count of how
@@ -114,9 +134,7 @@ func computeCacheKey(headers map[string][]string) string {
 	h := sha256.New()
 	keys := make([]string, 0, len(headers))
 	for k := range headers {
-		if !nonAuthHeaders[strings.ToLower(k)] {
-			keys = append(keys, k)
-		}
+		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -6,6 +6,7 @@ package auth
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"net/http"
 	"sort"
@@ -14,6 +15,14 @@ import (
 	"github.com/labstack/echo/v4"
 
 	pkgauth "github.com/platform-engineering-labs/formae/pkg/auth"
+)
+
+// Context keys under which the authenticated subject is stored on the echo
+// request context for downstream handlers, set on every allowed request
+// whether the verdict came fresh from the plugin or from the cache.
+const (
+	ContextKeySubject     = "auth.subject"
+	ContextKeySubjectName = "auth.subjectName"
 )
 
 // skipPaths are endpoints that don't require authentication.
@@ -39,8 +48,10 @@ func NewAuthMiddleware(handle *AuthPluginHandle, cache *AuthCache) echo.Middlewa
 			headers := map[string][]string(c.Request().Header)
 			cacheKey := computeCacheKey(headers)
 
-			if valid, found := cache.Get(cacheKey); found {
-				if valid {
+			if v, found := cache.Get(cacheKey); found {
+				if v.Valid {
+					c.Set(ContextKeySubject, v.Subject)
+					c.Set(ContextKeySubjectName, v.SubjectName)
 					return next(c)
 				}
 				return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
@@ -55,12 +66,15 @@ func NewAuthMiddleware(handle *AuthPluginHandle, cache *AuthCache) echo.Middlewa
 			}
 
 			if resp.CacheTTL > 0 {
-				cache.Set(cacheKey, resp.Valid, resp.CacheTTL)
+				cache.Set(cacheKey, Verdict{Valid: resp.Valid, Subject: resp.Subject, SubjectName: resp.SubjectName}, resp.CacheTTL)
 			}
 
 			if !resp.Valid {
 				return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
 			}
+
+			c.Set(ContextKeySubject, resp.Subject)
+			c.Set(ContextKeySubjectName, resp.SubjectName)
 
 			return next(c)
 		}
@@ -87,6 +101,11 @@ var nonAuthHeaders = map[string]bool{
 
 // computeCacheKey derives a cache key from auth-relevant request headers by
 // hashing their sorted key-value pairs, excluding known volatile headers.
+//
+// Each key and each value is written with a big-endian uint64 length prefix
+// so the encoding is injective: without delimiters, header shapes that
+// distribute the same bytes differently across keys and values (e.g. one
+// value "AB" vs. two values "A", "B") would hash identically.
 func computeCacheKey(headers map[string][]string) string {
 	h := sha256.New()
 	keys := make([]string, 0, len(headers))
@@ -96,10 +115,18 @@ func computeCacheKey(headers map[string][]string) string {
 		}
 	}
 	sort.Strings(keys)
+
+	var lenPrefix [8]byte
+	writeLengthDelimited := func(s string) {
+		binary.BigEndian.PutUint64(lenPrefix[:], uint64(len(s)))
+		h.Write(lenPrefix[:])
+		h.Write([]byte(s))
+	}
+
 	for _, k := range keys {
+		writeLengthDelimited(k)
 		for _, v := range headers[k] {
-			h.Write([]byte(k))
-			h.Write([]byte(v))
+			writeLengthDelimited(v)
 		}
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)[:16])

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -102,10 +102,14 @@ var nonAuthHeaders = map[string]bool{
 // computeCacheKey derives a cache key from auth-relevant request headers by
 // hashing their sorted key-value pairs, excluding known volatile headers.
 //
-// Each key and each value is written with a big-endian uint64 length prefix
-// so the encoding is injective: without delimiters, header shapes that
-// distribute the same bytes differently across keys and values (e.g. one
-// value "AB" vs. two values "A", "B") would hash identically.
+// The encoding is unambiguously decodable: each header contributes its
+// length-prefixed key, then a fixed-width big-endian uint64 count of how
+// many values it has, then each value with its own length prefix. The count
+// is what marks where one key's values end and the next key begins, so no
+// two distinct header sets can serialize to the same byte stream: not by
+// splitting a value's bytes differently (closed by the length prefixes),
+// and not by redistributing values across a different number of keys
+// (closed by the count).
 func computeCacheKey(headers map[string][]string) string {
 	h := sha256.New()
 	keys := make([]string, 0, len(headers))
@@ -116,16 +120,21 @@ func computeCacheKey(headers map[string][]string) string {
 	}
 	sort.Strings(keys)
 
-	var lenPrefix [8]byte
+	var buf [8]byte
+	writeUint64 := func(n uint64) {
+		binary.BigEndian.PutUint64(buf[:], n)
+		h.Write(buf[:])
+	}
 	writeLengthDelimited := func(s string) {
-		binary.BigEndian.PutUint64(lenPrefix[:], uint64(len(s)))
-		h.Write(lenPrefix[:])
+		writeUint64(uint64(len(s)))
 		h.Write([]byte(s))
 	}
 
 	for _, k := range keys {
 		writeLengthDelimited(k)
-		for _, v := range headers[k] {
+		values := headers[k]
+		writeUint64(uint64(len(values)))
+		for _, v := range values {
 			writeLengthDelimited(v)
 		}
 	}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/rpc"
+	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -298,11 +299,9 @@ func TestComputeCacheKey_Injective(t *testing.T) {
 
 // TestMiddleware_PluginNeverObservesExcludedHeaders covers every header in
 // the production nonAuthHeaders exclusion set (read from the package
-// variable itself, not restated here) and, for each one, proves the plugin
-// never sees it: a request carrying that header, with a plugin mock that
-// would report a different subject if it could see the header, still gets
-// the configured subject, and the header is absent from what the plugin
-// actually received.
+// variable itself, not restated here) and, for each one, proves two
+// properties: the plugin never sees it, and varying its value does not bust
+// the cache — the entire reason the exclusion set exists.
 func TestMiddleware_PluginNeverObservesExcludedHeaders(t *testing.T) {
 	headers := make([]string, 0, len(nonAuthHeaders))
 	for header := range nonAuthHeaders {
@@ -321,22 +320,70 @@ func TestMiddleware_PluginNeverObservesExcludedHeaders(t *testing.T) {
 			mock.leakOnHeader = canonical
 			mock.leakSubject = "leaked"
 
-			req := httptest.NewRequest(http.MethodGet, "/test", nil)
-			req.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
-			req.Header.Set(header, "excluded-value")
-			rec := httptest.NewRecorder()
-			e.ServeHTTP(rec, req)
+			// First request: cache miss, calls Validate.
+			req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req1.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+			req1.Header.Set(header, "excluded-value-one")
+			rec1 := httptest.NewRecorder()
+			e.ServeHTTP(rec1, req1)
 
-			if rec.Code != http.StatusOK {
-				t.Fatalf("expected 200, got %d", rec.Code)
+			if rec1.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rec1.Code)
 			}
-			if rec.Body.String() != "s" {
-				t.Fatalf("expected subject %q, got %q (the excluded header %q reached the plugin)", "s", rec.Body.String(), canonical)
+			if rec1.Body.String() != "s" {
+				t.Fatalf("expected subject %q, got %q (the excluded header %q reached the plugin)", "s", rec1.Body.String(), canonical)
 			}
 			if _, present := mock.lastHeaders[canonical]; present {
 				t.Fatalf("expected the plugin to never observe the excluded header %q, got %v", canonical, mock.lastHeaders)
 			}
+
+			// Second request: identical auth-relevant headers, a different
+			// value for the excluded header. This must still be a cache hit —
+			// varying only an excluded header must not bust the cache.
+			req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req2.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+			req2.Header.Set(header, "excluded-value-two")
+			rec2 := httptest.NewRecorder()
+			e.ServeHTTP(rec2, req2)
+
+			if rec2.Code != http.StatusOK {
+				t.Fatalf("second request: expected 200, got %d", rec2.Code)
+			}
+			if rec2.Body.String() != "s" {
+				t.Fatalf("second request: expected subject %q, got %q", "s", rec2.Body.String())
+			}
+			if mock.callCount != 1 {
+				t.Fatalf("expected 1 Validate call total for header %q (second request should be a cache hit), got %d", canonical, mock.callCount)
+			}
 		})
+	}
+}
+
+// TestNonAuthHeaders_PinnedMembership pins the exact contents of the
+// production exclusion set against a literal written here. Unlike the
+// table above, which is generated from nonAuthHeaders and so cannot see
+// membership changes in either direction, this comparison is against a
+// fixed value: removing a header silently weakens caching, and adding one
+// — Authorization above all — would silently keep it from ever reaching the
+// plugin. Either requires a deliberate update to the literal below.
+func TestNonAuthHeaders_PinnedMembership(t *testing.T) {
+	want := map[string]bool{
+		"accept":           true,
+		"accept-encoding":  true,
+		"accept-language":  true,
+		"cache-control":    true,
+		"connection":       true,
+		"content-length":   true,
+		"content-type":     true,
+		"date":             true,
+		"host":             true,
+		"user-agent":       true,
+		"x-correlation-id": true,
+		"x-request-id":     true,
+	}
+
+	if !reflect.DeepEqual(nonAuthHeaders, want) {
+		t.Fatalf("expected nonAuthHeaders to equal %v, got %v", want, nonAuthHeaders)
 	}
 }
 

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -20,6 +20,7 @@ import (
 
 // testMiddlewarePlugin is a configurable mock for middleware tests.
 type testMiddlewarePlugin struct {
+	pkgauth.UnimplementedAuthPlugin
 	validResponse bool
 	callCount     int
 }

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -22,6 +22,8 @@ import (
 type testMiddlewarePlugin struct {
 	pkgauth.UnimplementedAuthPlugin
 	validResponse bool
+	subject       string
+	subjectName   string
 	callCount     int
 }
 
@@ -32,6 +34,8 @@ func (p *testMiddlewarePlugin) Init(req *pkgauth.InitRequest, resp *pkgauth.Init
 func (p *testMiddlewarePlugin) Validate(req *pkgauth.ValidateRequest, resp *pkgauth.ValidateResponse) error {
 	p.callCount++
 	resp.Valid = p.validResponse
+	resp.Subject = p.subject
+	resp.SubjectName = p.subjectName
 	resp.CacheTTL = time.Minute
 	return nil
 }
@@ -62,7 +66,8 @@ func setupMiddleware(t *testing.T, validResponse bool) (*echo.Echo, *AuthPluginH
 	e := echo.New()
 	e.Use(NewAuthMiddleware(handle, cache))
 	e.GET("/test", func(c echo.Context) error {
-		return c.String(http.StatusOK, "ok")
+		subject, _ := c.Get(ContextKeySubject).(string)
+		return c.String(http.StatusOK, subject)
 	})
 
 	return e, handle, cache, mock
@@ -146,6 +151,68 @@ func TestMiddleware_CacheHit(t *testing.T) {
 	}
 	if mock.callCount != 1 {
 		t.Fatalf("second request: expected still 1 call (cache hit), got %d", mock.callCount)
+	}
+}
+
+func TestMiddleware_FreshResponseSetsSubjectOnContext(t *testing.T) {
+	e, _, _, mock := setupMiddleware(t, true)
+	mock.subject = "s"
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if rec.Body.String() != "s" {
+		t.Fatalf("expected subject %q on context, got %q", "s", rec.Body.String())
+	}
+}
+
+func TestMiddleware_CacheHitPopulatesSubjectOnContext(t *testing.T) {
+	e, _, _, mock := setupMiddleware(t, true)
+	mock.subject = "s"
+
+	// First request: cache miss → calls Validate, subject comes from the fresh response.
+	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req1.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+	rec1 := httptest.NewRecorder()
+	e.ServeHTTP(rec1, req1)
+
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first request: expected 200, got %d", rec1.Code)
+	}
+	if rec1.Body.String() != "s" {
+		t.Fatalf("first request: expected subject %q, got %q", "s", rec1.Body.String())
+	}
+
+	// Second request with the same credentials: cache hit, but the subject must
+	// still land on the context, and the plugin must not be called again.
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req2.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+	rec2 := httptest.NewRecorder()
+	e.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("second request: expected 200, got %d", rec2.Code)
+	}
+	if rec2.Body.String() != "s" {
+		t.Fatalf("second request (cache hit): expected subject %q on context, got %q", "s", rec2.Body.String())
+	}
+	if mock.callCount != 1 {
+		t.Fatalf("expected 1 Validate call (second request served from cache), got %d", mock.callCount)
+	}
+}
+
+func TestComputeCacheKey_Injective(t *testing.T) {
+	oneValue := map[string][]string{"Authorization": {"Bearer secretAuthorizationXYZ"}}
+	twoValues := map[string][]string{"Authorization": {"Bearer secret", "XYZ"}}
+
+	if computeCacheKey(oneValue) == computeCacheKey(twoValues) {
+		t.Fatal("expected different cache keys for header sets whose values concatenate to the same bytes")
 	}
 }
 

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/rpc"
+	"sort"
 	"testing"
 	"time"
 
@@ -89,6 +90,11 @@ func setupMiddleware(t *testing.T, validResponse bool) (*echo.Echo, *AuthPluginH
 	e.Use(NewAuthMiddleware(handle, cache))
 	e.GET("/test", func(c echo.Context) error {
 		subject, _ := c.Get(ContextKeySubject).(string)
+		subjectName, _ := c.Get(ContextKeySubjectName).(string)
+		// The response body carries the subject (existing assertions key off
+		// it) and this header carries the subject name, so tests can assert
+		// on both context values independently.
+		c.Response().Header().Set("X-Test-Subject-Name", subjectName)
 		return c.String(http.StatusOK, subject)
 	})
 
@@ -179,6 +185,7 @@ func TestMiddleware_CacheHit(t *testing.T) {
 func TestMiddleware_FreshResponseSetsSubjectOnContext(t *testing.T) {
 	e, _, _, mock := setupMiddleware(t, true)
 	mock.subject = "s"
+	mock.subjectName = "Sam Sample"
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
@@ -192,11 +199,15 @@ func TestMiddleware_FreshResponseSetsSubjectOnContext(t *testing.T) {
 	if rec.Body.String() != "s" {
 		t.Fatalf("expected subject %q on context, got %q", "s", rec.Body.String())
 	}
+	if got := rec.Header().Get("X-Test-Subject-Name"); got != "Sam Sample" {
+		t.Fatalf("expected subject name %q on context, got %q", "Sam Sample", got)
+	}
 }
 
 func TestMiddleware_CacheHitPopulatesSubjectOnContext(t *testing.T) {
 	e, _, _, mock := setupMiddleware(t, true)
 	mock.subject = "s"
+	mock.subjectName = "Sam Sample"
 
 	// First request: cache miss → calls Validate, subject comes from the fresh response.
 	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -210,9 +221,13 @@ func TestMiddleware_CacheHitPopulatesSubjectOnContext(t *testing.T) {
 	if rec1.Body.String() != "s" {
 		t.Fatalf("first request: expected subject %q, got %q", "s", rec1.Body.String())
 	}
+	if got := rec1.Header().Get("X-Test-Subject-Name"); got != "Sam Sample" {
+		t.Fatalf("first request: expected subject name %q, got %q", "Sam Sample", got)
+	}
 
-	// Second request with the same credentials: cache hit, but the subject must
-	// still land on the context, and the plugin must not be called again.
+	// Second request with the same credentials: cache hit, but the subject and
+	// subject name must still land on the context, reconstructed from the
+	// cache entry, and the plugin must not be called again.
 	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req2.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
 	rec2 := httptest.NewRecorder()
@@ -223,6 +238,9 @@ func TestMiddleware_CacheHitPopulatesSubjectOnContext(t *testing.T) {
 	}
 	if rec2.Body.String() != "s" {
 		t.Fatalf("second request (cache hit): expected subject %q on context, got %q", "s", rec2.Body.String())
+	}
+	if got := rec2.Header().Get("X-Test-Subject-Name"); got != "Sam Sample" {
+		t.Fatalf("second request (cache hit): expected subject name %q on context, got %q", "Sam Sample", got)
 	}
 	if mock.callCount != 1 {
 		t.Fatalf("expected 1 Validate call (second request served from cache), got %d", mock.callCount)
@@ -253,50 +271,72 @@ func TestComputeCacheKey_Injective(t *testing.T) {
 	if computeCacheKey(map[string][]string(twoHeaders)) == computeCacheKey(map[string][]string(oneHeaderThreeValues)) {
 		t.Fatal("expected different cache keys when the same bytes are distributed across a different number of headers and values")
 	}
+
+	// The same headers, assigned into two maps in opposite order, must hash
+	// to the same key: the key must not depend on map iteration order. Go
+	// randomizes iteration order per range, independently for each map, so
+	// the comparison is repeated many times to make an order-dependent
+	// implementation overwhelmingly likely to disagree at least once.
+	ascending := map[string][]string{}
+	ascending["Accept-Charset"] = []string{"utf-8"}
+	ascending["Authorization"] = []string{"Bearer token"}
+	ascending["X-Custom-Auth"] = []string{"one", "two"}
+	ascending["X-Signature"] = []string{"sig"}
+
+	descending := map[string][]string{}
+	descending["X-Signature"] = []string{"sig"}
+	descending["X-Custom-Auth"] = []string{"one", "two"}
+	descending["Authorization"] = []string{"Bearer token"}
+	descending["Accept-Charset"] = []string{"utf-8"}
+
+	for i := 0; i < 50; i++ {
+		if computeCacheKey(ascending) != computeCacheKey(descending) {
+			t.Fatalf("expected the same cache key regardless of map iteration order (repetition %d)", i)
+		}
+	}
 }
 
+// TestMiddleware_PluginNeverObservesExcludedHeaders covers every header in
+// the production nonAuthHeaders exclusion set (read from the package
+// variable itself, not restated here) and, for each one, proves the plugin
+// never sees it: a request carrying that header, with a plugin mock that
+// would report a different subject if it could see the header, still gets
+// the configured subject, and the header is absent from what the plugin
+// actually received.
 func TestMiddleware_PluginNeverObservesExcludedHeaders(t *testing.T) {
-	e, _, _, mock := setupMiddleware(t, true)
-	mock.subject = "s"
-	// If the plugin could see the excluded X-Request-Id header, it would
-	// report this subject instead of the configured one.
-	mock.leakOnHeader = "X-Request-Id"
-	mock.leakSubject = "leaked"
+	headers := make([]string, 0, len(nonAuthHeaders))
+	for header := range nonAuthHeaders {
+		headers = append(headers, header)
+	}
+	sort.Strings(headers)
 
-	// First request: cache miss, calls Validate.
-	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req1.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
-	req1.Header.Set("X-Request-Id", "request-one")
-	rec1 := httptest.NewRecorder()
-	e.ServeHTTP(rec1, req1)
+	for _, header := range headers {
+		header := header
+		t.Run(header, func(t *testing.T) {
+			e, _, _, mock := setupMiddleware(t, true)
+			mock.subject = "s"
+			canonical := http.CanonicalHeaderKey(header)
+			// If the plugin could see this excluded header, it would report
+			// this subject instead of the configured one.
+			mock.leakOnHeader = canonical
+			mock.leakSubject = "leaked"
 
-	if rec1.Code != http.StatusOK {
-		t.Fatalf("first request: expected 200, got %d", rec1.Code)
-	}
-	if rec1.Body.String() != "s" {
-		t.Fatalf("first request: expected subject %q, got %q (the excluded header reached the plugin)", "s", rec1.Body.String())
-	}
-	if _, present := mock.lastHeaders["X-Request-Id"]; present {
-		t.Fatalf("expected the plugin to never observe the excluded X-Request-Id header, got %v", mock.lastHeaders)
-	}
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+			req.Header.Set(header, "excluded-value")
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
 
-	// Second request: identical auth-relevant headers, a different value for
-	// the excluded header. Same cache key, so this is a cache hit and
-	// Validate is not called again.
-	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req2.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
-	req2.Header.Set("X-Request-Id", "request-two")
-	rec2 := httptest.NewRecorder()
-	e.ServeHTTP(rec2, req2)
-
-	if rec2.Code != http.StatusOK {
-		t.Fatalf("second request: expected 200, got %d", rec2.Code)
-	}
-	if rec2.Body.String() != "s" {
-		t.Fatalf("second request: expected subject %q, got %q", "s", rec2.Body.String())
-	}
-	if mock.callCount != 1 {
-		t.Fatalf("expected 1 Validate call total (second request served from cache), got %d", mock.callCount)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rec.Code)
+			}
+			if rec.Body.String() != "s" {
+				t.Fatalf("expected subject %q, got %q (the excluded header %q reached the plugin)", "s", rec.Body.String(), canonical)
+			}
+			if _, present := mock.lastHeaders[canonical]; present {
+				t.Fatalf("expected the plugin to never observe the excluded header %q, got %v", canonical, mock.lastHeaders)
+			}
+		})
 	}
 }
 

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -214,6 +214,23 @@ func TestComputeCacheKey_Injective(t *testing.T) {
 	if computeCacheKey(oneValue) == computeCacheKey(twoValues) {
 		t.Fatal("expected different cache keys for header sets whose values concatenate to the same bytes")
 	}
+
+	// Two headers with one value each vs. one header with three values: build
+	// both through http.Header, the same canonicalizing constructor the
+	// middleware uses when it reads c.Request().Header, so the header keys
+	// here match what computeCacheKey actually receives on the request path.
+	twoHeaders := http.Header{}
+	twoHeaders.Set("A", "X")
+	twoHeaders.Set("Ab", "Y")
+
+	oneHeaderThreeValues := http.Header{}
+	oneHeaderThreeValues.Set("A", "X")
+	oneHeaderThreeValues.Add("A", "Ab")
+	oneHeaderThreeValues.Add("A", "Y")
+
+	if computeCacheKey(map[string][]string(twoHeaders)) == computeCacheKey(map[string][]string(oneHeaderThreeValues)) {
+		t.Fatal("expected different cache keys when the same bytes are distributed across a different number of headers and values")
+	}
 }
 
 func TestMiddleware_DifferentCredentialsDifferentCacheKeys(t *testing.T) {

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -25,6 +25,17 @@ type testMiddlewarePlugin struct {
 	subject       string
 	subjectName   string
 	callCount     int
+
+	// lastHeaders captures exactly what the most recent Validate call
+	// received, so tests can assert on the plugin's actual observed input.
+	lastHeaders map[string][]string
+
+	// leakOnHeader, when non-empty, makes Validate respond with leakSubject
+	// whenever req.Headers contains this header — used to prove a header
+	// never reaches the plugin by showing what the plugin would report if
+	// it did.
+	leakOnHeader string
+	leakSubject  string
 }
 
 func (p *testMiddlewarePlugin) Init(req *pkgauth.InitRequest, resp *pkgauth.InitResponse) error {
@@ -33,6 +44,17 @@ func (p *testMiddlewarePlugin) Init(req *pkgauth.InitRequest, resp *pkgauth.Init
 
 func (p *testMiddlewarePlugin) Validate(req *pkgauth.ValidateRequest, resp *pkgauth.ValidateResponse) error {
 	p.callCount++
+	p.lastHeaders = req.Headers
+
+	if p.leakOnHeader != "" {
+		if _, leaked := req.Headers[p.leakOnHeader]; leaked {
+			resp.Valid = true
+			resp.Subject = p.leakSubject
+			resp.CacheTTL = time.Minute
+			return nil
+		}
+	}
+
 	resp.Valid = p.validResponse
 	resp.Subject = p.subject
 	resp.SubjectName = p.subjectName
@@ -230,6 +252,51 @@ func TestComputeCacheKey_Injective(t *testing.T) {
 
 	if computeCacheKey(map[string][]string(twoHeaders)) == computeCacheKey(map[string][]string(oneHeaderThreeValues)) {
 		t.Fatal("expected different cache keys when the same bytes are distributed across a different number of headers and values")
+	}
+}
+
+func TestMiddleware_PluginNeverObservesExcludedHeaders(t *testing.T) {
+	e, _, _, mock := setupMiddleware(t, true)
+	mock.subject = "s"
+	// If the plugin could see the excluded X-Request-Id header, it would
+	// report this subject instead of the configured one.
+	mock.leakOnHeader = "X-Request-Id"
+	mock.leakSubject = "leaked"
+
+	// First request: cache miss, calls Validate.
+	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req1.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+	req1.Header.Set("X-Request-Id", "request-one")
+	rec1 := httptest.NewRecorder()
+	e.ServeHTTP(rec1, req1)
+
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first request: expected 200, got %d", rec1.Code)
+	}
+	if rec1.Body.String() != "s" {
+		t.Fatalf("first request: expected subject %q, got %q (the excluded header reached the plugin)", "s", rec1.Body.String())
+	}
+	if _, present := mock.lastHeaders["X-Request-Id"]; present {
+		t.Fatalf("expected the plugin to never observe the excluded X-Request-Id header, got %v", mock.lastHeaders)
+	}
+
+	// Second request: identical auth-relevant headers, a different value for
+	// the excluded header. Same cache key, so this is a cache hit and
+	// Validate is not called again.
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req2.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+	req2.Header.Set("X-Request-Id", "request-two")
+	rec2 := httptest.NewRecorder()
+	e.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("second request: expected 200, got %d", rec2.Code)
+	}
+	if rec2.Body.String() != "s" {
+		t.Fatalf("second request: expected subject %q, got %q", "s", rec2.Body.String())
+	}
+	if mock.callCount != 1 {
+		t.Fatalf("expected 1 Validate call total (second request served from cache), got %d", mock.callCount)
 	}
 }
 

--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -689,7 +689,7 @@ func (a *App) getAuthAndNetHandlers() (http.Header, *http.Client, error) {
 			a.authClient = client
 		}
 
-		resp, err := a.authClient.GetAuthHeader()
+		resp, err := a.authClient.GetAuthHeader(false)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get auth header: %w", err)
 		}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -9,12 +9,30 @@ import (
 	"time"
 )
 
+// ErrorCode identifies a category of auth plugin error, letting callers
+// branch on failure kind without parsing the human-readable Error string.
+type ErrorCode string
+
+const (
+	// ErrorCodeUnsupported indicates the plugin does not implement this verb.
+	ErrorCodeUnsupported ErrorCode = "unsupported"
+	// ErrorCodeNotLoggedIn indicates there is no active session.
+	ErrorCodeNotLoggedIn ErrorCode = "not_logged_in"
+	// ErrorCodeSessionExpired indicates a previously active session has expired.
+	ErrorCodeSessionExpired ErrorCode = "session_expired"
+	// ErrorCodeIssuerUnreachable indicates the plugin could not reach its identity issuer.
+	ErrorCodeIssuerUnreachable ErrorCode = "issuer_unreachable"
+)
+
 // AuthPlugin is the interface that auth plugin binaries must implement.
 // Method signatures are net/rpc compatible (two args: request pointer, response pointer; returns error).
 type AuthPlugin interface {
 	Init(req *InitRequest, resp *InitResponse) error
 	Validate(req *ValidateRequest, resp *ValidateResponse) error
 	GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error
+	LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error
+	LoginWait(req *LoginWaitRequest, resp *LoginWaitResponse) error
+	Logout(req *LogoutRequest, resp *LogoutResponse) error
 }
 
 // InitRequest is sent once at startup to configure the plugin.
@@ -36,14 +54,63 @@ type ValidateRequest struct {
 type ValidateResponse struct {
 	Valid    bool
 	Error    string
-	CacheKey string
+	CacheKey string // retained for SOURCE compatibility with existing plugins; the host never reads it
 	CacheTTL time.Duration
+
+	Subject     string // verified stable subject id; empty when the plugin has no notion of one
+	SubjectName string // display hint only; never used for authorization
+	ErrorCode   ErrorCode
 }
 
 // GetAuthHeaderRequest requests auth headers for outgoing requests (CLI side).
-type GetAuthHeaderRequest struct{}
+type GetAuthHeaderRequest struct {
+	ForceRefresh bool // skip freshness checks and refresh the credential now
+}
 
 // GetAuthHeaderResponse contains the headers to attach to outgoing requests.
 type GetAuthHeaderResponse struct {
-	Headers map[string][]string
+	Headers   map[string][]string
+	Error     string
+	ErrorCode ErrorCode
+}
+
+// LoginStartRequest begins an interactive login flow.
+type LoginStartRequest struct {
+	Mode  string // "browser" | "device"
+	Force bool
+}
+
+// LoginStartResponse describes how the caller should carry out (or skip) the login flow.
+type LoginStartResponse struct {
+	Status           string // "started" | "already_authenticated"
+	Method           string // echoes Mode when Status=="started"
+	BrowserURL       string
+	VerificationURI  string
+	UserCode         string
+	SessionID        string
+	ExpiresInSeconds int
+	Subject          string // set when Status=="already_authenticated"
+	SubjectName      string
+	Error            string
+	ErrorCode        ErrorCode
+}
+
+// LoginWaitRequest polls for completion of a login flow started by LoginStart.
+type LoginWaitRequest struct{ SessionID string }
+
+// LoginWaitResponse reports the outcome of a login flow.
+type LoginWaitResponse struct {
+	Subject     string
+	SubjectName string
+	Error       string
+	ErrorCode   ErrorCode
+}
+
+// LogoutRequest ends the current session.
+type LogoutRequest struct{}
+
+// LogoutResponse is the plugin's response to Logout.
+type LogoutResponse struct {
+	Error     string
+	ErrorCode ErrorCode
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -29,6 +29,9 @@ const (
 type AuthPlugin interface {
 	Init(req *InitRequest, resp *InitResponse) error
 	Validate(req *ValidateRequest, resp *ValidateResponse) error
+	// GetAuthHeader: to fail closed on every host version, return a non-nil
+	// error rather than relying on GetAuthHeaderResponse's typed fields,
+	// which a host built against an earlier SDK cannot read.
 	GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error
 	LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error
 	LoginWait(req *LoginWaitRequest, resp *LoginWaitResponse) error
@@ -68,6 +71,14 @@ type GetAuthHeaderRequest struct {
 }
 
 // GetAuthHeaderResponse contains the headers to attach to outgoing requests.
+//
+// Error and ErrorCode were added in SDK 0.3.0. A host built against an
+// earlier SDK decodes only Headers and cannot observe either field, so a
+// nil error paired with empty Headers reads as successful authentication.
+// A plugin that must fail closed regardless of host version returns a
+// non-nil Go error from GetAuthHeader instead; these typed fields are
+// additive information for hosts new enough to read them, not a
+// substitute for that error.
 type GetAuthHeaderResponse struct {
 	Headers   map[string][]string
 	Error     string

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -28,6 +28,10 @@ const (
 // Method signatures are net/rpc compatible (two args: request pointer, response pointer; returns error).
 type AuthPlugin interface {
 	Init(req *InitRequest, resp *InitResponse) error
+	// Validate: return nil with Valid: false to deny a credential. Reserve a
+	// non-nil error for the plugin being genuinely unable to answer: the
+	// host maps any error from this call to plugin-unavailable, not to a
+	// rejected credential.
 	Validate(req *ValidateRequest, resp *ValidateResponse) error
 	// GetAuthHeader: to fail closed on every host version, return a non-nil
 	// error rather than relying on GetAuthHeaderResponse's typed fields,
@@ -60,9 +64,9 @@ type ValidateResponse struct {
 	CacheKey string // retained for SOURCE compatibility with existing plugins; the host never reads it
 	CacheTTL time.Duration
 
-	Subject     string // verified stable subject id; empty when the plugin has no notion of one
-	SubjectName string // display hint only; never used for authorization
-	ErrorCode   ErrorCode
+	Subject     string    // verified stable subject id; empty when the plugin has no notion of one
+	SubjectName string    // display hint only; never used for authorization
+	ErrorCode   ErrorCode // reserved; not currently surfaced to clients, so put the rejection reason on the plugin's stderr
 }
 
 // GetAuthHeaderRequest requests auth headers for outgoing requests (CLI side).
@@ -80,7 +84,7 @@ type GetAuthHeaderRequest struct {
 // additive information for hosts new enough to read them, not a
 // substitute for that error.
 type GetAuthHeaderResponse struct {
-	Headers   map[string][]string
+	Headers   map[string][]string // the client attaches only the canonical "Authorization" header; return the credential under that exact key
 	Error     string
 	ErrorCode ErrorCode
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -14,9 +14,10 @@ import (
 
 // fakePlugin is a test double implementing the AuthPlugin interface.
 type fakePlugin struct {
-	initCalled    bool
-	receivedCfg   json.RawMessage
-	validateUsers map[string]string // username -> password (plaintext for testing)
+	initCalled       bool
+	receivedCfg      json.RawMessage
+	validateUsers    map[string]string // username -> password (plaintext for testing)
+	lastForceRefresh bool
 }
 
 func (f *fakePlugin) Init(req *InitRequest, resp *InitResponse) error {
@@ -40,9 +41,26 @@ func (f *fakePlugin) Validate(req *ValidateRequest, resp *ValidateResponse) erro
 }
 
 func (f *fakePlugin) GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error {
+	f.lastForceRefresh = req.ForceRefresh
 	resp.Headers = map[string][]string{
 		"X-Api-Key": {"secret-key"},
 	}
+	return nil
+}
+
+func (f *fakePlugin) LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error {
+	resp.Status = "started"
+	resp.SessionID = "s-1"
+	return nil
+}
+
+func (f *fakePlugin) LoginWait(req *LoginWaitRequest, resp *LoginWaitResponse) error {
+	resp.Subject = "11111111-1111-4111-8111-111111111111"
+	resp.SubjectName = "dpanders"
+	return nil
+}
+
+func (f *fakePlugin) Logout(req *LogoutRequest, resp *LogoutResponse) error {
 	return nil
 }
 
@@ -144,7 +162,7 @@ func TestServerAndClient_GetAuthHeader(t *testing.T) {
 	defer client.Close()
 
 	var resp GetAuthHeaderResponse
-	err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp)
+	err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{ForceRefresh: true}, &resp)
 	if err != nil {
 		t.Fatalf("GetAuthHeader call failed: %v", err)
 	}
@@ -152,5 +170,75 @@ func TestServerAndClient_GetAuthHeader(t *testing.T) {
 	keys := resp.Headers["X-Api-Key"]
 	if len(keys) != 1 || keys[0] != "secret-key" {
 		t.Fatalf("expected X-Api-Key header with 'secret-key', got %v", resp.Headers)
+	}
+
+	if !plugin.lastForceRefresh {
+		t.Fatal("expected ForceRefresh to round-trip to the plugin")
+	}
+}
+
+func TestServerAndClient_LoginStart(t *testing.T) {
+	plugin := &fakePlugin{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	var resp LoginStartResponse
+	err := client.Call("AuthPlugin.LoginStart", &LoginStartRequest{Mode: "browser"}, &resp)
+	if err != nil {
+		t.Fatalf("LoginStart call failed: %v", err)
+	}
+	if resp.Status != "started" {
+		t.Fatalf("expected Status 'started', got %q", resp.Status)
+	}
+	if resp.SessionID != "s-1" {
+		t.Fatalf("expected SessionID 's-1', got %q", resp.SessionID)
+	}
+}
+
+func TestServerAndClient_LoginWait(t *testing.T) {
+	plugin := &fakePlugin{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	var resp LoginWaitResponse
+	err := client.Call("AuthPlugin.LoginWait", &LoginWaitRequest{SessionID: "s-1"}, &resp)
+	if err != nil {
+		t.Fatalf("LoginWait call failed: %v", err)
+	}
+	if resp.Subject != "11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("expected Subject '11111111-1111-4111-8111-111111111111', got %q", resp.Subject)
+	}
+	if resp.SubjectName != "dpanders" {
+		t.Fatalf("expected SubjectName 'dpanders', got %q", resp.SubjectName)
+	}
+}
+
+func TestServerAndClient_Logout(t *testing.T) {
+	plugin := &fakePlugin{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	var resp LogoutResponse
+	err := client.Call("AuthPlugin.Logout", &LogoutRequest{}, &resp)
+	if err != nil {
+		t.Fatalf("Logout call failed: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("expected no error, got %q", resp.Error)
+	}
+	if resp.ErrorCode != "" {
+		t.Fatalf("expected no error code, got %q", resp.ErrorCode)
 	}
 }

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/rpc"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -110,12 +111,74 @@ func (c *Client) Validate(req *ValidateRequest) (*ValidateResponse, error) {
 }
 
 // GetAuthHeader requests auth headers from the plugin for outgoing requests.
-func (c *Client) GetAuthHeader() (*GetAuthHeaderResponse, error) {
+// forceRefresh asks the plugin to skip freshness checks and refresh the
+// credential now.
+func (c *Client) GetAuthHeader(forceRefresh bool) (*GetAuthHeaderResponse, error) {
 	var resp GetAuthHeaderResponse
-	if err := c.rpcClient.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp); err != nil {
-		return nil, fmt.Errorf("auth client: get auth header: %w", err)
+	if err := c.call("GetAuthHeader", &GetAuthHeaderRequest{ForceRefresh: forceRefresh}, &resp); err != nil {
+		return nil, err
 	}
 	return &resp, nil
+}
+
+// LoginStart begins an interactive login flow on the plugin.
+func (c *Client) LoginStart(req *LoginStartRequest) (*LoginStartResponse, error) {
+	var resp LoginStartResponse
+	if err := c.call("LoginStart", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// LoginWait polls the plugin for completion of a login flow started by
+// LoginStart. It carries no client-side timeout: the plugin owns the bound
+// on how long the flow may take.
+func (c *Client) LoginWait(req *LoginWaitRequest) (*LoginWaitResponse, error) {
+	var resp LoginWaitResponse
+	if err := c.call("LoginWait", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Logout ends the current session on the plugin.
+func (c *Client) Logout() (*LogoutResponse, error) {
+	var resp LogoutResponse
+	if err := c.call("Logout", &LogoutRequest{}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// errorCoded is implemented by response types that carry an ErrorCode field,
+// letting call set it uniformly when a verb turns out to be unsupported.
+type errorCoded interface {
+	setUnsupported()
+}
+
+func (r *GetAuthHeaderResponse) setUnsupported() { r.ErrorCode = ErrorCodeUnsupported }
+func (r *LoginStartResponse) setUnsupported()    { r.ErrorCode = ErrorCodeUnsupported }
+func (r *LoginWaitResponse) setUnsupported()     { r.ErrorCode = ErrorCodeUnsupported }
+func (r *LogoutResponse) setUnsupported()        { r.ErrorCode = ErrorCodeUnsupported }
+
+// methodNotFoundPrefix is the text net/rpc prefixes to the error it returns
+// when the server has no registered method for the requested name.
+const methodNotFoundPrefix = "rpc: can't find method"
+
+// call invokes an AuthPlugin RPC method and translates net/rpc's
+// method-not-found transport error into the typed unsupported contract, so
+// an old already-built plugin binary that lacks a verb is indistinguishable
+// from a new one that declines it.
+func (c *Client) call(method string, req any, resp errorCoded) error {
+	err := c.rpcClient.Call("AuthPlugin."+method, req, resp)
+	if err == nil {
+		return nil
+	}
+	if strings.HasPrefix(err.Error(), methodNotFoundPrefix) {
+		resp.setUnsupported()
+		return nil
+	}
+	return fmt.Errorf("auth client: %s: %w", method, err)
 }
 
 // Close shuts down the RPC client, closes the connection, and kills the subprocess.

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/rpc"
 	"os/exec"
-	"strings"
 	"time"
 )
 
@@ -161,20 +160,26 @@ func (r *LoginStartResponse) setUnsupported()    { r.ErrorCode = ErrorCodeUnsupp
 func (r *LoginWaitResponse) setUnsupported()     { r.ErrorCode = ErrorCodeUnsupported }
 func (r *LogoutResponse) setUnsupported()        { r.ErrorCode = ErrorCodeUnsupported }
 
-// methodNotFoundPrefix is the text net/rpc prefixes to the error it returns
-// when the server has no registered method for the requested name.
-const methodNotFoundPrefix = "rpc: can't find method"
-
 // call invokes an AuthPlugin RPC method and translates net/rpc's
 // method-not-found transport error into the typed unsupported contract, so
 // an old already-built plugin binary that lacks a verb is indistinguishable
 // from a new one that declines it.
+//
+// The match is against the exact canonical error text net/rpc's server
+// produces for the specific method being called ("rpc: can't find method " +
+// serviceMethod), not a bare prefix. net/rpc surfaces both its own dispatch
+// failures and errors returned by an invoked method through the same
+// unstructured error channel, so a registered method that fails with an
+// error string that happens to start with that same prefix (e.g. a plugin
+// propagating a downstream RPC failure verbatim) must NOT be mistaken for an
+// absent method.
 func (c *Client) call(method string, req any, resp errorCoded) error {
-	err := c.rpcClient.Call("AuthPlugin."+method, req, resp)
+	serviceMethod := "AuthPlugin." + method
+	err := c.rpcClient.Call(serviceMethod, req, resp)
 	if err == nil {
 		return nil
 	}
-	if strings.HasPrefix(err.Error(), methodNotFoundPrefix) {
+	if err.Error() == "rpc: can't find method "+serviceMethod {
 		resp.setUnsupported()
 		return nil
 	}

--- a/pkg/auth/client_test.go
+++ b/pkg/auth/client_test.go
@@ -5,6 +5,7 @@
 package auth
 
 import (
+	"errors"
 	"net/rpc"
 	"testing"
 	"time"
@@ -253,6 +254,44 @@ func TestClient_UnsupportedVerbTranslation(t *testing.T) {
 				t.Fatalf("expected ErrorCode %q, got %q", tc.wantCode, code)
 			}
 		})
+	}
+}
+
+// confusingErrorPlugin implements the full AuthPlugin interface, but its
+// LoginStart method itself fails, returning an error whose text happens to
+// share the "rpc: can't find method" prefix net/rpc uses for its own
+// method-not-found error — for a different service and method than the one
+// invoked, as could occur when a plugin propagates a downstream RPC failure
+// verbatim (e.g. its own call to an issuer's RPC surface).
+type confusingErrorPlugin struct {
+	UnimplementedAuthPlugin
+}
+
+func (confusingErrorPlugin) Init(req *InitRequest, resp *InitResponse) error {
+	return nil
+}
+
+func (confusingErrorPlugin) LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error {
+	return errors.New("rpc: can't find method Issuer.Refresh")
+}
+
+// TestClient_Call_DoesNotMisclassifyDownstreamError exercises a method that
+// IS registered but whose own implementation fails with an error string that
+// happens to start with the same text net/rpc uses for a genuinely absent
+// method. call must surface this as a real, non-nil error rather than
+// translating it into ErrorCodeUnsupported.
+func TestClient_Call_DoesNotMisclassifyDownstreamError(t *testing.T) {
+	plugin := &confusingErrorPlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	var resp LoginStartResponse
+	err := client.call("LoginStart", &LoginStartRequest{Mode: "browser"}, &resp)
+	if err == nil {
+		t.Fatal("expected a non-nil error, got nil")
+	}
+	if resp.ErrorCode == ErrorCodeUnsupported {
+		t.Fatal("expected the downstream error not to be misclassified as ErrorCodeUnsupported")
 	}
 }
 

--- a/pkg/auth/client_test.go
+++ b/pkg/auth/client_test.go
@@ -71,7 +71,7 @@ func TestClient_GetAuthHeader(t *testing.T) {
 	client := newTestClient(t, plugin)
 	defer client.Close()
 
-	resp, err := client.GetAuthHeader()
+	resp, err := client.GetAuthHeader(false)
 	if err != nil {
 		t.Fatalf("GetAuthHeader failed: %v", err)
 	}
@@ -79,6 +79,180 @@ func TestClient_GetAuthHeader(t *testing.T) {
 	keys := resp.Headers["X-Api-Key"]
 	if len(keys) != 1 || keys[0] != "secret-key" {
 		t.Fatalf("expected X-Api-Key='secret-key', got %v", resp.Headers)
+	}
+}
+
+func TestClient_GetAuthHeader_ForceRefresh(t *testing.T) {
+	plugin := &fakePlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	if _, err := client.GetAuthHeader(true); err != nil {
+		t.Fatalf("GetAuthHeader failed: %v", err)
+	}
+
+	if !plugin.lastForceRefresh {
+		t.Fatal("expected ForceRefresh=true to transmit to the plugin")
+	}
+}
+
+func TestClient_LoginStart(t *testing.T) {
+	plugin := &fakePlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	resp, err := client.LoginStart(&LoginStartRequest{Mode: "browser"})
+	if err != nil {
+		t.Fatalf("LoginStart failed: %v", err)
+	}
+	if resp.Status != "started" {
+		t.Fatalf("expected Status 'started', got %q", resp.Status)
+	}
+	if resp.SessionID != "s-1" {
+		t.Fatalf("expected SessionID 's-1', got %q", resp.SessionID)
+	}
+}
+
+func TestClient_LoginWait(t *testing.T) {
+	plugin := &fakePlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	resp, err := client.LoginWait(&LoginWaitRequest{SessionID: "s-1"})
+	if err != nil {
+		t.Fatalf("LoginWait failed: %v", err)
+	}
+	if resp.Subject != "11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("expected Subject '11111111-1111-4111-8111-111111111111', got %q", resp.Subject)
+	}
+	if resp.SubjectName != "dpanders" {
+		t.Fatalf("expected SubjectName 'dpanders', got %q", resp.SubjectName)
+	}
+}
+
+func TestClient_Logout(t *testing.T) {
+	plugin := &fakePlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	resp, err := client.Logout()
+	if err != nil {
+		t.Fatalf("Logout failed: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("expected no error, got %q", resp.Error)
+	}
+	if resp.ErrorCode != "" {
+		t.Fatalf("expected no error code, got %q", resp.ErrorCode)
+	}
+}
+
+// legacyAuthPlugin implements only the pre-login-verb surface (Init,
+// Validate, GetAuthHeader), modelling an already-built plugin binary that
+// predates the LoginStart/LoginWait/Logout verbs.
+type legacyAuthPlugin struct{}
+
+func (legacyAuthPlugin) Init(req *InitRequest, resp *InitResponse) error {
+	return nil
+}
+
+func (legacyAuthPlugin) Validate(req *ValidateRequest, resp *ValidateResponse) error {
+	resp.Valid = true
+	return nil
+}
+
+func (legacyAuthPlugin) GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error {
+	resp.Headers = map[string][]string{"X-Api-Key": {"legacy-key"}}
+	return nil
+}
+
+// newLegacyTestClient wires a Client to an RPC server that registers only
+// the given legacy-shaped plugin, bypassing Serve (which requires the full
+// AuthPlugin interface) so the server genuinely lacks the login verbs.
+func newLegacyTestClient(t *testing.T, plugin any) *Client {
+	t.Helper()
+
+	clientConn, serverConn := pipeConn()
+
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("AuthPlugin", plugin); err != nil {
+		t.Fatalf("RegisterName: %v", err)
+	}
+	go srv.ServeConn(serverConn)
+
+	rpcClient := rpc.NewClient(clientConn)
+
+	return &Client{
+		rpcClient: rpcClient,
+		conn:      clientConn,
+	}
+}
+
+func TestClient_UnsupportedVerbTranslation(t *testing.T) {
+	client := newLegacyTestClient(t, &legacyAuthPlugin{})
+	defer client.Close()
+
+	cases := []struct {
+		name     string
+		call     func() (ErrorCode, error)
+		wantCode ErrorCode
+	}{
+		{
+			name: "GetAuthHeader",
+			call: func() (ErrorCode, error) {
+				resp, err := client.GetAuthHeader(false)
+				if err != nil {
+					return "", err
+				}
+				return resp.ErrorCode, nil
+			},
+			wantCode: "",
+		},
+		{
+			name: "LoginStart",
+			call: func() (ErrorCode, error) {
+				resp, err := client.LoginStart(&LoginStartRequest{Mode: "browser"})
+				if err != nil {
+					return "", err
+				}
+				return resp.ErrorCode, nil
+			},
+			wantCode: ErrorCodeUnsupported,
+		},
+		{
+			name: "LoginWait",
+			call: func() (ErrorCode, error) {
+				resp, err := client.LoginWait(&LoginWaitRequest{SessionID: "s-1"})
+				if err != nil {
+					return "", err
+				}
+				return resp.ErrorCode, nil
+			},
+			wantCode: ErrorCodeUnsupported,
+		},
+		{
+			name: "Logout",
+			call: func() (ErrorCode, error) {
+				resp, err := client.Logout()
+				if err != nil {
+					return "", err
+				}
+				return resp.ErrorCode, nil
+			},
+			wantCode: ErrorCodeUnsupported,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, err := tc.call()
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if code != tc.wantCode {
+				t.Fatalf("expected ErrorCode %q, got %q", tc.wantCode, code)
+			}
+		})
 	}
 }
 

--- a/pkg/auth/unimplemented.go
+++ b/pkg/auth/unimplemented.go
@@ -1,0 +1,44 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package auth
+
+// UnimplementedAuthPlugin can be embedded in an AuthPlugin implementation to
+// satisfy verbs the plugin does not support. Every stub returns a nil error
+// with ErrorCode set to ErrorCodeUnsupported, letting existing plugins adopt
+// the widened AuthPlugin interface without implementing every verb.
+//
+// Init is deliberately absent: every plugin implements it.
+type UnimplementedAuthPlugin struct{}
+
+// Validate reports the request as unsupported.
+func (UnimplementedAuthPlugin) Validate(req *ValidateRequest, resp *ValidateResponse) error {
+	resp.Valid = false
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}
+
+// GetAuthHeader reports the verb as unsupported.
+func (UnimplementedAuthPlugin) GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error {
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}
+
+// LoginStart reports the verb as unsupported.
+func (UnimplementedAuthPlugin) LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error {
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}
+
+// LoginWait reports the verb as unsupported.
+func (UnimplementedAuthPlugin) LoginWait(req *LoginWaitRequest, resp *LoginWaitResponse) error {
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}
+
+// Logout reports the verb as unsupported.
+func (UnimplementedAuthPlugin) Logout(req *LogoutRequest, resp *LogoutResponse) error {
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}

--- a/pkg/auth/unimplemented.go
+++ b/pkg/auth/unimplemented.go
@@ -4,10 +4,19 @@
 
 package auth
 
+import "errors"
+
 // UnimplementedAuthPlugin can be embedded in an AuthPlugin implementation to
-// satisfy verbs the plugin does not support. Every stub returns a nil error
+// satisfy verbs the plugin does not support. Most stubs return a nil error
 // with ErrorCode set to ErrorCodeUnsupported, letting existing plugins adopt
 // the widened AuthPlugin interface without implementing every verb.
+//
+// GetAuthHeader is the exception: it returns a Go error instead. A host
+// built against the pre-widening GetAuthHeaderResponse (Headers only, no
+// Error or ErrorCode) cannot observe those fields, so a nil-error response
+// with empty Headers reads as successful, unauthenticated access. Signaling
+// through the RPC error instead makes an agent-only plugin fail closed on
+// every host version, old or new.
 //
 // Init is deliberately absent: every plugin implements it.
 type UnimplementedAuthPlugin struct{}
@@ -19,10 +28,12 @@ func (UnimplementedAuthPlugin) Validate(req *ValidateRequest, resp *ValidateResp
 	return nil
 }
 
-// GetAuthHeader reports the verb as unsupported.
+// GetAuthHeader returns an RPC error rather than a typed response field: a
+// host running against the older GetAuthHeaderResponse shape (Headers only)
+// cannot see ErrorCode, and a nil error there is indistinguishable from a
+// successful, empty-headers response.
 func (UnimplementedAuthPlugin) GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error {
-	resp.ErrorCode = ErrorCodeUnsupported
-	return nil
+	return errors.New("auth plugin does not support GetAuthHeader")
 }
 
 // LoginStart reports the verb as unsupported.

--- a/pkg/auth/unimplemented_test.go
+++ b/pkg/auth/unimplemented_test.go
@@ -1,0 +1,105 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package auth
+
+import (
+	"net/rpc"
+	"testing"
+)
+
+// onlyInit embeds UnimplementedAuthPlugin and implements only Init itself,
+// showing that the embed alone satisfies the widened AuthPlugin interface.
+type onlyInit struct {
+	UnimplementedAuthPlugin
+}
+
+func (o *onlyInit) Init(req *InitRequest, resp *InitResponse) error {
+	return nil
+}
+
+var _ AuthPlugin = (*onlyInit)(nil)
+
+func TestUnimplementedAuthPlugin_StubsReturnUnsupported(t *testing.T) {
+	plugin := &onlyInit{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "Validate",
+			run: func(t *testing.T) {
+				var resp ValidateResponse
+				if err := client.Call("AuthPlugin.Validate", &ValidateRequest{}, &resp); err != nil {
+					t.Fatalf("Validate call failed: %v", err)
+				}
+				if resp.Valid {
+					t.Fatal("expected Valid=false")
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+		{
+			name: "GetAuthHeader",
+			run: func(t *testing.T) {
+				var resp GetAuthHeaderResponse
+				if err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp); err != nil {
+					t.Fatalf("GetAuthHeader call failed: %v", err)
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+		{
+			name: "LoginStart",
+			run: func(t *testing.T) {
+				var resp LoginStartResponse
+				if err := client.Call("AuthPlugin.LoginStart", &LoginStartRequest{}, &resp); err != nil {
+					t.Fatalf("LoginStart call failed: %v", err)
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+		{
+			name: "LoginWait",
+			run: func(t *testing.T) {
+				var resp LoginWaitResponse
+				if err := client.Call("AuthPlugin.LoginWait", &LoginWaitRequest{}, &resp); err != nil {
+					t.Fatalf("LoginWait call failed: %v", err)
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+		{
+			name: "Logout",
+			run: func(t *testing.T) {
+				var resp LogoutResponse
+				if err := client.Call("AuthPlugin.Logout", &LogoutRequest{}, &resp); err != nil {
+					t.Fatalf("Logout call failed: %v", err)
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.run)
+	}
+}

--- a/pkg/auth/unimplemented_test.go
+++ b/pkg/auth/unimplemented_test.go
@@ -21,6 +21,12 @@ func (o *onlyInit) Init(req *InitRequest, resp *InitResponse) error {
 
 var _ AuthPlugin = (*onlyInit)(nil)
 
+// TestUnimplementedAuthPlugin_StubsReturnUnsupported covers the four verbs
+// that report "unsupported" through the response's ErrorCode field with a
+// nil RPC error: Validate, LoginStart, LoginWait, Logout. These verbs did
+// not exist (or, for Validate, already fail closed via Valid=false) on
+// hosts predating the widened interface, so a typed field in the response
+// is safe.
 func TestUnimplementedAuthPlugin_StubsReturnUnsupported(t *testing.T) {
 	plugin := &onlyInit{}
 	clientConn, serverConn := pipeConn()
@@ -43,18 +49,6 @@ func TestUnimplementedAuthPlugin_StubsReturnUnsupported(t *testing.T) {
 				}
 				if resp.Valid {
 					t.Fatal("expected Valid=false")
-				}
-				if resp.ErrorCode != ErrorCodeUnsupported {
-					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
-				}
-			},
-		},
-		{
-			name: "GetAuthHeader",
-			run: func(t *testing.T) {
-				var resp GetAuthHeaderResponse
-				if err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp); err != nil {
-					t.Fatalf("GetAuthHeader call failed: %v", err)
 				}
 				if resp.ErrorCode != ErrorCodeUnsupported {
 					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
@@ -101,5 +95,28 @@ func TestUnimplementedAuthPlugin_StubsReturnUnsupported(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, tt.run)
+	}
+}
+
+// TestUnimplementedAuthPlugin_GetAuthHeaderFailsClosed exercises the one
+// stub that must signal unsupported through the RPC error channel instead
+// of a response field: a host built against the pre-widening
+// GetAuthHeaderResponse (Headers only) cannot see ErrorCode, so a nil-error
+// response with empty Headers would read as successful, unauthenticated
+// access. The call must come back with a non-nil error over the real
+// net/rpc round trip, not merely from the Go method in isolation.
+func TestUnimplementedAuthPlugin_GetAuthHeaderFailsClosed(t *testing.T) {
+	plugin := &onlyInit{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	var resp GetAuthHeaderResponse
+	err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp)
+	if err == nil {
+		t.Fatal("expected a non-nil error from GetAuthHeader")
 	}
 }

--- a/pkg/auth/version.go
+++ b/pkg/auth/version.go
@@ -10,4 +10,4 @@ const MinFormaeVersion = "0.84.0"
 
 // SDKVersion is the version of this auth SDK package.
 // Used in compatibility error messages to tell plugin authors which version to upgrade to.
-const SDKVersion = "0.2.1"
+const SDKVersion = "0.3.0"


### PR DESCRIPTION
Makes the agent carry the authenticated subject from the auth plugin through to the request context, so handlers can attribute work to a verified identity rather than only to a self-asserted client id.

**Stack:** A (#623, the SDK surface) → **B (this PR)** → C (command attribution + migrations) → D (CLI `login`/`logout` + 401 retry). **Base this on #623, not main.** Nothing outside `internal/auth` changes here; the handlers that consume the context values arrive in C.

## What changes

**The verdict cache widens from a bool to a `Verdict`.** It previously stored only `valid`. Since the middleware serves most requests from cache, storing only the boolean would mean attribution silently vanished on every hit after the first — the request allowed, but anonymous. The entry now carries `Valid`, `Subject` and `SubjectName`, and the middleware sets both context keys on the fresh path and the cached path alike. The cached path is the one that is easy to lose, so it has its own test asserting the plugin was called exactly once and the subject survived anyway.

`Subject` is the verified, authoritative id. `SubjectName` is a display hint and never participates in an authorization decision.

**`computeCacheKey` becomes injective.** It previously hashed sorted header keys and values with no delimiters, so distinct header sets could produce the same key and share a verdict. Length-prefixing every key and value is not sufficient on its own: with nothing marking where one key's value-list ends, `{"A": ["X"], "AB": ["Y"]}` and `{"A": ["X", "AB", "Y"]}` still encode identically. The encoding now writes, per header, the key, a fixed-width count of its values, then each value — so the stream is unambiguously decodable and no two distinct header sets can collide. That matters more than it did: a shared key now means a shared identity, not merely a shared allow/deny.

**The plugin is handed exactly the headers the cache key covers.** Previously the plugin received the complete header map while the key was computed over a filtered subset, so the cache's correctness rested on an unwritten convention that no plugin authenticates on an excluded header. Nothing enforced it, and two requests differing only in an excluded header would share an entry. Both inputs now come from a single filter call, so they cannot drift apart in a future edit. The membership of the exclusion set is unchanged.

## Testing

Beyond the behavioural cases, the new tests were checked against the mutations they exist to catch — each was applied temporarily and confirmed to make the intended test fail:

- deleting either `SubjectName` context assignment, on the fresh path and the cached path independently
- deleting `sort.Strings(keys)`, which would make the key nondeterministic and every request miss the cache
- computing the key from unfiltered headers, which would let an excluded header bust the cache
- adding `Authorization` to the exclusion set — a security-relevant over-exclusion that the per-header table cannot catch on its own, since it derives its cases from that same set, so the membership is pinned separately against a literal

Both properties of the exclusion set are pinned per header: the plugin never observes it, and varying it does not bust the cache.

`make test-unit` green repo-wide.

## Known, pre-existing, and deliberately not addressed here

Two things surfaced during review that live outside this diff and are worth their own issues rather than a drive-by:

- The verdict cache has no capacity bound and accepts the plugin's `CacheTTL` without a host-side ceiling. Both predate this PR. The plugin is the intended owner of the TTL cap, and the revocation window it implies is stated in the design; a host-side ceiling plus bounded eviction would still be worthwhile defence in depth.
- The 10s `Validate` timeout abandons the RPC rather than cancelling it, because net/rpc calls are not cancellable. A blocked plugin therefore leaves pending calls and goroutines behind. This is a known property of the mechanism, not new here.
