### PR TITLE
fix(tests): pass the subject arguments the apply signature now requires

### DIFF
--- a/internal/workflow_tests/local/apply_forma/secret_json_test.go
+++ b/internal/workflow_tests/local/apply_forma/secret_json_test.go
@@ -300,7 +300,7 @@ func TestSecretJSON_RefWithJSONPathResolvesOnUpdate(t *testing.T) {
 			Resources: []pkgmodel.Resource{secret, consumerWith("Private")},
 			Targets:   targets,
 		}
-		_, err = m.ApplyForma(createForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(createForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -330,7 +330,7 @@ func TestSecretJSON_RefWithJSONPathResolvesOnUpdate(t *testing.T) {
 			Resources: []pkgmodel.Resource{secret, consumerWith("PublicRead")},
 			Targets:   targets,
 		}
-		_, err = m.ApplyForma(updateForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(updateForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err,
 			"re-applying a stack whose resource takes a $json value from a secret must be admitted")
 		waitForCommands(t, m, 2)
@@ -473,7 +473,7 @@ func TestSecretJSON_ChangedJSONPathResolvesToExtractedScalarInPatch(t *testing.T
 			Resources: []pkgmodel.Resource{secret, consumerWith("Private", "db.password")},
 			Targets:   targets,
 		}
-		_, err = m.ApplyForma(createForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(createForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -490,7 +490,7 @@ func TestSecretJSON_ChangedJSONPathResolvesToExtractedScalarInPatch(t *testing.T
 			Resources: []pkgmodel.Resource{secret, consumerWith("PublicRead", "db.altPassword")},
 			Targets:   targets,
 		}
-		_, err = m.ApplyForma(updateForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(updateForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err,
 			"moving a $json extraction to another leaf must be admitted")
 		waitForCommands(t, m, 2)
@@ -653,7 +653,7 @@ func TestSecretJSON_PriorPropertiesRedactSchemaOpaqueField(t *testing.T) {
 			Resources: []pkgmodel.Resource{secret, consumerWith("Private")},
 			Targets:   targets,
 		}
-		_, err = m.ApplyForma(createForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(createForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -669,7 +669,7 @@ func TestSecretJSON_PriorPropertiesRedactSchemaOpaqueField(t *testing.T) {
 			Resources: []pkgmodel.Resource{secret, consumerWith("PublicRead")},
 			Targets:   targets,
 		}
-		_, err = m.ApplyForma(updateForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(updateForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForCommands(t, m, 2)
 
@@ -797,7 +797,7 @@ func TestSecret_BareRefResolvesOnUpdate(t *testing.T) {
 			Resources: []pkgmodel.Resource{secret, consumerWith("Private")},
 			Targets:   targets,
 		}
-		_, err = m.ApplyForma(createForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(createForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -813,7 +813,7 @@ func TestSecret_BareRefResolvesOnUpdate(t *testing.T) {
 			Resources: []pkgmodel.Resource{secret, consumerWith("PublicRead")},
 			Targets:   targets,
 		}
-		_, err = m.ApplyForma(updateForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id")
+		_, err = m.ApplyForma(updateForma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForCommands(t, m, 2)
 


### PR DESCRIPTION
`Metastructure.ApplyForma` grew `subject` and `subjectName` parameters when commands started carrying a verified identity. The call sites in `secret_json_test.go` were written against the previous signature, on a branch that had not yet seen that change, so `internal/workflow_tests/local/apply_forma` stopped compiling once both landed on main.

Textually the two changes never touched the same lines, so nothing conflicted and both PRs were green against their own bases. Only their combination breaks, which is why it reached main.

The eight call sites pass empty strings, matching the one already-updated call in the same file and every call in the sibling tests: a local workflow test has no authenticated subject.

`go vet -tags=unit ./...` is clean repo-wide and `go test -tags=unit ./internal/workflow_tests/local/apply_forma/...` passes.