### PR TITLE
feat(cli): follow Omarchy 4 themes alongside Omarchy 3

### DIFF
--- a/internal/cli/tui/theme/omarchy.go
+++ b/internal/cli/tui/theme/omarchy.go
@@ -12,32 +12,55 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-// omarchyColors is the flat colors.toml an Omarchy theme publishes at
-// ~/.config/omarchy/current/theme/colors.toml. Absent keys stay empty; the
-// mapper (mapOmarchyPalette) applies per-key fallbacks.
+// omarchyColors is the flat colors.toml an Omarchy theme publishes in its
+// current-theme directory. Absent keys stay empty; the mapper
+// (mapOmarchyPalette) applies per-key fallbacks.
+//
+// Two generations of the format are read from the same struct. Omarchy 3 named
+// colors by ANSI slot (color0..color15) and declared light mode with a
+// light.mode marker file. Omarchy 4 ("Quattro") replaced both: colors carry
+// semantic role names and mode is a key in this file. The two vocabularies are
+// disjoint in practice, so every field simply stays empty for the generation
+// that does not use it and the mapper's fallback chains pick whichever is
+// populated. Canonical (semantic) names are tried first, matching the
+// precedence omarchy-theme-color applies.
 type omarchyColors struct {
+	// Mode is Omarchy 4's declared appearance, "light" or "dark".
+	Mode string `toml:"mode"`
+
 	Background          string `toml:"background"`
 	Foreground          string `toml:"foreground"`
 	Accent              string `toml:"accent"`
 	Cursor              string `toml:"cursor"`
 	SelectionForeground string `toml:"selection_foreground"`
 	SelectionBackground string `toml:"selection_background"`
-	Color0              string `toml:"color0"`
-	Color1              string `toml:"color1"`
-	Color2              string `toml:"color2"`
-	Color3              string `toml:"color3"`
-	Color4              string `toml:"color4"`
-	Color5              string `toml:"color5"`
-	Color6              string `toml:"color6"`
-	Color7              string `toml:"color7"`
-	Color8              string `toml:"color8"`
-	Color9              string `toml:"color9"`
-	Color10             string `toml:"color10"`
-	Color11             string `toml:"color11"`
-	Color12             string `toml:"color12"`
-	Color13             string `toml:"color13"`
-	Color14             string `toml:"color14"`
-	Color15             string `toml:"color15"`
+
+	// Omarchy 4 semantic names. Only the roles formae's palette consumes are
+	// declared; the rest of the 24-color set is deliberately not carried.
+	Muted           string `toml:"muted"`
+	LightForeground string `toml:"light_foreground"`
+	Red             string `toml:"red"`
+	Green           string `toml:"green"`
+	Yellow          string `toml:"yellow"`
+	Blue            string `toml:"blue"`
+	Magenta         string `toml:"magenta"`
+
+	Color0  string `toml:"color0"`
+	Color1  string `toml:"color1"`
+	Color2  string `toml:"color2"`
+	Color3  string `toml:"color3"`
+	Color4  string `toml:"color4"`
+	Color5  string `toml:"color5"`
+	Color6  string `toml:"color6"`
+	Color7  string `toml:"color7"`
+	Color8  string `toml:"color8"`
+	Color9  string `toml:"color9"`
+	Color10 string `toml:"color10"`
+	Color11 string `toml:"color11"`
+	Color12 string `toml:"color12"`
+	Color13 string `toml:"color13"`
+	Color14 string `toml:"color14"`
+	Color15 string `toml:"color15"`
 }
 
 // parseOmarchyColors decodes an Omarchy colors.toml document.
@@ -70,11 +93,19 @@ func mapOmarchyPalette(oc omarchyColors) paletteFile {
 		return &colorValue{Light: hex, Dark: hex}
 	}
 
