### PR TITLE
feat(agent): log the source of a command state transition

### DIFF
--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -1059,9 +1059,7 @@ func (f *FormaCommandPersister) markResourceUpdateAsComplete(msg *messages.MarkR
 		// Calculate new command state
 		cmd.State = overallCommandState(cmd)
 		f.Log().Debug("MarkResourceUpdateAsComplete: computed overallCommandState",
-			"commandID", msg.CommandID,
-			"newState", cmd.State,
-			"pendingCompletions", cached.pendingCompletions)
+			commandStateLogFields(cmd, cached.pendingCompletions)...)
 
 		// If command is in final state, do full finalization (hash sensitive data, potentially delete, etc.)
 		// Otherwise just update command meta for performance
@@ -1199,6 +1197,18 @@ func (f *FormaCommandPersister) bulkUpdateResourceState(
 	}
 
 	return true, nil
+}
+
+// commandStateLogFields returns the structured fields logged when a command's
+// overall state is recomputed. Source is included so consumers can tell user
+// commands from scheduler bookkeeping.
+func commandStateLogFields(cmd *forma_command.FormaCommand, pending int) []any {
+	return []any{
+		"commandID", cmd.ID,
+		"newState", cmd.State,
+		"pendingCompletions", pending,
+		"source", cmd.Source,
+	}
 }
 
 func overallCommandState(command *forma_command.FormaCommand) forma_command.CommandState {

--- a/internal/metastructure/forma_persister/forma_command_persister_test.go
+++ b/internal/metastructure/forma_persister/forma_command_persister_test.go
@@ -9,6 +9,8 @@ package forma_persister
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -582,6 +584,18 @@ func TestBuildResourceUpdateIndex_DuplicateKsuids(t *testing.T) {
 	assert.Len(t, ksuidOpToIndex, 2)
 	assert.Equal(t, 0, ksuidOpToIndex[resourceUpdateKey(ksuid1, resource_update.OperationDelete)])
 	assert.Equal(t, 1, ksuidOpToIndex[resourceUpdateKey(ksuid1, resource_update.OperationCreate)])
+}
+
+func TestCommandStateLogFieldsIncludeSource(t *testing.T) {
+	cmd := &forma_command.FormaCommand{
+		ID:     "abc",
+		State:  forma_command.CommandStateFailed,
+		Source: forma_command.SourceSynchronizer,
+	}
+	got := fmt.Sprint(commandStateLogFields(cmd, 3))
+	if !strings.Contains(got, "source") || !strings.Contains(got, "synchronizer") {
+		t.Fatalf("log fields must carry the command source, got: %s", got)
+	}
 }
 
 func TestCachedCommand_FindResourceUpdateIndex(t *testing.T) {


### PR DESCRIPTION
## Summary

The command-state log line records `commandID`, `newState` and `pendingCompletions`, but not which subsystem initiated the command. Commands created by the synchronizer, discovery, the auto-reconciler and the stack expirer are indistinguishable from user applies and destroys in the logs.

That matters for log-based alerting. An alert on failed commands cannot tell a user apply that broke from a periodic sync that was interrupted, so restarting the agent produces failure alerts for work nobody ran, and there is no field to filter on.

This adds `source` to that line, drawn from the value already persisted on the command. The fields move into a small helper so the set stays in one place.