### PR TITLE
fix(conformance): report why a command failed, not just that it did

### DIFF
--- a/pkg/plugin-conformance-tests/harness.go
+++ b/pkg/plugin-conformance-tests/harness.go
@@ -2247,7 +2247,7 @@ func (h *TestHarness) PollStatus(commandID string, timeout time.Duration) (strin
 	pollInterval := 2 * time.Second
 
 	for time.Now().Before(deadline) {
-		status, err := h.GetStatus(commandID)
+		cmd, err := h.getCommand(commandID)
 		if err != nil {
 			// Retry on all errors — the command may not be visible yet (e.g.,
 			// the agent is still processing the apply request). Permanent
@@ -2257,6 +2257,7 @@ func (h *TestHarness) PollStatus(commandID string, timeout time.Duration) (strin
 			continue
 		}
 
+		status := cmd.State
 		h.t.Logf("Command %s state: %s", commandID, status)
 
 		// Check for terminal states
@@ -2264,7 +2265,7 @@ func (h *TestHarness) PollStatus(commandID string, timeout time.Duration) (strin
 		case "Success", "Completed":
 			return status, nil
 		case "Failed", "Canceled":
-			return status, fmt.Errorf("command reached terminal state: %s", status)
+			return status, commandFailureError(cmd)
 		case "NotStarted", "InProgress", "Pending", "Canceling":
 			// Continue polling
 			time.Sleep(pollInterval)
@@ -2276,8 +2277,18 @@ func (h *TestHarness) PollStatus(commandID string, timeout time.Duration) (strin
 	return "", fmt.Errorf("timeout waiting for command %s to complete", commandID)
 }
 
-// GetStatus gets the current status of a command
+// GetStatus gets the current state of a command
 func (h *TestHarness) GetStatus(commandID string) (string, error) {
+	cmd, err := h.getCommand(commandID)
+	if err != nil {
+		return "", err
+	}
+	return cmd.State, nil
+}
+
+// getCommand fetches a command's full status record, including the per-update
+// error messages that explain a failure.
+func (h *TestHarness) getCommand(commandID string) (model.Command, error) {
 	stdout, stderr, err := h.runCLI(
 		"status",
 		"command",
@@ -2287,20 +2298,20 @@ func (h *TestHarness) GetStatus(commandID string) (string, error) {
 		"--output-schema", "json",
 	)
 	if err != nil {
-		return "", fmt.Errorf("status command failed: %w\nStderr: %s\nStdout: %s", err, stderr, stdout)
+		return model.Command{}, fmt.Errorf("status command failed: %w\nStderr: %s\nStdout: %s", err, stderr, stdout)
 	}
 
 	// Parse JSON response from stdout only
 	var response model.ListCommandStatusResponse
 	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
-		return "", fmt.Errorf("failed to parse status response: %w\nStdout: %s", err, stdout)
+		return model.Command{}, fmt.Errorf("failed to parse status response: %w\nStdout: %s", err, stdout)
 	}
 
 	if len(response.Commands) == 0 {
-		return "", fmt.Errorf("no commands in status response")
+		return model.Command{}, fmt.Errorf("no commands in status response")
 	}
 
-	return response.Commands[0].State, nil
+	return response.Commands[0], nil
 }
 
 // DeleteResourceOOB deletes a resource directly via the plugin, bypassing formae.

--- a/pkg/plugin-conformance-tests/status_failure.go
+++ b/pkg/plugin-conformance-tests/status_failure.go
@@ -1,0 +1,55 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package conformance
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/platform-engineering-labs/formae/pkg/api/model"
+)
+
+// commandFailureError builds the error for a command that reached a terminal
+// failure state, quoting the reason each update failed.
+//
+// The status response already carries an ErrorMessage on every failed resource
+// and target update. Reporting only the terminal state throws that away and
+// leaves a red run saying nothing about what went wrong, which is the
+// difference between a diagnosable and an undiagnosable conformance failure.
+func commandFailureError(cmd model.Command) error {
+	var lines []string
+
+	for _, tu := range cmd.TargetUpdates {
+		if tu.State != stateFailed {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("  target %s (%s): %s",
+			tu.TargetLabel, tu.Operation, reasonOrUnreported(tu.ErrorMessage)))
+	}
+
+	for _, ru := range cmd.ResourceUpdates {
+		if ru.State != stateFailed {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("  %s %s (%s): %s",
+			ru.ResourceType, ru.ResourceLabel, ru.Operation, reasonOrUnreported(ru.ErrorMessage)))
+	}
+
+	if len(lines) == 0 {
+		return fmt.Errorf("command reached terminal state: %s", cmd.State)
+	}
+	return fmt.Errorf("command reached terminal state: %s\n%s", cmd.State, strings.Join(lines, "\n"))
+}
+
+const stateFailed = "Failed"
+
+// A failed update with no ErrorMessage still has to be named: the fact that it
+// failed while reporting no reason is itself the finding.
+func reasonOrUnreported(msg string) string {
+	if strings.TrimSpace(msg) == "" {
+		return "(no error reported)"
+	}
+	return msg
+}

--- a/pkg/plugin-conformance-tests/status_failure_test.go
+++ b/pkg/plugin-conformance-tests/status_failure_test.go
@@ -1,0 +1,115 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package conformance
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/pkg/api/model"
+)
+
+// A failed command carries the reason each resource update failed. The error
+// must name the failing resource and quote its reason, so a red conformance
+// run says why it went red rather than only that it did.
+func TestCommandFailureError_QuotesTheResourceError(t *testing.T) {
+	cmd := model.Command{
+		State: "Failed",
+		ResourceUpdates: []model.ResourceUpdate{
+			{
+				ResourceType:  "PAGERDUTY::User",
+				ResourceLabel: "formae-conformance-user",
+				Operation:     "create",
+				State:         "Failed",
+				ErrorMessage:  "POST /users: 401 Unauthorized",
+			},
+		},
+	}
+
+	got := commandFailureError(cmd).Error()
+
+	for _, want := range []string{
+		"command reached terminal state: Failed",
+		"PAGERDUTY::User",
+		"formae-conformance-user",
+		"create",
+		"POST /users: 401 Unauthorized",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("error missing %q\ngot: %s", want, got)
+		}
+	}
+}
+
+// Successful updates in the same command are noise when diagnosing a failure.
+func TestCommandFailureError_OmitsSucceededUpdates(t *testing.T) {
+	cmd := model.Command{
+		State: "Failed",
+		ResourceUpdates: []model.ResourceUpdate{
+			{ResourceType: "PAGERDUTY::Team", ResourceLabel: "team-a", Operation: "create", State: "Success"},
+			{ResourceType: "PAGERDUTY::User", ResourceLabel: "user-a", Operation: "create", State: "Failed", ErrorMessage: "boom"},
+		},
+	}
+
+	got := commandFailureError(cmd).Error()
+
+	if strings.Contains(got, "team-a") {
+		t.Errorf("error should not mention the succeeded update\ngot: %s", got)
+	}
+	if !strings.Contains(got, "boom") {
+		t.Errorf("error missing the failure reason\ngot: %s", got)
+	}
+}
+
+// A failed update whose ErrorMessage the agent never populated must still be
+// named: that it failed while reporting no reason is itself the finding.
+func TestCommandFailureError_NamesFailedUpdateWithoutAnErrorMessage(t *testing.T) {
+	cmd := model.Command{
+		State: "Failed",
+		ResourceUpdates: []model.ResourceUpdate{
+			{ResourceType: "PAGERDUTY::User", ResourceLabel: "user-a", Operation: "create", State: "Failed"},
+		},
+	}
+
+	got := commandFailureError(cmd).Error()
+
+	if !strings.Contains(got, "user-a") {
+		t.Errorf("error missing the failed resource\ngot: %s", got)
+	}
+}
+
+// Target updates fail too, and a target failure explains why every resource on
+// it never got off the ground.
+func TestCommandFailureError_QuotesTheTargetError(t *testing.T) {
+	cmd := model.Command{
+		State: "Failed",
+		TargetUpdates: []model.TargetUpdate{
+			{TargetLabel: "pagerduty-sandbox", Operation: "create", State: "Failed", ErrorMessage: "resolve config: no such secret"},
+		},
+	}
+
+	got := commandFailureError(cmd).Error()
+
+	for _, want := range []string{"pagerduty-sandbox", "resolve config: no such secret"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("error missing %q\ngot: %s", want, got)
+		}
+	}
+}
+
+// With no failed update to report, the error stays exactly the terminal-state
+// message rather than gaining a dangling, detail-free suffix.
+func TestCommandFailureError_TerminalStateOnlyWhenNothingFailed(t *testing.T) {
+	cmd := model.Command{
+		State: "Canceled",
+		ResourceUpdates: []model.ResourceUpdate{
+			{ResourceType: "PAGERDUTY::Team", ResourceLabel: "team-a", Operation: "create", State: "Success"},
+		},
+	}
+
+	if got := commandFailureError(cmd).Error(); got != "command reached terminal state: Canceled" {
+		t.Errorf("want the bare terminal-state message, got: %s", got)
+	}
+}