-	textSecondary := pick(oc.Color7, oc.Foreground)
-	textSubtle := pick(oc.Color8, oc.Color7, oc.Foreground)
-	border := pick(oc.Color8, oc.Color7)
-	primary := pick(oc.Accent, oc.Color4)
-	secondary := pick(oc.Color5, oc.Accent)
+	// Each chain reads the Omarchy 4 semantic name first, then the Omarchy 3
+	// ANSI slot it replaced. The pairings are omarchy's own (see the ansi_alias
+	// table in omarchy-theme-color): muted==color8, red==color1, green==color2,
+	// yellow==color3, blue==color4, magenta==color5, light_foreground==color7.
+	textSecondary := pick(oc.LightForeground, oc.Color7, oc.Foreground)
+	textSubtle := pick(oc.Muted, oc.Color8, oc.Color7, oc.Foreground)
+	border := pick(oc.Muted, oc.Color8, oc.Color7)
+	primary := pick(oc.Accent, oc.Blue, oc.Color4)
+	secondary := pick(oc.Magenta, oc.Color5, oc.Accent)
+	muted := pick(oc.Muted, oc.Color8)
+	red := pick(oc.Red, oc.Color1)
+	green := pick(oc.Green, oc.Color2)
+	yellow := pick(oc.Yellow, oc.Color3)
 
 	return paletteFile{
 		Base:          mirror(oc.Background),
@@ -87,7 +118,9 @@ func mapOmarchyPalette(oc omarchyColors) paletteFile {
 		// it, so the band must sit next to the background, not next to the text.
 		// selection_background is a terminal text-selection color, meaningful only
 		// when paired with selection_foreground (which replaces the text color too),
-		// so it is deliberately not mapped here.
+		// so it is deliberately not mapped here. Omarchy 4's "selection" key is the
+		// same thing under a new name (omarchy derives selection_background from it
+		// and pairs it with bright_foreground), so it is not mapped either.
 		//
 		// Derivation needs a parseable background. A palette whose background is
 		// not hex (termenv also accepts a bare ANSI index) leaves this unset, and
@@ -95,23 +128,23 @@ func mapOmarchyPalette(oc omarchyColors) paletteFile {
 		Selection:       mirror(selectionBand(oc.Background, oc.Foreground, primary)),
 		PrimaryAccent:   mirror(primary),
 		SecondaryAccent: mirror(secondary),
-		Error:           mirror(oc.Color1),
-		ErrorSubtle:     mirror(oc.Color1),
-		ErrorBright:     mirror(oc.Color1),
-		Warning:         mirror(oc.Color3),
-		// Unmanaged mirrors Error (both color1), matching quiet's own
+		Error:           mirror(red),
+		ErrorSubtle:     mirror(red),
+		ErrorBright:     mirror(red),
+		Warning:         mirror(yellow),
+		// Unmanaged mirrors Error (both red), matching quiet's own
 		// unmanaged==error relationship, so the inventory marker follows the
 		// palette instead of a fixed red.
-		Unmanaged:  mirror(oc.Color1),
-		Done:       mirror(oc.Color2),
-		InProgress: mirror(pick(oc.Color8, oc.Color7)),
-		Pending:    mirror(oc.Color8),
-		OpCreate:   mirror(oc.Color2),
-		OpUpdate:   mirror(oc.Color3),
-		OpDelete:   mirror(oc.Color1),
+		Unmanaged:  mirror(red),
+		Done:       mirror(green),
+		InProgress: mirror(pick(oc.Muted, oc.Color8, oc.Color7)),
+		Pending:    mirror(muted),
+		OpCreate:   mirror(green),
+		OpUpdate:   mirror(yellow),
+		OpDelete:   mirror(red),
 		OpReplace:  mirror(secondary),
-		OpDetach:   mirror(oc.Color8),
-		OpKeep:     mirror(oc.Color8),
+		OpDetach:   mirror(muted),
+		OpKeep:     mirror(muted),
 		// Color the logo wordmark with the OS accent so the printed logo follows
 		// the Omarchy theme, mirroring how rich tints its wordmark. The propeller
 		// stays brand orange.
@@ -119,14 +152,40 @@ func mapOmarchyPalette(oc omarchyColors) paletteFile {
 	}
 }
 
-// omarchyThemeDir is the resolved OS theme directory the "omarchy" theme reads
-// (following the ~/.config/omarchy/current symlink). Empty if HOME is unset.
+// omarchyThemeDirs lists the candidate OS theme directories, current generation
+// first. Omarchy 4 keeps the active theme under ~/.local/state and deletes the
+// ~/.config location on upgrade without leaving a symlink behind, so both have
+// to be probed: a Quattro machine only has the first, an Omarchy 3 machine only
+// the second. Either entry is omitted when the environment cannot name it.
+func omarchyThemeDirs() []string {
+	var dirs []string
+	if state := os.Getenv("XDG_STATE_HOME"); state != "" {
+		dirs = append(dirs, filepath.Join(state, "omarchy", "current", "theme"))
+	} else if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, ".local", "state", "omarchy", "current", "theme"))
+	}
+	if cfg, err := os.UserConfigDir(); err == nil {
+		dirs = append(dirs, filepath.Join(cfg, "omarchy", "current", "theme"))
+	}
+	return dirs
+}
+
+// omarchyThemeDir is the OS theme directory the "omarchy" theme reads: the
+// first candidate that actually holds a colors.toml. With no Omarchy install at
+// all it names the current generation's path, so the resolver's warning points
+// at where a theme is expected rather than at a location Omarchy has retired.
+// Empty when the environment names no candidate (no HOME).
 func omarchyThemeDir() string {
-	cfg, err := os.UserConfigDir()
-	if err != nil {
+	dirs := omarchyThemeDirs()
+	for _, dir := range dirs {
+		if _, err := os.Stat(filepath.Join(dir, "colors.toml")); err == nil {
+			return dir
+		}
+	}
+	if len(dirs) == 0 {
 		return ""
 	}
-	return filepath.Join(cfg, "omarchy", "current", "theme")
+	return dirs[0]
 }
 
 // resolveOmarchy builds the "omarchy" theme by mapping dir/colors.toml onto
@@ -159,15 +218,33 @@ func resolveOmarchy(dir string, warn func(string)) *Theme {
 }
 
 // omarchyAutoAppearance reports the appearance ("light"/"dark") the Omarchy
-// theme at dir declares, via the presence of a light.mode marker file. Returns
-// "" when dir has no colors.toml (no Omarchy theme to follow).
+// theme at dir declares: the Omarchy 4 mode key in colors.toml first, then the
+// Omarchy 3 light.mode marker file, defaulting to dark. Returns "" when dir has
+// no colors.toml (no Omarchy theme to follow).
+//
+// omarchy-theme-color also accepts a legacy theme_type key and, failing
+// everything, guesses from background luminance. Neither is mirrored here: no
+// Omarchy theme has ever shipped theme_type, and the luminance guess only
+// applies to hand-written user themes that declare no mode at all, which land
+// on the same dark default either way.
 func omarchyAutoAppearance(dir string) string {
 	if dir == "" {
 		return ""
 	}
-	if _, err := os.Stat(filepath.Join(dir, "colors.toml")); err != nil {
+	data, err := os.ReadFile(filepath.Join(dir, "colors.toml"))
+	if err != nil {
 		return ""
 	}
+	// Omarchy 4 declares the appearance in colors.toml. Only the two values it
+	// defines are a verdict; anything else falls through to the marker, so a
+	// theme with an unrecognised mode is treated as not having declared one.
+	if oc, err := parseOmarchyColors(data); err == nil {
+		switch oc.Mode {
+		case "light", "dark":
+			return oc.Mode
+		}
+	}
+	// Omarchy 3 marked light themes with a file beside colors.toml.
 	if _, err := os.Stat(filepath.Join(dir, "light.mode")); err == nil {
 		return "light"
 	}

--- a/internal/cli/tui/theme/omarchy.go
+++ b/internal/cli/tui/theme/omarchy.go
@@ -159,7 +159,10 @@ func mapOmarchyPalette(oc omarchyColors) paletteFile {
 // the second. Either entry is omitted when the environment cannot name it.
 func omarchyThemeDirs() []string {
 	var dirs []string
-	if state := os.Getenv("XDG_STATE_HOME"); state != "" {
+	// A relative XDG base directory is invalid per the spec and is ignored, which
+	// is what os.UserConfigDir does for XDG_CONFIG_HOME below. Without the same
+	// check here a relative value would probe a working-directory-relative path.
+	if state := os.Getenv("XDG_STATE_HOME"); filepath.IsAbs(state) {
 		dirs = append(dirs, filepath.Join(state, "omarchy", "current", "theme"))
 	} else if home, err := os.UserHomeDir(); err == nil {
 		dirs = append(dirs, filepath.Join(home, ".local", "state", "omarchy", "current", "theme"))

--- a/internal/cli/tui/theme/omarchy_test.go
+++ b/internal/cli/tui/theme/omarchy_test.go
@@ -311,6 +311,26 @@ func TestOmarchyThemeDir_StateDirDefaultsUnderHome(t *testing.T) {
 	}
 }
 
+// The XDG spec calls a relative base directory invalid and says to ignore it,
+// which is what os.UserConfigDir does for XDG_CONFIG_HOME. The state dir has to
+// agree, or a relative value silently probes (and then names in the warning) a
+// working-directory-relative path.
+func TestOmarchyThemeDir_RelativeStateHomeIsIgnored(t *testing.T) {
+	for _, stateHome := range []string{"relative/path", "   "} {
+		t.Run(stateHome, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_STATE_HOME", stateHome)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+			want := installOmarchyTheme(t, filepath.Join(home, ".local", "state"))
+
+			if got := omarchyThemeDir(); got != want {
+				t.Errorf("omarchyThemeDir() = %q, want the HOME default %q", got, want)
+			}
+		})
+	}
+}
+
 // With no Omarchy install at all the resolver still needs a path to name in its
 // warning, and the current generation is the one to name.
 func TestOmarchyThemeDir_NoInstallNamesStateDir(t *testing.T) {

--- a/internal/cli/tui/theme/omarchy_test.go
+++ b/internal/cli/tui/theme/omarchy_test.go
@@ -9,6 +9,7 @@ package theme
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -118,6 +119,106 @@ func TestMapOmarchyPalette_SelectionBandIsDerivedFromBackground(t *testing.T) {
 	}
 }
 
+// quattroColors is the semantic palette shape Omarchy 4 publishes: no ANSI
+// colorN keys at all, colors named by role instead. Omarchy 4's own "selection"
+// key is not carried; see the Selection comment in mapOmarchyPalette.
+func quattroColors() omarchyColors {
+	return omarchyColors{
+		Mode:            "dark",
+		Accent:          "#7aa2f7",
+		Muted:           "#414868",
+		Background:      "#1a1b26",
+		Foreground:      "#a9b1d6",
+		LightForeground: "#b4bee6",
+		Red:             "#f7768e",
+		Yellow:          "#e0af68",
+		Green:           "#9ece6a",
+		Blue:            "#7aa2f7",
+		Magenta:         "#ad8ee6",
+	}
+}
+
+// nilPaletteSlots names every paletteFile field left unset. Reflection rather
+// than a hand-listed set, so a slot added to paletteFile later is covered here
+// without anyone remembering to extend this test.
+func nilPaletteSlots(p paletteFile) []string {
+	var nils []string
+	v := reflect.ValueOf(p)
+	for i := 0; i < v.NumField(); i++ {
+		if v.Field(i).IsNil() {
+			nils = append(nils, v.Type().Field(i).Name)
+		}
+	}
+	return nils
+}
+
+// A semantic-only palette must fill every slot. Omarchy 4 dropped colorN
+// entirely, so a mapper that reads only ANSI keys leaves most of the palette
+// empty and the theme silently inherits quiet's colors.
+func TestMapOmarchyPalette_SemanticPaletteFillsEverySlot(t *testing.T) {
+	p := mapOmarchyPalette(quattroColors())
+
+	if nils := nilPaletteSlots(p); len(nils) > 0 {
+		t.Errorf("unset palette slots from a semantic-only palette: %v", nils)
+	}
+}
+
+// The semantic names each drive the slot the corresponding ANSI key used to.
+func TestMapOmarchyPalette_SemanticNamesDriveSlots(t *testing.T) {
+	p := mapOmarchyPalette(quattroColors())
+
+	for _, tc := range []struct {
+		slot string
+		got  *colorValue
+		want string
+	}{
+		{"Error (red)", p.Error, "#f7768e"},
+		{"Warning (yellow)", p.Warning, "#e0af68"},
+		{"Done (green)", p.Done, "#9ece6a"},
+		{"OpCreate (green)", p.OpCreate, "#9ece6a"},
+		{"OpUpdate (yellow)", p.OpUpdate, "#e0af68"},
+		{"OpDelete (red)", p.OpDelete, "#f7768e"},
+		{"SecondaryAccent (magenta)", p.SecondaryAccent, "#ad8ee6"},
+		{"OpReplace (magenta)", p.OpReplace, "#ad8ee6"},
+		{"TextSubtle (muted)", p.TextSubtle, "#414868"},
+		{"Border (muted)", p.Border, "#414868"},
+		{"Pending (muted)", p.Pending, "#414868"},
+		{"TextSecondary (light_foreground)", p.TextSecondary, "#b4bee6"},
+	} {
+		if tc.got == nil || tc.got.Dark != tc.want {
+			t.Errorf("%s = %+v, want %s", tc.slot, tc.got, tc.want)
+		}
+	}
+}
+
+// An accent-less semantic palette falls back to blue, the way it used to fall
+// back to color4.
+func TestMapOmarchyPalette_SemanticAccentFallsBackToBlue(t *testing.T) {
+	oc := quattroColors()
+	oc.Accent = ""
+	p := mapOmarchyPalette(oc)
+
+	if got := p.PrimaryAccent; got == nil || got.Dark != "#7aa2f7" {
+		t.Errorf("PrimaryAccent = %+v, want fallback to blue #7aa2f7", got)
+	}
+}
+
+// A theme carrying both spellings is Omarchy 3 output read by an Omarchy 4
+// resolver: the canonical semantic name wins, matching omarchy-theme-color.
+func TestMapOmarchyPalette_CanonicalNameWinsOverANSI(t *testing.T) {
+	oc := quattroColors()
+	oc.Color1 = "#ff0000" // legacy red, must lose to the canonical Red
+	oc.Color8 = "#00ff00" // legacy bright-black, must lose to the canonical Muted
+	p := mapOmarchyPalette(oc)
+
+	if got := p.Error; got == nil || got.Dark != "#f7768e" {
+		t.Errorf("Error = %+v, want canonical red #f7768e to win over color1", got)
+	}
+	if got := p.TextSubtle; got == nil || got.Dark != "#414868" {
+		t.Errorf("TextSubtle = %+v, want canonical muted #414868 to win over color8", got)
+	}
+}
+
 func TestMapOmarchyPalette_Fallbacks(t *testing.T) {
 	// Only background + foreground + accent + the ANSI reds/greens present;
 	// text_secondary/border/etc. must fall back, never end up empty.
@@ -133,6 +234,91 @@ func TestMapOmarchyPalette_Fallbacks(t *testing.T) {
 	// SecondaryAccent has no color5 → falls back to accent.
 	if got := p.SecondaryAccent; got == nil || got.Dark != "#0000ff" {
 		t.Errorf("SecondaryAccent = %+v, want fallback to accent #0000ff", got)
+	}
+}
+
+// installOmarchyTheme writes a minimal colors.toml under root's
+// omarchy/current/theme and returns that theme dir.
+func installOmarchyTheme(t *testing.T, root string) string {
+	t.Helper()
+	dir := filepath.Join(root, "omarchy", "current", "theme")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "colors.toml"), []byte("background = \"#1a1b26\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// omarchyHome points HOME and both XDG roots at fresh temp dirs and returns the
+// state and config roots, so a test can install a theme under either.
+func omarchyHome(t *testing.T) (stateRoot, configRoot string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stateRoot = filepath.Join(home, ".local", "state")
+	configRoot = filepath.Join(home, ".config")
+	t.Setenv("XDG_STATE_HOME", stateRoot)
+	t.Setenv("XDG_CONFIG_HOME", configRoot)
+	return stateRoot, configRoot
+}
+
+// Omarchy 4 moved the active theme out of ~/.config into ~/.local/state and
+// removed the old directory outright, leaving no compatibility symlink. Looking
+// only in the config dir finds nothing on a Quattro machine.
+func TestOmarchyThemeDir_FindsStateDir(t *testing.T) {
+	stateRoot, _ := omarchyHome(t)
+	want := installOmarchyTheme(t, stateRoot)
+
+	if got := omarchyThemeDir(); got != want {
+		t.Errorf("omarchyThemeDir() = %q, want the state dir %q", got, want)
+	}
+}
+
+// Omarchy 3 installs keep the theme in the config dir and must keep working.
+func TestOmarchyThemeDir_FallsBackToConfigDir(t *testing.T) {
+	_, configRoot := omarchyHome(t)
+	want := installOmarchyTheme(t, configRoot)
+
+	if got := omarchyThemeDir(); got != want {
+		t.Errorf("omarchyThemeDir() = %q, want the legacy config dir %q", got, want)
+	}
+}
+
+// A machine upgraded in place can have a stale config-dir theme left over; the
+// state dir is the live one.
+func TestOmarchyThemeDir_StateDirWinsOverConfigDir(t *testing.T) {
+	stateRoot, configRoot := omarchyHome(t)
+	want := installOmarchyTheme(t, stateRoot)
+	installOmarchyTheme(t, configRoot)
+
+	if got := omarchyThemeDir(); got != want {
+		t.Errorf("omarchyThemeDir() = %q, want the state dir %q to win", got, want)
+	}
+}
+
+// XDG_STATE_HOME is frequently unset; the state dir still resolves under HOME.
+func TestOmarchyThemeDir_StateDirDefaultsUnderHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	want := installOmarchyTheme(t, filepath.Join(home, ".local", "state"))
+
+	if got := omarchyThemeDir(); got != want {
+		t.Errorf("omarchyThemeDir() = %q, want %q", got, want)
+	}
+}
+
+// With no Omarchy install at all the resolver still needs a path to name in its
+// warning, and the current generation is the one to name.
+func TestOmarchyThemeDir_NoInstallNamesStateDir(t *testing.T) {
+	stateRoot, _ := omarchyHome(t)
+	want := filepath.Join(stateRoot, "omarchy", "current", "theme")
+
+	if got := omarchyThemeDir(); got != want {
+		t.Errorf("omarchyThemeDir() = %q, want %q", got, want)
 	}
 }
 
@@ -268,6 +454,69 @@ func containsAny(xs []string, sub string) bool {
 		}
 	}
 	return false
+}
+
+// writeOmarchyColors writes a colors.toml with the given body into a new dir.
+func writeOmarchyColors(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "colors.toml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// Omarchy 4 declares appearance with a mode key inside colors.toml. No Quattro
+// theme ships the light.mode marker, so a marker-only check reports every light
+// theme as dark.
+func TestOmarchyAutoAppearance_ModeKey(t *testing.T) {
+	light := writeOmarchyColors(t, "mode = \"light\"\nbackground = \"#ffffff\"\n")
+	if got := omarchyAutoAppearance(light); got != "light" {
+		t.Errorf("mode = \"light\" → %q, want light", got)
+	}
+
+	dark := writeOmarchyColors(t, "mode = \"dark\"\nbackground = \"#1a1b26\"\n")
+	if got := omarchyAutoAppearance(dark); got != "dark" {
+		t.Errorf("mode = \"dark\" → %q, want dark", got)
+	}
+}
+
+// The mode key is canonical, so it wins over a stale marker left behind by an
+// upgrade.
+func TestOmarchyAutoAppearance_ModeKeyWinsOverMarker(t *testing.T) {
+	dir := writeOmarchyColors(t, "mode = \"dark\"\nbackground = \"#1a1b26\"\n")
+	if err := os.WriteFile(filepath.Join(dir, "light.mode"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := omarchyAutoAppearance(dir); got != "dark" {
+		t.Errorf("mode = \"dark\" alongside a light.mode marker → %q, want dark", got)
+	}
+}
+
+// A mode value outside light/dark is not a verdict; the marker still decides.
+func TestOmarchyAutoAppearance_UnknownModeFallsThrough(t *testing.T) {
+	dir := writeOmarchyColors(t, "mode = \"sepia\"\nbackground = \"#ffffff\"\n")
+	if err := os.WriteFile(filepath.Join(dir, "light.mode"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := omarchyAutoAppearance(dir); got != "light" {
+		t.Errorf("unrecognised mode with a light.mode marker → %q, want light", got)
+	}
+}
+
+// A colors.toml that cannot be parsed must not claim an appearance it does not
+// know; the marker still decides.
+func TestOmarchyAutoAppearance_MalformedFallsBackToMarker(t *testing.T) {
+	dir := writeOmarchyColors(t, "= not toml =")
+	if err := os.WriteFile(filepath.Join(dir, "light.mode"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := omarchyAutoAppearance(dir); got != "light" {
+		t.Errorf("malformed colors.toml with a light.mode marker → %q, want light", got)
+	}
 }
 
 func TestOmarchyAutoAppearance(t *testing.T) {

--- a/internal/cli/tui/theme/omarchywatch.go
+++ b/internal/cli/tui/theme/omarchywatch.go
@@ -18,7 +18,8 @@ type ApplyThemeMsg struct{ Theme *Theme }
 // OmarchyWatcher watches the Omarchy current-theme symlink and its parent dir
 // for changes and re-resolves the "omarchy" theme on any event. It handles both
 // the atomic symlink swap omarchy-theme-set performs (repointing
-// ~/.config/omarchy/current/theme) and an in-place colors.toml edit.
+// <omarchy root>/current/theme) and an in-place colors.toml edit. The root is
+// whichever generation's location omarchyThemeDir resolved.
 type OmarchyWatcher struct {
 	w    *fsnotify.Watcher
 	warn func(string)
@@ -29,7 +30,7 @@ type OmarchyWatcher struct {
 	watchedTarget string
 }
 
-// NewOmarchyWatcher starts watching ~/.config/omarchy/{current, current/theme}.
+// NewOmarchyWatcher starts watching <omarchy root>/{current, current/theme}.
 // The watch is best-effort: paths that do not exist yet are skipped (a later
 // create fires on the parent).
 func NewOmarchyWatcher() (*OmarchyWatcher, error) {
@@ -53,13 +54,13 @@ func NewOmarchyWatcher() (*OmarchyWatcher, error) {
 // across swaps and firing a spurious ApplyThemeMsg if the old (no-longer-
 // current) theme's colors.toml is later edited.
 func (o *OmarchyWatcher) arm() {
-	cfgRoot := omarchyThemeDir()     // .../omarchy/current/theme
-	current := filepath.Dir(cfgRoot) // .../omarchy/current
-	parent := filepath.Dir(current)  // .../omarchy
-	_ = o.w.Add(parent)              // ignore errors: not-yet-existing paths fire via parent
+	themeDir := omarchyThemeDir()     // .../omarchy/current/theme
+	current := filepath.Dir(themeDir) // .../omarchy/current
+	parent := filepath.Dir(current)   // .../omarchy
+	_ = o.w.Add(parent)               // ignore errors: not-yet-existing paths fire via parent
 	_ = o.w.Add(current)
 
-	target, err := filepath.EvalSymlinks(cfgRoot)
+	target, err := filepath.EvalSymlinks(themeDir)
 	if err != nil {
 		// No install yet, or a dangling symlink: leave watchedTarget as-is
 		// (best-effort; a later create fires on "current").

--- a/internal/cli/tui/theme/omarchywatch_test.go
+++ b/internal/cli/tui/theme/omarchywatch_test.go
@@ -13,17 +13,32 @@ import (
 	"time"
 )
 
-// setupOmarchyHome builds a ~/.config/omarchy/current/theme -> themes/<name>
-// layout under a temp HOME and returns (home, root). This matches the
-// omarchyThemeDir() contract pinned by TestResolve_OmarchyRoutesToOmarchyResolver
-// (Phase A): "current" is a stable directory; "theme" is the symlink that
-// omarchy-theme-set atomically repoints.
+// setupOmarchyHome builds an Omarchy 3 layout: ~/.config/omarchy/current/theme
+// -> themes/<name>, under a temp HOME. Returns (home, root).
 func setupOmarchyHome(t *testing.T, initial string) (string, string) {
+	t.Helper()
+	return setupOmarchyHomeUnder(t, ".config", initial)
+}
+
+// setupQuattroOmarchyHome builds an Omarchy 4 layout, where the active theme
+// lives under ~/.local/state instead of ~/.config.
+func setupQuattroOmarchyHome(t *testing.T, initial string) (string, string) {
+	t.Helper()
+	return setupOmarchyHomeUnder(t, filepath.Join(".local", "state"), initial)
+}
+
+// setupOmarchyHomeUnder builds a <home>/<rel>/omarchy/current/theme ->
+// themes/<name> layout under a temp HOME and returns (home, root). "current" is
+// a stable directory; "theme" is the symlink that omarchy-theme-set atomically
+// repoints. Both XDG roots are pinned at the temp HOME so the ambient
+// environment cannot supply a competing Omarchy install.
+func setupOmarchyHomeUnder(t *testing.T, rel, initial string) (string, string) {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	root := filepath.Join(home, ".config", "omarchy")
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	root := filepath.Join(home, rel, "omarchy")
 	themes := filepath.Join(root, "themes")
 	current := filepath.Join(root, "current")
 	if err := os.MkdirAll(filepath.Join(themes, initial), 0o755); err != nil {
@@ -85,6 +100,46 @@ func TestOmarchyWatcher_InPlaceEdit(t *testing.T) {
 	}
 	if th.Palette.PrimaryAccent.Dark != "#abcdef" {
 		t.Errorf("PrimaryAccent.Dark = %q, want #abcdef after edit", th.Palette.PrimaryAccent.Dark)
+	}
+}
+
+// Live theme following must work on the Omarchy 4 layout, where the active
+// theme lives under ~/.local/state and the ~/.config location no longer exists.
+// The watcher takes its roots from omarchyThemeDir(), so it follows a semantic
+// (colorN-free) palette through an atomic theme swap there.
+func TestOmarchyWatcher_SymlinkSwapUnderStateDir(t *testing.T) {
+	_, root := setupQuattroOmarchyHome(t, "alpha")
+	themes := filepath.Join(root, "themes")
+	if err := os.MkdirAll(filepath.Join(themes, "beta"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A Quattro palette: semantic names, no ANSI colorN keys.
+	if err := os.WriteFile(filepath.Join(themes, "beta", "colors.toml"),
+		[]byte("mode=\"dark\"\nbackground=\"#000000\"\nforeground=\"#ffffff\"\naccent=\"#beef00\"\nmuted=\"#888888\"\nred=\"#ff0000\"\ngreen=\"#00ff00\"\nyellow=\"#ffff00\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	w, err := NewOmarchyWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	tmp := filepath.Join(themes, "theme.tmp")
+	if err := os.Symlink(filepath.Join(themes, "beta"), tmp); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(tmp, filepath.Join(root, "current", "theme")); err != nil {
+		t.Fatal(err)
+	}
+
+	th := drainOne(t, w)
+	if th == nil || th.Palette.PrimaryAccent.Dark != "#beef00" {
+		t.Fatalf("after swap under the state dir, PrimaryAccent = %v, want #beef00", th)
+	}
+	// The semantic palette drove the status colors, not quiet's inherited ones.
+	if th.Palette.Error.Dark != "#ff0000" {
+		t.Errorf("Error = %q, want #ff0000 from the semantic red", th.Palette.Error.Dark)
 	}
 }
 

--- a/internal/schema/pkl/assets/formae/Config.pkl
+++ b/internal/schema/pkl/assets/formae/Config.pkl
@@ -305,8 +305,10 @@ class CliConfig {
 
     // Theme name: a built-in (quiet, rich, colorblind, omarchy) or the stem of
     // a TOML file in ~/.config/formae/themes/. "omarchy" derives its palette
-    // live from ~/.config/omarchy/current/theme/colors.toml. "formae" is an
-    // alias for quiet. Unknown names fall back to quiet at runtime.
+    // live from the active Omarchy theme's colors.toml, found under
+    // ~/.local/state/omarchy/current/theme (Omarchy 4) or
+    // ~/.config/omarchy/current/theme (Omarchy 3). "formae" is an alias for
+    // quiet. Unknown names fall back to quiet at runtime.
     theme: String = "quiet"
 
     // Appearance selects which side of every adaptive color the CLI renders:


### PR DESCRIPTION
## Summary

Omarchy 4 ("Quattro", currently in beta) changes three things the `omarchy` CLI theme depends on. Any one of them alone takes theme following down, so this adds support for the new generation while keeping Omarchy 3 working unchanged.

**1. The active theme directory moved.** Quattro relocates it from `~/.config/omarchy/current/theme` to `~/.local/state/omarchy/current/theme`, and the upgrade migration deletes the old path outright without leaving a compatibility symlink. formae looked only in the config dir, so on a Quattro machine it found nothing and fell back to `quiet`. Both locations are now probed, current generation first.

**2. `colors.toml` changed format.** The ANSI `color0`..`color15` keys are gone, replaced by semantic role names (`muted`, `red`, `green`, `yellow`, `blue`, `magenta`, `light_foreground`) plus a wider 24-color set. Only `background`, `foreground` and `accent` survived, so even with the path fixed most of the palette would have gone unset and silently inherited `quiet`'s colors. Each palette slot now resolves from the semantic name before the ANSI slot it replaced, using omarchy's own alias pairings.

**3. Light themes declare `mode` instead of a marker file.** No Quattro theme ships `light.mode`; appearance is a `mode` key inside `colors.toml`. The marker-only check reported all five light themes as dark under `cli.appearance = "auto"`. Appearance now reads `mode`, falling back to the marker.

## Compatibility

The two vocabularies are disjoint in practice, so no format detection or normalization layer is needed: an Omarchy 3 `colors.toml` leaves every semantic field empty and each fallback chain reduces to exactly what it was. Confirmed that no published Omarchy 3 theme defines any semantic key.

Verified against every published theme of both generations:

- All 22 Omarchy 4 themes fill every palette slot, report their declared mode, and produce a selection band that clears the WCAG contrast floor against their own text.
- All 19 Omarchy 3 themes resolve to an identical palette (deep-equal over the whole palette) and still take their appearance from the marker file.

## Notes

- Quattro's `selection` key is deliberately left unmapped, for the same reason `selection_background` already was: it is a text-selection color paired with a foreground replacement, so mapping it onto the cursor-row band can put the band directly behind text of the same color. The band stays derived from the background.
- `Surface` still mirrors `background`. Quattro's `dark_background` / `lighter_background` would allow a real raised/recessed distinction, but that is left alone rather than guessing the direction.
- omarchy's legacy `theme_type` key and its background-luminance mode guess are not mirrored. No Omarchy theme has ever shipped `theme_type`, and the luminance guess only applies to hand-written user themes declaring no mode, which reach the same dark default anyway.
- The watcher needed no logic change; it takes its roots from the theme-directory resolution and follows automatically. New coverage pins live theme following on the Quattro layout.

The upstream PR is still open and pre-release, so the format could shift before it merges. The `mode` key and the semantic names are load-bearing for Quattro's whole templating system; the derivation constants are less settled.