### PR TITLE
feat(cli): resolve the agent connection as a sum type and route hosted requests

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"syscall"
 	"time"
@@ -25,7 +26,14 @@ type Client struct {
 	resty    *resty.Client
 }
 
-func NewClient(cfg pkgmodel.APIConfig, auth http.Header, net *http.Client) *Client {
+// InstallationHeader routes a request to one hosted installation. The edge
+// rejects it duplicated or comma-joined, so it is set once on the client.
+const InstallationHeader = "Formae-Installation"
+
+// NewClient builds an API client for a resolved connection. The arm decides
+// both the endpoint and the headers: a hosted connection always carries the
+// installation routing header, a classic one never does.
+func NewClient(conn pkgmodel.Connection, auth http.Header, net *http.Client) *Client {
 	client := resty.New()
 
 	if net != nil {
@@ -34,6 +42,16 @@ func NewClient(cfg pkgmodel.APIConfig, auth http.Header, net *http.Client) *Clie
 
 	if auth != nil {
 		client.SetHeader("Authorization", auth.Get("Authorization"))
+	}
+
+	endpoint := ""
+	switch c := conn.(type) {
+	case *pkgmodel.HostedConnection:
+		endpoint = c.Endpoint
+		client.SetHeader(InstallationHeader, c.Installation)
+		client.SetRedirectPolicy(sameOriginRedirectPolicy(c.Endpoint))
+	case *pkgmodel.ClassicConnection:
+		endpoint = formatEndpoint(c.URL, c.Port)
 	}
 
 	// Return a clear error for 401 responses instead of letting each method
@@ -45,17 +63,59 @@ func NewClient(cfg pkgmodel.APIConfig, auth http.Header, net *http.Client) *Clie
 		return nil
 	})
 
-	return &Client{
-		endpoint: formatEndpoint(cfg.URL, cfg.Port),
-		resty:    client,
+	return &Client{endpoint: endpoint, resty: client}
+}
+
+// sameOriginRedirectPolicy refuses any redirect that leaves the configured
+// origin. Go strips Authorization across a cross-host redirect but forwards
+// custom headers, so without this the installation routing header would
+// follow the redirect to another server. resty's DomainCheckRedirectPolicy is
+// not enough here: it compares hostnames and ignores the port.
+func sameOriginRedirectPolicy(endpoint string) resty.RedirectPolicy {
+	configured, err := url.Parse(endpoint)
+	if err != nil {
+		return resty.NoRedirectPolicy()
 	}
+	want := originOf(configured)
+
+	return resty.RedirectPolicyFunc(func(req *http.Request, via []*http.Request) error {
+		if got := originOf(req.URL); got != want {
+			return fmt.Errorf(
+				"refusing to follow a redirect from %s to %s: hosted requests carry a credential "+
+					"and installation routing", want, got,
+			)
+		}
+		// Same origin: carry the original headers across, which is what
+		// resty's own policies do for a same-host redirect.
+		for k, v := range via[0].Header {
+			if _, exists := req.Header[k]; !exists {
+				req.Header[k] = v
+			}
+		}
+		return nil
+	})
+}
+
+// originOf renders scheme://host:port with the scheme's default port made
+// explicit, so the same host on another port is a different origin.
+func originOf(u *url.URL) string {
+	port := u.Port()
+	if port == "" {
+		port = "80"
+		if strings.EqualFold(u.Scheme, "https") {
+			port = "443"
+		}
+	}
+	return strings.ToLower(u.Scheme+"://"+u.Hostname()) + ":" + port
 }
 
 // formatEndpoint builds the API endpoint string. It omits the port when it
 // matches the scheme default (443 for HTTPS, 80 for HTTP) so that Go's HTTP
-// client does not include a redundant port in the Host header.
+// client does not include a redundant port in the Host header, and when the
+// port is zero, which means the URL already carries one.
 func formatEndpoint(url string, port int) string {
-	if (port == 443 && strings.HasPrefix(url, "https://")) ||
+	if port == 0 ||
+		(port == 443 && strings.HasPrefix(url, "https://")) ||
 		(port == 80 && strings.HasPrefix(url, "http://")) {
 		return url
 	}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -85,13 +85,6 @@ func sameOriginRedirectPolicy(endpoint string) resty.RedirectPolicy {
 					"and installation routing", want, got,
 			)
 		}
-		// Same origin: carry the original headers across, which is what
-		// resty's own policies do for a same-host redirect.
-		for k, v := range via[0].Header {
-			if _, exists := req.Header[k]; !exists {
-				req.Header[k] = v
-			}
-		}
 		return nil
 	})
 }

