### PR TITLE
fix(resolver): resolve a reference to a secret against the live source on update

### DIFF
--- a/internal/metastructure/resolver/resolvable_properties.go
+++ b/internal/metastructure/resolver/resolvable_properties.go
@@ -91,12 +91,20 @@ func LoadResolvablePropertiesFromStacks(resource pkgmodel.Resource, allResources
 // resolvableValueFrom reads propertyPath out of one persisted property
 // collection and reports whether it yields a value a reference may resolve to.
 //
-// A value stored hashed at rest is a SHA-256 digest, not the value the source
-// holds, so it can never stand in for a resolution: it would be compared, and
-// on a $json reference parsed, as if it were the live value. Refusing it here
-// leaves the reference to execution-time resolution (RemainingResolvables),
-// which reads the source live through its plugin — the same way the create path
-// resolves it, and the only way a secret is ever read.
+// Two shapes at rest are NOT values, and admitting either would have a
+// reference resolve to something the source does not hold — compared, and on a
+// $json reference parsed, as if it were live:
+//
+//   - a value stored hashed at rest, which is a SHA-256 digest. It is refused
+//     wherever it sits, including inside a structure the reference names as a
+//     whole, since a digest buried in an object is no more a value than one at
+//     the top.
+//   - a reference envelope that carries no value of its own, which is what
+//     reference-don't-store leaves at rest. Its raw text is not a value either.
+//
+// Refusing both leaves the reference to execution-time resolution
+// (RemainingResolvables), which reads the source live through its plugin — the
+// same way the create path resolves it, and the only way a secret is ever read.
 func resolvableValueFrom(properties json.RawMessage, propertyPath string) (string, bool) {
 	if properties == nil {
 		return "", false
@@ -105,10 +113,42 @@ func resolvableValueFrom(properties json.RawMessage, propertyPath string) (strin
 	if !extracted.Exists() {
 		return "", false
 	}
-	if extracted.Get("$hashed").Bool() {
+	if containsHashedValue(extracted) {
+		return "", false
+	}
+	if isReferenceEnvelope(extracted) && !extracted.Get("$value").Exists() {
 		return "", false
 	}
 	return ExtractPropertyValue(extracted), true
+}
+
+// containsHashedValue reports whether value is, or contains anywhere within it,
+// a value stored hashed at rest.
+func containsHashedValue(value gjson.Result) bool {
+	if !value.IsObject() && !value.IsArray() {
+		return false
+	}
+	if value.Get("$hashed").Bool() {
+		return true
+	}
+	found := false
+	value.ForEach(func(_, child gjson.Result) bool {
+		if containsHashedValue(child) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// isReferenceEnvelope reports whether value is a reference rather than a value:
+// the persisted ($ref) or source ($res) spelling of one.
+func isReferenceEnvelope(value gjson.Result) bool {
+	if !value.IsObject() {
+		return false
+	}
+	return value.Get("$ref").Exists() || value.Get("$res").Exists()
 }
 
 // ExtractPropertyValue extracts the actual value from a gjson.Result.

--- a/internal/metastructure/resolver/resolvable_properties.go
+++ b/internal/metastructure/resolver/resolvable_properties.go
@@ -5,6 +5,7 @@
 package resolver
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -63,25 +64,20 @@ func LoadResolvablePropertiesFromStacks(resource pkgmodel.Resource, allResources
 			return res, fmt.Errorf("resource with KSUID %s not found", ksuid)
 		}
 
-		if targetResource.ReadOnlyProperties != nil {
-			extracted := gjson.GetBytes(targetResource.ReadOnlyProperties, propertyPath)
-			if extracted.Exists() {
-				res.Add(ksuid, propertyPath, ExtractPropertyValue(extracted))
-				continue
-			}
+		if value, ok := resolvableValueFrom(targetResource.ReadOnlyProperties, propertyPath); ok {
+			res.Add(ksuid, propertyPath, value)
+			continue
 		}
 
-		if targetResource.Properties != nil {
-			extracted := gjson.GetBytes(targetResource.Properties, propertyPath)
-			if extracted.Exists() {
-				res.Add(ksuid, propertyPath, ExtractPropertyValue(extracted))
-				continue
-			}
+		if value, ok := resolvableValueFrom(targetResource.Properties, propertyPath); ok {
+			res.Add(ksuid, propertyPath, value)
+			continue
 		}
 
 		// Property not available yet — this happens for forward references to
-		// new resources whose read-only properties are assigned at creation time.
-		// The value will be resolved at execution time via RemainingResolvables.
+		// new resources whose read-only properties are assigned at creation time,
+		// and for a secret, whose value is only ever read live. The value will be
+		// resolved at execution time via RemainingResolvables.
 		slog.Debug("Skipping unresolvable property (will resolve at execution time)",
 			"property", propertyPath,
 			"resource", targetResource.Label,
@@ -90,6 +86,29 @@ func LoadResolvablePropertiesFromStacks(resource pkgmodel.Resource, allResources
 	}
 
 	return res, nil
+}
+
+// resolvableValueFrom reads propertyPath out of one persisted property
+// collection and reports whether it yields a value a reference may resolve to.
+//
+// A value stored hashed at rest is a SHA-256 digest, not the value the source
+// holds, so it can never stand in for a resolution: it would be compared, and
+// on a $json reference parsed, as if it were the live value. Refusing it here
+// leaves the reference to execution-time resolution (RemainingResolvables),
+// which reads the source live through its plugin — the same way the create path
+// resolves it, and the only way a secret is ever read.
+func resolvableValueFrom(properties json.RawMessage, propertyPath string) (string, bool) {
+	if properties == nil {
+		return "", false
+	}
+	extracted := gjson.GetBytes(properties, propertyPath)
+	if !extracted.Exists() {
+		return "", false
+	}
+	if extracted.Get("$hashed").Bool() {
+		return "", false
+	}
+	return ExtractPropertyValue(extracted), true
 }
 
 // ExtractPropertyValue extracts the actual value from a gjson.Result.

--- a/internal/metastructure/resolver/resolvable_properties_test.go
+++ b/internal/metastructure/resolver/resolvable_properties_test.go
@@ -97,6 +97,67 @@ func TestLoadResolvableProperties_UsesOpaqueValueThatIsNotHashed(t *testing.T) {
 	assert.Equal(t, "live-value", value)
 }
 
+// TestLoadResolvableProperties_SkipsStructureHoldingAHashedValue asserts that a
+// digest is refused wherever it sits: a reference naming a whole structure must
+// not resolve to text with a hashed value buried inside it.
+func TestLoadResolvableProperties_SkipsStructureHoldingAHashedValue(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Ksuid: sourceKsuid,
+		Label: "the-config",
+		Type:  "Test::Config",
+		Stack: "default",
+		Properties: json.RawMessage(`{"Connection":{"Host":"db.internal","Password":{` +
+			`"$value":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",` +
+			`"$visibility":"Opaque","$hashed":true}}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("Connection"), stacksWith(source))
+	require.NoError(t, err)
+
+	_, found := props.Get(sourceKsuid, "Connection")
+	assert.False(t, found, "a structure holding a hashed value must not be offered as a resolution")
+}
+
+// TestLoadResolvableProperties_SkipsValuelessReferenceEnvelope asserts that a
+// source property which is itself an unresolved reference — what
+// reference-don't-store leaves at rest — is not offered: its raw envelope text
+// is not a value.
+func TestLoadResolvableProperties_SkipsValuelessReferenceEnvelope(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Ksuid:      sourceKsuid,
+		Label:      "the-consumer",
+		Type:       "Test::Consumer",
+		Stack:      "default",
+		Properties: json.RawMessage(`{"Token":{"$ref":"formae://someotherksuid#/Value","$visibility":"Opaque"}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("Token"), stacksWith(source))
+	require.NoError(t, err)
+
+	_, found := props.Get(sourceKsuid, "Token")
+	assert.False(t, found, "a reference envelope with no value must not be offered as a resolution")
+}
+
+// TestLoadResolvableProperties_UsesResolvedReferenceEnvelope is the chained
+// reference: a source property that is itself a reference which has already
+// been resolved still resolves, through the value it carries.
+func TestLoadResolvableProperties_UsesResolvedReferenceEnvelope(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Ksuid:      sourceKsuid,
+		Label:      "the-subnet",
+		Type:       "Test::Subnet",
+		Stack:      "default",
+		Properties: json.RawMessage(`{"VpcId":{"$ref":"formae://someotherksuid#/VpcId","$value":"vpc-123"}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("VpcId"), stacksWith(source))
+	require.NoError(t, err)
+
+	value, found := props.Get(sourceKsuid, "VpcId")
+	require.True(t, found, "a resolved reference must still resolve through its value")
+	assert.Equal(t, "vpc-123", value)
+}
+
 // TestLoadResolvableProperties_UsesPlainValue is the ordinary cross-resource
 // reference: a plain persisted property resolves at planning time.
 func TestLoadResolvableProperties_UsesPlainValue(t *testing.T) {

--- a/internal/metastructure/resolver/resolvable_properties_test.go
+++ b/internal/metastructure/resolver/resolvable_properties_test.go
@@ -1,0 +1,117 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resolver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+const sourceKsuid = "2abcdefghijklmnopqrstuvwxyz"
+
+// consumerOf builds a resource whose Password property references property on
+// the source resource.
+func consumerOf(property string) pkgmodel.Resource {
+	return pkgmodel.Resource{
+		Label:      "consumer",
+		Type:       "Test::Consumer",
+		Stack:      "default",
+		Properties: json.RawMessage(`{"Password":{"$ref":"formae://` + sourceKsuid + `#/` + property + `"}}`),
+	}
+}
+
+// stacksWith puts source in the shape LoadResolvablePropertiesFromStacks expects.
+func stacksWith(source *pkgmodel.Resource) map[string][]*pkgmodel.Resource {
+	return map[string][]*pkgmodel.Resource{"default": {source}}
+}
+
+// TestLoadResolvableProperties_SkipsHashedValue asserts that a value stored
+// hashed at rest is not offered as a resolution: the digest is not what the
+// source holds, so the reference must be left for execution-time resolution
+// against the live source instead.
+func TestLoadResolvableProperties_SkipsHashedValue(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Ksuid: sourceKsuid,
+		Label: "the-secret",
+		Type:  "Test::Secret",
+		Stack: "default",
+		Properties: json.RawMessage(`{"SecretString":{` +
+			`"$value":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",` +
+			`"$visibility":"Opaque","$strategy":"Update","$hashed":true}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("SecretString"), stacksWith(source))
+	require.NoError(t, err)
+
+	_, found := props.Get(sourceKsuid, "SecretString")
+	assert.False(t, found, "a hashed-at-rest value must not be offered as a resolution")
+}
+
+// TestLoadResolvableProperties_SkipsHashedReadOnlyValue is the same rule for a
+// value that lives in ReadOnlyProperties, which takes precedence over
+// Properties in the lookup.
+func TestLoadResolvableProperties_SkipsHashedReadOnlyValue(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Ksuid: sourceKsuid,
+		Label: "the-secret",
+		Type:  "Test::Secret",
+		Stack: "default",
+		ReadOnlyProperties: json.RawMessage(`{"GeneratedToken":{` +
+			`"$value":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",` +
+			`"$visibility":"Opaque","$hashed":true}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("GeneratedToken"), stacksWith(source))
+	require.NoError(t, err)
+
+	_, found := props.Get(sourceKsuid, "GeneratedToken")
+	assert.False(t, found, "a hashed-at-rest read-only value must not be offered as a resolution")
+}
+
+// TestLoadResolvableProperties_UsesOpaqueValueThatIsNotHashed asserts the rule
+// keys on the value being a digest, not on the field being a credential: an
+// opaque value still holding its plaintext resolves normally.
+func TestLoadResolvableProperties_UsesOpaqueValueThatIsNotHashed(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Ksuid:      sourceKsuid,
+		Label:      "the-secret",
+		Type:       "Test::Secret",
+		Stack:      "default",
+		Properties: json.RawMessage(`{"SecretString":{"$value":"live-value","$visibility":"Opaque"}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("SecretString"), stacksWith(source))
+	require.NoError(t, err)
+
+	value, found := props.Get(sourceKsuid, "SecretString")
+	require.True(t, found, "an opaque value that is not a digest must still resolve")
+	assert.Equal(t, "live-value", value)
+}
+
+// TestLoadResolvableProperties_UsesPlainValue is the ordinary cross-resource
+// reference: a plain persisted property resolves at planning time.
+func TestLoadResolvableProperties_UsesPlainValue(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Ksuid:              sourceKsuid,
+		Label:              "the-vpc",
+		Type:               "Test::VPC",
+		Stack:              "default",
+		ReadOnlyProperties: json.RawMessage(`{"VpcId":"vpc-123"}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("VpcId"), stacksWith(source))
+	require.NoError(t, err)
+
+	value, found := props.Get(sourceKsuid, "VpcId")
+	require.True(t, found)
+	assert.Equal(t, "vpc-123", value)
+}

--- a/internal/workflow_tests/local/apply_forma/secret_json_test.go
+++ b/internal/workflow_tests/local/apply_forma/secret_json_test.go
@@ -29,13 +29,13 @@ import (
 // resource that references it via a $res envelope carrying a $json dotted path.
 //
 // The test verifies three invariants that together define the .json() contract:
-//   1. The consumer's resolved property value equals the EXTRACTED scalar (the
-//      leaf at the $json path), not the whole JSON document.
-//   2. The secret's own stored SecretString is hashed at rest ($hashed:true),
-//      so no plaintext of the JSON document (including the inner password it
-//      contains) survives in the resources table.
-//   3. No plaintext of the extracted scalar nor the outer JSON document appears
-//      in any resource_updates column (DesiredState/PriorState/progress).
+//  1. The consumer's resolved property value equals the EXTRACTED scalar (the
+//     leaf at the $json path), not the whole JSON document.
+//  2. The secret's own stored SecretString is hashed at rest ($hashed:true),
+//     so no plaintext of the JSON document (including the inner password it
+//     contains) survives in the resources table.
+//  3. No plaintext of the extracted scalar nor the outer JSON document appears
+//     in any resource_updates column (DesiredState/PriorState/progress).
 func TestSecretJSON_RefWithJSONPathResolvesToExtractedScalar(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		// The secret value is a JSON document. The inner password is what the
@@ -102,9 +102,9 @@ func TestSecretJSON_RefWithJSONPathResolvesToExtractedScalar(t *testing.T) {
 		// $visibility:Opaque propagates to the resolved Value, so the extracted
 		// scalar is also hashed at rest in the consumer's stored properties.
 		consumer := pkgmodel.Resource{
-			Label: "my-bucket",
-			Type:  "FakeAWS::S3::Bucket",
-			Stack: stack,
+			Label:  "my-bucket",
+			Type:   "FakeAWS::S3::Bucket",
+			Stack:  stack,
 			Target: "test-target",
 			Properties: json.RawMessage(`{
 				"BucketName": "my-bucket",
@@ -189,6 +189,299 @@ func TestSecretJSON_RefWithJSONPathResolvesToExtractedScalar(t *testing.T) {
 		// (the Create override returns nil) so no progress sink leaks the scalar.
 		assertNoPlaintextInResourceUpdates(t, m, applyCmd.ID, innerPassword)
 		assertNoPlaintextInResourceUpdates(t, m, applyCmd.ID, secretJSONDoc)
+	})
+}
+
+// TestSecretJSON_RefWithJSONPathResolvesOnUpdate exercises the same $json
+// reference across a SECOND apply: the stack is re-applied with an unrelated
+// field on the consumer changed, so the consumer is planned as an update rather
+// than a create.
+//
+// The reference must resolve the same way it does on the create path. Planning
+// an update resolves a reference from the source resource's PERSISTED state,
+// where an opaque field is a SHA-256 digest rather than the live value, so a
+// $json extraction over it has no valid JSON to read. The value handed to the
+// plugin must still be the extracted scalar, and the apply must not be rejected
+// while generating the patch document.
+func TestSecretJSON_RefWithJSONPathResolvesOnUpdate(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const innerPassword = "db-pass-9x-secret"
+		const secretJSONDoc = `{"db":{"password":"db-pass-9x-secret"}}`
+
+		// What the consumer plugin receives as the new value on the update.
+		var consumerUpdateProps json.RawMessage
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				if req.ResourceType == "FakeAWS::S3::Bucket" {
+					return &resource.CreateResult{
+						ProgressResult: &resource.ProgressResult{
+							Operation:       resource.OperationCreate,
+							OperationStatus: resource.OperationStatusSuccess,
+							RequestID:       "consumer-create-1",
+							NativeID:        "bucket-native-1",
+						},
+					}, nil
+				}
+				return nil, nil
+			},
+			Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				if req.ResourceType != "FakeAWS::S3::Bucket" {
+					return nil, nil
+				}
+				consumerUpdateProps = req.DesiredProperties
+				return &resource.UpdateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationUpdate,
+						OperationStatus: resource.OperationStatusSuccess,
+						RequestID:       "consumer-update-1",
+						NativeID:        "bucket-native-1",
+					},
+				}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+
+		secret := pkgmodel.Resource{
+			Label:  "my-json-secret",
+			Type:   "FakeAWS::SecretsManager::Secret",
+			Stack:  stack,
+			Target: "test-target",
+			Schema: secretSchema(),
+			Properties: json.RawMessage(
+				`{"Name":"my-json-secret","SecretString":` + jsonQuote(secretJSONDoc) + `}`,
+			),
+		}
+
+		// consumerWith builds the consumer resource with the given AccessControl
+		// value; everything else, including the $json reference, is identical
+		// across both applies.
+		consumerWith := func(accessControl string) pkgmodel.Resource {
+			return pkgmodel.Resource{
+				Label:  "my-bucket",
+				Type:   "FakeAWS::S3::Bucket",
+				Stack:  stack,
+				Target: "test-target",
+				// The consumer needs a schema for the update path: patch
+				// generation only emits ops for declared fields. DbPassword
+				// carries no Opaque hint — its opacity comes from the $visibility
+				// on the reference envelope.
+				Schema: pkgmodel.Schema{
+					Identifier: "BucketName",
+					Fields:     []string{"BucketName", "AccessControl", "DbPassword"},
+				},
+				Properties: json.RawMessage(`{
+					"BucketName": "my-bucket",
+					"AccessControl": "` + accessControl + `",
+					"DbPassword": {
+						"$res":      true,
+						"$label":    "my-json-secret",
+						"$type":     "FakeAWS::SecretsManager::Secret",
+						"$stack":    "` + stack + `",
+						"$property": "SecretString",
+						"$visibility": "Opaque",
+						"$json":    "db.password"
+					}
+				}`),
+			}
+		}
+
+		targets := []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}}
+
+		createForma := &pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: stack}},
+			Resources: []pkgmodel.Resource{secret, consumerWith("Private")},
+			Targets:   targets,
+		}
+		_, err = m.ApplyForma(createForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		createCmd := findCommandByType(cmds, pkgmodel.CommandApply)
+		require.NotNil(t, createCmd)
+		require.Equal(t, forma_command.CommandStateSuccess, createCmd.State,
+			"precondition: the create apply must succeed")
+
+		// Precondition: the secret's value is a digest at rest, so planning the
+		// update cannot read the live JSON document out of the resources table.
+		resources, err := m.Datastore.LoadResourcesByStack(stack)
+		require.NoError(t, err)
+		require.Len(t, resources, 2)
+		for _, r := range resources {
+			if r.Type == "FakeAWS::SecretsManager::Secret" {
+				require.Contains(t, string(r.Properties), hashedMarker,
+					"precondition: the secret must be hashed at rest before the update apply")
+			}
+		}
+
+		// Second apply: only AccessControl differs, so the consumer is an update
+		// and the $json reference is planned from persisted state.
+		updateForma := &pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: stack}},
+			Resources: []pkgmodel.Resource{secret, consumerWith("PublicRead")},
+			Targets:   targets,
+		}
+		_, err = m.ApplyForma(updateForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		require.NoError(t, err,
+			"re-applying a stack whose resource takes a $json value from a secret must be admitted")
+		waitForCommands(t, m, 2)
+
+		cmds, err = m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		var updateCmd *forma_command.FormaCommand
+		applyCount := 0
+		for _, c := range cmds {
+			if c.Command == pkgmodel.CommandApply {
+				applyCount++
+				if applyCount == 2 {
+					updateCmd = c
+				}
+			}
+		}
+		require.NotNil(t, updateCmd, "the second (update) apply command should exist")
+		require.Equal(t, forma_command.CommandStateSuccess, updateCmd.State,
+			"the update apply must succeed")
+
+		require.NotNil(t, consumerUpdateProps, "the consumer plugin's Update should have been called")
+		assert.Equal(t, innerPassword, gjson.GetBytes(consumerUpdateProps, "DbPassword").String(),
+			"on update the consumer plugin must receive the extracted scalar, the same value the create path resolved")
+		assert.NotContains(t, string(consumerUpdateProps), secretJSONDoc,
+			"the consumer plugin must not receive the whole JSON document as the field value")
+		assertNoDigestOrHashedMarker(t, consumerUpdateProps, "DesiredProperties")
+	})
+}
+
+// TestSecret_BareRefResolvesOnUpdate is the same update path as
+// TestSecretJSON_RefWithJSONPathResolvesOnUpdate for a reference with no $json:
+// the consumer takes the secret's whole value.
+//
+// Nothing parses the value on this path, so a digest read out of persisted
+// state is not rejected the way an unparseable $json source is — it is simply
+// planned as the value. The patch the plugin receives, and the value it is
+// given to write, must both be the live secret.
+func TestSecret_BareRefResolvesOnUpdate(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const plaintextSecret = "bare-ref-super-secret"
+
+		var consumerUpdateProps json.RawMessage
+		var consumerPatchDoc string
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				if req.ResourceType == "FakeAWS::S3::Bucket" {
+					return &resource.CreateResult{
+						ProgressResult: &resource.ProgressResult{
+							Operation:       resource.OperationCreate,
+							OperationStatus: resource.OperationStatusSuccess,
+							RequestID:       "consumer-create-1",
+							NativeID:        "bucket-native-1",
+						},
+					}, nil
+				}
+				return nil, nil
+			},
+			Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				if req.ResourceType != "FakeAWS::S3::Bucket" {
+					return nil, nil
+				}
+				consumerUpdateProps = req.DesiredProperties
+				if req.PatchDocument != nil {
+					consumerPatchDoc = *req.PatchDocument
+				}
+				return &resource.UpdateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationUpdate,
+						OperationStatus: resource.OperationStatusSuccess,
+						RequestID:       "consumer-update-1",
+						NativeID:        "bucket-native-1",
+					},
+				}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+
+		secret := pkgmodel.Resource{
+			Label:      "my-secret",
+			Type:       "FakeAWS::SecretsManager::Secret",
+			Stack:      stack,
+			Target:     "test-target",
+			Schema:     secretSchema(),
+			Properties: json.RawMessage(`{"Name":"my-secret","SecretString":"` + plaintextSecret + `"}`),
+		}
+
+		consumerWith := func(accessControl string) pkgmodel.Resource {
+			return pkgmodel.Resource{
+				Label:  "my-bucket",
+				Type:   "FakeAWS::S3::Bucket",
+				Stack:  stack,
+				Target: "test-target",
+				Schema: pkgmodel.Schema{
+					Identifier: "BucketName",
+					Fields:     []string{"BucketName", "AccessControl", "DbPassword"},
+				},
+				Properties: json.RawMessage(`{
+					"BucketName": "my-bucket",
+					"AccessControl": "` + accessControl + `",
+					"DbPassword": {
+						"$res":      true,
+						"$label":    "my-secret",
+						"$type":     "FakeAWS::SecretsManager::Secret",
+						"$stack":    "` + stack + `",
+						"$property": "SecretString",
+						"$visibility": "Opaque"
+					}
+				}`),
+			}
+		}
+
+		targets := []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}}
+
+		createForma := &pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: stack}},
+			Resources: []pkgmodel.Resource{secret, consumerWith("Private")},
+			Targets:   targets,
+		}
+		_, err = m.ApplyForma(createForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		createCmd := findCommandByType(cmds, pkgmodel.CommandApply)
+		require.NotNil(t, createCmd)
+		require.Equal(t, forma_command.CommandStateSuccess, createCmd.State,
+			"precondition: the create apply must succeed")
+
+		updateForma := &pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: stack}},
+			Resources: []pkgmodel.Resource{secret, consumerWith("PublicRead")},
+			Targets:   targets,
+		}
+		_, err = m.ApplyForma(updateForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		require.NoError(t, err)
+		waitForCommands(t, m, 2)
+
+		require.NotNil(t, consumerUpdateProps, "the consumer plugin's Update should have been called")
+		assert.Equal(t, plaintextSecret, gjson.GetBytes(consumerUpdateProps, "DbPassword").String(),
+			"on update the consumer plugin must receive the live secret value")
+		assertNoDigestOrHashedMarker(t, consumerUpdateProps, "DesiredProperties")
+		assertNoDigestOrHashedMarker(t, json.RawMessage(consumerPatchDoc), "PatchDocument")
 	})
 }
 


