### PR TITLE
fix(metastructure): ignore stale NotFound reads when persisting deletes

### DIFF
--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -1688,7 +1688,7 @@ func (d *DatastoreAuroraDataAPI) LoadResourcesByStack(stackLabel string) ([]*pkg
 	ctx := context.Background()
 
 	query := `
-		SELECT data, ksuid
+		SELECT data, ksuid, version
 		FROM resources r1
 		WHERE stack = :stack
 		AND NOT EXISTS (
@@ -1711,7 +1711,7 @@ func (d *DatastoreAuroraDataAPI) LoadResourcesByStack(stackLabel string) ([]*pkg
 
 	var resources []*pkgmodel.Resource
 	for _, record := range output.Records {
-		if len(record) < 2 {
+		if len(record) < 3 {
 			continue
 		}
 
@@ -1723,6 +1723,10 @@ func (d *DatastoreAuroraDataAPI) LoadResourcesByStack(stackLabel string) ([]*pkg
 		if err != nil {
 			return nil, err
 		}
+		version, err := getStringField(record[2])
+		if err != nil {
+			return nil, err
+		}
 
 		var resource pkgmodel.Resource
 		if err := json.Unmarshal([]byte(jsonData), &resource); err != nil {
@@ -1730,6 +1734,7 @@ func (d *DatastoreAuroraDataAPI) LoadResourcesByStack(stackLabel string) ([]*pkg
 		}
 
 		resource.Ksuid = ksuid
+		resource.Version = version
 		resources = append(resources, &resource)
 	}
 

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -1625,7 +1625,7 @@ func (d *DatastoreAuroraDataAPI) LoadAllResourcesByStack() (map[string][]*pkgmod
 	ctx := context.Background()
 
 	query := `
-		SELECT data, ksuid
+		SELECT data, ksuid, version
 		FROM resources r1
 		WHERE NOT EXISTS (
 			SELECT 1
@@ -1646,7 +1646,7 @@ func (d *DatastoreAuroraDataAPI) LoadAllResourcesByStack() (map[string][]*pkgmod
 
 	var allResources []*pkgmodel.Resource
 	for _, record := range output.Records {
-		if len(record) < 2 {
+		if len(record) < 3 {
 			continue
 		}
 
@@ -1658,6 +1658,10 @@ func (d *DatastoreAuroraDataAPI) LoadAllResourcesByStack() (map[string][]*pkgmod
 		if err != nil {
 			return nil, err
 		}
+		version, err := getStringField(record[2])
+		if err != nil {
+			return nil, err
+		}
 
 		var resource pkgmodel.Resource
 		if err := json.Unmarshal([]byte(jsonData), &resource); err != nil {
@@ -1665,6 +1669,7 @@ func (d *DatastoreAuroraDataAPI) LoadAllResourcesByStack() (map[string][]*pkgmod
 		}
 
 		resource.Ksuid = ksuid
+		resource.Version = version
 		allResources = append(allResources, &resource)
 	}
 
@@ -1963,7 +1968,7 @@ func (d *DatastoreAuroraDataAPI) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel
 	ctx := context.Background()
 
 	query := `
-	SELECT data, ksuid
+	SELECT data, ksuid, version
 	FROM resources
 	WHERE uri = :uri
 	AND operation != :operation AND operation != 'reaped'
@@ -1985,7 +1990,7 @@ func (d *DatastoreAuroraDataAPI) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel
 	}
 
 	record := output.Records[0]
-	if len(record) < 2 {
+	if len(record) < 3 {
 		return nil, fmt.Errorf("unexpected record length: %d", len(record))
 	}
 
@@ -1999,12 +2004,18 @@ func (d *DatastoreAuroraDataAPI) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel
 		return nil, fmt.Errorf("failed to parse ksuid: %w", err)
 	}
 
+	version, err := getStringField(record[2])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse version: %w", err)
+	}
+
 	var resource pkgmodel.Resource
 	if err := json.Unmarshal([]byte(jsonData), &resource); err != nil {
 		return nil, err
 	}
 
 	resource.Ksuid = ksuid
+	resource.Version = version
 	return &resource, nil
 }
 

--- a/internal/datastore/mssql/mssql_resources.go
+++ b/internal/datastore/mssql/mssql_resources.go
@@ -828,7 +828,7 @@ func (d *DatastoreMSSQL) LoadResourcesByStack(stackLabel string) ([]*pkgmodel.Re
 	defer span.End()
 
 	query := fmt.Sprintf(`
-	SELECT data, ksuid
+	SELECT data, ksuid, version
 	FROM resources r1
 	WHERE stack = @p1
 	AND NOT EXISTS (
@@ -848,8 +848,8 @@ func (d *DatastoreMSSQL) LoadResourcesByStack(stackLabel string) ([]*pkgmodel.Re
 
 	var resources []*pkgmodel.Resource
 	for rows.Next() {
-		var jsonData, ksuid string
-		if err := rows.Scan(&jsonData, &ksuid); err != nil {
+		var jsonData, ksuid, version string
+		if err := rows.Scan(&jsonData, &ksuid, &version); err != nil {
 			return nil, err
 		}
 
@@ -858,6 +858,7 @@ func (d *DatastoreMSSQL) LoadResourcesByStack(stackLabel string) ([]*pkgmodel.Re
 			return nil, err
 		}
 		resource.Ksuid = ksuid
+		resource.Version = version
 		resources = append(resources, &resource)
 	}
 

--- a/internal/datastore/mssql/mssql_resources.go
+++ b/internal/datastore/mssql/mssql_resources.go
@@ -330,7 +330,7 @@ func (d *DatastoreMSSQL) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resourc
 	defer span.End()
 
 	query := fmt.Sprintf(`
-	SELECT TOP (1) data, ksuid
+	SELECT TOP (1) data, ksuid, version
 	FROM resources
 	WHERE uri = @p1
 	AND operation != @p2 AND operation != 'reaped'
@@ -338,8 +338,8 @@ func (d *DatastoreMSSQL) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resourc
 	`, binColl)
 	row := d.conn.QueryRowContext(ctx, query, string(uri), string(resource_update.OperationDelete))
 
-	var jsonData, ksuid string
-	if err := row.Scan(&jsonData, &ksuid); err != nil {
+	var jsonData, ksuid, version string
+	if err := row.Scan(&jsonData, &ksuid, &version); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
@@ -351,6 +351,7 @@ func (d *DatastoreMSSQL) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resourc
 		return nil, err
 	}
 	resource.Ksuid = ksuid
+	resource.Version = version
 	return &resource, nil
 }
 
@@ -868,7 +869,7 @@ func (d *DatastoreMSSQL) LoadAllResourcesByStack() (map[string][]*pkgmodel.Resou
 	defer span.End()
 
 	query := fmt.Sprintf(`
-	SELECT data, ksuid
+	SELECT data, ksuid, version
 	FROM resources r1
 	WHERE NOT EXISTS (
 		SELECT 1
@@ -887,8 +888,8 @@ func (d *DatastoreMSSQL) LoadAllResourcesByStack() (map[string][]*pkgmodel.Resou
 
 	stackResourcesMap := make(map[string][]*pkgmodel.Resource)
 	for rows.Next() {
-		var jsonData, ksuid string
-		if err := rows.Scan(&jsonData, &ksuid); err != nil {
+		var jsonData, ksuid, version string
+		if err := rows.Scan(&jsonData, &ksuid, &version); err != nil {
 			return nil, err
 		}
 
@@ -897,6 +898,7 @@ func (d *DatastoreMSSQL) LoadAllResourcesByStack() (map[string][]*pkgmodel.Resou
 			return nil, err
 		}
 		resource.Ksuid = ksuid
+		resource.Version = version
 		if resource.Stack != "" {
 			stackResourcesMap[resource.Stack] = append(stackResourcesMap[resource.Stack], &resource)
 		}

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -1714,7 +1714,7 @@ func (d DatastorePostgres) LoadResourcesByStack(stackLabel string) ([]*pkgmodel.
 	defer span.End()
 
 	query := `
-	SELECT data, ksuid
+	SELECT data, ksuid, version
 	FROM resources r1
 	WHERE stack = $1
 	AND NOT EXISTS (
@@ -1734,8 +1734,8 @@ func (d DatastorePostgres) LoadResourcesByStack(stackLabel string) ([]*pkgmodel.
 
 	var resources []*pkgmodel.Resource
 	for rows.Next() {
-		var jsonData, ksuid string
-		if err := rows.Scan(&jsonData, &ksuid); err != nil {
+		var jsonData, ksuid, version string
+		if err := rows.Scan(&jsonData, &ksuid, &version); err != nil {
 			return nil, err
 		}
 
@@ -1745,6 +1745,7 @@ func (d DatastorePostgres) LoadResourcesByStack(stackLabel string) ([]*pkgmodel.
 		}
 
 		resource.Ksuid = ksuid
+		resource.Version = version
 		resources = append(resources, &resource)
 	}
 

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -1240,7 +1240,7 @@ func (d DatastorePostgres) LoadAllResourcesByStack() (map[string][]*pkgmodel.Res
 	defer span.End()
 
 	query := `
-	SELECT data, ksuid
+	SELECT data, ksuid, version
 	FROM resources r1
 	WHERE NOT EXISTS (
 		SELECT 1
@@ -1259,8 +1259,8 @@ func (d DatastorePostgres) LoadAllResourcesByStack() (map[string][]*pkgmodel.Res
 
 	var allResources []*pkgmodel.Resource
 	for rows.Next() {
-		var jsonData, ksuid string
-		if err := rows.Scan(&jsonData, &ksuid); err != nil {
+		var jsonData, ksuid, version string
+		if err := rows.Scan(&jsonData, &ksuid, &version); err != nil {
 			return nil, err
 		}
 
@@ -1270,6 +1270,7 @@ func (d DatastorePostgres) LoadAllResourcesByStack() (map[string][]*pkgmodel.Res
 		}
 
 		resource.Ksuid = ksuid
+		resource.Version = version
 		allResources = append(allResources, &resource)
 	}
 
@@ -1371,7 +1372,7 @@ func (d DatastorePostgres) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resou
 	defer span.End()
 
 	query := `
-	SELECT data, ksuid
+	SELECT data, ksuid, version
 	FROM resources
 	WHERE uri = $1
 	AND operation != $2 AND operation != 'reaped'
@@ -1382,7 +1383,8 @@ func (d DatastorePostgres) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resou
 
 	var jsonData string
 	var ksuid string
-	if err := row.Scan(&jsonData, &ksuid); err != nil {
+	var version string
+	if err := row.Scan(&jsonData, &ksuid, &version); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil // Resource not found, return nil without error
 		}
@@ -1395,6 +1397,7 @@ func (d DatastorePostgres) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resou
 	}
 
 	resource.Ksuid = ksuid
+	resource.Version = version
 	return &resource, nil
 }
 

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -1240,7 +1240,7 @@ func (d DatastoreSQLite) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resourc
 	defer span.End()
 
 	query := `
-	SELECT data, ksuid
+	SELECT data, ksuid, version
 	FROM resources
 	WHERE uri = ?
 	AND operation != ? AND operation != 'reaped'
@@ -1251,7 +1251,8 @@ func (d DatastoreSQLite) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resourc
 
 	var jsonData string
 	var ksuid string
-	if err := row.Scan(&jsonData, &ksuid); err != nil {
+	var version string
+	if err := row.Scan(&jsonData, &ksuid, &version); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil // Resource not found, return nil without error
 		}
@@ -1264,6 +1265,7 @@ func (d DatastoreSQLite) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resourc
 	}
 
 	loadedResource.Ksuid = ksuid
+	loadedResource.Version = version
 
 	return &loadedResource, nil
 }
@@ -1495,7 +1497,7 @@ func (d DatastoreSQLite) LoadAllResourcesByStack() (map[string][]*pkgmodel.Resou
 	defer span.End()
 
 	query := `
-	SELECT data, ksuid
+	SELECT data, ksuid, version
 	FROM resources r1
 	WHERE NOT EXISTS (
 	SELECT 1
@@ -1514,8 +1516,8 @@ func (d DatastoreSQLite) LoadAllResourcesByStack() (map[string][]*pkgmodel.Resou
 
 	var allResources []*pkgmodel.Resource
 	for rows.Next() {
-		var jsonData, ksuid string
-		if err := rows.Scan(&jsonData, &ksuid); err != nil {
+		var jsonData, ksuid, version string
+		if err := rows.Scan(&jsonData, &ksuid, &version); err != nil {
 			return nil, err
 		}
 
@@ -1525,6 +1527,7 @@ func (d DatastoreSQLite) LoadAllResourcesByStack() (map[string][]*pkgmodel.Resou
 		}
 
 		resource.Ksuid = ksuid
+		resource.Version = version
 		allResources = append(allResources, &resource)
 	}
 

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -1552,7 +1552,7 @@ func (d DatastoreSQLite) LoadResourcesByStack(stackLabel string) ([]*pkgmodel.Re
 	defer span.End()
 
 	query := `
-	SELECT data, ksuid
+	SELECT data, ksuid, version
 	FROM resources r1
 	WHERE stack = ?
 	AND NOT EXISTS (
@@ -1572,8 +1572,8 @@ func (d DatastoreSQLite) LoadResourcesByStack(stackLabel string) ([]*pkgmodel.Re
 
 	var resources []*pkgmodel.Resource
 	for rows.Next() {
-		var jsonData, ksuid string
-		if err := rows.Scan(&jsonData, &ksuid); err != nil {
+		var jsonData, ksuid, version string
+		if err := rows.Scan(&jsonData, &ksuid, &version); err != nil {
 			return nil, err
 		}
 
@@ -1583,6 +1583,7 @@ func (d DatastoreSQLite) LoadResourcesByStack(stackLabel string) ([]*pkgmodel.Re
 		}
 
 		resource.Ksuid = ksuid
+		resource.Version = version
 		resources = append(resources, &resource)
 	}
 

--- a/internal/metastructure/resource_persister/resource_persister.go
+++ b/internal/metastructure/resource_persister/resource_persister.go
@@ -384,6 +384,17 @@ func formaCommandFromOperation(operation pkgresource.Operation) pkgmodel.Command
 func (rp *ResourcePersister) recordMovedSinceGenerated(resourceUpdate *resource_update.ResourceUpdate) bool {
 	generated := resourceUpdate.PriorState
 	if generated.Version == "" {
+		// Only a synchronize snapshot is planned off a loaded row and so is
+		// expected to carry a version; a missing one there means the command
+		// was rebuilt after a restart, which is indeterminate. Discovery builds
+		// its updates from the forma instead (see generateResourceUpdatesForSync),
+		// so its reads never carry a version and their NotFound is a real
+		// signal — including the sentinel-target path that cleans up rows whose
+		// target has been deleted. Reading that as staleness would strand those
+		// rows forever.
+		if resourceUpdate.Source != resource_update.FormaCommandSourceSynchronize {
+			return false
+		}
 		slog.Debug("Treating a NotFound read as stale: the snapshot carries no row version",
 			"resourceLabel", generated.Label)
 		return true

--- a/internal/metastructure/resource_persister/resource_persister.go
+++ b/internal/metastructure/resource_persister/resource_persister.go
@@ -155,6 +155,25 @@ func (rp *ResourcePersister) storeResourceUpdate(commandID string, resourceOpera
 
 	resourceUpdate.Operation = resourceOperationFromPluginOperation(resourceOperation, pluginOperation, relevantProgress)
 
+	// A NotFound Read is converted into a delete above so out-of-band deletions
+	// get absorbed. That conversion is only sound while the record still
+	// describes the object the Read probed. A sync cycle plans against a
+	// snapshot and can execute its reads minutes later, by which time an apply
+	// may have replaced the resource and moved the record onto a new identity;
+	// the Read then probes the old one, truthfully reports NotFound, and acting
+	// on it would tombstone a live resource's record. Dropping the update is the
+	// safe direction: the next sync cycle plans afresh, so a genuine deletion is
+	// still absorbed one cycle later.
+	if pluginOperation == pkgresource.OperationRead &&
+		resourceUpdate.Operation == resource_update.OperationDelete &&
+		rp.recordMovedSinceGenerated(resourceUpdate) {
+		slog.Debug("Skipping delete from a stale NotFound read; the record moved since the read was planned",
+			"resourceLabel", resourceUpdate.DesiredState.Label,
+			"stackLabel", resourceUpdate.StackLabel,
+			"probedNativeID", resourceUpdate.PriorState.NativeID)
+		return "", nil
+	}
+
 	// This can cause a validation error when the delete op is in fact valid.
 	// Subsequently no delete is persisted and the system doesn't work as expected.
 	// To avoid this, we skip the validation when the operation is a delete.
@@ -346,6 +365,42 @@ func formaCommandFromOperation(operation pkgresource.Operation) pkgmodel.Command
 	default:
 		return pkgmodel.CommandApply
 	}
+}
+
+// recordMovedSinceGenerated reports whether the stored record has been written
+// by another command since this update was generated. PriorState is the
+// snapshot the generator captured (see NewResourceUpdateForSyncWithFilter), so
+// comparing it against the current row answers "did the record move under me".
+// An absent snapshot identity or an absent row means there is nothing to
+// contradict, so the caller proceeds.
+func (rp *ResourcePersister) recordMovedSinceGenerated(resourceUpdate *resource_update.ResourceUpdate) bool {
+	generated := resourceUpdate.PriorState
+	if generated.NativeID == "" {
+		return false
+	}
+
+	current, err := rp.datastore.LoadResource(generated.URI())
+	if err != nil {
+		slog.Error("Failed to load resource while checking read staleness",
+			"resourceLabel", generated.Label,
+			"error", err)
+		return false
+	}
+	if current == nil || current.NativeID == "" {
+		return false
+	}
+
+	if current.NativeID != generated.NativeID {
+		return true
+	}
+
+	// The identity is unchanged, but the record can still have been rewritten
+	// under it — a replace recreates a resource whose native id is a stable
+	// name under that same name. Compare against PreviousProperties, the
+	// generator's copy of the stored properties; PriorState.Properties is not
+	// usable here, having been converted for Read use.
+	return len(resourceUpdate.PreviousProperties) > 0 &&
+		!util.JsonEqualRaw(current.Properties, resourceUpdate.PreviousProperties)
 }
 
 func resourceOperationFromPluginOperation(resourceOperation resource_update.OperationType, pluginOperation pkgresource.Operation, progress *plugin.TrackedProgress) resource_update.OperationType {

--- a/internal/metastructure/resource_persister/resource_persister.go
+++ b/internal/metastructure/resource_persister/resource_persister.go
@@ -403,7 +403,13 @@ func (rp *ResourcePersister) recordMovedSinceGenerated(resourceUpdate *resource_
 		return true
 	}
 	if current == nil {
-		return false
+		// No live row to compare against, which is also what a row hidden by
+		// reaping looks like. The delete branch performs its own lookup, so
+		// reporting "not moved" here would let a row that reappears between the
+		// two calls be tombstoned, shadowing one that target recovery could
+		// otherwise restore. Nothing is lost by declining: with no live row the
+		// delete had nothing to remove anyway.
+		return true
 	}
 
 	return current.Version != generated.Version

--- a/internal/metastructure/resource_persister/resource_persister.go
+++ b/internal/metastructure/resource_persister/resource_persister.go
@@ -371,8 +371,10 @@ func formaCommandFromOperation(operation pkgresource.Operation) pkgmodel.Command
 // by another command since this update was generated. PriorState is the
 // snapshot the generator captured (see NewResourceUpdateForSyncWithFilter), so
 // comparing it against the current row answers "did the record move under me".
-// An absent snapshot identity or an absent row means there is nothing to
-// contradict, so the caller proceeds.
+// An absent snapshot identity or an absent row means there is nothing for the
+// record to have moved away from, so the caller proceeds; a lookup that fails
+// is indeterminate and reports moved, so the delete is dropped rather than
+// risked.
 func (rp *ResourcePersister) recordMovedSinceGenerated(resourceUpdate *resource_update.ResourceUpdate) bool {
 	generated := resourceUpdate.PriorState
 	if generated.NativeID == "" {
@@ -381,10 +383,16 @@ func (rp *ResourcePersister) recordMovedSinceGenerated(resourceUpdate *resource_
 
 	current, err := rp.datastore.LoadResource(generated.URI())
 	if err != nil {
-		slog.Error("Failed to load resource while checking read staleness",
+		// Fail closed. Reporting "not moved" here would hand the delete to a
+		// caller that performs its own load; if that one succeeds it finds the
+		// replacement row and tombstones it, which is the data loss this guard
+		// exists to prevent. A lookup we could not complete is no evidence that
+		// the record still matches, so treat it as moved and let the next sync
+		// cycle decide on fresh state.
+		slog.Warn("Treating a NotFound read as stale: the staleness lookup failed",
 			"resourceLabel", generated.Label,
 			"error", err)
-		return false
+		return true
 	}
 	if current == nil || current.NativeID == "" {
 		return false

--- a/internal/metastructure/resource_persister/resource_persister.go
+++ b/internal/metastructure/resource_persister/resource_persister.go
@@ -369,15 +369,19 @@ func formaCommandFromOperation(operation pkgresource.Operation) pkgmodel.Command
 
 // recordMovedSinceGenerated reports whether the stored record has been written
 // by another command since this update was generated. PriorState is the
-// snapshot the generator captured (see NewResourceUpdateForSyncWithFilter), so
-// comparing it against the current row answers "did the record move under me".
-// An absent snapshot identity or an absent row means there is nothing for the
-// record to have moved away from, so the caller proceeds; a lookup that fails
-// is indeterminate and reports moved, so the delete is dropped rather than
-// risked.
+// snapshot the generator captured (see NewResourceUpdateForSyncWithFilter) and
+// carries the row version it was loaded from, which is monotonic per URI, so an
+// inequality against the current row is exact: it catches a replace that keeps
+// the native id and the properties byte-identical just as readily as one that
+// changes them.
+//
+// An absent snapshot version (a resource that did not come from a loader) or an
+// absent row means there is nothing to compare, so the caller proceeds. A lookup
+// that fails is indeterminate and reports moved, so the delete is dropped rather
+// than risked.
 func (rp *ResourcePersister) recordMovedSinceGenerated(resourceUpdate *resource_update.ResourceUpdate) bool {
 	generated := resourceUpdate.PriorState
-	if generated.NativeID == "" {
+	if generated.Version == "" {
 		return false
 	}
 
@@ -394,21 +398,11 @@ func (rp *ResourcePersister) recordMovedSinceGenerated(resourceUpdate *resource_
 			"error", err)
 		return true
 	}
-	if current == nil || current.NativeID == "" {
+	if current == nil {
 		return false
 	}
 
-	if current.NativeID != generated.NativeID {
-		return true
-	}
-
-	// The identity is unchanged, but the record can still have been rewritten
-	// under it — a replace recreates a resource whose native id is a stable
-	// name under that same name. Compare against PreviousProperties, the
-	// generator's copy of the stored properties; PriorState.Properties is not
-	// usable here, having been converted for Read use.
-	return len(resourceUpdate.PreviousProperties) > 0 &&
-		!util.JsonEqualRaw(current.Properties, resourceUpdate.PreviousProperties)
+	return current.Version != generated.Version
 }
 
 func resourceOperationFromPluginOperation(resourceOperation resource_update.OperationType, pluginOperation pkgresource.Operation, progress *plugin.TrackedProgress) resource_update.OperationType {

--- a/internal/metastructure/resource_persister/resource_persister.go
+++ b/internal/metastructure/resource_persister/resource_persister.go
@@ -423,7 +423,16 @@ func (rp *ResourcePersister) recordMovedSinceGenerated(resourceUpdate *resource_
 		return true
 	}
 
-	return current.Version != generated.Version
+	if current.Version != generated.Version {
+		return true
+	}
+
+	// The version alone is not a complete witness: storeResource reuses it when
+	// only ReadOnlyProperties changed, rewriting that row in place. Compare
+	// those too, so a refresh confined to read-only state still counts as a
+	// rewrite. (Both sides are the stored representation, so they differ only
+	// if something actually wrote.)
+	return !util.JsonEqualRaw(current.ReadOnlyProperties, generated.ReadOnlyProperties)
 }
 
 func resourceOperationFromPluginOperation(resourceOperation resource_update.OperationType, pluginOperation pkgresource.Operation, progress *plugin.TrackedProgress) resource_update.OperationType {

--- a/internal/metastructure/resource_persister/resource_persister.go
+++ b/internal/metastructure/resource_persister/resource_persister.go
@@ -375,14 +375,18 @@ func formaCommandFromOperation(operation pkgresource.Operation) pkgmodel.Command
 // the native id and the properties byte-identical just as readily as one that
 // changes them.
 //
-// An absent snapshot version (a resource that did not come from a loader) or an
-// absent row means there is nothing to compare, so the caller proceeds. A lookup
-// that fails is indeterminate and reports moved, so the delete is dropped rather
-// than risked.
+// Everything indeterminate reports moved, so the delete is dropped rather than
+// risked. That covers a lookup that failed and a snapshot with no version — the
+// latter is what a command resumed after a restart rebuilds, since the version
+// describes a row and is not serialized with the resource. The cost is bounded:
+// the resource keeps its record until a later cycle plans afresh against a
+// versioned snapshot, and a genuine deletion is absorbed then.
 func (rp *ResourcePersister) recordMovedSinceGenerated(resourceUpdate *resource_update.ResourceUpdate) bool {
 	generated := resourceUpdate.PriorState
 	if generated.Version == "" {
-		return false
+		slog.Debug("Treating a NotFound read as stale: the snapshot carries no row version",
+			"resourceLabel", generated.Label)
+		return true
 	}
 
 	current, err := rp.datastore.LoadResource(generated.URI())

--- a/internal/metastructure/resource_persister/resource_persister_test.go
+++ b/internal/metastructure/resource_persister/resource_persister_test.go
@@ -2527,6 +2527,54 @@ func (d *loadResourceFlakyDatastore) LoadResource(uri pkgmodel.FormaeURI) (*pkgm
 	return d.Datastore.LoadResource(uri)
 }
 
+func TestResourcePersister_StaleSyncReadDoesNotDeleteAfterReadOnlyRewrite(t *testing.T) {
+	persister, sender, ds, err := newResourcePersisterForTest(t)
+	require.NoError(t, err)
+
+	res := pkgmodel.Resource{
+		Label:              "task-def",
+		Type:               "FakeAWS::ECS::TaskDefinition",
+		Stack:              "test-stack",
+		Ksuid:              util.NewID(),
+		Managed:            true,
+		NativeID:           "arn:task-definition/app:4",
+		Properties:         json.RawMessage(`{"memory":"512"}`),
+		ReadOnlyProperties: json.RawMessage(`{"status":"ACTIVE"}`),
+	}
+	persistCreateForTest(t, persister, sender, res, "cmd-plan")
+
+	byStack, err := ds.LoadResourcesByStack("test-stack")
+	require.NoError(t, err)
+	require.Len(t, byStack, 1)
+	generatedFrom := byStack[0]
+	require.NotEmpty(t, generatedFrom.Version)
+
+	// Another command refreshes only read-only state. The datastore rewrites
+	// that row in place and deliberately reuses its version, so the version
+	// alone cannot witness this rewrite.
+	refreshed := res
+	refreshed.ReadOnlyProperties = json.RawMessage(`{"status":"INACTIVE"}`)
+	persistCreateForTest(t, persister, sender, refreshed, "cmd-refresh")
+
+	afterRefresh, err := ds.LoadResourcesByStack("test-stack")
+	require.NoError(t, err)
+	require.Len(t, afterRefresh, 1)
+	require.Equal(t, generatedFrom.Version, afterRefresh[0].Version,
+		"premise: a read-only-only rewrite reuses the row version")
+
+	result := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "cmd-sync",
+		ResourceOperation: resource_update.OperationRead,
+		PluginOperation:   resource.OperationRead,
+		ResourceUpdate:    syncReadNotFoundForTest(*generatedFrom, "arn:task-definition/app:4"),
+	})
+	require.NoError(t, result.Error)
+
+	resources, err := ds.LoadResourcesByStack("test-stack")
+	require.NoError(t, err)
+	require.Len(t, resources, 1, "a record rewritten since the read was planned must survive, even when the rewrite reused the version")
+}
+
 func TestResourcePersister_DiscoveryReadNotFoundStillDeletesOrphanedRow(t *testing.T) {
 	persister, sender, ds, err := newResourcePersisterForTest(t)
 	require.NoError(t, err)

--- a/internal/metastructure/resource_persister/resource_persister_test.go
+++ b/internal/metastructure/resource_persister/resource_persister_test.go
@@ -2510,14 +2510,63 @@ type loadResourceFlakyDatastore struct {
 	datastore.Datastore
 	failURI pkgmodel.FormaeURI
 	armed   bool
+	// hide makes the single armed call report the row as absent rather than
+	// failing, which is what a reaped row looks like to LoadResource.
+	hide bool
 }
 
 func (d *loadResourceFlakyDatastore) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resource, error) {
 	if d.armed && uri == d.failURI {
 		d.armed = false
+		if d.hide {
+			return nil, nil
+		}
 		return nil, errors.New("transient datastore failure")
 	}
 	return d.Datastore.LoadResource(uri)
+}
+
+func TestResourcePersister_StaleReadGuardFailsClosedWhenLiveRowIsHidden(t *testing.T) {
+	realDatastore, err := newTestDatastore()
+	require.NoError(t, err)
+
+	flaky := &loadResourceFlakyDatastore{Datastore: realDatastore, hide: true}
+	persister, sender, err := newResourcePersisterWithDatastore(t, flaky)
+	require.NoError(t, err)
+
+	res := pkgmodel.Resource{
+		Label:      "task-def",
+		Type:       "FakeAWS::ECS::TaskDefinition",
+		Stack:      "test-stack",
+		Ksuid:      util.NewID(),
+		Managed:    true,
+		NativeID:   "arn:task-definition/app:4",
+		Properties: json.RawMessage(`{"memory":"512"}`),
+	}
+	persistCreateForTest(t, persister, sender, res, "cmd-plan")
+
+	generatedFrom, err := realDatastore.LoadResource(res.URI())
+	require.NoError(t, err)
+	require.NotNil(t, generatedFrom)
+
+	// The staleness lookup sees no live row, as it would for a row hidden by
+	// reaping, while the delete path's own lookup still finds one. Without a
+	// guard the tombstone lands and shadows a row that recovery could have
+	// restored.
+	flaky.failURI = res.URI()
+	flaky.armed = true
+
+	result := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "cmd-sync",
+		ResourceOperation: resource_update.OperationRead,
+		PluginOperation:   resource.OperationRead,
+		ResourceUpdate:    syncReadNotFoundForTest(*generatedFrom, "arn:task-definition/app:4"),
+	})
+	require.NoError(t, result.Error)
+
+	resources, err := realDatastore.LoadResourcesByStack("test-stack")
+	require.NoError(t, err)
+	require.Len(t, resources, 1, "a staleness lookup that finds no live row must not let the delete through")
 }
 
 func newResourcePersisterWithDatastore(t *testing.T, ds datastore.Datastore) (*unit.TestActor, gen.PID, error) {

--- a/internal/metastructure/resource_persister/resource_persister_test.go
+++ b/internal/metastructure/resource_persister/resource_persister_test.go
@@ -2438,11 +2438,14 @@ func TestResourcePersister_StaleSyncReadDoesNotDeleteContentIdenticalRecreation(
 	}
 	persistCreateForTest(t, persister, sender, res, "cmd-initial")
 
-	// The snapshot the sync cycle plans from, taken the way the generator
-	// takes it: straight off the stored record.
-	generatedFrom, err := ds.LoadResource(res.URI())
+	// The snapshot the sync cycle plans from, taken through the same loader
+	// the sync generator uses (LoadResourcesByStack), not a more convenient
+	// one — the guard is only real if it works on that path.
+	byStack, err := ds.LoadResourcesByStack("test-stack")
 	require.NoError(t, err)
-	require.NotNil(t, generatedFrom)
+	require.Len(t, byStack, 1)
+	generatedFrom := byStack[0]
+	require.NotEmpty(t, generatedFrom.Version, "the sync generator's loader must supply the row version")
 
 	// A target-driven replace destroys and recreates the resource with
 	// identical content, so neither the identity nor the properties change.

--- a/internal/metastructure/resource_persister/resource_persister_test.go
+++ b/internal/metastructure/resource_persister/resource_persister_test.go
@@ -2286,6 +2286,12 @@ func TestResourcePersister_StaleSyncReadDoesNotDeleteMovedRecord(t *testing.T) {
 	}
 	persistCreateForTest(t, persister, sender, atRevision4, "cmd-plan")
 
+	// The snapshot the sync plans from, taken off the stored record the way
+	// the generator takes it.
+	generatedFrom, err := ds.LoadResource(atRevision4.URI())
+	require.NoError(t, err)
+	require.NotNil(t, generatedFrom)
+
 	// An apply replaces the resource; the record now points at :5 and the
 	// cloud has deregistered :4.
 	atRevision5 := atRevision4
@@ -2298,7 +2304,7 @@ func TestResourcePersister_StaleSyncReadDoesNotDeleteMovedRecord(t *testing.T) {
 		CommandID:         "cmd-sync",
 		ResourceOperation: resource_update.OperationRead,
 		PluginOperation:   resource.OperationRead,
-		ResourceUpdate:    syncReadNotFoundForTest(atRevision4, "arn:task-definition/app:4"),
+		ResourceUpdate:    syncReadNotFoundForTest(*generatedFrom, "arn:task-definition/app:4"),
 	})
 	require.NoError(t, result.Error)
 
@@ -2323,13 +2329,18 @@ func TestResourcePersister_SyncReadNotFoundDeletesUnchangedRecord(t *testing.T) 
 	}
 	persistCreateForTest(t, persister, sender, current, "cmd-apply")
 
+	generatedFrom, err := ds.LoadResource(current.URI())
+	require.NoError(t, err)
+	require.NotNil(t, generatedFrom)
+
 	// The resource was deleted out of band: the sync planned against the
-	// current record and its read of that same identity came back NotFound.
+	// current record, nothing has rewritten it since, and its read of that
+	// same identity came back NotFound.
 	result := persister.Call(sender, resource_update.PersistResourceUpdate{
 		CommandID:         "cmd-sync",
 		ResourceOperation: resource_update.OperationRead,
 		PluginOperation:   resource.OperationRead,
-		ResourceUpdate:    syncReadNotFoundForTest(current, "arn:task-definition/app:5"),
+		ResourceUpdate:    syncReadNotFoundForTest(*generatedFrom, "arn:task-definition/app:5"),
 	})
 	require.NoError(t, result.Error)
 
@@ -2355,6 +2366,10 @@ func TestResourcePersister_StaleSyncReadDoesNotDeleteRecordChangedUnderSameNativ
 	}
 	persistCreateForTest(t, persister, sender, asPlanned, "cmd-plan")
 
+	generatedFrom, err := ds.LoadResource(asPlanned.URI())
+	require.NoError(t, err)
+	require.NotNil(t, generatedFrom)
+
 	// An apply rewrites the record under that same identity.
 	rewritten := asPlanned
 	rewritten.Properties = json.RawMessage(`{"versioning":"Enabled"}`)
@@ -2365,13 +2380,86 @@ func TestResourcePersister_StaleSyncReadDoesNotDeleteRecordChangedUnderSameNativ
 		CommandID:         "cmd-sync",
 		ResourceOperation: resource_update.OperationRead,
 		PluginOperation:   resource.OperationRead,
-		ResourceUpdate:    syncReadNotFoundForTest(asPlanned, "assets-bucket"),
+		ResourceUpdate:    syncReadNotFoundForTest(*generatedFrom, "assets-bucket"),
 	})
 	require.NoError(t, result.Error)
 
 	resources, err := ds.LoadResourcesByStack("test-stack")
 	require.NoError(t, err)
 	require.Len(t, resources, 1, "a NotFound read must not delete a record rewritten since the read was planned")
+}
+
+// persistDeleteForTest tombstones a resource through the persister the way a
+// successful cloud delete does.
+func persistDeleteForTest(t *testing.T, persister *unit.TestActor, sender gen.PID, res pkgmodel.Resource, commandID string) {
+	t.Helper()
+
+	result := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         commandID,
+		ResourceOperation: resource_update.OperationDelete,
+		PluginOperation:   resource.OperationDelete,
+		ResourceUpdate: resource_update.ResourceUpdate{
+			DesiredState:   res,
+			ResourceTarget: pkgmodel.Target{Label: "test-target", Namespace: "test-namespace"},
+			State:          resource_update.ResourceUpdateStateSuccess,
+			StackLabel:     res.Stack,
+			ProgressResult: []plugin.TrackedProgress{
+				{
+					ProgressResult: resource.ProgressResult{
+						Operation:       resource.OperationDelete,
+						OperationStatus: resource.OperationStatusSuccess,
+						NativeID:        res.NativeID,
+					},
+					ResourceType: res.Type,
+					StartTs:      util.TimeNow(),
+					ModifiedTs:   util.TimeNow(),
+					Attempts:     1,
+				},
+			},
+		},
+	})
+	require.NoError(t, result.Error)
+}
+
+func TestResourcePersister_StaleSyncReadDoesNotDeleteContentIdenticalRecreation(t *testing.T) {
+	persister, sender, ds, err := newResourcePersisterForTest(t)
+	require.NoError(t, err)
+
+	// A resource whose identity is a stable name, so a replace recreates it
+	// under the same NativeID with byte-identical stored properties.
+	res := pkgmodel.Resource{
+		Label:      "assets-bucket",
+		Type:       "FakeAWS::S3::Bucket",
+		Stack:      "test-stack",
+		Ksuid:      util.NewID(),
+		Managed:    true,
+		NativeID:   "assets-bucket",
+		Properties: json.RawMessage(`{"versioning":"Enabled"}`),
+	}
+	persistCreateForTest(t, persister, sender, res, "cmd-initial")
+
+	// The snapshot the sync cycle plans from, taken the way the generator
+	// takes it: straight off the stored record.
+	generatedFrom, err := ds.LoadResource(res.URI())
+	require.NoError(t, err)
+	require.NotNil(t, generatedFrom)
+
+	// A target-driven replace destroys and recreates the resource with
+	// identical content, so neither the identity nor the properties change.
+	persistDeleteForTest(t, persister, sender, res, "cmd-replace")
+	persistCreateForTest(t, persister, sender, res, "cmd-replace")
+
+	result := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "cmd-sync",
+		ResourceOperation: resource_update.OperationRead,
+		PluginOperation:   resource.OperationRead,
+		ResourceUpdate:    syncReadNotFoundForTest(*generatedFrom, "assets-bucket"),
+	})
+	require.NoError(t, result.Error)
+
+	resources, err := ds.LoadResourcesByStack("test-stack")
+	require.NoError(t, err)
+	require.Len(t, resources, 1, "a NotFound read must not delete a record recreated since the read was planned, even when the recreation is content-identical")
 }
 
 // loadResourceFlakyDatastore fails the next LoadResource for one URI a single
@@ -2427,6 +2515,10 @@ func TestResourcePersister_StaleReadGuardFailsClosedWhenLookupErrors(t *testing.
 	}
 	persistCreateForTest(t, persister, sender, atRevision4, "cmd-plan")
 
+	generatedFrom, err := realDatastore.LoadResource(atRevision4.URI())
+	require.NoError(t, err)
+	require.NotNil(t, generatedFrom)
+
 	atRevision5 := atRevision4
 	atRevision5.NativeID = "arn:task-definition/app:5"
 	atRevision5.Properties = json.RawMessage(`{"memory":"1024"}`)
@@ -2441,7 +2533,7 @@ func TestResourcePersister_StaleReadGuardFailsClosedWhenLookupErrors(t *testing.
 		CommandID:         "cmd-sync",
 		ResourceOperation: resource_update.OperationRead,
 		PluginOperation:   resource.OperationRead,
-		ResourceUpdate:    syncReadNotFoundForTest(atRevision4, "arn:task-definition/app:4"),
+		ResourceUpdate:    syncReadNotFoundForTest(*generatedFrom, "arn:task-definition/app:4"),
 	})
 	require.NoError(t, result.Error)
 

--- a/internal/metastructure/resource_persister/resource_persister_test.go
+++ b/internal/metastructure/resource_persister/resource_persister_test.go
@@ -2465,6 +2465,44 @@ func TestResourcePersister_StaleSyncReadDoesNotDeleteContentIdenticalRecreation(
 	require.Len(t, resources, 1, "a NotFound read must not delete a record recreated since the read was planned, even when the recreation is content-identical")
 }
 
+func TestResourcePersister_StaleSyncReadDoesNotDeleteWhenSnapshotVersionIsUnknown(t *testing.T) {
+	persister, sender, ds, err := newResourcePersisterForTest(t)
+	require.NoError(t, err)
+
+	atRevision4 := pkgmodel.Resource{
+		Label:      "task-def",
+		Type:       "FakeAWS::ECS::TaskDefinition",
+		Stack:      "test-stack",
+		Ksuid:      util.NewID(),
+		Managed:    true,
+		NativeID:   "arn:task-definition/app:4",
+		Properties: json.RawMessage(`{"memory":"512"}`),
+	}
+	persistCreateForTest(t, persister, sender, atRevision4, "cmd-plan")
+
+	atRevision5 := atRevision4
+	atRevision5.NativeID = "arn:task-definition/app:5"
+	persistCreateForTest(t, persister, sender, atRevision5, "cmd-apply")
+
+	// A command resumed after an agent restart rebuilds its updates from the
+	// serialized snapshot, which does not carry the row version. The guard
+	// cannot tell whether the record moved, and must not gamble on it.
+	resumed := syncReadNotFoundForTest(atRevision4, "arn:task-definition/app:4")
+	require.Empty(t, resumed.PriorState.Version)
+
+	result := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "cmd-sync-resumed",
+		ResourceOperation: resource_update.OperationRead,
+		PluginOperation:   resource.OperationRead,
+		ResourceUpdate:    resumed,
+	})
+	require.NoError(t, result.Error)
+
+	resources, err := ds.LoadResourcesByStack("test-stack")
+	require.NoError(t, err)
+	require.Len(t, resources, 1, "an unknown snapshot version must not be read as unchanged")
+}
+
 // loadResourceFlakyDatastore fails the next LoadResource for one URI a single
 // time and serves every other call from the real datastore, reproducing a
 // transient lookup failure.

--- a/internal/metastructure/resource_persister/resource_persister_test.go
+++ b/internal/metastructure/resource_persister/resource_persister_test.go
@@ -2249,6 +2249,7 @@ func syncReadNotFoundForTest(generatedFrom pkgmodel.Resource, probedNativeID str
 		ResourceTarget:     pkgmodel.Target{Label: "test-target", Namespace: "test-namespace"},
 		Operation:          resource_update.OperationRead,
 		State:              resource_update.ResourceUpdateStateSuccess,
+		Source:             resource_update.FormaCommandSourceSynchronize,
 		StackLabel:         generatedFrom.Stack,
 		PreviousProperties: generatedFrom.Properties,
 		ProgressResult: []plugin.TrackedProgress{
@@ -2524,6 +2525,42 @@ func (d *loadResourceFlakyDatastore) LoadResource(uri pkgmodel.FormaeURI) (*pkgm
 		return nil, errors.New("transient datastore failure")
 	}
 	return d.Datastore.LoadResource(uri)
+}
+
+func TestResourcePersister_DiscoveryReadNotFoundStillDeletesOrphanedRow(t *testing.T) {
+	persister, sender, ds, err := newResourcePersisterForTest(t)
+	require.NoError(t, err)
+
+	orphan := pkgmodel.Resource{
+		Label:      "orphan",
+		Type:       "FakeAWS::S3::Bucket",
+		Stack:      "test-stack",
+		Ksuid:      util.NewID(),
+		Managed:    true,
+		NativeID:   "orphan-bucket",
+		Properties: json.RawMessage(`{"versioning":"Enabled"}`),
+	}
+	persistCreateForTest(t, persister, sender, orphan, "cmd-create")
+
+	// Discovery builds its updates straight from the forma rather than from a
+	// loaded row, so they carry no row version. The sentinel-target path relies
+	// on that NotFound to clean up a row whose target is gone, so an absent
+	// version must not be read as staleness here.
+	update := syncReadNotFoundForTest(orphan, "orphan-bucket")
+	update.Source = resource_update.FormaCommandSourceDiscovery
+	require.Empty(t, update.PriorState.Version)
+
+	result := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "cmd-discovery",
+		ResourceOperation: resource_update.OperationRead,
+		PluginOperation:   resource.OperationRead,
+		ResourceUpdate:    update,
+	})
+	require.NoError(t, result.Error)
+
+	resources, err := ds.LoadResourcesByStack("test-stack")
+	require.NoError(t, err)
+	require.Empty(t, resources, "discovery must still be able to clean up an orphaned row")
 }
 
 func TestResourcePersister_StaleReadGuardFailsClosedWhenLiveRowIsHidden(t *testing.T) {

--- a/internal/metastructure/resource_persister/resource_persister_test.go
+++ b/internal/metastructure/resource_persister/resource_persister_test.go
@@ -2199,3 +2199,176 @@ func TestResourcePersister_DetachNotifiesAutoReconcilerWhenNoPolicyRemains(t *te
 		Once().
 		Assert()
 }
+
+// persistCreateForTest stores a resource through the persister the way a
+// successful create does, so a test can seed the record at a given NativeID.
+func persistCreateForTest(t *testing.T, persister *unit.TestActor, sender gen.PID, res pkgmodel.Resource, commandID string) {
+	t.Helper()
+
+	result := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         commandID,
+		ResourceOperation: resource_update.OperationCreate,
+		PluginOperation:   resource.OperationCreate,
+		ResourceUpdate: resource_update.ResourceUpdate{
+			DesiredState:   res,
+			ResourceTarget: pkgmodel.Target{Label: "test-target", Namespace: "test-namespace"},
+			State:          resource_update.ResourceUpdateStateSuccess,
+			StackLabel:     res.Stack,
+			ProgressResult: []plugin.TrackedProgress{
+				{
+					ProgressResult: resource.ProgressResult{
+						Operation:          resource.OperationCreate,
+						OperationStatus:    resource.OperationStatusSuccess,
+						NativeID:           res.NativeID,
+						ResourceProperties: res.Properties,
+					},
+					ResourceType: res.Type,
+					StartTs:      util.TimeNow(),
+					ModifiedTs:   util.TimeNow(),
+					Attempts:     1,
+				},
+			},
+		},
+	})
+	require.NoError(t, result.Error)
+}
+
+// syncReadNotFoundForTest builds the ResourceUpdate a sync cycle produces for a
+// resource whose Read came back NotFound. generatedFrom is the record as it
+// stood when the sync planned the read; probedNativeID is the id the Read
+// actually asked the plugin about, which the ResourceUpdater copies onto
+// DesiredState from the progress before the persist call.
+func syncReadNotFoundForTest(generatedFrom pkgmodel.Resource, probedNativeID string) resource_update.ResourceUpdate {
+	desired := generatedFrom
+	desired.NativeID = probedNativeID
+
+	return resource_update.ResourceUpdate{
+		PriorState:         generatedFrom,
+		DesiredState:       desired,
+		ResourceTarget:     pkgmodel.Target{Label: "test-target", Namespace: "test-namespace"},
+		Operation:          resource_update.OperationRead,
+		State:              resource_update.ResourceUpdateStateSuccess,
+		StackLabel:         generatedFrom.Stack,
+		PreviousProperties: generatedFrom.Properties,
+		ProgressResult: []plugin.TrackedProgress{
+			{
+				ProgressResult: resource.ProgressResult{
+					Operation:       resource.OperationRead,
+					OperationStatus: resource.OperationStatusSuccess,
+					ErrorCode:       resource.OperationErrorCodeNotFound,
+					NativeID:        probedNativeID,
+				},
+				ResourceType: generatedFrom.Type,
+				StartTs:      util.TimeNow(),
+				ModifiedTs:   util.TimeNow(),
+				Attempts:     1,
+			},
+		},
+	}
+}
+
+func TestResourcePersister_StaleSyncReadDoesNotDeleteMovedRecord(t *testing.T) {
+	persister, sender, ds, err := newResourcePersisterForTest(t)
+	require.NoError(t, err)
+
+	ksuid := util.NewID()
+
+	// The record as the sync cycle saw it when it planned its read.
+	atRevision4 := pkgmodel.Resource{
+		Label:      "task-def",
+		Type:       "FakeAWS::ECS::TaskDefinition",
+		Stack:      "test-stack",
+		Ksuid:      ksuid,
+		Managed:    true,
+		NativeID:   "arn:task-definition/app:4",
+		Properties: json.RawMessage(`{"memory":"512"}`),
+	}
+	persistCreateForTest(t, persister, sender, atRevision4, "cmd-plan")
+
+	// An apply replaces the resource; the record now points at :5 and the
+	// cloud has deregistered :4.
+	atRevision5 := atRevision4
+	atRevision5.NativeID = "arn:task-definition/app:5"
+	atRevision5.Properties = json.RawMessage(`{"memory":"1024"}`)
+	persistCreateForTest(t, persister, sender, atRevision5, "cmd-apply")
+
+	// The sync's queued read finally runs, against the deregistered :4.
+	result := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "cmd-sync",
+		ResourceOperation: resource_update.OperationRead,
+		PluginOperation:   resource.OperationRead,
+		ResourceUpdate:    syncReadNotFoundForTest(atRevision4, "arn:task-definition/app:4"),
+	})
+	require.NoError(t, result.Error)
+
+	resources, err := ds.LoadResourcesByStack("test-stack")
+	require.NoError(t, err)
+	require.Len(t, resources, 1, "a NotFound read of an identity the record has moved past must not delete it")
+	assert.Equal(t, "arn:task-definition/app:5", resources[0].NativeID)
+}
+
+func TestResourcePersister_SyncReadNotFoundDeletesUnchangedRecord(t *testing.T) {
+	persister, sender, ds, err := newResourcePersisterForTest(t)
+	require.NoError(t, err)
+
+	current := pkgmodel.Resource{
+		Label:      "task-def",
+		Type:       "FakeAWS::ECS::TaskDefinition",
+		Stack:      "test-stack",
+		Ksuid:      util.NewID(),
+		Managed:    true,
+		NativeID:   "arn:task-definition/app:5",
+		Properties: json.RawMessage(`{"memory":"1024"}`),
+	}
+	persistCreateForTest(t, persister, sender, current, "cmd-apply")
+
+	// The resource was deleted out of band: the sync planned against the
+	// current record and its read of that same identity came back NotFound.
+	result := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "cmd-sync",
+		ResourceOperation: resource_update.OperationRead,
+		PluginOperation:   resource.OperationRead,
+		ResourceUpdate:    syncReadNotFoundForTest(current, "arn:task-definition/app:5"),
+	})
+	require.NoError(t, result.Error)
+
+	resources, err := ds.LoadResourcesByStack("test-stack")
+	require.NoError(t, err)
+	assert.Empty(t, resources, "an out-of-band delete must still be absorbed")
+}
+
+func TestResourcePersister_StaleSyncReadDoesNotDeleteRecordChangedUnderSameNativeID(t *testing.T) {
+	persister, sender, ds, err := newResourcePersisterForTest(t)
+	require.NoError(t, err)
+
+	// A resource whose identity is a stable name, so a replace recreates it
+	// under the same NativeID.
+	asPlanned := pkgmodel.Resource{
+		Label:      "assets-bucket",
+		Type:       "FakeAWS::S3::Bucket",
+		Stack:      "test-stack",
+		Ksuid:      util.NewID(),
+		Managed:    true,
+		NativeID:   "assets-bucket",
+		Properties: json.RawMessage(`{"versioning":"Suspended"}`),
+	}
+	persistCreateForTest(t, persister, sender, asPlanned, "cmd-plan")
+
+	// An apply rewrites the record under that same identity.
+	rewritten := asPlanned
+	rewritten.Properties = json.RawMessage(`{"versioning":"Enabled"}`)
+	persistCreateForTest(t, persister, sender, rewritten, "cmd-apply")
+
+	// The sync's queued read runs against the snapshot it planned from.
+	result := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "cmd-sync",
+		ResourceOperation: resource_update.OperationRead,
+		PluginOperation:   resource.OperationRead,
+		ResourceUpdate:    syncReadNotFoundForTest(asPlanned, "assets-bucket"),
+	})
+	require.NoError(t, result.Error)
+
+	resources, err := ds.LoadResourcesByStack("test-stack")
+	require.NoError(t, err)
+	require.Len(t, resources, 1, "a NotFound read must not delete a record rewritten since the read was planned")
+}

--- a/internal/metastructure/resource_persister/resource_persister_test.go
+++ b/internal/metastructure/resource_persister/resource_persister_test.go
@@ -9,6 +9,7 @@ package resource_persister
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -2371,4 +2372,80 @@ func TestResourcePersister_StaleSyncReadDoesNotDeleteRecordChangedUnderSameNativ
 	resources, err := ds.LoadResourcesByStack("test-stack")
 	require.NoError(t, err)
 	require.Len(t, resources, 1, "a NotFound read must not delete a record rewritten since the read was planned")
+}
+
+// loadResourceFlakyDatastore fails the next LoadResource for one URI a single
+// time and serves every other call from the real datastore, reproducing a
+// transient lookup failure.
+type loadResourceFlakyDatastore struct {
+	datastore.Datastore
+	failURI pkgmodel.FormaeURI
+	armed   bool
+}
+
+func (d *loadResourceFlakyDatastore) LoadResource(uri pkgmodel.FormaeURI) (*pkgmodel.Resource, error) {
+	if d.armed && uri == d.failURI {
+		d.armed = false
+		return nil, errors.New("transient datastore failure")
+	}
+	return d.Datastore.LoadResource(uri)
+}
+
+func newResourcePersisterWithDatastore(t *testing.T, ds datastore.Datastore) (*unit.TestActor, gen.PID, error) {
+	env := map[gen.Env]any{
+		"Datastore": ds,
+		"DiscoveryConfig": pkgmodel.DiscoveryConfig{
+			Enabled:  true,
+			Interval: 10 * time.Minute,
+		},
+	}
+
+	actor, err := unit.Spawn(t, NewResourcePersister, unit.WithEnv(env))
+	if err != nil {
+		return nil, gen.PID{}, err
+	}
+
+	return actor, gen.PID{Node: "test", ID: 100}, nil
+}
+
+func TestResourcePersister_StaleReadGuardFailsClosedWhenLookupErrors(t *testing.T) {
+	realDatastore, err := newTestDatastore()
+	require.NoError(t, err)
+
+	flaky := &loadResourceFlakyDatastore{Datastore: realDatastore}
+	persister, sender, err := newResourcePersisterWithDatastore(t, flaky)
+	require.NoError(t, err)
+
+	atRevision4 := pkgmodel.Resource{
+		Label:      "task-def",
+		Type:       "FakeAWS::ECS::TaskDefinition",
+		Stack:      "test-stack",
+		Ksuid:      util.NewID(),
+		Managed:    true,
+		NativeID:   "arn:task-definition/app:4",
+		Properties: json.RawMessage(`{"memory":"512"}`),
+	}
+	persistCreateForTest(t, persister, sender, atRevision4, "cmd-plan")
+
+	atRevision5 := atRevision4
+	atRevision5.NativeID = "arn:task-definition/app:5"
+	atRevision5.Properties = json.RawMessage(`{"memory":"1024"}`)
+	persistCreateForTest(t, persister, sender, atRevision5, "cmd-apply")
+
+	// Fail the staleness lookup only. The delete path's own lookup still
+	// succeeds, so nothing else stops the tombstone from landing.
+	flaky.failURI = atRevision4.URI()
+	flaky.armed = true
+
+	result := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "cmd-sync",
+		ResourceOperation: resource_update.OperationRead,
+		PluginOperation:   resource.OperationRead,
+		ResourceUpdate:    syncReadNotFoundForTest(atRevision4, "arn:task-definition/app:4"),
+	})
+	require.NoError(t, result.Error)
+
+	resources, err := realDatastore.LoadResourcesByStack("test-stack")
+	require.NoError(t, err)
+	require.Len(t, resources, 1, "a staleness lookup that errors must not let the delete through")
 }

--- a/internal/workflow_tests/local/synchronizer_stale_read_test.go
+++ b/internal/workflow_tests/local/synchronizer_stale_read_test.go
@@ -1,0 +1,147 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// A sync cycle plans its reads against a snapshot of the records and can
+// execute them minutes later. This drives that window through the real
+// synchronizer: the resource is replaced while the queued read is in flight, so
+// the read probes an identity the record has already moved past and truthfully
+// reports NotFound. The record must survive, because the resource behind it is
+// live under its new identity.
+func TestSynchronizer_StaleReadDoesNotDeleteReplacedResource(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const (
+			stackLabel = "stale-read-stack"
+			plannedID  = "arn:task-definition/app:4"
+			replacedID = "arn:task-definition/app:5"
+		)
+
+		var (
+			ds datastore.Datastore
+			// armed keeps the replacement out of the apply's own reads: it is
+			// set only once the apply has settled, so the window is exercised
+			// against a read the sync planned.
+			armed       atomic.Bool
+			replaceOnce sync.Once
+			replaced    = make(chan struct{})
+		)
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				return &resource.CreateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationCreate,
+						OperationStatus: resource.OperationStatusSuccess,
+						RequestID:       "create-1",
+						NativeID:        plannedID,
+					},
+				}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				if !armed.Load() || request.NativeID != plannedID {
+					return &resource.ReadResult{
+						ResourceType: request.ResourceType,
+						Properties:   `{"memory":"512"}`,
+					}, nil
+				}
+
+				// The sync planned this read against the record as it stood.
+				// Land the replacement now, so the answer below concerns an
+				// identity the record has already moved past — the production
+				// sequence, made deterministic.
+				replaceOnce.Do(func() {
+					defer close(replaced)
+
+					stored, err := ds.LoadResourcesByStack(stackLabel)
+					if err != nil || len(stored) != 1 {
+						return
+					}
+					replacement := *stored[0]
+					replacement.NativeID = replacedID
+					replacement.Properties = json.RawMessage(`{"memory":"1024"}`)
+					_, _ = ds.StoreResource(&replacement, "cmd-simulated-apply")
+				})
+
+				// The old revision has been deregistered.
+				return &resource.ReadResult{
+					ResourceType: request.ResourceType,
+					ErrorCode:    resource.OperationErrorCodeNotFound,
+				}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, cleanup, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer cleanup()
+		require.NoError(t, err)
+		ds = m.Datastore
+
+		f := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: stackLabel}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label:      "task-def",
+					Type:       "FakeAWS::Resource",
+					Properties: json.RawMessage(`{"memory":"512"}`),
+					Schema:     pkgmodel.Schema{Fields: []string{"memory"}},
+					Stack:      stackLabel,
+					Target:     "test-target",
+				},
+			},
+			Targets: []pkgmodel.Target{{Label: "test-target"}},
+		}
+
+		_, err = m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			stored, err := ds.LoadResourcesByStack(stackLabel)
+			return err == nil && len(stored) == 1 && stored[0].NativeID == plannedID
+		}, 15*time.Second, 100*time.Millisecond, "the apply should leave one record at the planned identity")
+
+		armed.Store(true)
+		require.NoError(t, m.ForceSync())
+
+		select {
+		case <-replaced:
+		case <-time.After(15 * time.Second):
+			t.Fatal("sync never read the planned identity, so the stale-read window was never exercised")
+		}
+
+		// The read has answered NotFound, so any delete it produces lands
+		// within this window. The record must never disappear.
+		require.Never(t, func() bool {
+			stored, err := ds.LoadResourcesByStack(stackLabel)
+			return err == nil && len(stored) == 0
+		}, 5*time.Second, 100*time.Millisecond,
+			"the record must survive a stale NotFound read of a superseded identity")
+
+		stored, err := ds.LoadResourcesByStack(stackLabel)
+		require.NoError(t, err)
+		require.Len(t, stored, 1, "exactly one record must remain")
+		require.Equal(t, replacedID, stored[0].NativeID, "the surviving record must be the replacement")
+	})
+}

--- a/pkg/model/resource.go
+++ b/pkg/model/resource.go
@@ -37,10 +37,13 @@ type Resource struct {
 	// by the loaders that read it out of the resources table alongside Ksuid.
 	// It is monotonic per URI (a KSUID minted on every write), so comparing it
 	// against a later read answers whether the record was rewritten in between.
-	// Only meaningful on a resource that came from one of those loaders: it is
-	// empty on resources you construct, and any value embedded in a stored row
-	// is superseded by the column on load.
-	Version string `json:"Version,omitempty"`
+	//
+	// Deliberately not serialized: it describes the row, not the resource. That
+	// keeps it out of the stored payload, so a stale value can never be read
+	// back out of one, and out of generated forma and JSON output. It is
+	// therefore empty on any resource that did not come straight from a loader,
+	// which callers must read as "unknown" rather than "unchanged".
+	Version string `json:"-"`
 }
 
 // ResourceSummary is a lightweight projection of a resource row that carries only

--- a/pkg/model/resource.go
+++ b/pkg/model/resource.go
@@ -33,6 +33,14 @@ type Resource struct {
 	Managed            bool            `json:"Managed,omitempty"` // Whether the resource is managed by Formae or not
 	Ksuid              string          `json:"Ksuid,omitempty"`
 	Alias              string          `json:"Alias,omitempty"` // previous label, used to rename in place
+	// Version is the datastore row version this resource was loaded from, set
+	// by the loaders that read it out of the resources table alongside Ksuid.
+	// It is monotonic per URI (a KSUID minted on every write), so comparing it
+	// against a later read answers whether the record was rewritten in between.
+	// Only meaningful on a resource that came from one of those loaders: it is
+	// empty on resources you construct, and any value embedded in a stored row
+	// is superseded by the column on load.
+	Version string `json:"Version,omitempty"`
 }
 
 // ResourceSummary is a lightweight projection of a resource row that carries only


### PR DESCRIPTION
## Summary

A sync cycle plans its reads against a snapshot of the resource records and can execute them minutes later. If an apply replaces a resource inside that window, the queued read probes the resource's previous native identity, truthfully reports NotFound, and the read-to-delete conversion in the persister tombstones the record of a resource that is live.

The visible symptom is a resource that vanishes from inventory while it is still running in the cloud: the next simulate plans a bare create with content identical to what is already deployed, and dependent resources that reference it lose their cascade until a second apply.

This is not specific to any one resource type. Any resource whose identity changes on replace, or whose record is rewritten while a read is queued, is exposed. It surfaces most often on resources that replace on every property change.

## Change

Drop the derived delete when the stored record has been written since the read was planned, comparing the current row against the snapshot the generator already captures in `PriorState` and `PreviousProperties`. No new field, no migration, no new datastore method.

Skipping is the safe direction. The next sync cycle plans afresh, so a genuine out-of-band deletion is still absorbed one cycle later, whereas acting on a stale NotFound destroys the record outright.

Three tests cover it: a read of an identity the record has moved past must not delete; a read of a record rewritten under an unchanged native id must not delete; and an out-of-band delete against an unchanged record must still be absorbed, so drift absorption keeps working.