### PR TITLE
test(blackbox): stop stale commands from resurrecting TTL-destroyed slots

### DIFF
--- a/tests/blackbox/executor.go
+++ b/tests/blackbox/executor.go
@@ -345,7 +345,7 @@ func (h *TestHarness) reconcileCompletedAcceptedCommands(t *testing.T, model *St
 	for i := len(completed) - 1; i >= 0; i-- {
 		cc := completed[i]
 		t.Logf("reconcileCompletedAcceptedCommands: command %s completed early (state=%s)", cc.ac.CommandID, cc.cmd.State)
-		correctModelFromCommandOutcome(t, &cc.cmd, model, model.Pool, cc.ac.Snapshots, corrected, cc.ac.IsReconcile)
+		correctModelFromCommandOutcome(t, &cc.cmd, model, model.Pool, cc.ac.Snapshots, corrected, cc.ac.IsReconcile, cc.ac.SupersededSlots)
 	}
 
 	model.AcceptedCommands = remaining
@@ -866,7 +866,7 @@ func applyReconcileGuarantee(model *StateModel, stackIdx int, reconcileIDs []int
 // first) by DrainPendingCommands. The corrected map tracks which resources
 // have already been corrected by a later command — earlier commands skip
 // those resources so the latest outcome wins.
-func correctModelFromCommandOutcome(t *testing.T, cmd *apimodel.Command, model *StateModel, pool *ResourcePool, snapshots []ResourceSnapshot, corrected map[struct{ stackIdx, slotIdx int }]bool, isReconcile bool) {
+func correctModelFromCommandOutcome(t *testing.T, cmd *apimodel.Command, model *StateModel, pool *ResourcePool, snapshots []ResourceSnapshot, corrected map[struct{ stackIdx, slotIdx int }]bool, isReconcile bool, superseded map[ResourceSlotRef]bool) {
 	t.Helper()
 
 	if cmd == nil {
@@ -897,6 +897,15 @@ func correctModelFromCommandOutcome(t *testing.T, cmd *apimodel.Command, model *
 		}
 
 		key := slotKey{stackIdx, slotIdx}
+
+		// Skip slots whose outcome in this command was superseded by a later
+		// event (a TTL destroy observed outside the drain's command list).
+		if superseded[ResourceSlotRef{StackIndex: stackIdx, SlotIndex: slotIdx}] {
+			t.Logf("correctModelFromCommandOutcome: skipping stack=%s slot=%d (superseded by TTL destroy)",
+				model.Stack(stackIdx).Label, slotIdx)
+			delete(snapBySlot, key)
+			continue
+		}
 
 		// Skip if a later command already corrected this resource.
 		if corrected[key] {
@@ -1003,6 +1012,9 @@ func correctModelFromCommandOutcome(t *testing.T, cmd *apimodel.Command, model *
 	if cmd.State != "Success" {
 		for key, snap := range snapBySlot {
 			if corrected[key] {
+				continue
+			}
+			if superseded[ResourceSlotRef{StackIndex: key.stackIdx, SlotIndex: key.slotIdx}] {
 				continue
 			}
 			if model.IsAuthoritativeSlot(key.stackIdx, key.slotIdx) {
@@ -2056,7 +2068,7 @@ func (h *TestHarness) DrainPendingCommands(t *testing.T, model *StateModel, time
 	for i := len(drained) - 1; i >= 0; i-- {
 		dc := drained[i]
 		if dc.cmd != nil {
-			correctModelFromCommandOutcome(t, dc.cmd, model, model.Pool, dc.ac.Snapshots, corrected, dc.ac.IsReconcile)
+			correctModelFromCommandOutcome(t, dc.cmd, model, model.Pool, dc.ac.Snapshots, corrected, dc.ac.IsReconcile, dc.ac.SupersededSlots)
 		}
 	}
 	h.reconcileAmbiguousFailedCommands(t, model, drained)
@@ -2233,6 +2245,32 @@ func (h *TestHarness) ForceCheckTTLAndWait(t *testing.T, model *StateModel) {
 					}
 				}
 			}
+
+			// Every command still in AcceptedCommands was accepted before this
+			// destroy was observed, so its outcomes for the destroyed slots are
+			// stale. The drain's per-pass corrected map cannot express that (the
+			// TTL command is folded in here, not drained), and the authoritative
+			// mark alone does not survive a stale create-Success RU — the
+			// correction path lets creates clear authoritative status. Mark the
+			// destroyed slots superseded on the surviving commands so their
+			// corrections skip them.
+			var destroyedRefs []ResourceSlotRef
+			for slotIdx := range model.Stack(stackIdx).Resources {
+				destroyedRefs = append(destroyedRefs, ResourceSlotRef{StackIndex: stackIdx, SlotIndex: slotIdx})
+			}
+			if model.Pool != nil && expiredLabel == model.ProviderStackLabel {
+				for otherStackIdx := range model.Stacks {
+					if otherStackIdx == stackIdx {
+						continue
+					}
+					for slotIdx := range model.Stack(otherStackIdx).Resources {
+						if model.Pool.IsCrossStack(slotIdx) {
+							destroyedRefs = append(destroyedRefs, ResourceSlotRef{StackIndex: otherStackIdx, SlotIndex: slotIdx})
+						}
+					}
+				}
+			}
+			model.SupersedeSlots(destroyedRefs)
 		}
 		model.Stacks[stackIdx].TTLExpired = false
 		t.Logf("ForceCheckTTLAndWait: stack %s command %s completed: %s", expiredLabel, commandID, cmd.State)

--- a/tests/blackbox/operations.go
+++ b/tests/blackbox/operations.go
@@ -147,6 +147,14 @@ type AcceptedCommand struct {
 	// DrainPendingCommands can include its outcome when resolving conflicts
 	// between overlapping commands (reverse-order processing).
 	Resolved bool
+	// SupersededSlots marks slots whose outcome in THIS command has been
+	// overtaken by a later event the drain's per-pass corrected map cannot
+	// see (a TTL destroy observed via ForceCheckTTLAndWait, which folds its
+	// command into the model directly instead of leaving it in
+	// AcceptedCommands). Corrections skip these slots: the newer event is
+	// ground truth, and without this a stale create-Success RU would clear
+	// the destroy's authoritative mark and resurrect the slot in the model.
+	SupersededSlots map[ResourceSlotRef]bool
 }
 
 type ResourceSlotRef struct {

--- a/tests/blackbox/state_model.go
+++ b/tests/blackbox/state_model.go
@@ -167,6 +167,25 @@ func (m *StateModel) ClearNativeID(stackIdx, slotIdx int) {
 	delete(m.NativeIDs, nativeIDKey(stackIdx, slotIdx))
 }
 
+// SupersedeSlots marks the given slots as superseded on every currently
+// accepted command. Called when a TTL destroy is observed: every command
+// still in AcceptedCommands was accepted before that destroy, so whatever
+// those commands report for these slots is stale and corrections must not
+// apply it.
+func (m *StateModel) SupersedeSlots(refs []ResourceSlotRef) {
+	if len(refs) == 0 {
+		return
+	}
+	for i := range m.AcceptedCommands {
+		if m.AcceptedCommands[i].SupersededSlots == nil {
+			m.AcceptedCommands[i].SupersededSlots = make(map[ResourceSlotRef]bool, len(refs))
+		}
+		for _, ref := range refs {
+			m.AcceptedCommands[i].SupersededSlots[ref] = true
+		}
+	}
+}
+
 // FindDriftEligibleResource finds a managed resource that exists in the model,
 // has a tracked NativeID, and is untouched by in-flight commands. Used for
 // selecting OOB drift targets: drift is absorbed synchronously via a forced

--- a/tests/blackbox/state_model_test.go
+++ b/tests/blackbox/state_model_test.go
@@ -42,7 +42,7 @@ func TestCorrectModelFromCommandOutcome_FailedCreateForcesNotExist(t *testing.T)
 	}
 
 	corrected := map[struct{ stackIdx, slotIdx int }]bool{}
-	correctModelFromCommandOutcome(t, cmd, model, nil, snapshots, corrected, true)
+	correctModelFromCommandOutcome(t, cmd, model, nil, snapshots, corrected, true, nil)
 
 	require.Equal(t, StateNotExist, model.Resource(0, 1).State,
 		"a failed create must leave the slot NotExist, not revert to a stale Exists snapshot")
@@ -68,7 +68,7 @@ func TestCorrectModelFromCommandOutcome_FailedDeleteRevertsToSnapshot(t *testing
 	}
 
 	corrected := map[struct{ stackIdx, slotIdx int }]bool{}
-	correctModelFromCommandOutcome(t, cmd, model, nil, snapshots, corrected, true)
+	correctModelFromCommandOutcome(t, cmd, model, nil, snapshots, corrected, true, nil)
 
 	require.Equal(t, StateExists, model.Resource(0, 1).State,
 		"a failed delete leaves the resource in place, reverting to its Exists snapshot")
@@ -95,8 +95,8 @@ func TestCorrectModelFromCommandOutcome_ReverseOrderFailedCreatesStayNotExist(t 
 	corrected := map[struct{ stackIdx, slotIdx int }]bool{}
 	newerSnap := []ResourceSnapshot{{StackIndex: 0, SlotIndex: 1, State: StateNotExist}}
 	olderSnap := []ResourceSnapshot{{StackIndex: 0, SlotIndex: 1, State: StateExists}} // stale
-	correctModelFromCommandOutcome(t, newerCmd, model, nil, newerSnap, corrected, true)
-	correctModelFromCommandOutcome(t, olderCmd, model, nil, olderSnap, corrected, true)
+	correctModelFromCommandOutcome(t, newerCmd, model, nil, newerSnap, corrected, true, nil)
+	correctModelFromCommandOutcome(t, olderCmd, model, nil, olderSnap, corrected, true, nil)
 
 	require.Equal(t, StateNotExist, model.Resource(0, 1).State,
 		"an older failed-create command must not resurrect a slot from its stale Exists snapshot")
@@ -579,7 +579,7 @@ func TestCorrectModelFromCommandOutcome_UnmentionedCrossStackSlotReverts(t *test
 		ResourceUpdates: nil, // the command died before reaching this slot
 	}
 	corrected := map[struct{ stackIdx, slotIdx int }]bool{}
-	correctModelFromCommandOutcome(t, cmd, model, model.Pool, snapshots, corrected, false)
+	correctModelFromCommandOutcome(t, cmd, model, model.Pool, snapshots, corrected, false, nil)
 
 	require.Equal(t, StateNotExist, model.Resource(1, crossIdx).State,
 		"an unmentioned cross-stack slot in a failed command reverts to its snapshot")
@@ -668,4 +668,55 @@ func TestStateModel_Stack(t *testing.T) {
 	stack1 := model.Stack(1)
 	require.NotNil(t, stack1)
 	assert.Equal(t, "stack-1", stack1.Label)
+}
+
+// A TTL destroy observed via ForceCheckTTLAndWait supersedes every command
+// accepted before it. A stale command that finished Failed but carries a
+// create-Success RU for a cascade-destroyed cross-stack slot must not
+// resurrect that slot in the model: the create would otherwise clear the
+// destroy's authoritative mark and re-apply Exists while the inventory row
+// is gone.
+func TestCorrectModelFromCommandOutcome_TTLSupersededSlotStaysDestroyed(t *testing.T) {
+	model := NewStateModel(3, 10) // pool config with cross-stack slots
+	require.NotNil(t, model.Pool)
+	xslot := -1
+	for i := range model.Pool.Slots {
+		if model.Pool.IsCrossStack(i) {
+			xslot = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, xslot, "pool must have a cross-stack slot")
+
+	// An apply optimistically created the cross-stack slot and was tracked.
+	model.ApplyCreated(2, []int{xslot}, "")
+	model.TrackAcceptedCommand("cmd-old", nil, []ResourceSlotRef{{StackIndex: 2, SlotIndex: xslot}}, 0, true)
+
+	// A TTL destroy of the provider stack is observed and modeled the way
+	// ForceCheckTTLAndWait does it: destroyed, authoritative, and superseding
+	// the outcomes of every command accepted before it.
+	model.ApplyDestroyed(2, []int{xslot})
+	model.MarkAuthoritativeSlot(2, xslot)
+	model.SupersedeSlots([]ResourceSlotRef{{StackIndex: 2, SlotIndex: xslot}})
+
+	// The stale command drains afterwards: Failed overall, but its RU for the
+	// cross-stack slot reported create Success (it completed before the TTL).
+	cmd := &apimodel.Command{
+		CommandID: "cmd-old",
+		State:     "Failed",
+		ResourceUpdates: []apimodel.ResourceUpdate{{
+			StackName:     "stack-2",
+			ResourceLabel: model.LabelForResource(2, xslot),
+			Operation:     "create",
+			State:         "Success",
+		}},
+	}
+	corrected := map[struct{ stackIdx, slotIdx int }]bool{}
+	ac := model.AcceptedCommands[0]
+	correctModelFromCommandOutcome(t, cmd, model, model.Pool, ac.Snapshots, corrected, true, ac.SupersededSlots)
+
+	require.Equal(t, StateNotExist, model.Resource(2, xslot).State,
+		"a TTL-destroyed slot must not be resurrected by a stale command's create RU")
+	require.True(t, model.IsAuthoritativeSlot(2, xslot),
+		"the TTL destroy's authoritative mark must survive the stale correction")
 }


### PR DESCRIPTION
## Summary

Fixes a seed-dependent FullChaos failure surfaced by the first combined property run after #658 (observed on #659's CI): `inventory=NotExist but model expects Exists` for a cross-stack slot.

The mechanism, traced from the failing run's log: `ForceCheckTTLAndWait` folds an observed TTL destroy into the model directly rather than leaving the destroy command in `AcceptedCommands`, so the drain's per-pass `corrected` map never represents it and the "newest command wins" ordering breaks across correction passes. The authoritative-slot mark stood in for that ordering, but the correction path deliberately lets creates clear authoritative status (so post-TTL re-creates work). A command accepted *before* the destroy that finished Failed while carrying a create-Success RU for a destroyed slot therefore cleared the mark and resurrected the slot in the model, while the agent's cascade had already removed the inventory row. Cross-stack dependents of an expired provider stack were the visible victims: the existing supersession purge only drops commands whose slots all live on the destroyed stack, so commands on other stacks escaped it. Pre-#658 this was invisible because cross-stack slots were excluded from model-vs-inventory assertions.

The fix restores the ordering information instead of adding another special case: when a TTL destroy is observed, every command still in `AcceptedCommands` predates it, so its destroyed slots (the stack's own and the cascade-destroyed cross-stack dependents) are marked superseded on those commands. Corrections skip superseded slots in both the RU pass and the unmentioned-slot revert.

The regression test reproduces the exact shape (stale Failed command with a create-Success RU for a cascade-destroyed cross-stack slot) and fails without the fix. Full non-property suite green; FullChaos green at 25 checks locally.

Blocks #659's CI (which hit this on a rebase re-run) and #668; neither PR's content is related to the failure.