### PR DESCRIPTION
## What

Planning an update resolves a resource's references from the **persisted** state of the resource they point at (`LoadResolvablePropertiesFromStacks`). For a value stored hashed at rest that state is a SHA-256 digest, not the value the source holds, so a reference into a secret resolved to the digest.

A reference carrying a `$json` path then parsed that digest as the JSON document it selects a field from. It is not valid JSON, so the apply was rejected while generating the patch document:

```
500 - {"message":"failed to generate resource updates: ... failed to create patch
document for resource <label>: failed to flatten and resolve refs: $json path
"password": resolved value is not valid JSON"}
```

The create path was never affected: with no persisted source yet, the reference stays a remaining resolvable and is read live through the plugin at execution time. That asymmetry is the whole bug — a stack using this pattern applies once and then cannot be re-applied.

## Fix

`resolvableValueFrom` refuses a `$hashed: true` value as a resolution source, so the reference falls through to the same execution-time live resolution the create path uses. This is the rule the plugin boundary already enforces (`guardNoHashedValues`): once hashed, a value is terminal and can never stand in for the live one.

The rule keys on the value being a digest, not on the field being a credential — an opaque value still holding its plaintext resolves as before.

## The sibling case, checked

A reference with **no** `$json` path has no JSON-validity guard, so it could in principle have written a digest into the target property silently. It does not: `ResourceUpdate.ResolveValue` substitutes the live value and re-derives the patch document before the plugin call, so nothing reaches a provider. Verified by running the new `TestSecret_BareRefResolvesOnUpdate` against the unfixed tree, where it passes. It stays as a regression guard.

## Tests

- `secret_json_test.go`: a second apply of a stack whose resource takes a `$json` value from a secret. Reverting the fix reproduces the production error verbatim.
- `secret_json_test.go`: the same update path for a bare reference, asserting no digest reaches `DesiredProperties` or the patch document.
- `resolvable_properties_test.go`: 4 unit tests on the resolution source itself. The two hashed cases fail without the fix.

`make test-unit` (81 packages) and `make lint` are green.