--- a/internal/api/client_connection_test.go
+++ b/internal/api/client_connection_test.go
@@ -1,0 +1,130 @@
+//go:build unit
+
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func recordingServer(t *testing.T, seen *[]http.Header) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*seen = append(*seen, r.Header.Clone())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"0.0.0"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestHostedConnectionSendsInstallationHeaderOnEveryRequest(t *testing.T) {
+	var seen []http.Header
+	srv := recordingServer(t, &seen)
+
+	conn := &pkgmodel.HostedConnection{
+		Endpoint:     srv.URL,
+		Installation: "3f2b8c14-0000-4000-8000-000000000000",
+	}
+	c := NewClient(conn, http.Header{"Authorization": []string{"Bearer t"}}, srv.Client())
+
+	_, err := c.Stats()
+	require.NoError(t, err)
+	_, err = c.Stats()
+	require.NoError(t, err)
+
+	require.Len(t, seen, 2)
+	for _, h := range seen {
+		assert.Equal(t, []string{"3f2b8c14-0000-4000-8000-000000000000"}, h.Values(InstallationHeader),
+			"the edge rejects the routing header duplicated or comma-joined")
+		assert.Equal(t, "Bearer t", h.Get("Authorization"))
+	}
+}
+
+func TestClassicConnectionSendsNoInstallationHeader(t *testing.T) {
+	var seen []http.Header
+	srv := recordingServer(t, &seen)
+
+	c := NewClient(&pkgmodel.ClassicConnection{URL: srv.URL}, nil, srv.Client())
+
+	_, err := c.Stats()
+	require.NoError(t, err)
+
+	require.Len(t, seen, 1)
+	assert.Empty(t, seen[0].Values(InstallationHeader))
+	assert.Empty(t, seen[0].Get("Authorization"))
+}
+
+// A profile that configures an auth plugin against a self-hosted agent still
+// authenticates: classic and unauthenticated are not the same thing.
+func TestClassicConnectionSendsAuthorizationWhenConfigured(t *testing.T) {
+	var seen []http.Header
+	srv := recordingServer(t, &seen)
+
+	c := NewClient(&pkgmodel.ClassicConnection{URL: srv.URL},
+		http.Header{"Authorization": []string{"Basic abc"}}, srv.Client())
+
+	_, err := c.Stats()
+	require.NoError(t, err)
+
+	require.Len(t, seen, 1)
+	assert.Equal(t, "Basic abc", seen[0].Get("Authorization"))
+}
+
+// A redirect to another origin must carry neither the credential nor the
+// routing header. Both test servers listen on 127.0.0.1, so this also pins
+// that the policy compares the port: a hostname-only check would pass here.
+func TestHostedConnectionRefusesCrossOriginRedirect(t *testing.T) {
+	var elsewhereSeen []http.Header
+	elsewhere := recordingServer(t, &elsewhereSeen)
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, elsewhere.URL+"/api/v1/stats", http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(redirector.Close)
+
+	conn := &pkgmodel.HostedConnection{
+		Endpoint:     redirector.URL,
+		Installation: "3f2b8c14-0000-4000-8000-000000000000",
+	}
+	c := NewClient(conn, http.Header{"Authorization": []string{"Bearer t"}}, redirector.Client())
+
+	_, err := c.Stats()
+	require.Error(t, err)
+	assert.Empty(t, elsewhereSeen, "neither the credential nor the routing header may reach another origin")
+}
+
+func TestHostedConnectionFollowsSameOriginRedirect(t *testing.T) {
+	var seen []http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/redirected" {
+			http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+			return
+		}
+		seen = append(seen, r.Header.Clone())
+		_, _ = w.Write([]byte(`{"version":"0.0.0"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	conn := &pkgmodel.HostedConnection{
+		Endpoint:     srv.URL,
+		Installation: "3f2b8c14-0000-4000-8000-000000000000",
+	}
+	c := NewClient(conn, http.Header{"Authorization": []string{"Bearer t"}}, srv.Client())
+
+	_, err := c.Stats()
+	require.NoError(t, err)
+	require.Len(t, seen, 1)
+	assert.Equal(t, "3f2b8c14-0000-4000-8000-000000000000", seen[0].Get(InstallationHeader))
+	assert.Equal(t, "Bearer t", seen[0].Get("Authorization"))
+}

--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -89,8 +89,8 @@ type App struct {
 
 	// newAPIClient constructs the API client used for a single retried
 	// operation. Nil in the real constructor, where it defaults to
-	// api.NewClient against a.Config.Cli.API; tests inject a stub pointed at
-	// an httptest server.
+	// api.NewClient against a.Config.Cli.Connection; tests inject a stub
+	// pointed at an httptest server.
 	newAPIClient func(authHeader http.Header, net *http.Client) *api.Client
 }
 
@@ -120,7 +120,7 @@ func (a *App) NewClient() (*api.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return api.NewClient(a.Config.Cli.API, auth, net), nil
+	return api.NewClient(a.Config.Cli.Connection, auth, net), nil
 }
 
 // Theme resolves the active CLI theme from config, falling back to quiet when
@@ -839,12 +839,13 @@ func (a *App) authProvider() (authHeaderProvider, error) {
 
 // apiClient constructs an API client for a single operation from the given
 // auth header and network client, preferring the injectable newAPIClient
-// (set by tests) and falling back to api.NewClient against a.Config.Cli.API.
+// (set by tests) and falling back to api.NewClient against
+// a.Config.Cli.Connection.
 func (a *App) apiClient(authHeader http.Header, net *http.Client) *api.Client {
 	if a.newAPIClient != nil {
 		return a.newAPIClient(authHeader, net)
 	}
-	return api.NewClient(a.Config.Cli.API, authHeader, net)
+	return api.NewClient(a.Config.Cli.Connection, authHeader, net)
 }
 
 // withAuthRetry runs op once with the current auth header. When op fails

--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -789,7 +789,7 @@ func (*NoAuthPluginError) Error() string {
 // block, so callers that need a plugin outright — such as `formae login` —
 // can fail with a clear message instead of dereferencing a nil client.
 func (a *App) AuthClient() (*pkgauth.Client, error) {
-	if a.Config.Cli.Auth == nil {
+	if a.Config.Cli.AuthConfig() == nil {
 		return nil, &NoAuthPluginError{}
 	}
 
@@ -797,7 +797,7 @@ func (a *App) AuthClient() (*pkgauth.Client, error) {
 	defer a.memoMu.Unlock()
 
 	if a.authClient == nil {
-		authType := gjson.GetBytes(a.Config.Cli.Auth, "type").String()
+		authType := gjson.GetBytes(a.Config.Cli.AuthConfig(), "type").String()
 		devPluginDir := util.ExpandHomePath(a.Config.PluginDir)
 		binPath, err := os.Executable()
 		if err != nil {
@@ -817,7 +817,7 @@ func (a *App) AuthClient() (*pkgauth.Client, error) {
 		if matched == nil {
 			return nil, fmt.Errorf("auth plugin %q not installed", authType)
 		}
-		client, err := pkgauth.NewClient(matched.BinaryPath, a.Config.Cli.Auth)
+		client, err := pkgauth.NewClient(matched.BinaryPath, a.Config.Cli.AuthConfig())
 		if err != nil {
 			return nil, fmt.Errorf("failed to start auth plugin: %w", err)
 		}
@@ -873,7 +873,7 @@ func (a *App) withAuthRetry(op func(authHeader http.Header, net *http.Client) er
 	}
 
 	var authErr api.AuthenticationError
-	if !errors.As(err, &authErr) || a.Config.Cli.Auth == nil {
+	if !errors.As(err, &authErr) || a.Config.Cli.AuthConfig() == nil {
 		return err
 	}
 
@@ -958,7 +958,7 @@ func hasCredential(headers map[string][]string) bool {
 func (a *App) getAuthAndNetHandlers() (http.Header, *http.Client, error) {
 	var authHeader http.Header
 
-	if a.Config.Cli.Auth != nil {
+	if a.Config.Cli.AuthConfig() != nil {
 		client, err := a.authProvider()
 		if err != nil {
 			return nil, nil, err

--- a/internal/cli/app/app_apply_integration_test.go
+++ b/internal/cli/app/app_apply_integration_test.go
@@ -59,7 +59,7 @@ func TestApply_PreflightAndSubmissionAreSeparateHits(t *testing.T) {
 	a := &App{
 		Config: &pkgmodel.Config{
 			Cli: pkgmodel.CliConfig{
-				API:                   pkgmodel.APIConfig{URL: ts.URL, Port: 80},
+				Connection:            &pkgmodel.ClassicConnection{URL: ts.URL, Port: 80},
 				DisableUsageReporting: true,
 			},
 		},

--- a/internal/cli/app/app_auth_retry_test.go
+++ b/internal/cli/app/app_auth_retry_test.go
@@ -104,7 +104,11 @@ func appWithAuthPlugin(provider authHeaderProvider) *App {
 	return &App{
 		Config: &pkgmodel.Config{
 			Cli: pkgmodel.CliConfig{
-				Auth: json.RawMessage(`{"type":"stub"}`),
+				Connection: &pkgmodel.ClassicConnection{
+					URL:  "http://localhost",
+					Port: 49684,
+					Auth: json.RawMessage(`{"type":"stub"}`),
+				},
 			},
 		},
 		authClientFactory: func() (authHeaderProvider, error) { return provider, nil },
@@ -256,7 +260,13 @@ func TestWithAuthRetry_ForcedAuthClientFailureSurfacesRealError(t *testing.T) {
 	calls := 0
 	a := &App{
 		Config: &pkgmodel.Config{
-			Cli: pkgmodel.CliConfig{Auth: json.RawMessage(`{"type":"stub"}`)},
+			Cli: pkgmodel.CliConfig{
+				Connection: &pkgmodel.ClassicConnection{
+					URL:  "http://localhost",
+					Port: 49684,
+					Auth: json.RawMessage(`{"type":"stub"}`),
+				},
+			},
 		},
 		authClientFactory: func() (authHeaderProvider, error) {
 			calls++
@@ -534,7 +544,7 @@ func TestWithAuthRetry_HTTPIntegration(t *testing.T) {
 		forcedResp:  headerResp("fresh"),
 	}
 	a := newAppWithServer(ts.URL)
-	a.Config.Cli.Auth = json.RawMessage(`{"type":"stub"}`)
+	a.Config.Cli.Connection.(*pkgmodel.ClassicConnection).Auth = json.RawMessage(`{"type":"stub"}`)
 	a.authClientFactory = func() (authHeaderProvider, error) { return provider, nil }
 
 	var stats *apimodel.Stats
@@ -575,7 +585,7 @@ func TestRunBeforeCommand_StylesAuthorizationDeniedError(t *testing.T) {
 		forcedResp:  headerResp("still-stale"),
 	}
 	a := newAppWithServer(ts.URL)
-	a.Config.Cli.Auth = json.RawMessage(`{"type":"stub"}`)
+	a.Config.Cli.Connection.(*pkgmodel.ClassicConnection).Auth = json.RawMessage(`{"type":"stub"}`)
 	a.authClientFactory = func() (authHeaderProvider, error) { return provider, nil }
 
 	compatible, _, _, err := a.runBeforeCommand(true)

--- a/internal/cli/app/resource_wrappers_test.go
+++ b/internal/cli/app/resource_wrappers_test.go
@@ -39,7 +39,7 @@ func newAppWithServer(baseURL string) *App {
 	return &App{
 		Config: &pkgmodel.Config{
 			Cli: pkgmodel.CliConfig{
-				API: pkgmodel.APIConfig{
+				Connection: &pkgmodel.ClassicConnection{
 					URL:  baseURL,
 					Port: 80,
 				},

--- a/internal/cli/apply/apply_e2e_test.go
+++ b/internal/cli/apply/apply_e2e_test.go
@@ -122,7 +122,7 @@ func TestApplyTUI_EndToEnd(t *testing.T) {
 	// Port 80 + http URL passes the httptest URL through formatEndpoint unmodified.
 	srv := api.NewServer(t.Context(), fake, nil, nil, nil, nil)
 	baseURL := apitest.NewTestServer(t, srv.Handler())
-	client := api.NewClient(pkgmodel.APIConfig{URL: baseURL, Port: 80}, nil, nil)
+	client := api.NewClient(&pkgmodel.ClassicConnection{URL: baseURL, Port: 80}, nil, nil)
 
 	// Stub the seams: applyFn posts through the REAL HTTP stack; simview is
 	// stubbed to Confirmed; launchWatch runs the REAL statuswatch model via

--- a/internal/cli/cancel/cancel_e2e_test.go
+++ b/internal/cli/cancel/cancel_e2e_test.go
@@ -66,7 +66,7 @@ func TestCancelE2E_PerIDSubmit(t *testing.T) {
 	// Real API server wrapping the fake metastructure; real client against it.
 	srv := api.NewServer(t.Context(), fake, nil, nil, nil, nil)
 	baseURL := apitest.NewTestServer(t, srv.Handler())
-	client := api.NewClient(pkgmodel.APIConfig{URL: baseURL, Port: 80}, nil, nil)
+	client := api.NewClient(&pkgmodel.ClassicConnection{URL: baseURL, Port: 80}, nil, nil)
 
 	// Stub seams to route through the real HTTP stack
 	origGetStatus := getCommandsStatusFn
@@ -154,7 +154,7 @@ func TestCancelE2E_ForceWatch_AbandonedInView(t *testing.T) {
 
 	srv := api.NewServer(t.Context(), fake, nil, nil, nil, nil)
 	baseURL := apitest.NewTestServer(t, srv.Handler())
-	client := api.NewClient(pkgmodel.APIConfig{URL: baseURL, Port: 80}, nil, nil)
+	client := api.NewClient(&pkgmodel.ClassicConnection{URL: baseURL, Port: 80}, nil, nil)
 
 	origGetStatus := getCommandsStatusFn
 	origCancel := cancelCommandFn

--- a/internal/cli/destroy/destroy_e2e_test.go
+++ b/internal/cli/destroy/destroy_e2e_test.go
@@ -121,7 +121,7 @@ func TestDestroyTUI_EndToEnd(t *testing.T) {
 	// Port 80 + http URL passes the httptest URL through formatEndpoint unmodified.
 	srv := api.NewServer(t.Context(), fake, nil, nil, nil, nil)
 	baseURL := apitest.NewTestServer(t, srv.Handler())
-	client := api.NewClient(pkgmodel.APIConfig{URL: baseURL, Port: 80}, nil, nil)
+	client := api.NewClient(&pkgmodel.ClassicConnection{URL: baseURL, Port: 80}, nil, nil)
 
 	// Stub the seams: destroyFn posts through the REAL HTTP stack; simview is
 	// stubbed to Confirmed; launchWatch runs the REAL statuswatch model via
@@ -217,7 +217,7 @@ func TestDestroyTUI_EndToEnd_CascadeAbort(t *testing.T) {
 
 	srv := api.NewServer(t.Context(), fake, nil, nil, nil, nil)
 	baseURL := apitest.NewTestServer(t, srv.Handler())
-	client := api.NewClient(pkgmodel.APIConfig{URL: baseURL, Port: 80}, nil, nil)
+	client := api.NewClient(&pkgmodel.ClassicConnection{URL: baseURL, Port: 80}, nil, nil)
 
 	stubSeams(t)
 

--- a/internal/cli/inventory/inventory_e2e_test.go
+++ b/internal/cli/inventory/inventory_e2e_test.go
@@ -53,7 +53,7 @@ func newE2EApp(baseURL string) *app.App {
 	return &app.App{
 		Config: &pkgmodel.Config{
 			Cli: pkgmodel.CliConfig{
-				API: pkgmodel.APIConfig{
+				Connection: &pkgmodel.ClassicConnection{
 					URL:  baseURL,
 					Port: 80,
 				},

--- a/internal/cli/profile/configview/view.go
+++ b/internal/cli/profile/configview/view.go
@@ -196,10 +196,10 @@ func datastoreView(d pkgmodel.DatastoreConfig, mask string) map[string]any {
 func artifactsView(a pkgmodel.ArtifactConfig, mask string) map[string]any {
 	repos := make([]any, 0, len(a.Repositories))
 	for _, r := range a.Repositories {
-		repos = append(repos, map[string]any{"uri": r.URI.String(), "type": string(r.Type)})
+		repos = append(repos, map[string]any{"uri": r.URI.Redacted(), "type": string(r.Type)})
 	}
 	return map[string]any{
-		"url":          a.URL.String(),
+		"url":          a.URL.Redacted(),
 		"repositories": repos,
 		"username":     maskIfSet(a.Username, mask),
 		"password":     maskIfSet(a.Password, mask),

--- a/internal/cli/profile/configview/view.go
+++ b/internal/cli/profile/configview/view.go
@@ -1,0 +1,267 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+// Package configview builds the redacted, versioned view of a resolved
+// formae configuration that `formae profile show` renders. Both output modes
+// consume this one value, so what counts as a secret cannot differ between
+// them.
+//
+// Inclusion policy: typed non-secret fields are emitted; typed secrets are
+// replaced by the caller's mask; opaque per-plugin blocks are reduced to their
+// type discriminator, and free-form connection parameters are omitted, because
+// in both cases a credential can hide under a key this package cannot name.
+package configview
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/tidwall/gjson"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// SchemaVersion identifies the shape of this view. Consumers read it before
+// anything else; bump it when a field changes meaning or disappears.
+const SchemaVersion = 1
+
+const (
+	// Redacted replaces a secret in machine output.
+	Redacted = "<redacted>"
+	// HumanMask replaces a secret in human output, matching how the CLI masks
+	// opaque values elsewhere.
+	HumanMask = "••••••••"
+)
+
+func From(profile string, cfg *pkgmodel.Config, mask string) map[string]any {
+	v := map[string]any{
+		"schemaVersion": SchemaVersion,
+		"profile":       profile,
+		"cli":           cliView(cfg.Cli),
+		"agent":         agentView(cfg.Agent, mask),
+		"artifacts":     artifactsView(cfg.Artifacts, mask),
+		"pluginDir":     cfg.PluginDir,
+	}
+	if n := networkView(cfg.Network, mask); n != nil {
+		v["network"] = n
+	}
+	if len(cfg.Warnings) > 0 {
+		v["warnings"] = cfg.Warnings
+	}
+	return v
+}
+
+func cliView(cli pkgmodel.CliConfig) map[string]any {
+	return map[string]any{
+		"connection":            connectionView(cli.Connection),
+		"disableUsageReporting": cli.DisableUsageReporting,
+		"theme":                 cli.Theme,
+		"appearance":            cli.Appearance,
+	}
+}
+
+// connectionView tags the arm, so a consumer switches on mode rather than
+// probing for a field, and emits only that arm's fields.
+func connectionView(conn pkgmodel.Connection) map[string]any {
+	switch c := conn.(type) {
+	case *pkgmodel.HostedConnection:
+		return map[string]any{
+			"mode":         "hosted",
+			"endpoint":     c.Endpoint,
+			"installation": c.Installation,
+			"auth":         opaqueView(c.Auth),
+		}
+	case *pkgmodel.ClassicConnection:
+		v := map[string]any{"mode": "classic", "url": c.URL, "port": c.Port}
+		if a := opaqueView(c.Auth); a != nil {
+			v["auth"] = a
+		}
+		return v
+	default:
+		return nil
+	}
+}
+
+// opaqueView reduces an opaque per-plugin block to its discriminator. Its
+// other keys belong to a plugin we may not ship, so we cannot know which of
+// them hold credentials.
+func opaqueView(raw json.RawMessage) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	t := gjson.GetBytes(raw, "type").String()
+	if t == "" {
+		return nil
+	}
+	return map[string]any{"type": t}
+}
+
+func agentView(a pkgmodel.AgentConfig, mask string) map[string]any {
+	return map[string]any{
+		"server": map[string]any{
+			"nodename":      a.Server.Nodename,
+			"hostname":      a.Server.Hostname,
+			"port":          a.Server.Port,
+			"ergoPort":      a.Server.ErgoPort,
+			"registrarPort": a.Server.RegistrarPort,
+			"observerPort":  a.Server.ObserverPort,
+			"tlsCert":       a.Server.TLSCert,
+			"tlsKey":        a.Server.TLSKey,
+			"secret":        maskIfSet(a.Server.Secret, mask),
+		},
+		"datastore": datastoreView(a.Datastore, mask),
+		"retry": map[string]any{
+			"statusCheckInterval": dur(a.Retry.StatusCheckInterval),
+			"maxRetries":          a.Retry.MaxRetries,
+			"retryDelay":          dur(a.Retry.RetryDelay),
+		},
+		"synchronization": map[string]any{
+			"enabled":  a.Synchronization.Enabled,
+			"interval": dur(a.Synchronization.Interval),
+		},
+		"discovery": map[string]any{
+			"enabled":                 a.Discovery.Enabled,
+			"interval":                dur(a.Discovery.Interval),
+			"labelTagKeys":            a.Discovery.LabelTagKeys,
+			"resourceTypesToDiscover": a.Discovery.ResourceTypesToDiscover,
+		},
+		"logging": map[string]any{
+			"filePath":        a.Logging.FilePath,
+			"fileLogLevel":    a.Logging.FileLogLevel.String(),
+			"consoleLogLevel": a.Logging.ConsoleLogLevel.String(),
+		},
+		"stackExpirer": map[string]any{
+			"disabled": a.StackExpirer.Disabled,
+			"interval": dur(a.StackExpirer.Interval),
+		},
+		"oTel": map[string]any{
+			"enabled":     a.OTel.Enabled,
+			"serviceName": a.OTel.ServiceName,
+			"otlp": map[string]any{
+				"enabled":     a.OTel.OTLP.Enabled,
+				"endpoint":    a.OTel.OTLP.Endpoint,
+				"protocol":    a.OTel.OTLP.Protocol,
+				"insecure":    a.OTel.OTLP.Insecure,
+				"temporality": a.OTel.OTLP.Temporality,
+			},
+			"prometheus": map[string]any{"enabled": a.OTel.Prometheus.Enabled},
+		},
+		"auth":            opaqueView(a.Auth),
+		"resourcePlugins": resourcePluginsView(a.ResourcePlugins),
+	}
+}
+
+func datastoreView(d pkgmodel.DatastoreConfig, mask string) map[string]any {
+	v := map[string]any{"datastoreType": d.DatastoreType}
+	switch d.DatastoreType {
+	case pkgmodel.SqliteDatastore:
+		v["sqlite"] = map[string]any{"filePath": d.Sqlite.FilePath}
+	case pkgmodel.PostgresDatastore:
+		// connectionParams is appended to the connection string verbatim and
+		// can carry a password, so it is omitted rather than masked.
+		v["postgres"] = map[string]any{
+			"host":     d.Postgres.Host,
+			"port":     d.Postgres.Port,
+			"user":     d.Postgres.User,
+			"password": maskIfSet(d.Postgres.Password, mask),
+			"database": d.Postgres.Database,
+			"schema":   d.Postgres.Schema,
+		}
+	case pkgmodel.MSSQLDatastore:
+		v["mssql"] = map[string]any{
+			"host":                   d.MSSQL.Host,
+			"port":                   d.MSSQL.Port,
+			"database":               d.MSSQL.Database,
+			"authMode":               d.MSSQL.AuthMode,
+			"user":                   d.MSSQL.User,
+			"password":               maskIfSet(d.MSSQL.Password, mask),
+			"encrypt":                d.MSSQL.Encrypt,
+			"trustServerCertificate": d.MSSQL.TrustServerCertificate,
+			"maxOpenConns":           d.MSSQL.MaxOpenConns,
+			"connMaxLifetime":        dur(d.MSSQL.ConnMaxLifetime),
+		}
+	case pkgmodel.AuroraDataAPIDatastore:
+		v["auroraDataAPI"] = map[string]any{
+			"clusterARN": d.AuroraDataAPI.ClusterARN,
+			"secretARN":  d.AuroraDataAPI.SecretARN,
+			"database":   d.AuroraDataAPI.Database,
+			"region":     d.AuroraDataAPI.Region,
+			"endpoint":   d.AuroraDataAPI.Endpoint,
+		}
+	}
+	return v
+}
+
+func artifactsView(a pkgmodel.ArtifactConfig, mask string) map[string]any {
+	repos := make([]any, 0, len(a.Repositories))
+	for _, r := range a.Repositories {
+		repos = append(repos, map[string]any{"uri": r.URI.String(), "type": string(r.Type)})
+	}
+	return map[string]any{
+		"url":          a.URL.String(),
+		"repositories": repos,
+		"username":     maskIfSet(a.Username, mask),
+		"password":     maskIfSet(a.Password, mask),
+	}
+}
+
+func resourcePluginsView(plugins []pkgmodel.ResourcePluginUserConfig) []any {
+	out := make([]any, 0, len(plugins))
+	for _, p := range plugins {
+		v := map[string]any{
+			"type":                    p.Type,
+			"enabled":                 p.Enabled,
+			"resourceTypesToDiscover": p.ResourceTypesToDiscover,
+			"discoveryFilters":        len(p.DiscoveryFilters),
+			// pluginConfig is opaque per-plugin data and is not emitted.
+		}
+		if p.RateLimit != nil {
+			v["rateLimit"] = map[string]any{
+				"scope":                            string(p.RateLimit.Scope),
+				"maxRequestsPerSecondForNamespace": p.RateLimit.MaxRequestsPerSecondForNamespace,
+			}
+		}
+		if p.Retry != nil {
+			v["retry"] = map[string]any{
+				"statusCheckInterval": dur(p.Retry.StatusCheckInterval),
+				"maxRetries":          p.Retry.MaxRetries,
+				"retryDelay":          dur(p.Retry.RetryDelay),
+			}
+		}
+		if p.LabelConfig != nil {
+			v["labelConfig"] = map[string]any{"defaultQuery": p.LabelConfig.DefaultQuery}
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+func networkView(n *pkgmodel.NetworkConfig, mask string) map[string]any {
+	if n == nil {
+		return nil
+	}
+	v := map[string]any{"type": n.Type}
+	if n.Tailscale != nil {
+		v["tailscale"] = map[string]any{
+			"tls":           n.Tailscale.TLS,
+			"hostname":      n.Tailscale.Hostname,
+			"advertiseTags": n.Tailscale.AdvertiseTags,
+			"authKey":       maskIfSet(n.Tailscale.AuthKey, mask),
+		}
+	}
+	// LegacyRawJSON is an opaque blob from the deprecated plugins.network
+	// block and is not emitted: its shape belongs to a network plugin.
+	return v
+}
+
+// maskIfSet masks a secret that has a value and leaves an unset one empty, so
+// a reader can tell "not configured" from "configured, not shown".
+func maskIfSet(v, mask string) string {
+	if v == "" {
+		return ""
+	}
+	return mask
+}
+
+func dur(d time.Duration) string { return d.String() }

--- a/internal/cli/profile/configview/view_test.go
+++ b/internal/cli/profile/configview/view_test.go
@@ -8,6 +8,8 @@ package configview
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/url"
 	"testing"
 	"time"
 
@@ -17,7 +19,15 @@ import (
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
-func hostedConfig() *pkgmodel.Config {
+func mustParseURL(t *testing.T, raw string) url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return *u
+}
+
+func hostedConfig(t *testing.T) *pkgmodel.Config {
+	t.Helper()
 	return &pkgmodel.Config{
 		Cli: pkgmodel.CliConfig{
 			Connection: &pkgmodel.HostedConnection{
@@ -39,11 +49,20 @@ func hostedConfig() *pkgmodel.Config {
 				},
 			},
 		},
+		Artifacts: pkgmodel.ArtifactConfig{
+			URL: mustParseURL(t, "https://bob:artifactpw@hub.example/repos/x#stable"),
+			Repositories: []pkgmodel.Repository{
+				{
+					URI:  mustParseURL(t, "https://alice:repopw@hub.example/repos/y"),
+					Type: pkgmodel.RepositoryTypeFormaePlugin,
+				},
+			},
+		},
 	}
 }
 
 func TestHostedConnectionIsTagged(t *testing.T) {
-	v := From("prod", hostedConfig(), Redacted)
+	v := From("prod", hostedConfig(t), Redacted)
 
 	assert.Equal(t, SchemaVersion, v["schemaVersion"])
 	assert.Equal(t, "prod", v["profile"])
@@ -56,7 +75,7 @@ func TestHostedConnectionIsTagged(t *testing.T) {
 }
 
 func TestClassicConnectionIsTaggedAndCarriesNoInstallation(t *testing.T) {
-	cfg := hostedConfig()
+	cfg := hostedConfig(t)
 	cfg.Cli.Connection = &pkgmodel.ClassicConnection{URL: "http://localhost", Port: 49684}
 
 	conn := From("dev", cfg, Redacted)["cli"].(map[string]any)["connection"].(map[string]any)
@@ -71,13 +90,13 @@ func TestClassicConnectionIsTaggedAndCarriesNoInstallation(t *testing.T) {
 // plugin's field names are unknowable, so anything else risks printing a
 // credential under a name no allowlist anticipated.
 func TestOpaqueAuthEmitsTypeOnly(t *testing.T) {
-	conn := From("prod", hostedConfig(), Redacted)["cli"].(map[string]any)["connection"].(map[string]any)
+	conn := From("prod", hostedConfig(t), Redacted)["cli"].(map[string]any)["connection"].(map[string]any)
 
 	assert.Equal(t, map[string]any{"type": "oidc"}, conn["auth"])
 }
 
 func TestTypedSecretsAreMasked(t *testing.T) {
-	v := From("prod", hostedConfig(), Redacted)
+	v := From("prod", hostedConfig(t), Redacted)
 	agent := v["agent"].(map[string]any)
 	pg := agent["datastore"].(map[string]any)["postgres"].(map[string]any)
 
@@ -89,23 +108,65 @@ func TestTypedSecretsAreMasked(t *testing.T) {
 }
 
 func TestMaskIsCallerChosen(t *testing.T) {
-	v := From("prod", hostedConfig(), HumanMask)
+	v := From("prod", hostedConfig(t), HumanMask)
 
 	assert.Equal(t, HumanMask, v["agent"].(map[string]any)["server"].(map[string]any)["secret"])
 }
 
 func TestDurationsRenderAsStrings(t *testing.T) {
-	v := From("prod", hostedConfig(), Redacted)
+	v := From("prod", hostedConfig(t), Redacted)
 
 	assert.Equal(t, "30s", v["agent"].(map[string]any)["retry"].(map[string]any)["retryDelay"])
 }
 
 func TestNoSecretSurvivesSerialisation(t *testing.T) {
-	out, err := json.Marshal(From("prod", hostedConfig(), Redacted))
+	out, err := json.Marshal(From("prod", hostedConfig(t), Redacted))
 	require.NoError(t, err)
 
 	assert.Contains(t, string(out), `"schemaVersion":1`)
-	for _, secret := range []string{"hunter2", "s3cret", "alsosecret", "formae-cli"} {
+	for _, secret := range []string{"hunter2", "s3cret", "alsosecret", "formae-cli", "artifactpw", "repopw"} {
 		assert.NotContains(t, string(out), secret)
 	}
+}
+
+func TestNetworkSectionIsOmittedWhenUnset(t *testing.T) {
+	v := From("prod", hostedConfig(t), Redacted)
+
+	assert.NotContains(t, v, "network")
+}
+
+func TestNetworkSectionMasksTheTailscaleAuthKey(t *testing.T) {
+	cfg := hostedConfig(t)
+	cfg.Network = &pkgmodel.NetworkConfig{
+		Type: "tailscale",
+		Tailscale: &pkgmodel.TailscaleConfig{
+			TLS:           true,
+			Hostname:      "agent",
+			AdvertiseTags: []string{"tag:formae"},
+			AuthKey:       "tskey-auth-secret",
+		},
+	}
+
+	v := From("prod", cfg, Redacted)
+
+	network := v["network"].(map[string]any)
+	assert.Equal(t, "tailscale", network["type"])
+	tailscale := network["tailscale"].(map[string]any)
+	assert.Equal(t, "agent", tailscale["hostname"])
+	assert.Equal(t, Redacted, tailscale["authKey"])
+	assert.NotContains(t, fmt.Sprintf("%v", v), "tskey-auth-secret")
+}
+
+// An artifacts URL or repository URI that embeds credentials is redacted:
+// url.URL.String() prints embedded userinfo verbatim, so the view must use
+// Redacted() instead.
+func TestArtifactURLCredentialsAreRedacted(t *testing.T) {
+	v := From("prod", hostedConfig(t), Redacted)
+	artifacts := v["artifacts"].(map[string]any)
+
+	assert.Equal(t, "https://bob:xxxxx@hub.example/repos/x#stable", artifacts["url"])
+
+	repos := artifacts["repositories"].([]any)
+	require.Len(t, repos, 1)
+	assert.Equal(t, "https://alice:xxxxx@hub.example/repos/y", repos[0].(map[string]any)["uri"])
 }

--- a/internal/cli/profile/configview/view_test.go
+++ b/internal/cli/profile/configview/view_test.go
@@ -1,0 +1,111 @@
+//go:build unit
+
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package configview
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func hostedConfig() *pkgmodel.Config {
+	return &pkgmodel.Config{
+		Cli: pkgmodel.CliConfig{
+			Connection: &pkgmodel.HostedConnection{
+				Endpoint:     "https://cloud.formae.ai",
+				Installation: "3f2b8c14-0000-4000-8000-000000000000",
+				Auth:         json.RawMessage(`{"type":"oidc","clientId":"formae-cli"}`),
+			},
+			Theme: "quiet",
+		},
+		Agent: pkgmodel.AgentConfig{
+			Server: pkgmodel.ServerConfig{Port: 49684, Secret: "s3cret"},
+			Retry:  pkgmodel.RetryConfig{RetryDelay: 30 * time.Second},
+			Datastore: pkgmodel.DatastoreConfig{
+				DatastoreType: pkgmodel.PostgresDatastore,
+				Postgres: pkgmodel.PostgresConfig{
+					Host:             "db.internal",
+					Password:         "hunter2",
+					ConnectionParams: "sslmode=require&password=alsosecret",
+				},
+			},
+		},
+	}
+}
+
+func TestHostedConnectionIsTagged(t *testing.T) {
+	v := From("prod", hostedConfig(), Redacted)
+
+	assert.Equal(t, SchemaVersion, v["schemaVersion"])
+	assert.Equal(t, "prod", v["profile"])
+
+	conn := v["cli"].(map[string]any)["connection"].(map[string]any)
+	assert.Equal(t, "hosted", conn["mode"])
+	assert.Equal(t, "https://cloud.formae.ai", conn["endpoint"])
+	assert.Equal(t, "3f2b8c14-0000-4000-8000-000000000000", conn["installation"])
+	assert.NotContains(t, conn, "url")
+}
+
+func TestClassicConnectionIsTaggedAndCarriesNoInstallation(t *testing.T) {
+	cfg := hostedConfig()
+	cfg.Cli.Connection = &pkgmodel.ClassicConnection{URL: "http://localhost", Port: 49684}
+
+	conn := From("dev", cfg, Redacted)["cli"].(map[string]any)["connection"].(map[string]any)
+
+	assert.Equal(t, "classic", conn["mode"])
+	assert.Equal(t, "http://localhost", conn["url"])
+	assert.Equal(t, 49684, conn["port"])
+	assert.NotContains(t, conn, "installation")
+}
+
+// An opaque auth block is emitted as its discriminator alone: a third-party
+// plugin's field names are unknowable, so anything else risks printing a
+// credential under a name no allowlist anticipated.
+func TestOpaqueAuthEmitsTypeOnly(t *testing.T) {
+	conn := From("prod", hostedConfig(), Redacted)["cli"].(map[string]any)["connection"].(map[string]any)
+
+	assert.Equal(t, map[string]any{"type": "oidc"}, conn["auth"])
+}
+
+func TestTypedSecretsAreMasked(t *testing.T) {
+	v := From("prod", hostedConfig(), Redacted)
+	agent := v["agent"].(map[string]any)
+	pg := agent["datastore"].(map[string]any)["postgres"].(map[string]any)
+
+	assert.Equal(t, Redacted, agent["server"].(map[string]any)["secret"])
+	assert.Equal(t, Redacted, pg["password"])
+	assert.Equal(t, "db.internal", pg["host"], "non-secret neighbours stay readable")
+	assert.NotContains(t, pg, "connectionParams",
+		"connection parameters are appended to the connection string and can carry a password")
+}
+
+func TestMaskIsCallerChosen(t *testing.T) {
+	v := From("prod", hostedConfig(), HumanMask)
+
+	assert.Equal(t, HumanMask, v["agent"].(map[string]any)["server"].(map[string]any)["secret"])
+}
+
+func TestDurationsRenderAsStrings(t *testing.T) {
+	v := From("prod", hostedConfig(), Redacted)
+
+	assert.Equal(t, "30s", v["agent"].(map[string]any)["retry"].(map[string]any)["retryDelay"])
+}
+
+func TestNoSecretSurvivesSerialisation(t *testing.T) {
+	out, err := json.Marshal(From("prod", hostedConfig(), Redacted))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), `"schemaVersion":1`)
+	for _, secret := range []string{"hunter2", "s3cret", "alsosecret", "formae-cli"} {
+		assert.NotContains(t, string(out), secret)
+	}
+}

--- a/internal/cli/profile/profile.go
+++ b/internal/cli/profile/profile.go
@@ -63,6 +63,7 @@ func ProfileCmd() *cobra.Command {
 	command.AddCommand(
 		newListCmd(),
 		newCurrentCmd(),
+		newShowCmd(),
 		newUseCmd(),
 		newSaveCmd(),
 		newCreateCmd(),

--- a/internal/cli/profile/render.go
+++ b/internal/cli/profile/render.go
@@ -6,6 +6,7 @@ package profile
 
 import (
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -65,6 +66,20 @@ func renderCurrentHuman(th *theme.Theme, active string, tty bool) string {
 // components.AckLine helper.
 func renderAck(th *theme.Theme, text string) string {
 	return components.AckLine(th, components.AckDone, text)
+}
+
+// printConfigWarnings writes a config's warnings, one per line, in the same
+// shape App.PrintBanner uses. It takes the writer rather than reaching for
+// os.Stderr so the caller decides the stream and tests can read it back.
+func printConfigWarnings(w io.Writer, th *theme.Theme, warnings []string) {
+	if len(warnings) == 0 {
+		return
+	}
+	label := lipgloss.NewStyle().Foreground(th.Palette.Warning).Render("Warning:")
+	for _, warning := range warnings {
+		_, _ = fmt.Fprintf(w, "%s %s\n", label, warning)
+	}
+	_, _ = fmt.Fprintln(w)
 }
 
 // renderConfigView renders a config view as themed sections in a fixed order,

--- a/internal/cli/profile/render.go
+++ b/internal/cli/profile/render.go
@@ -5,6 +5,8 @@
 package profile
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -63,4 +65,95 @@ func renderCurrentHuman(th *theme.Theme, active string, tty bool) string {
 // components.AckLine helper.
 func renderAck(th *theme.Theme, text string) string {
 	return components.AckLine(th, components.AckDone, text)
+}
+
+// renderConfigView renders a config view as themed sections in a fixed order,
+// so two runs of the same profile read identically. Section headers sit at
+// column 0 with their fields indented beneath, matching the CLI convention in
+// components.SectionHeader.
+func renderConfigView(th *theme.Theme, view map[string]any) string {
+	var sections []string
+
+	if cli, ok := view["cli"].(map[string]any); ok {
+		if conn, ok := cli["connection"].(map[string]any); ok {
+			sections = append(sections, section(th, "Connection", pairsOf(conn)))
+		}
+		sections = append(sections, section(th, "CLI", pairsOf(withoutKey(cli, "connection"))))
+	}
+	for _, s := range []struct{ key, title string }{
+		{"agent", "Agent"},
+		{"artifacts", "Artifacts"},
+		{"network", "Network"},
+	} {
+		if m, ok := view[s.key].(map[string]any); ok {
+			sections = append(sections, section(th, s.title, pairsOf(m)))
+		}
+	}
+	if dir, ok := view["pluginDir"].(string); ok && dir != "" {
+		sections = append(sections, section(th, "Plugins", [][2]string{{"pluginDir", dir}}))
+	}
+
+	name, _ := view["profile"].(string)
+	head := lipgloss.NewStyle().Foreground(th.Palette.TextPrimary).Render(name)
+	return head + "\n\n" + strings.Join(sections, "\n\n")
+}
+
+func section(th *theme.Theme, title string, pairs [][2]string) string {
+	return components.SectionHeader(th, title) + "\n" +
+		components.Indent(components.FieldList(th, pairs), 2)
+}
+
+// pairsOf flattens a view section into sorted label/value pairs, rendering a
+// nested object as dotted keys and a list as one indexed entry per item, so a
+// whole section fits one aligned field list.
+func pairsOf(m map[string]any) [][2]string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var pairs [][2]string
+	for _, k := range keys {
+		switch v := m[k].(type) {
+		case map[string]any:
+			for _, nested := range pairsOf(v) {
+				pairs = append(pairs, [2]string{k + "." + nested[0], nested[1]})
+			}
+		case []any:
+			for i, item := range v {
+				label := fmt.Sprintf("%s[%d]", k, i)
+				if nested, ok := item.(map[string]any); ok {
+					for _, n := range pairsOf(nested) {
+						pairs = append(pairs, [2]string{label + "." + n[0], n[1]})
+					}
+					continue
+				}
+				pairs = append(pairs, [2]string{label, fmt.Sprintf("%v", item)})
+			}
+		case []string:
+			for i, item := range v {
+				pairs = append(pairs, [2]string{fmt.Sprintf("%s[%d]", k, i), item})
+			}
+		case nil:
+			// omit: an absent optional is not a field
+		case string:
+			if v != "" {
+				pairs = append(pairs, [2]string{k, v})
+			}
+		default:
+			pairs = append(pairs, [2]string{k, fmt.Sprintf("%v", v)})
+		}
+	}
+	return pairs
+}
+
+func withoutKey(m map[string]any, key string) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if k != key {
+			out[k] = v
+		}
+	}
+	return out
 }

--- a/internal/cli/profile/routing_integration_test.go
+++ b/internal/cli/profile/routing_integration_test.go
@@ -24,7 +24,7 @@ func minimalProfile(host string, port int) string {
 	return fmt.Sprintf(`amends "formae:/Config.pkl"
 
 cli {
-    api {
+    connection = new Classic {
         url  = %q
         port = %d
     }

--- a/internal/cli/profile/show.go
+++ b/internal/cli/profile/show.go
@@ -1,0 +1,64 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package profile
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/platform-engineering-labs/formae/internal/cli/app"
+	"github.com/platform-engineering-labs/formae/internal/cli/printer"
+	"github.com/platform-engineering-labs/formae/internal/cli/profile/configview"
+	"github.com/platform-engineering-labs/formae/internal/cli/profile/store"
+)
+
+func newShowCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "show [<name>]",
+		Short: "Print a profile's resolved configuration",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cc *cobra.Command, args []string) error {
+			consumer, schema, err := resolveOutput(cc)
+			if err != nil {
+				return err
+			}
+			s, err := openStore()
+			if err != nil {
+				return err
+			}
+
+			name := ""
+			if len(args) == 1 {
+				name = args[0]
+				if err := store.ValidateName(name); err != nil {
+					return err
+				}
+			} else if name, err = s.Active(); err != nil {
+				return err
+			}
+
+			a := &app.App{}
+			if err := a.LoadConfig(s.ProfilePath(name), ""); err != nil {
+				return fmt.Errorf("failed to read profile %q: %w", name, err)
+			}
+
+			if consumer == printer.ConsumerMachine {
+				view := configview.From(name, a.Config, configview.Redacted)
+				p := printer.NewMachineReadablePrinter[map[string]any](cc.OutOrStdout(), schema)
+				return p.Print(&view)
+			}
+
+			// PrintBanner also surfaces the loaded profile's config warnings,
+			// including its deprecation notices, on stderr.
+			a.PrintBanner()
+			view := configview.From(name, a.Config, configview.HumanMask)
+			_, _ = fmt.Fprintln(cc.OutOrStdout(), renderConfigView(a.Theme(), view))
+			return nil
+		},
+	}
+	addOutputFlags(c)
+	return c
+}

