### PR TITLE
fix(ci): cap mutation-test memory so a runaway mutant cannot kill the runner

### DIFF
--- a/.github/workflows/mutation-test-pages.yml
+++ b/.github/workflows/mutation-test-pages.yml
@@ -57,6 +57,8 @@ jobs:
       - name: Setup local-data-api
         run: make local-data-api-ci
 
+      # Same confinement as mutation-test-pr.yml: a mutant that allocates
+      # without bound must OOM its own test process, not the runner VM.
       - name: Run full mutation test suite
         env:
           FORMAE_TEST_AURORA_CLUSTER_ARN: arn:aws:rds:us-east-1:123456789012:cluster:local
@@ -66,7 +68,12 @@ jobs:
           AWS_ACCESS_KEY_ID: test
           AWS_SECRET_ACCESS_KEY: test
           AWS_REGION: us-east-1
-        run: ./scripts/mutation-test.sh
+        run: |
+          sudo mkdir /sys/fs/cgroup/mutation
+          echo 12G | sudo tee /sys/fs/cgroup/mutation/memory.max
+          echo 0 | sudo tee /sys/fs/cgroup/mutation/memory.swap.max
+          echo $$ | sudo tee /sys/fs/cgroup/mutation/cgroup.procs
+          ./scripts/mutation-test.sh
 
       - name: Generate coverage diff
         run: ./scripts/coverage-diff.sh

--- a/.github/workflows/mutation-test-pr.yml
+++ b/.github/workflows/mutation-test-pr.yml
@@ -43,5 +43,18 @@ jobs:
       - name: Stamp the version
         run: make version-semver
 
+      # A mutant can turn a bounded loop into one that allocates without
+      # bound, exhausting the VM before gremlins' per-mutant timeout can
+      # fire; the runner is then torn down mid-run and gremlins exits 0
+      # without a report. Confining the run to a memory-capped cgroup makes
+      # the kernel kill the runaway test process instead: gremlins records
+      # the mutant as killed and the run completes. The cap leaves the
+      # 16 GB runner room for the runner agent; swap is denied so a runaway
+      # dies quickly instead of thrashing.
       - name: Run mutation tests on changed packages
-        run: ./scripts/mutation-test-changed.sh
+        run: |
+          sudo mkdir /sys/fs/cgroup/mutation
+          echo 12G | sudo tee /sys/fs/cgroup/mutation/memory.max
+          echo 0 | sudo tee /sys/fs/cgroup/mutation/memory.swap.max
+          echo $$ | sudo tee /sys/fs/cgroup/mutation/cgroup.procs
+          ./scripts/mutation-test-changed.sh


### PR DESCRIPTION
## Summary

The `mutation-test-pr` check has been failing on any PR whose changed packages carry heavy test suites, and the nightly `mutation-test-pages` run has failed every night for weeks. All of these deaths share one log signature: gremlins is mid-run when the runner logs "The runner has received a shutdown signal" and the job is killed.

The mechanism, reproduced locally: a mutant can negate a loop bound and turn a bounded padding loop (for example the panel-height padding in `internal/cli/status/agentview.go`) into one that appends forever. The test process allocates gigabytes within seconds, faster than gremlins' per-mutant timeout can fire, and exhausts the VM. The runner is torn down, gremlins takes the shutdown signal, exits 0, and writes no report, which the check correctly classifies as "no usable result".

## Fix

Run the mutation step inside a memory-capped cgroup with swap denied, in both workflows. When a mutant runs away, the kernel OOM killer now takes out the ballooning test process inside the cgroup; gremlins observes a failed test, records the mutant as killed (which is the semantically right verdict for a mutant that would crash the program), and the run completes with a report.

Verified locally by running gremlins v0.6.0 on `internal/cli/status`:

- Uncapped: the test process grows past 12 GB in seconds on the padding-loop negation mutant and the machine OOMs, gremlins exits 0 with no report, mirroring CI.
- Capped (`memory.max` + `memory.swap.max=0`, OOM-continue semantics): the same run completes in 40 seconds with a valid report, and the runaway mutant is recorded as KILLED.

The 12 GB cap is sized against the observed baseline of a normal run (2 to 6 GB aggregate across gremlins' four workers) while leaving the 16 GB runner room for the runner agent. If a legitimate suite ever exceeds the cap, the cost is a falsely killed mutant in an advisory score, not a dead runner.

Complementary to #653, which confines each gremlins invocation to the invoked package: that shrinks runs, this makes a runaway mutant in any run survivable.