### PR TITLE
feat(datastore): record an append-only agent boot event on startup

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -164,6 +164,10 @@ func (a *Agent) Start() error {
 			return
 		}
 
+		// Append this process start to the agent's own boot history. Best-effort
+		// and never fatal; see recordBoot.
+		recordBoot(ms.Datastore, formae.Version)
+
 		// Pass auth handle to metastructure for supervisor injection
 		if authHandle != nil {
 			ms.AuthPluginHandle = authHandle

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -164,10 +164,6 @@ func (a *Agent) Start() error {
 			return
 		}
 
-		// Append this process start to the agent's own boot history. Best-effort
-		// and never fatal; see recordBoot.
-		recordBoot(a.ctx, ms.Datastore, formae.Version)
-
 		// Pass auth handle to metastructure for supervisor injection
 		if authHandle != nil {
 			ms.AuthPluginHandle = authHandle
@@ -179,6 +175,14 @@ func (a *Agent) Start() error {
 			slog.Error("Failed to start metastructure", "error", err)
 			return
 		}
+
+		// Append this process start to the agent's own boot history. Deliberately
+		// after ms.Start(): the SQLite backend runs on a single connection
+		// (SetMaxOpenConns(1)), so a stalled boot write issued beforehand would
+		// hold the only connection while startup's own database work queued behind
+		// it. Best-effort, cancellable and off the startup goroutine; see
+		// recordBoot.
+		recordBoot(a.ctx, ms.Datastore, formae.Version)
 
 		// Start Ergo actor metrics collection (only if OTel is enabled)
 		if a.cfg.Agent.OTel.Enabled {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -166,7 +166,7 @@ func (a *Agent) Start() error {
 
 		// Append this process start to the agent's own boot history. Best-effort
 		// and never fatal; see recordBoot.
-		recordBoot(ms.Datastore, formae.Version)
+		recordBoot(a.ctx, ms.Datastore, formae.Version)
 
 		// Pass auth handle to metastructure for supervisor injection
 		if authHandle != nil {

--- a/internal/agent/boot.go
+++ b/internal/agent/boot.go
@@ -12,19 +12,33 @@ type bootRecorder interface {
 	RecordAgentBoot(version string) error
 }
 
-// recordBoot appends the boot row for this process start.
+// recordBoot appends the boot row for this process start, off the startup path.
 //
-// Best-effort by design, and never fatal. The row exists so a reader outside
-// this process can answer "which version is this agent" for an installation
-// that has not yet run any command. A display concern must not be able to stop
-// a customer's agent from starting, so a failure is logged and abandoned.
+// The row exists so a reader outside this process can answer "which version is
+// this agent" for an installation that has not yet run any command. It is a
+// display concern, and a display concern must not be able to stop or stall a
+// customer's agent from starting.
 //
-// Not retried: a retry that mattered would have to block startup, and a
-// background one is a goroutine, a backoff and a lifecycle to get right for a
-// version string. The cost is that a transient failure leaves the reader on the
+// That takes two things, not one. Swallowing the error covers a datastore that
+// says no. Running off the startup goroutine covers a datastore that says
+// nothing at all: every backend issues this statement on context.Background()
+// with no deadline, so an unresponsive database blocks in the driver rather
+// than returning, and a synchronous call would hold up startup indefinitely.
+//
+// The returned channel closes once the attempt finishes. Startup ignores it;
+// tests wait on it rather than sleeping.
+//
+// Not retried: a retry that mattered would have to be waited on, and a
+// background one is a backoff and a lifecycle to get right for a version
+// string. The cost is that a transient failure leaves the reader on the
 // previous boot's version until the next start.
-func recordBoot(ds bootRecorder, version string) {
-	if err := ds.RecordAgentBoot(version); err != nil {
-		slog.Warn("Failed to record agent boot; continuing startup", "error", err)
-	}
+func recordBoot(ds bootRecorder, version string) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := ds.RecordAgentBoot(version); err != nil {
+			slog.Warn("Failed to record agent boot; continuing startup", "error", err)
+		}
+	}()
+	return done
 }

--- a/internal/agent/boot.go
+++ b/internal/agent/boot.go
@@ -4,12 +4,15 @@
 
 package agent
 
-import "log/slog"
+import (
+	"context"
+	"log/slog"
+)
 
 // bootRecorder is the slice of the datastore this file needs: appending one row
 // per agent start.
 type bootRecorder interface {
-	RecordAgentBoot(version string) error
+	RecordAgentBoot(ctx context.Context, version string) error
 }
 
 // recordBoot appends the boot row for this process start, off the startup path.
@@ -25,6 +28,11 @@ type bootRecorder interface {
 // with no deadline, so an unresponsive database blocks in the driver rather
 // than returning, and a synchronous call would hold up startup indefinitely.
 //
+// The context is the agent's own, so a stop cancels an in-flight write. Without
+// that, the goroutine keeps a pooled connection checked out and closing the pool
+// waits for it, which turns the stalled-database case into a hung shutdown
+// instead of a hung startup.
+//
 // The returned channel closes once the attempt finishes. Startup ignores it;
 // tests wait on it rather than sleeping.
 //
@@ -32,11 +40,11 @@ type bootRecorder interface {
 // background one is a backoff and a lifecycle to get right for a version
 // string. The cost is that a transient failure leaves the reader on the
 // previous boot's version until the next start.
-func recordBoot(ds bootRecorder, version string) <-chan struct{} {
+func recordBoot(ctx context.Context, ds bootRecorder, version string) <-chan struct{} {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		if err := ds.RecordAgentBoot(version); err != nil {
+		if err := ds.RecordAgentBoot(ctx, version); err != nil {
 			slog.Warn("Failed to record agent boot; continuing startup", "error", err)
 		}
 	}()

--- a/internal/agent/boot.go
+++ b/internal/agent/boot.go
@@ -1,0 +1,30 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package agent
+
+import "log/slog"
+
+// bootRecorder is the slice of the datastore this file needs: appending one row
+// per agent start.
+type bootRecorder interface {
+	RecordAgentBoot(version string) error
+}
+
+// recordBoot appends the boot row for this process start.
+//
+// Best-effort by design, and never fatal. The row exists so a reader outside
+// this process can answer "which version is this agent" for an installation
+// that has not yet run any command. A display concern must not be able to stop
+// a customer's agent from starting, so a failure is logged and abandoned.
+//
+// Not retried: a retry that mattered would have to block startup, and a
+// background one is a goroutine, a backoff and a lifecycle to get right for a
+// version string. The cost is that a transient failure leaves the reader on the
+// previous boot's version until the next start.
+func recordBoot(ds bootRecorder, version string) {
+	if err := ds.RecordAgentBoot(version); err != nil {
+		slog.Warn("Failed to record agent boot; continuing startup", "error", err)
+	}
+}

--- a/internal/agent/boot_test.go
+++ b/internal/agent/boot_test.go
@@ -1,0 +1,48 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package agent
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubBootRecorder struct {
+	calls []string
+	err   error
+}
+
+func (s *stubBootRecorder) RecordAgentBoot(version string) error {
+	s.calls = append(s.calls, version)
+	return s.err
+}
+
+func TestRecordBootWritesOnce(t *testing.T) {
+	rec := &stubBootRecorder{}
+
+	recordBoot(rec, "0.89.0")
+
+	require.Len(t, rec.calls, 1, "exactly one boot row per process start")
+	assert.Equal(t, []string{"0.89.0"}, rec.calls)
+}
+
+// A failing boot record must not stop the agent. The row exists to tell a
+// console which version is running; letting a display feature take down a
+// customer's agent inverts the value entirely, which is the same reasoning that
+// makes the exporter sidecar non-essential.
+func TestRecordBootSwallowsFailure(t *testing.T) {
+	rec := &stubBootRecorder{err: errors.New("datastore unavailable")}
+
+	assert.NotPanics(t, func() {
+		recordBoot(rec, "0.89.0")
+	}, "a failed boot record must never propagate or panic")
+
+	assert.Len(t, rec.calls, 1, "the failure is not retried in-line")
+}

--- a/internal/agent/boot_test.go
+++ b/internal/agent/boot_test.go
@@ -8,29 +8,44 @@ package agent
 
 import (
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type stubBootRecorder struct {
-	calls []string
-	err   error
+	mu      sync.Mutex
+	calls   []string
+	err     error
+	release chan struct{} // when non-nil, RecordAgentBoot blocks until closed
 }
 
 func (s *stubBootRecorder) RecordAgentBoot(version string) error {
+	if s.release != nil {
+		<-s.release
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.calls = append(s.calls, version)
 	return s.err
+}
+
+func (s *stubBootRecorder) recorded() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.calls...)
 }
 
 func TestRecordBootWritesOnce(t *testing.T) {
 	rec := &stubBootRecorder{}
 
-	recordBoot(rec, "0.89.0")
+	<-recordBoot(rec, "0.89.0")
 
-	require.Len(t, rec.calls, 1, "exactly one boot row per process start")
-	assert.Equal(t, []string{"0.89.0"}, rec.calls)
+	require.Len(t, rec.recorded(), 1, "exactly one boot row per process start")
+	assert.Equal(t, []string{"0.89.0"}, rec.recorded())
 }
 
 // A failing boot record must not stop the agent. The row exists to tell a
@@ -41,8 +56,32 @@ func TestRecordBootSwallowsFailure(t *testing.T) {
 	rec := &stubBootRecorder{err: errors.New("datastore unavailable")}
 
 	assert.NotPanics(t, func() {
-		recordBoot(rec, "0.89.0")
+		<-recordBoot(rec, "0.89.0")
 	}, "a failed boot record must never propagate or panic")
 
-	assert.Len(t, rec.calls, 1, "the failure is not retried in-line")
+	assert.Len(t, rec.recorded(), 1, "the failure is not retried in-line")
+}
+
+// Swallowing the error is not enough to make the write best-effort: an
+// unresponsive datastore blocks in the driver rather than returning, and every
+// backend runs this statement on context.Background() with no deadline. If the
+// call were synchronous, a stalled database would hold up agent startup
+// indefinitely, which is the same outage the swallowed error exists to prevent.
+func TestRecordBootDoesNotBlockStartup(t *testing.T) {
+	rec := &stubBootRecorder{release: make(chan struct{})}
+	defer close(rec.release)
+
+	returned := make(chan struct{})
+	go func() {
+		recordBoot(rec, "0.89.0")
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("recordBoot blocked on an unresponsive datastore; startup must not wait on it")
+	}
+
+	assert.Empty(t, rec.recorded(), "the write is still in flight, and startup carried on regardless")
 }

--- a/internal/agent/boot_test.go
+++ b/internal/agent/boot_test.go
@@ -7,6 +7,7 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -21,11 +22,25 @@ type stubBootRecorder struct {
 	calls   []string
 	err     error
 	release chan struct{} // when non-nil, RecordAgentBoot blocks until closed
+	gotCtx  context.Context
 }
 
-func (s *stubBootRecorder) RecordAgentBoot(version string) error {
+func (s *stubBootRecorder) context() context.Context {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.gotCtx
+}
+
+func (s *stubBootRecorder) RecordAgentBoot(ctx context.Context, version string) error {
+	s.mu.Lock()
+	s.gotCtx = ctx
+	s.mu.Unlock()
 	if s.release != nil {
-		<-s.release
+		select {
+		case <-s.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -42,7 +57,7 @@ func (s *stubBootRecorder) recorded() []string {
 func TestRecordBootWritesOnce(t *testing.T) {
 	rec := &stubBootRecorder{}
 
-	<-recordBoot(rec, "0.89.0")
+	<-recordBoot(context.Background(), rec, "0.89.0")
 
 	require.Len(t, rec.recorded(), 1, "exactly one boot row per process start")
 	assert.Equal(t, []string{"0.89.0"}, rec.recorded())
@@ -56,7 +71,7 @@ func TestRecordBootSwallowsFailure(t *testing.T) {
 	rec := &stubBootRecorder{err: errors.New("datastore unavailable")}
 
 	assert.NotPanics(t, func() {
-		<-recordBoot(rec, "0.89.0")
+		<-recordBoot(context.Background(), rec, "0.89.0")
 	}, "a failed boot record must never propagate or panic")
 
 	assert.Len(t, rec.recorded(), 1, "the failure is not retried in-line")
@@ -73,7 +88,7 @@ func TestRecordBootDoesNotBlockStartup(t *testing.T) {
 
 	returned := make(chan struct{})
 	go func() {
-		recordBoot(rec, "0.89.0")
+		recordBoot(context.Background(), rec, "0.89.0")
 		close(returned)
 	}()
 
@@ -84,4 +99,28 @@ func TestRecordBootDoesNotBlockStartup(t *testing.T) {
 	}
 
 	assert.Empty(t, rec.recorded(), "the write is still in flight, and startup carried on regardless")
+}
+
+// Running off the startup goroutine stops a stalled write delaying startup, but
+// it hands the same stall to shutdown: the insert keeps a pooled connection
+// checked out, and closing the pool waits for it. The write must therefore be
+// cancellable by the agent's own context, or a database that stops responding
+// turns an ordinary stop into a hang.
+func TestRecordBootIsCancelledWithTheAgent(t *testing.T) {
+	rec := &stubBootRecorder{release: make(chan struct{})}
+	defer close(rec.release)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := recordBoot(ctx, rec, "0.89.0")
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelling the agent context must abandon the in-flight boot write")
+	}
+
+	require.NotNil(t, rec.context(), "the recorder must be handed a cancellable context")
+	assert.ErrorIs(t, rec.context().Err(), context.Canceled)
 }

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -6298,9 +6298,7 @@ func (d *DatastoreAuroraDataAPI) ForceCancelResourceUpdates(commandID string, in
 }
 
 // RecordAgentBoot appends one agent_boots row for this process start.
-func (d *DatastoreAuroraDataAPI) RecordAgentBoot(version string) error {
-	ctx := context.Background()
-
+func (d *DatastoreAuroraDataAPI) RecordAgentBoot(ctx context.Context, version string) error {
 	query := `INSERT INTO agent_boots (boot_id, version, booted_at) VALUES (:boot_id, :version, :booted_at::timestamp)`
 	params := []types.SqlParameter{
 		{Name: aws.String("boot_id"), Value: &types.FieldMemberStringValue{Value: mksuid.New().String()}},

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -6296,3 +6296,20 @@ func (d *DatastoreAuroraDataAPI) ForceCancelResourceUpdates(commandID string, in
 
 	return result, nil
 }
+
+// RecordAgentBoot appends one agent_boots row for this process start.
+func (d *DatastoreAuroraDataAPI) RecordAgentBoot(version string) error {
+	ctx := context.Background()
+
+	query := `INSERT INTO agent_boots (boot_id, version, booted_at) VALUES (:boot_id, :version, :booted_at::timestamp)`
+	params := []types.SqlParameter{
+		{Name: aws.String("boot_id"), Value: &types.FieldMemberStringValue{Value: mksuid.New().String()}},
+		{Name: aws.String("version"), Value: &types.FieldMemberStringValue{Value: version}},
+		{Name: aws.String("booted_at"), Value: &types.FieldMemberStringValue{Value: time.Now().UTC().Format(time.RFC3339Nano)}},
+	}
+
+	if _, err := d.executeStatement(ctx, query, params); err != nil {
+		return fmt.Errorf("failed to record agent boot: %w", err)
+	}
+	return nil
+}

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -104,6 +104,14 @@ type ResourceVersion struct {
 	Resource *pkgmodel.Resource
 }
 
+// AgentBoot is one recorded agent process start. Append-only; see
+// Datastore.RecordAgentBoot.
+type AgentBoot struct {
+	BootID   string
+	Version  string
+	BootedAt time.Time
+}
+
 // ForceCancelRow is an in-progress resource update that should be force-canceled.
 // It carries the progress JSON to append to the row's progress_result, and the
 // serialized most-recent-progress entry to store as most_recent_progress.
@@ -505,4 +513,14 @@ type Datastore interface {
 	// (split by prior state) and the intended rows that were already terminal (Skipped). Idempotent:
 	// a retry affects zero rows and returns the same Skipped set.
 	ForceCancelResourceUpdates(commandID string, inProgress []ForceCancelRow, notStarted []ResourceUpdateRef, modifiedTs time.Time) (ForceCancelResult, error)
+
+	// RecordAgentBoot appends one row recording that this agent process started
+	// and which build it is running. Append-only: rows are never updated or
+	// deleted, so the sequence is the agent's start history.
+	//
+	// Nothing in the agent reads these rows back. They exist for an
+	// out-of-process reader that needs the running version for an installation
+	// which has not yet run any command, a question the command history cannot
+	// answer because agent_version only exists on a command row.
+	RecordAgentBoot(version string) error
 }

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -5,6 +5,7 @@
 package datastore
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -522,5 +523,5 @@ type Datastore interface {
 	// out-of-process reader that needs the running version for an installation
 	// which has not yet run any command, a question the command history cannot
 	// answer because agent_version only exists on a command row.
-	RecordAgentBoot(version string) error
+	RecordAgentBoot(ctx context.Context, version string) error
 }

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -53,6 +53,12 @@ type TestDatastore struct {
 	// and none on a rejected/no-op reap. Backends that don't provide it leave it
 	// nil and the relevant assertions are skipped.
 	CountReapAuditRowsForTest func(label string) (int, error)
+	// LoadAgentBootsForTest returns every agent_boots row ordered by
+	// (booted_at, boot_id) ascending. The agent has no read path for these rows
+	// by design (the reader is a separate process), so the suite needs a direct
+	// accessor to prove they were written and that they accumulate. Backends
+	// that don't provide it leave it nil and the relevant tests t.Skip().
+	LoadAgentBootsForTest func() ([]datastore.AgentBoot, error)
 	// SetStackValidFromForTest rewrites the valid_from of the named stack's
 	// versions, in ascending version order, to the supplied timestamps. Used to
 	// age a stack deterministically instead of sleeping, so TTL expiry can be
@@ -115,6 +121,10 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunMonotonicTerminalityTest(t, newDS)
 	RunMonotonicTerminalityRaceTest(t, newDS)
 	RunForceCancelResourceUpdatesTest(t, newDS)
+
+	RunRecordAgentBoot(t, newDS)
+	RunAgentBootsAreAppendOnly(t, newDS)
+	RunRecordAgentBootEmptyVersion(t, newDS)
 
 	RunStoreResource(t, newDS)
 	RunUpdateResource(t, newDS)

--- a/internal/datastore/dstest/suite_agent_boots.go
+++ b/internal/datastore/dstest/suite_agent_boots.go
@@ -1,0 +1,101 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package dstest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// RunRecordAgentBoot verifies that recording a boot writes exactly one row
+// carrying the supplied version, a non-empty id, and a timestamp at the moment
+// it was recorded.
+func RunRecordAgentBoot(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("RecordAgentBoot_WritesOneRow", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		if td.LoadAgentBootsForTest == nil {
+			t.Skip("backend does not provide LoadAgentBootsForTest")
+		}
+
+		before := time.Now().UTC().Add(-time.Second)
+		require.NoError(t, ds.RecordAgentBoot("0.89.0"))
+		after := time.Now().UTC().Add(time.Second)
+
+		boots, err := td.LoadAgentBootsForTest()
+		require.NoError(t, err)
+		require.Len(t, boots, 1, "exactly one row per recorded boot")
+
+		assert.Equal(t, "0.89.0", boots[0].Version)
+		assert.NotEmpty(t, boots[0].BootID, "boot id must be non-empty")
+		assert.False(t, boots[0].BootedAt.Before(before), "booted_at must not precede the call")
+		assert.False(t, boots[0].BootedAt.After(after), "booted_at must not follow the call")
+	})
+}
+
+// RunAgentBootsAreAppendOnly verifies that successive boots accumulate rather
+// than overwrite, and that ordering by (booted_at, boot_id) recovers the order
+// they were recorded in. The feed reads the most recent row by exactly that
+// ordering, so a backend that cannot reproduce it would report a stale version.
+func RunAgentBootsAreAppendOnly(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("AgentBoots_AppendOnlyAndOrdered", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		if td.LoadAgentBootsForTest == nil {
+			t.Skip("backend does not provide LoadAgentBootsForTest")
+		}
+
+		versions := []string{"0.88.0", "0.89.0", "0.89.1"}
+		for _, v := range versions {
+			require.NoError(t, ds.RecordAgentBoot(v))
+		}
+
+		boots, err := td.LoadAgentBootsForTest()
+		require.NoError(t, err)
+		require.Len(t, boots, len(versions), "each boot appends a row, none overwrite")
+
+		seen := make(map[string]struct{}, len(boots))
+		for i, b := range boots {
+			assert.Equal(t, versions[i], b.Version, "rows come back in recorded order")
+			_, dup := seen[b.BootID]
+			assert.False(t, dup, "boot ids must be distinct")
+			seen[b.BootID] = struct{}{}
+		}
+	})
+}
+
+// RunRecordAgentBootEmptyVersion verifies that a source build, which carries no
+// stamped version, still records a boot. The row is what tells the console an
+// agent is alive at all, so refusing to write one because the version string is
+// empty would blank the header for exactly the local and e2e builds that report
+// "0.0.0" or nothing.
+func RunRecordAgentBootEmptyVersion(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("RecordAgentBoot_EmptyVersion", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		if td.LoadAgentBootsForTest == nil {
+			t.Skip("backend does not provide LoadAgentBootsForTest")
+		}
+
+		require.NoError(t, ds.RecordAgentBoot(""))
+
+		boots, err := td.LoadAgentBootsForTest()
+		require.NoError(t, err)
+		require.Len(t, boots, 1)
+		assert.Empty(t, boots[0].Version)
+		assert.NotEmpty(t, boots[0].BootID, "an unversioned boot still gets an id")
+	})
+}

--- a/internal/datastore/dstest/suite_agent_boots.go
+++ b/internal/datastore/dstest/suite_agent_boots.go
@@ -7,6 +7,7 @@
 package dstest
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -28,7 +29,7 @@ func RunRecordAgentBoot(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 		}
 
 		before := time.Now().UTC().Add(-time.Second)
-		require.NoError(t, ds.RecordAgentBoot("0.89.0"))
+		require.NoError(t, ds.RecordAgentBoot(context.Background(), "0.89.0"))
 		after := time.Now().UTC().Add(time.Second)
 
 		boots, err := td.LoadAgentBootsForTest()
@@ -58,7 +59,7 @@ func RunAgentBootsAreAppendOnly(t *testing.T, newDS func(t *testing.T) TestDatas
 
 		versions := []string{"0.88.0", "0.89.0", "0.89.1"}
 		for _, v := range versions {
-			require.NoError(t, ds.RecordAgentBoot(v))
+			require.NoError(t, ds.RecordAgentBoot(context.Background(), v))
 		}
 
 		boots, err := td.LoadAgentBootsForTest()
@@ -90,7 +91,7 @@ func RunRecordAgentBootEmptyVersion(t *testing.T, newDS func(t *testing.T) TestD
 			t.Skip("backend does not provide LoadAgentBootsForTest")
 		}
 
-		require.NoError(t, ds.RecordAgentBoot(""))
+		require.NoError(t, ds.RecordAgentBoot(context.Background(), ""))
 
 		boots, err := td.LoadAgentBootsForTest()
 		require.NoError(t, err)

--- a/internal/datastore/migrations_mssql/00020_agent_boots.sql
+++ b/internal/datastore/migrations_mssql/00020_agent_boots.sql
@@ -1,0 +1,29 @@
+-- © 2025 Platform Engineering Labs Inc.
+--
+-- SPDX-License-Identifier: FSL-1.1-ALv2
+
+-- +goose Up
+-- Append-only record of agent starts. One row per process start, carrying the
+-- build the agent is running. Nothing in the agent reads it back: it exists so
+-- an out-of-process reader can answer "which version is this agent, and is it
+-- alive" for an installation that has not yet run any command, which the
+-- command history cannot answer because there are no commands.
+-- +goose StatementBegin
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'agent_boots')
+BEGIN
+    CREATE TABLE agent_boots (
+        boot_id   nvarchar(450) NOT NULL PRIMARY KEY,
+        version   nvarchar(max) NOT NULL,
+        booted_at datetime2 NOT NULL
+    );
+    CREATE INDEX idx_agent_boots_booted_at ON agent_boots (booted_at, boot_id);
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+IF EXISTS (SELECT 1 FROM sys.tables WHERE name = 'agent_boots')
+BEGIN
+    DROP TABLE agent_boots;
+END;
+-- +goose StatementEnd

--- a/internal/datastore/migrations_postgres/00021_agent_boots.sql
+++ b/internal/datastore/migrations_postgres/00021_agent_boots.sql
@@ -1,0 +1,21 @@
+-- © 2025 Platform Engineering Labs Inc.
+--
+-- SPDX-License-Identifier: FSL-1.1-ALv2
+
+-- +goose Up
+-- Append-only record of agent starts. One row per process start, carrying the
+-- build the agent is running. Nothing in the agent reads it back: it exists so
+-- an out-of-process reader can answer "which version is this agent, and is it
+-- alive" for an installation that has not yet run any command, which the
+-- command history cannot answer because there are no commands.
+CREATE TABLE IF NOT EXISTS agent_boots (
+    boot_id   TEXT PRIMARY KEY,
+    version   TEXT NOT NULL,
+    booted_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_boots_booted_at ON agent_boots (booted_at, boot_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_agent_boots_booted_at;
+DROP TABLE IF EXISTS agent_boots;

--- a/internal/datastore/migrations_sqlite/00020_agent_boots.sql
+++ b/internal/datastore/migrations_sqlite/00020_agent_boots.sql
@@ -1,0 +1,21 @@
+-- © 2025 Platform Engineering Labs Inc.
+--
+-- SPDX-License-Identifier: FSL-1.1-ALv2
+
+-- +goose Up
+-- Append-only record of agent starts. One row per process start, carrying the
+-- build the agent is running. Nothing in the agent reads it back: it exists so
+-- an out-of-process reader can answer "which version is this agent, and is it
+-- alive" for an installation that has not yet run any command, which the
+-- command history cannot answer because there are no commands.
+CREATE TABLE IF NOT EXISTS agent_boots (
+    boot_id   TEXT PRIMARY KEY,
+    version   TEXT NOT NULL,
+    booted_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_boots_booted_at ON agent_boots (booted_at, boot_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_agent_boots_booted_at;
+DROP TABLE IF EXISTS agent_boots;

--- a/internal/datastore/mock_datastore_test.go
+++ b/internal/datastore/mock_datastore_test.go
@@ -5,6 +5,7 @@
 package datastore
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -203,6 +204,6 @@ func (m *mockDatastore) ForceCancelResourceUpdates(_ string, _ []ForceCancelRow,
 	return ForceCancelResult{}, nil
 }
 
-func (m *mockDatastore) RecordAgentBoot(_ string) error {
+func (m *mockDatastore) RecordAgentBoot(_ context.Context, _ string) error {
 	return nil
 }

--- a/internal/datastore/mock_datastore_test.go
+++ b/internal/datastore/mock_datastore_test.go
@@ -202,3 +202,7 @@ func (m *mockDatastore) UpdateFormaCommandTargetUpdates(_ string, _ json.RawMess
 func (m *mockDatastore) ForceCancelResourceUpdates(_ string, _ []ForceCancelRow, _ []ResourceUpdateRef, _ time.Time) (ForceCancelResult, error) {
 	return ForceCancelResult{}, nil
 }
+
+func (m *mockDatastore) RecordAgentBoot(_ string) error {
+	return nil
+}

--- a/internal/datastore/mssql/mssql_datastore.go
+++ b/internal/datastore/mssql/mssql_datastore.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/XSAM/otelsql"
+	"github.com/demula/mksuid/v2"
 	json "github.com/goccy/go-json"
 	_ "github.com/microsoft/go-mssqldb"
 	_ "github.com/microsoft/go-mssqldb/azuread"
@@ -963,6 +964,21 @@ func (d *DatastoreMSSQL) UpdateFormaCommandTargetUpdates(commandID string, targe
 	}
 	if rowsAffected == 0 {
 		return fmt.Errorf("forma command not found: %s", commandID)
+	}
+	return nil
+}
+
+// RecordAgentBoot appends one agent_boots row for this process start.
+func (d *DatastoreMSSQL) RecordAgentBoot(version string) error {
+	ctx, span := mssqlTracer.Start(context.Background(), "RecordAgentBoot")
+	defer span.End()
+
+	_, err := d.conn.ExecContext(ctx,
+		"INSERT INTO agent_boots (boot_id, version, booted_at) VALUES (@p1, @p2, @p3)",
+		mksuid.New().String(), version, time.Now().UTC(),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to record agent boot: %w", err)
 	}
 	return nil
 }

--- a/internal/datastore/mssql/mssql_datastore.go
+++ b/internal/datastore/mssql/mssql_datastore.go
@@ -969,8 +969,8 @@ func (d *DatastoreMSSQL) UpdateFormaCommandTargetUpdates(commandID string, targe
 }
 
 // RecordAgentBoot appends one agent_boots row for this process start.
-func (d *DatastoreMSSQL) RecordAgentBoot(version string) error {
-	ctx, span := mssqlTracer.Start(context.Background(), "RecordAgentBoot")
+func (d *DatastoreMSSQL) RecordAgentBoot(ctx context.Context, version string) error {
+	ctx, span := mssqlTracer.Start(ctx, "RecordAgentBoot")
 	defer span.End()
 
 	_, err := d.conn.ExecContext(ctx,

--- a/internal/datastore/mssql/mssql_dstest_test.go
+++ b/internal/datastore/mssql/mssql_dstest_test.go
@@ -15,6 +15,7 @@ import (
 
 	_ "github.com/microsoft/go-mssqldb"
 
+	"github.com/platform-engineering-labs/formae/internal/datastore"
 	"github.com/platform-engineering-labs/formae/internal/datastore/dstest"
 	"github.com/platform-engineering-labs/formae/internal/datastore/mssql"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
@@ -76,6 +77,22 @@ func TestDatastore(t *testing.T) {
 					uri, version, target, operation,
 				)
 				return err
+			},
+			LoadAgentBootsForTest: func() ([]datastore.AgentBoot, error) {
+				rows, err := conn.Query(`SELECT boot_id, version, booted_at FROM agent_boots ORDER BY booted_at, boot_id`)
+				if err != nil {
+					return nil, err
+				}
+				defer rows.Close() //nolint:errcheck
+				var out []datastore.AgentBoot
+				for rows.Next() {
+					var b datastore.AgentBoot
+					if err := rows.Scan(&b.BootID, &b.Version, &b.BootedAt); err != nil {
+						return nil, err
+					}
+					out = append(out, b)
+				}
+				return out, rows.Err()
 			},
 			SetTargetHealthStateForTest: func(label, state string) error {
 				_, err := conn.Exec(

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -5086,3 +5086,15 @@ func (d DatastorePostgres) ForceCancelResourceUpdates(commandID string, inProgre
 
 	return result, nil
 }
+
+// RecordAgentBoot appends one agent_boots row for this process start.
+func (d DatastorePostgres) RecordAgentBoot(version string) error {
+	ctx, span := tracer.Start(context.Background(), "RecordAgentBoot")
+	defer span.End()
+
+	query := `INSERT INTO agent_boots (boot_id, version, booted_at) VALUES ($1, $2, $3)`
+	if _, err := d.pool.Exec(ctx, query, mksuid.New().String(), version, time.Now().UTC()); err != nil {
+		return fmt.Errorf("failed to record agent boot: %w", err)
+	}
+	return nil
+}

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -5088,8 +5088,8 @@ func (d DatastorePostgres) ForceCancelResourceUpdates(commandID string, inProgre
 }
 
 // RecordAgentBoot appends one agent_boots row for this process start.
-func (d DatastorePostgres) RecordAgentBoot(version string) error {
-	ctx, span := tracer.Start(context.Background(), "RecordAgentBoot")
+func (d DatastorePostgres) RecordAgentBoot(ctx context.Context, version string) error {
+	ctx, span := tracer.Start(ctx, "RecordAgentBoot")
 	defer span.End()
 
 	query := `INSERT INTO agent_boots (boot_id, version, booted_at) VALUES ($1, $2, $3)`

--- a/internal/datastore/postgres/postgres_test.go
+++ b/internal/datastore/postgres/postgres_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/demula/mksuid/v2"
 	"github.com/jackc/pgx/v5"
+	"github.com/platform-engineering-labs/formae/internal/datastore"
 	"github.com/platform-engineering-labs/formae/internal/datastore/dstest"
 	"github.com/platform-engineering-labs/formae/internal/datastore/postgres"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
@@ -371,6 +372,23 @@ func TestDatastore(t *testing.T) {
 				// exhausts Postgres's connection limit ("too many clients already").
 				d.Close()
 				return d.CleanUp()
+			},
+			LoadAgentBootsForTest: func() ([]datastore.AgentBoot, error) {
+				rows, err := d.Pool().Query(context.Background(),
+					`SELECT boot_id, version, booted_at FROM agent_boots ORDER BY booted_at, boot_id`)
+				if err != nil {
+					return nil, err
+				}
+				defer rows.Close()
+				var out []datastore.AgentBoot
+				for rows.Next() {
+					var b datastore.AgentBoot
+					if err := rows.Scan(&b.BootID, &b.Version, &b.BootedAt); err != nil {
+						return nil, err
+					}
+					out = append(out, b)
+				}
+				return out, rows.Err()
 			},
 			SetTargetHealthStateForTest: func(label, state string) error {
 				_, err := d.Pool().Exec(context.Background(),

--- a/internal/datastore/sqlite/agent_boots_test.go
+++ b/internal/datastore/sqlite/agent_boots_test.go
@@ -1,0 +1,53 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package sqlite
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SQLite has no timestamp type, so booted_at is stored as text and ordered as
+// text. The reader picks the newest boot with ORDER BY booted_at, so the stored
+// format has to sort lexicographically in the same order it sorts
+// chronologically.
+//
+// time.RFC3339Nano does not: it drops trailing zeros from the fractional part,
+// so an earlier ".5Z" compares greater than a later ".500000001Z" ('Z' > '0')
+// and the reader would report a stale version. Two boots inside one second is
+// what a crash-looping agent does, so this is reachable rather than theoretical.
+func TestAgentBootTimestampSortsChronologically(t *testing.T) {
+	base := time.Date(2026, 8, 15, 10, 30, 45, 0, time.UTC)
+
+	ordered := []time.Time{
+		base,
+		base.Add(500 * time.Millisecond),   // .5 -> trailing zeros
+		base.Add(500*time.Millisecond + 1), // .500000001
+		base.Add(900 * time.Millisecond),   // .9 -> trailing zeros
+		base.Add(time.Second),
+	}
+
+	for i := 1; i < len(ordered); i++ {
+		prev := agentBootTimestamp(ordered[i-1])
+		cur := agentBootTimestamp(ordered[i])
+
+		require.True(t, ordered[i-1].Before(ordered[i]), "fixture must be chronological")
+		assert.Less(t, prev, cur,
+			"text order must match time order: %q must sort before %q", prev, cur)
+	}
+}
+
+func TestAgentBootTimestampRoundTrips(t *testing.T) {
+	want := time.Date(2026, 8, 15, 10, 30, 45, 500000001, time.UTC)
+
+	got, err := time.Parse(time.RFC3339Nano, agentBootTimestamp(want))
+	require.NoError(t, err)
+	assert.True(t, want.Equal(got), "stored form must parse back to the same instant")
+}

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -5357,12 +5357,13 @@ func (d DatastoreSQLite) CleanUp() error {
 func (d DatastoreSQLite) Conn() *sql.DB { return d.conn }
 
 // RecordAgentBoot appends one agent_boots row for this process start.
-func (d DatastoreSQLite) RecordAgentBoot(version string) error {
-	_, span := sqliteTracer.Start(context.Background(), "RecordAgentBoot")
+func (d DatastoreSQLite) RecordAgentBoot(ctx context.Context, version string) error {
+	ctx, span := sqliteTracer.Start(ctx, "RecordAgentBoot")
 	defer span.End()
 
 	bootedAt := time.Now().UTC()
-	_, err := d.conn.Exec(
+	_, err := d.conn.ExecContext(
+		ctx,
 		`INSERT INTO agent_boots (boot_id, version, booted_at) VALUES (?, ?, ?)`,
 		mksuid.New().String(), version, bootedAt.Format(time.RFC3339Nano),
 	)

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -5357,15 +5357,26 @@ func (d DatastoreSQLite) CleanUp() error {
 func (d DatastoreSQLite) Conn() *sql.DB { return d.conn }
 
 // RecordAgentBoot appends one agent_boots row for this process start.
+// agentBootTimestampLayout is RFC 3339 with a fixed-width nanosecond fraction.
+// SQLite stores booted_at as text and the reader orders by it, so the format
+// has to sort lexicographically in chronological order. time.RFC3339Nano does
+// not qualify: it strips trailing zeros, so ".5Z" compares greater than the
+// later ".500000001Z".
+const agentBootTimestampLayout = "2006-01-02T15:04:05.000000000Z07:00"
+
+// agentBootTimestamp renders a boot time for storage and comparison in SQLite.
+func agentBootTimestamp(t time.Time) string {
+	return t.UTC().Format(agentBootTimestampLayout)
+}
+
 func (d DatastoreSQLite) RecordAgentBoot(ctx context.Context, version string) error {
 	ctx, span := sqliteTracer.Start(ctx, "RecordAgentBoot")
 	defer span.End()
 
-	bootedAt := time.Now().UTC()
 	_, err := d.conn.ExecContext(
 		ctx,
 		`INSERT INTO agent_boots (boot_id, version, booted_at) VALUES (?, ?, ?)`,
-		mksuid.New().String(), version, bootedAt.Format(time.RFC3339Nano),
+		mksuid.New().String(), version, agentBootTimestamp(time.Now().UTC()),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to record agent boot: %w", err)

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -5355,3 +5355,19 @@ func (d DatastoreSQLite) CleanUp() error {
 // Conn returns the underlying database connection. Used by test helpers that
 // need direct SQL access (e.g. forcing health_state for guard assertions).
 func (d DatastoreSQLite) Conn() *sql.DB { return d.conn }
+
+// RecordAgentBoot appends one agent_boots row for this process start.
+func (d DatastoreSQLite) RecordAgentBoot(version string) error {
+	_, span := sqliteTracer.Start(context.Background(), "RecordAgentBoot")
+	defer span.End()
+
+	bootedAt := time.Now().UTC()
+	_, err := d.conn.Exec(
+		`INSERT INTO agent_boots (boot_id, version, booted_at) VALUES (?, ?, ?)`,
+		mksuid.New().String(), version, bootedAt.Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to record agent boot: %w", err)
+	}
+	return nil
+}

--- a/internal/datastore/sqlite/sqlite_test.go
+++ b/internal/datastore/sqlite/sqlite_test.go
@@ -80,6 +80,28 @@ func TestDatastore(t *testing.T) {
 				}
 				return op, err
 			},
+			LoadAgentBootsForTest: func() ([]datastore.AgentBoot, error) {
+				conn := d.Conn()
+				rows, err := conn.Query(`SELECT boot_id, version, booted_at FROM agent_boots ORDER BY booted_at, boot_id`)
+				if err != nil {
+					return nil, err
+				}
+				defer rows.Close() //nolint:errcheck
+				var out []datastore.AgentBoot
+				for rows.Next() {
+					var b datastore.AgentBoot
+					var ts string
+					if err := rows.Scan(&b.BootID, &b.Version, &ts); err != nil {
+						return nil, err
+					}
+					b.BootedAt, err = time.Parse(time.RFC3339Nano, ts)
+					if err != nil {
+						return nil, err
+					}
+					out = append(out, b)
+				}
+				return out, rows.Err()
+			},
 			CountReapAuditRowsForTest: func(label string) (int, error) {
 				conn := d.Conn()
 				var n int

--- a/internal/metastructure/extract_resources_test.go
+++ b/internal/metastructure/extract_resources_test.go
@@ -576,3 +576,7 @@ func TestExtractResources_BatchedPolicyLookups(t *testing.T) {
 	assert.Equal(t, 1, ds.loadStacksByLabelsCalls, "LoadStacksByLabels must be called exactly once")
 	assert.Equal(t, 0, ds.getStackByLabelCalls, "GetStackByLabel must not be called (N+1 avoided)")
 }
+
+func (m *mockExtractDatastore) RecordAgentBoot(_ string) error {
+	return nil
+}

--- a/internal/metastructure/extract_resources_test.go
+++ b/internal/metastructure/extract_resources_test.go
@@ -5,6 +5,7 @@
 package metastructure
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -577,6 +578,6 @@ func TestExtractResources_BatchedPolicyLookups(t *testing.T) {
 	assert.Equal(t, 0, ds.getStackByLabelCalls, "GetStackByLabel must not be called (N+1 avoided)")
 }
 
-func (m *mockExtractDatastore) RecordAgentBoot(_ string) error {
+func (m *mockExtractDatastore) RecordAgentBoot(_ context.Context, _ string) error {
 	return nil
 }

--- a/internal/metastructure/resource_summaries_test.go
+++ b/internal/metastructure/resource_summaries_test.go
@@ -5,6 +5,7 @@
 package metastructure
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -450,6 +451,6 @@ func TestExtractResourceByKsuid_DeletedReturnsNil(t *testing.T) {
 	assert.Equal(t, 0, ds.loadResourceByIdCalls, "must not fall back to LoadResourceById")
 }
 
-func (m *mockSummaryDatastore) RecordAgentBoot(_ string) error {
+func (m *mockSummaryDatastore) RecordAgentBoot(_ context.Context, _ string) error {
 	return nil
 }

--- a/internal/metastructure/resource_summaries_test.go
+++ b/internal/metastructure/resource_summaries_test.go
@@ -449,3 +449,7 @@ func TestExtractResourceByKsuid_DeletedReturnsNil(t *testing.T) {
 	assert.Equal(t, 0, ds.batchGetTripletsCalls, "must not call BatchGetTripletsByKSUIDs for deleted resource")
 	assert.Equal(t, 0, ds.loadResourceByIdCalls, "must not fall back to LoadResourceById")
 }
+
+func (m *mockSummaryDatastore) RecordAgentBoot(_ string) error {
+	return nil
+}


### PR DESCRIPTION
## What

Adds an append-only `agent_boots` table, one row per agent process start, carrying the build the agent is running and when it started. Migrated across sqlite, postgres and mssql; aurora reuses the postgres set.

## Why

The agent already stamps `agent_version` onto every command row, which answers "which build ran this command". It cannot answer "which build is this agent running" for an installation that has not yet run one, because there are no commands to read it from. A freshly provisioned agent is exactly the case that needs answering.

Nothing in the agent reads these rows back: the reader is a separate process, so the write is the whole feature and the shared suite reaches the rows through a backend-provided test accessor.

## The write must never harm the agent

It is a display concern, so it must not be able to stop, stall or outlive a customer's agent starting. That turned out to need four things rather than one, three of them found by review:

- **Errors are swallowed.** A datastore that says no is logged and abandoned.
- **It runs off the startup goroutine.** Every backend issues the statement with no deadline, so a datastore that says *nothing* blocks in the driver rather than returning. Synchronously, a stalled database would have held up startup indefinitely.
- **It takes a context, and gets the agent's.** Async alone moved the stall to shutdown: the insert keeps a pooled connection checked out and closing the pool waits for it. `RecordAgentBoot` is the only method on the `Datastore` interface that takes a context, which is a deliberate exception rather than a new convention.
- **It runs after `ms.Start()`.** The SQLite backend has `SetMaxOpenConns(1)`, so a stalled write issued earlier would hold the single connection while startup's own database work queued behind it. Being on its own goroutine does not help when there is one connection to contend for.

It is not retried. A retry that mattered would have to be waited on, and a background one is a backoff and a lifecycle to get right for a version string. The cost, stated rather than implied: a transient failure leaves the reader on the previous boot's version until the next start.

## SQLite timestamp ordering

SQLite has no timestamp type, so `booted_at` is text and is ordered as text. `time.RFC3339Nano` strips trailing zeros, so an earlier `.5Z` compares greater than a later `.500000001Z` and the reader would report a stale version — reachable, because two boots inside one second is what a crash-looping agent does. Stored with a fixed-width nanosecond fraction instead, which also removes a latent flake from the shared suite.

## Testing

TDD throughout; every test was watched failing first, and the migration was removed afterwards to confirm the suite detects the feature's absence rather than only itself.

- Shared datastore suite, so all four backends are covered: one row per boot, append-only and ordered, and an unversioned (source build) boot still recorded.
- Agent: the write happens once, a failure is swallowed, a stalled datastore does not block startup, and cancelling the agent context abandons an in-flight write.
- SQLite: text ordering matches chronological ordering, and the stored form round-trips.

`make lint` clean. The only failing package in the full unit run is `internal/schema/pkl`, which fails identically on a clean worktree at the same base and is unrelated to this change.

Design and review history: PLA-668.