--- a/internal/cli/profile/show.go
+++ b/internal/cli/profile/show.go
@@ -10,9 +10,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/platform-engineering-labs/formae/internal/cli/app"
+	"github.com/platform-engineering-labs/formae/internal/cli/banner"
 	"github.com/platform-engineering-labs/formae/internal/cli/printer"
 	"github.com/platform-engineering-labs/formae/internal/cli/profile/configview"
 	"github.com/platform-engineering-labs/formae/internal/cli/profile/store"
+	"github.com/platform-engineering-labs/formae/internal/cli/tui/theme"
 )
 
 func newShowCmd() *cobra.Command {
@@ -51,11 +53,23 @@ func newShowCmd() *cobra.Command {
 				return p.Print(&view)
 			}
 
-			// PrintBanner also surfaces the loaded profile's config warnings,
-			// including its deprecation notices, on stderr.
-			a.PrintBanner()
+			// The theme follows the active profile, like every other command:
+			// it is the user's environment, not a property of the profile
+			// being displayed. Resolved only on a TTY, so piped output stays a
+			// pure read of the named profile.
+			w := cc.OutOrStdout()
+			th := theme.New("formae")
+			if isTerminal(w) {
+				th = applyTheme(cc)
+			}
+			banner.PrintBanner()
+
+			// The shown profile's own warnings, including its deprecation
+			// notices, go to stderr so they never enter piped output.
+			printConfigWarnings(cc.ErrOrStderr(), th, a.Config.Warnings)
+
 			view := configview.From(name, a.Config, configview.HumanMask)
-			_, _ = fmt.Fprintln(cc.OutOrStdout(), renderConfigView(a.Theme(), view))
+			_, _ = fmt.Fprintln(w, renderConfigView(th, view))
 			return nil
 		},
 	}

