### PR TITLE
chore(ci): validate the mutation-test memory cap end to end

### DIFF
--- a/.github/workflows/mutation-test-pages.yml
+++ b/.github/workflows/mutation-test-pages.yml
@@ -57,6 +57,8 @@ jobs:
       - name: Setup local-data-api
         run: make local-data-api-ci
 
+      # Same confinement as mutation-test-pr.yml: a mutant that allocates
+      # without bound must OOM its own test process, not the runner VM.
       - name: Run full mutation test suite
         env:
           FORMAE_TEST_AURORA_CLUSTER_ARN: arn:aws:rds:us-east-1:123456789012:cluster:local
@@ -66,7 +68,12 @@ jobs:
           AWS_ACCESS_KEY_ID: test
           AWS_SECRET_ACCESS_KEY: test
           AWS_REGION: us-east-1
-        run: ./scripts/mutation-test.sh
+        run: |
+          sudo mkdir /sys/fs/cgroup/mutation
+          echo 12G | sudo tee /sys/fs/cgroup/mutation/memory.max
+          echo 0 | sudo tee /sys/fs/cgroup/mutation/memory.swap.max
+          echo $$ | sudo tee /sys/fs/cgroup/mutation/cgroup.procs
+          ./scripts/mutation-test.sh
 
       - name: Generate coverage diff
         run: ./scripts/coverage-diff.sh

--- a/.github/workflows/mutation-test-pr.yml
+++ b/.github/workflows/mutation-test-pr.yml
@@ -43,5 +43,18 @@ jobs:
       - name: Stamp the version
         run: make version-semver
 
+      # A mutant can turn a bounded loop into one that allocates without
+      # bound, exhausting the VM before gremlins' per-mutant timeout can
+      # fire; the runner is then torn down mid-run and gremlins exits 0
+      # without a report. Confining the run to a memory-capped cgroup makes
+      # the kernel kill the runaway test process instead: gremlins records
+      # the mutant as killed and the run completes. The cap leaves the
+      # 16 GB runner room for the runner agent; swap is denied so a runaway
+      # dies quickly instead of thrashing.
       - name: Run mutation tests on changed packages
-        run: ./scripts/mutation-test-changed.sh
+        run: |
+          sudo mkdir /sys/fs/cgroup/mutation
+          echo 12G | sudo tee /sys/fs/cgroup/mutation/memory.max
+          echo 0 | sudo tee /sys/fs/cgroup/mutation/memory.swap.max
+          echo $$ | sudo tee /sys/fs/cgroup/mutation/cgroup.procs
+          ./scripts/mutation-test-changed.sh

--- a/internal/cli/status/agentview.go
+++ b/internal/cli/status/agentview.go
@@ -49,7 +49,8 @@ type panelSpec struct {
 	lines []string
 }
 
-// boxWidth returns the widest line of a rendered box.
+// boxWidth returns the widest line of a rendered box, measured as display
+// width rather than byte length.
 func boxWidth(box string) int {
 	maxW := 0
 	for _, l := range strings.Split(box, "\n") {


### PR DESCRIPTION
## Summary

Draft validation PR for #665, not for merging. It carries the workflow change from that branch plus a comment-only edit to `internal/cli/status`, the package whose padding-loop negation mutant reproducibly OOMs the runner today. Because the check runs against the merge ref, the `mutation-test-pr` run here executes under the new memory cap while mutating exactly the code that kills the current setup. A green mutation check here is the end-to-end proof; the PR gets closed after.