### PR TITLE
fix(secrets): keep secret material out of the synthesized cascade patch

### DIFF
--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/constants"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/transformations"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
@@ -1614,6 +1615,14 @@ func synthesizeCascadeUpdatePatch(
 		}
 		path := jsonPointerFromDotPath(ref.TargetPath)
 
+		// A secret never travels in this document. What is synthesized here is
+		// presentation data — it reaches simulate output, the CLI, the stored
+		// changeset and the logs — and it is built from the incoming forma,
+		// which has not been through the persist-time hashing, so a secret
+		// written as a literal arrives in cleartext. The change is still
+		// named: only the value is withheld.
+		opaqueSource := cascadeSourceIsOpaque(dep, ref, formaByKsuid[ksuid])
+
 		// Try to recover the new value from the forma's parent state.
 		// For REPLACE'd parents, the recovered value is only trustworthy
 		// for user-provided source fields. Provider-assigned fields
@@ -1622,7 +1631,7 @@ func synthesizeCascadeUpdatePatch(
 		// cached one — emit the marker so the renderer uses the friendly
 		// "to point at the new <source>" phrasing instead of misleading
 		// the operator with a stale concrete value.
-		if parent, ok := formaByKsuid[ksuid]; ok && parent != nil && ref.SourcePropertyName != "" && len(parent.Properties) > 0 {
+		if parent, ok := formaByKsuid[ksuid]; ok && !opaqueSource && parent != nil && ref.SourcePropertyName != "" && len(parent.Properties) > 0 {
 			sourceFieldIsProviderAssigned := false
 			if replacedKsuids[ksuid] {
 				if hint, hintOk := parent.Schema.Hints[stripArrayIndicesForHintLookup(ref.SourcePropertyName)]; hintOk && hint.HasProviderDefault {
@@ -1638,15 +1647,21 @@ func synthesizeCascadeUpdatePatch(
 			}
 		}
 
-		// Provider-assigned source on a REPLACE'd parent (or no recoverable
-		// value at all): emit a marker the CLI renderer recognises.
+		// Provider-assigned source on a REPLACE'd parent, an opaque source, or
+		// no recoverable value at all: emit a marker the CLI renderer
+		// recognises. An opaque source carries no current value; the renderer
+		// omits the "(current: …)" clause and still names the source.
+		currentValue := ref.CurrentValue
+		if opaqueSource {
+			currentValue = ""
+		}
 		ops = append(ops, op{
 			Op:   "replace",
 			Path: path,
 			Value: map[string]any{
 				"$cascade-resolvable": true,
 				"$source-label":       ksuidToLabel[ksuid],
-				"$current-value":      ref.CurrentValue,
+				"$current-value":      currentValue,
 			},
 		})
 	}
@@ -1654,6 +1669,30 @@ func synthesizeCascadeUpdatePatch(
 		return nil, nil
 	}
 	return json.Marshal(ops)
+}
+
+// cascadeSourceIsOpaque reports whether the value a cascade op would carry for
+// this reference is a secret, asking all three places that can know it.
+//
+// The consumer's own envelope is asked first because it is the only one always
+// present: the parent may be absent from the forma entirely, and a reference
+// into a secret carries the visibility it inherited from the source's schema.
+// The parent, when present, is asked both by schema (the declaration, via the
+// same union of schema hints and the agent-side known-opaque table that
+// persistence hashes on) and by value (an inline opaque envelope), since a
+// value can be opaque either way.
+func cascadeSourceIsOpaque(dep pkgmodel.Resource, ref resolver.ResolvableRef, parent *pkgmodel.Resource) bool {
+	if gjson.GetBytes(dep.Properties, ref.TargetPath).Get("$visibility").String() == pkgmodel.VisibilityOpaque {
+		return true
+	}
+	if parent == nil || ref.SourcePropertyName == "" {
+		return false
+	}
+	property := stripArrayIndicesForHintLookup(ref.SourcePropertyName)
+	if referencesOpaqueProperty(transformations.OpaqueFields(parent.Schema, parent.Type), property) {
+		return true
+	}
+	return gjson.GetBytes(parent.Properties, ref.SourcePropertyName).Get("$visibility").String() == pkgmodel.VisibilityOpaque
 }
 
 // looksLikeResolvable reports whether a gjson Result is itself a $ref/$value

--- a/internal/metastructure/resource_update/resource_update_generator_cascade_opacity_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_cascade_opacity_test.go
@@ -1,0 +1,144 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+const (
+	cascadeSecret = "sup3rs3cret-plaintext"
+	cascadeDigest = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+// secretHolder is the resource being deleted or replaced: it declares an
+// opaque property, held in one of the shapes a value takes over its lifetime.
+func secretHolder(ksuid, heldAs string) *pkgmodel.Resource {
+	return &pkgmodel.Resource{
+		Label: "db",
+		Type:  "Test::Database",
+		Ksuid: ksuid,
+		Schema: pkgmodel.Schema{
+			Fields: []string{"Name", "GeneratedPassword"},
+			Hints:  map[string]pkgmodel.FieldHint{"GeneratedPassword": {Opaque: true}},
+		},
+		Properties: json.RawMessage(`{"Name":"db","GeneratedPassword":` + heldAs + `}`),
+	}
+}
+
+// secretConsumer references the holder's opaque property, carrying the cached
+// resolution the consumer last saw at that path.
+func secretConsumer(ksuid, cachedValue string) pkgmodel.Resource {
+	return pkgmodel.Resource{
+		Label: "app",
+		Type:  "Test::App",
+		Properties: json.RawMessage(`{"AppName":"app","DbPassword":{` +
+			`"$ref":"formae://` + ksuid + `#/GeneratedPassword","$value":"` + cachedValue + `"}}`),
+	}
+}
+
+// TestSynthesizeCascadeUpdatePatch_DoesNotEmitSecretMaterial asserts that the
+// patch synthesized for a cascade update never carries secret material.
+//
+// That document is presentation data: it reaches simulate output, the CLI
+// renderer, the stored changeset and the logs. It is built from the incoming
+// forma, which has not been through the persist-time hashing, so a secret
+// written as a literal arrives here in cleartext.
+//
+// The change must still be named, so the source label survives redaction; only
+// the value is withheld.
+func TestSynthesizeCascadeUpdatePatch_DoesNotEmitSecretMaterial(t *testing.T) {
+	const parentKsuid = "dbksuid00000000000000000000"
+
+	cases := []struct {
+		name        string
+		heldAs      string
+		cachedValue string
+	}{
+		{
+			// A literal in the forma, before any persist-time hashing.
+			name:        "source held as a bare value",
+			heldAs:      `"` + cascadeSecret + `"`,
+			cachedValue: cascadeSecret,
+		},
+		{
+			name:        "source held as an opaque envelope",
+			heldAs:      `{"$value":"` + cascadeSecret + `","$visibility":"Opaque"}`,
+			cachedValue: cascadeSecret,
+		},
+		{
+			// Already hashed at rest: the digest is not cleartext, but it is
+			// still the stored form of a secret and has no business in a plan.
+			name:        "source held as a hashed envelope",
+			heldAs:      `{"$value":"` + cascadeDigest + `","$visibility":"Opaque","$hashed":true}`,
+			cachedValue: cascadeDigest,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			patchDoc, err := synthesizeCascadeUpdatePatch(
+				secretConsumer(parentKsuid, tc.cachedValue),
+				map[string]bool{parentKsuid: true},
+				nil,
+				map[string]string{parentKsuid: "db"},
+				map[string]*pkgmodel.Resource{parentKsuid: secretHolder(parentKsuid, tc.heldAs)},
+			)
+			require.NoError(t, err)
+			require.NotEmpty(t, patchDoc, "the cascade op must still be planned")
+
+			patch := string(patchDoc)
+			assert.NotContains(t, patch, cascadeSecret,
+				"the synthesized patch is presentation data and must not carry the secret: %s", patch)
+			assert.NotContains(t, patch, cascadeDigest,
+				"the stored digest of a secret must not reach the plan either: %s", patch)
+
+			assert.Contains(t, patch, `"path":"/DbPassword"`,
+				"the change must still be named so the operator sees it")
+			assert.Contains(t, patch, `"db"`,
+				"the source label must survive redaction so the renderer can name the parent")
+		})
+	}
+}
+
+// TestSynthesizeCascadeUpdatePatch_NonSecretValueSurvives asserts the guard
+// stays narrow: an ordinary value is still carried, so the operator keeps
+// seeing what a cascade is about to set.
+func TestSynthesizeCascadeUpdatePatch_NonSecretValueSurvives(t *testing.T) {
+	const parentKsuid = "vpcksuid0000000000000000000"
+
+	parent := &pkgmodel.Resource{
+		Label:      "vpc",
+		Type:       "Test::VPC",
+		Ksuid:      parentKsuid,
+		Schema:     pkgmodel.Schema{Fields: []string{"VpcId"}},
+		Properties: json.RawMessage(`{"VpcId":"vpc-12345"}`),
+	}
+	consumer := pkgmodel.Resource{
+		Label: "subnet",
+		Type:  "Test::Subnet",
+		Properties: json.RawMessage(`{"VpcRef":{"$ref":"formae://` + parentKsuid +
+			`#/VpcId","$value":"vpc-old"}}`),
+	}
+
+	patchDoc, err := synthesizeCascadeUpdatePatch(
+		consumer,
+		map[string]bool{parentKsuid: true},
+		nil,
+		map[string]string{parentKsuid: "vpc"},
+		map[string]*pkgmodel.Resource{parentKsuid: parent},
+	)
+	require.NoError(t, err)
+	assert.Contains(t, string(patchDoc), "vpc-12345",
+		"a non-secret cascade value must still be shown")
+}


### PR DESCRIPTION
## What

`synthesizeCascadeUpdatePatch` builds the patch shown for a cascade update — the op list a consumer gets when a resource it references is deleted or replaced. That document is **presentation data**: simulate output, the CLI renderer, the stored changeset, and the logs. It applied no opacity guard.

Two paths, with different reachability.

**Direct extraction — reachable, and cleartext.** The value is read straight out of the parent in `formaByKsuid`, which is built from `forma.Resources`, the incoming user declaration. That has never been through `PersistValueTransformer`, so a secret written as a literal in a forma arrives here in the clear. `looksLikeResolvable` only skips `$ref`/`$value` wrappers, so a bare string is not skipped:

```json
[{"op":"replace","path":"/DbPassword","value":"sup3rs3cret-plaintext"}]
```

**Marker fallback — unguarded, usually a digest.** When direct extraction is skipped, the marker embeds the consumer's cached `$value`. For correctly persisted data that is a digest rather than cleartext, but nothing enforced it:

```json
[{"op":"replace","path":"/DbPassword","value":{"$cascade-resolvable":true,"$current-value":"sup3rs3cret-plaintext","$source-label":"db"}}]
```

## Fix

`cascadeSourceIsOpaque` asks all three places that can know whether the value is a secret:

- the **consumer's own envelope** — asked first because it is the only one always present (the parent may be absent from the forma entirely), and because a reference into a secret carries the visibility it inherited from the source's schema;
- the **parent's schema**, through `transformations.OpaqueFields`, the same union of schema hints and the agent-side known-opaque table that persistence hashes on, so the plan and the datastore cannot disagree about what is secret;
- the **parent's value**, for an inline opaque envelope.

An opaque source takes the marker path with an empty `$current-value`. The renderer already omits the `(current: …)` clause when that is empty, so the line degrades to `set /DbPassword → new db` — the change stays named, only the value is withheld. That is redaction rather than omission, as the issue asked for.

**A digest is withheld too.** The issue treated the hashed-envelope case as passing, since a digest is not cleartext. I've made it stricter: a digest is the stored form of a secret and has no business in a plan. Say the word if you'd rather keep showing it.

## Tests

`resource_update_generator_cascade_opacity_test.go` covers all three shapes a source value takes (bare literal, opaque envelope, hashed envelope), asserting no secret material reaches the patch while the path and source label survive. All three fail without the fix, reproducing the reported output byte-for-byte.

A companion test pins that the guard stays narrow: an ordinary value is still carried, so the operator keeps seeing what a cascade will set. The pre-existing `TestSynthesizeCascadeUpdatePatch_ProviderAssignedSource`, which asserts the marker carries the current value "so the user sees what's being replaced", still passes.

## Scope

Independent of the conditional-propagation work. This defect is on the shipped delete/replace cascade path today; widening the set of references that flow through the synthesizer would raise exposure but did not introduce it.

`make test-unit` and `make lint` are green.