### PR TITLE
feat(agent): record the authenticated subject on command records

### DIFF
--- a/internal/api/apitest/fake_metastructure.go
+++ b/internal/api/apitest/fake_metastructure.go
@@ -24,6 +24,14 @@ type WrappedCommandResponse struct {
 	Error                 error
 }
 
+// RecordedSubject captures the subject and subjectName a command-creating
+// method was called with, so seam tests can assert the request's
+// authenticated identity actually reached the metastructure call.
+type RecordedSubject struct {
+	Subject     string
+	SubjectName string
+}
+
 type WrappedExtractResponse struct {
 	Forma *pkgmodel.Forma
 	Error error
@@ -97,23 +105,34 @@ type FakeMetastructure struct {
 	RecordedExtractQueries   []string
 	RecordedSummaryQueries   []string
 	RecordedKsuidLookups     []string
+
+	// RecordedApplySubjects, RecordedDestroySubjects, RecordedDestroyByQuerySubjects,
+	// and RecordedReconcileSubjects capture the subject/subjectName each
+	// command-creating call was made with, one entry appended per call.
+	RecordedApplySubjects          []RecordedSubject
+	RecordedDestroySubjects        []RecordedSubject
+	RecordedDestroyByQuerySubjects []RecordedSubject
+	RecordedReconcileSubjects      []RecordedSubject
 }
 
-func (m *FakeMetastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string) (*apimodel.SubmitCommandResponse, error) {
+func (m *FakeMetastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string, subject string, subjectName string) (*apimodel.SubmitCommandResponse, error) {
+	m.RecordedApplySubjects = append(m.RecordedApplySubjects, RecordedSubject{Subject: subject, SubjectName: subjectName})
 	nextResponse := m.ApplyResponses[0]
 	m.ApplyResponses = m.ApplyResponses[1:]
 
 	return nextResponse.SubmitCommandResponse, nextResponse.Error
 }
 
-func (m *FakeMetastructure) DestroyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string) (*apimodel.SubmitCommandResponse, error) {
+func (m *FakeMetastructure) DestroyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string, subject string, subjectName string) (*apimodel.SubmitCommandResponse, error) {
+	m.RecordedDestroySubjects = append(m.RecordedDestroySubjects, RecordedSubject{Subject: subject, SubjectName: subjectName})
 	nextResponse := m.DestroyResponses[0]
 	m.DestroyResponses = m.DestroyResponses[1:]
 
 	return nextResponse.SubmitCommandResponse, nextResponse.Error
 }
 
-func (m *FakeMetastructure) DestroyByQuery(query string, config *config.FormaCommandConfig, clientID string) (*apimodel.SubmitCommandResponse, error) {
+func (m *FakeMetastructure) DestroyByQuery(query string, config *config.FormaCommandConfig, clientID string, subject string, subjectName string) (*apimodel.SubmitCommandResponse, error) {
+	m.RecordedDestroyByQuerySubjects = append(m.RecordedDestroyByQuerySubjects, RecordedSubject{Subject: subject, SubjectName: subjectName})
 	nextResponse := m.DestroyResponses[0]
 	m.DestroyResponses = m.DestroyResponses[1:]
 
@@ -255,7 +274,8 @@ func (m *FakeMetastructure) ForceReap() error {
 	return nil
 }
 
-func (m *FakeMetastructure) ForceAutoReconcile(stackLabel string) (*apimodel.ForceReconcileResponse, error) {
+func (m *FakeMetastructure) ForceAutoReconcile(stackLabel string, subject string, subjectName string) (*apimodel.ForceReconcileResponse, error) {
+	m.RecordedReconcileSubjects = append(m.RecordedReconcileSubjects, RecordedSubject{Subject: subject, SubjectName: subjectName})
 	nextResponse := m.ReconcileResponses[0]
 	m.ReconcileResponses = m.ReconcileResponses[1:]
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -118,6 +118,17 @@ func (s *Server) configureAuth() {
 	}
 }
 
+// subjectFromContext reads the verified subject and its display-name hint off
+// the echo request context, where the auth middleware puts them on every
+// allowed request. Neither key is set when no auth plugin is configured
+// (classic mode), so the type assertions fall through to "" rather than
+// failing the request.
+func subjectFromContext(c echo.Context) (subject string, subjectName string) {
+	subject, _ = c.Get(auth.ContextKeySubject).(string)
+	subjectName, _ = c.Get(auth.ContextKeySubjectName).(string)
+	return subject, subjectName
+}
+
 // configureNetwork sets up the network listener by loading the appropriate network plugin based on the configuration.
 func (s *Server) configureNetwork() (string, error) {
 	if s.networkConfig != nil {
@@ -291,6 +302,7 @@ func (s *Server) SubmitFormaCommand(c echo.Context) error {
 	if clientID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "Client-ID header is required")
 	}
+	subject, subjectName := subjectFromContext(c)
 	command := c.FormValue("command")
 	if command == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "command is required")
@@ -315,7 +327,7 @@ func (s *Server) SubmitFormaCommand(c echo.Context) error {
 			Mode:     mode,
 			Simulate: simulate,
 			Force:    force,
-		}, clientID)
+		}, clientID, subject, subjectName)
 		if err != nil {
 			return mapError(c, err)
 		}
@@ -328,7 +340,7 @@ func (s *Server) SubmitFormaCommand(c echo.Context) error {
 		query := c.FormValue("query")
 		if query != "" {
 			// If query is provided, use it
-			response, err = s.metastructure.DestroyByQuery(query, &config.FormaCommandConfig{Simulate: simulate, OnDependents: onDependents}, clientID)
+			response, err = s.metastructure.DestroyByQuery(query, &config.FormaCommandConfig{Simulate: simulate, OnDependents: onDependents}, clientID, subject, subjectName)
 		} else {
 			// Otherwise, expect a Forma file
 			if !hasFormaFile(c) {
@@ -338,7 +350,7 @@ func (s *Server) SubmitFormaCommand(c echo.Context) error {
 			if getFormaErr != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, getFormaErr.Error())
 			}
-			response, err = s.metastructure.DestroyForma(forma, &config.FormaCommandConfig{Simulate: simulate, OnDependents: onDependents}, clientID)
+			response, err = s.metastructure.DestroyForma(forma, &config.FormaCommandConfig{Simulate: simulate, OnDependents: onDependents}, clientID, subject, subjectName)
 		}
 		if err != nil {
 			return mapError(c, err)
@@ -595,7 +607,8 @@ func (s *Server) ListDrift(c echo.Context) error {
 // @Router /stacks/{stack}/reconcile [post]
 func (s *Server) ForceReconcile(c echo.Context) error {
 	stackLabel := c.Param("stack")
-	result, err := s.metastructure.ForceAutoReconcile(stackLabel)
+	subject, subjectName := subjectFromContext(c)
+	result, err := s.metastructure.ForceAutoReconcile(stackLabel, subject, subjectName)
 	if err != nil {
 		return mapError(c, err)
 	}

--- a/internal/api/server_subject_test.go
+++ b/internal/api/server_subject_test.go
@@ -1,0 +1,215 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/platform-engineering-labs/formae/internal/api/apitest"
+	"github.com/platform-engineering-labs/formae/internal/auth"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// testSubject and testSubjectName are the fixture identity used across every
+// seeded row below, standing in for a verified caller the auth middleware
+// would have placed on the request context.
+const (
+	testSubject     = "11111111-1111-4111-8111-111111111111"
+	testSubjectName = "dpanders"
+)
+
+// subjectContextShim is an echo.MiddlewareFunc that seeds the context keys
+// the real auth middleware (auth.NewAuthMiddleware) sets on an allowed
+// request, without wiring up a live auth plugin. Tests use it to reproduce
+// exactly what a handler sees after authentication, then invoke the handler
+// directly.
+func subjectContextShim(subject, subjectName string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Set(auth.ContextKeySubject, subject)
+			c.Set(auth.ContextKeySubjectName, subjectName)
+			return next(c)
+		}
+	}
+}
+
+// newFormaCommandRequest builds a multipart /commands request carrying the
+// given form fields, matching the shape SubmitFormaCommand expects. It
+// optionally attaches an empty Forma file, mirroring the pattern already
+// used throughout server_test.go.
+func newFormaCommandRequest(t *testing.T, form map[string]string, includeFile bool) *http.Request {
+	t.Helper()
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	for key, value := range form {
+		if err := writer.WriteField(key, value); err != nil {
+			t.Fatalf("failed to write form field %q: %v", key, err)
+		}
+	}
+
+	if includeFile {
+		part, err := writer.CreateFormFile("file", "forma.json")
+		if err != nil {
+			t.Fatalf("failed to create form file: %v", err)
+		}
+		jsonData, err := json.Marshal(&pkgmodel.Forma{})
+		if err != nil {
+			t.Fatalf("failed to marshal JSON: %v", err)
+		}
+		if _, err := part.Write(jsonData); err != nil {
+			t.Fatalf("failed to write JSON data to form file: %v", err)
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("failed to close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/commands", body)
+	req.Header.Set("Client-ID", "test-client-id")
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
+}
+
+// subjectSeamCase exercises one command-creating endpoint end to end through
+// the handler, seeding (or withholding) the auth context values, then
+// asserting what the metastructure call actually received.
+type subjectSeamCase struct {
+	name        string
+	subject     string
+	subjectName string
+	seedContext bool // false reproduces classic mode: no auth plugin, no middleware, no context values.
+
+	setup      func(meta *apitest.FakeMetastructure)
+	newRequest func(t *testing.T) *http.Request
+	setParams  func(c echo.Context)
+	invoke     func(server *Server, c echo.Context) error
+	recorded   func(meta *apitest.FakeMetastructure) []apitest.RecordedSubject
+}
+
+func TestServer_CommandEndpoints_ThreadAuthenticatedSubject(t *testing.T) {
+	cases := []subjectSeamCase{
+		{
+			name:        "apply threads the authenticated subject to ApplyForma",
+			subject:     testSubject,
+			subjectName: testSubjectName,
+			seedContext: true,
+			setup: func(meta *apitest.FakeMetastructure) {
+				meta.ApplyResponses = []apitest.WrappedCommandResponse{{&apimodel.SubmitCommandResponse{CommandID: "cmd-apply"}, nil}}
+			},
+			newRequest: func(t *testing.T) *http.Request {
+				return newFormaCommandRequest(t, map[string]string{"command": "apply", "mode": "patch", "simulate": "false"}, true)
+			},
+			invoke:   func(server *Server, c echo.Context) error { return server.SubmitFormaCommand(c) },
+			recorded: func(meta *apitest.FakeMetastructure) []apitest.RecordedSubject { return meta.RecordedApplySubjects },
+		},
+		{
+			name:        "destroy threads the authenticated subject to DestroyForma",
+			subject:     testSubject,
+			subjectName: testSubjectName,
+			seedContext: true,
+			setup: func(meta *apitest.FakeMetastructure) {
+				meta.DestroyResponses = []apitest.WrappedCommandResponse{{&apimodel.SubmitCommandResponse{CommandID: "cmd-destroy"}, nil}}
+			},
+			newRequest: func(t *testing.T) *http.Request {
+				return newFormaCommandRequest(t, map[string]string{"command": "destroy", "simulate": "false"}, true)
+			},
+			invoke:   func(server *Server, c echo.Context) error { return server.SubmitFormaCommand(c) },
+			recorded: func(meta *apitest.FakeMetastructure) []apitest.RecordedSubject { return meta.RecordedDestroySubjects },
+		},
+		{
+			name:        "destroy-by-query threads the authenticated subject to DestroyByQuery",
+			subject:     testSubject,
+			subjectName: testSubjectName,
+			seedContext: true,
+			setup: func(meta *apitest.FakeMetastructure) {
+				meta.DestroyResponses = []apitest.WrappedCommandResponse{{&apimodel.SubmitCommandResponse{CommandID: "cmd-destroy-query"}, nil}}
+			},
+			newRequest: func(t *testing.T) *http.Request {
+				return newFormaCommandRequest(t, map[string]string{"command": "destroy", "simulate": "false", "query": "stack:test"}, false)
+			},
+			invoke: func(server *Server, c echo.Context) error { return server.SubmitFormaCommand(c) },
+			recorded: func(meta *apitest.FakeMetastructure) []apitest.RecordedSubject {
+				return meta.RecordedDestroyByQuerySubjects
+			},
+		},
+		{
+			name:        "force-reconcile threads the authenticated subject to ForceAutoReconcile",
+			subject:     testSubject,
+			subjectName: testSubjectName,
+			seedContext: true,
+			setup: func(meta *apitest.FakeMetastructure) {
+				meta.ReconcileResponses = []apitest.WrappedReconcileResponse{{Response: &apimodel.ForceReconcileResponse{CommandID: "cmd-reconcile"}, Error: nil}}
+			},
+			newRequest: func(t *testing.T) *http.Request {
+				return httptest.NewRequest(http.MethodPost, "/api/v1/stacks/production/reconcile", nil)
+			},
+			setParams: func(c echo.Context) {
+				c.SetParamNames("stack")
+				c.SetParamValues("production")
+			},
+			invoke:   func(server *Server, c echo.Context) error { return server.ForceReconcile(c) },
+			recorded: func(meta *apitest.FakeMetastructure) []apitest.RecordedSubject { return meta.RecordedReconcileSubjects },
+		},
+		{
+			// Classic mode: no auth plugin configured, so the middleware never
+			// runs and neither context key is ever set. The handler must not
+			// panic or error on the missing values, and must pass empty strings
+			// through rather than fabricating an identity.
+			name:        "no subject on the context passes empty strings through (classic mode)",
+			subject:     "",
+			subjectName: "",
+			seedContext: false,
+			setup: func(meta *apitest.FakeMetastructure) {
+				meta.ApplyResponses = []apitest.WrappedCommandResponse{{&apimodel.SubmitCommandResponse{CommandID: "cmd-classic"}, nil}}
+			},
+			newRequest: func(t *testing.T) *http.Request {
+				return newFormaCommandRequest(t, map[string]string{"command": "apply", "mode": "patch", "simulate": "false"}, true)
+			},
+			invoke:   func(server *Server, c echo.Context) error { return server.SubmitFormaCommand(c) },
+			recorded: func(meta *apitest.FakeMetastructure) []apitest.RecordedSubject { return meta.RecordedApplySubjects },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := &apitest.FakeMetastructure{}
+			tc.setup(meta)
+
+			server := NewServer(t.Context(), meta, nil, nil, nil, nil)
+
+			req := tc.newRequest(t)
+			rec := httptest.NewRecorder()
+			c := server.echo.NewContext(req, rec)
+			if tc.setParams != nil {
+				tc.setParams(c)
+			}
+
+			handler := echo.HandlerFunc(func(c echo.Context) error { return tc.invoke(server, c) })
+			if tc.seedContext {
+				handler = subjectContextShim(tc.subject, tc.subjectName)(handler)
+			}
+
+			assert.NoError(t, handler(c))
+
+			recorded := tc.recorded(meta)
+			if assert.Len(t, recorded, 1, "expected exactly one call to have reached the metastructure") {
+				assert.Equal(t, apitest.RecordedSubject{Subject: tc.subject, SubjectName: tc.subjectName}, recorded[0])
+			}
+		})
+	}
+}

--- a/internal/auth/auth_plugin_handle_test.go
+++ b/internal/auth/auth_plugin_handle_test.go
@@ -20,6 +20,7 @@ import (
 
 // mockAuthPlugin implements pkgauth.AuthPlugin for testing.
 type mockAuthPlugin struct {
+	pkgauth.UnimplementedAuthPlugin
 	validResponse bool
 }
 

--- a/internal/auth/cache.go
+++ b/internal/auth/cache.go
@@ -11,6 +11,14 @@ import (
 
 const defaultReapInterval = 60 * time.Second
 
+// Verdict is a cached auth validation result: whether the request is
+// allowed, and the subject attribution that goes with that answer.
+type Verdict struct {
+	Valid       bool
+	Subject     string
+	SubjectName string
+}
+
 // AuthCache is a TTL-based cache for auth validation results.
 // Keyed by a hash of the Authorization header to avoid repeated RPC calls
 // for the same credentials. A background reaper removes expired entries
@@ -22,7 +30,7 @@ type AuthCache struct {
 }
 
 type cacheEntry struct {
-	valid     bool
+	verdict   Verdict
 	expiresAt time.Time
 }
 
@@ -35,24 +43,24 @@ func NewAuthCache() *AuthCache {
 	return c
 }
 
-// Get returns the cached validation result for the given key.
-// Returns (valid, true) on cache hit, (false, false) on miss or expiry.
-func (c *AuthCache) Get(key string) (valid bool, found bool) {
+// Get returns the cached verdict for the given key.
+// Returns (verdict, true) on cache hit, (Verdict{}, false) on miss or expiry.
+func (c *AuthCache) Get(key string) (Verdict, bool) {
 	c.mu.RLock()
 	entry, ok := c.entries[key]
 	c.mu.RUnlock()
 
 	if !ok || time.Now().After(entry.expiresAt) {
-		return false, false
+		return Verdict{}, false
 	}
-	return entry.valid, true
+	return entry.verdict, true
 }
 
-// Set stores a validation result with the given TTL.
-func (c *AuthCache) Set(key string, valid bool, ttl time.Duration) {
+// Set stores a verdict with the given TTL.
+func (c *AuthCache) Set(key string, v Verdict, ttl time.Duration) {
 	c.mu.Lock()
 	c.entries[key] = &cacheEntry{
-		valid:     valid,
+		verdict:   v,
 		expiresAt: time.Now().Add(ttl),
 	}
 	c.mu.Unlock()

--- a/internal/auth/cache_test.go
+++ b/internal/auth/cache_test.go
@@ -23,14 +23,14 @@ func TestAuthCache_SetAndGet(t *testing.T) {
 	cache := NewAuthCache()
 	defer cache.Stop()
 
-	cache.Set("key1", true, time.Minute)
+	cache.Set("key1", Verdict{Valid: true, Subject: "s", SubjectName: "Sam"}, time.Minute)
 
-	valid, found := cache.Get("key1")
+	v, found := cache.Get("key1")
 	if !found {
 		t.Fatal("expected cache hit")
 	}
-	if !valid {
-		t.Fatal("expected valid=true")
+	if v.Valid != true || v.Subject != "s" || v.SubjectName != "Sam" {
+		t.Fatalf("expected Verdict{Valid:true, Subject:%q, SubjectName:%q} to round-trip, got %+v", "s", "Sam", v)
 	}
 }
 
@@ -38,14 +38,14 @@ func TestAuthCache_SetInvalidAndGet(t *testing.T) {
 	cache := NewAuthCache()
 	defer cache.Stop()
 
-	cache.Set("key1", false, time.Minute)
+	cache.Set("key1", Verdict{Valid: false}, time.Minute)
 
-	valid, found := cache.Get("key1")
+	v, found := cache.Get("key1")
 	if !found {
 		t.Fatal("expected cache hit")
 	}
-	if valid {
-		t.Fatal("expected valid=false")
+	if v.Valid {
+		t.Fatal("expected Valid=false")
 	}
 }
 
@@ -53,7 +53,7 @@ func TestAuthCache_Expiry(t *testing.T) {
 	cache := NewAuthCache()
 	defer cache.Stop()
 
-	cache.Set("key1", true, 10*time.Millisecond)
+	cache.Set("key1", Verdict{Valid: true}, 10*time.Millisecond)
 
 	time.Sleep(20 * time.Millisecond)
 
@@ -67,15 +67,15 @@ func TestAuthCache_OverwriteEntry(t *testing.T) {
 	cache := NewAuthCache()
 	defer cache.Stop()
 
-	cache.Set("key1", true, time.Minute)
-	cache.Set("key1", false, time.Minute)
+	cache.Set("key1", Verdict{Valid: true}, time.Minute)
+	cache.Set("key1", Verdict{Valid: false}, time.Minute)
 
-	valid, found := cache.Get("key1")
+	v, found := cache.Get("key1")
 	if !found {
 		t.Fatal("expected cache hit")
 	}
-	if valid {
-		t.Fatal("expected valid=false after overwrite")
+	if v.Valid {
+		t.Fatal("expected Valid=false after overwrite")
 	}
 }
 
@@ -83,17 +83,17 @@ func TestAuthCache_IndependentKeys(t *testing.T) {
 	cache := NewAuthCache()
 	defer cache.Stop()
 
-	cache.Set("alice", true, time.Minute)
-	cache.Set("bob", false, time.Minute)
+	cache.Set("alice", Verdict{Valid: true, Subject: "alice"}, time.Minute)
+	cache.Set("bob", Verdict{Valid: false}, time.Minute)
 
-	aliceValid, found := cache.Get("alice")
-	if !found || !aliceValid {
-		t.Fatal("expected alice=valid")
+	alice, found := cache.Get("alice")
+	if !found || !alice.Valid || alice.Subject != "alice" {
+		t.Fatalf("expected alice=valid with Subject=alice, got %+v (found=%v)", alice, found)
 	}
 
-	bobValid, found := cache.Get("bob")
-	if !found || bobValid {
-		t.Fatal("expected bob=invalid")
+	bob, found := cache.Get("bob")
+	if !found || bob.Valid {
+		t.Fatalf("expected bob=invalid, got %+v (found=%v)", bob, found)
 	}
 }
 
@@ -101,8 +101,8 @@ func TestAuthCache_ReapExpired(t *testing.T) {
 	cache := NewAuthCache()
 	defer cache.Stop()
 
-	cache.Set("expired", true, 10*time.Millisecond)
-	cache.Set("alive", true, time.Minute)
+	cache.Set("expired", Verdict{Valid: true}, 10*time.Millisecond)
+	cache.Set("alive", Verdict{Valid: true}, time.Minute)
 
 	time.Sleep(20 * time.Millisecond)
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -45,7 +45,7 @@ func NewAuthMiddleware(handle *AuthPluginHandle, cache *AuthCache) echo.Middlewa
 				}
 			}
 
-			headers := map[string][]string(c.Request().Header)
+			headers := authRelevantHeaders(map[string][]string(c.Request().Header))
 			cacheKey := computeCacheKey(headers)
 
 			if v, found := cache.Get(cacheKey); found {
@@ -83,7 +83,8 @@ func NewAuthMiddleware(handle *AuthPluginHandle, cache *AuthCache) echo.Middlewa
 
 // nonAuthHeaders are headers known to be volatile or unrelated to authentication.
 // Excluding them prevents per-request variance (User-Agent, X-Request-Id, etc.)
-// from defeating the auth cache.
+// from defeating the auth cache. This is the same exclusion set that gates
+// what the auth plugin is allowed to see; see authRelevantHeaders.
 var nonAuthHeaders = map[string]bool{
 	"accept":           true,
 	"accept-encoding":  true,
@@ -99,8 +100,27 @@ var nonAuthHeaders = map[string]bool{
 	"x-request-id":     true,
 }
 
-// computeCacheKey derives a cache key from auth-relevant request headers by
-// hashing their sorted key-value pairs, excluding known volatile headers.
+// authRelevantHeaders returns the subset of headers not excluded by
+// nonAuthHeaders. It is the single source of truth for what enters both the
+// plugin's Validate call and computeCacheKey: the middleware filters once
+// and feeds the same map to each, so the plugin can never see a header the
+// cache key doesn't already cover, and the two can never drift apart. That
+// alignment is what makes a cached verdict trustworthy: it cannot outlive a
+// change in anything the plugin was able to authenticate on, because the
+// plugin was never able to authenticate on anything outside the cache key.
+func authRelevantHeaders(headers map[string][]string) map[string][]string {
+	filtered := make(map[string][]string, len(headers))
+	for k, v := range headers {
+		if !nonAuthHeaders[strings.ToLower(k)] {
+			filtered[k] = v
+		}
+	}
+	return filtered
+}
+
+// computeCacheKey derives a cache key from headers by hashing their sorted
+// key-value pairs. Callers pass authRelevantHeaders' output, not raw
+// request headers, so the key only ever reflects auth-relevant headers.
 //
 // The encoding is unambiguously decodable: each header contributes its
 // length-prefixed key, then a fixed-width big-endian uint64 count of how
@@ -114,9 +134,7 @@ func computeCacheKey(headers map[string][]string) string {
 	h := sha256.New()
 	keys := make([]string, 0, len(headers))
 	for k := range headers {
-		if !nonAuthHeaders[strings.ToLower(k)] {
-			keys = append(keys, k)
-		}
+		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -6,6 +6,7 @@ package auth
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"net/http"
 	"sort"
@@ -14,6 +15,14 @@ import (
 	"github.com/labstack/echo/v4"
 
 	pkgauth "github.com/platform-engineering-labs/formae/pkg/auth"
+)
+
+// Context keys under which the authenticated subject is stored on the echo
+// request context for downstream handlers, set on every allowed request
+// whether the verdict came fresh from the plugin or from the cache.
+const (
+	ContextKeySubject     = "auth.subject"
+	ContextKeySubjectName = "auth.subjectName"
 )
 
 // skipPaths are endpoints that don't require authentication.
@@ -39,8 +48,10 @@ func NewAuthMiddleware(handle *AuthPluginHandle, cache *AuthCache) echo.Middlewa
 			headers := map[string][]string(c.Request().Header)
 			cacheKey := computeCacheKey(headers)
 
-			if valid, found := cache.Get(cacheKey); found {
-				if valid {
+			if v, found := cache.Get(cacheKey); found {
+				if v.Valid {
+					c.Set(ContextKeySubject, v.Subject)
+					c.Set(ContextKeySubjectName, v.SubjectName)
 					return next(c)
 				}
 				return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
@@ -55,12 +66,15 @@ func NewAuthMiddleware(handle *AuthPluginHandle, cache *AuthCache) echo.Middlewa
 			}
 
 			if resp.CacheTTL > 0 {
-				cache.Set(cacheKey, resp.Valid, resp.CacheTTL)
+				cache.Set(cacheKey, Verdict{Valid: resp.Valid, Subject: resp.Subject, SubjectName: resp.SubjectName}, resp.CacheTTL)
 			}
 
 			if !resp.Valid {
 				return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
 			}
+
+			c.Set(ContextKeySubject, resp.Subject)
+			c.Set(ContextKeySubjectName, resp.SubjectName)
 
 			return next(c)
 		}
@@ -87,6 +101,11 @@ var nonAuthHeaders = map[string]bool{
 
 // computeCacheKey derives a cache key from auth-relevant request headers by
 // hashing their sorted key-value pairs, excluding known volatile headers.
+//
+// Each key and each value is written with a big-endian uint64 length prefix
+// so the encoding is injective: without delimiters, header shapes that
+// distribute the same bytes differently across keys and values (e.g. one
+// value "AB" vs. two values "A", "B") would hash identically.
 func computeCacheKey(headers map[string][]string) string {
 	h := sha256.New()
 	keys := make([]string, 0, len(headers))
@@ -96,10 +115,18 @@ func computeCacheKey(headers map[string][]string) string {
 		}
 	}
 	sort.Strings(keys)
+
+	var lenPrefix [8]byte
+	writeLengthDelimited := func(s string) {
+		binary.BigEndian.PutUint64(lenPrefix[:], uint64(len(s)))
+		h.Write(lenPrefix[:])
+		h.Write([]byte(s))
+	}
+
 	for _, k := range keys {
+		writeLengthDelimited(k)
 		for _, v := range headers[k] {
-			h.Write([]byte(k))
-			h.Write([]byte(v))
+			writeLengthDelimited(v)
 		}
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)[:16])

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -102,10 +102,14 @@ var nonAuthHeaders = map[string]bool{
 // computeCacheKey derives a cache key from auth-relevant request headers by
 // hashing their sorted key-value pairs, excluding known volatile headers.
 //
-// Each key and each value is written with a big-endian uint64 length prefix
-// so the encoding is injective: without delimiters, header shapes that
-// distribute the same bytes differently across keys and values (e.g. one
-// value "AB" vs. two values "A", "B") would hash identically.
+// The encoding is unambiguously decodable: each header contributes its
+// length-prefixed key, then a fixed-width big-endian uint64 count of how
+// many values it has, then each value with its own length prefix. The count
+// is what marks where one key's values end and the next key begins, so no
+// two distinct header sets can serialize to the same byte stream: not by
+// splitting a value's bytes differently (closed by the length prefixes),
+// and not by redistributing values across a different number of keys
+// (closed by the count).
 func computeCacheKey(headers map[string][]string) string {
 	h := sha256.New()
 	keys := make([]string, 0, len(headers))
@@ -116,16 +120,21 @@ func computeCacheKey(headers map[string][]string) string {
 	}
 	sort.Strings(keys)
 
-	var lenPrefix [8]byte
+	var buf [8]byte
+	writeUint64 := func(n uint64) {
+		binary.BigEndian.PutUint64(buf[:], n)
+		h.Write(buf[:])
+	}
 	writeLengthDelimited := func(s string) {
-		binary.BigEndian.PutUint64(lenPrefix[:], uint64(len(s)))
-		h.Write(lenPrefix[:])
+		writeUint64(uint64(len(s)))
 		h.Write([]byte(s))
 	}
 
 	for _, k := range keys {
 		writeLengthDelimited(k)
-		for _, v := range headers[k] {
+		values := headers[k]
+		writeUint64(uint64(len(values)))
+		for _, v := range values {
 			writeLengthDelimited(v)
 		}
 	}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/rpc"
+	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -298,11 +299,9 @@ func TestComputeCacheKey_Injective(t *testing.T) {
 
 // TestMiddleware_PluginNeverObservesExcludedHeaders covers every header in
 // the production nonAuthHeaders exclusion set (read from the package
-// variable itself, not restated here) and, for each one, proves the plugin
-// never sees it: a request carrying that header, with a plugin mock that
-// would report a different subject if it could see the header, still gets
-// the configured subject, and the header is absent from what the plugin
-// actually received.
+// variable itself, not restated here) and, for each one, proves two
+// properties: the plugin never sees it, and varying its value does not bust
+// the cache — the entire reason the exclusion set exists.
 func TestMiddleware_PluginNeverObservesExcludedHeaders(t *testing.T) {
 	headers := make([]string, 0, len(nonAuthHeaders))
 	for header := range nonAuthHeaders {
@@ -321,22 +320,70 @@ func TestMiddleware_PluginNeverObservesExcludedHeaders(t *testing.T) {
 			mock.leakOnHeader = canonical
 			mock.leakSubject = "leaked"
 
-			req := httptest.NewRequest(http.MethodGet, "/test", nil)
-			req.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
-			req.Header.Set(header, "excluded-value")
-			rec := httptest.NewRecorder()
-			e.ServeHTTP(rec, req)
+			// First request: cache miss, calls Validate.
+			req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req1.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+			req1.Header.Set(header, "excluded-value-one")
+			rec1 := httptest.NewRecorder()
+			e.ServeHTTP(rec1, req1)
 
-			if rec.Code != http.StatusOK {
-				t.Fatalf("expected 200, got %d", rec.Code)
+			if rec1.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rec1.Code)
 			}
-			if rec.Body.String() != "s" {
-				t.Fatalf("expected subject %q, got %q (the excluded header %q reached the plugin)", "s", rec.Body.String(), canonical)
+			if rec1.Body.String() != "s" {
+				t.Fatalf("expected subject %q, got %q (the excluded header %q reached the plugin)", "s", rec1.Body.String(), canonical)
 			}
 			if _, present := mock.lastHeaders[canonical]; present {
 				t.Fatalf("expected the plugin to never observe the excluded header %q, got %v", canonical, mock.lastHeaders)
 			}
+
+			// Second request: identical auth-relevant headers, a different
+			// value for the excluded header. This must still be a cache hit —
+			// varying only an excluded header must not bust the cache.
+			req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req2.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+			req2.Header.Set(header, "excluded-value-two")
+			rec2 := httptest.NewRecorder()
+			e.ServeHTTP(rec2, req2)
+
+			if rec2.Code != http.StatusOK {
+				t.Fatalf("second request: expected 200, got %d", rec2.Code)
+			}
+			if rec2.Body.String() != "s" {
+				t.Fatalf("second request: expected subject %q, got %q", "s", rec2.Body.String())
+			}
+			if mock.callCount != 1 {
+				t.Fatalf("expected 1 Validate call total for header %q (second request should be a cache hit), got %d", canonical, mock.callCount)
+			}
 		})
+	}
+}
+
+// TestNonAuthHeaders_PinnedMembership pins the exact contents of the
+// production exclusion set against a literal written here. Unlike the
+// table above, which is generated from nonAuthHeaders and so cannot see
+// membership changes in either direction, this comparison is against a
+// fixed value: removing a header silently weakens caching, and adding one
+// — Authorization above all — would silently keep it from ever reaching the
+// plugin. Either requires a deliberate update to the literal below.
+func TestNonAuthHeaders_PinnedMembership(t *testing.T) {
+	want := map[string]bool{
+		"accept":           true,
+		"accept-encoding":  true,
+		"accept-language":  true,
+		"cache-control":    true,
+		"connection":       true,
+		"content-length":   true,
+		"content-type":     true,
+		"date":             true,
+		"host":             true,
+		"user-agent":       true,
+		"x-correlation-id": true,
+		"x-request-id":     true,
+	}
+
+	if !reflect.DeepEqual(nonAuthHeaders, want) {
+		t.Fatalf("expected nonAuthHeaders to equal %v, got %v", want, nonAuthHeaders)
 	}
 }
 

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -20,6 +20,7 @@ import (
 
 // testMiddlewarePlugin is a configurable mock for middleware tests.
 type testMiddlewarePlugin struct {
+	pkgauth.UnimplementedAuthPlugin
 	validResponse bool
 	callCount     int
 }

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -22,6 +22,8 @@ import (
 type testMiddlewarePlugin struct {
 	pkgauth.UnimplementedAuthPlugin
 	validResponse bool
+	subject       string
+	subjectName   string
 	callCount     int
 }
 
@@ -32,6 +34,8 @@ func (p *testMiddlewarePlugin) Init(req *pkgauth.InitRequest, resp *pkgauth.Init
 func (p *testMiddlewarePlugin) Validate(req *pkgauth.ValidateRequest, resp *pkgauth.ValidateResponse) error {
 	p.callCount++
 	resp.Valid = p.validResponse
+	resp.Subject = p.subject
+	resp.SubjectName = p.subjectName
 	resp.CacheTTL = time.Minute
 	return nil
 }
@@ -62,7 +66,8 @@ func setupMiddleware(t *testing.T, validResponse bool) (*echo.Echo, *AuthPluginH
 	e := echo.New()
 	e.Use(NewAuthMiddleware(handle, cache))
 	e.GET("/test", func(c echo.Context) error {
-		return c.String(http.StatusOK, "ok")
+		subject, _ := c.Get(ContextKeySubject).(string)
+		return c.String(http.StatusOK, subject)
 	})
 
 	return e, handle, cache, mock
@@ -146,6 +151,68 @@ func TestMiddleware_CacheHit(t *testing.T) {
 	}
 	if mock.callCount != 1 {
 		t.Fatalf("second request: expected still 1 call (cache hit), got %d", mock.callCount)
+	}
+}
+
+func TestMiddleware_FreshResponseSetsSubjectOnContext(t *testing.T) {
+	e, _, _, mock := setupMiddleware(t, true)
+	mock.subject = "s"
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if rec.Body.String() != "s" {
+		t.Fatalf("expected subject %q on context, got %q", "s", rec.Body.String())
+	}
+}
+
+func TestMiddleware_CacheHitPopulatesSubjectOnContext(t *testing.T) {
+	e, _, _, mock := setupMiddleware(t, true)
+	mock.subject = "s"
+
+	// First request: cache miss → calls Validate, subject comes from the fresh response.
+	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req1.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+	rec1 := httptest.NewRecorder()
+	e.ServeHTTP(rec1, req1)
+
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first request: expected 200, got %d", rec1.Code)
+	}
+	if rec1.Body.String() != "s" {
+		t.Fatalf("first request: expected subject %q, got %q", "s", rec1.Body.String())
+	}
+
+	// Second request with the same credentials: cache hit, but the subject must
+	// still land on the context, and the plugin must not be called again.
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req2.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+	rec2 := httptest.NewRecorder()
+	e.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("second request: expected 200, got %d", rec2.Code)
+	}
+	if rec2.Body.String() != "s" {
+		t.Fatalf("second request (cache hit): expected subject %q on context, got %q", "s", rec2.Body.String())
+	}
+	if mock.callCount != 1 {
+		t.Fatalf("expected 1 Validate call (second request served from cache), got %d", mock.callCount)
+	}
+}
+
+func TestComputeCacheKey_Injective(t *testing.T) {
+	oneValue := map[string][]string{"Authorization": {"Bearer secretAuthorizationXYZ"}}
+	twoValues := map[string][]string{"Authorization": {"Bearer secret", "XYZ"}}
+
+	if computeCacheKey(oneValue) == computeCacheKey(twoValues) {
+		t.Fatal("expected different cache keys for header sets whose values concatenate to the same bytes")
 	}
 }
 

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/rpc"
+	"sort"
 	"testing"
 	"time"
 
@@ -89,6 +90,11 @@ func setupMiddleware(t *testing.T, validResponse bool) (*echo.Echo, *AuthPluginH
 	e.Use(NewAuthMiddleware(handle, cache))
 	e.GET("/test", func(c echo.Context) error {
 		subject, _ := c.Get(ContextKeySubject).(string)
+		subjectName, _ := c.Get(ContextKeySubjectName).(string)
+		// The response body carries the subject (existing assertions key off
+		// it) and this header carries the subject name, so tests can assert
+		// on both context values independently.
+		c.Response().Header().Set("X-Test-Subject-Name", subjectName)
 		return c.String(http.StatusOK, subject)
 	})
 
@@ -179,6 +185,7 @@ func TestMiddleware_CacheHit(t *testing.T) {
 func TestMiddleware_FreshResponseSetsSubjectOnContext(t *testing.T) {
 	e, _, _, mock := setupMiddleware(t, true)
 	mock.subject = "s"
+	mock.subjectName = "Sam Sample"
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
@@ -192,11 +199,15 @@ func TestMiddleware_FreshResponseSetsSubjectOnContext(t *testing.T) {
 	if rec.Body.String() != "s" {
 		t.Fatalf("expected subject %q on context, got %q", "s", rec.Body.String())
 	}
+	if got := rec.Header().Get("X-Test-Subject-Name"); got != "Sam Sample" {
+		t.Fatalf("expected subject name %q on context, got %q", "Sam Sample", got)
+	}
 }
 
 func TestMiddleware_CacheHitPopulatesSubjectOnContext(t *testing.T) {
 	e, _, _, mock := setupMiddleware(t, true)
 	mock.subject = "s"
+	mock.subjectName = "Sam Sample"
 
 	// First request: cache miss → calls Validate, subject comes from the fresh response.
 	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -210,9 +221,13 @@ func TestMiddleware_CacheHitPopulatesSubjectOnContext(t *testing.T) {
 	if rec1.Body.String() != "s" {
 		t.Fatalf("first request: expected subject %q, got %q", "s", rec1.Body.String())
 	}
+	if got := rec1.Header().Get("X-Test-Subject-Name"); got != "Sam Sample" {
+		t.Fatalf("first request: expected subject name %q, got %q", "Sam Sample", got)
+	}
 
-	// Second request with the same credentials: cache hit, but the subject must
-	// still land on the context, and the plugin must not be called again.
+	// Second request with the same credentials: cache hit, but the subject and
+	// subject name must still land on the context, reconstructed from the
+	// cache entry, and the plugin must not be called again.
 	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req2.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
 	rec2 := httptest.NewRecorder()
@@ -223,6 +238,9 @@ func TestMiddleware_CacheHitPopulatesSubjectOnContext(t *testing.T) {
 	}
 	if rec2.Body.String() != "s" {
 		t.Fatalf("second request (cache hit): expected subject %q on context, got %q", "s", rec2.Body.String())
+	}
+	if got := rec2.Header().Get("X-Test-Subject-Name"); got != "Sam Sample" {
+		t.Fatalf("second request (cache hit): expected subject name %q on context, got %q", "Sam Sample", got)
 	}
 	if mock.callCount != 1 {
 		t.Fatalf("expected 1 Validate call (second request served from cache), got %d", mock.callCount)
@@ -253,50 +271,72 @@ func TestComputeCacheKey_Injective(t *testing.T) {
 	if computeCacheKey(map[string][]string(twoHeaders)) == computeCacheKey(map[string][]string(oneHeaderThreeValues)) {
 		t.Fatal("expected different cache keys when the same bytes are distributed across a different number of headers and values")
 	}
+
+	// The same headers, assigned into two maps in opposite order, must hash
+	// to the same key: the key must not depend on map iteration order. Go
+	// randomizes iteration order per range, independently for each map, so
+	// the comparison is repeated many times to make an order-dependent
+	// implementation overwhelmingly likely to disagree at least once.
+	ascending := map[string][]string{}
+	ascending["Accept-Charset"] = []string{"utf-8"}
+	ascending["Authorization"] = []string{"Bearer token"}
+	ascending["X-Custom-Auth"] = []string{"one", "two"}
+	ascending["X-Signature"] = []string{"sig"}
+
+	descending := map[string][]string{}
+	descending["X-Signature"] = []string{"sig"}
+	descending["X-Custom-Auth"] = []string{"one", "two"}
+	descending["Authorization"] = []string{"Bearer token"}
+	descending["Accept-Charset"] = []string{"utf-8"}
+
+	for i := 0; i < 50; i++ {
+		if computeCacheKey(ascending) != computeCacheKey(descending) {
+			t.Fatalf("expected the same cache key regardless of map iteration order (repetition %d)", i)
+		}
+	}
 }
 
+// TestMiddleware_PluginNeverObservesExcludedHeaders covers every header in
+// the production nonAuthHeaders exclusion set (read from the package
+// variable itself, not restated here) and, for each one, proves the plugin
+// never sees it: a request carrying that header, with a plugin mock that
+// would report a different subject if it could see the header, still gets
+// the configured subject, and the header is absent from what the plugin
+// actually received.
 func TestMiddleware_PluginNeverObservesExcludedHeaders(t *testing.T) {
-	e, _, _, mock := setupMiddleware(t, true)
-	mock.subject = "s"
-	// If the plugin could see the excluded X-Request-Id header, it would
-	// report this subject instead of the configured one.
-	mock.leakOnHeader = "X-Request-Id"
-	mock.leakSubject = "leaked"
+	headers := make([]string, 0, len(nonAuthHeaders))
+	for header := range nonAuthHeaders {
+		headers = append(headers, header)
+	}
+	sort.Strings(headers)
 
-	// First request: cache miss, calls Validate.
-	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req1.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
-	req1.Header.Set("X-Request-Id", "request-one")
-	rec1 := httptest.NewRecorder()
-	e.ServeHTTP(rec1, req1)
+	for _, header := range headers {
+		header := header
+		t.Run(header, func(t *testing.T) {
+			e, _, _, mock := setupMiddleware(t, true)
+			mock.subject = "s"
+			canonical := http.CanonicalHeaderKey(header)
+			// If the plugin could see this excluded header, it would report
+			// this subject instead of the configured one.
+			mock.leakOnHeader = canonical
+			mock.leakSubject = "leaked"
 
-	if rec1.Code != http.StatusOK {
-		t.Fatalf("first request: expected 200, got %d", rec1.Code)
-	}
-	if rec1.Body.String() != "s" {
-		t.Fatalf("first request: expected subject %q, got %q (the excluded header reached the plugin)", "s", rec1.Body.String())
-	}
-	if _, present := mock.lastHeaders["X-Request-Id"]; present {
-		t.Fatalf("expected the plugin to never observe the excluded X-Request-Id header, got %v", mock.lastHeaders)
-	}
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+			req.Header.Set(header, "excluded-value")
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
 
-	// Second request: identical auth-relevant headers, a different value for
-	// the excluded header. Same cache key, so this is a cache hit and
-	// Validate is not called again.
-	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req2.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
-	req2.Header.Set("X-Request-Id", "request-two")
-	rec2 := httptest.NewRecorder()
-	e.ServeHTTP(rec2, req2)
-
-	if rec2.Code != http.StatusOK {
-		t.Fatalf("second request: expected 200, got %d", rec2.Code)
-	}
-	if rec2.Body.String() != "s" {
-		t.Fatalf("second request: expected subject %q, got %q", "s", rec2.Body.String())
-	}
-	if mock.callCount != 1 {
-		t.Fatalf("expected 1 Validate call total (second request served from cache), got %d", mock.callCount)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rec.Code)
+			}
+			if rec.Body.String() != "s" {
+				t.Fatalf("expected subject %q, got %q (the excluded header %q reached the plugin)", "s", rec.Body.String(), canonical)
+			}
+			if _, present := mock.lastHeaders[canonical]; present {
+				t.Fatalf("expected the plugin to never observe the excluded header %q, got %v", canonical, mock.lastHeaders)
+			}
+		})
 	}
 }
 

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -214,6 +214,23 @@ func TestComputeCacheKey_Injective(t *testing.T) {
 	if computeCacheKey(oneValue) == computeCacheKey(twoValues) {
 		t.Fatal("expected different cache keys for header sets whose values concatenate to the same bytes")
 	}
+
+	// Two headers with one value each vs. one header with three values: build
+	// both through http.Header, the same canonicalizing constructor the
+	// middleware uses when it reads c.Request().Header, so the header keys
+	// here match what computeCacheKey actually receives on the request path.
+	twoHeaders := http.Header{}
+	twoHeaders.Set("A", "X")
+	twoHeaders.Set("Ab", "Y")
+
+	oneHeaderThreeValues := http.Header{}
+	oneHeaderThreeValues.Set("A", "X")
+	oneHeaderThreeValues.Add("A", "Ab")
+	oneHeaderThreeValues.Add("A", "Y")
+
+	if computeCacheKey(map[string][]string(twoHeaders)) == computeCacheKey(map[string][]string(oneHeaderThreeValues)) {
+		t.Fatal("expected different cache keys when the same bytes are distributed across a different number of headers and values")
+	}
 }
 
 func TestMiddleware_DifferentCredentialsDifferentCacheKeys(t *testing.T) {

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -25,6 +25,17 @@ type testMiddlewarePlugin struct {
 	subject       string
 	subjectName   string
 	callCount     int
+
+	// lastHeaders captures exactly what the most recent Validate call
+	// received, so tests can assert on the plugin's actual observed input.
+	lastHeaders map[string][]string
+
+	// leakOnHeader, when non-empty, makes Validate respond with leakSubject
+	// whenever req.Headers contains this header — used to prove a header
+	// never reaches the plugin by showing what the plugin would report if
+	// it did.
+	leakOnHeader string
+	leakSubject  string
 }
 
 func (p *testMiddlewarePlugin) Init(req *pkgauth.InitRequest, resp *pkgauth.InitResponse) error {
@@ -33,6 +44,17 @@ func (p *testMiddlewarePlugin) Init(req *pkgauth.InitRequest, resp *pkgauth.Init
 
 func (p *testMiddlewarePlugin) Validate(req *pkgauth.ValidateRequest, resp *pkgauth.ValidateResponse) error {
 	p.callCount++
+	p.lastHeaders = req.Headers
+
+	if p.leakOnHeader != "" {
+		if _, leaked := req.Headers[p.leakOnHeader]; leaked {
+			resp.Valid = true
+			resp.Subject = p.leakSubject
+			resp.CacheTTL = time.Minute
+			return nil
+		}
+	}
+
 	resp.Valid = p.validResponse
 	resp.Subject = p.subject
 	resp.SubjectName = p.subjectName
@@ -230,6 +252,51 @@ func TestComputeCacheKey_Injective(t *testing.T) {
 
 	if computeCacheKey(map[string][]string(twoHeaders)) == computeCacheKey(map[string][]string(oneHeaderThreeValues)) {
 		t.Fatal("expected different cache keys when the same bytes are distributed across a different number of headers and values")
+	}
+}
+
+func TestMiddleware_PluginNeverObservesExcludedHeaders(t *testing.T) {
+	e, _, _, mock := setupMiddleware(t, true)
+	mock.subject = "s"
+	// If the plugin could see the excluded X-Request-Id header, it would
+	// report this subject instead of the configured one.
+	mock.leakOnHeader = "X-Request-Id"
+	mock.leakSubject = "leaked"
+
+	// First request: cache miss, calls Validate.
+	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req1.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+	req1.Header.Set("X-Request-Id", "request-one")
+	rec1 := httptest.NewRecorder()
+	e.ServeHTTP(rec1, req1)
+
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first request: expected 200, got %d", rec1.Code)
+	}
+	if rec1.Body.String() != "s" {
+		t.Fatalf("first request: expected subject %q, got %q (the excluded header reached the plugin)", "s", rec1.Body.String())
+	}
+	if _, present := mock.lastHeaders["X-Request-Id"]; present {
+		t.Fatalf("expected the plugin to never observe the excluded X-Request-Id header, got %v", mock.lastHeaders)
+	}
+
+	// Second request: identical auth-relevant headers, a different value for
+	// the excluded header. Same cache key, so this is a cache hit and
+	// Validate is not called again.
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req2.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+	req2.Header.Set("X-Request-Id", "request-two")
+	rec2 := httptest.NewRecorder()
+	e.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("second request: expected 200, got %d", rec2.Code)
+	}
+	if rec2.Body.String() != "s" {
+		t.Fatalf("second request: expected subject %q, got %q", "s", rec2.Body.String())
+	}
+	if mock.callCount != 1 {
+		t.Fatalf("expected 1 Validate call total (second request served from cache), got %d", mock.callCount)
 	}
 }
 

--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -689,7 +689,7 @@ func (a *App) getAuthAndNetHandlers() (http.Header, *http.Client, error) {
 			a.authClient = client
 		}
 
-		resp, err := a.authClient.GetAuthHeader()
+		resp, err := a.authClient.GetAuthHeader(false)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get auth header: %w", err)
 		}

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -747,10 +747,10 @@ func (d *DatastoreAuroraDataAPI) StoreFormaCommand(fa *forma_command.FormaComman
 	query := fmt.Sprintf(`
 	INSERT INTO %s (command_id, timestamp, command, state, agent_version, client_id, agent_id,
 		description_text, description_confirm, config_mode, config_force, config_simulate,
-		target_updates, stack_updates, policy_updates, modified_ts, source)
+		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name)
 	VALUES (:command_id, :timestamp::timestamp, :command, :state, :agent_version, :client_id, :agent_id,
 		:description_text, :description_confirm, :config_mode, :config_force, :config_simulate,
-		:target_updates, :stack_updates, :policy_updates, :modified_ts::timestamp, :source)
+		:target_updates, :stack_updates, :policy_updates, :modified_ts::timestamp, :source, :subject, :subject_name)
 	ON CONFLICT (command_id) DO UPDATE
 	SET timestamp = EXCLUDED.timestamp,
 	command = EXCLUDED.command,
@@ -767,7 +767,9 @@ func (d *DatastoreAuroraDataAPI) StoreFormaCommand(fa *forma_command.FormaComman
 	stack_updates = EXCLUDED.stack_updates,
 	policy_updates = EXCLUDED.policy_updates,
 	modified_ts = EXCLUDED.modified_ts,
-	source = EXCLUDED.source
+	source = EXCLUDED.source,
+	subject = EXCLUDED.subject,
+	subject_name = EXCLUDED.subject_name
 	`, datastore.CommandsTable)
 
 	params := []types.SqlParameter{
@@ -788,6 +790,8 @@ func (d *DatastoreAuroraDataAPI) StoreFormaCommand(fa *forma_command.FormaComman
 		{Name: aws.String("policy_updates"), Value: &types.FieldMemberStringValue{Value: string(policyUpdatesJSON)}},
 		{Name: aws.String("modified_ts"), Value: &types.FieldMemberStringValue{Value: fa.ModifiedTs.UTC().Format(time.RFC3339Nano)}},
 		{Name: aws.String("source"), Value: &types.FieldMemberStringValue{Value: string(fa.Source)}},
+		{Name: aws.String("subject"), Value: &types.FieldMemberStringValue{Value: fa.Subject}},
+		{Name: aws.String("subject_name"), Value: &types.FieldMemberStringValue{Value: fa.SubjectName}},
 	}
 
 	_, err = d.executeStatement(ctx, query, params)
@@ -813,7 +817,7 @@ func (d *DatastoreAuroraDataAPI) LoadFormaCommands() ([]*forma_command.FormaComm
 	query := `
 	SELECT command_id, timestamp, command, state, client_id,
 		description_text, description_confirm, config_mode, config_force, config_simulate,
-		target_updates, stack_updates, policy_updates, modified_ts, source
+		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name
 	FROM forma_commands
 	ORDER BY timestamp DESC
 	`
@@ -849,7 +853,7 @@ func (d *DatastoreAuroraDataAPI) LoadIncompleteFormaCommands() ([]*forma_command
 	query := `
 	SELECT command_id, timestamp, command, state, client_id,
 		description_text, description_confirm, config_mode, config_force, config_simulate,
-		target_updates, stack_updates, policy_updates, modified_ts, source
+		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name
 	FROM forma_commands
 	WHERE command != :sync_command AND state IN (:state_not_started, :state_in_progress)
 	ORDER BY timestamp DESC
@@ -887,7 +891,7 @@ func (d *DatastoreAuroraDataAPI) LoadIncompleteFormaCommands() ([]*forma_command
 
 // parseFormaCommandRecord parses a single forma_commands row into a FormaCommand.
 func (d *DatastoreAuroraDataAPI) parseFormaCommandRecord(record []types.Field) (*forma_command.FormaCommand, error) {
-	if len(record) < 15 {
+	if len(record) < 17 {
 		return nil, fmt.Errorf("unexpected record length: %d", len(record))
 	}
 
@@ -906,6 +910,8 @@ func (d *DatastoreAuroraDataAPI) parseFormaCommandRecord(record []types.Field) (
 	policyUpdatesJSON, _ := getStringField(record[12])
 	modifiedTs, _ := getTimestampField(record[13])
 	source, _ := getStringField(record[14])
+	subject, _ := getStringField(record[15])
+	subjectName, _ := getStringField(record[16])
 
 	var targetUpdates []target_update.TargetUpdate
 	if targetUpdatesJSON != "" {
@@ -942,6 +948,8 @@ func (d *DatastoreAuroraDataAPI) parseFormaCommandRecord(record []types.Field) (
 		PolicyUpdates: policyUpdates,
 		ModifiedTs:    modifiedTs,
 		Source:        forma_command.Source(source),
+		Subject:       subject,
+		SubjectName:   subjectName,
 	}, nil
 }
 
@@ -970,7 +978,7 @@ func (d *DatastoreAuroraDataAPI) GetFormaCommandByCommandID(commandID string) (*
 	query := `
 	SELECT command_id, timestamp, command, state, client_id,
 		description_text, description_confirm, config_mode, config_force, config_simulate,
-		target_updates, stack_updates, policy_updates, modified_ts, source
+		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name
 	FROM forma_commands
 	WHERE command_id = :command_id
 	`
@@ -1008,7 +1016,7 @@ func (d *DatastoreAuroraDataAPI) GetMostRecentFormaCommandByClientID(clientID st
 	query := `
 	SELECT command_id, timestamp, command, state, client_id,
 		description_text, description_confirm, config_mode, config_force, config_simulate,
-		target_updates, stack_updates, policy_updates, modified_ts, source
+		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name
 	FROM forma_commands
 	WHERE client_id = :client_id
 	ORDER BY timestamp DESC
@@ -1201,7 +1209,7 @@ func (d *DatastoreAuroraDataAPI) QueryFormaCommands(statusQuery *datastore.Statu
 	queryStr := `
 	SELECT command_id, timestamp, command, state, client_id,
 		description_text, description_confirm, config_mode, config_force, config_simulate,
-		target_updates, stack_updates, policy_updates, modified_ts, source
+		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name
 	FROM forma_commands
 	WHERE 1=1
 	`
@@ -6169,6 +6177,20 @@ func (d *DatastoreAuroraDataAPI) NullResourceUpdateModifiedTsForTesting(ksuid st
 	query := `UPDATE resource_updates SET modified_ts = NULL WHERE ksuid = :ksuid`
 	params := []types.SqlParameter{
 		{Name: aws.String("ksuid"), Value: &types.FieldMemberStringValue{Value: ksuid}},
+	}
+	_, err := d.executeStatement(ctx, query, params)
+	return err
+}
+
+// NullFormaCommandSubjectForTesting clears subject and subject_name on the
+// forma_commands row for a command_id, so tests can stage the unattributed
+// rows a pre-migration command leaves behind — stored state no public API
+// produces, since a Go string is always a value (at worst "").
+func (d *DatastoreAuroraDataAPI) NullFormaCommandSubjectForTesting(commandID string) error {
+	ctx := context.Background()
+	query := `UPDATE forma_commands SET subject = NULL, subject_name = NULL WHERE command_id = :command_id`
+	params := []types.SqlParameter{
+		{Name: aws.String("command_id"), Value: &types.FieldMemberStringValue{Value: commandID}},
 	}
 	_, err := d.executeStatement(ctx, query, params)
 	return err

--- a/internal/datastore/aurora/aurora_test.go
+++ b/internal/datastore/aurora/aurora_test.go
@@ -73,6 +73,9 @@ func TestDatastore(t *testing.T) {
 			NullResourceUpdateModifiedTsForTest: func(ksuid string) error {
 				return d.NullResourceUpdateModifiedTsForTesting(ksuid)
 			},
+			NullFormaCommandSubjectForTest: func(commandID string) error {
+				return d.NullFormaCommandSubjectForTesting(commandID)
+			},
 		}
 	})
 }

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -83,6 +83,14 @@ type TestDatastore struct {
 	// than on characters. Backends storing a real timestamp type leave it nil
 	// and the relevant tests t.Skip().
 	SetResourceUpdateModifiedTsRawForTest func(ksuid, raw string) error
+	// NullFormaCommandSubjectForTest sets subject and subject_name to SQL NULL
+	// on the forma_commands row for the given commandID, so tests can stage the
+	// unattributed rows a pre-migration command leaves behind — stored state no
+	// public API produces, since a Go string is always a value (at worst "").
+	// Used to assert that such a row reads back Subject/SubjectName as "".
+	// Backends that don't provide it leave it nil and the relevant tests
+	// t.Skip().
+	NullFormaCommandSubjectForTest func(commandID string) error
 }
 
 // RunAll runs the full datastore test suite against the provided factory.
@@ -94,6 +102,8 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunLoadIncompleteFormaCommandsTest(t, newDS)
 	RunGetFormaApplyByFormaHash(t, newDS)
 	RunStoreAndLoadFormaCommandOptionalFields(t, newDS)
+	RunStoreAndLoadFormaCommandEmptySubject(t, newDS)
+	RunFormaCommandSubjectNullRoundTrip(t, newDS)
 	RunStoreFormaCommandSyncSkipsResourceUpdates(t, newDS)
 	RunCommandSourceRoundTrip(t, newDS)
 	RunGetMostRecentFormaCommandByClientID(t, newDS)

--- a/internal/datastore/dstest/suite_forma_commands.go
+++ b/internal/datastore/dstest/suite_forma_commands.go
@@ -206,6 +206,8 @@ func RunStoreAndLoadFormaCommandOptionalFields(t *testing.T, newDS func(t *testi
 		cmd := &forma_command.FormaCommand{
 			ID:          util.NewID(),
 			ClientID:    "synchronizer",
+			Subject:     "11111111-1111-4111-8111-111111111111",
+			SubjectName: "dpanders",
 			Command:     pkgmodel.CommandApply,
 			State:       forma_command.CommandStatePending,
 			Description: pkgmodel.Description{Text: "deploy production stack"},
@@ -225,8 +227,88 @@ func RunStoreAndLoadFormaCommandOptionalFields(t *testing.T, newDS func(t *testi
 		loaded, err := ds.GetFormaCommandByCommandID(cmd.ID)
 		assert.NoError(t, err)
 		assert.Equal(t, "synchronizer", loaded.ClientID)
+		assert.Equal(t, "11111111-1111-4111-8111-111111111111", loaded.Subject)
+		assert.Equal(t, "dpanders", loaded.SubjectName)
 		assert.Equal(t, "deploy production stack", loaded.Description.Text)
 		assert.Equal(t, pkgmodel.FormaApplyModePatch, loaded.Config.Mode)
+	})
+}
+
+// RunStoreAndLoadFormaCommandEmptySubject verifies that a command stored with
+// no authenticated subject (the classic-mode / internal-origin case) reads
+// both Subject and SubjectName back as "".
+func RunStoreAndLoadFormaCommandEmptySubject(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("StoreAndLoad_FormaCommand_EmptySubject", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		cmd := &forma_command.FormaCommand{
+			ID:          util.NewID(),
+			ClientID:    "stack-expirer",
+			Subject:     "",
+			SubjectName: "",
+			Command:     pkgmodel.CommandDestroy,
+			State:       forma_command.CommandStatePending,
+			ResourceUpdates: []resource_update.ResourceUpdate{
+				{
+					DesiredState:   pkgmodel.Resource{Properties: json.RawMessage("{}")},
+					ResourceTarget: pkgmodel.Target{Label: "t", Namespace: "default", Config: json.RawMessage("{}")},
+					State:          resource_update.ResourceUpdateStateNotStarted,
+				},
+			},
+		}
+
+		err := ds.StoreFormaCommand(cmd, cmd.ID)
+		assert.NoError(t, err)
+
+		loaded, err := ds.GetFormaCommandByCommandID(cmd.ID)
+		assert.NoError(t, err)
+		assert.Equal(t, "", loaded.Subject)
+		assert.Equal(t, "", loaded.SubjectName)
+	})
+}
+
+// RunFormaCommandSubjectNullRoundTrip verifies that a forma_commands row whose
+// subject/subject_name columns are SQL NULL — the state every row written
+// before this migration is in — reads back through the normal Datastore API
+// as "", not as an error or a literal "NULL" string. Skips on backends that
+// don't provide the raw NULL-setting hook.
+func RunFormaCommandSubjectNullRoundTrip(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("FormaCommandSubject_NullRoundTrip", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		if td.NullFormaCommandSubjectForTest == nil {
+			t.Skip("backend does not provide NullFormaCommandSubjectForTest")
+		}
+
+		cmd := &forma_command.FormaCommand{
+			ID:          util.NewID(),
+			ClientID:    "synchronizer",
+			Subject:     "11111111-1111-4111-8111-111111111111",
+			SubjectName: "dpanders",
+			Command:     pkgmodel.CommandApply,
+			State:       forma_command.CommandStatePending,
+			ResourceUpdates: []resource_update.ResourceUpdate{
+				{
+					DesiredState:   pkgmodel.Resource{Properties: json.RawMessage("{}")},
+					ResourceTarget: pkgmodel.Target{Label: "t", Namespace: "default", Config: json.RawMessage("{}")},
+					State:          resource_update.ResourceUpdateStateNotStarted,
+				},
+			},
+		}
+		err := ds.StoreFormaCommand(cmd, cmd.ID)
+		assert.NoError(t, err)
+
+		err = td.NullFormaCommandSubjectForTest(cmd.ID)
+		assert.NoError(t, err)
+
+		loaded, err := ds.GetFormaCommandByCommandID(cmd.ID)
+		assert.NoError(t, err)
+		assert.Equal(t, "", loaded.Subject, "a NULL subject column must read back as \"\"")
+		assert.Equal(t, "", loaded.SubjectName, "a NULL subject_name column must read back as \"\"")
 	})
 }
 

--- a/internal/datastore/migrations_mssql/00019_forma_commands_subject.sql
+++ b/internal/datastore/migrations_mssql/00019_forma_commands_subject.sql
@@ -1,0 +1,14 @@
+-- © 2025 Platform Engineering Labs Inc.
+--
+-- SPDX-License-Identifier: FSL-1.1-ALv2
+
+-- +goose Up
+-- Persist the verified subject (and its display-name hint) that triggered a
+-- FormaCommand, alongside the existing self-asserted ClientID device
+-- attribution. Both columns are nullable: rows written before this migration,
+-- and any command created without an authenticated caller (classic mode,
+-- internal origins), have no subject to record.
+ALTER TABLE forma_commands ADD subject nvarchar(max) NULL, subject_name nvarchar(max) NULL;
+
+-- +goose Down
+ALTER TABLE forma_commands DROP COLUMN subject, subject_name;

--- a/internal/datastore/migrations_postgres/00020_forma_commands_subject.sql
+++ b/internal/datastore/migrations_postgres/00020_forma_commands_subject.sql
@@ -1,0 +1,16 @@
+-- © 2025 Platform Engineering Labs Inc.
+--
+-- SPDX-License-Identifier: FSL-1.1-ALv2
+
+-- +goose Up
+-- Persist the verified subject (and its display-name hint) that triggered a
+-- FormaCommand, alongside the existing self-asserted ClientID device
+-- attribution. Both columns are nullable: rows written before this migration,
+-- and any command created without an authenticated caller (classic mode,
+-- internal origins), have no subject to record.
+ALTER TABLE forma_commands ADD COLUMN IF NOT EXISTS subject TEXT;
+ALTER TABLE forma_commands ADD COLUMN IF NOT EXISTS subject_name TEXT;
+
+-- +goose Down
+ALTER TABLE forma_commands DROP COLUMN IF EXISTS subject_name;
+ALTER TABLE forma_commands DROP COLUMN IF EXISTS subject;

--- a/internal/datastore/migrations_sqlite/00019_forma_commands_subject.sql
+++ b/internal/datastore/migrations_sqlite/00019_forma_commands_subject.sql
@@ -1,0 +1,17 @@
+-- © 2025 Platform Engineering Labs Inc.
+--
+-- SPDX-License-Identifier: FSL-1.1-ALv2
+
+-- +goose Up
+-- Persist the verified subject (and its display-name hint) that triggered a
+-- FormaCommand, alongside the existing self-asserted ClientID device
+-- attribution. Both columns are nullable: rows written before this migration,
+-- and any command created without an authenticated caller (classic mode,
+-- internal origins), have no subject to record.
+ALTER TABLE forma_commands ADD COLUMN subject TEXT;
+ALTER TABLE forma_commands ADD COLUMN subject_name TEXT;
+
+-- +goose Down
+-- SQLite doesn't support DROP COLUMN before 3.35.0; leaving the columns in
+-- place on rollback is safe (the application ignores extra columns).
+SELECT 1;

--- a/internal/datastore/mssql/mssql_datastore.go
+++ b/internal/datastore/mssql/mssql_datastore.go
@@ -219,7 +219,7 @@ const formaCommandWithResourceUpdatesQueryBase = `
 SELECT
 	fc.command_id, fc.timestamp, fc.command, fc.state, fc.client_id,
 	fc.description_text, fc.description_confirm, fc.config_mode, fc.config_force, fc.config_simulate,
-	fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source,
+	fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name,
 	ru.ksuid, ru.operation, ru.state, ru.start_ts, ru.modified_ts,
 	ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 	ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
@@ -244,6 +244,7 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 	var targetUpdatesJSON, stackUpdatesJSON, policyUpdatesJSON []byte
 	var fcModifiedTs *time.Time
 	var fcSource *string
+	var fcSubject, fcSubjectName *string
 
 	var ruKsuid, ruOperation, ruState *string
 	var ruStartTs, ruModifiedTs *time.Time
@@ -258,7 +259,7 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 	err := rows.Scan(
 		&commandID, &fcTimestamp, &fcCommand, &fcState, &fcClientID,
 		&descriptionText, &descriptionConfirm, &configMode, &configForce, &configSimulate,
-		&targetUpdatesJSON, &stackUpdatesJSON, &policyUpdatesJSON, &fcModifiedTs, &fcSource,
+		&targetUpdatesJSON, &stackUpdatesJSON, &policyUpdatesJSON, &fcModifiedTs, &fcSource, &fcSubject, &fcSubjectName,
 		&ruKsuid, &ruOperation, &ruState, &ruStartTs, &ruModifiedTs,
 		&ruRetries, &ruRemaining, &ruVersion, &ruStackLabel, &ruGroupID, &ruSource,
 		&resourceJSON, &resourceTargetJSON, &existingResourceJSON, &existingTargetJSON,
@@ -291,6 +292,12 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 	}
 	if fcSource != nil {
 		cmd.Source = forma_command.Source(*fcSource)
+	}
+	if fcSubject != nil {
+		cmd.Subject = *fcSubject
+	}
+	if fcSubjectName != nil {
+		cmd.SubjectName = *fcSubjectName
 	}
 
 	if len(targetUpdatesJSON) > 0 {
@@ -472,7 +479,7 @@ func (d *DatastoreMSSQL) StoreFormaCommand(fa *forma_command.FormaCommand, comma
 		fa.ClientID, d.agentID, fa.Description.Text, fa.Description.Confirm,
 		string(fa.Config.Mode), fa.Config.Force, fa.Config.Simulate,
 		string(targetUpdatesJSON), string(stackUpdatesJSON), string(policyUpdatesJSON), fa.ModifiedTs.UTC(),
-		string(fa.Source),
+		string(fa.Source), fa.Subject, fa.SubjectName,
 	}
 
 	tx, err := d.conn.BeginTx(ctx, nil)
@@ -492,7 +499,8 @@ func (d *DatastoreMSSQL) StoreFormaCommand(fa *forma_command.FormaCommand, comma
 		client_id = @p6, agent_id = @p7, description_text = @p8,
 		description_confirm = @p9, config_mode = @p10, config_force = @p11,
 		config_simulate = @p12, target_updates = @p13, stack_updates = @p14,
-		policy_updates = @p15, modified_ts = @p16, source = @p17
+		policy_updates = @p15, modified_ts = @p16, source = @p17,
+		subject = @p18, subject_name = @p19
 	WHERE command_id = @p1`, datastore.CommandsTable)
 
 	res, err := tx.ExecContext(ctx, updateQuery, args...)
@@ -509,8 +517,8 @@ func (d *DatastoreMSSQL) StoreFormaCommand(fa *forma_command.FormaCommand, comma
 		INSERT INTO %[1]s
 			(command_id, timestamp, command, state, agent_version, client_id, agent_id,
 			 description_text, description_confirm, config_mode, config_force, config_simulate,
-			 target_updates, stack_updates, policy_updates, modified_ts, source)
-		VALUES (@p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16, @p17)`,
+			 target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name)
+		VALUES (@p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16, @p17, @p18, @p19)`,
 			datastore.CommandsTable)
 		if _, err := tx.ExecContext(ctx, insertQuery, args...); err != nil {
 			slog.Error("failed to store FormaCommand (insert)", "error", err)

--- a/internal/datastore/mssql/mssql_dstest_test.go
+++ b/internal/datastore/mssql/mssql_dstest_test.go
@@ -132,6 +132,12 @@ func TestDatastore(t *testing.T) {
 				)
 				return err
 			},
+			NullFormaCommandSubjectForTest: func(commandID string) error {
+				_, err := conn.Exec(
+					`UPDATE forma_commands SET subject = NULL, subject_name = NULL WHERE command_id = @p1`, commandID,
+				)
+				return err
+			},
 			CleanUpFn: func() error {
 				ds.Close()
 				m, err := sql.Open("sqlserver", dstestMSSQLBase+"&database=master")

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -211,8 +211,8 @@ func (d DatastorePostgres) StoreFormaCommand(fa *forma_command.FormaCommand, com
 	query := fmt.Sprintf(`
 	INSERT INTO %s (command_id, timestamp, command, state, agent_version, client_id, agent_id,
 		description_text, description_confirm, config_mode, config_force, config_simulate,
-		target_updates, stack_updates, policy_updates, modified_ts, source)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
 	ON CONFLICT (command_id) DO UPDATE
 	SET timestamp = EXCLUDED.timestamp,
 	command = EXCLUDED.command,
@@ -229,12 +229,14 @@ func (d DatastorePostgres) StoreFormaCommand(fa *forma_command.FormaCommand, com
 	stack_updates = EXCLUDED.stack_updates,
 	policy_updates = EXCLUDED.policy_updates,
 	modified_ts = EXCLUDED.modified_ts,
-	source = EXCLUDED.source
+	source = EXCLUDED.source,
+	subject = EXCLUDED.subject,
+	subject_name = EXCLUDED.subject_name
 	`, datastore.CommandsTable)
 
 	_, err = d.pool.Exec(ctx, query, commandID, fa.StartTs.UTC(), fa.Command, fa.State, formae.Version, fa.ClientID, d.agentID,
 		fa.Description.Text, fa.Description.Confirm, fa.Config.Mode, fa.Config.Force, fa.Config.Simulate,
-		targetUpdatesJSON, stackUpdatesJSON, policyUpdatesJSON, fa.ModifiedTs.UTC(), string(fa.Source))
+		targetUpdatesJSON, stackUpdatesJSON, policyUpdatesJSON, fa.ModifiedTs.UTC(), string(fa.Source), fa.Subject, fa.SubjectName)
 	if err != nil {
 		slog.Error("failed to store FormaCommand", "query", query, "error", err)
 		return err
@@ -258,7 +260,7 @@ const formaCommandWithResourceUpdatesQueryBasePostgres = `
 SELECT
 	fc.command_id, fc.timestamp, fc.command, fc.state, fc.client_id,
 	fc.description_text, fc.description_confirm, fc.config_mode, fc.config_force, fc.config_simulate,
-	fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source,
+	fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name,
 	ru.ksuid, ru.operation, ru.state, ru.start_ts, ru.modified_ts,
 	ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 	ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
@@ -286,6 +288,7 @@ func scanJoinedRowPostgres(rows pgx.Rows) (*forma_command.FormaCommand, *resourc
 	var policyUpdatesJSON []byte
 	var fcModifiedTs *time.Time
 	var fcSource *string
+	var fcSubject, fcSubjectName *string
 
 	// ResourceUpdate fields (all nullable due to LEFT JOIN)
 	var ruKsuid, ruOperation, ruState *string
@@ -302,7 +305,7 @@ func scanJoinedRowPostgres(rows pgx.Rows) (*forma_command.FormaCommand, *resourc
 		// FormaCommand columns
 		&commandID, &fcTimestamp, &fcCommand, &fcState, &fcClientID,
 		&descriptionText, &descriptionConfirm, &configMode, &configForce, &configSimulate,
-		&targetUpdatesJSON, &stackUpdatesJSON, &policyUpdatesJSON, &fcModifiedTs, &fcSource,
+		&targetUpdatesJSON, &stackUpdatesJSON, &policyUpdatesJSON, &fcModifiedTs, &fcSource, &fcSubject, &fcSubjectName,
 		// ResourceUpdate columns
 		&ruKsuid, &ruOperation, &ruState, &ruStartTs, &ruModifiedTs,
 		&ruRetries, &ruRemaining, &ruVersion, &ruStackLabel, &ruGroupID, &ruSource,
@@ -342,6 +345,12 @@ func scanJoinedRowPostgres(rows pgx.Rows) (*forma_command.FormaCommand, *resourc
 	}
 	if fcSource != nil {
 		cmd.Source = forma_command.Source(*fcSource)
+	}
+	if fcSubject != nil {
+		cmd.Subject = *fcSubject
+	}
+	if fcSubjectName != nil {
+		cmd.SubjectName = *fcSubjectName
 	}
 
 	if len(targetUpdatesJSON) > 0 {
@@ -695,7 +704,7 @@ func (d DatastorePostgres) QueryFormaCommands(query *datastore.StatusQuery) ([]*
 		SELECT
 			fc.command_id, fc.timestamp, fc.command, fc.state, fc.client_id,
 			fc.description_text, fc.description_confirm, fc.config_mode, fc.config_force, fc.config_simulate,
-			fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source,
+			fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name,
 			ru.ksuid, ru.operation, ru.state, ru.start_ts, ru.modified_ts,
 			ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 			ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -425,6 +425,12 @@ func TestDatastore(t *testing.T) {
 				)
 				return err
 			},
+			NullFormaCommandSubjectForTest: func(commandID string) error {
+				_, err := d.Pool().Exec(context.Background(),
+					`UPDATE forma_commands SET subject = NULL, subject_name = NULL WHERE command_id = $1`, commandID,
+				)
+				return err
+			},
 		}
 	})
 }

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -180,12 +180,12 @@ func (d DatastoreSQLite) StoreFormaCommand(fa *forma_command.FormaCommand, comma
 	query := fmt.Sprintf(`INSERT OR REPLACE INTO %s
 		(command_id, timestamp, command, state, agent_version, client_id, agent_id,
 		 description_text, description_confirm, config_mode, config_force, config_simulate,
-		 target_updates, stack_updates, policy_updates, modified_ts, source)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, datastore.CommandsTable)
+		 target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, datastore.CommandsTable)
 
 	_, err = d.conn.Exec(query, commandID, startTsUTC, fa.Command, fa.State, formae.Version, fa.ClientID, d.agentID,
 		fa.Description.Text, descriptionConfirm, fa.Config.Mode, configForce, configSimulate,
-		targetUpdatesJSON, stackUpdatesJSON, policyUpdatesJSON, modifiedTsUTC, string(fa.Source))
+		targetUpdatesJSON, stackUpdatesJSON, policyUpdatesJSON, modifiedTsUTC, string(fa.Source), fa.Subject, fa.SubjectName)
 	if err != nil {
 		slog.Error("Query", "query", query, "error", err)
 		return err
@@ -210,7 +210,7 @@ const formaCommandWithResourceUpdatesQueryBase = `
 SELECT
 	fc.command_id, fc.timestamp, fc.command, fc.state, fc.client_id,
 	fc.description_text, fc.description_confirm, fc.config_mode, fc.config_force, fc.config_simulate,
-	fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source,
+	fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name,
 	ru.ksuid, ru.operation, ru.state, ru.start_ts, ru.modified_ts,
 	ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 	ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
@@ -238,6 +238,7 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 	var policyUpdatesJSON []byte
 	var fcModifiedTs sql.NullString
 	var fcSource sql.NullString
+	var fcSubject, fcSubjectName sql.NullString
 
 	// ResourceUpdate fields (all nullable due to LEFT JOIN)
 	var ruKsuid, ruOperation, ruState sql.NullString
@@ -254,7 +255,7 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 		// FormaCommand columns
 		&commandID, &fcTimestamp, &command, &fcState, &clientID,
 		&descriptionText, &descriptionConfirm, &configMode, &configForce, &configSimulate,
-		&targetUpdatesJSON, &stackUpdatesJSON, &policyUpdatesJSON, &fcModifiedTs, &fcSource,
+		&targetUpdatesJSON, &stackUpdatesJSON, &policyUpdatesJSON, &fcModifiedTs, &fcSource, &fcSubject, &fcSubjectName,
 		// ResourceUpdate columns
 		&ruKsuid, &ruOperation, &ruState, &ruStartTs, &ruModifiedTs,
 		&ruRetries, &ruRemaining, &ruVersion, &ruStackLabel, &ruGroupID, &ruSource,
@@ -289,6 +290,12 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 	cmd.Config.Simulate = configSimulate.Valid && configSimulate.Int64 == 1
 	if fcSource.Valid {
 		cmd.Source = forma_command.Source(fcSource.String)
+	}
+	if fcSubject.Valid {
+		cmd.Subject = fcSubject.String
+	}
+	if fcSubjectName.Valid {
+		cmd.SubjectName = fcSubjectName.String
 	}
 
 	// Parse timestamp - convert to UTC
@@ -535,7 +542,7 @@ func (d DatastoreSQLite) GetMostRecentFormaCommandByClientID(clientID string) (*
 		SELECT
 			fc.command_id, fc.timestamp, fc.command, fc.state, fc.client_id,
 			fc.description_text, fc.description_confirm, fc.config_mode, fc.config_force, fc.config_simulate,
-			fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source,
+			fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name,
 			ru.ksuid, ru.operation, ru.state, ru.start_ts, ru.modified_ts,
 			ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 			ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
@@ -911,7 +918,7 @@ func (d DatastoreSQLite) QueryFormaCommands(query *datastore.StatusQuery) ([]*fo
 		SELECT
 			fc.command_id, fc.timestamp, fc.command, fc.state, fc.client_id,
 			fc.description_text, fc.description_confirm, fc.config_mode, fc.config_force, fc.config_simulate,
-			fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source,
+			fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name,
 			ru.ksuid, ru.operation, ru.state, ru.start_ts, ru.modified_ts,
 			ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 			ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,

--- a/internal/datastore/sqlite/sqlite_test.go
+++ b/internal/datastore/sqlite/sqlite_test.go
@@ -113,6 +113,13 @@ func TestDatastore(t *testing.T) {
 				)
 				return err
 			},
+			NullFormaCommandSubjectForTest: func(commandID string) error {
+				conn := d.Conn()
+				_, err := conn.Exec(
+					`UPDATE forma_commands SET subject = NULL, subject_name = NULL WHERE command_id = ?`, commandID,
+				)
+				return err
+			},
 		}
 	})
 }

--- a/internal/metastructure/auto_reconciler.go
+++ b/internal/metastructure/auto_reconciler.go
@@ -267,7 +267,7 @@ type reconcileResult struct {
 // prepareReconcile builds a reconcile FormaCommand and Changeset from the stack's last-reconcile snapshot.
 // It returns nil (with no error) when no drift is detected. The caller is responsible for persisting
 // the command and starting the changeset execution.
-func prepareReconcile(ds datastore.Datastore, stackLabel string, clientID string) (*reconcileResult, error) {
+func prepareReconcile(ds datastore.Datastore, stackLabel string, clientID string, subject string, subjectName string) (*reconcileResult, error) {
 	// Get resources at last reconcile as full Resource objects
 	snapshots, err := ds.GetResourcesAtLastReconcile(stackLabel)
 	if err != nil {
@@ -360,6 +360,8 @@ func prepareReconcile(ds datastore.Datastore, stackLabel string, clientID string
 		nil, // No stack updates
 		nil, // No policy updates
 		clientID,
+		subject,
+		subjectName,
 		forma_command.SourceAutoReconciler,
 	)
 
@@ -393,7 +395,7 @@ func startReconcile(proc gen.Process, data *AutoReconcilerData, stackLabel strin
 		return "", nil // Not an error - just skip and reschedule
 	}
 
-	result, err := prepareReconcile(data.datastore, stackLabel, "auto-reconciler")
+	result, err := prepareReconcile(data.datastore, stackLabel, "auto-reconciler", "", "")
 	if err != nil {
 		return "", err
 	}

--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -772,6 +772,8 @@ func synchronizeResources(op ListOperation, namespace string, target pkgmodel.Ta
 		nil, // No stack updates on discovery
 		nil, // No policy updates on discovery
 		"discovery",
+		"",
+		"",
 		forma_command.SourceDiscovery,
 	)
 

--- a/internal/metastructure/forma_command/forma_command.go
+++ b/internal/metastructure/forma_command/forma_command.go
@@ -54,6 +54,8 @@ type FormaCommand struct {
 	Config          config.FormaCommandConfig        `json:"Config"`
 	Command         pkgmodel.Command                 `json:"Command"`
 	ClientID        string                           `json:"ClientId,omitempty"`
+	Subject         string                           `json:"Subject,omitempty"`
+	SubjectName     string                           `json:"SubjectName,omitempty"`
 	Source          Source                           `json:"Source,omitempty"`
 }
 
@@ -75,6 +77,8 @@ func NewFormaCommand(
 	stackUpdates []stack_update.StackUpdate,
 	policyUpdates []policy_update.PolicyUpdate,
 	clientID string,
+	subject string,
+	subjectName string,
 	source Source,
 ) *FormaCommand {
 	return &FormaCommand{
@@ -90,6 +94,8 @@ func NewFormaCommand(
 		Description:     forma.Description,
 		State:           CommandStateNotStarted,
 		ClientID:        clientID,
+		Subject:         subject,
+		SubjectName:     subjectName,
 		Source:          source,
 	}
 }

--- a/internal/metastructure/forma_command/forma_command_test.go
+++ b/internal/metastructure/forma_command/forma_command_test.go
@@ -1,0 +1,51 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package forma_command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// NewFormaCommand stores the authenticated subject and its display-name hint
+// alongside the existing device-attribution ClientID.
+func TestNewFormaCommand_StoresSubjectAndSubjectName(t *testing.T) {
+	fc := NewFormaCommand(
+		&pkgmodel.Forma{},
+		&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch},
+		pkgmodel.CommandApply,
+		nil, nil, nil, nil,
+		"client-abc",
+		"11111111-1111-4111-8111-111111111111",
+		"dpanders",
+		SourceUser,
+	)
+
+	assert.Equal(t, "client-abc", fc.ClientID)
+	assert.Equal(t, "11111111-1111-4111-8111-111111111111", fc.Subject)
+	assert.Equal(t, "dpanders", fc.SubjectName)
+}
+
+// NewFormaCommand leaves Subject and SubjectName empty when the caller has no
+// authenticated identity to attribute (classic mode, or an internal origin).
+func TestNewFormaCommand_EmptySubjectAndSubjectName(t *testing.T) {
+	fc := NewFormaCommand(
+		&pkgmodel.Forma{},
+		&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch},
+		pkgmodel.CommandApply,
+		nil, nil, nil, nil,
+		"",
+		"",
+		"",
+		SourceAutoReconciler,
+	)
+
+	assert.Equal(t, "", fc.Subject)
+	assert.Equal(t, "", fc.SubjectName)
+}

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -51,9 +51,9 @@ const (
 )
 
 type MetastructureAPI interface {
-	ApplyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string) (*apimodel.SubmitCommandResponse, error)
-	DestroyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string) (*apimodel.SubmitCommandResponse, error)
-	DestroyByQuery(query string, config *config.FormaCommandConfig, clientID string) (*apimodel.SubmitCommandResponse, error)
+	ApplyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string, subject string, subjectName string) (*apimodel.SubmitCommandResponse, error)
+	DestroyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string, subject string, subjectName string) (*apimodel.SubmitCommandResponse, error)
+	DestroyByQuery(query string, config *config.FormaCommandConfig, clientID string, subject string, subjectName string) (*apimodel.SubmitCommandResponse, error)
 	CancelCommand(commandID string, force bool, clientID string) (*changeset.CancelResponse, error)
 	CancelCommandsByQuery(query string, force bool, clientID string) (*apimodel.CancelCommandResponse, error)
 	ListFormaCommandStatus(query string, clientID string, n int) (*apimodel.ListCommandStatusResponse, error)
@@ -65,7 +65,7 @@ type MetastructureAPI interface {
 	ExtractPolicies() ([]apimodel.PolicyInventoryItem, error)
 	ForceSync() error
 	ForceDiscovery() error
-	ForceAutoReconcile(stackLabel string) (*apimodel.ForceReconcileResponse, error)
+	ForceAutoReconcile(stackLabel string, subject string, subjectName string) (*apimodel.ForceReconcileResponse, error)
 	ForceCheckTTL() (*apimodel.ForceCheckTTLResponse, error)
 	ForceReap() error
 	ListDrift(stack string) (*apimodel.ModifiedStack, error)
@@ -295,7 +295,7 @@ func (m *Metastructure) callActor(targetPID gen.ProcessID, message any) (any, er
 	}
 }
 
-func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string) (*apimodel.SubmitCommandResponse, error) {
+func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string, subject string, subjectName string) (*apimodel.SubmitCommandResponse, error) {
 	m.commandMu.Lock()
 	defer m.commandMu.Unlock()
 
@@ -321,7 +321,7 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 		}
 	}
 
-	fa, err := FormaCommandFromForma(forma, config, pkgmodel.CommandApply, m.Datastore, clientID, resource_update.FormaCommandSourceUser, m.Cfg.Agent.Synchronization.Interval)
+	fa, err := FormaCommandFromForma(forma, config, pkgmodel.CommandApply, m.Datastore, clientID, subject, subjectName, resource_update.FormaCommandSourceUser, m.Cfg.Agent.Synchronization.Interval)
 	if err != nil {
 		if requiredFieldsErr, ok := err.(apimodel.RequiredFieldMissingOnCreateError); ok {
 			return nil, requiredFieldsErr
@@ -596,13 +596,15 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 
 func translateToAPICommand(fa *forma_command.FormaCommand) apimodel.Command {
 	apiCommand := apimodel.Command{
-		CommandID: fa.ID,
-		Command:   string(fa.Command),
-		Mode:      string(fa.Config.Mode),
-		Source:    string(fa.Source),
-		State:     string(fa.State),
-		StartTs:   fa.StartTs,
-		EndTs:     fa.ModifiedTs,
+		CommandID:   fa.ID,
+		Command:     string(fa.Command),
+		Mode:        string(fa.Config.Mode),
+		Source:      string(fa.Source),
+		Subject:     fa.Subject,
+		SubjectName: fa.SubjectName,
+		State:       string(fa.State),
+		StartTs:     fa.StartTs,
+		EndTs:       fa.ModifiedTs,
 	}
 	for _, ru := range fa.ResourceUpdates {
 		var dur time.Duration = 0
@@ -730,7 +732,7 @@ func translateToAPICommand(fa *forma_command.FormaCommand) apimodel.Command {
 	return apiCommand
 }
 
-func (m *Metastructure) DestroyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string) (*apimodel.SubmitCommandResponse, error) {
+func (m *Metastructure) DestroyForma(forma *pkgmodel.Forma, config *config.FormaCommandConfig, clientID string, subject string, subjectName string) (*apimodel.SubmitCommandResponse, error) {
 	m.commandMu.Lock()
 	defer m.commandMu.Unlock()
 
@@ -750,7 +752,7 @@ func (m *Metastructure) DestroyForma(forma *pkgmodel.Forma, config *config.Forma
 		}
 	}
 
-	fa, err := FormaCommandFromForma(forma, config, pkgmodel.CommandDestroy, m.Datastore, clientID, resource_update.FormaCommandSourceUser, m.Cfg.Agent.Synchronization.Interval)
+	fa, err := FormaCommandFromForma(forma, config, pkgmodel.CommandDestroy, m.Datastore, clientID, subject, subjectName, resource_update.FormaCommandSourceUser, m.Cfg.Agent.Synchronization.Interval)
 	if err != nil {
 		slog.Error("Failed to create destroy from forma", "error", err)
 		return nil, err
@@ -861,7 +863,7 @@ func (m *Metastructure) DestroyForma(forma *pkgmodel.Forma, config *config.Forma
 	}, nil
 }
 
-func (m *Metastructure) DestroyByQuery(query string, config *config.FormaCommandConfig, clientID string) (*apimodel.SubmitCommandResponse, error) {
+func (m *Metastructure) DestroyByQuery(query string, config *config.FormaCommandConfig, clientID string, subject string, subjectName string) (*apimodel.SubmitCommandResponse, error) {
 	q := querier.NewBlugeQuerier(m.Datastore)
 	resources, err := q.QueryResourcesForDestroy(query)
 	if err != nil {
@@ -878,7 +880,7 @@ func (m *Metastructure) DestroyByQuery(query string, config *config.FormaCommand
 
 	forma := pkgmodel.FormaFromResources(managedResources)
 
-	return m.DestroyForma(forma, config, clientID)
+	return m.DestroyForma(forma, config, clientID, subject, subjectName)
 }
 
 func (m *Metastructure) CancelCommand(commandID string, force bool, clientID string) (*changeset.CancelResponse, error) {
@@ -1127,7 +1129,7 @@ func (m *Metastructure) ForceReap() error {
 	return nil
 }
 
-func (m *Metastructure) ForceAutoReconcile(stackLabel string) (*apimodel.ForceReconcileResponse, error) {
+func (m *Metastructure) ForceAutoReconcile(stackLabel string, subject string, subjectName string) (*apimodel.ForceReconcileResponse, error) {
 	m.commandMu.Lock()
 	defer m.commandMu.Unlock()
 
@@ -1173,7 +1175,7 @@ func (m *Metastructure) ForceAutoReconcile(stackLabel string) (*apimodel.ForceRe
 	}
 
 	// Prepare the reconcile command and changeset
-	result, err := prepareReconcile(m.Datastore, stackLabel, "force-reconcile")
+	result, err := prepareReconcile(m.Datastore, stackLabel, "force-reconcile", subject, subjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -1837,6 +1839,8 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 	command pkgmodel.Command,
 	ds datastore.Datastore,
 	clientID string,
+	subject string,
+	subjectName string,
 	source resource_update.FormaCommandSource,
 	syncInterval time.Duration) (*forma_command.FormaCommand, error) {
 
@@ -1999,6 +2003,8 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 		stackUpdates,
 		policyUpdates,
 		clientID,
+		subject,
+		subjectName,
 		forma_command.SourceUser,
 	), nil
 }

--- a/internal/metastructure/stack_expirer.go
+++ b/internal/metastructure/stack_expirer.go
@@ -261,6 +261,8 @@ func prepareDestroyExpiredStack(ds datastore.Datastore, stackInfo datastore.Expi
 		[]stack_update.StackUpdate{}, // No stack updates on destroy
 		nil,                          // No policy updates on destroy
 		clientID,
+		"",
+		"",
 		forma_command.SourceStackExpirer,
 	)
 

--- a/internal/metastructure/synchronizer.go
+++ b/internal/metastructure/synchronizer.go
@@ -319,6 +319,8 @@ func synchronizeAllResources(state gen.Atom, data SynchronizerData, proc gen.Pro
 		nil, // No stack updates on sync
 		nil, // No policy updates on sync
 		"synchronizer",
+		"",
+		"",
 		forma_command.SourceSynchronizer,
 	)
 	data.commandID = syncCommand.ID

--- a/internal/metastructure/target_reaper/target_reaper_test.go
+++ b/internal/metastructure/target_reaper/target_reaper_test.go
@@ -233,6 +233,8 @@ func TestReapCandidates_SkipsTargetWithIncompleteCommand(t *testing.T) {
 		},
 		nil, nil, nil,
 		"test-client",
+		"",
+		"",
 		forma_command.SourceUser,
 	)
 	require.NoError(t, ds.StoreFormaCommand(cmd, cmd.ID))

--- a/internal/metastructure/translate_test.go
+++ b/internal/metastructure/translate_test.go
@@ -30,9 +30,23 @@ func TestTranslateToAPICommand_IncludesMode(t *testing.T) {
 func TestTranslateToAPICommand_Source(t *testing.T) {
 	fa := forma_command.NewFormaCommand(
 		&pkgmodel.Forma{}, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch},
-		pkgmodel.CommandSync, nil, nil, nil, nil, "",
+		pkgmodel.CommandSync, nil, nil, nil, nil, "", "", "",
 		forma_command.SourceSynchronizer,
 	)
 	api := translateToAPICommand(fa)
 	assert.Equal(t, "synchronizer", api.Source)
+}
+
+// translateToAPICommand copies the authenticated Subject and its display-name
+// hint from the FormaCommand into the API-facing Command.
+func TestTranslateToAPICommand_Subject(t *testing.T) {
+	fa := forma_command.NewFormaCommand(
+		&pkgmodel.Forma{}, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch},
+		pkgmodel.CommandApply, nil, nil, nil, nil, "client-abc",
+		"11111111-1111-4111-8111-111111111111", "dpanders",
+		forma_command.SourceUser,
+	)
+	api := translateToAPICommand(fa)
+	assert.Equal(t, "11111111-1111-4111-8111-111111111111", api.Subject)
+	assert.Equal(t, "dpanders", api.SubjectName)
 }

--- a/internal/workflow_tests/distributed/happy_path_test.go
+++ b/internal/workflow_tests/distributed/happy_path_test.go
@@ -19,16 +19,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
 	"github.com/platform-engineering-labs/formae/internal/logging"
 	"github.com/platform-engineering-labs/formae/internal/metastructure"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
-	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
-	plugindiscovery "github.com/platform-engineering-labs/formae/pkg/plugin/discovery"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	plugindiscovery "github.com/platform-engineering-labs/formae/pkg/plugin/discovery"
 )
 
 // TestMetastructure_ExternalPlugin_Registration tests the distributed plugin workflow
@@ -131,7 +131,7 @@ func TestMetastructure_ExternalPlugin_ApplyForma_HappyPath(t *testing.T) {
 		_, err := m.ApplyForma(
 			forma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id",
+			"test-client-id", "", "",
 		)
 		require.NoError(t, err, "ApplyForma should not return an error")
 

--- a/internal/workflow_tests/local/apply_forma/absorbed_drift_test.go
+++ b/internal/workflow_tests/local/apply_forma/absorbed_drift_test.go
@@ -119,7 +119,7 @@ func TestApplyForma_SoftReconcile_AbsorbedDriftDoesNotBlockNewResources(t *testi
 		_, err = m.ApplyForma(
 			initial,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 
 		var commands []*forma_command.FormaCommand
@@ -157,7 +157,7 @@ func TestApplyForma_SoftReconcile_AbsorbedDriftDoesNotBlockNewResources(t *testi
 		_, err = m.ApplyForma(
 			patch,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
@@ -215,7 +215,7 @@ func TestApplyForma_SoftReconcile_AbsorbedDriftDoesNotBlockNewResources(t *testi
 		_, err = m.ApplyForma(
 			reconcileWithNewResource,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		assert.NoError(t, err, "reconcile with absorbed drift and new resource should not be rejected")
 
 		require.Eventually(t, func() bool {

--- a/internal/workflow_tests/local/apply_forma/attaches_to_destroy_test.go
+++ b/internal/workflow_tests/local/apply_forma/attaches_to_destroy_test.go
@@ -141,7 +141,7 @@ func TestAttachesToInvertDestroyOrder(t *testing.T) {
 		_, err = m.ApplyForma(
 			forma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err, "ApplyForma should not error")
 
 		// Wait for apply to complete
@@ -160,7 +160,7 @@ func TestAttachesToInvertDestroyOrder(t *testing.T) {
 		_, err = m.DestroyForma(
 			forma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err, "DestroyForma should not error")
 
 		// Wait for destroy to complete

--- a/internal/workflow_tests/local/apply_forma/cascade_replace_cross_form_test.go
+++ b/internal/workflow_tests/local/apply_forma/cascade_replace_cross_form_test.go
@@ -171,7 +171,7 @@ func TestApplyForma_ParentReplace_CrossFormRef_DependentIsRepointed(t *testing.T
 
 		_, err = m.ApplyForma(formaFor("parent-v1"), &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
@@ -208,7 +208,7 @@ func TestApplyForma_ParentReplace_CrossFormRef_DependentIsRepointed(t *testing.T
 
 		_, err = m.ApplyForma(formaFor("parent-v2"), &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {

--- a/internal/workflow_tests/local/apply_forma/cascade_replace_test.go
+++ b/internal/workflow_tests/local/apply_forma/cascade_replace_test.go
@@ -158,7 +158,7 @@ func TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated(t *testing
 
 		_, err = m.ApplyForma(v1Forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
@@ -217,7 +217,7 @@ func TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated(t *testing
 		simResp, err := m.ApplyForma(v2Forma, &config.FormaCommandConfig{
 			Mode:     pkgmodel.FormaApplyModeReconcile,
 			Simulate: true,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 		require.True(t, simResp.Simulation.ChangesRequired, "v2 should produce changes")
 
@@ -252,7 +252,7 @@ func TestApplyForma_ParentReplace_NonCreateOnlyRef_DependentIsUpdated(t *testing
 		// re-derives the patch, and the provider's Update receives it.
 		_, err = m.ApplyForma(v2Forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {

--- a/internal/workflow_tests/local/apply_forma/conflicting_updates_test.go
+++ b/internal/workflow_tests/local/apply_forma/conflicting_updates_test.go
@@ -85,6 +85,8 @@ func TestMetastructure_ApplyWhileAnotherFormaIsModifyingTheStack_ReturnsConflict
 			nil, // No stack updates for test
 			nil, // No policy updates for test
 			"",
+			"",
+			"",
 			forma_command.SourceUser)
 		executingForma.State = forma_command.CommandStateInProgress
 
@@ -109,7 +111,7 @@ func TestMetastructure_ApplyWhileAnotherFormaIsModifyingTheStack_ReturnsConflict
 				},
 			},
 		}
-		_ = forma_command.NewFormaCommand(newForma, &config.FormaCommandConfig{}, pkgmodel.CommandApply, newFormaResourceUpdates, nil, nil, nil, "", forma_command.SourceUser)
+		_ = forma_command.NewFormaCommand(newForma, &config.FormaCommandConfig{}, pkgmodel.CommandApply, newFormaResourceUpdates, nil, nil, nil, "", "", "", forma_command.SourceUser)
 		err = m.Datastore.StoreFormaCommand(executingForma, "1")
 		if err != nil {
 			t.Fatalf("Failed to store forma command: %v", err)
@@ -121,7 +123,7 @@ func TestMetastructure_ApplyWhileAnotherFormaIsModifyingTheStack_ReturnsConflict
 			Simulate: false,
 		}
 
-		_, err = m.ApplyForma(newForma, &cfg, "test")
+		_, err = m.ApplyForma(newForma, &cfg, "test", "", "")
 		assert.Error(t, err)
 
 		var conflictErr apimodel.FormaConflictingCommandsError
@@ -170,6 +172,8 @@ func TestMetastructure_ApplyFormaRejectIfResourceIsUpdating(t *testing.T) {
 			nil, // No stack updates
 			nil, // No policy updates
 			"",
+			"",
+			"",
 			forma_command.SourceUser)
 		executingForma.State = forma_command.CommandStateInProgress
 		err = m.Datastore.StoreFormaCommand(executingForma, "1")
@@ -205,6 +209,8 @@ func TestMetastructure_ApplyFormaRejectIfResourceIsUpdating(t *testing.T) {
 			nil, // No target updates
 			nil, // No stack updates
 			nil, // No policy updates
+			"",
+			"",
 			"",
 			forma_command.SourceUser)
 		anotherExecutingForma.State = forma_command.CommandStateInProgress
@@ -277,14 +283,14 @@ func TestMetastructure_ApplyFormaRejectIfResourceIsUpdating(t *testing.T) {
 			newTestResourceUpdate("test-resource7", "FakeAWS::S3::Bucket", "test-stack2", "test-target", resource_update.ResourceUpdateStateNotStarted, resource_update.OperationCreate),
 		}
 
-		_ = forma_command.NewFormaCommand(newForma, &config.FormaCommandConfig{}, pkgmodel.CommandApply, newFormaResourceUpdates, nil, nil, nil, "", forma_command.SourceUser)
+		_ = forma_command.NewFormaCommand(newForma, &config.FormaCommandConfig{}, pkgmodel.CommandApply, newFormaResourceUpdates, nil, nil, nil, "", "", "", forma_command.SourceUser)
 
 		cfg := config.FormaCommandConfig{
 			Mode:     pkgmodel.FormaApplyModeReconcile,
 			Simulate: false,
 		}
 
-		_, err = m.ApplyForma(newForma, &cfg, "test")
+		_, err = m.ApplyForma(newForma, &cfg, "test", "", "")
 		assert.Error(t, err)
 
 		var conflictErr apimodel.FormaConflictingCommandsError

--- a/internal/workflow_tests/local/apply_forma/embed_resolvable_test.go
+++ b/internal/workflow_tests/local/apply_forma/embed_resolvable_test.go
@@ -39,8 +39,8 @@ func TestMetastructure_RejectsOpaqueEmbed(t *testing.T) {
 		framedSpan := pkgmodel.FrameEnvelope(opaqueEnvelope)
 
 		embedField := map[string]any{
-			"$embed":     true,
-			"$template":  "prefix-" + framedSpan + "-suffix",
+			"$embed":    true,
+			"$template": "prefix-" + framedSpan + "-suffix",
 		}
 		embedFieldJSON, err := json.Marshal(embedField)
 		require.NoError(t, err)
@@ -68,7 +68,7 @@ func TestMetastructure_RejectsOpaqueEmbed(t *testing.T) {
 
 		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client-id")
+		}, "test-client-id", "", "")
 
 		require.Error(t, err, "apply should be rejected when an opaque resolvable is embedded in a string field")
 		assert.Contains(t, err.Error(), "opaque")
@@ -132,7 +132,7 @@ func TestMetastructure_RejectsOpaqueEmbed_InArray(t *testing.T) {
 
 		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client-id")
+		}, "test-client-id", "", "")
 
 		require.Error(t, err, "apply should be rejected when an opaque resolvable is embedded inside an array element")
 		assert.Contains(t, err.Error(), "opaque")
@@ -268,7 +268,7 @@ func TestEmbed_ResolvesToPluginInOneApply(t *testing.T) {
 
 		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
@@ -411,7 +411,7 @@ func TestEmbed_PersistedStateStaysStructured(t *testing.T) {
 
 		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
@@ -563,7 +563,7 @@ func TestEmbed_SyncPreservesEnvelope(t *testing.T) {
 
 		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		// Wait for the apply to complete.

--- a/internal/workflow_tests/local/apply_forma/happy_path_test.go
+++ b/internal/workflow_tests/local/apply_forma/happy_path_test.go
@@ -73,7 +73,7 @@ func TestMetastructure_ApplyFormaSuccess(t *testing.T) {
 		_, err = m.ApplyForma(
 			forma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		assert.NoError(t, err)
 
 		var commands []*forma_command.FormaCommand
@@ -130,7 +130,7 @@ func TestMetastructure_ApplyFormaCommandSuccess(t *testing.T) {
 		_, err = m.ApplyForma(
 			forma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		assert.NoError(t, err)
 
 		assert.Eventually(t, func() bool {
@@ -207,7 +207,7 @@ func TestMetastructure_ApplyFormaImplicitReplaceMode(t *testing.T) {
 		}
 		m.ApplyForma(f0, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		assert.Eventually(t, func() bool {
 			fas, err := m.Datastore.LoadFormaCommands()
@@ -237,7 +237,7 @@ func TestMetastructure_ApplyFormaImplicitReplaceMode(t *testing.T) {
 		}
 		m.ApplyForma(_f1, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		assert.NoError(t, err)
 		assert.Eventually(t, func() bool {
@@ -343,7 +343,7 @@ func TestMetastructure_ApplyFormaCreateReplaceUpdate(t *testing.T) {
 		// Apply initial resource
 		m.ApplyForma(initialForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		// Verify initial creation
 		assert.Eventually(t, func() bool {
@@ -394,7 +394,7 @@ func TestMetastructure_ApplyFormaCreateReplaceUpdate(t *testing.T) {
 		// Apply replacement (should delete and recreate)
 		m.ApplyForma(replaceForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		// Verify replacement (delete + create)
 		// Commands are ordered by timestamp DESC, so the newest (replace) command is at index 0
@@ -471,7 +471,7 @@ func TestMetastructure_ApplyFormaCreateReplaceUpdate(t *testing.T) {
 		// Apply update (should update in place)
 		m.ApplyForma(updateForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		// Verify update
 		// Commands are ordered by timestamp DESC, so the newest (update) command is at index 0

--- a/internal/workflow_tests/local/apply_forma/hard_reconcile_test.go
+++ b/internal/workflow_tests/local/apply_forma/hard_reconcile_test.go
@@ -118,7 +118,7 @@ func TestApplyForma_HardReconcile(t *testing.T) {
 		_, err = m.ApplyForma(
 			initial,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		assert.NoError(t, err)
 
 		var commands []*forma_command.FormaCommand
@@ -160,7 +160,7 @@ func TestApplyForma_HardReconcile(t *testing.T) {
 		_, err = m.ApplyForma(
 			patch,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		assert.NoError(t, err)
 
 		require.Eventually(t, func() bool {
@@ -211,7 +211,7 @@ func TestApplyForma_HardReconcile(t *testing.T) {
 		_, err = m.ApplyForma(
 			reconcile,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false, Force: true},
-			"test-client-id")
+			"test-client-id", "", "")
 		assert.NoError(t, err)
 
 		assert.Eventually(t, func() bool {

--- a/internal/workflow_tests/local/apply_forma/non_enriching_secret_guard_test.go
+++ b/internal/workflow_tests/local/apply_forma/non_enriching_secret_guard_test.go
@@ -159,7 +159,7 @@ func TestNonEnrichingSecretGuard_DestroySucceeds(t *testing.T) {
 			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
 		}
 
-		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -176,7 +176,7 @@ func TestNonEnrichingSecretGuard_DestroySucceeds(t *testing.T) {
 		assert.Contains(t, string(resources[0].Properties), hashedMarker,
 			"precondition: the secret must be hashed at rest before destroy")
 
-		_, err = m.DestroyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.DestroyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -257,7 +257,7 @@ func TestNonEnrichingSecretGuard_UpdateNonSecretFieldSucceeds(t *testing.T) {
 			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
 		}
 
-		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -290,7 +290,7 @@ func TestNonEnrichingSecretGuard_UpdateNonSecretFieldSucceeds(t *testing.T) {
 			}},
 			Targets: []pkgmodel.Target{},
 		}
-		_, err = m.ApplyForma(formaUpdate, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(formaUpdate, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 

--- a/internal/workflow_tests/local/apply_forma/opaque_value_test.go
+++ b/internal/workflow_tests/local/apply_forma/opaque_value_test.go
@@ -69,7 +69,7 @@ func TestMetastructure_ApplyFormaHashesOpaqueValues(t *testing.T) {
 
 		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client-id")
+		}, "test-client-id", "", "")
 		require.NoError(t, err)
 
 		assert.Eventually(t, func() bool {

--- a/internal/workflow_tests/local/apply_forma/plugin_error_test.go
+++ b/internal/workflow_tests/local/apply_forma/plugin_error_test.go
@@ -79,7 +79,7 @@ func TestMetastructure_ApplyFormaFailed(t *testing.T) {
 			},
 		}
 
-		m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 
 		assert.Eventually(t, func() bool {
 			fas, err := m.Datastore.LoadFormaCommands()
@@ -148,7 +148,7 @@ func TestMetastructure_ApplyFormaFailedAfterRetries(t *testing.T) {
 			},
 		}
 
-		m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 
 		assert.Eventually(t, func() bool {
 			fas, err := m.Datastore.LoadFormaCommands()

--- a/internal/workflow_tests/local/apply_forma/readonly_output_resolvable_test.go
+++ b/internal/workflow_tests/local/apply_forma/readonly_output_resolvable_test.go
@@ -117,7 +117,7 @@ func TestMetastructure_ReconcileResolvesReadOnlyOutputReference(t *testing.T) {
 
 		m.ApplyForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		var bucketUpdate resource_update.ResourceUpdate
 		require.Eventually(t, func() bool {

--- a/internal/workflow_tests/local/apply_forma/reference_provenance_execution_test.go
+++ b/internal/workflow_tests/local/apply_forma/reference_provenance_execution_test.go
@@ -147,7 +147,7 @@ func TestApplyForma_UnchangedReference_IsAbsentFromTheExecutedPatch(t *testing.T
 
 		_, err = m.ApplyForma(formaFor("note-v1"), &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 		require.Eventually(t, func() bool {
 			fas, _ := m.Datastore.LoadFormaCommands()
@@ -164,7 +164,7 @@ func TestApplyForma_UnchangedReference_IsAbsentFromTheExecutedPatch(t *testing.T
 		simResp, err := m.ApplyForma(v2, &config.FormaCommandConfig{
 			Mode:     pkgmodel.FormaApplyModeReconcile,
 			Simulate: true,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 		require.True(t, simResp.Simulation.ChangesRequired, "changing the note should produce a change")
 		var plannedPatch string
@@ -179,7 +179,7 @@ func TestApplyForma_UnchangedReference_IsAbsentFromTheExecutedPatch(t *testing.T
 
 		_, err = m.ApplyForma(v2, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 		require.Eventually(t, func() bool {
 			fas, _ := m.Datastore.LoadFormaCommands()

--- a/internal/workflow_tests/local/apply_forma/res_test.go
+++ b/internal/workflow_tests/local/apply_forma/res_test.go
@@ -128,7 +128,7 @@ func TestMetastructure_ApplyFormaWithRes(t *testing.T) {
 
 		m.ApplyForma(bucketForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModePatch,
-		}, "test")
+		}, "test", "", "")
 
 		assert.Eventually(t, func() bool {
 			fas, err := m.Datastore.LoadFormaCommands()

--- a/internal/workflow_tests/local/apply_forma/runtime_dependency_destroy_test.go
+++ b/internal/workflow_tests/local/apply_forma/runtime_dependency_destroy_test.go
@@ -219,7 +219,7 @@ func TestRuntimeDependency_DestroyOrder(t *testing.T) {
 		_, err = m.ApplyForma(
 			forma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err, "ApplyForma should not error")
 
 		assert.Eventually(t, func() bool {
@@ -236,7 +236,7 @@ func TestRuntimeDependency_DestroyOrder(t *testing.T) {
 		_, err = m.DestroyForma(
 			forma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err, "DestroyForma should not error")
 
 		assert.Eventually(t, func() bool {

--- a/internal/workflow_tests/local/apply_forma/secret_hashing_test.go
+++ b/internal/workflow_tests/local/apply_forma/secret_hashing_test.go
@@ -167,7 +167,7 @@ func TestSecretHashing_EnrichedReadBareSecretHashedEverywhere(t *testing.T) {
 			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
 		}
 
-		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -267,7 +267,7 @@ func TestSecretHashing_NoPerpetualDrift(t *testing.T) {
 			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
 		}
 
-		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -347,7 +347,7 @@ func TestSecretHashing_UpdateNonSecretFieldOnSecretResourceSucceeds(t *testing.T
 			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
 		}
 
-		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -371,7 +371,7 @@ func TestSecretHashing_UpdateNonSecretFieldOnSecretResourceSucceeds(t *testing.T
 			}},
 			Targets: []pkgmodel.Target{},
 		}
-		_, err = m.ApplyForma(formaUpdate, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(formaUpdate, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -453,7 +453,7 @@ func TestSecretHashing_ResolveCacheDoesNotLogSecret(t *testing.T) {
 			},
 		}
 
-		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -510,7 +510,7 @@ func TestSecretHashing_TargetConfigResolvedSecretStoredAsReference(t *testing.T)
 			},
 		}
 
-		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 

--- a/internal/workflow_tests/local/apply_forma/secret_json_test.go
+++ b/internal/workflow_tests/local/apply_forma/secret_json_test.go
@@ -29,13 +29,13 @@ import (
 // resource that references it via a $res envelope carrying a $json dotted path.
 //
 // The test verifies three invariants that together define the .json() contract:
-//   1. The consumer's resolved property value equals the EXTRACTED scalar (the
-//      leaf at the $json path), not the whole JSON document.
-//   2. The secret's own stored SecretString is hashed at rest ($hashed:true),
-//      so no plaintext of the JSON document (including the inner password it
-//      contains) survives in the resources table.
-//   3. No plaintext of the extracted scalar nor the outer JSON document appears
-//      in any resource_updates column (DesiredState/PriorState/progress).
+//  1. The consumer's resolved property value equals the EXTRACTED scalar (the
+//     leaf at the $json path), not the whole JSON document.
+//  2. The secret's own stored SecretString is hashed at rest ($hashed:true),
+//     so no plaintext of the JSON document (including the inner password it
+//     contains) survives in the resources table.
+//  3. No plaintext of the extracted scalar nor the outer JSON document appears
+//     in any resource_updates column (DesiredState/PriorState/progress).
 func TestSecretJSON_RefWithJSONPathResolvesToExtractedScalar(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		// The secret value is a JSON document. The inner password is what the
@@ -102,9 +102,9 @@ func TestSecretJSON_RefWithJSONPathResolvesToExtractedScalar(t *testing.T) {
 		// $visibility:Opaque propagates to the resolved Value, so the extracted
 		// scalar is also hashed at rest in the consumer's stored properties.
 		consumer := pkgmodel.Resource{
-			Label: "my-bucket",
-			Type:  "FakeAWS::S3::Bucket",
-			Stack: stack,
+			Label:  "my-bucket",
+			Type:   "FakeAWS::S3::Bucket",
+			Stack:  stack,
 			Target: "test-target",
 			Properties: json.RawMessage(`{
 				"BucketName": "my-bucket",
@@ -126,7 +126,7 @@ func TestSecretJSON_RefWithJSONPathResolvesToExtractedScalar(t *testing.T) {
 			Targets:   []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
 		}
 
-		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 

--- a/internal/workflow_tests/local/apply_forma/soft_reconcile_test.go
+++ b/internal/workflow_tests/local/apply_forma/soft_reconcile_test.go
@@ -143,7 +143,7 @@ func TestApplyForma_SoftReconcile_ReturnsMostRecentChangesPerStack(t *testing.T)
 		_, err = m.ApplyForma(
 			initial,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		assert.NoError(t, err)
 
 		var commands []*forma_command.FormaCommand
@@ -187,7 +187,7 @@ func TestApplyForma_SoftReconcile_ReturnsMostRecentChangesPerStack(t *testing.T)
 		_, err = m.ApplyForma(
 			firstPatch,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		assert.NoError(t, err)
 
 		assert.Eventually(t, func() bool {
@@ -243,7 +243,7 @@ func TestApplyForma_SoftReconcile_ReturnsMostRecentChangesPerStack(t *testing.T)
 		_, err = m.ApplyForma(
 			secondPatch,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		assert.NoError(t, err)
 
 		assert.Eventually(t, func() bool {
@@ -299,7 +299,7 @@ func TestApplyForma_SoftReconcile_ReturnsMostRecentChangesPerStack(t *testing.T)
 		_, err = m.ApplyForma(
 			reconcile,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: true}, // '--force' should be false by default
-			"test-client-id")
+			"test-client-id", "", "")
 		assert.Error(t, err)
 
 		var rejectedErr apimodel.FormaReconcileRejectedError
@@ -461,7 +461,7 @@ func TestApplyForma_SoftReconcile_ReturnsEmtpyFormaCommandNoChangesAreDetected(t
 		_, err = m.ApplyForma(
 			initial,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		assert.NoError(t, err)
 
 		var commands []*forma_command.FormaCommand
@@ -504,7 +504,7 @@ func TestApplyForma_SoftReconcile_ReturnsEmtpyFormaCommandNoChangesAreDetected(t
 		_, err = m.ApplyForma(
 			patch,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		assert.NoError(t, err)
 
 		assert.Eventually(t, func() bool {
@@ -558,7 +558,7 @@ func TestApplyForma_SoftReconcile_ReturnsEmtpyFormaCommandNoChangesAreDetected(t
 		_, err = m.ApplyForma(
 			reconcile,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: true}, // '--force' should be false by default
-			"test-client-id")
+			"test-client-id", "", "")
 		assert.NoError(t, err)
 
 		// The command should not have been executed or stored

--- a/internal/workflow_tests/local/apply_forma/target_config_resolve_destroy_test.go
+++ b/internal/workflow_tests/local/apply_forma/target_config_resolve_destroy_test.go
@@ -148,7 +148,7 @@ func TestTargetConfigResolve_DestroyResolvesSecretBackedTarget(t *testing.T) {
 		}
 
 		// ── Apply: stand up all three pieces ──────────────────────────────────────
-		_, err = m.ApplyForma(forma, defaultApplyConfig(), "test-client-id")
+		_, err = m.ApplyForma(forma, defaultApplyConfig(), "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -173,7 +173,7 @@ func TestTargetConfigResolve_DestroyResolvesSecretBackedTarget(t *testing.T) {
 		// suppressing the synthetic Resolve — so the bucket Delete received the raw
 		// $ref. After the fix the synthetic Resolve is always synthesized when the
 		// persisted config carries opaque refs, regardless of the Delete TU.
-		_, err = m.DestroyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.DestroyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 

--- a/internal/workflow_tests/local/apply_forma/target_config_resolve_test.go
+++ b/internal/workflow_tests/local/apply_forma/target_config_resolve_test.go
@@ -158,7 +158,7 @@ func TestTargetConfigResolve_UnchangedTargetWithOpaqueRef(t *testing.T) {
 			},
 		}
 
-		_, err = m.ApplyForma(applyOne, defaultApplyConfig(), "test-client-id")
+		_, err = m.ApplyForma(applyOne, defaultApplyConfig(), "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -210,7 +210,7 @@ func TestTargetConfigResolve_UnchangedTargetWithOpaqueRef(t *testing.T) {
 			Targets: []pkgmodel.Target{},
 		}
 
-		_, err = m.ApplyForma(applyTwo, defaultApplyConfig(), "test-client-id")
+		_, err = m.ApplyForma(applyTwo, defaultApplyConfig(), "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 

--- a/internal/workflow_tests/local/apply_forma/target_destroy_test.go
+++ b/internal/workflow_tests/local/apply_forma/target_destroy_test.go
@@ -107,7 +107,7 @@ func TestDestroyForma_TargetOnly(t *testing.T) {
 			},
 		}
 
-		_, err = m.ApplyForma(applyForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(applyForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForCommands(t, m, 1)
 
@@ -123,7 +123,7 @@ func TestDestroyForma_TargetOnly(t *testing.T) {
 			},
 		}
 
-		_, err = m.DestroyForma(destroyForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.DestroyForma(destroyForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForCommands(t, m, 2)
 
@@ -184,14 +184,14 @@ func TestDestroyForma_TargetWithResourcesInSameTarget(t *testing.T) {
 		}
 
 		// Step 1: Apply
-		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForCommands(t, m, 1)
 
 		// Step 2: Destroy the same forma (target + resources in that target).
 		// The resource is deleted but the plain target (no $ref) survives
 		// because the forma has resources — plain targets persist independently.
-		_, err = m.DestroyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.DestroyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForCommands(t, m, 2)
 
@@ -263,7 +263,7 @@ func TestDestroyForma_TargetWithResourcesInDifferentTarget(t *testing.T) {
 			},
 		}
 
-		_, err = m.ApplyForma(applyForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(applyForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForCommands(t, m, 1)
 
@@ -292,7 +292,7 @@ func TestDestroyForma_TargetWithResourcesInDifferentTarget(t *testing.T) {
 			},
 		}
 
-		_, err = m.DestroyForma(destroyForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.DestroyForma(destroyForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForCommands(t, m, 2)
 

--- a/internal/workflow_tests/local/apply_forma/target_replace_test.go
+++ b/internal/workflow_tests/local/apply_forma/target_replace_test.go
@@ -79,7 +79,7 @@ func TestApplyForma_TargetReplace_HappyPath(t *testing.T) {
 		_, err = m.ApplyForma(
 			initialForma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 
 		// Wait for the first command to complete
@@ -118,7 +118,7 @@ func TestApplyForma_TargetReplace_HappyPath(t *testing.T) {
 		_, err = m.ApplyForma(
 			replaceForma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 
 		// Step 3: Wait for the second command to complete
@@ -211,7 +211,7 @@ func TestApplyForma_TargetReplace_SimulateWarnsAboutUnmanagedResources(t *testin
 		_, err = m.ApplyForma(
 			initialForma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 
 		// Wait for the first command to complete
@@ -262,7 +262,7 @@ func TestApplyForma_TargetReplace_SimulateWarnsAboutUnmanagedResources(t *testin
 		resp, err := m.ApplyForma(
 			simulateForma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: true},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 
 		// Step 4: Verify the simulation response
@@ -326,7 +326,7 @@ func TestApplyForma_TargetMutableConfigChange_UpdatesInPlace(t *testing.T) {
 		_, err = m.ApplyForma(
 			initialForma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 
 		assert.Eventually(t, func() bool {
@@ -364,7 +364,7 @@ func TestApplyForma_TargetMutableConfigChange_UpdatesInPlace(t *testing.T) {
 		_, err = m.ApplyForma(
 			updateForma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 
 		// Step 3: Wait for the second command to complete

--- a/internal/workflow_tests/local/apply_forma/target_resolvables_test.go
+++ b/internal/workflow_tests/local/apply_forma/target_resolvables_test.go
@@ -93,7 +93,7 @@ func TestApplyForma_TargetWithResolvables(t *testing.T) {
 		_, err = m.ApplyForma(
 			forma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 
 		// Wait for the command to complete
@@ -202,7 +202,7 @@ func TestApplyForma_TargetWithResolvables_FromTripletURI(t *testing.T) {
 		_, err = m.ApplyForma(
 			forma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 
 		// Wait for the command to complete
@@ -287,7 +287,7 @@ func TestApplyForma_DestroyThenReapplyTargetWithResolvables(t *testing.T) {
 		// Step 1: Apply
 		_, err = m.ApplyForma(makeForma(),
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 		assert.Eventually(t, func() bool {
 			incomplete, _ := m.Datastore.LoadIncompleteFormaCommands()
@@ -302,7 +302,7 @@ func TestApplyForma_DestroyThenReapplyTargetWithResolvables(t *testing.T) {
 		// Step 2: Destroy — both the resource and the targets are deleted.
 		_, err = m.DestroyForma(makeForma(),
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 		assert.Eventually(t, func() bool {
 			cmds, _ := m.Datastore.LoadFormaCommands()
@@ -322,7 +322,7 @@ func TestApplyForma_DestroyThenReapplyTargetWithResolvables(t *testing.T) {
 		// Step 3: Re-apply — both targets are re-created from scratch.
 		_, err = m.ApplyForma(makeForma(),
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 		assert.Eventually(t, func() bool {
 			cmds, _ := m.Datastore.LoadFormaCommands()
@@ -481,7 +481,7 @@ func TestApplyForma_DestroyOrder_TargetReachabilityComposesWithAttachesTo(t *tes
 		// Apply
 		_, err = m.ApplyForma(forma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 		assert.Eventually(t, func() bool {
 			incomplete, _ := m.Datastore.LoadIncompleteFormaCommands()
@@ -495,7 +495,7 @@ func TestApplyForma_DestroyOrder_TargetReachabilityComposesWithAttachesTo(t *tes
 		// Destroy
 		_, err = m.DestroyForma(forma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 		assert.Eventually(t, func() bool {
 			cmds, _ := m.Datastore.LoadFormaCommands()
@@ -598,7 +598,7 @@ func TestApplyForma_ReapplyTargetResolvablesSameValue_NoReplace(t *testing.T) {
 		// First apply
 		_, err = m.ApplyForma(makeForma(),
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 
 		assert.Eventually(t, func() bool {
@@ -611,7 +611,7 @@ func TestApplyForma_ReapplyTargetResolvablesSameValue_NoReplace(t *testing.T) {
 		// Second apply — same forma, same resolved values
 		resp, err := m.ApplyForma(makeForma(),
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
-			"test-client-id")
+			"test-client-id", "", "")
 		require.NoError(t, err)
 
 		// A target update IS expected: the raw config format changed (existing has

--- a/internal/workflow_tests/local/apply_forma/unmanaged_resource_test.go
+++ b/internal/workflow_tests/local/apply_forma/unmanaged_resource_test.go
@@ -134,7 +134,7 @@ func TestApplyForma_ReconcileFormaContainingUnmanagedResource(t *testing.T) {
 			Targets:   []pkgmodel.Target{{Label: "test-target", Namespace: "FakeAWS"}},
 		}
 
-		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false}, "test-client-id")
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false}, "test-client-id", "", "")
 		assert.NoError(t, err)
 
 		assert.Eventually(t, func() bool {

--- a/internal/workflow_tests/local/apply_forma/unmanaged_tagless_resource_test.go
+++ b/internal/workflow_tests/local/apply_forma/unmanaged_tagless_resource_test.go
@@ -107,7 +107,7 @@ func TestApplyForma_ReconcileFormaContainingUnmanagedTaglessResource(t *testing.
 		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
 			Mode:     pkgmodel.FormaApplyModeReconcile,
 			Simulate: false,
-		}, "test-client-id")
+		}, "test-client-id", "", "")
 		require.NoError(t, err, "ApplyForma should not return an error")
 
 		// Wait for the command to complete successfully
@@ -226,7 +226,7 @@ func TestApplyForma_ReconcileFormaWithExistingStackAndUnmanagedTaglessResource(t
 		_, err = m.ApplyForma(initialForma, &config.FormaCommandConfig{
 			Mode:     pkgmodel.FormaApplyModeReconcile,
 			Simulate: false,
-		}, "test-client-id-1")
+		}, "test-client-id-1", "", "")
 		require.NoError(t, err, "Failed to apply initial forma")
 
 		// Wait for initial command to complete
@@ -290,7 +290,7 @@ func TestApplyForma_ReconcileFormaWithExistingStackAndUnmanagedTaglessResource(t
 		_, err = m.ApplyForma(formaWithUnmanagedResource, &config.FormaCommandConfig{
 			Mode:     pkgmodel.FormaApplyModeReconcile,
 			Simulate: false,
-		}, "test-client-id-2")
+		}, "test-client-id-2", "", "")
 		require.NoError(t, err, "ApplyForma should not return an error")
 
 		// Step 4: Wait for the command to complete successfully

--- a/internal/workflow_tests/local/apply_forma/writeonly_opaque_test.go
+++ b/internal/workflow_tests/local/apply_forma/writeonly_opaque_test.go
@@ -67,7 +67,7 @@ func TestWriteOnlyOpaqueLiteralStoredAsCanonicalValue(t *testing.T) {
 			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
 		}
 
-		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 

--- a/internal/workflow_tests/local/auto_reconciler_test.go
+++ b/internal/workflow_tests/local/auto_reconciler_test.go
@@ -102,7 +102,7 @@ func TestAutoReconciler_ReconcileAfterSyncChange(t *testing.T) {
 		// Apply the forma (initial reconcile)
 		m.ApplyForma(f, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 
 		// Wait for the initial apply to complete
 		r := require.New(t)
@@ -193,7 +193,7 @@ func TestForceReconcile_RejectedWithoutPolicy(t *testing.T) {
 
 		m.ApplyForma(f, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 
 		// Wait for the apply to complete
 		r := require.New(t)
@@ -208,7 +208,7 @@ func TestForceReconcile_RejectedWithoutPolicy(t *testing.T) {
 		)
 
 		// Attempt force-reconcile — should be rejected
-		resp, err := m.ForceAutoReconcile("no-policy-stack")
+		resp, err := m.ForceAutoReconcile("no-policy-stack", "", "")
 		r.Error(err, "ForceAutoReconcile should return an error when no auto-reconcile policy is attached")
 		r.Nil(resp)
 
@@ -309,7 +309,7 @@ func TestAutoReconciler_RetriesFailedUpdate(t *testing.T) {
 
 		m.ApplyForma(f, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 
 		r := require.New(t)
 
@@ -458,7 +458,7 @@ func TestAutoReconciler_RetriesFailureAndRevertsOOBDriftSimultaneously(t *testin
 			},
 			Targets: targets,
 		}
-		m.ApplyForma(f1, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		m.ApplyForma(f1, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 
 		r := require.New(t)
 		r.Eventually(func() bool {
@@ -477,7 +477,7 @@ func TestAutoReconciler_RetriesFailureAndRevertsOOBDriftSimultaneously(t *testin
 			},
 			Targets: targets,
 		}
-		m.ApplyForma(f2, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		m.ApplyForma(f2, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 
 		// Wait for the second reconcile to settle: A and C at v2, B still at v1.
 		r.Eventually(func() bool {
@@ -636,7 +636,7 @@ func TestAutoReconciler_RevertsInterveningPatch(t *testing.T) {
 			Resources: []pkgmodel.Resource{resourceTemplate(v1)},
 			Targets:   targets,
 		}
-		m.ApplyForma(f1, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		m.ApplyForma(f1, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 
 		r := require.New(t)
 		r.Eventually(func() bool {
@@ -655,7 +655,7 @@ func TestAutoReconciler_RevertsInterveningPatch(t *testing.T) {
 			Resources: []pkgmodel.Resource{resourceTemplate(vPatched)},
 			Targets:   targets,
 		}
-		m.ApplyForma(fPatch, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch}, "test-client")
+		m.ApplyForma(fPatch, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch}, "test-client", "", "")
 
 		r.Eventually(func() bool {
 			resources, err := m.Datastore.LoadResourcesByStack("patch-undo-stack")
@@ -765,7 +765,7 @@ func TestAutoReconciler_PreservesUnchangedResourcesAfterPartialFailure(t *testin
 			},
 			Targets: targets,
 		}
-		m.ApplyForma(f1, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		m.ApplyForma(f1, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 
 		r := require.New(t)
 		r.Eventually(func() bool {
@@ -784,7 +784,7 @@ func TestAutoReconciler_PreservesUnchangedResourcesAfterPartialFailure(t *testin
 			},
 			Targets: targets,
 		}
-		m.ApplyForma(f2, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		m.ApplyForma(f2, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 
 		// Wait for the second reconcile to settle: A still at v1 (its
 		// update failed), B and C still at v1 (untouched). All three
@@ -915,7 +915,7 @@ func TestAutoReconciler_DestroyedResourcesStayDestroyed(t *testing.T) {
 			},
 			Targets: targets,
 		}
-		m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 
 		r := require.New(t)
 		r.Eventually(func() bool {
@@ -932,7 +932,7 @@ func TestAutoReconciler_DestroyedResourcesStayDestroyed(t *testing.T) {
 		createCount.Store(0)
 
 		// Phase 2: destroy the stack.
-		m.DestroyForma(f, &config.FormaCommandConfig{}, "test-client")
+		m.DestroyForma(f, &config.FormaCommandConfig{}, "test-client", "", "")
 		r.Eventually(func() bool {
 			resources, err := m.Datastore.LoadResourcesByStack("destroy-stack")
 			return err == nil && len(resources) == 0

--- a/internal/workflow_tests/local/cancel_command_test.go
+++ b/internal/workflow_tests/local/cancel_command_test.go
@@ -156,7 +156,7 @@ func TestMetastructure_CancelCommand(t *testing.T) {
 		// Apply the forma
 		resp, err := m.ApplyForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 

--- a/internal/workflow_tests/local/cascade_delete_test.go
+++ b/internal/workflow_tests/local/cascade_delete_test.go
@@ -52,7 +52,7 @@ func TestMetastructure_DestroyWithCascade_SimulateShowsCascades(t *testing.T) {
 
 		_, err = m.ApplyForma(parentForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		// Wait for parent to be created
@@ -112,7 +112,7 @@ func TestMetastructure_DestroyWithCascade_SimulateShowsCascades(t *testing.T) {
 		resp, err := m.DestroyForma(destroyParentOnlyForma, &config.FormaCommandConfig{
 			Mode:     pkgmodel.FormaApplyModeReconcile,
 			Simulate: true,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		// Step 4: Verify cascade detection in the simulation response
@@ -176,7 +176,7 @@ func TestDestroyWithCascade_SimulateShowsCascadeTargets(t *testing.T) {
 
 		_, err = m.ApplyForma(providerForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		// Step 2: Wait for apply to complete
@@ -206,7 +206,7 @@ func TestDestroyWithCascade_SimulateShowsCascadeTargets(t *testing.T) {
 		resp, err := m.DestroyForma(providerForma, &config.FormaCommandConfig{
 			Mode:     pkgmodel.FormaApplyModeReconcile,
 			Simulate: true,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		// Step 6: Assert — simulation response includes a target update for "consumer" with IsCascade=true
@@ -256,7 +256,7 @@ func TestDestroyWithCascade_CascadeDeletesDependentTargetAndResources(t *testing
 
 		_, err = m.ApplyForma(providerForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		// Step 2: Wait for apply to complete, get cluster KSUID
@@ -309,7 +309,7 @@ func TestDestroyWithCascade_CascadeDeletesDependentTargetAndResources(t *testing
 		_, err = m.DestroyForma(providerForma, &config.FormaCommandConfig{
 			Mode:         pkgmodel.FormaApplyModeReconcile,
 			OnDependents: "cascade",
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		// Step 6: Wait for destroy to complete
@@ -366,7 +366,7 @@ func TestDestroyWithCascade_TargetDependentsAbortByDefault(t *testing.T) {
 
 		_, err = m.ApplyForma(providerForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		assert.Eventually(t, func() bool {
@@ -394,7 +394,7 @@ func TestDestroyWithCascade_TargetDependentsAbortByDefault(t *testing.T) {
 		// consumer target, and no command is executed.
 		_, err = m.DestroyForma(providerForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.Error(t, err, "default destroy must abort when a dependent target exists")
 
 		var depErr apimodel.FormaTargetHasDependentsError
@@ -412,7 +412,7 @@ func TestDestroyWithCascade_TargetDependentsAbortByDefault(t *testing.T) {
 		_, err = m.DestroyForma(providerForma, &config.FormaCommandConfig{
 			Mode:         pkgmodel.FormaApplyModeReconcile,
 			OnDependents: "cascade",
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err, "on-dependents=cascade must be accepted")
 
 		assert.Eventually(t, func() bool {
@@ -451,7 +451,7 @@ func TestDestroyWithCascade_ResourceDependentsAbortByDefault(t *testing.T) {
 		}
 		_, err = m.ApplyForma(providerForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		assert.Eventually(t, func() bool {
@@ -482,7 +482,7 @@ func TestDestroyWithCascade_ResourceDependentsAbortByDefault(t *testing.T) {
 		// cross-stack dependent, and nothing runs.
 		_, err = m.DestroyForma(providerForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.Error(t, err, "default destroy must abort when a dependent resource exists")
 
 		var depErr apimodel.FormaResourceHasDependentsError
@@ -501,7 +501,7 @@ func TestDestroyWithCascade_ResourceDependentsAbortByDefault(t *testing.T) {
 		_, err = m.DestroyForma(providerForma, &config.FormaCommandConfig{
 			Mode:         pkgmodel.FormaApplyModeReconcile,
 			OnDependents: "cascade",
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err, "on-dependents=cascade must be accepted")
 	})
 }

--- a/internal/workflow_tests/local/cross_stack_persist_test.go
+++ b/internal/workflow_tests/local/cross_stack_persist_test.go
@@ -79,7 +79,7 @@ func TestMetastructure_SuccessfulCreatePersistedInFailedCommand(t *testing.T) {
 
 		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		require.NoError(t, err)
 
 		// Wait for command to complete (should fail due to res-b)

--- a/internal/workflow_tests/local/destroy_forma_test.go
+++ b/internal/workflow_tests/local/destroy_forma_test.go
@@ -66,7 +66,7 @@ func TestMetastructure_ApplyThenDestroyForma(t *testing.T) {
 		}
 		m.ApplyForma(f, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		assert.Eventually(t, func() bool {
 			fas, err := m.Datastore.LoadFormaCommands()
@@ -88,7 +88,7 @@ func TestMetastructure_ApplyThenDestroyForma(t *testing.T) {
 
 		m.DestroyForma(f, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		// Wait for destroy to complete
 		assert.Eventually(t, func() bool {
@@ -202,7 +202,7 @@ func TestMetastructure_DestroyReadThrottlingShouldRetryAndFail(t *testing.T) {
 
 		m.ApplyForma(f, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		// Wait for create to succeed
 		assert.Eventually(t, func() bool {
@@ -216,7 +216,7 @@ func TestMetastructure_DestroyReadThrottlingShouldRetryAndFail(t *testing.T) {
 		// Step 2: Destroy the resource — the Read (sync) phase should hit Throttling
 		m.DestroyForma(f, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		// Wait for destroy to complete — should FAIL because Read retries are exhausted
 		assert.Eventually(t, func() bool {
@@ -286,7 +286,7 @@ func TestMetastructure_DestroyPolicyOnlyForma(t *testing.T) {
 		// Apply the policy first
 		applyResp, err := m.ApplyForma(f, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModePatch,
-		}, "test")
+		}, "test", "", "")
 		assert.NoError(t, err)
 		assert.NotNil(t, applyResp)
 
@@ -307,7 +307,7 @@ func TestMetastructure_DestroyPolicyOnlyForma(t *testing.T) {
 		// Now destroy the policy-only forma
 		destroyResp, err := m.DestroyForma(f, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 		assert.NoError(t, err)
 		assert.NotNil(t, destroyResp)
 

--- a/internal/workflow_tests/local/discovery_resolve_test.go
+++ b/internal/workflow_tests/local/discovery_resolve_test.go
@@ -154,7 +154,7 @@ func TestDiscoveryResolve_TargetConfigOpaqueRefIsResolvedBeforeList(t *testing.T
 			},
 		}
 
-		_, err = m.ApplyForma(applyOne, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "discovery-resolve-client")
+		_, err = m.ApplyForma(applyOne, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "discovery-resolve-client", "", "")
 		require.NoError(t, err)
 
 		// Wait for the apply to complete before triggering discovery.

--- a/internal/workflow_tests/local/force_cancel_command_test.go
+++ b/internal/workflow_tests/local/force_cancel_command_test.go
@@ -115,7 +115,7 @@ func TestMetastructure_ForceCancelCommand_ReachesCanceledImmediately(t *testing.
 
 		resp, err := m.ApplyForma(twoBucketForma(), &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		commandID := resp.CommandID
@@ -195,7 +195,7 @@ func TestMetastructure_ForceCancelCommand_ConvergesWhereNonForceHangs(t *testing
 
 		resp, err := m.ApplyForma(twoBucketForma(), &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 		require.NoError(t, err)
 		commandID := resp.CommandID
 
@@ -292,7 +292,7 @@ func TestMetastructure_ForceCancelCommand_PersisterFailureTerminatesNoActors(t *
 
 		resp, err := m.ApplyForma(twoBucketForma(), &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 		require.NoError(t, err)
 		commandID := resp.CommandID
 
@@ -352,7 +352,7 @@ func TestMetastructure_ForceCancelCommand_CommandWritePersistFailureSurfaces(t *
 
 		resp, err := m.ApplyForma(twoBucketForma(), &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 		require.NoError(t, err)
 		commandID := resp.CommandID
 
@@ -402,7 +402,7 @@ func TestMetastructure_ForceCancelCommand_ResourceStatesAttributeCommandID(t *te
 
 		resp, err := m.ApplyForma(twoBucketForma(), &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		canceledCommandID := resp.CommandID
@@ -453,7 +453,7 @@ func TestMetastructure_ForceCancelCommand_WriteFenceDropsLateMessages(t *testing
 
 		resp, err := m.ApplyForma(twoBucketForma(), &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 		require.NoError(t, err)
 		commandID := resp.CommandID
 

--- a/internal/workflow_tests/local/git_test.go
+++ b/internal/workflow_tests/local/git_test.go
@@ -68,7 +68,7 @@ func TestMetastructure_FormaAppliedSuccess(t *testing.T) {
 
 		o.ApplyForma(f, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		assert.Eventually(t, func() bool {
 			fas, err := o.Datastore.LoadFormaCommands()
@@ -143,7 +143,7 @@ func TestMetastructure_FormaAppliedPartialSuccess(t *testing.T) {
 
 		o.ApplyForma(f, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		assert.Eventually(t, func() bool {
 			fas, err := o.Datastore.LoadFormaCommands()

--- a/internal/workflow_tests/local/missing_in_action_test.go
+++ b/internal/workflow_tests/local/missing_in_action_test.go
@@ -154,7 +154,7 @@ func TestSlowHeartbeatIsNotDeclaredMissingInAction(t *testing.T) {
 
 		resp, err := m.ApplyForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 		require.NoError(t, err)
 
 		// A failed resource update is terminal, so reaching Success is proof the
@@ -230,7 +230,7 @@ func TestFailedStatusCheckReportsThePluginError(t *testing.T) {
 
 		resp, err := m.ApplyForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {

--- a/internal/workflow_tests/local/resilience_test.go
+++ b/internal/workflow_tests/local/resilience_test.go
@@ -87,7 +87,7 @@ func TestMetastructure_FinishIncompleteFormaCommands(t *testing.T) {
 			},
 		}
 
-		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		assert.NoError(t, err)
 
 		time.Sleep(5 * time.Millisecond)
@@ -144,10 +144,10 @@ func TestMetastructure_FinishIncompleteFormaCommands(t *testing.T) {
 // command without spawning a changeset executor.
 //
 // Scenario:
-// 1. Store a command with all resource updates already in terminal states
-//    (simulating a crash between last resource completion and command finalization)
-// 2. Restart the metastructure, triggering ReRunIncompleteCommands
-// 3. Verify the command transitions to the correct final state
+//  1. Store a command with all resource updates already in terminal states
+//     (simulating a crash between last resource completion and command finalization)
+//  2. Restart the metastructure, triggering ReRunIncompleteCommands
+//  3. Verify the command transitions to the correct final state
 func TestMetastructure_FinalizeAllTerminalAfterCrash(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		overrides := &pkgplugin.ResourcePluginOverrides{}
@@ -242,12 +242,12 @@ func TestMetastructure_FinalizeAllTerminalAfterCrash(t *testing.T) {
 // ProgressResult) are not re-included in the recovery changeset after a crash.
 //
 // This prevents the pendingCompletions underflow bug where:
-// 1. Resource B depends on A, A fails → B is cascade-marked as Failed
-// 2. Agent crashes
-// 3. On restart, B has state=Failed but empty ProgressResult
-// 4. Without the fix, UpdateState() would see empty progress → NotStarted
-// 5. Recovery changeset includes B, FormaCommandPersister counts B as already
-//    terminal → pendingCompletions too low → underflow on B's completion
+//  1. Resource B depends on A, A fails → B is cascade-marked as Failed
+//  2. Agent crashes
+//  3. On restart, B has state=Failed but empty ProgressResult
+//  4. Without the fix, UpdateState() would see empty progress → NotStarted
+//  5. Recovery changeset includes B, FormaCommandPersister counts B as already
+//     terminal → pendingCompletions too low → underflow on B's completion
 func TestMetastructure_CascadedFailuresNotReExecutedAfterCrash(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		createCallCount := 0

--- a/internal/workflow_tests/local/stack_test.go
+++ b/internal/workflow_tests/local/stack_test.go
@@ -68,7 +68,7 @@ func TestMetastructure_StoreNewStack(t *testing.T) {
 
 		m.ApplyForma(formaInitial, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		require.Eventually(t, func() bool {
 			fas, _ := m.Datastore.LoadFormaCommands()
@@ -161,7 +161,7 @@ func TestMetastructure_StorePatchStack(t *testing.T) {
 
 		m.ApplyForma(formaInitial, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		require.Eventually(t, func() bool {
 			fas, _ := m.Datastore.LoadFormaCommands()
@@ -196,7 +196,7 @@ func TestMetastructure_StorePatchStack(t *testing.T) {
 
 		m.ApplyForma(formaPatch, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModePatch,
-		}, "test")
+		}, "test", "", "")
 
 		require.Eventually(t, func() bool {
 			fas, _ := m.Datastore.LoadFormaCommands()
@@ -278,7 +278,7 @@ func TestMetastructure_StorePatchAddResourceToStack(t *testing.T) {
 
 		m.ApplyForma(formaInitial, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		time.Sleep(2 * time.Second)
 
@@ -304,7 +304,7 @@ func TestMetastructure_StorePatchAddResourceToStack(t *testing.T) {
 
 		m.ApplyForma(formaPatch, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModePatch,
-		}, "test")
+		}, "test", "", "")
 
 		time.Sleep(2 * time.Second)
 
@@ -357,7 +357,7 @@ func TestMetastructure_StackForApplyImplicitReplaceModeWithRemoveOfOneResource(t
 
 		formaCommand, _ := FormaCommandFromForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, pkgmodel.CommandApply, m.Datastore, "test", resource_update.FormaCommandSourceUser, m.Cfg.Agent.Synchronization.Interval)
+		}, pkgmodel.CommandApply, m.Datastore, "test", "", "", resource_update.FormaCommandSourceUser, m.Cfg.Agent.Synchronization.Interval)
 
 		assert.Equal(t, formaCommand.ResourceUpdates[0].State, forma_command.CommandStateNotStarted)
 
@@ -406,7 +406,7 @@ func TestMetastructure_StackForApplyImplicitReplaceModeWithRenameLabelOfResource
 
 		formaCommand, _ := FormaCommandFromForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, pkgmodel.CommandApply, m.Datastore, "test", resource_update.FormaCommandSourceUser, m.Cfg.Agent.Synchronization.Interval)
+		}, pkgmodel.CommandApply, m.Datastore, "test", "", "", resource_update.FormaCommandSourceUser, m.Cfg.Agent.Synchronization.Interval)
 
 		assert.Equal(t, formaCommand.ResourceUpdates[0].State, resource_update.ResourceUpdateStateNotStarted)
 
@@ -444,7 +444,7 @@ func TestMetastructure_StackOnlyForma_RejectsEmptyStackCreation(t *testing.T) {
 
 		_, err = m.ApplyForma(stackOnlyForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModePatch,
-		}, "test-client")
+		}, "test-client", "", "")
 
 		// Should be rejected with FormaEmptyStackRejectedError
 		require.Error(t, err)
@@ -482,7 +482,7 @@ func TestMetastructure_StackOnlyForma_RejectsEmptyStackCreation_ReconcileMode(t 
 
 		_, err = m.ApplyForma(stackOnlyForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 
 		// Should be rejected with FormaEmptyStackRejectedError
 		require.Error(t, err)
@@ -538,7 +538,7 @@ func TestMetastructure_StackOnlyForma_UpdateDescription(t *testing.T) {
 
 		m.ApplyForma(initialForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 
 		// Wait for initial apply to complete
 		require.Eventually(t, func() bool {
@@ -571,7 +571,7 @@ func TestMetastructure_StackOnlyForma_UpdateDescription(t *testing.T) {
 
 		m.ApplyForma(updateForma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModePatch,
-		}, "test-client-2")
+		}, "test-client-2", "", "")
 
 		// The update command should complete with Success state
 		require.Eventually(t, func() bool {

--- a/internal/workflow_tests/local/stats_test.go
+++ b/internal/workflow_tests/local/stats_test.go
@@ -157,7 +157,7 @@ func TestMetastructure_Stats(t *testing.T) {
 
 		_, err = m.ApplyForma(formaInitial, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client-id")
+		}, "test-client-id", "", "")
 
 		assert.NoError(t, err)
 
@@ -194,7 +194,7 @@ func TestMetastructure_Stats(t *testing.T) {
 		}, 10*time.Second, 100*time.Millisecond,
 			"the failed create must be counted once at the resource-update tier")
 
-		_, err = m.DestroyForma(formaInitial, &config.FormaCommandConfig{}, "test-client-id2")
+		_, err = m.DestroyForma(formaInitial, &config.FormaCommandConfig{}, "test-client-id2", "", "")
 
 		assert.NoError(t, err)
 

--- a/internal/workflow_tests/local/supervision_cascade_test.go
+++ b/internal/workflow_tests/local/supervision_cascade_test.go
@@ -169,7 +169,7 @@ func TestExecutorTerminationCascadesToResourceUpdaters(t *testing.T) {
 		respB, err := m.ApplyForma(
 			formaWithOneResource("stack-b", "b-vpc"),
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
-			"test-client",
+			"test-client", "", "",
 		)
 		require.NoError(t, err)
 		commandIDB := respB.CommandID
@@ -212,7 +212,7 @@ func TestExecutorTerminationCascadesToResourceUpdaters(t *testing.T) {
 		respA, err := m.ApplyForma(
 			formaWithOneResource("stack-a", "a-vpc"),
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
-			"test-client",
+			"test-client", "", "",
 		)
 		require.NoError(t, err)
 		commandIDA := respA.CommandID
@@ -295,7 +295,7 @@ func TestExecutorTerminationCascadesToResolveCache(t *testing.T) {
 		resp, err := m.ApplyForma(
 			formaWithOneResource("stack-rc", "rc-vpc"),
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
-			"test-client",
+			"test-client", "", "",
 		)
 		require.NoError(t, err)
 		commandID := resp.CommandID
@@ -387,7 +387,7 @@ func TestExecutorTerminationCascadesToTargetUpdaters(t *testing.T) {
 
 		seedResp, err := m.ApplyForma(seedForma,
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
-			"test-client")
+			"test-client", "", "")
 		require.NoError(t, err)
 
 		// Wait for the seed command to complete successfully.
@@ -412,7 +412,7 @@ func TestExecutorTerminationCascadesToTargetUpdaters(t *testing.T) {
 				Targets: []pkgmodel.Target{{Label: "consumer-b", Namespace: "FakeAWS", Config: consumerConfig}},
 			},
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
-			"test-client",
+			"test-client", "", "",
 		)
 		require.NoError(t, err)
 		commandIDB := respB.CommandID
@@ -440,7 +440,7 @@ func TestExecutorTerminationCascadesToTargetUpdaters(t *testing.T) {
 				Targets: []pkgmodel.Target{{Label: "consumer-a", Namespace: "FakeAWS", Config: consumerConfig}},
 			},
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
-			"test-client",
+			"test-client", "", "",
 		)
 		require.NoError(t, err)
 		commandIDA := respA.CommandID
@@ -515,7 +515,7 @@ func TestResourceUpdaterTerminationCascadesToPluginOperator(t *testing.T) {
 		resp, err := m.ApplyForma(
 			formaWithOneResource("stack-op", "op-vpc"),
 			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
-			"test-client",
+			"test-client", "", "",
 		)
 		require.NoError(t, err)
 		commandID := resp.CommandID
@@ -675,7 +675,7 @@ func TestPluginOperatorCrashConvergesViaTimeout(t *testing.T) {
 
 		resp, err := m.ApplyForma(forma, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test-client")
+		}, "test-client", "", "")
 		require.NoError(t, err)
 		commandID := resp.CommandID
 

--- a/internal/workflow_tests/local/sync_target_config_resolve_test.go
+++ b/internal/workflow_tests/local/sync_target_config_resolve_test.go
@@ -175,7 +175,7 @@ func TestSyncResolve_TargetConfigOpaqueRefIsResolvedBeforeRead(t *testing.T) {
 			},
 		}
 
-		_, err = m.ApplyForma(applyOne, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "sync-resolve-client")
+		_, err = m.ApplyForma(applyOne, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "sync-resolve-client", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 

--- a/internal/workflow_tests/local/synchronizer_opaque_test.go
+++ b/internal/workflow_tests/local/synchronizer_opaque_test.go
@@ -81,7 +81,7 @@ func TestSynchronizer_OpaqueSecretOutOfBandDrift(t *testing.T) {
 			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
 		}
 
-		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 

--- a/internal/workflow_tests/local/synchronizer_secret_consumer_test.go
+++ b/internal/workflow_tests/local/synchronizer_secret_consumer_test.go
@@ -234,7 +234,7 @@ func TestSynchronizer_SecretConsumerOutOfBandDrift(t *testing.T) {
 		}
 
 		// ───────────────────────── STEP 1: APPLY ─────────────────────────
-		_, err = m.ApplyForma(buildForma("v1"), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(buildForma("v1"), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 		t.Log("########## STEP 1: initial apply (S.secret=v1, R.consumes=$res->S.secret) ##########")
@@ -292,7 +292,7 @@ func TestSynchronizer_SecretConsumerOutOfBandDrift(t *testing.T) {
 
 		// ─────── STEP 3: reconcile SAME forma (desired S=v1) ──────────────
 		t.Log("########## STEP 3: reconcile re-apply SAME forma (desired S.secret=v1) ##########")
-		_, err3 := m.ApplyForma(buildForma("v1"), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err3 := m.ApplyForma(buildForma("v1"), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		// Plain reconcile with the OLD desired (v1) is rejected because the OOB drift
 		// (S.secret is now v2 at rest) makes the stack "modified since the last
 		// reconcile". This is legitimate drift protection — desired v1 genuinely
@@ -315,7 +315,7 @@ func TestSynchronizer_SecretConsumerOutOfBandDrift(t *testing.T) {
 		updateReceived = map[string]json.RawMessage{} // isolate this apply's writes
 		mu.Unlock()
 		t.Log("########## STEP 4a: absorb via PLAIN reconcile — desired S.secret=v2 ##########")
-		_, err4 := m.ApplyForma(buildForma("v2"), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err4 := m.ApplyForma(buildForma("v2"), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		// With R.consumes correctly hashed(v2) at rest, the absorbed desired (v2,
 		// matching the live/ingested value) is now accepted — R is no longer
 		// perpetually "unabsorbed", so the guard clears WITHOUT Force. A corrupted
@@ -512,7 +512,7 @@ func TestSynchronizer_SecretConsumer_ResEnvelope_OutOfBandDrift(t *testing.T) {
 		// starts as a plain opaque-secret-carrying field; we then rewrite it, at
 		// rest, into the STRUCTURED $res envelope that a non-translating path
 		// would have persisted.
-		_, err = m.ApplyForma(buildForma("v1"), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(buildForma("v1"), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 		dumpState("after STEP 1 apply")

--- a/internal/workflow_tests/local/synchronizer_test.go
+++ b/internal/workflow_tests/local/synchronizer_test.go
@@ -123,7 +123,7 @@ func TestSynchronizer_ApplyThenChangeThenSyncStack(t *testing.T) {
 
 		m.ApplyForma(f, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		require := require.New(t)
 		require.Eventually(
@@ -236,7 +236,7 @@ func TestSynchronizer_ApplyThenDestroyThenSyncStack(t *testing.T) {
 
 		m.ApplyForma(f, &config.FormaCommandConfig{
 			Mode: pkgmodel.FormaApplyModeReconcile,
-		}, "test")
+		}, "test", "", "")
 
 		require := require.New(t)
 		require.Eventually(
@@ -319,7 +319,7 @@ func TestSynchronizer_SynchronizeOnce(t *testing.T) {
 			},
 		}
 
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
 		assert.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -405,7 +405,7 @@ func TestSynchronizer_SyncHandlesResourceNotFound(t *testing.T) {
 			},
 		}
 
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
 
 		assert.Eventually(t, func() bool {
 			fas, err := m.Datastore.LoadFormaCommands()
@@ -533,7 +533,7 @@ func TestSynchronizer_OverlapProtection(t *testing.T) {
 			Targets: []pkgmodel.Target{{Label: "test-target"}},
 		}
 
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
 		require.NoError(t, err)
 
 		// Wait for resources to be created
@@ -677,7 +677,7 @@ func TestSynchronizer_ExcludesResourcesBeingUpdatedByApply(t *testing.T) {
 			Targets: []pkgmodel.Target{{Label: "test-target"}},
 		}
 
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
 		require.NoError(t, err)
 
 		// Wait for initial resource creation
@@ -710,7 +710,7 @@ func TestSynchronizer_ExcludesResourcesBeingUpdatedByApply(t *testing.T) {
 				},
 				Targets: []pkgmodel.Target{}, // Empty - target already exists and hasn't changed
 			}
-			_, err := m.ApplyForma(fUpdate, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+			_, err := m.ApplyForma(fUpdate, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
 			assert.NoError(t, err)
 		}()
 
@@ -893,7 +893,7 @@ func TestSynchronizer_SyncDoesNotOverwriteApplyStackChange(t *testing.T) {
 			}},
 			Targets: []pkgmodel.Target{},
 		}
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
@@ -993,7 +993,7 @@ func TestSynchronizer_UnregistersResourcesAfterFailedChangeset(t *testing.T) {
 			Targets: []pkgmodel.Target{{Label: "test-target"}},
 		}
 
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
 		require.NoError(t, err)
 
 		// Wait for resource creation to complete
@@ -1032,7 +1032,7 @@ func TestSynchronizer_UnregistersResourcesAfterFailedChangeset(t *testing.T) {
 			Targets: []pkgmodel.Target{},
 		}
 
-		_, err = m.ApplyForma(fUpdate, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+		_, err = m.ApplyForma(fUpdate, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
 		require.NoError(t, err)
 
 		// Wait for the update command to reach a terminal state
@@ -1152,7 +1152,7 @@ func TestSynchronizer_SyncPicksUpNewSchemaFields(t *testing.T) {
 			Targets: []pkgmodel.Target{{Label: "test-target"}},
 		}
 
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -1323,7 +1323,7 @@ func TestSynchronizer_TargetDeleteCleanupIsIdempotentWithSync(t *testing.T) {
 		}
 
 		_, err = m.ApplyForma(forma,
-			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
 		require.NoError(t, err)
 
 		assert.Eventually(t, func() bool {
@@ -1362,7 +1362,7 @@ func TestSynchronizer_TargetDeleteCleanupIsIdempotentWithSync(t *testing.T) {
 		// - provider target (no $ref → survives)
 		// - unmanaged discovered resource (not in forma → not destroyed)
 		_, err = m.DestroyForma(forma,
-			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
 		require.NoError(t, err)
 
 		assert.Eventually(t, func() bool {
@@ -1517,7 +1517,7 @@ func TestTargetDelete_ForgetsUnmanagedResourcesImmediately(t *testing.T) {
 		}
 
 		_, err = m.ApplyForma(forma,
-			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
 		require.NoError(t, err)
 
 		assert.Eventually(t, func() bool {
@@ -1543,7 +1543,7 @@ func TestTargetDelete_ForgetsUnmanagedResourcesImmediately(t *testing.T) {
 
 		// ── Destroy: deletes managed resources + the consumer target ──
 		_, err = m.DestroyForma(forma,
-			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test")
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
 		require.NoError(t, err)
 
 		assert.Eventually(t, func() bool {

--- a/internal/workflow_tests/local/target_reap_admission_test.go
+++ b/internal/workflow_tests/local/target_reap_admission_test.go
@@ -75,7 +75,7 @@ func TestApplyForma_ReapedTargetResourceOnlyRejected(t *testing.T) {
 			},
 			Targets: []pkgmodel.Target{{Label: "reap-admit-target"}},
 		}
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 		r.NoError(err)
 
 		r.Eventually(func() bool {
@@ -94,7 +94,7 @@ func TestApplyForma_ReapedTargetResourceOnlyRejected(t *testing.T) {
 				{Label: "res1", Type: "FakeAWS::Resource", Properties: v1, Schema: schema, Stack: "reap-admit-stack", Target: "reap-admit-target"},
 			},
 		}
-		_, err = m.ApplyForma(resourceOnly, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch}, "rejected-client")
+		_, err = m.ApplyForma(resourceOnly, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch}, "rejected-client", "", "")
 		r.Error(err, "an apply that touches a reaped target without re-declaring it must be rejected")
 
 		var reapedErr apimodel.TargetReapedError
@@ -131,7 +131,7 @@ func TestDestroyForma_ReapedTargetNotRejected(t *testing.T) {
 			},
 			Targets: []pkgmodel.Target{{Label: "reap-destroy-admit-target"}},
 		}
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 		r.NoError(err)
 
 		r.Eventually(func() bool {
@@ -144,7 +144,7 @@ func TestDestroyForma_ReapedTargetNotRejected(t *testing.T) {
 		targetOnly := &pkgmodel.Forma{
 			Targets: []pkgmodel.Target{{Label: "reap-destroy-admit-target"}},
 		}
-		_, err = m.DestroyForma(targetOnly, &config.FormaCommandConfig{}, "test-client")
+		_, err = m.DestroyForma(targetOnly, &config.FormaCommandConfig{}, "test-client", "", "")
 		r.NoError(err, "destroy against a reaped target must not be rejected")
 
 		var reapedErr apimodel.TargetReapedError

--- a/internal/workflow_tests/local/target_reap_e2e_test.go
+++ b/internal/workflow_tests/local/target_reap_e2e_test.go
@@ -92,7 +92,7 @@ func TestTargetReap_FullLifecycleAndRecovery(t *testing.T) {
 		}
 
 		// Stage 1: initial apply creates the resource; the target is healthy.
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 		r.NoError(err)
 		r.Eventually(func() bool {
 			resources, err := m.Datastore.LoadResourcesByStack("lifecycle-stack")
@@ -151,7 +151,7 @@ func TestTargetReap_FullLifecycleAndRecovery(t *testing.T) {
 				{Label: "svc", Type: "FakeAWS::Resource", Properties: v1, Schema: schema, Stack: "lifecycle-stack", Target: "lifecycle-target"},
 			},
 		}
-		_, err = m.ApplyForma(resourceOnly, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch}, "rejected-client")
+		_, err = m.ApplyForma(resourceOnly, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch}, "rejected-client", "", "")
 		r.Error(err, "an apply touching a reaped target without re-declaring it must be rejected")
 		var reapedErr apimodel.TargetReapedError
 		r.True(errors.As(err, &reapedErr), "error must be a TargetReapedError, got %T: %v", err, err)
@@ -159,7 +159,7 @@ func TestTargetReap_FullLifecycleAndRecovery(t *testing.T) {
 		// Stage 5: re-applying the SAME forma re-declares the target and
 		// recovers it: fresh incarnation, resource re-adopted, reachable again,
 		// accrual reset to zero.
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 		r.NoError(err, "recovery re-apply must be admitted")
 
 		r.Eventually(func() bool {
@@ -253,7 +253,7 @@ func TestTargetReap_SyncRaceDoesNotResurrect(t *testing.T) {
 			},
 			Targets: []pkgmodel.Target{{Label: "sync-race-target"}},
 		}
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 		r.NoError(err)
 		r.Eventually(func() bool {
 			resources, err := m.Datastore.LoadResourcesByStack("sync-race-stack")

--- a/internal/workflow_tests/local/target_reap_recovery_crash_test.go
+++ b/internal/workflow_tests/local/target_reap_recovery_crash_test.go
@@ -100,7 +100,7 @@ func TestApplyForma_RecoveryReAdoptSurvivesCrash(t *testing.T) {
 			},
 			Targets: []pkgmodel.Target{{Label: "crash-target"}},
 		}
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 		r.NoError(err)
 
 		r.Eventually(func() bool {
@@ -119,7 +119,7 @@ func TestApplyForma_RecoveryReAdoptSurvivesCrash(t *testing.T) {
 		// update runs first and commits (fresh incarnation + un-reaped resources);
 		// the resource re-adopt hangs as InProgress.
 		recoveryPhase.Store(true)
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 		r.NoError(err, "recovery re-apply must be admitted")
 
 		// Wait until the recover target update has committed: fresh incarnation and

--- a/internal/workflow_tests/local/target_reap_recovery_test.go
+++ b/internal/workflow_tests/local/target_reap_recovery_test.go
@@ -71,7 +71,7 @@ func TestApplyForma_RecoversReapedTargetWithResource(t *testing.T) {
 			},
 			Targets: []pkgmodel.Target{{Label: "recover-target"}},
 		}
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 		r.NoError(err)
 
 		r.Eventually(func() bool {
@@ -92,7 +92,7 @@ func TestApplyForma_RecoversReapedTargetWithResource(t *testing.T) {
 		r.Len(reaped, 1, "the resource must be reaped before recovery")
 
 		// Re-apply the SAME unchanged forma (re-declares the target) → recovery.
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 		r.NoError(err, "recovery re-apply must be admitted")
 
 		// The target recovers with a FRESH incarnation and is no longer reaped.

--- a/internal/workflow_tests/local/target_reap_stack_cleanup_test.go
+++ b/internal/workflow_tests/local/target_reap_stack_cleanup_test.go
@@ -61,7 +61,7 @@ func TestTargetReap_EmptiedStackIsCleanedUp(t *testing.T) {
 		}
 
 		// Apply: the stack exists and holds its one resource.
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 		r.NoError(err)
 		r.Eventually(func() bool {
 			resources, err := m.Datastore.LoadResourcesByStack("reap-cleanup-stack")

--- a/internal/workflow_tests/local/target_reap_test.go
+++ b/internal/workflow_tests/local/target_reap_test.go
@@ -140,7 +140,7 @@ func TestAutoReconciler_ReapedTargetNotResurrected(t *testing.T) {
 			},
 			Targets: targets,
 		}
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 		r.NoError(err)
 
 		r.Eventually(func() bool {
@@ -312,7 +312,7 @@ func TestDestroyForma_ReapedTargetCleansUpTombstones(t *testing.T) {
 			},
 			Targets: []pkgmodel.Target{{Label: "reap-destroy-target"}},
 		}
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 		r.NoError(err)
 
 		r.Eventually(func() bool {
@@ -331,7 +331,7 @@ func TestDestroyForma_ReapedTargetCleansUpTombstones(t *testing.T) {
 		targetOnly := &pkgmodel.Forma{
 			Targets: []pkgmodel.Target{{Label: "reap-destroy-target"}},
 		}
-		_, err = m.DestroyForma(targetOnly, &config.FormaCommandConfig{}, "test-client")
+		_, err = m.DestroyForma(targetOnly, &config.FormaCommandConfig{}, "test-client", "", "")
 		r.NoError(err)
 
 		r.Eventually(func() bool {
@@ -384,7 +384,7 @@ func TestTargetReap_NestedTargetsReapIndependently(t *testing.T) {
 			},
 			Targets: []pkgmodel.Target{{Label: "nested-parent-target"}},
 		}
-		_, err = m.ApplyForma(parentForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		_, err = m.ApplyForma(parentForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 		r.NoError(err)
 		r.Eventually(func() bool {
 			resources, err := m.Datastore.LoadResourcesByStack("nested-stack")

--- a/internal/workflow_tests/local/target_reap_wiring_test.go
+++ b/internal/workflow_tests/local/target_reap_wiring_test.go
@@ -119,7 +119,7 @@ func TestTargetReaper_ForceReap_PostReapNoResurrection(t *testing.T) {
 			},
 			Targets: []pkgmodel.Target{{Label: "force-reap-target"}},
 		}
-		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client")
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client", "", "")
 		r.NoError(err)
 		r.Eventually(func() bool {
 			resources, err := m.Datastore.LoadResourcesByStack("force-reap-stack")
@@ -149,7 +149,7 @@ func TestTargetReaper_ForceReap_PostReapNoResurrection(t *testing.T) {
 				{Label: "doomed", Type: "FakeAWS::Resource", Properties: v1, Schema: schema, Stack: "force-reap-stack", Target: "force-reap-target"},
 			},
 		}
-		_, err = m.ApplyForma(resourceOnly, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch}, "rejected-client")
+		_, err = m.ApplyForma(resourceOnly, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch}, "rejected-client", "", "")
 		r.Error(err, "an apply touching a really-reaped target without re-declaring it must be rejected")
 		var reapedErr apimodel.TargetReapedError
 		r.True(errors.As(err, &reapedErr), "error must be a TargetReapedError, got %T: %v", err, err)

--- a/pkg/api/model/types.go
+++ b/pkg/api/model/types.go
@@ -37,6 +37,8 @@ type Command struct {
 	Command         string           `json:"Command"`
 	Mode            string           `json:"Mode,omitempty"` // "reconcile" | "patch"
 	Source          string           `json:"Source,omitempty"`
+	Subject         string           `json:",omitempty"`
+	SubjectName     string           `json:",omitempty"`
 	State           string           `json:"State"`
 	StartTs         time.Time        `json:"StartTs,omitempty"`
 	EndTs           time.Time        `json:"EndTs,omitempty"`

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -9,12 +9,30 @@ import (
 	"time"
 )
 
+// ErrorCode identifies a category of auth plugin error, letting callers
+// branch on failure kind without parsing the human-readable Error string.
+type ErrorCode string
+
+const (
+	// ErrorCodeUnsupported indicates the plugin does not implement this verb.
+	ErrorCodeUnsupported ErrorCode = "unsupported"
+	// ErrorCodeNotLoggedIn indicates there is no active session.
+	ErrorCodeNotLoggedIn ErrorCode = "not_logged_in"
+	// ErrorCodeSessionExpired indicates a previously active session has expired.
+	ErrorCodeSessionExpired ErrorCode = "session_expired"
+	// ErrorCodeIssuerUnreachable indicates the plugin could not reach its identity issuer.
+	ErrorCodeIssuerUnreachable ErrorCode = "issuer_unreachable"
+)
+
 // AuthPlugin is the interface that auth plugin binaries must implement.
 // Method signatures are net/rpc compatible (two args: request pointer, response pointer; returns error).
 type AuthPlugin interface {
 	Init(req *InitRequest, resp *InitResponse) error
 	Validate(req *ValidateRequest, resp *ValidateResponse) error
 	GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error
+	LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error
+	LoginWait(req *LoginWaitRequest, resp *LoginWaitResponse) error
+	Logout(req *LogoutRequest, resp *LogoutResponse) error
 }
 
 // InitRequest is sent once at startup to configure the plugin.
@@ -36,14 +54,63 @@ type ValidateRequest struct {
 type ValidateResponse struct {
 	Valid    bool
 	Error    string
-	CacheKey string
+	CacheKey string // retained for SOURCE compatibility with existing plugins; the host never reads it
 	CacheTTL time.Duration
+
+	Subject     string // verified stable subject id; empty when the plugin has no notion of one
+	SubjectName string // display hint only; never used for authorization
+	ErrorCode   ErrorCode
 }
 
 // GetAuthHeaderRequest requests auth headers for outgoing requests (CLI side).
-type GetAuthHeaderRequest struct{}
+type GetAuthHeaderRequest struct {
+	ForceRefresh bool // skip freshness checks and refresh the credential now
+}
 
 // GetAuthHeaderResponse contains the headers to attach to outgoing requests.
 type GetAuthHeaderResponse struct {
-	Headers map[string][]string
+	Headers   map[string][]string
+	Error     string
+	ErrorCode ErrorCode
+}
+
+// LoginStartRequest begins an interactive login flow.
+type LoginStartRequest struct {
+	Mode  string // "browser" | "device"
+	Force bool
+}
+
+// LoginStartResponse describes how the caller should carry out (or skip) the login flow.
+type LoginStartResponse struct {
+	Status           string // "started" | "already_authenticated"
+	Method           string // echoes Mode when Status=="started"
+	BrowserURL       string
+	VerificationURI  string
+	UserCode         string
+	SessionID        string
+	ExpiresInSeconds int
+	Subject          string // set when Status=="already_authenticated"
+	SubjectName      string
+	Error            string
+	ErrorCode        ErrorCode
+}
+
+// LoginWaitRequest polls for completion of a login flow started by LoginStart.
+type LoginWaitRequest struct{ SessionID string }
+
+// LoginWaitResponse reports the outcome of a login flow.
+type LoginWaitResponse struct {
+	Subject     string
+	SubjectName string
+	Error       string
+	ErrorCode   ErrorCode
+}
+
+// LogoutRequest ends the current session.
+type LogoutRequest struct{}
+
+// LogoutResponse is the plugin's response to Logout.
+type LogoutResponse struct {
+	Error     string
+	ErrorCode ErrorCode
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -29,6 +29,9 @@ const (
 type AuthPlugin interface {
 	Init(req *InitRequest, resp *InitResponse) error
 	Validate(req *ValidateRequest, resp *ValidateResponse) error
+	// GetAuthHeader: to fail closed on every host version, return a non-nil
+	// error rather than relying on GetAuthHeaderResponse's typed fields,
+	// which a host built against an earlier SDK cannot read.
 	GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error
 	LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error
 	LoginWait(req *LoginWaitRequest, resp *LoginWaitResponse) error
@@ -68,6 +71,14 @@ type GetAuthHeaderRequest struct {
 }
 
 // GetAuthHeaderResponse contains the headers to attach to outgoing requests.
+//
+// Error and ErrorCode were added in SDK 0.3.0. A host built against an
+// earlier SDK decodes only Headers and cannot observe either field, so a
+// nil error paired with empty Headers reads as successful authentication.
+// A plugin that must fail closed regardless of host version returns a
+// non-nil Go error from GetAuthHeader instead; these typed fields are
+// additive information for hosts new enough to read them, not a
+// substitute for that error.
 type GetAuthHeaderResponse struct {
 	Headers   map[string][]string
 	Error     string

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -28,6 +28,10 @@ const (
 // Method signatures are net/rpc compatible (two args: request pointer, response pointer; returns error).
 type AuthPlugin interface {
 	Init(req *InitRequest, resp *InitResponse) error
+	// Validate: return nil with Valid: false to deny a credential. Reserve a
+	// non-nil error for the plugin being genuinely unable to answer: the
+	// host maps any error from this call to plugin-unavailable, not to a
+	// rejected credential.
 	Validate(req *ValidateRequest, resp *ValidateResponse) error
 	// GetAuthHeader: to fail closed on every host version, return a non-nil
 	// error rather than relying on GetAuthHeaderResponse's typed fields,
@@ -60,9 +64,9 @@ type ValidateResponse struct {
 	CacheKey string // retained for SOURCE compatibility with existing plugins; the host never reads it
 	CacheTTL time.Duration
 
-	Subject     string // verified stable subject id; empty when the plugin has no notion of one
-	SubjectName string // display hint only; never used for authorization
-	ErrorCode   ErrorCode
+	Subject     string    // verified stable subject id; empty when the plugin has no notion of one
+	SubjectName string    // display hint only; never used for authorization
+	ErrorCode   ErrorCode // reserved; not currently surfaced to clients, so put the rejection reason on the plugin's stderr
 }
 
 // GetAuthHeaderRequest requests auth headers for outgoing requests (CLI side).
@@ -80,7 +84,7 @@ type GetAuthHeaderRequest struct {
 // additive information for hosts new enough to read them, not a
 // substitute for that error.
 type GetAuthHeaderResponse struct {
-	Headers   map[string][]string
+	Headers   map[string][]string // the client attaches only the canonical "Authorization" header; return the credential under that exact key
 	Error     string
 	ErrorCode ErrorCode
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -14,9 +14,10 @@ import (
 
 // fakePlugin is a test double implementing the AuthPlugin interface.
 type fakePlugin struct {
-	initCalled    bool
-	receivedCfg   json.RawMessage
-	validateUsers map[string]string // username -> password (plaintext for testing)
+	initCalled       bool
+	receivedCfg      json.RawMessage
+	validateUsers    map[string]string // username -> password (plaintext for testing)
+	lastForceRefresh bool
 }
 
 func (f *fakePlugin) Init(req *InitRequest, resp *InitResponse) error {
@@ -40,9 +41,26 @@ func (f *fakePlugin) Validate(req *ValidateRequest, resp *ValidateResponse) erro
 }
 
 func (f *fakePlugin) GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error {
+	f.lastForceRefresh = req.ForceRefresh
 	resp.Headers = map[string][]string{
 		"X-Api-Key": {"secret-key"},
 	}
+	return nil
+}
+
+func (f *fakePlugin) LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error {
+	resp.Status = "started"
+	resp.SessionID = "s-1"
+	return nil
+}
+
+func (f *fakePlugin) LoginWait(req *LoginWaitRequest, resp *LoginWaitResponse) error {
+	resp.Subject = "11111111-1111-4111-8111-111111111111"
+	resp.SubjectName = "dpanders"
+	return nil
+}
+
+func (f *fakePlugin) Logout(req *LogoutRequest, resp *LogoutResponse) error {
 	return nil
 }
 
@@ -144,7 +162,7 @@ func TestServerAndClient_GetAuthHeader(t *testing.T) {
 	defer client.Close()
 
 	var resp GetAuthHeaderResponse
-	err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp)
+	err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{ForceRefresh: true}, &resp)
 	if err != nil {
 		t.Fatalf("GetAuthHeader call failed: %v", err)
 	}
@@ -152,5 +170,75 @@ func TestServerAndClient_GetAuthHeader(t *testing.T) {
 	keys := resp.Headers["X-Api-Key"]
 	if len(keys) != 1 || keys[0] != "secret-key" {
 		t.Fatalf("expected X-Api-Key header with 'secret-key', got %v", resp.Headers)
+	}
+
+	if !plugin.lastForceRefresh {
+		t.Fatal("expected ForceRefresh to round-trip to the plugin")
+	}
+}
+
+func TestServerAndClient_LoginStart(t *testing.T) {
+	plugin := &fakePlugin{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	var resp LoginStartResponse
+	err := client.Call("AuthPlugin.LoginStart", &LoginStartRequest{Mode: "browser"}, &resp)
+	if err != nil {
+		t.Fatalf("LoginStart call failed: %v", err)
+	}
+	if resp.Status != "started" {
+		t.Fatalf("expected Status 'started', got %q", resp.Status)
+	}
+	if resp.SessionID != "s-1" {
+		t.Fatalf("expected SessionID 's-1', got %q", resp.SessionID)
+	}
+}
+
+func TestServerAndClient_LoginWait(t *testing.T) {
+	plugin := &fakePlugin{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	var resp LoginWaitResponse
+	err := client.Call("AuthPlugin.LoginWait", &LoginWaitRequest{SessionID: "s-1"}, &resp)
+	if err != nil {
+		t.Fatalf("LoginWait call failed: %v", err)
+	}
+	if resp.Subject != "11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("expected Subject '11111111-1111-4111-8111-111111111111', got %q", resp.Subject)
+	}
+	if resp.SubjectName != "dpanders" {
+		t.Fatalf("expected SubjectName 'dpanders', got %q", resp.SubjectName)
+	}
+}
+
+func TestServerAndClient_Logout(t *testing.T) {
+	plugin := &fakePlugin{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	var resp LogoutResponse
+	err := client.Call("AuthPlugin.Logout", &LogoutRequest{}, &resp)
+	if err != nil {
+		t.Fatalf("Logout call failed: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("expected no error, got %q", resp.Error)
+	}
+	if resp.ErrorCode != "" {
+		t.Fatalf("expected no error code, got %q", resp.ErrorCode)
 	}
 }

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/rpc"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -110,12 +111,74 @@ func (c *Client) Validate(req *ValidateRequest) (*ValidateResponse, error) {
 }
 
 // GetAuthHeader requests auth headers from the plugin for outgoing requests.
-func (c *Client) GetAuthHeader() (*GetAuthHeaderResponse, error) {
+// forceRefresh asks the plugin to skip freshness checks and refresh the
+// credential now.
+func (c *Client) GetAuthHeader(forceRefresh bool) (*GetAuthHeaderResponse, error) {
 	var resp GetAuthHeaderResponse
-	if err := c.rpcClient.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp); err != nil {
-		return nil, fmt.Errorf("auth client: get auth header: %w", err)
+	if err := c.call("GetAuthHeader", &GetAuthHeaderRequest{ForceRefresh: forceRefresh}, &resp); err != nil {
+		return nil, err
 	}
 	return &resp, nil
+}
+
+// LoginStart begins an interactive login flow on the plugin.
+func (c *Client) LoginStart(req *LoginStartRequest) (*LoginStartResponse, error) {
+	var resp LoginStartResponse
+	if err := c.call("LoginStart", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// LoginWait polls the plugin for completion of a login flow started by
+// LoginStart. It carries no client-side timeout: the plugin owns the bound
+// on how long the flow may take.
+func (c *Client) LoginWait(req *LoginWaitRequest) (*LoginWaitResponse, error) {
+	var resp LoginWaitResponse
+	if err := c.call("LoginWait", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Logout ends the current session on the plugin.
+func (c *Client) Logout() (*LogoutResponse, error) {
+	var resp LogoutResponse
+	if err := c.call("Logout", &LogoutRequest{}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// errorCoded is implemented by response types that carry an ErrorCode field,
+// letting call set it uniformly when a verb turns out to be unsupported.
+type errorCoded interface {
+	setUnsupported()
+}
+
+func (r *GetAuthHeaderResponse) setUnsupported() { r.ErrorCode = ErrorCodeUnsupported }
+func (r *LoginStartResponse) setUnsupported()    { r.ErrorCode = ErrorCodeUnsupported }
+func (r *LoginWaitResponse) setUnsupported()     { r.ErrorCode = ErrorCodeUnsupported }
+func (r *LogoutResponse) setUnsupported()        { r.ErrorCode = ErrorCodeUnsupported }
+
+// methodNotFoundPrefix is the text net/rpc prefixes to the error it returns
+// when the server has no registered method for the requested name.
+const methodNotFoundPrefix = "rpc: can't find method"
+
+// call invokes an AuthPlugin RPC method and translates net/rpc's
+// method-not-found transport error into the typed unsupported contract, so
+// an old already-built plugin binary that lacks a verb is indistinguishable
+// from a new one that declines it.
+func (c *Client) call(method string, req any, resp errorCoded) error {
+	err := c.rpcClient.Call("AuthPlugin."+method, req, resp)
+	if err == nil {
+		return nil
+	}
+	if strings.HasPrefix(err.Error(), methodNotFoundPrefix) {
+		resp.setUnsupported()
+		return nil
+	}
+	return fmt.Errorf("auth client: %s: %w", method, err)
 }
 
 // Close shuts down the RPC client, closes the connection, and kills the subprocess.

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/rpc"
 	"os/exec"
-	"strings"
 	"time"
 )
 
@@ -161,20 +160,26 @@ func (r *LoginStartResponse) setUnsupported()    { r.ErrorCode = ErrorCodeUnsupp
 func (r *LoginWaitResponse) setUnsupported()     { r.ErrorCode = ErrorCodeUnsupported }
 func (r *LogoutResponse) setUnsupported()        { r.ErrorCode = ErrorCodeUnsupported }
 
-// methodNotFoundPrefix is the text net/rpc prefixes to the error it returns
-// when the server has no registered method for the requested name.
-const methodNotFoundPrefix = "rpc: can't find method"
-
 // call invokes an AuthPlugin RPC method and translates net/rpc's
 // method-not-found transport error into the typed unsupported contract, so
 // an old already-built plugin binary that lacks a verb is indistinguishable
 // from a new one that declines it.
+//
+// The match is against the exact canonical error text net/rpc's server
+// produces for the specific method being called ("rpc: can't find method " +
+// serviceMethod), not a bare prefix. net/rpc surfaces both its own dispatch
+// failures and errors returned by an invoked method through the same
+// unstructured error channel, so a registered method that fails with an
+// error string that happens to start with that same prefix (e.g. a plugin
+// propagating a downstream RPC failure verbatim) must NOT be mistaken for an
+// absent method.
 func (c *Client) call(method string, req any, resp errorCoded) error {
-	err := c.rpcClient.Call("AuthPlugin."+method, req, resp)
+	serviceMethod := "AuthPlugin." + method
+	err := c.rpcClient.Call(serviceMethod, req, resp)
 	if err == nil {
 		return nil
 	}
-	if strings.HasPrefix(err.Error(), methodNotFoundPrefix) {
+	if err.Error() == "rpc: can't find method "+serviceMethod {
 		resp.setUnsupported()
 		return nil
 	}

--- a/pkg/auth/client_test.go
+++ b/pkg/auth/client_test.go
@@ -5,6 +5,7 @@
 package auth
 
 import (
+	"errors"
 	"net/rpc"
 	"testing"
 	"time"
@@ -253,6 +254,44 @@ func TestClient_UnsupportedVerbTranslation(t *testing.T) {
 				t.Fatalf("expected ErrorCode %q, got %q", tc.wantCode, code)
 			}
 		})
+	}
+}
+
+// confusingErrorPlugin implements the full AuthPlugin interface, but its
+// LoginStart method itself fails, returning an error whose text happens to
+// share the "rpc: can't find method" prefix net/rpc uses for its own
+// method-not-found error — for a different service and method than the one
+// invoked, as could occur when a plugin propagates a downstream RPC failure
+// verbatim (e.g. its own call to an issuer's RPC surface).
+type confusingErrorPlugin struct {
+	UnimplementedAuthPlugin
+}
+
+func (confusingErrorPlugin) Init(req *InitRequest, resp *InitResponse) error {
+	return nil
+}
+
+func (confusingErrorPlugin) LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error {
+	return errors.New("rpc: can't find method Issuer.Refresh")
+}
+
+// TestClient_Call_DoesNotMisclassifyDownstreamError exercises a method that
+// IS registered but whose own implementation fails with an error string that
+// happens to start with the same text net/rpc uses for a genuinely absent
+// method. call must surface this as a real, non-nil error rather than
+// translating it into ErrorCodeUnsupported.
+func TestClient_Call_DoesNotMisclassifyDownstreamError(t *testing.T) {
+	plugin := &confusingErrorPlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	var resp LoginStartResponse
+	err := client.call("LoginStart", &LoginStartRequest{Mode: "browser"}, &resp)
+	if err == nil {
+		t.Fatal("expected a non-nil error, got nil")
+	}
+	if resp.ErrorCode == ErrorCodeUnsupported {
+		t.Fatal("expected the downstream error not to be misclassified as ErrorCodeUnsupported")
 	}
 }
 

--- a/pkg/auth/client_test.go
+++ b/pkg/auth/client_test.go
@@ -71,7 +71,7 @@ func TestClient_GetAuthHeader(t *testing.T) {
 	client := newTestClient(t, plugin)
 	defer client.Close()
 
-	resp, err := client.GetAuthHeader()
+	resp, err := client.GetAuthHeader(false)
 	if err != nil {
 		t.Fatalf("GetAuthHeader failed: %v", err)
 	}
@@ -79,6 +79,180 @@ func TestClient_GetAuthHeader(t *testing.T) {
 	keys := resp.Headers["X-Api-Key"]
 	if len(keys) != 1 || keys[0] != "secret-key" {
 		t.Fatalf("expected X-Api-Key='secret-key', got %v", resp.Headers)
+	}
+}
+
+func TestClient_GetAuthHeader_ForceRefresh(t *testing.T) {
+	plugin := &fakePlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	if _, err := client.GetAuthHeader(true); err != nil {
+		t.Fatalf("GetAuthHeader failed: %v", err)
+	}
+
+	if !plugin.lastForceRefresh {
+		t.Fatal("expected ForceRefresh=true to transmit to the plugin")
+	}
+}
+
+func TestClient_LoginStart(t *testing.T) {
+	plugin := &fakePlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	resp, err := client.LoginStart(&LoginStartRequest{Mode: "browser"})
+	if err != nil {
+		t.Fatalf("LoginStart failed: %v", err)
+	}
+	if resp.Status != "started" {
+		t.Fatalf("expected Status 'started', got %q", resp.Status)
+	}
+	if resp.SessionID != "s-1" {
+		t.Fatalf("expected SessionID 's-1', got %q", resp.SessionID)
+	}
+}
+
+func TestClient_LoginWait(t *testing.T) {
+	plugin := &fakePlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	resp, err := client.LoginWait(&LoginWaitRequest{SessionID: "s-1"})
+	if err != nil {
+		t.Fatalf("LoginWait failed: %v", err)
+	}
+	if resp.Subject != "11111111-1111-4111-8111-111111111111" {
+		t.Fatalf("expected Subject '11111111-1111-4111-8111-111111111111', got %q", resp.Subject)
+	}
+	if resp.SubjectName != "dpanders" {
+		t.Fatalf("expected SubjectName 'dpanders', got %q", resp.SubjectName)
+	}
+}
+
+func TestClient_Logout(t *testing.T) {
+	plugin := &fakePlugin{}
+	client := newTestClient(t, plugin)
+	defer client.Close()
+
+	resp, err := client.Logout()
+	if err != nil {
+		t.Fatalf("Logout failed: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("expected no error, got %q", resp.Error)
+	}
+	if resp.ErrorCode != "" {
+		t.Fatalf("expected no error code, got %q", resp.ErrorCode)
+	}
+}
+
+// legacyAuthPlugin implements only the pre-login-verb surface (Init,
+// Validate, GetAuthHeader), modelling an already-built plugin binary that
+// predates the LoginStart/LoginWait/Logout verbs.
+type legacyAuthPlugin struct{}
+
+func (legacyAuthPlugin) Init(req *InitRequest, resp *InitResponse) error {
+	return nil
+}
+
+func (legacyAuthPlugin) Validate(req *ValidateRequest, resp *ValidateResponse) error {
+	resp.Valid = true
+	return nil
+}
+
+func (legacyAuthPlugin) GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error {
+	resp.Headers = map[string][]string{"X-Api-Key": {"legacy-key"}}
+	return nil
+}
+
+// newLegacyTestClient wires a Client to an RPC server that registers only
+// the given legacy-shaped plugin, bypassing Serve (which requires the full
+// AuthPlugin interface) so the server genuinely lacks the login verbs.
+func newLegacyTestClient(t *testing.T, plugin any) *Client {
+	t.Helper()
+
+	clientConn, serverConn := pipeConn()
+
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("AuthPlugin", plugin); err != nil {
+		t.Fatalf("RegisterName: %v", err)
+	}
+	go srv.ServeConn(serverConn)
+
+	rpcClient := rpc.NewClient(clientConn)
+
+	return &Client{
+		rpcClient: rpcClient,
+		conn:      clientConn,
+	}
+}
+
+func TestClient_UnsupportedVerbTranslation(t *testing.T) {
+	client := newLegacyTestClient(t, &legacyAuthPlugin{})
+	defer client.Close()
+
+	cases := []struct {
+		name     string
+		call     func() (ErrorCode, error)
+		wantCode ErrorCode
+	}{
+		{
+			name: "GetAuthHeader",
+			call: func() (ErrorCode, error) {
+				resp, err := client.GetAuthHeader(false)
+				if err != nil {
+					return "", err
+				}
+				return resp.ErrorCode, nil
+			},
+			wantCode: "",
+		},
+		{
+			name: "LoginStart",
+			call: func() (ErrorCode, error) {
+				resp, err := client.LoginStart(&LoginStartRequest{Mode: "browser"})
+				if err != nil {
+					return "", err
+				}
+				return resp.ErrorCode, nil
+			},
+			wantCode: ErrorCodeUnsupported,
+		},
+		{
+			name: "LoginWait",
+			call: func() (ErrorCode, error) {
+				resp, err := client.LoginWait(&LoginWaitRequest{SessionID: "s-1"})
+				if err != nil {
+					return "", err
+				}
+				return resp.ErrorCode, nil
+			},
+			wantCode: ErrorCodeUnsupported,
+		},
+		{
+			name: "Logout",
+			call: func() (ErrorCode, error) {
+				resp, err := client.Logout()
+				if err != nil {
+					return "", err
+				}
+				return resp.ErrorCode, nil
+			},
+			wantCode: ErrorCodeUnsupported,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, err := tc.call()
+			if err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+			if code != tc.wantCode {
+				t.Fatalf("expected ErrorCode %q, got %q", tc.wantCode, code)
+			}
+		})
 	}
 }
 

--- a/pkg/auth/unimplemented.go
+++ b/pkg/auth/unimplemented.go
@@ -1,0 +1,44 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package auth
+
+// UnimplementedAuthPlugin can be embedded in an AuthPlugin implementation to
+// satisfy verbs the plugin does not support. Every stub returns a nil error
+// with ErrorCode set to ErrorCodeUnsupported, letting existing plugins adopt
+// the widened AuthPlugin interface without implementing every verb.
+//
+// Init is deliberately absent: every plugin implements it.
+type UnimplementedAuthPlugin struct{}
+
+// Validate reports the request as unsupported.
+func (UnimplementedAuthPlugin) Validate(req *ValidateRequest, resp *ValidateResponse) error {
+	resp.Valid = false
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}
+
+// GetAuthHeader reports the verb as unsupported.
+func (UnimplementedAuthPlugin) GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error {
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}
+
+// LoginStart reports the verb as unsupported.
+func (UnimplementedAuthPlugin) LoginStart(req *LoginStartRequest, resp *LoginStartResponse) error {
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}
+
+// LoginWait reports the verb as unsupported.
+func (UnimplementedAuthPlugin) LoginWait(req *LoginWaitRequest, resp *LoginWaitResponse) error {
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}
+
+// Logout reports the verb as unsupported.
+func (UnimplementedAuthPlugin) Logout(req *LogoutRequest, resp *LogoutResponse) error {
+	resp.ErrorCode = ErrorCodeUnsupported
+	return nil
+}

--- a/pkg/auth/unimplemented.go
+++ b/pkg/auth/unimplemented.go
@@ -4,10 +4,19 @@
 
 package auth
 
+import "errors"
+
 // UnimplementedAuthPlugin can be embedded in an AuthPlugin implementation to
-// satisfy verbs the plugin does not support. Every stub returns a nil error
+// satisfy verbs the plugin does not support. Most stubs return a nil error
 // with ErrorCode set to ErrorCodeUnsupported, letting existing plugins adopt
 // the widened AuthPlugin interface without implementing every verb.
+//
+// GetAuthHeader is the exception: it returns a Go error instead. A host
+// built against the pre-widening GetAuthHeaderResponse (Headers only, no
+// Error or ErrorCode) cannot observe those fields, so a nil-error response
+// with empty Headers reads as successful, unauthenticated access. Signaling
+// through the RPC error instead makes an agent-only plugin fail closed on
+// every host version, old or new.
 //
 // Init is deliberately absent: every plugin implements it.
 type UnimplementedAuthPlugin struct{}
@@ -19,10 +28,12 @@ func (UnimplementedAuthPlugin) Validate(req *ValidateRequest, resp *ValidateResp
 	return nil
 }
 
-// GetAuthHeader reports the verb as unsupported.
+// GetAuthHeader returns an RPC error rather than a typed response field: a
+// host running against the older GetAuthHeaderResponse shape (Headers only)
+// cannot see ErrorCode, and a nil error there is indistinguishable from a
+// successful, empty-headers response.
 func (UnimplementedAuthPlugin) GetAuthHeader(req *GetAuthHeaderRequest, resp *GetAuthHeaderResponse) error {
-	resp.ErrorCode = ErrorCodeUnsupported
-	return nil
+	return errors.New("auth plugin does not support GetAuthHeader")
 }
 
 // LoginStart reports the verb as unsupported.

--- a/pkg/auth/unimplemented_test.go
+++ b/pkg/auth/unimplemented_test.go
@@ -1,0 +1,105 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package auth
+
+import (
+	"net/rpc"
+	"testing"
+)
+
+// onlyInit embeds UnimplementedAuthPlugin and implements only Init itself,
+// showing that the embed alone satisfies the widened AuthPlugin interface.
+type onlyInit struct {
+	UnimplementedAuthPlugin
+}
+
+func (o *onlyInit) Init(req *InitRequest, resp *InitResponse) error {
+	return nil
+}
+
+var _ AuthPlugin = (*onlyInit)(nil)
+
+func TestUnimplementedAuthPlugin_StubsReturnUnsupported(t *testing.T) {
+	plugin := &onlyInit{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "Validate",
+			run: func(t *testing.T) {
+				var resp ValidateResponse
+				if err := client.Call("AuthPlugin.Validate", &ValidateRequest{}, &resp); err != nil {
+					t.Fatalf("Validate call failed: %v", err)
+				}
+				if resp.Valid {
+					t.Fatal("expected Valid=false")
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+		{
+			name: "GetAuthHeader",
+			run: func(t *testing.T) {
+				var resp GetAuthHeaderResponse
+				if err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp); err != nil {
+					t.Fatalf("GetAuthHeader call failed: %v", err)
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+		{
+			name: "LoginStart",
+			run: func(t *testing.T) {
+				var resp LoginStartResponse
+				if err := client.Call("AuthPlugin.LoginStart", &LoginStartRequest{}, &resp); err != nil {
+					t.Fatalf("LoginStart call failed: %v", err)
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+		{
+			name: "LoginWait",
+			run: func(t *testing.T) {
+				var resp LoginWaitResponse
+				if err := client.Call("AuthPlugin.LoginWait", &LoginWaitRequest{}, &resp); err != nil {
+					t.Fatalf("LoginWait call failed: %v", err)
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+		{
+			name: "Logout",
+			run: func(t *testing.T) {
+				var resp LogoutResponse
+				if err := client.Call("AuthPlugin.Logout", &LogoutRequest{}, &resp); err != nil {
+					t.Fatalf("Logout call failed: %v", err)
+				}
+				if resp.ErrorCode != ErrorCodeUnsupported {
+					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.run)
+	}
+}

--- a/pkg/auth/unimplemented_test.go
+++ b/pkg/auth/unimplemented_test.go
@@ -21,6 +21,12 @@ func (o *onlyInit) Init(req *InitRequest, resp *InitResponse) error {
 
 var _ AuthPlugin = (*onlyInit)(nil)
 
+// TestUnimplementedAuthPlugin_StubsReturnUnsupported covers the four verbs
+// that report "unsupported" through the response's ErrorCode field with a
+// nil RPC error: Validate, LoginStart, LoginWait, Logout. These verbs did
+// not exist (or, for Validate, already fail closed via Valid=false) on
+// hosts predating the widened interface, so a typed field in the response
+// is safe.
 func TestUnimplementedAuthPlugin_StubsReturnUnsupported(t *testing.T) {
 	plugin := &onlyInit{}
 	clientConn, serverConn := pipeConn()
@@ -43,18 +49,6 @@ func TestUnimplementedAuthPlugin_StubsReturnUnsupported(t *testing.T) {
 				}
 				if resp.Valid {
 					t.Fatal("expected Valid=false")
-				}
-				if resp.ErrorCode != ErrorCodeUnsupported {
-					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
-				}
-			},
-		},
-		{
-			name: "GetAuthHeader",
-			run: func(t *testing.T) {
-				var resp GetAuthHeaderResponse
-				if err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp); err != nil {
-					t.Fatalf("GetAuthHeader call failed: %v", err)
 				}
 				if resp.ErrorCode != ErrorCodeUnsupported {
 					t.Fatalf("expected ErrorCode %q, got %q", ErrorCodeUnsupported, resp.ErrorCode)
@@ -101,5 +95,28 @@ func TestUnimplementedAuthPlugin_StubsReturnUnsupported(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, tt.run)
+	}
+}
+
+// TestUnimplementedAuthPlugin_GetAuthHeaderFailsClosed exercises the one
+// stub that must signal unsupported through the RPC error channel instead
+// of a response field: a host built against the pre-widening
+// GetAuthHeaderResponse (Headers only) cannot see ErrorCode, so a nil-error
+// response with empty Headers would read as successful, unauthenticated
+// access. The call must come back with a non-nil error over the real
+// net/rpc round trip, not merely from the Go method in isolation.
+func TestUnimplementedAuthPlugin_GetAuthHeaderFailsClosed(t *testing.T) {
+	plugin := &onlyInit{}
+	clientConn, serverConn := pipeConn()
+
+	go Serve(plugin, serverConn)
+
+	client := rpc.NewClient(clientConn)
+	defer client.Close()
+
+	var resp GetAuthHeaderResponse
+	err := client.Call("AuthPlugin.GetAuthHeader", &GetAuthHeaderRequest{}, &resp)
+	if err == nil {
+		t.Fatal("expected a non-nil error from GetAuthHeader")
 	}
 }

--- a/pkg/auth/version.go
+++ b/pkg/auth/version.go
@@ -10,4 +10,4 @@ const MinFormaeVersion = "0.84.0"
 
 // SDKVersion is the version of this auth SDK package.
 // Used in compatibility error messages to tell plugin authors which version to upgrade to.
-const SDKVersion = "0.2.1"
+const SDKVersion = "0.3.0"


### PR DESCRIPTION
Records a verified identity on command rows. Commands already carry a `ClientID` — a self-asserted header holding a machine-generated identifier, which names a device and does so untrustworthily. `Subject` names a person, and the agent verified it. The two coexist: device attribution and accountability are different questions.

**Stack:** A (#623, SDK surface) → B (#624, host cache + middleware) → **C (this PR)** → D (CLI `login`/`logout` + 401 retry). **Base this on #624, not main.**

## What changes

`FormaCommand` gains `Subject` and `SubjectName`. The four command-creating API handlers read them off the request context — where PR B's middleware put them — and thread them down to the metastructure layer. `pkg/api/model.Command` exposes both with `omitempty`.

Two nullable columns, across **three** migration files for **four** backends: sqlite `00019`, mssql `00019`, postgres `00020`. The streams are deliberately not in lockstep (sqlite and mssql ended at `00018`, postgres at `00019`), and aurora has no file of its own because it embeds the postgres stream.

## Which commands get a subject, and which must not

Exactly four endpoints record one: apply, destroy, destroy-by-query, and `POST /stacks/{stack}/reconcile`. Every background origin — the timer auto-reconciler, the synchronizer, discovery, the stack expirer — records none.

That distinction is the substance of this PR, not a detail. A background command that inherited a stale user identity would be a *false* accountability record, which is worse than no record at all. Force-reconcile is the one that has to be handled deliberately: it reaches `ForceAutoReconcile` → `prepareReconcile`, sharing machinery with the timer path that must stay anonymous, and today it stamps the literal client id `force-reconcile`. Without explicit threading it would silently lose attribution on a destructive path.

`CancelCommandsByQuery` takes no subject parameter at all: it cancels existing commands and creates no row.

## Nullable columns are not a formality

Rows written before this migration hold SQL `NULL`, not `""`. A bare `string` scan fails at runtime on exactly those rows — and a test against a freshly migrated schema would never catch it, because every row it writes has a value. Each backend handles the NULL following its own existing convention: `sql.NullString` in sqlite, `*string` in postgres and mssql, and aurora reuses its `getStringField` helper, whose Data API decoding already maps a null field to `""`.

The shared datastore suite (which all four backends run) covers this with a case that forces the columns to genuine SQL `NULL` through a test-only hook and then reads back through the normal path. A row written with empty strings exercises a different path and would pass even if NULL handling were broken, so both cases exist and they are not redundant.

## Testing

All four backends green: sqlite, postgres, mssql, and aurora. `make test-unit` and `make test-all` green.

The handler seam test (`internal/api/server_subject_test.go`) covers all four endpoints plus a fifth row for classic mode — no auth plugin configured, no subject on the context, empty strings passed through rather than a panic or an error. That fifth row guards the common case for existing users. It lives at the handler/metastructure seam rather than deeper because `apitest.NewTestServer` has no datastore behind it; row-level persistence is proven by the datastore suite instead, and end-to-end coverage comes later in the tranche.

The seam test passed on first run, since the handler wiring landed with the threading commit. It was checked against the mutation it exists to catch: forcing the shared context extraction to return empty strings fails all four seeded rows and leaves the classic-mode row passing, as it should.

## One thing worth knowing

`make postgres-up` starts postgres on port 5433 as user `formae`, but the postgres datastore test hardcodes `localhost:5432` with `postgres`/`admin`. The documented target does not work with the suite it exists for. This predates the PR; the postgres results above were produced by running postgres the way CI actually does. Worth its own fix rather than a drive-by here.