--- a/internal/cli/profile/show_test.go
+++ b/internal/cli/profile/show_test.go
@@ -94,7 +94,7 @@ func TestShowHumanRendersSections(t *testing.T) {
 	assert.Contains(t, out, "Connection")
 	assert.Contains(t, out, "cloud.formae.ai")
 	assert.NotContains(t, out, "schemaVersion", "the schema version is machine bookkeeping")
-	assert.NotContains(t, out, "{", "human output is not a serialisation format")
+	assert.NotRegexp(t, `"[a-zA-Z]+":`, out, "human output carries no JSON key-quote pattern")
 }
 
 // A secret Pkl resolves from the environment never existed in the profile

--- a/internal/cli/profile/show_test.go
+++ b/internal/cli/profile/show_test.go
@@ -1,0 +1,134 @@
+//go:build unit
+
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package profile
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const hostedProfilePkl = `amends "formae:/Config.pkl"
+
+cli {
+    connection = new Hosted {
+        endpoint = "https://cloud.formae.ai"
+        installation = "3f2b8c14-0000-4000-8000-000000000000"
+        auth = new Dynamic { type = "oidc" }
+    }
+}
+`
+
+// seedProfileBodies points the store at a temp config dir holding profiles
+// with the given contents, and makes active the active pointer.
+func seedProfileBodies(t *testing.T, active string, bodies map[string]string) {
+	t.Helper()
+	cfgDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(cfgDir, "profiles"), 0o755))
+	for name, body := range bodies {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(cfgDir, "profiles", name+".pkl"), []byte(body), 0o600))
+	}
+	if active != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "active"), []byte(active+"\n"), 0o600))
+	}
+	t.Setenv("FORMAE_CONFIG_DIR", cfgDir)
+}
+
+func runShow(t *testing.T, args ...string) string {
+	t.Helper()
+	var out bytes.Buffer
+	cmd := newShowCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs(args)
+	require.NoError(t, cmd.Execute())
+	return out.String()
+}
+
+func TestShowMachineJSONEmitsTheTaggedConnection(t *testing.T) {
+	seedProfileBodies(t, "prod", map[string]string{"prod": hostedProfilePkl})
+
+	out := runShow(t, "prod", "--output-consumer", "machine", "--output-schema", "json")
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.EqualValues(t, 1, got["schemaVersion"])
+	conn := got["cli"].(map[string]any)["connection"].(map[string]any)
+	assert.Equal(t, "hosted", conn["mode"])
+	assert.Equal(t, "3f2b8c14-0000-4000-8000-000000000000", conn["installation"])
+	assert.NotContains(t, out, "\x1b[", "machine output carries no ANSI")
+}
+
+func TestShowMachineYAMLIsAccepted(t *testing.T) {
+	seedProfileBodies(t, "prod", map[string]string{"prod": hostedProfilePkl})
+
+	out := runShow(t, "prod", "--output-consumer", "machine", "--output-schema", "yaml")
+
+	assert.Contains(t, out, "schemaVersion: 1")
+	assert.Contains(t, out, "mode: hosted")
+}
+
+func TestShowWithNoArgumentUsesTheActiveProfile(t *testing.T) {
+	seedProfileBodies(t, "prod", map[string]string{"prod": hostedProfilePkl})
+
+	out := runShow(t, "--output-consumer", "machine", "--output-schema", "json")
+
+	assert.Contains(t, out, `"profile":"prod"`)
+}
+
+func TestShowHumanRendersSections(t *testing.T) {
+	seedProfileBodies(t, "prod", map[string]string{"prod": hostedProfilePkl})
+
+	out := runShow(t, "prod")
+
+	assert.Contains(t, out, "Connection")
+	assert.Contains(t, out, "cloud.formae.ai")
+	assert.NotContains(t, out, "schemaVersion", "the schema version is machine bookkeeping")
+	assert.NotContains(t, out, "{", "human output is not a serialisation format")
+}
+
+// A secret Pkl resolves from the environment never existed in the profile
+// file, so redaction has to act on the resolved value rather than the text.
+func TestShowRedactsASecretResolvedFromTheEnvironment(t *testing.T) {
+	const profile = `amends "formae:/Config.pkl"
+
+agent {
+    datastore {
+        datastoreType = "postgres"
+        postgres {
+            host = "db.internal"
+            password = read("env:FORMAE_TEST_DB_PASSWORD")
+        }
+    }
+}
+`
+	t.Setenv("FORMAE_TEST_DB_PASSWORD", "hunter2")
+	seedProfileBodies(t, "prod", map[string]string{"prod": profile})
+
+	out := runShow(t, "prod", "--output-consumer", "machine", "--output-schema", "json")
+
+	assert.NotContains(t, out, "hunter2")
+	assert.Contains(t, out, "db.internal")
+}
+
+func TestShowRejectsUnknownProfile(t *testing.T) {
+	seedProfileBodies(t, "prod", map[string]string{"prod": hostedProfilePkl})
+
+	cmd := newShowCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"nope"})
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "nope"), "the error names the profile asked for")
+}

