### PR TITLE
test(blackbox): predict patch outcomes with the agent's field semantics

### DIFF
--- a/tests/blackbox/executor.go
+++ b/tests/blackbox/executor.go
@@ -1150,7 +1150,15 @@ func (h *TestHarness) executeApply(t *testing.T, op *Operation, model *StateMode
 	// Immediate model update: predict outcomes at submission time.
 	successIDs := successfulResourceIDs(op, op.StackIndex, op.ResourceIDs, model.Pool, false, model)
 	if len(successIDs) > 0 {
-		resolvedProps := model.ResolvePropertiesForResources(op.StackIndex, successIDs, op.Properties, op.ChildProperties)
+		// Reconcile declares complete state; patch is a per-field diff whose
+		// prediction must apply the agent's field semantics (a no-op patch
+		// yields no resource update, so a wrong prediction is never corrected).
+		var resolvedProps map[int]string
+		if op.ApplyMode == "reconcile" {
+			resolvedProps = model.ResolvePropertiesForResources(op.StackIndex, successIDs, op.Properties, op.ChildProperties)
+		} else {
+			resolvedProps = model.ResolvePatchPropertiesForResources(op.StackIndex, successIDs, op.Properties, op.ChildProperties)
+		}
 		model.ApplyCreatedResolved(op.StackIndex, resolvedProps)
 	}
 	if op.ApplyMode == "reconcile" {

--- a/tests/blackbox/state_model.go
+++ b/tests/blackbox/state_model.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
 // ResourceState represents whether a resource is expected to exist.
@@ -597,6 +599,129 @@ func (m *StateModel) ResolvePropertiesForResource(stackIndex, id int, properties
 	resolved := strings.Replace(childProperties, `"NAME"`, `"`+label+`"`, 1)
 	parentLabel := m.parentIdentifierForResource(stackIndex, id)
 	return strings.Replace(resolved, `"PARENT_ID"`, `"`+parentLabel+`"`, 1)
+}
+
+// ResolvePatchPropertiesForResources expands per-operation property templates
+// into the exact expected post-patch properties for the given resource IDs.
+// A patch is a per-field diff against the current resource, not a declaration
+// of complete state, so for slots that already exist the drawn properties are
+// merged with the current ones under the agent's field semantics: an empty
+// array means "not specified" (the agent strips empty arrays), set-typed
+// fields are additive, entity-set fields upsert by their key field,
+// array-typed fields replace wholesale, and scalars replace. A patch whose
+// fields are all no-ops therefore predicts the current properties exactly,
+// matching the empty diff for which the agent issues no resource update.
+// Slots that do not exist yet are created with the drawn properties verbatim.
+func (m *StateModel) ResolvePatchPropertiesForResources(stackIndex int, resourceIDs []int, properties, childProperties string) map[int]string {
+	propertiesByID := make(map[int]string, len(resourceIDs))
+	for _, id := range resourceIDs {
+		resolved := m.ResolvePropertiesForResource(stackIndex, id, properties, childProperties)
+		if res := m.Resource(stackIndex, id); res != nil && res.State == StateExists && res.Properties != "" {
+			resolved = mergePatchProperties(res.Properties, resolved, testResourceSchema.Hints)
+		}
+		propertiesByID[id] = resolved
+	}
+	return propertiesByID
+}
+
+func mergePatchProperties(currentJSON, patchJSON string, hints map[string]pkgmodel.FieldHint) string {
+	var current, patch map[string]any
+	if err := json.Unmarshal([]byte(currentJSON), &current); err != nil {
+		return patchJSON
+	}
+	if err := json.Unmarshal([]byte(patchJSON), &patch); err != nil {
+		return patchJSON
+	}
+	merged := make(map[string]any, len(current)+len(patch))
+	for k, v := range current {
+		merged[k] = v
+	}
+	for k, v := range patch {
+		arr, isArr := v.([]any)
+		if !isArr {
+			merged[k] = v
+			continue
+		}
+		if len(arr) == 0 {
+			continue
+		}
+		cur, _ := merged[k].([]any)
+		switch hints[k].UpdateMethod {
+		case pkgmodel.FieldUpdateMethodArray:
+			merged[k] = arr
+		case pkgmodel.FieldUpdateMethodEntitySet:
+			merged[k] = upsertByEntityKey(cur, arr, hints[k].IndexField)
+		default:
+			merged[k] = unionByValue(cur, arr)
+		}
+	}
+	b, err := json.Marshal(merged)
+	if err != nil {
+		return patchJSON
+	}
+	return string(b)
+}
+
+// unionByValue keeps the current elements in order and appends patch elements
+// not already present (JSON equality).
+func unionByValue(current, patch []any) []any {
+	out := append([]any(nil), current...)
+	for _, p := range patch {
+		if !containsJSONValue(out, p) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func containsJSONValue(arr []any, target any) bool {
+	tb, err := json.Marshal(target)
+	if err != nil {
+		return false
+	}
+	for _, e := range arr {
+		eb, err := json.Marshal(e)
+		if err != nil {
+			continue
+		}
+		if string(eb) == string(tb) {
+			return true
+		}
+	}
+	return false
+}
+
+// upsertByEntityKey replaces current elements whose key field matches a patch
+// element in place and appends patch elements with new keys.
+func upsertByEntityKey(current, patch []any, keyField string) []any {
+	keyOf := func(e any) (string, bool) {
+		m, ok := e.(map[string]any)
+		if !ok {
+			return "", false
+		}
+		k, ok := m[keyField].(string)
+		return k, ok
+	}
+	out := append([]any(nil), current...)
+	usedKeys := make(map[string]bool)
+	for i, e := range out {
+		ek, ok := keyOf(e)
+		if !ok {
+			continue
+		}
+		for _, p := range patch {
+			if pk, ok := keyOf(p); ok && pk == ek {
+				out[i] = p
+				usedKeys[pk] = true
+			}
+		}
+	}
+	for _, p := range patch {
+		if pk, ok := keyOf(p); ok && !usedKeys[pk] {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // NormalizePropertiesForResource rewrites a resource properties blob into the

--- a/tests/blackbox/state_model_test.go
+++ b/tests/blackbox/state_model_test.go
@@ -349,6 +349,54 @@ func TestStateModel_CheckModelVsInventory_PropertiesAndType(t *testing.T) {
 	assert.NotEmpty(t, violations)
 }
 
+// A patch is not a reconcile: the agent computes a per-field diff against the
+// current resource, so the model's patch prediction must apply the same field
+// semantics instead of storing the drawn properties verbatim. An empty array
+// means "not specified" (the agent strips empty arrays), set-typed fields are
+// additive, entity-set fields upsert by their key field, array-typed fields
+// replace wholesale, and scalars replace.
+func TestStateModel_PatchPredictionAppliesFieldSemantics(t *testing.T) {
+	model := NewStateModel(1, 3)
+	model.ApplyCreated(0, []int{0}, `{"Name":"res-stack-0-a","Value":"v1","SetTags":["alpha","beta"],"EntityTags":[{"Key":"env","Value":"a"},{"Key":"team","Value":"b"}],"OrderedItems":["first","second"]}`)
+
+	patch := `{"Name":"NAME","Value":"v2","SetTags":["gamma","alpha"],"EntityTags":[{"Key":"env","Value":"c"}],"OrderedItems":[]}`
+	resolved := model.ResolvePatchPropertiesForResources(0, []int{0}, patch, "")
+
+	assert.JSONEq(t,
+		`{"Name":"res-stack-0-a","Value":"v2","SetTags":["alpha","beta","gamma"],"EntityTags":[{"Key":"env","Value":"c"},{"Key":"team","Value":"b"}],"OrderedItems":["first","second"]}`,
+		resolved[0],
+		"scalar replaces, set unions, entity-set upserts by Key, empty array keeps current")
+}
+
+// A patch whose fields are all no-ops against the current resource must
+// predict exactly the current properties: the agent computes an empty diff
+// and issues no resource update, so no later correction will fix a wrong
+// prediction.
+func TestStateModel_PatchPredictionNoOpPatchKeepsCurrentProperties(t *testing.T) {
+	model := NewStateModel(1, 3)
+	current := `{"Name":"res-stack-0-a","Value":"v2","SetTags":["gamma","delta","alpha","epsilon"],"EntityTags":[],"OrderedItems":["first","third","fourth"]}`
+	model.ApplyCreated(0, []int{0}, current)
+
+	patch := `{"Name":"NAME","Value":"v2","SetTags":[],"EntityTags":[],"OrderedItems":["first","third","fourth"]}`
+	resolved := model.ResolvePatchPropertiesForResources(0, []int{0}, patch, "")
+
+	assert.JSONEq(t, current, resolved[0],
+		"an all-no-op patch predicts the current properties unchanged")
+}
+
+// A patch that targets a resource the model does not have yet is a create:
+// the drawn properties are the created state, exactly as before.
+func TestStateModel_PatchPredictionCreateUsesDrawnProperties(t *testing.T) {
+	model := NewStateModel(1, 3)
+
+	patch := `{"Name":"NAME","Value":"v1","SetTags":["alpha"],"EntityTags":[],"OrderedItems":[]}`
+	resolved := model.ResolvePatchPropertiesForResources(0, []int{1}, patch, "")
+
+	assert.JSONEq(t, `{"Name":"res-stack-0-b","Value":"v1","SetTags":["alpha"],"EntityTags":[],"OrderedItems":[]}`,
+		resolved[1],
+		"patch-creates take the drawn properties verbatim")
+}
+
 func TestStateModel_ResolvePropertiesForResources_WithPool(t *testing.T) {
 	model := NewStateModel(2, 5)
 	resolved := model.ResolvePropertiesForResources(


### PR DESCRIPTION
## Why

The remaining property-suite failure signature after the drift-determinism rewrite: `inventory properties=... SetTags=[...] but model expects SetTags=[]`, with every other field agreeing. This is the same class as the property-content mismatch recorded on 2026-08-13, and it just reproduced on #655's CI run.

The state model stored a patch operation's drawn properties verbatim as the expected end state. A patch is a per-field diff, not a declaration of complete state: an empty array means the field is unspecified (the agent strips empty arrays), set-typed fields are additive, entity-set fields upsert by their key field, and only array-typed fields and scalars replace. The failure fires when a drawn patch is a complete no-op against the current resource: the agent computes an empty diff and issues **no resource update** for that slot, so nothing ever corrects the wrong verbatim prediction at drain time. It needs the drawn scalars and ordered arrays to match current values by chance, which is why it survives most runs.

Reproduced trace (from the #655 failure): a canceled reconcile left `res-stack-0-b` created with `SetTags=[gamma,delta,alpha,epsilon]`; a later patch drew identical `Value`/`OrderedItems` and `SetTags=[]`; the patch command's resource updates contain no entry for that slot; the model kept the verbatim `SetTags=[]` prediction and diverged from inventory.

## What

`ResolvePatchPropertiesForResources` merges drawn patch properties into the current ones under the agent's field semantics (empty array = keep current; set = union; entity-set = upsert by `IndexField`; array = replace; scalar = replace). An all-no-op patch now predicts the current properties exactly, matching the agent's empty diff. Patch-creates keep taking drawn properties verbatim; reconcile predictions are unchanged; slots with a real diff still get corrected from their resource update at drain, as before.

## Verification

- Three new model tests (written first, watched fail): field-semantics merge, all-no-op patch predicts current, patch-create unchanged.
- Full model test suite green; `TestProperty_FullChaos` green at 25 checks locally (4m45s).
- `go vet` clean under the property tag.