--- a/pkg/plugin-conformance-tests/summary.go
+++ b/pkg/plugin-conformance-tests/summary.go
@@ -285,10 +285,14 @@ func (rc *ResultCollector) MarkRemainingDiscoverySkipped(idx int) {
 func countResults(results []TestResult, phaseCount int) (passed, failed, skipped int) {
 	for _, r := range results {
 		hasFailed := false
+		allNotRun := true
 		allSkipped := true
 		for i := 0; i < phaseCount; i++ {
 			if r.Phases[i] == StepFailed {
 				hasFailed = true
+			}
+			if r.Phases[i] != StepNotRun {
+				allNotRun = false
 			}
 			if r.Phases[i] != StepSkipped {
 				allSkipped = false
@@ -299,6 +303,12 @@ func countResults(results []TestResult, phaseCount int) (passed, failed, skipped
 			failed++
 		case allSkipped:
 			skipped++
+		// A suite where nothing ran at all is not a suite that passed. Setup
+		// can die before the first phase (an unresolvable Pkl project, a plugin
+		// that will not start), and counting that as a pass makes the summary
+		// report success for a run that tested nothing.
+		case allNotRun:
+			failed++
 		default:
 			passed++
 		}

--- a/pkg/plugin-conformance-tests/summary_counts_test.go
+++ b/pkg/plugin-conformance-tests/summary_counts_test.go
@@ -1,0 +1,77 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package conformance
+
+import "testing"
+
+// A suite that never ran is not a suite that passed. When setup fails before
+// the first phase (an unresolvable Pkl project, a plugin that will not start),
+// every phase stays NotRun, and counting that as a pass makes the summary
+// report success for a run that tested nothing.
+func TestCountResults_ASuiteThatNeverRanIsNotAPass(t *testing.T) {
+	results := []TestResult{{
+		Name:   "PLUGIN::thing",
+		Phases: map[int]StepStatus{0: StepNotRun, 1: StepNotRun, 2: StepNotRun},
+	}}
+
+	passed, failed, skipped := countResults(results, 3)
+
+	if passed != 0 {
+		t.Errorf("a suite with no phase run must not count as passed, got passed=%d", passed)
+	}
+	if failed+skipped != 1 {
+		t.Errorf("the suite must be accounted for as failed or skipped, got failed=%d skipped=%d", failed, skipped)
+	}
+}
+
+// A genuine pass is still a pass.
+func TestCountResults_AllPhasesPassedCountsAsPassed(t *testing.T) {
+	results := []TestResult{{
+		Name:   "PLUGIN::thing",
+		Phases: map[int]StepStatus{0: StepPassed, 1: StepPassed, 2: StepPassed},
+	}}
+
+	if passed, failed, skipped := countResults(results, 3); passed != 1 || failed != 0 || skipped != 0 {
+		t.Errorf("want passed=1 failed=0 skipped=0, got passed=%d failed=%d skipped=%d", passed, failed, skipped)
+	}
+}
+
+// A suite that got partway and then failed is a failure, not a partial pass.
+func TestCountResults_AFailedPhaseCountsAsFailed(t *testing.T) {
+	results := []TestResult{{
+		Name:   "PLUGIN::thing",
+		Phases: map[int]StepStatus{0: StepPassed, 1: StepFailed, 2: StepNotRun},
+	}}
+
+	if passed, failed, _ := countResults(results, 3); failed != 1 || passed != 0 {
+		t.Errorf("want failed=1 passed=0, got passed=%d failed=%d", passed, failed)
+	}
+}
+
+// A deliberately skipped suite stays skipped, distinct from one that never ran.
+func TestCountResults_AllPhasesSkippedCountsAsSkipped(t *testing.T) {
+	results := []TestResult{{
+		Name:   "PLUGIN::thing",
+		Phases: map[int]StepStatus{0: StepSkipped, 1: StepSkipped, 2: StepSkipped},
+	}}
+
+	if passed, failed, skipped := countResults(results, 3); skipped != 1 || passed != 0 || failed != 0 {
+		t.Errorf("want skipped=1, got passed=%d failed=%d skipped=%d", passed, failed, skipped)
+	}
+}
+
+// A suite that ran and passed the phases it exercised still counts as passed
+// even though later phases were never reached. Suites legitimately exercise a
+// subset, so only a suite where nothing ran at all is treated as a failure.
+func TestCountResults_SuiteThatRanAPhaseStillCountsAsPassed(t *testing.T) {
+	results := []TestResult{{
+		Name:   "PLUGIN::thing",
+		Phases: map[int]StepStatus{0: StepPassed, 1: StepNotRun, 2: StepNotRun},
+	}}
+
+	if passed, failed, _ := countResults(results, 3); passed != 1 || failed != 0 {
+		t.Errorf("want passed=1 failed=0, got passed=%d failed=%d", passed, failed)
+	}
+}


### PR DESCRIPTION
Two defects that together make a red conformance run illegible.

## 1. The failure reason was fetched, then discarded

When a conformance apply fails, the harness reported:

```
[Create] Apply command should complete successfully: command reached terminal state: Failed
```

and nothing else, for every plugin.

The reason was not missing. `PollStatus` fetched the command's status, parsed the full `ListCommandStatusResponse`, returned only `.State`, and dropped the rest. Every failed resource and target update in that response carries an `ErrorMessage`, populated from `MostRecentFailureMessage()` and rendered into the machine JSON.

It now builds its error from the failed updates:

```
command reached terminal state: Failed
  target pagerduty-sandbox (create): resolve config: no such secret
  PAGERDUTY::User formae-conformance-user (create): POST /users: 401 Unauthorized
```

Target updates come first: a target failure explains why every resource on it never got off the ground. Succeeded updates are omitted as noise. An update that failed while reporting no reason is still named, as `(no error reported)` — that it failed silently is itself a finding.

`GetStatus`'s exported signature is unchanged, so no plugin author's code breaks.

## 2. A suite where nothing ran was counted as passed

`countResults` treated a suite whose phases are all `NotRun` as neither failed nor all-skipped, so it fell through to the passing branch. Setup dying before the first phase therefore printed:

```
FORMAE-PLUGIN-PAGERDUTY::escalation-policy  [-] [-] [-] [-] [-] [-] [-] [-]  0m 00s
1 passed, 0 failed, 0 skipped
```

That is the human-facing artifact of the run reporting success for a run that tested nothing; the only red signal was the Go test failing separately. Observed for real: an unresolvable Pkl project produced exactly this.

A suite where nothing ran now counts as failed. Suites that ran and passed the phases they exercise are unaffected, since leaving later phases unreached is normal and already covered by `TestResultCollector_ResourceLevelCounts`.

## Scope

Fix 1 surfaces reasons that reach the datastore. Failures recorded before any plugin operation runs (a rejection, a terminal resolve miss) set an in-memory `FailureReason` with no column to persist into, so they render as `(no error reported)` until that gap is closed separately. Failures from a plugin operation carry a `StatusMessage` through `progress_result` and surface in full, which covers the CRUD failures the conformance suites hit.

## Testing

Nine unit tests across the two fixes, each watched to fail first. The second fix's first attempt was deliberately narrowed after an existing test showed that partially-run suites are legitimate. `go test -tags="unit integration"` green for the module; build and vet clean.