--- a/internal/cli/profile/show_test.go
+++ b/internal/cli/profile/show_test.go
@@ -9,13 +9,19 @@ package profile
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/cli/tui/components"
+	"github.com/platform-engineering-labs/formae/internal/cli/tui/theme"
 )
 
 const hostedProfilePkl = `amends "formae:/Config.pkl"
@@ -131,4 +137,42 @@ func TestShowRejectsUnknownProfile(t *testing.T) {
 
 	require.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "nope"), "the error names the profile asked for")
+}
+
+// The theme follows the active profile rather than the one being displayed:
+// it is the user's environment, the same as for every other command in this
+// group. Showing a profile must not adopt that profile's theme.
+func TestShowRendersInTheActiveProfilesTheme(t *testing.T) {
+	seedProfileBodies(t, "prod", map[string]string{
+		"prod": hostedProfilePkl,
+		"demo": hostedProfilePkl,
+	})
+
+	origTTY := isTerminal
+	isTerminal = func(_ io.Writer) bool { return true }
+	t.Cleanup(func() { isTerminal = origTTY })
+
+	// The built-in palettes share a section-header colour, so the resolved
+	// theme is given a distinctive one: without it the assertions below would
+	// hold no matter which theme the command picked.
+	resolved := *theme.New("quiet")
+	resolved.Palette.SecondaryAccent = lipgloss.AdaptiveColor{Light: "#123456", Dark: "#123456"}
+
+	origApply := applyTheme
+	called := false
+	applyTheme = func(_ *cobra.Command) *theme.Theme {
+		called = true
+		return &resolved
+	}
+	t.Cleanup(func() { applyTheme = origApply })
+
+	out := runShow(t, "demo")
+
+	assert.True(t, called, "show must resolve the theme from the active profile")
+
+	want := components.SectionHeader(&resolved, "Connection")
+	def := components.SectionHeader(theme.New("formae"), "Connection")
+	require.NotEqual(t, def, want, "the two themes must render differently for this assertion to mean anything")
+	assert.Contains(t, out, want, "show must render in the resolved active-profile theme")
+	assert.NotContains(t, out, def, "show must not fall back to the default theme")
 }

--- a/internal/cli/profile/store/template.go
+++ b/internal/cli/profile/store/template.go
@@ -23,7 +23,7 @@ const StubTemplate = `amends "formae:/Config.pkl"   // the formae config schema 
 //
 //   // Point the CLI at a remote agent:
 //   cli {
-//       api {
+//       connection = new Classic {
 //           url  = "http://my-agent.example.com"
 //           port = 49684
 //       }

--- a/internal/cli/profile/store/template_content_test.go
+++ b/internal/cli/profile/store/template_content_test.go
@@ -1,0 +1,22 @@
+//go:build unit
+
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The generated profile teaches the canonical form, so a new user's first
+// edit does not start from a deprecated setting.
+func TestTemplateDocumentsTheConnectionForm(t *testing.T) {
+	tmpl := StubTemplate
+
+	assert.Contains(t, tmpl, "connection = new Classic")
+	assert.NotContains(t, tmpl, "api {")
+}

