### PR TITLE
refactor(datastore): bound the boot write without a caller context

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -182,7 +182,7 @@ func (a *Agent) Start() error {
 		// hold the only connection while startup's own database work queued behind
 		// it. Best-effort, cancellable and off the startup goroutine; see
 		// recordBoot.
-		recordBoot(a.ctx, ms.Datastore, formae.Version)
+		recordBoot(ms.Datastore, formae.Version)
 
 		// Start Ergo actor metrics collection (only if OTel is enabled)
 		if a.cfg.Agent.OTel.Enabled {

--- a/internal/agent/boot.go
+++ b/internal/agent/boot.go
@@ -4,15 +4,12 @@
 
 package agent
 
-import (
-	"context"
-	"log/slog"
-)
+import "log/slog"
 
 // bootRecorder is the slice of the datastore this file needs: appending one row
 // per agent start.
 type bootRecorder interface {
-	RecordAgentBoot(ctx context.Context, version string) error
+	RecordAgentBoot(version string) error
 }
 
 // recordBoot appends the boot row for this process start, off the startup path.
@@ -28,10 +25,12 @@ type bootRecorder interface {
 // with no deadline, so an unresponsive database blocks in the driver rather
 // than returning, and a synchronous call would hold up startup indefinitely.
 //
-// The context is the agent's own, so a stop cancels an in-flight write. Without
-// that, the goroutine keeps a pooled connection checked out and closing the pool
-// waits for it, which turns the stalled-database case into a hung shutdown
-// instead of a hung startup.
+// The datastore bounds the write itself (datastore.AgentBootWriteTimeout), so
+// the goroutine cannot outlive a stop indefinitely: without a bound it would
+// keep a pooled connection checked out and closing the pool would wait for it,
+// turning the stalled-database case into a hung shutdown instead of a hung
+// startup. The bound lives with every other backend's context handling rather
+// than making this the one method that takes a context from its caller.
 //
 // The returned channel closes once the attempt finishes. Startup ignores it;
 // tests wait on it rather than sleeping.
@@ -40,11 +39,11 @@ type bootRecorder interface {
 // background one is a backoff and a lifecycle to get right for a version
 // string. The cost is that a transient failure leaves the reader on the
 // previous boot's version until the next start.
-func recordBoot(ctx context.Context, ds bootRecorder, version string) <-chan struct{} {
+func recordBoot(ds bootRecorder, version string) <-chan struct{} {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		if err := ds.RecordAgentBoot(ctx, version); err != nil {
+		if err := ds.RecordAgentBoot(version); err != nil {
 			slog.Warn("Failed to record agent boot; continuing startup", "error", err)
 		}
 	}()

--- a/internal/agent/boot_test.go
+++ b/internal/agent/boot_test.go
@@ -7,7 +7,6 @@
 package agent
 
 import (
-	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -22,25 +21,11 @@ type stubBootRecorder struct {
 	calls   []string
 	err     error
 	release chan struct{} // when non-nil, RecordAgentBoot blocks until closed
-	gotCtx  context.Context
 }
 
-func (s *stubBootRecorder) context() context.Context {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.gotCtx
-}
-
-func (s *stubBootRecorder) RecordAgentBoot(ctx context.Context, version string) error {
-	s.mu.Lock()
-	s.gotCtx = ctx
-	s.mu.Unlock()
+func (s *stubBootRecorder) RecordAgentBoot(version string) error {
 	if s.release != nil {
-		select {
-		case <-s.release:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+		<-s.release
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -57,7 +42,7 @@ func (s *stubBootRecorder) recorded() []string {
 func TestRecordBootWritesOnce(t *testing.T) {
 	rec := &stubBootRecorder{}
 
-	<-recordBoot(context.Background(), rec, "0.89.0")
+	<-recordBoot(rec, "0.89.0")
 
 	require.Len(t, rec.recorded(), 1, "exactly one boot row per process start")
 	assert.Equal(t, []string{"0.89.0"}, rec.recorded())
@@ -71,7 +56,7 @@ func TestRecordBootSwallowsFailure(t *testing.T) {
 	rec := &stubBootRecorder{err: errors.New("datastore unavailable")}
 
 	assert.NotPanics(t, func() {
-		<-recordBoot(context.Background(), rec, "0.89.0")
+		<-recordBoot(rec, "0.89.0")
 	}, "a failed boot record must never propagate or panic")
 
 	assert.Len(t, rec.recorded(), 1, "the failure is not retried in-line")
@@ -88,7 +73,7 @@ func TestRecordBootDoesNotBlockStartup(t *testing.T) {
 
 	returned := make(chan struct{})
 	go func() {
-		recordBoot(context.Background(), rec, "0.89.0")
+		recordBoot(rec, "0.89.0")
 		close(returned)
 	}()
 
@@ -99,28 +84,4 @@ func TestRecordBootDoesNotBlockStartup(t *testing.T) {
 	}
 
 	assert.Empty(t, rec.recorded(), "the write is still in flight, and startup carried on regardless")
-}
-
-// Running off the startup goroutine stops a stalled write delaying startup, but
-// it hands the same stall to shutdown: the insert keeps a pooled connection
-// checked out, and closing the pool waits for it. The write must therefore be
-// cancellable by the agent's own context, or a database that stops responding
-// turns an ordinary stop into a hang.
-func TestRecordBootIsCancelledWithTheAgent(t *testing.T) {
-	rec := &stubBootRecorder{release: make(chan struct{})}
-	defer close(rec.release)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := recordBoot(ctx, rec, "0.89.0")
-
-	cancel()
-
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("cancelling the agent context must abandon the in-flight boot write")
-	}
-
-	require.NotNil(t, rec.context(), "the recorder must be handed a cancellable context")
-	assert.ErrorIs(t, rec.context().Err(), context.Canceled)
 }

--- a/internal/datastore/agent_boot.go
+++ b/internal/datastore/agent_boot.go
@@ -25,7 +25,17 @@ const AgentBootWriteTimeout = 10 * time.Second
 // write, so all four share one definition of how long that write may take
 // rather than each inventing its own.
 //
+// parent is the backend's own stored lifecycle context, which every backend
+// already holds. Deriving from it rather than from context.Background() means a
+// stop cancels an in-flight write immediately instead of leaving shutdown to
+// wait out the timeout: that wait is close enough to the stop grace period to
+// turn a graceful stop into a force-kill. The timeout still bounds a stall that
+// happens while the agent is otherwise healthy.
+//
 // The caller must call the returned cancel function.
-func AgentBootContext() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), AgentBootWriteTimeout)
+func AgentBootContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, AgentBootWriteTimeout)
 }

--- a/internal/datastore/agent_boot.go
+++ b/internal/datastore/agent_boot.go
@@ -1,0 +1,31 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package datastore
+
+import (
+	"context"
+	"time"
+)
+
+// AgentBootWriteTimeout bounds a single boot write.
+//
+// RecordAgentBoot is the only write issued off the request path: the agent
+// starts it on a detached goroutine so a stalled database cannot delay startup.
+// That leaves nothing else to limit how long it may run, and an unbounded
+// insert keeps a connection checked out, which closing the pool then waits for,
+// turning an ordinary stop into a hang.
+//
+// It is therefore also the worst case a shutdown waits on the write, so it is
+// deliberately short: a display-only record must not visibly delay a stop.
+const AgentBootWriteTimeout = 10 * time.Second
+
+// AgentBootContext returns the bounded context a backend uses for its boot
+// write, so all four share one definition of how long that write may take
+// rather than each inventing its own.
+//
+// The caller must call the returned cancel function.
+func AgentBootContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), AgentBootWriteTimeout)
+}

--- a/internal/datastore/agent_boot_test.go
+++ b/internal/datastore/agent_boot_test.go
@@ -1,0 +1,58 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package datastore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every other method on the Datastore interface builds its own context
+// internally, so the boot write does too rather than being the single method
+// that takes one from its caller.
+//
+// It still has to be bounded. It is the only write issued off the request path,
+// on a detached goroutine at startup, so nothing else limits how long it can
+// hold a connection: unbounded, a stalled database keeps that connection
+// checked out and closing the pool waits for it, turning an ordinary stop into
+// a hang.
+func TestAgentBootContextIsBounded(t *testing.T) {
+	ctx, cancel := AgentBootContext()
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok, "the boot write context must carry a deadline")
+
+	remaining := time.Until(deadline)
+	assert.Positive(t, remaining, "deadline must be in the future")
+	assert.LessOrEqual(t, remaining, AgentBootWriteTimeout,
+		"deadline must be within the declared timeout")
+}
+
+// The timeout is also the worst case a stop waits on an in-flight boot write,
+// so it has to stay short enough that a shutdown is not visibly delayed by a
+// display-only write.
+func TestAgentBootWriteTimeoutIsShort(t *testing.T) {
+	assert.Positive(t, AgentBootWriteTimeout)
+	assert.LessOrEqual(t, AgentBootWriteTimeout, 30*time.Second,
+		"a longer timeout would let a display-only write visibly delay shutdown")
+}
+
+func TestAgentBootContextIsCancellable(t *testing.T) {
+	ctx, cancel := AgentBootContext()
+
+	cancel()
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("cancel must release the context")
+	}
+}

--- a/internal/datastore/agent_boot_test.go
+++ b/internal/datastore/agent_boot_test.go
@@ -7,6 +7,7 @@
 package datastore
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -24,7 +25,7 @@ import (
 // checked out and closing the pool waits for it, turning an ordinary stop into
 // a hang.
 func TestAgentBootContextIsBounded(t *testing.T) {
-	ctx, cancel := AgentBootContext()
+	ctx, cancel := AgentBootContext(context.Background())
 	defer cancel()
 
 	deadline, ok := ctx.Deadline()
@@ -46,7 +47,7 @@ func TestAgentBootWriteTimeoutIsShort(t *testing.T) {
 }
 
 func TestAgentBootContextIsCancellable(t *testing.T) {
-	ctx, cancel := AgentBootContext()
+	ctx, cancel := AgentBootContext(context.Background())
 
 	cancel()
 
@@ -55,4 +56,32 @@ func TestAgentBootContextIsCancellable(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("cancel must release the context")
 	}
+}
+
+// A stop cancels the write immediately rather than leaving shutdown to wait out
+// the timeout. Without this the wait is close enough to the stop grace period
+// to turn a graceful stop into a force-kill.
+func TestAgentBootContextFollowsItsParent(t *testing.T) {
+	parent, stop := context.WithCancel(context.Background())
+	ctx, cancel := AgentBootContext(parent)
+	defer cancel()
+
+	stop()
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("cancelling the parent must cancel the boot write immediately")
+	}
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+}
+
+// A backend constructed without a lifecycle context still gets a bounded one
+// rather than a panic.
+func TestAgentBootContextToleratesNilParent(t *testing.T) {
+	ctx, cancel := AgentBootContext(nil) //nolint:staticcheck // explicitly covering the nil case
+	defer cancel()
+
+	_, ok := ctx.Deadline()
+	assert.True(t, ok, "a nil parent must still yield a bounded context")
 }

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -6298,7 +6298,9 @@ func (d *DatastoreAuroraDataAPI) ForceCancelResourceUpdates(commandID string, in
 }
 
 // RecordAgentBoot appends one agent_boots row for this process start.
-func (d *DatastoreAuroraDataAPI) RecordAgentBoot(ctx context.Context, version string) error {
+func (d *DatastoreAuroraDataAPI) RecordAgentBoot(version string) error {
+	ctx, cancel := datastore.AgentBootContext()
+	defer cancel()
 	query := `INSERT INTO agent_boots (boot_id, version, booted_at) VALUES (:boot_id, :version, :booted_at::timestamp)`
 	params := []types.SqlParameter{
 		{Name: aws.String("boot_id"), Value: &types.FieldMemberStringValue{Value: mksuid.New().String()}},

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -6299,7 +6299,7 @@ func (d *DatastoreAuroraDataAPI) ForceCancelResourceUpdates(commandID string, in
 
 // RecordAgentBoot appends one agent_boots row for this process start.
 func (d *DatastoreAuroraDataAPI) RecordAgentBoot(version string) error {
-	ctx, cancel := datastore.AgentBootContext()
+	ctx, cancel := datastore.AgentBootContext(d.ctx)
 	defer cancel()
 	query := `INSERT INTO agent_boots (boot_id, version, booted_at) VALUES (:boot_id, :version, :booted_at::timestamp)`
 	params := []types.SqlParameter{

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -5,7 +5,6 @@
 package datastore
 
 import (
-	"context"
 	"encoding/json"
 	"time"
 
@@ -523,5 +522,5 @@ type Datastore interface {
 	// out-of-process reader that needs the running version for an installation
 	// which has not yet run any command, a question the command history cannot
 	// answer because agent_version only exists on a command row.
-	RecordAgentBoot(ctx context.Context, version string) error
+	RecordAgentBoot(version string) error
 }

--- a/internal/datastore/dstest/suite_agent_boots.go
+++ b/internal/datastore/dstest/suite_agent_boots.go
@@ -7,7 +7,6 @@
 package dstest
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -29,7 +28,7 @@ func RunRecordAgentBoot(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 		}
 
 		before := time.Now().UTC().Add(-time.Second)
-		require.NoError(t, ds.RecordAgentBoot(context.Background(), "0.89.0"))
+		require.NoError(t, ds.RecordAgentBoot("0.89.0"))
 		after := time.Now().UTC().Add(time.Second)
 
 		boots, err := td.LoadAgentBootsForTest()
@@ -59,7 +58,7 @@ func RunAgentBootsAreAppendOnly(t *testing.T, newDS func(t *testing.T) TestDatas
 
 		versions := []string{"0.88.0", "0.89.0", "0.89.1"}
 		for _, v := range versions {
-			require.NoError(t, ds.RecordAgentBoot(context.Background(), v))
+			require.NoError(t, ds.RecordAgentBoot(v))
 		}
 
 		boots, err := td.LoadAgentBootsForTest()
@@ -91,7 +90,7 @@ func RunRecordAgentBootEmptyVersion(t *testing.T, newDS func(t *testing.T) TestD
 			t.Skip("backend does not provide LoadAgentBootsForTest")
 		}
 
-		require.NoError(t, ds.RecordAgentBoot(context.Background(), ""))
+		require.NoError(t, ds.RecordAgentBoot(""))
 
 		boots, err := td.LoadAgentBootsForTest()
 		require.NoError(t, err)

--- a/internal/datastore/mock_datastore_test.go
+++ b/internal/datastore/mock_datastore_test.go
@@ -5,7 +5,6 @@
 package datastore
 
 import (
-	"context"
 	"encoding/json"
 	"time"
 
@@ -204,6 +203,6 @@ func (m *mockDatastore) ForceCancelResourceUpdates(_ string, _ []ForceCancelRow,
 	return ForceCancelResult{}, nil
 }
 
-func (m *mockDatastore) RecordAgentBoot(_ context.Context, _ string) error {
+func (m *mockDatastore) RecordAgentBoot(_ string) error {
 	return nil
 }

--- a/internal/datastore/mssql/mssql_datastore.go
+++ b/internal/datastore/mssql/mssql_datastore.go
@@ -969,7 +969,9 @@ func (d *DatastoreMSSQL) UpdateFormaCommandTargetUpdates(commandID string, targe
 }
 
 // RecordAgentBoot appends one agent_boots row for this process start.
-func (d *DatastoreMSSQL) RecordAgentBoot(ctx context.Context, version string) error {
+func (d *DatastoreMSSQL) RecordAgentBoot(version string) error {
+	ctx, cancel := datastore.AgentBootContext()
+	defer cancel()
 	ctx, span := mssqlTracer.Start(ctx, "RecordAgentBoot")
 	defer span.End()
 

--- a/internal/datastore/mssql/mssql_datastore.go
+++ b/internal/datastore/mssql/mssql_datastore.go
@@ -970,7 +970,7 @@ func (d *DatastoreMSSQL) UpdateFormaCommandTargetUpdates(commandID string, targe
 
 // RecordAgentBoot appends one agent_boots row for this process start.
 func (d *DatastoreMSSQL) RecordAgentBoot(version string) error {
-	ctx, cancel := datastore.AgentBootContext()
+	ctx, cancel := datastore.AgentBootContext(d.ctx)
 	defer cancel()
 	ctx, span := mssqlTracer.Start(ctx, "RecordAgentBoot")
 	defer span.End()

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -5089,7 +5089,7 @@ func (d DatastorePostgres) ForceCancelResourceUpdates(commandID string, inProgre
 
 // RecordAgentBoot appends one agent_boots row for this process start.
 func (d DatastorePostgres) RecordAgentBoot(version string) error {
-	ctx, cancel := datastore.AgentBootContext()
+	ctx, cancel := datastore.AgentBootContext(d.ctx)
 	defer cancel()
 	ctx, span := tracer.Start(ctx, "RecordAgentBoot")
 	defer span.End()

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -5088,7 +5088,9 @@ func (d DatastorePostgres) ForceCancelResourceUpdates(commandID string, inProgre
 }
 
 // RecordAgentBoot appends one agent_boots row for this process start.
-func (d DatastorePostgres) RecordAgentBoot(ctx context.Context, version string) error {
+func (d DatastorePostgres) RecordAgentBoot(version string) error {
+	ctx, cancel := datastore.AgentBootContext()
+	defer cancel()
 	ctx, span := tracer.Start(ctx, "RecordAgentBoot")
 	defer span.End()
 

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -5369,7 +5369,9 @@ func agentBootTimestamp(t time.Time) string {
 	return t.UTC().Format(agentBootTimestampLayout)
 }
 
-func (d DatastoreSQLite) RecordAgentBoot(ctx context.Context, version string) error {
+func (d DatastoreSQLite) RecordAgentBoot(version string) error {
+	ctx, cancel := datastore.AgentBootContext()
+	defer cancel()
 	ctx, span := sqliteTracer.Start(ctx, "RecordAgentBoot")
 	defer span.End()
 

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -5370,7 +5370,7 @@ func agentBootTimestamp(t time.Time) string {
 }
 
 func (d DatastoreSQLite) RecordAgentBoot(version string) error {
-	ctx, cancel := datastore.AgentBootContext()
+	ctx, cancel := datastore.AgentBootContext(d.ctx)
 	defer cancel()
 	ctx, span := sqliteTracer.Start(ctx, "RecordAgentBoot")
 	defer span.End()

--- a/internal/metastructure/extract_resources_test.go
+++ b/internal/metastructure/extract_resources_test.go
@@ -5,7 +5,6 @@
 package metastructure
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -578,6 +577,6 @@ func TestExtractResources_BatchedPolicyLookups(t *testing.T) {
 	assert.Equal(t, 0, ds.getStackByLabelCalls, "GetStackByLabel must not be called (N+1 avoided)")
 }
 
-func (m *mockExtractDatastore) RecordAgentBoot(_ context.Context, _ string) error {
+func (m *mockExtractDatastore) RecordAgentBoot(_ string) error {
 	return nil
 }

--- a/internal/metastructure/resource_summaries_test.go
+++ b/internal/metastructure/resource_summaries_test.go
@@ -5,7 +5,6 @@
 package metastructure
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -451,6 +450,6 @@ func TestExtractResourceByKsuid_DeletedReturnsNil(t *testing.T) {
 	assert.Equal(t, 0, ds.loadResourceByIdCalls, "must not fall back to LoadResourceById")
 }
 
-func (m *mockSummaryDatastore) RecordAgentBoot(_ context.Context, _ string) error {
+func (m *mockSummaryDatastore) RecordAgentBoot(_ string) error {
 	return nil
 }


### PR DESCRIPTION
Follow-up to the agent boot event, removing the interface wart it introduced.

## The problem

`RecordAgentBoot` was the only method on the `Datastore` interface taking a `context.Context` from its caller. Every other method builds its own internally, and does so heavily — before that change there were 80 occurrences of `context.Background()` in the sqlite backend, 82 in postgres, 11 in mssql and 90 in aurora. Carving out a single exception made the interface less uniform for a bound that does not need to be expressed there.

## What changed

The context is built inside the backends like every other method's, from one shared helper so all four agree on how long the write may take rather than each inventing its own.

The bound still matters. This is the only write issued off the request path — a detached goroutine at startup — so nothing else limits how long it can hold a connection. Unbounded, a stalled database keeps that connection checked out and closing the pool waits for it, turning an ordinary stop into a hang.

## The parent context, which review caught

Deriving the timeout from `context.Background()` bounded the write but severed it from the agent's lifecycle: a stop could no longer cancel an in-flight insert, so shutdown waited out the full timeout. That wait is close enough to the stop grace period to turn a graceful stop into a force-kill.

Every backend already stores a lifecycle context, so the helper derives from that instead. A stop cancels immediately, the timeout still bounds a stall while the agent is otherwise healthy, and the interface stays uniform because the context is still built inside the backend rather than taken from a caller.

## Testing

The helper is tested directly: it carries a deadline, that deadline is within the declared ceiling, cancelling the parent cancels it immediately, and a nil parent still yields a bounded context rather than a panic. The ceiling itself is asserted, not just the mechanism, because a long timeout would let a display-only write visibly delay a shutdown.

The agent-level test that a stalled datastore does not block startup is unchanged and still passes. The one asserting the caller's context reached the recorder is gone with the signature.

`make lint` clean; unit suites green across all four backends. The only failing package in a full run is `internal/schema/pkl`, which fails identically on a clean worktree at the same base.