### PR TITLE
fix(secrets): inherit opacity for a reference into a map-shaped secret

### DIFF
--- a/internal/metastructure/resource_update/inherited_opacity_test.go
+++ b/internal/metastructure/resource_update/inherited_opacity_test.go
@@ -1,0 +1,107 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// secretAndConsumer builds a source resource whose schema declares both a scalar
+// and a map-shaped secret field, and a consumer referencing property on it with
+// no author-written $visibility. Opacity has to be inherited from the source's
+// schema, which is the only place a secret is declared.
+func secretAndConsumer(property string) []*pkgmodel.Resource {
+	return []*pkgmodel.Resource{
+		{
+			Label: "the-secret",
+			Type:  "Test::Secret",
+			Stack: "default",
+			Schema: pkgmodel.Schema{
+				Fields: []string{"SecretString", "data"},
+				Hints: map[string]pkgmodel.FieldHint{
+					"SecretString": {Opaque: true},
+					"data":         {Opaque: true},
+				},
+			},
+			Properties: json.RawMessage(`{}`),
+		},
+		{
+			Label: "consumer",
+			Type:  "Test::Consumer",
+			Stack: "default",
+			Properties: json.RawMessage(`{"Password":{"$res":true,"$label":"the-secret",` +
+				`"$type":"Test::Secret","$stack":"default","$property":"` + property + `"}}`),
+		},
+	}
+}
+
+// TestMarkInheritedOpaque_ReferenceToSecret covers every shape a secret
+// reference takes. Each must come out marked Opaque, because that marking is
+// what causes the resolved value to be hashed at rest; a reference that misses
+// it persists its secret in cleartext.
+func TestMarkInheritedOpaque_ReferenceToSecret(t *testing.T) {
+	cases := []struct {
+		name     string
+		property string
+	}{
+		// secret.res.secretValue
+		{"scalar secret", "SecretString"},
+		// secret.res.secretValue.json("password") — $json rides the envelope and
+		// leaves the property path alone.
+		{"scalar secret with a $json path", "SecretString"},
+		// secret.res.secretValue.at("token") — the key is folded into the
+		// property path, so the leaf is not itself a declared opaque field.
+		{"map secret selecting one key", "data.token"},
+		// secret.res.secretValue.at("a.b") — a key containing the separator.
+		{"map secret with an escaped key", `data.a\.b`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resources := secretAndConsumer(tc.property)
+			markInheritedOpaqueResolvables(resources)
+
+			assert.Equal(t, pkgmodel.VisibilityOpaque,
+				gjson.GetBytes(resources[1].Properties, "Password.$visibility").String(),
+				"a reference to %q must inherit Opaque, or its resolved value is stored in cleartext; got %s",
+				tc.property, resources[1].Properties)
+		})
+	}
+}
+
+// TestMarkInheritedOpaque_LeavesNonSecretReferenceAlone asserts the rule stays
+// narrow: a reference to a property that is not opaque, and one whose top-level
+// field is not opaque either, are both left untouched.
+func TestMarkInheritedOpaque_LeavesNonSecretReferenceAlone(t *testing.T) {
+	for _, property := range []string{"Arn", "config.endpoint"} {
+		resources := secretAndConsumer(property)
+		markInheritedOpaqueResolvables(resources)
+
+		assert.Empty(t, gjson.GetBytes(resources[1].Properties, "Password.$visibility").String(),
+			"a reference to non-secret property %q must not be marked Opaque", property)
+	}
+}
+
+// TestMarkInheritedOpaque_KeepsAuthoredVisibility asserts an explicit visibility
+// on the envelope wins, so inheritance never overwrites what the author wrote.
+func TestMarkInheritedOpaque_KeepsAuthoredVisibility(t *testing.T) {
+	resources := secretAndConsumer("SecretString")
+	resources[1].Properties = json.RawMessage(`{"Password":{"$res":true,"$label":"the-secret",` +
+		`"$type":"Test::Secret","$stack":"default","$property":"SecretString","$visibility":"Clear"}}`)
+
+	markInheritedOpaqueResolvables(resources)
+
+	assert.Equal(t, pkgmodel.VisibilityClear,
+		gjson.GetBytes(resources[1].Properties, "Password.$visibility").String(),
+		"an explicitly authored visibility must be preserved")
+}

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -2369,6 +2369,27 @@ func markOpaqueResolvablesInProps(propsJSON string, opaqueByTriplet map[pkgmodel
 	return result, true
 }
 
+// referencesOpaqueProperty reports whether propertyName names an opaque property
+// of the source, given the source's set of opaque property names.
+//
+// A reference into a MAP-shaped secret selects one key and carries the key folded
+// into the property path (e.g. "data.token", produced by
+// secret.res.secretValue.at("token")). The opaque name is the parent field, since
+// the field is stored as a single envelope with no per-key sub-structure, so the
+// leaf path is never in the set and matching it alone would leave the reference
+// un-marked and its resolved value unhashed at rest. Test the top-level field too,
+// mirroring resolver.isSourcePropertyOpaque.
+func referencesOpaqueProperty(opaque map[string]bool, propertyName string) bool {
+	if propertyName == "" {
+		return false
+	}
+	if opaque[propertyName] {
+		return true
+	}
+	root, _, nested := strings.Cut(propertyName, ".")
+	return nested && opaque[root]
+}
+
 // collectOpaqueResolvablePaths records the gjson/sjson path of every $res envelope
 // that references a known Opaque property and does not already carry $visibility.
 func collectOpaqueResolvablePaths(basePath string, value gjson.Result, opaqueByTriplet map[pkgmodel.TripletKey]map[string]bool, paths *[]string) {
@@ -2385,7 +2406,7 @@ func collectOpaqueResolvablePaths(basePath string, value gjson.Result, opaqueByT
 			Type:  value.Get("$type").String(),
 		}
 		property := value.Get("$property").String()
-		if set, ok := opaqueByTriplet[triplet]; ok && property != "" && set[property] {
+		if set, ok := opaqueByTriplet[triplet]; ok && referencesOpaqueProperty(set, property) {
 			*paths = append(*paths, basePath)
 		}
 		return


### PR DESCRIPTION
## What

A secret is declared once, on the source's schema (`FieldHint.Opaque`), and a reference to it inherits that opacity rather than restating it — `markInheritedOpaqueResolvables` stamps `$visibility: Opaque` onto any `$res` envelope pointing at a declared-opaque property. That marking is what causes the resolved value to be hashed at rest, so a reference that misses it persists its secret in cleartext.

A reference into a **map-shaped** secret (`secret.res.secretValue.at("token")`, the Kubernetes `data` / Vault KV shape) folds the key into the property path, giving `$property: "data.token"`, while the schema declares the parent field `data`. The matcher compared the path against the declared names exactly, so it never hit, and the reference was left unmarked.

Measured before the fix:

| reference | `$property` | stamped |
|---|---|---|
| `secret.res.secretValue` | `SecretString` | `Opaque` |
| `secret.res.secretValue.json("password")` | `SecretString` | `Opaque` |
| `secret.res.secretValue.at("token")` | `data.token` | **nothing** |

## Fix

`referencesOpaqueProperty` also tests the top-level field when the path is nested. This mirrors what `resolver.isSourcePropertyOpaque` already does when deciding the same question from the source side, and its reasoning applies identically: the field is stored as a single envelope with no per-key sub-structure, so the leaf path is never itself a declared name.

Scalar references are unaffected (their path *is* the declared name). A reference to a non-opaque property, at either level, stays unmarked. An explicitly authored `$visibility` still wins.

## Reachability

Latent rather than live: the `SecretMapAccessor` path exists in the core schema, but no shipped plugin currently exposes a map-shaped secret. It must be fixed before Kubernetes secret adoption lands, which is exactly what would make it exploitable.

## Tests

`inherited_opacity_test.go` covers all four reference shapes (scalar, `$json`, `.at()`, and `.at()` with a separator-containing key), the negative cases at both levels, and preservation of an authored visibility. The two `.at()` cases fail without the fix.

`make test-unit` and `make lint` are green.