--- a/internal/cli/profile/store/template_test.go
+++ b/internal/cli/profile/store/template_test.go
@@ -37,8 +37,9 @@ func TestStubTemplate_ParsesWithEmptyPluginDir(t *testing.T) {
 // A minimal config that only `amends` the schema — materializing no cli/agent
 // values — must still evaluate to a complete, working localhost setup purely
 // from schema defaults. This is what lets the clean-install stub stay minimal
-// (no materialized snapshot to drift from the schema): cli.api must carry a
-// default of its own, not be a required property the user has to fill in.
+// (no materialized snapshot to drift from the schema): cli.connection must
+// carry a default of its own, not be a required property the user has to
+// fill in.
 func TestSchemaDefaults_BareAmendsYieldsLocalhost(t *testing.T) {
 	t.Setenv("FORMAE_PLUGIN_DIR", t.TempDir()) // empty: no plugin wrappers
 	dir := t.TempDir()

--- a/internal/cli/profile/store/template_test.go
+++ b/internal/cli/profile/store/template_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/platform-engineering-labs/formae/internal/cli/profile/store"
 	"github.com/platform-engineering-labs/formae/internal/schema/pkl"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,8 +28,10 @@ func TestStubTemplate_ParsesWithEmptyPluginDir(t *testing.T) {
 
 	cfg, err := pkl.PKL{}.FormaeConfig(path)
 	require.NoError(t, err, "stub must parse with no plugins installed")
-	assert.Equal(t, "http://localhost", cfg.Cli.API.URL)
-	assert.Equal(t, 49684, cfg.Cli.API.Port)
+	classic, ok := cfg.Cli.Connection.(*pkgmodel.ClassicConnection)
+	require.True(t, ok)
+	assert.Equal(t, "http://localhost", classic.URL)
+	assert.Equal(t, 49684, classic.Port)
 }
 
 // A minimal config that only `amends` the schema — materializing no cli/agent
@@ -44,8 +47,10 @@ func TestSchemaDefaults_BareAmendsYieldsLocalhost(t *testing.T) {
 
 	cfg, err := pkl.PKL{}.FormaeConfig(path)
 	require.NoError(t, err, "a bare amends must evaluate from schema defaults alone")
-	assert.Equal(t, "http://localhost", cfg.Cli.API.URL)
-	assert.Equal(t, 49684, cfg.Cli.API.Port)
+	classic, ok := cfg.Cli.Connection.(*pkgmodel.ClassicConnection)
+	require.True(t, ok)
+	assert.Equal(t, "http://localhost", classic.URL)
+	assert.Equal(t, 49684, classic.Port)
 	assert.Equal(t, "localhost", cfg.Agent.Server.Hostname)
 	assert.Equal(t, 49684, cfg.Agent.Server.Port)
 }

--- a/internal/cli/profile/store/template_test.go
+++ b/internal/cli/profile/store/template_test.go
@@ -37,9 +37,10 @@ func TestStubTemplate_ParsesWithEmptyPluginDir(t *testing.T) {
 // A minimal config that only `amends` the schema — materializing no cli/agent
 // values — must still evaluate to a complete, working localhost setup purely
 // from schema defaults. This is what lets the clean-install stub stay minimal
-// (no materialized snapshot to drift from the schema): cli.connection must
-// carry a default of its own, not be a required property the user has to
-// fill in.
+// (no materialized snapshot to drift from the schema): the schema declares
+// cli.connection as an optional `(Classic|Hosted)?` with no default of its
+// own, and the localhost fallback is supplied in Go, by buildConnection in
+// internal/schema/pkl/connection.go, when cli.connection is unset.
 func TestSchemaDefaults_BareAmendsYieldsLocalhost(t *testing.T) {
 	t.Setenv("FORMAE_PLUGIN_DIR", t.TempDir()) // empty: no plugin wrappers
 	dir := t.TempDir()

--- a/internal/cli/status/watch_e2e_test.go
+++ b/internal/cli/status/watch_e2e_test.go
@@ -130,7 +130,7 @@ func TestStatusWatchTUI_EndToEnd(t *testing.T) {
 	baseURL := apitest.NewTestServer(t, srv.Handler())
 
 	// Construct the real API client pointing at the test server.
-	client := api.NewClient(pkgmodel.APIConfig{URL: baseURL, Port: 80}, nil, nil)
+	client := api.NewClient(&pkgmodel.ClassicConnection{URL: baseURL, Port: 80}, nil, nil)
 
 	m := statuswatch.New(theme.New("formae"), clientAdapter{client}, statuswatch.Options{
 		MaxResults:   10,

--- a/internal/schema/pkl/assets/formae/Config.pkl
+++ b/internal/schema/pkl/assets/formae/Config.pkl
@@ -264,6 +264,28 @@ class ApiConfig {
     port: Port = 49684
 }
 
+/// A connection to a self-hosted formae agent.
+class Classic {
+    url: String = "http://localhost"
+
+    port: Port = 49684
+
+    /// Optional: a self-hosted agent may be protected by an auth plugin.
+    auth: (BaseCliAuthConfig|Dynamic)?
+}
+
+/// A connection to a hosted formae installation.
+class Hosted {
+    /// Absolute https origin. Validated when the configuration is loaded.
+    endpoint: String
+
+    /// The installation this client addresses, as a canonical lowercase UUID.
+    installation: String
+
+    /// Required: a hosted installation always authenticates.
+    auth: (BaseCliAuthConfig|Dynamic)
+}
+
 class Repository {
   /// Orbital repository URI (optionally with #channel fragment).
   uri: Uri
@@ -297,10 +319,20 @@ class ArtifactConfig {
 }
 
 class CliConfig {
-    api: ApiConfig
+    /// Where this client sends commands. Exactly one of the two forms, by
+    /// construction: a connection is either classic or hosted, never both.
+    connection: (Classic|Hosted)?
+
+    /// Deprecated: use `connection = new Classic { ... }`.
+    ///
+    /// Declared nullable with no default on purpose. Writing `= null` here
+    /// breaks the nested `cli { api { ... } }` form this property exists to
+    /// keep working.
+    api: ApiConfig?
 
     disableUsageReporting: Boolean = false
 
+    /// Deprecated: set `auth` inside `connection`.
     auth: (BaseCliAuthConfig|Dynamic)?
 
     // Theme name: a built-in (quiet, rich, colorblind, omarchy) or the stem of

--- a/internal/schema/pkl/config_connection_test.go
+++ b/internal/schema/pkl/config_connection_test.go
@@ -1,0 +1,64 @@
+//go:build unit
+
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package pkl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pklmodel "github.com/platform-engineering-labs/formae/internal/schema/pkl/model"
+)
+
+func evalConfig(t *testing.T, path string) *pklmodel.Config {
+	t.Helper()
+	cfg, err := PKL{}.rawConfig(path)
+	require.NoError(t, err)
+	return cfg
+}
+
+func TestConnectionDecodesHostedArm(t *testing.T) {
+	cfg := evalConfig(t, "testdata/config/connection_hosted.pkl")
+
+	hosted, ok := cfg.Cli.Connection.(*pklmodel.HostedConnection)
+	require.True(t, ok, "expected *HostedConnection, got %T", cfg.Cli.Connection)
+	assert.Equal(t, "https://cloud.formae.ai", hosted.Endpoint)
+	assert.Equal(t, "3f2b8c14-0000-4000-8000-000000000000", hosted.Installation)
+	require.NotNil(t, hosted.Auth)
+	assert.Equal(t, "oidc", hosted.Auth.Properties["type"])
+}
+
+func TestConnectionDecodesClassicArm(t *testing.T) {
+	cfg := evalConfig(t, "testdata/config/connection_classic.pkl")
+
+	classic, ok := cfg.Cli.Connection.(*pklmodel.ClassicConnection)
+	require.True(t, ok, "expected *ClassicConnection, got %T", cfg.Cli.Connection)
+	assert.Equal(t, "http://agent.example", classic.URL)
+	assert.Equal(t, int32(8080), classic.Port)
+	assert.Nil(t, classic.Auth)
+}
+
+func TestConnectionAbsentDecodesToNil(t *testing.T) {
+	cfg := evalConfig(t, "testdata/config/connection_absent.pkl")
+
+	assert.Nil(t, cfg.Cli.Connection)
+	assert.Nil(t, cfg.Cli.API)
+}
+
+// A profile written in the nested amendment form the CLI documents still
+// evaluates, and its values still arrive in the decode model. The deprecated
+// properties must stay nullable with no explicit default: declaring them
+// `= null` makes this form fail to evaluate.
+func TestLegacyNestedAPIAmendmentStillEvaluates(t *testing.T) {
+	cfg := evalConfig(t, "testdata/config/legacy_api_nested.pkl")
+
+	require.NotNil(t, cfg.Cli.API)
+	assert.Equal(t, "http://agent.example", cfg.Cli.API.URL)
+	assert.Equal(t, int32(8080), cfg.Cli.API.Port)
+	assert.Nil(t, cfg.Cli.Connection)
+}

--- a/internal/schema/pkl/connection.go
+++ b/internal/schema/pkl/connection.go
@@ -1,0 +1,176 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package pkl
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"regexp"
+	"strings"
+
+	pklgo "github.com/apple/pkl-go/pkl"
+	"github.com/tidwall/gjson"
+
+	pklmodel "github.com/platform-engineering-labs/formae/internal/schema/pkl/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+const (
+	defaultClassicURL  = "http://localhost"
+	defaultClassicPort = 49684
+)
+
+// installationRE matches the canonical lowercase UUID text form. The
+// constraint is syntactic on purpose: it mirrors what the edge accepts as a
+// routing key, and says nothing about UUID version or variant bits.
+var installationRE = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// buildConnection resolves the CLI's connection, translating the deprecated
+// cli.api, cli.auth, and plugins.authentication settings when they are the
+// only form present. Setting a legacy field alongside an explicit connection
+// is an error rather than a precedence rule: those fields carry a credential,
+// and a configuration that names two endpoints does not say which one the
+// credential is for.
+func buildConnection(
+	cli *pklmodel.CliConfig,
+	legacyCliAuth json.RawMessage,
+	warnings *[]string,
+) (pkgmodel.Connection, error) {
+	legacy := legacyFieldsSet(cli, legacyCliAuth)
+
+	if cli.Connection != nil {
+		if len(legacy) > 0 {
+			return nil, fmt.Errorf(
+				"cli.connection is set alongside deprecated %s; remove the deprecated settings, "+
+					"since cli.connection replaces them",
+				strings.Join(legacy, " and "),
+			)
+		}
+		return translateConnection(cli.Connection)
+	}
+
+	classic := &pkgmodel.ClassicConnection{URL: defaultClassicURL, Port: defaultClassicPort}
+	if cli.API != nil {
+		classic.URL = cli.API.URL
+		classic.Port = int(cli.API.Port)
+		warn(warnings, "cli.api is deprecated; migrate to cli.connection = new Classic { url; port }")
+	}
+	switch {
+	case len(cli.Auth.Properties) > 0:
+		classic.Auth = translateAuthConfig(&cli.Auth)
+		warn(warnings, "cli.auth is deprecated; set auth inside cli.connection")
+	case len(legacyCliAuth) > 0:
+		// plugins.authentication already warned when it was applied.
+		classic.Auth = legacyCliAuth
+	}
+	return classic, nil
+}
+
+func legacyFieldsSet(cli *pklmodel.CliConfig, legacyCliAuth json.RawMessage) []string {
+	var set []string
+	if cli.API != nil {
+		set = append(set, "cli.api")
+	}
+	switch {
+	case len(cli.Auth.Properties) > 0:
+		set = append(set, "cli.auth")
+	case len(legacyCliAuth) > 0:
+		set = append(set, "plugins.authentication")
+	}
+	return set
+}
+
+func warn(warnings *[]string, msg string) {
+	slog.Warn(msg)
+	*warnings = append(*warnings, msg)
+}
+
+func translateConnection(decoded any) (pkgmodel.Connection, error) {
+	switch conn := decoded.(type) {
+	case *pklmodel.ClassicConnection:
+		return &pkgmodel.ClassicConnection{
+			URL:  conn.URL,
+			Port: int(conn.Port),
+			Auth: translateOptionalAuth(conn.Auth),
+		}, nil
+
+	case *pklmodel.HostedConnection:
+		endpoint, err := canonicalHostedEndpoint(conn.Endpoint)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateInstallation(conn.Installation); err != nil {
+			return nil, err
+		}
+		auth := translateOptionalAuth(conn.Auth)
+		if err := validateAuthUsable(auth); err != nil {
+			return nil, err
+		}
+		return &pkgmodel.HostedConnection{
+			Endpoint:     endpoint,
+			Installation: conn.Installation,
+			Auth:         auth,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("cli.connection has an unsupported type %T", decoded)
+	}
+}
+
+func translateOptionalAuth(obj *pklgo.Object) json.RawMessage {
+	if obj == nil {
+		return nil
+	}
+	return translateAuthConfig(obj)
+}
+
+// canonicalHostedEndpoint parses and canonicalises a hosted endpoint into an
+// origin with no trailing slash, so request URLs can be built by joining a
+// path onto it rather than by concatenating strings.
+func canonicalHostedEndpoint(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("cli.connection endpoint %q is not a valid URL: %w", raw, err)
+	}
+	if !strings.EqualFold(u.Scheme, "https") || u.Host == "" {
+		return "", fmt.Errorf("cli.connection endpoint %q must be an absolute https URL", raw)
+	}
+	if u.User != nil {
+		return "", fmt.Errorf("cli.connection endpoint %q must not embed credentials", raw)
+	}
+	if u.RawQuery != "" {
+		return "", fmt.Errorf("cli.connection endpoint %q must not carry a query string", raw)
+	}
+	if u.Fragment != "" {
+		return "", fmt.Errorf("cli.connection endpoint %q must not carry a fragment", raw)
+	}
+	if u.Path != "" && u.Path != "/" {
+		return "", fmt.Errorf("cli.connection endpoint %q must not carry a path", raw)
+	}
+	host := strings.TrimSuffix(strings.ToLower(u.Host), ":443")
+	return "https://" + host, nil
+}
+
+func validateInstallation(id string) error {
+	if !installationRE.MatchString(id) {
+		return fmt.Errorf("cli.connection installation %q must be a canonical lowercase UUID", id)
+	}
+	return nil
+}
+
+// validateAuthUsable rejects an auth block that satisfies the schema without
+// naming a plugin. The type system can require the property, but not that its
+// contents identify anything.
+func validateAuthUsable(raw json.RawMessage) error {
+	if len(raw) == 0 {
+		return fmt.Errorf("cli.connection auth is required for a hosted connection")
+	}
+	if gjson.GetBytes(raw, "type").String() == "" {
+		return fmt.Errorf("cli.connection auth must carry a non-empty type")
+	}
+	return nil
+}

--- a/internal/schema/pkl/connection_test.go
+++ b/internal/schema/pkl/connection_test.go
@@ -84,15 +84,6 @@ func TestConnectionWithALegacyFieldIsALoadError(t *testing.T) {
 	}
 }
 
-func TestLegacyFieldsAlsoPopulateTheCompatibilityView(t *testing.T) {
-	cfg, err := loadConfig(t, "testdata/config/connection_hosted.pkl")
-	require.NoError(t, err)
-
-	assert.NotNil(t, cfg.Cli.AuthConfig())
-	assert.Equal(t, cfg.Cli.AuthConfig(), cfg.Cli.Auth,
-		"the legacy view is derived from the connection while callers migrate")
-}
-
 func TestHostedEndpointMustBeHTTPS(t *testing.T) {
 	_, err := loadConfig(t, "testdata/config/hosted_bad_endpoint.pkl")
 

--- a/internal/schema/pkl/connection_test.go
+++ b/internal/schema/pkl/connection_test.go
@@ -1,0 +1,140 @@
+//go:build unit
+
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package pkl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func loadConfig(t *testing.T, path string) (*pkgmodel.Config, error) {
+	t.Helper()
+	return PKL{}.FormaeConfig(path)
+}
+
+func TestHostedConnectionTranslates(t *testing.T) {
+	cfg, err := loadConfig(t, "testdata/config/connection_hosted.pkl")
+	require.NoError(t, err)
+
+	hosted, ok := cfg.Cli.Connection.(*pkgmodel.HostedConnection)
+	require.True(t, ok, "expected *HostedConnection, got %T", cfg.Cli.Connection)
+	assert.Equal(t, "https://cloud.formae.ai", hosted.Endpoint)
+	assert.Equal(t, "3f2b8c14-0000-4000-8000-000000000000", hosted.Installation)
+	assert.JSONEq(t, `{"type":"oidc","issuer":"https://auth.formae.ai"}`, string(hosted.Auth))
+}
+
+func TestAbsentConnectionResolvesToClassicDefaults(t *testing.T) {
+	cfg, err := loadConfig(t, "testdata/config/connection_absent.pkl")
+	require.NoError(t, err)
+
+	classic, ok := cfg.Cli.Connection.(*pkgmodel.ClassicConnection)
+	require.True(t, ok, "expected *ClassicConnection, got %T", cfg.Cli.Connection)
+	assert.Equal(t, "http://localhost", classic.URL)
+	assert.Equal(t, 49684, classic.Port)
+	assert.Empty(t, cfg.Warnings)
+}
+
+func TestLegacyAPISynthesisesClassicAndWarns(t *testing.T) {
+	cfg, err := loadConfig(t, "testdata/config/legacy_api_nested.pkl")
+	require.NoError(t, err)
+
+	classic, ok := cfg.Cli.Connection.(*pkgmodel.ClassicConnection)
+	require.True(t, ok, "expected *ClassicConnection, got %T", cfg.Cli.Connection)
+	assert.Equal(t, "http://agent.example", classic.URL)
+	assert.Equal(t, 8080, classic.Port)
+	require.Len(t, cfg.Warnings, 1)
+	assert.Contains(t, cfg.Warnings[0], "cli.api is deprecated")
+}
+
+func TestLegacyAuthSynthesisesClassicAndWarns(t *testing.T) {
+	cfg, err := loadConfig(t, "testdata/config/legacy_auth_only.pkl")
+	require.NoError(t, err)
+
+	classic, ok := cfg.Cli.Connection.(*pkgmodel.ClassicConnection)
+	require.True(t, ok, "expected *ClassicConnection, got %T", cfg.Cli.Connection)
+	assert.JSONEq(t, `{"type":"basic","username":"u","password":"p"}`, string(classic.Auth))
+	require.Len(t, cfg.Warnings, 1)
+	assert.Contains(t, cfg.Warnings[0], "cli.auth is deprecated")
+}
+
+// The legacy fields carry a credential, so a configuration that sets one
+// alongside an explicit connection is ambiguous about which endpoint that
+// credential is for. Every legacy source is rejected rather than ranked.
+func TestConnectionWithALegacyFieldIsALoadError(t *testing.T) {
+	cases := []struct{ name, fixture, wants string }{
+		{"cli.api", "testdata/config/connection_and_legacy_api.pkl", "cli.api"},
+		{"cli.auth", "testdata/config/connection_and_legacy_auth.pkl", "cli.auth"},
+		{"plugins.authentication", "testdata/config/connection_and_plugins_auth.pkl", "plugins.authentication"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := loadConfig(t, tc.fixture)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "cli.connection")
+			assert.Contains(t, err.Error(), tc.wants)
+		})
+	}
+}
+
+func TestLegacyFieldsAlsoPopulateTheCompatibilityView(t *testing.T) {
+	cfg, err := loadConfig(t, "testdata/config/connection_hosted.pkl")
+	require.NoError(t, err)
+
+	assert.NotNil(t, cfg.Cli.AuthConfig())
+	assert.Equal(t, cfg.Cli.AuthConfig(), cfg.Cli.Auth,
+		"the legacy view is derived from the connection while callers migrate")
+}
+
+func TestHostedEndpointMustBeHTTPS(t *testing.T) {
+	_, err := loadConfig(t, "testdata/config/hosted_bad_endpoint.pkl")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "https")
+}
+
+func TestCanonicalHostedEndpoint(t *testing.T) {
+	cases := []struct{ name, in, want, wantErr string }{
+		{name: "plain", in: "https://cloud.formae.ai", want: "https://cloud.formae.ai"},
+		{name: "trailing slash", in: "https://cloud.formae.ai/", want: "https://cloud.formae.ai"},
+		{name: "explicit 443", in: "https://cloud.formae.ai:443", want: "https://cloud.formae.ai"},
+		{name: "other port kept", in: "https://cloud.formae.ai:8443", want: "https://cloud.formae.ai:8443"},
+		{name: "uppercase", in: "HTTPS://Cloud.Formae.AI", want: "https://cloud.formae.ai"},
+		{name: "http", in: "http://cloud.formae.ai", wantErr: "https"},
+		{name: "userinfo", in: "https://u:p@cloud.formae.ai", wantErr: "credentials"},
+		{name: "query", in: "https://cloud.formae.ai?a=b", wantErr: "query"},
+		{name: "fragment", in: "https://cloud.formae.ai#f", wantErr: "fragment"},
+		{name: "path", in: "https://cloud.formae.ai/api", wantErr: "path"},
+		{name: "relative", in: "cloud.formae.ai", wantErr: "https"},
+		{name: "empty", in: "", wantErr: "https"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := canonicalHostedEndpoint(tc.in)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestValidateInstallation(t *testing.T) {
+	assert.NoError(t, validateInstallation("3f2b8c14-0000-4000-8000-000000000000"))
+	for _, bad := range []string{
+		"", "3F2B8C14-0000-4000-8000-000000000000", "3f2b8c14", "not-a-uuid",
+		" 3f2b8c14-0000-4000-8000-000000000000",
+	} {
+		assert.Error(t, validateInstallation(bad), "expected %q to be rejected", bad)
+	}
+}

--- a/internal/schema/pkl/model/config.go
+++ b/internal/schema/pkl/model/config.go
@@ -18,6 +18,8 @@ func init() {
 	pkl.RegisterMapping("formae.Config#MatchFilter", MatchFilter{})
 	pkl.RegisterMapping("formae.Config#FilterCondition", FilterCondition{})
 	pkl.RegisterMapping("formae.Config#Repository", Repository{})
+	pkl.RegisterMapping("formae.Config#Classic", ClassicConnection{})
+	pkl.RegisterMapping("formae.Config#Hosted", HostedConnection{})
 }
 
 // ResourcePlugin nested types used when decoding BaseResourcePluginConfig
@@ -190,6 +192,20 @@ type APIConfig struct {
 	Port int32  `pkl:"port"`
 }
 
+// ClassicConnection decodes `formae.Config#Classic`.
+type ClassicConnection struct {
+	URL  string      `pkl:"url"`
+	Port int32       `pkl:"port"`
+	Auth *pkl.Object `pkl:"auth"`
+}
+
+// HostedConnection decodes `formae.Config#Hosted`.
+type HostedConnection struct {
+	Endpoint     string      `pkl:"endpoint"`
+	Installation string      `pkl:"installation"`
+	Auth         *pkl.Object `pkl:"auth"`
+}
+
 type Repository struct {
 	URI  url.URL `pkl:"uri"`
 	Type string  `pkl:"type"`
@@ -203,7 +219,11 @@ type ArtifactConfig struct {
 }
 
 type CliConfig struct {
-	API                   APIConfig  `pkl:"api"`
+	// Connection holds *ClassicConnection or *HostedConnection, or nil when
+	// the property is unset. pkl-go dispatches on the registered Pkl class
+	// name, so the decoder picks the concrete type.
+	Connection            any        `pkl:"connection"`
+	API                   *APIConfig `pkl:"api"`
 	DisableUsageReporting bool       `pkl:"disableUsageReporting"`
 	Auth                  pkl.Object `pkl:"auth"`
 	Theme                 string     `pkl:"theme"`

--- a/internal/schema/pkl/pkl.go
+++ b/internal/schema/pkl/pkl.go
@@ -78,7 +78,7 @@ func (p PKL) FormaeConfig(path string) (*pkgmodel.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	return translateConfig(config), nil
+	return translateConfig(config)
 }
 
 // rawConfig evaluates the Pkl configuration at path into the decode model,
@@ -173,7 +173,7 @@ func (p PKL) rawConfig(path string) (*pklmodel.Config, error) {
 	return config, nil
 }
 
-func translateConfig(config *pklmodel.Config) *pkgmodel.Config {
+func translateConfig(config *pklmodel.Config) (*pkgmodel.Config, error) {
 	translated := pkgmodel.Config{
 		Agent: pkgmodel.AgentConfig{
 			Server: pkgmodel.ServerConfig{
@@ -260,14 +260,7 @@ func translateConfig(config *pklmodel.Config) *pkgmodel.Config {
 		},
 		Artifacts: translateArtifactConfig(&config.Artifacts),
 		Cli: pkgmodel.CliConfig{
-			API: func() pkgmodel.APIConfig {
-				if config.Cli.API == nil {
-					return pkgmodel.APIConfig{URL: "http://localhost", Port: 49684}
-				}
-				return pkgmodel.APIConfig{URL: config.Cli.API.URL, Port: int(config.Cli.API.Port)}
-			}(),
 			DisableUsageReporting: config.Cli.DisableUsageReporting,
-			Auth:                  translateAuthConfig(&config.Cli.Auth),
 			Theme:                 config.Cli.Theme,
 			Appearance:            config.Cli.Appearance,
 		},
@@ -277,7 +270,24 @@ func translateConfig(config *pklmodel.Config) *pkgmodel.Config {
 	translated.Network = translateNetworkConfig(config.Network)
 
 	// Backwards compatibility: fall back to deprecated plugins block
-	applyDeprecatedPluginsConfig(config.Plugins, &translated)
+	var legacyCliAuth json.RawMessage
+	applyDeprecatedPluginsConfig(config.Plugins, &translated, &legacyCliAuth)
+
+	conn, err := buildConnection(&config.Cli, legacyCliAuth, &translated.Warnings)
+	if err != nil {
+		return nil, err
+	}
+	translated.Cli.Connection = conn
+
+	// Derived compatibility view, removed once every caller reads Connection.
+	switch c := conn.(type) {
+	case *pkgmodel.ClassicConnection:
+		translated.Cli.API = pkgmodel.APIConfig{URL: c.URL, Port: c.Port}
+		translated.Cli.Auth = c.Auth
+	case *pkgmodel.HostedConnection:
+		translated.Cli.API = pkgmodel.APIConfig{URL: c.Endpoint, Port: 443}
+		translated.Cli.Auth = c.Auth
+	}
 
 	// Warn when global settings conflict with per-plugin overrides
 	checkResourcePluginDeprecations(&translated)
@@ -285,7 +295,7 @@ func translateConfig(config *pklmodel.Config) *pkgmodel.Config {
 	// Synthesize Repositories from legacy flat fields and emit deprecation warnings
 	emitArtifactDeprecationWarnings(&translated)
 
-	return &translated
+	return &translated, nil
 }
 
 // emitArtifactDeprecationWarnings synthesizes a canonical Repositories entry from
@@ -355,7 +365,11 @@ func checkResourcePluginDeprecations(translated *pkgmodel.Config) {
 // applyDeprecatedPluginsConfig copies values from the deprecated plugins block
 // to their new locations, emitting deprecation warnings. New paths take precedence.
 // Warnings are collected in translated.Warnings so callers (CLI) can display them.
-func applyDeprecatedPluginsConfig(plugins *pklmodel.PluginConfig, translated *pkgmodel.Config) {
+func applyDeprecatedPluginsConfig(
+	plugins *pklmodel.PluginConfig,
+	translated *pkgmodel.Config,
+	legacyCliAuth *json.RawMessage,
+) {
 	if plugins == nil {
 		return
 	}
@@ -367,13 +381,18 @@ func applyDeprecatedPluginsConfig(plugins *pklmodel.PluginConfig, translated *pk
 		translated.PluginDir = plugins.PluginDir
 	}
 
-	if plugins.Authentication != nil && translated.Agent.Auth == nil {
-		w := "Your configuration file uses deprecated 'plugins.authentication' — migrate to 'agent.auth' and 'cli.auth'"
+	if plugins.Authentication != nil {
+		w := "Your configuration file uses deprecated 'plugins.authentication' - migrate to 'agent.auth' and 'cli.auth'"
 		slog.Warn(w)
 		translated.Warnings = append(translated.Warnings, w)
 		authJSON := translateDynamic(plugins.Authentication)
-		translated.Agent.Auth = authJSON
-		translated.Cli.Auth = authJSON
+		// The agent keeps its explicit setting when it has one; the CLI's
+		// legacy credential is resolved separately, so an explicit agent.auth
+		// no longer silently leaves the CLI unauthenticated.
+		if translated.Agent.Auth == nil {
+			translated.Agent.Auth = authJSON
+		}
+		*legacyCliAuth = authJSON
 	}
 
 	if plugins.Network != nil && translated.Network == nil {

--- a/internal/schema/pkl/pkl.go
+++ b/internal/schema/pkl/pkl.go
@@ -279,16 +279,6 @@ func translateConfig(config *pklmodel.Config) (*pkgmodel.Config, error) {
 	}
 	translated.Cli.Connection = conn
 
-	// Derived compatibility view, removed once every caller reads Connection.
-	switch c := conn.(type) {
-	case *pkgmodel.ClassicConnection:
-		translated.Cli.API = pkgmodel.APIConfig{URL: c.URL, Port: c.Port}
-		translated.Cli.Auth = c.Auth
-	case *pkgmodel.HostedConnection:
-		translated.Cli.API = pkgmodel.APIConfig{URL: c.Endpoint, Port: 443}
-		translated.Cli.Auth = c.Auth
-	}
-
 	// Warn when global settings conflict with per-plugin overrides
 	checkResourcePluginDeprecations(&translated)
 

--- a/internal/schema/pkl/pkl.go
+++ b/internal/schema/pkl/pkl.go
@@ -74,6 +74,16 @@ func (p PKL) SupportsExtract() bool {
 }
 
 func (p PKL) FormaeConfig(path string) (*pkgmodel.Config, error) {
+	config, err := p.rawConfig(path)
+	if err != nil {
+		return nil, err
+	}
+	return translateConfig(config), nil
+}
+
+// rawConfig evaluates the Pkl configuration at path into the decode model,
+// without translating it into the runtime model.
+func (p PKL) rawConfig(path string) (*pklmodel.Config, error) {
 	formaeFs, err := fs.Sub(assets, "assets/formae")
 	if err != nil {
 		return nil, err
@@ -160,7 +170,7 @@ func (p PKL) FormaeConfig(path string) (*pkgmodel.Config, error) {
 		return nil, fmt.Errorf("failed to evaluate PKL configuration file '%s': %w", path, err)
 	}
 
-	return translateConfig(config), nil
+	return config, nil
 }
 
 func translateConfig(config *pklmodel.Config) *pkgmodel.Config {
@@ -250,10 +260,12 @@ func translateConfig(config *pklmodel.Config) *pkgmodel.Config {
 		},
 		Artifacts: translateArtifactConfig(&config.Artifacts),
 		Cli: pkgmodel.CliConfig{
-			API: pkgmodel.APIConfig{
-				URL:  config.Cli.API.URL,
-				Port: int(config.Cli.API.Port),
-			},
+			API: func() pkgmodel.APIConfig {
+				if config.Cli.API == nil {
+					return pkgmodel.APIConfig{URL: "http://localhost", Port: 49684}
+				}
+				return pkgmodel.APIConfig{URL: config.Cli.API.URL, Port: int(config.Cli.API.Port)}
+			}(),
 			DisableUsageReporting: config.Cli.DisableUsageReporting,
 			Auth:                  translateAuthConfig(&config.Cli.Auth),
 			Theme:                 config.Cli.Theme,

--- a/internal/schema/pkl/testdata/config/connection_absent.pkl
+++ b/internal/schema/pkl/testdata/config/connection_absent.pkl
@@ -1,0 +1,7 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "formae:/Config.pkl"

--- a/internal/schema/pkl/testdata/config/connection_and_legacy_api.pkl
+++ b/internal/schema/pkl/testdata/config/connection_and_legacy_api.pkl
@@ -1,0 +1,12 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "formae:/Config.pkl"
+
+cli {
+    connection = new Classic { url = "http://a.example" }
+    api { url = "http://b.example" }
+}

--- a/internal/schema/pkl/testdata/config/connection_and_legacy_auth.pkl
+++ b/internal/schema/pkl/testdata/config/connection_and_legacy_auth.pkl
@@ -1,0 +1,12 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "formae:/Config.pkl"
+
+cli {
+    connection = new Classic { url = "http://a.example" }
+    auth = new Dynamic { type = "basic"; username = "u"; password = "p" }
+}

--- a/internal/schema/pkl/testdata/config/connection_and_plugins_auth.pkl
+++ b/internal/schema/pkl/testdata/config/connection_and_plugins_auth.pkl
@@ -1,0 +1,15 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "formae:/Config.pkl"
+
+cli {
+    connection = new Classic { url = "http://a.example" }
+}
+
+plugins {
+    authentication = new Dynamic { type = "basic"; username = "u"; password = "p" }
+}

--- a/internal/schema/pkl/testdata/config/connection_classic.pkl
+++ b/internal/schema/pkl/testdata/config/connection_classic.pkl
@@ -1,0 +1,14 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "formae:/Config.pkl"
+
+cli {
+    connection = new Classic {
+        url = "http://agent.example"
+        port = 8080
+    }
+}

--- a/internal/schema/pkl/testdata/config/connection_hosted.pkl
+++ b/internal/schema/pkl/testdata/config/connection_hosted.pkl
@@ -1,0 +1,15 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "formae:/Config.pkl"
+
+cli {
+    connection = new Hosted {
+        endpoint = "https://cloud.formae.ai"
+        installation = "3f2b8c14-0000-4000-8000-000000000000"
+        auth = new Dynamic { type = "oidc"; issuer = "https://auth.formae.ai" }
+    }
+}

--- a/internal/schema/pkl/testdata/config/hosted_bad_endpoint.pkl
+++ b/internal/schema/pkl/testdata/config/hosted_bad_endpoint.pkl
@@ -1,0 +1,15 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "formae:/Config.pkl"
+
+cli {
+    connection = new Hosted {
+        endpoint = "http://cloud.formae.ai"
+        installation = "3f2b8c14-0000-4000-8000-000000000000"
+        auth = new Dynamic { type = "oidc" }
+    }
+}

--- a/internal/schema/pkl/testdata/config/legacy_api_nested.pkl
+++ b/internal/schema/pkl/testdata/config/legacy_api_nested.pkl
@@ -1,0 +1,14 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "formae:/Config.pkl"
+
+cli {
+    api {
+        url = "http://agent.example"
+        port = 8080
+    }
+}

--- a/internal/schema/pkl/testdata/config/legacy_auth_only.pkl
+++ b/internal/schema/pkl/testdata/config/legacy_auth_only.pkl
@@ -1,0 +1,11 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "formae:/Config.pkl"
+
+cli {
+    auth = new Dynamic { type = "basic"; username = "u"; password = "p" }
+}

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -239,6 +239,36 @@ type APIConfig struct {
 	Port int
 }
 
+// Connection is where the CLI sends commands. It has exactly two arms, so a
+// configuration cannot be both classic and hosted, and a hosted connection
+// cannot exist without the installation it addresses.
+type Connection interface {
+	isConnection()
+}
+
+// ClassicConnection addresses a self-hosted agent.
+type ClassicConnection struct {
+	URL  string
+	Port int
+	// Auth is the opaque per-plugin auth configuration, nil when the agent
+	// needs no credential.
+	Auth json.RawMessage
+}
+
+func (*ClassicConnection) isConnection() {}
+
+// HostedConnection addresses one installation behind the hosted endpoint.
+// Endpoint is a canonical https origin and Installation a canonical lowercase
+// UUID: both are validated when the configuration is loaded, so consumers can
+// use them directly.
+type HostedConnection struct {
+	Endpoint     string
+	Installation string
+	Auth         json.RawMessage
+}
+
+func (*HostedConnection) isConnection() {}
+
 // RepositoryType discriminates orbital repositories by purpose.
 type RepositoryType string
 
@@ -263,11 +293,29 @@ type ArtifactConfig struct {
 }
 
 type CliConfig struct {
-	API                   APIConfig
+	Connection Connection
+
+	// API and Auth are the pre-connection view of the same settings, kept
+	// while callers migrate to Connection. Both are derived from Connection
+	// by the config loader; nothing else should write them.
+	API  APIConfig
+	Auth json.RawMessage
+
 	DisableUsageReporting bool
-	Auth                  json.RawMessage
 	Theme                 string
 	Appearance            string
+}
+
+// AuthConfig returns the auth plugin configuration carried by the connection,
+// or nil when the profile configures no auth plugin.
+func (c CliConfig) AuthConfig() json.RawMessage {
+	switch conn := c.Connection.(type) {
+	case *ClassicConnection:
+		return conn.Auth
+	case *HostedConnection:
+		return conn.Auth
+	}
+	return nil
 }
 
 type Config struct {

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -234,11 +234,6 @@ type AgentConfig struct {
 	ResourcePlugins []ResourcePluginUserConfig
 }
 
-type APIConfig struct {
-	URL  string
-	Port int
-}
-
 // Connection is where the CLI sends commands. It has exactly two arms, so a
 // configuration cannot be both classic and hosted, and a hosted connection
 // cannot exist without the installation it addresses.
@@ -294,12 +289,6 @@ type ArtifactConfig struct {
 
 type CliConfig struct {
 	Connection Connection
-
-	// API and Auth are the pre-connection view of the same settings, kept
-	// while callers migrate to Connection. Both are derived from Connection
-	// by the config loader; nothing else should write them.
-	API  APIConfig
-	Auth json.RawMessage
 
 	DisableUsageReporting bool
 	Theme                 string

--- a/pkg/model/connection_test.go
+++ b/pkg/model/connection_test.go
@@ -1,0 +1,23 @@
+//go:build unit
+
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthConfigReadsTheActiveArm(t *testing.T) {
+	raw := json.RawMessage(`{"type":"oidc"}`)
+
+	assert.Equal(t, raw, CliConfig{Connection: &HostedConnection{Auth: raw}}.AuthConfig())
+	assert.Equal(t, raw, CliConfig{Connection: &ClassicConnection{Auth: raw}}.AuthConfig())
+	assert.Nil(t, CliConfig{Connection: &ClassicConnection{}}.AuthConfig())
+	assert.Nil(t, CliConfig{}.AuthConfig())
+}

--- a/pkg/plugin-conformance-tests/harness.go
+++ b/pkg/plugin-conformance-tests/harness.go
@@ -314,7 +314,7 @@ agent {
 }
 
 cli {
-    api {
+    connection = new Classic {
         port = %d
     }
 	disableUsageReporting = true
@@ -668,7 +668,7 @@ agent {
 }
 
 cli {
-    api {
+    connection = new Classic {
         port = %%d
     }
 	disableUsageReporting = true

--- a/tests/blackbox/harness.go
+++ b/tests/blackbox/harness.go
@@ -683,7 +683,7 @@ func (h *TestHarness) startAgent(t *testing.T, timeout time.Duration, openGate b
 	require.NoError(t, err, "Failed to start agent")
 	h.agentCmd = cmd
 
-	h.client = api.NewClient(pkgmodel.APIConfig{
+	h.client = api.NewClient(&pkgmodel.ClassicConnection{
 		URL:  "http://localhost",
 		Port: h.port,
 	}, nil, nil)

--- a/tests/e2e/go/agent.go
+++ b/tests/e2e/go/agent.go
@@ -142,11 +142,11 @@ func StartAgent(t *testing.T, binaryPath string, opts ...AgentOption) *Agent {
         }
     }`, options.authUsername, options.authBcryptHash)
 		cliAuthBlock = fmt.Sprintf(`
-    auth {
-        type = "auth-basic"
-        username = %q
-        password = %q
-    }`, options.authUsername, options.authPassword)
+        auth = new Dynamic {
+            type = "auth-basic"
+            username = %q
+            password = %q
+        }`, options.authUsername, options.authPassword)
 	}
 
 	// Intentionally no pluginDir override. cfg.PluginDir defaults to
@@ -189,10 +189,10 @@ agent {
 }
 
 cli {
-    api {
-        port = %d
+    connection = new Classic {
+        port = %d%s
     }
-    disableUsageReporting = true%s
+    disableUsageReporting = true
 }
 `, options.pklImports, pluginDirBlock, port, dbPath, discoveryEnabled, options.discoveryInterval, resourceTypesBlock, logPath, agentAuthBlock, options.resourcePluginsBlock, port, cliAuthBlock)
 

--- a/tests/e2e/go/auth_basic_test.go
+++ b/tests/e2e/go/auth_basic_test.go
@@ -110,7 +110,7 @@ func TestAuthBasic(t *testing.T) {
 	})
 
 	t.Run("CLI command with auth succeeds", func(t *testing.T) {
-		// The agent config includes cli.auth with the correct credentials.
+		// The agent config includes cli.connection.auth with the correct credentials.
 		// The CLI reads this config, spawns the auth-basic plugin to obtain
 		// an Authorization header, and sends an authenticated request.
 		cli := NewFormaeCLI(bin, agent.ConfigPath(), agent.Port())
@@ -122,19 +122,19 @@ func TestAuthBasic(t *testing.T) {
 	})
 
 	t.Run("CLI command without auth config fails against auth-protected agent", func(t *testing.T) {
-		// Create a config that points at the same agent but has NO cli.auth.
+		// Create a config that points at the same agent but has NO cli.connection.auth.
 		// The CLI will not send credentials, so the agent must reject the request.
 		noAuthConfigDir := t.TempDir()
 		noAuthConfigPath := filepath.Join(noAuthConfigDir, "formae-no-auth.conf.pkl")
 
 		noAuthConfig := fmt.Sprintf(`/*
- * e2e test config — NO cli.auth
+ * e2e test config — NO cli.connection.auth
  */
 
 amends "formae:/Config.pkl"
 
 cli {
-    api {
+    connection = new Classic {
         port = %d
     }
     disableUsageReporting = true

--- a/tests/e2e/go/profile_routing_test.go
+++ b/tests/e2e/go/profile_routing_test.go
@@ -54,13 +54,13 @@ func closedPortE2E(t *testing.T) (string, int) {
 }
 
 // writeProfilePKL writes a minimal formae PKL profile that points the CLI at
-// the given url and port. No agent block or plugins — just the cli.api section.
+// the given url and port. No agent block or plugins — just cli.connection.
 func writeProfilePKL(t *testing.T, path, url string, port int) {
 	t.Helper()
 	content := fmt.Sprintf(`amends "formae:/Config.pkl"
 
 cli {
-    api {
+    connection = new Classic {
         url  = %q
         port = %d
     }


### PR DESCRIPTION
## Summary

The CLI's connection to an agent was two independent settings: `cli.api { url, port }` and an opaque `cli.auth` block. Hosted formae adds a third piece, an installation id sent as a routing header, and the combination of "which endpoint" and "which credential" must never be ambiguous, because guessing wrong sends a bearer token to the wrong server. Both fields also carry schema defaults, so "the user set this" was not observable at all: `cli.api` always arrived populated with `http://localhost:49684`.

This replaces the pair with one sum-typed property, so the contradictory states become unwritable rather than detected:

```pkl
cli {
    connection = new Hosted {
        endpoint = "https://cloud.formae.ai"
        installation = "3f2b8c14-0000-4000-8000-000000000000"
        auth = new Dynamic { type = "oidc" }
    }
}

cli {
    connection = new Classic { url = "http://my-agent.example.com"; port = 49684 }
}
```

A connection cannot be both classic and hosted, and a hosted one cannot exist without the installation it addresses or the credential it needs. What the type cannot express is validated at load: the endpoint is parsed and canonicalised (https only, no userinfo, query, fragment or path), the installation must be a canonical lowercase UUID, and the auth block must name a plugin.

`api.NewClient` is now built from the resolved connection and dispatches on the arm, so a hosted connection always sends `Formae-Installation` exactly once and a classic one never does, without either arm consulting a flag. Hosted requests also refuse redirects that leave the configured origin: Go strips `Authorization` across a cross-host redirect but forwards custom headers, so the routing header would otherwise follow. The check compares scheme, host and port, since resty's own domain policy ignores the port.

## Backwards compatibility

`cli.api` and `cli.auth` keep working and synthesise a classic connection with a deprecation warning, as does the older `plugins.authentication` block. Config files outlive binaries and this is a public tool with released users, so no removal release is proposed here; that needs migration tooling and evidence people have moved.

Two details are load-bearing rather than stylistic:

- The deprecated properties are declared nullable **with no explicit default**. Writing `= null` would break every profile using the documented nested `cli { api { url = ... } }` form, because amending a null-defaulted property yields a `Dynamic` and fails type-checking. A test pins this.
- Setting `cli.connection` alongside any deprecated setting is a hard load error naming both, not a precedence rule. Those settings carry a credential, and a config naming two endpoints does not say which one it is for.

The deprecated CLI auth path also no longer depends on `agent.auth`: previously `plugins.authentication` reached the CLI only when `agent.auth` was unset, which could leave the CLI with no credential at all.

## `formae profile show`

New subcommand, and the first one that shows a profile's *resolved* configuration: `diff` shells out to `diff -u` on raw file text and `edit` opens the file, so neither resolves amends or schema defaults. Human output is themed sections using the active profile's theme; `--output-consumer machine` emits the same view as JSON or YAML behind a `schemaVersion`, which an MCP server can consume for classification and routing instead of scraping the Pkl text: mode, endpoint and installation. It deliberately does not serve auth. The connection's auth block is reduced to its `type` discriminator like any other opaque per-plugin config, so a consumer that needs a credential cannot get one from here, by design.

Secrets are redacted in both modes from one shared view, so the two cannot disagree. Typed secrets are masked, opaque per-plugin blocks emit only their `type` discriminator, and postgres/mssql `connectionParams` are omitted entirely since they are appended to the connection string verbatim and can carry a password. URLs are rendered with `Redacted()` so credentials embedded in an artifacts URI do not print either.

## Notes for review

- `make test-e2e` was not run (needs AWS credentials and a staged installer tree). Unit, integration and lint are green.
- Known gap, deliberately left: when two deprecated sources are set at once alongside a connection, the error names only one of them.
- Implements PLA-427. A pre-existing bug surfaced while building the config viewer is filed separately as PLA-635 (the Aurora Data API `endpoint` is absent from the schema and dropped in translation, so it can never be set from config).
