### PR TITLE
chore(plugin): pin the credential module at a resolvable version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1
 	github.com/platform-engineering-labs/formae/pkg/auth v0.0.0-00010101000000-000000000000
-	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-00010101000000-000000000000
+	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-20260821213704-ba68bacf6dd6
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.6
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.0.0-00010101000000-000000000000
 	github.com/platform-engineering-labs/formae/tests/testcontrol v0.0.0-00010101000000-000000000000

--- a/pkg/plugin-conformance-tests/go.mod
+++ b/pkg/plugin-conformance-tests/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/masterminds/semver v1.5.0 // indirect
 	github.com/miekg/dns v1.1.72 // indirect
 	github.com/naegelejd/go-acl v0.0.0-20260323030528-42e4d61407df // indirect
-	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-00010101000000-000000000000 // indirect
+	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-20260821213704-ba68bacf6dd6 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.1 // indirect

--- a/pkg/plugin/go.mod
+++ b/pkg/plugin/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/klauspost/compress v1.18.5
 	github.com/masterminds/semver v1.5.0
-	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-00010101000000-000000000000
+	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-20260821213704-ba68bacf6dd6 // re-pin to a real tag at release time
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.6
 	github.com/stretchr/testify v1.11.1
 	github.com/vmihailenco/msgpack/v5 v5.4.1

--- a/tests/e2e/go/fixtures/oidc-echo-plugin/go.mod
+++ b/tests/e2e/go/fixtures/oidc-echo-plugin/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
 	github.com/masterminds/semver v1.5.0 // indirect
-	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-00010101000000-000000000000 // indirect
+	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-20260821213704-ba68bacf6dd6 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.1 // indirect
 	github.com/theory/jsonpath v0.10.2 // indirect

--- a/tests/testplugin/go.mod
+++ b/tests/testplugin/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
-	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-00010101000000-000000000000 // indirect
+	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-20260821213704-ba68bacf6dd6 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.1 // indirect


### PR DESCRIPTION
The placeholder pseudo-version `v0.0.0-00010101000000-000000000000` on the `pkg/credential` requirement resolved only through the in-tree `replace` directives, so anything consuming the published `pkg/plugin` or `pkg/plugin-conformance-tests` modules from outside this repo could not resolve the dependency at all. Pinning the pseudo-version of the commit that introduced the module makes `go get` work for external consumers, while the local replaces keep in-tree development on the working copy (the same shape `pkg/model` already uses). The pin moves to a real tag when one is cut at release time.