### PR TITLE
feat(connect): one quick-create link, Enter-to-continue, themed outcome lines

### DIFF
--- a/internal/cli/connect/aws.go
+++ b/internal/cli/connect/aws.go
@@ -38,7 +38,8 @@ func awsCmd() *cobra.Command {
 		},
 	}
 	c.Flags().String("account", "", "AWS account id to connect (12 digits; always explicit, never inferred)")
-	c.Flags().Bool("quick-create", false, "Emit the two CloudFormation console links and stop; nothing is registered")
+	c.Flags().Bool("quick-create", false, "Emit the CloudFormation console link; interactively, finish by registering in the same sitting")
+	c.Flags().Bool("provider-exists", false, "The account was connected to formae before: the shared OIDC identity provider already exists, so the stack creates the role only")
 	c.Flags().String("role-arn", "", "Trust already exists (an applied quick-create stack, or a role you made yourself): validate and register only")
 	c.Flags().String("profile-aws", "", "Provision directly with a local AWS shared-config profile, then register")
 	c.Flags().String("region", "", "AWS region for the local path (flag > profile region; quick-create has no region input)")
@@ -57,6 +58,7 @@ func readOptions(cc *cobra.Command) (options, error) {
 	}
 	opts.Account, _ = cc.Flags().GetString("account")
 	opts.QuickCreate, _ = cc.Flags().GetBool("quick-create")
+	opts.ProviderExists, _ = cc.Flags().GetBool("provider-exists")
 	opts.ProfileAWS, _ = cc.Flags().GetString("profile-aws")
 	opts.RoleArn, _ = cc.Flags().GetString("role-arn")
 	opts.Region, _ = cc.Flags().GetString("region")

--- a/internal/cli/connect/contract_test.go
+++ b/internal/cli/connect/contract_test.go
@@ -321,7 +321,7 @@ func TestContractYAMLVariant(t *testing.T) {
 
 	require.NoError(t, err, "out: %s", out)
 	assert.Contains(t, out, "phase: registered")
-	assert.Contains(t, out, "schemaVersion: 1")
+	assert.Contains(t, out, "schemaVersion: 2")
 	assert.Contains(t, out, "status: registered_unverified")
 }
 
@@ -338,7 +338,7 @@ func TestContractHumanOutputCarriesNoJSON(t *testing.T) {
 	assert.NotContains(t, out, "{")
 	assert.Contains(t, out, "registered aws account "+testAccount)
 	assert.Contains(t, out, contractRoleArn)
-	assert.Contains(t, out, "not verified by formae")
+	assert.Contains(t, out, "registered aws account")
 }
 
 func TestContractClassicProfileIsHostedRequired(t *testing.T) {
@@ -518,7 +518,7 @@ func TestContractRegisterSucceeds(t *testing.T) {
 
 	require.NoError(t, err, "out: %s", out)
 	got := decodeOut(t, out)
-	assert.Equal(t, float64(1), got["schemaVersion"])
+	assert.Equal(t, float64(2), got["schemaVersion"])
 	assert.Equal(t, "registered", got["phase"])
 	assert.Equal(t, "registered_unverified", got["status"])
 	assert.Equal(t, "aws", got["cloud"])
@@ -628,16 +628,93 @@ func TestContractQuickCreateNoInputEmitsLinksAndRegistersNothing(t *testing.T) {
 
 	require.NoError(t, err, "out: %s", out)
 	got := decodeOut(t, out)
-	assert.Equal(t, float64(1), got["schemaVersion"])
+	assert.Equal(t, float64(2), got["schemaVersion"])
 	assert.Equal(t, "links", got["phase"])
 	assert.Equal(t, "aws", got["cloud"])
 	assert.Equal(t, testAccount, got["account"])
 	assert.Equal(t, contractInstallation, got["installation"])
-	assert.Contains(t, got["providerStackUrl"], "formae-oidc-provider")
-	assert.Contains(t, got["roleStackUrl"], "formae-connect-"+contractInstallation)
+	assert.Contains(t, got["stackUrl"], "formae-connect-"+contractInstallation)
+	assert.Contains(t, got["stackUrl"], "param_CreateProvider=true")
+	assert.Equal(t, true, got["createProvider"])
+	assert.NotContains(t, out, "providerStackUrl")
 	assert.Equal(t, contractRoleArn, got["expectedRoleArn"])
 	assert.Contains(t, got["resumeCommand"], "--role-arn")
 	assert.Empty(t, cp.posts(), "quick-create registers nothing")
+}
+
+// --provider-exists rides the machine document and flips the link parameter,
+// so a conversational harness can ask the question and pass the answer.
+func TestContractQuickCreateProviderExists(t *testing.T) {
+	cp := newControlPlane(t)
+	seedProfile(t, cp, hostedProfile(contractInstallation))
+	stubCredentials(t, bearerAnswer("t1"))
+
+	out, err := runConnect(t, "aws", "--account", testAccount, "--quick-create", "--provider-exists",
+		"--no-input", "--output-consumer", "machine", "--output-schema", "json")
+
+	require.NoError(t, err, "out: %s", out)
+	got := decodeOut(t, out)
+	assert.Contains(t, got["stackUrl"], "param_CreateProvider=false")
+	assert.Equal(t, false, got["createProvider"])
+}
+
+// When the hint knows the account, interactive quick-create asks whether the
+// provider already exists and carries the answer into the link.
+func TestContractQuickCreateAsksProviderQuestionWhenHintKnowsTheAccount(t *testing.T) {
+	interactiveTTY(t)
+	cp := newControlPlane(t)
+	cp.setupBody = defaultSetupBody(t, []map[string]any{{
+		"cloud": "aws", "account": testAccount,
+		"installationId": contractInstallation, "installationName": "inst",
+		"tenantName": "default", "orgName": "acme",
+	}})
+	seedProfile(t, cp, hostedProfile(contractInstallation))
+	stubCredentials(t, bearerAnswer("t1"))
+	stubConfirms(t, true)
+	asked := stubProviderExistsPrompt(t, true, nil)
+	stubRoleArnPrompt(t, "", nil)
+
+	out, err := runConnect(t, "aws", "--account", testAccount, "--quick-create")
+
+	require.NoError(t, err, "out: %s", out)
+	assert.Equal(t, 1, *asked, "the provider question is asked when the hint knows the account")
+	assert.Contains(t, out, "param_CreateProvider=false")
+}
+
+// A fresh account asks nothing: the common case stays one link, zero
+// questions, provider created by default.
+func TestContractQuickCreateSkipsProviderQuestionForFreshAccount(t *testing.T) {
+	interactiveTTY(t)
+	cp := newControlPlane(t)
+	seedProfile(t, cp, hostedProfile(contractInstallation))
+	stubCredentials(t, bearerAnswer("t1"))
+	stubConfirms(t, true)
+	asked := stubProviderExistsPrompt(t, true, nil)
+	stubRoleArnPrompt(t, "", nil)
+
+	out, err := runConnect(t, "aws", "--account", testAccount, "--quick-create")
+
+	require.NoError(t, err, "out: %s", out)
+	assert.Equal(t, 0, *asked, "no question for a fresh account")
+	assert.Contains(t, out, "param_CreateProvider=true")
+}
+
+// Interactive quick-create finishes on a bare Enter: the expected ARN is
+// registered without a paste. A pasted ARN still wins when it differs.
+func TestContractQuickCreateEnterRegistersExpectedArn(t *testing.T) {
+	interactiveTTY(t)
+	cp := newControlPlane(t)
+	seedProfile(t, cp, hostedProfile(contractInstallation))
+	stubCredentials(t, bearerAnswer("t1"))
+	stubConfirms(t, true)
+	stubRoleArnPrompt(t, "", nil)
+
+	out, err := runConnect(t, "aws", "--account", testAccount, "--quick-create")
+
+	require.NoError(t, err, "out: %s", out)
+	posts := cp.posts()
+	require.Len(t, posts, 1, "Enter registers the expected ARN")
+	assert.Contains(t, posts[0].Body, contractRoleArn)
 }
 
 // 409 answers are disambiguated by reading the listing: the same ARN is the

--- a/internal/cli/connect/flow.go
+++ b/internal/cli/connect/flow.go
@@ -22,10 +22,14 @@ import (
 type options struct {
 	Account     string
 	QuickCreate bool
-	ProfileAWS  string
-	RoleArn     string
-	Region      string
-	NoInput     bool
+	// ProviderExists flips the link's CreateProvider parameter for an account
+	// that was connected before: the shared OIDC provider already exists and
+	// IAM allows only one per issuer.
+	ProviderExists bool
+	ProfileAWS     string
+	RoleArn        string
+	Region         string
+	NoInput        bool
 
 	// ConfigFlag and ProfileFlag are carried verbatim into the resume hint:
 	// a fresh shell may have a different active profile.
@@ -57,6 +61,9 @@ func decideMode(opts options, tty bool) (mode, error) {
 	}
 	if opts.Region != "" && opts.ProfileAWS == "" {
 		return 0, cmd.FlagErrorf("--region applies only to the local path; pass it with --profile-aws")
+	}
+	if opts.ProviderExists && !opts.QuickCreate {
+		return 0, cmd.FlagErrorf("--provider-exists answers a question only quick-create asks; pass it with --quick-create")
 	}
 	if opts.NoInput {
 		var missing []string
@@ -153,6 +160,19 @@ func warnOnNameMismatch(actual, expected string) string {
 	}
 	return fmt.Sprintf("the role is named %q where this installation's expected role name is %q; "+
 		"registering the role you named", actual, expected)
+}
+
+// accountInHint reports whether any aws hint entry names the account — on
+// any installation, including the one being connected. A known account means
+// the shared provider very likely exists, so the interactive flow asks
+// instead of assuming a first connection.
+func accountInHint(hint []cloudapi.ConnectedAccount, account string) bool {
+	for _, entry := range hint {
+		if entry.Cloud == "aws" && entry.Account == account {
+			return true
+		}
+	}
+	return false
 }
 
 // connectedElsewhere returns the hint entries naming the stated AWS account on

--- a/internal/cli/connect/flow_test.go
+++ b/internal/cli/connect/flow_test.go
@@ -97,6 +97,23 @@ func TestDecideMode_RegionIsRefusedOffTheLocalPath(t *testing.T) {
 	assert.Equal(t, modeLocal, mode)
 }
 
+// --provider-exists answers a question only quick-create asks.
+func TestDecideMode_ProviderExistsIsRefusedOffQuickCreate(t *testing.T) {
+	for _, opts := range []options{
+		{Account: testAccount, RoleArn: "arn:aws:iam::" + testAccount + ":role/r", ProviderExists: true},
+		{Account: testAccount, ProfileAWS: "dev", ProviderExists: true},
+		{Account: testAccount, ProviderExists: true},
+	} {
+		_, err := decideMode(opts, true)
+		flagError(t, err)
+		assert.Contains(t, err.Error(), "--quick-create")
+	}
+
+	mode, err := decideMode(options{Account: testAccount, QuickCreate: true, ProviderExists: true}, true)
+	require.NoError(t, err)
+	assert.Equal(t, modeQuickCreate, mode)
+}
+
 func TestDecideMode_AccountMustBeTwelveDigits(t *testing.T) {
 	for _, account := range []string{"123", "1234567890123", "12345678901a", "  123456789012", "-23456789012"} {
 		_, err := decideMode(options{Account: account, QuickCreate: true}, true)
@@ -192,6 +209,20 @@ func TestWarnOnNameMismatch(t *testing.T) {
 // connectedElsewhere warns only about the same AWS account on a different
 // installation: a GCP account string equal to a 12-digit AWS id is not this
 // account, and the installation being connected is not "elsewhere".
+// Any aws hint entry for the account means the provider very likely exists —
+// including this installation's own prior connection. Other clouds never
+// match.
+func TestAccountInHint(t *testing.T) {
+	hint := []cloudapi.ConnectedAccount{
+		{Cloud: "gcp", Account: testAccount, InstallationID: "other"},
+		{Cloud: "aws", Account: "999999999999", InstallationID: "other"},
+	}
+	assert.False(t, accountInHint(hint, testAccount))
+
+	hint = append(hint, cloudapi.ConnectedAccount{Cloud: "aws", Account: testAccount, InstallationID: testInstallation})
+	assert.True(t, accountInHint(hint, testAccount))
+}
+
 func TestConnectedElsewhere(t *testing.T) {
 	self := "3HzFPXfPDGhwLJJVtaHbmFs6vLa"
 	other := "2ZaBcDeFgHiJkLmNoPqRsTuVwXy"

--- a/internal/cli/connect/form.go
+++ b/internal/cli/connect/form.go
@@ -28,6 +28,24 @@ const (
 // consents are testable without a TTY.
 var confirmFn = components.RunConfirm
 
+// confirmProviderExistsFn asks whether the shared identity provider already
+// exists in the account. Asked only when the connection hint knows the
+// account — a fresh account skips the question and creates the provider. A
+// seam so the flow is testable without a TTY.
+var confirmProviderExistsFn = func(th *theme.Theme, account string) (bool, error) {
+	exists := true
+	confirm := huh.NewConfirm().
+		Title("Account " + account + " looks connected to formae already").
+		Description("IAM allows one formae identity provider per account. Does it already exist?").
+		Affirmative("It exists — create the role only").
+		Negative("First connection — create both").
+		Value(&exists)
+	if err := components.NewThemedForm(th, huh.NewGroup(confirm)).Run(); err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
 // promptRoleArnFn is the in-sitting quick-create wait: a paste prompt titled
 // with the RoleArn output name, not a poll — the CLI holds no AWS credentials
 // on the quick-create path, so it cannot watch CREATE_COMPLETE.
@@ -35,7 +53,9 @@ var promptRoleArnFn = func(th *theme.Theme, expectedArn string) (string, error) 
 	var arn string
 	input := huh.NewInput().
 		Title("RoleArn stack output").
-		Description("Apply both stacks in the console, then paste the role stack's RoleArn output here.\nExpected: " + expectedArn).
+		Description("Apply the stack in the console, then press Enter once it shows CREATE_COMPLETE.\n" +
+			"Expected: " + expectedArn + "\n" +
+			"Paste the RoleArn output only if it differs.").
 		Value(&arn)
 	if err := components.NewThemedForm(th, huh.NewGroup(input)).Run(); err != nil {
 		return "", err

--- a/internal/cli/connect/form_test.go
+++ b/internal/cli/connect/form_test.go
@@ -80,6 +80,18 @@ func stubConfirms(t *testing.T, answers ...bool) *confirmStub {
 	return stub
 }
 
+func stubProviderExistsPrompt(t *testing.T, exists bool, err error) *int {
+	t.Helper()
+	calls := new(int)
+	restore := confirmProviderExistsFn
+	confirmProviderExistsFn = func(_ *theme.Theme, _ string) (bool, error) {
+		*calls++
+		return exists, err
+	}
+	t.Cleanup(func() { confirmProviderExistsFn = restore })
+	return calls
+}
+
 func stubRoleArnPrompt(t *testing.T, arn string, err error) *int {
 	t.Helper()
 	calls := new(int)
@@ -200,7 +212,7 @@ func TestFormQuickCreateWaitsAndRegistersThePastedArn(t *testing.T) {
 	require.Len(t, confirms.prompts, 1)
 	assert.Contains(t, confirms.prompts[0], "PowerUserAccess + IAM management")
 	assert.Equal(t, 1, *waits)
-	assert.Contains(t, out, "formae-oidc-provider", "the links print before the wait")
+	assert.Contains(t, out, "param_CreateProvider=true", "the link prints before the wait")
 	assert.Contains(t, out, "registered")
 	posts := cp.posts()
 	require.Len(t, posts, 1)

--- a/internal/cli/connect/machine.go
+++ b/internal/cli/connect/machine.go
@@ -20,7 +20,7 @@ import (
 // connectSchemaVersion identifies the shape of both documents. A consumer
 // reads it before any other field, so a document it cannot understand is an
 // error rather than a guess.
-const connectSchemaVersion = 1
+const connectSchemaVersion = 2
 
 // The registration statuses: registered_unverified always — the CLI cannot
 // verify the stack was applied and does not pretend otherwise — and
@@ -31,20 +31,21 @@ const (
 )
 
 // linksView is the quick-create emit: self-contained, so a consumer can drive
-// the console flow and come back with the RoleArn.
+// the console flow and come back with the RoleArn. CreateProvider echoes the
+// answer carried into the link, so a consumer sees which stack variant it is
+// driving.
 type linksView struct {
-	SchemaVersion          int      `json:"schemaVersion" yaml:"schemaVersion"`
-	Phase                  string   `json:"phase" yaml:"phase"` // "links"
-	Cloud                  string   `json:"cloud" yaml:"cloud"`
-	Account                string   `json:"account" yaml:"account"`
-	Installation           string   `json:"installation" yaml:"installation"`
-	ProviderStackURL       string   `json:"providerStackUrl" yaml:"providerStackUrl"`
-	RoleStackURL           string   `json:"roleStackUrl" yaml:"roleStackUrl"`
-	ExpectedRoleArn        string   `json:"expectedRoleArn" yaml:"expectedRoleArn"`
-	ProviderTemplateSha256 string   `json:"providerTemplateSha256" yaml:"providerTemplateSha256"`
-	RoleTemplateSha256     string   `json:"roleTemplateSha256" yaml:"roleTemplateSha256"`
-	ResumeCommand          string   `json:"resumeCommand" yaml:"resumeCommand"`
-	Warnings               []string `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+	SchemaVersion   int      `json:"schemaVersion" yaml:"schemaVersion"`
+	Phase           string   `json:"phase" yaml:"phase"` // "links"
+	Cloud           string   `json:"cloud" yaml:"cloud"`
+	Account         string   `json:"account" yaml:"account"`
+	Installation    string   `json:"installation" yaml:"installation"`
+	StackURL        string   `json:"stackUrl" yaml:"stackUrl"`
+	ExpectedRoleArn string   `json:"expectedRoleArn" yaml:"expectedRoleArn"`
+	TemplateSha256  string   `json:"templateSha256" yaml:"templateSha256"`
+	CreateProvider  bool     `json:"createProvider" yaml:"createProvider"`
+	ResumeCommand   string   `json:"resumeCommand" yaml:"resumeCommand"`
+	Warnings        []string `json:"warnings,omitempty" yaml:"warnings,omitempty"`
 }
 
 // registeredView reports registration. Status is the two-value enum above.
@@ -62,18 +63,17 @@ type registeredView struct {
 // multi-installation and name-mismatch warnings ride Warnings.
 func linksDocument(plan quickCreatePlan, account, installationID string, warnings []string) linksView {
 	return linksView{
-		SchemaVersion:          connectSchemaVersion,
-		Phase:                  "links",
-		Cloud:                  "aws",
-		Account:                account,
-		Installation:           installationID,
-		ProviderStackURL:       plan.ProviderStackURL,
-		RoleStackURL:           plan.RoleStackURL,
-		ExpectedRoleArn:        plan.ExpectedRoleArn,
-		ProviderTemplateSha256: plan.ProviderDigest,
-		RoleTemplateSha256:     plan.RoleDigest,
-		ResumeCommand:          plan.ResumeCommand,
-		Warnings:               warnings,
+		SchemaVersion:   connectSchemaVersion,
+		Phase:           "links",
+		Cloud:           "aws",
+		Account:         account,
+		Installation:    installationID,
+		StackURL:        plan.StackURL,
+		ExpectedRoleArn: plan.ExpectedRoleArn,
+		TemplateSha256:  plan.TemplateDigest,
+		CreateProvider:  plan.CreateProvider,
+		ResumeCommand:   plan.ResumeCommand,
+		Warnings:        warnings,
 	}
 }
 

--- a/internal/cli/connect/machine_test.go
+++ b/internal/cli/connect/machine_test.go
@@ -36,22 +36,21 @@ func TestLinksDocument_CarriesExactlyTheDeclaredFields(t *testing.T) {
 	require.NoError(t, emitLinks(&out, "json", linksDocument(plan, testAccount, testInstallation, []string{"careful"})))
 
 	got := decodeDoc(t, out.String())
-	assert.Equal(t, float64(1), got["schemaVersion"])
+	assert.Equal(t, float64(2), got["schemaVersion"])
 	assert.Equal(t, "links", got["phase"])
 	assert.Equal(t, "aws", got["cloud"])
 	assert.Equal(t, testAccount, got["account"])
 	assert.Equal(t, testInstallation, got["installation"])
-	assert.Equal(t, plan.ProviderStackURL, got["providerStackUrl"])
-	assert.Equal(t, plan.RoleStackURL, got["roleStackUrl"])
+	assert.Equal(t, plan.StackURL, got["stackUrl"])
 	assert.Equal(t, plan.ExpectedRoleArn, got["expectedRoleArn"])
-	assert.Equal(t, plan.ProviderDigest, got["providerTemplateSha256"])
-	assert.Equal(t, plan.RoleDigest, got["roleTemplateSha256"])
+	assert.Equal(t, plan.TemplateDigest, got["templateSha256"])
+	assert.Equal(t, true, got["createProvider"])
 	assert.Equal(t, plan.ResumeCommand, got["resumeCommand"])
 	assert.Equal(t, []any{"careful"}, got["warnings"])
 
 	// The declared keys and nothing else: prose this repo did not write never
 	// rides the stream.
-	assert.Len(t, got, 12)
+	assert.Len(t, got, 11)
 }
 
 func TestLinksDocument_OmitsEmptyWarnings(t *testing.T) {
@@ -75,7 +74,7 @@ func TestRegisteredDocument_PinsBothStatusValues(t *testing.T) {
 			registeredDocument(status, testAccount, roleArn, []string{"w"})))
 
 		got := decodeDoc(t, out.String())
-		assert.Equal(t, float64(1), got["schemaVersion"])
+		assert.Equal(t, float64(2), got["schemaVersion"])
 		assert.Equal(t, "registered", got["phase"])
 		assert.Equal(t, status, got["status"])
 		assert.Equal(t, "aws", got["cloud"])
@@ -93,7 +92,7 @@ func TestDocuments_SupportYAML(t *testing.T) {
 	require.NoError(t, emitRegistered(&out, "yaml",
 		registeredDocument(statusRegisteredUnverified, testAccount, "arn:aws:iam::"+testAccount+":role/r", nil)))
 	assert.Contains(t, out.String(), "phase: registered")
-	assert.Contains(t, out.String(), "schemaVersion: 1")
+	assert.Contains(t, out.String(), "schemaVersion: 2")
 }
 
 // An error the flow did not declare reaches the wire as internal, with a

--- a/internal/cli/connect/provision.go
+++ b/internal/cli/connect/provision.go
@@ -84,7 +84,7 @@ func runLocal(cc *cobra.Command, opts options, consumer printer.Consumer, schema
 	if consumer == printer.ConsumerMachine {
 		return emitRegistered(cc.OutOrStdout(), schema, v)
 	}
-	return printRegisteredHuman(cc.OutOrStdout(), v, s.InstallationID)
+	return printRegisteredHuman(cc.OutOrStdout(), isInteractive(), clicmd.ResolveConfiguredTheme(cc), v, s.InstallationID)
 }
 
 // classifyProvision maps provx's typed errors onto declared codes. Anything

--- a/internal/cli/connect/quickcreate.go
+++ b/internal/cli/connect/quickcreate.go
@@ -27,14 +27,11 @@ import (
 // the values is a constants-only change. A releasecheck-tagged gate test
 // fails the release pipeline while any placeholder remains.
 const (
-	providerStackName         = "formae-oidc-provider"
-	providerTemplateKey       = "formae-oidc-provider.yaml"
-	providerTemplateVersionID = "GCkhsMGjUAKV_qs7m7uYl6j5879bUjgu"
-	providerTemplateSHA256    = "1104e93afd716ffbda670158f6a89d42e8869dbe38a466d79ccd473b5e30683d"
-
+	// Template 0.2.0: the shared OIDC provider rides in the role template
+	// behind CreateProvider, so quick-create emits exactly one link.
 	roleTemplateKey       = "formae-connect-role.yaml"
-	roleTemplateVersionID = "NpQAD3Vxf_JcswPJ4VuSSBoUp0gY2.uq"
-	roleTemplateSHA256    = "62b24a36898a9ecaf21c4869f617a8cc457eec61ea0bee32ce8426dcb87bf15e"
+	roleTemplateVersionID = "PINNED_AT_PUBLICATION"
+	roleTemplateSHA256    = "PINNED_AT_PUBLICATION"
 
 	quickCreateConsole = "https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review"
 )
@@ -42,22 +39,23 @@ const (
 // quickCreatePlan is everything the emit step prints and the machine document
 // carries. Self-contained: a consumer needs no second command to act on it.
 type quickCreatePlan struct {
-	ProviderStackURL string
-	RoleStackURL     string
-	RoleStackName    string // formae-connect-<installation KSUID>
-	ExpectedRoleArn  string
-	ProviderDigest   string
-	RoleDigest       string
-	ResumeCommand    string
-	SkipStepOne      string
-	CapabilityNote   string
-	Warnings         []string
+	StackURL        string
+	StackName       string // formae-connect-<installation KSUID>
+	ExpectedRoleArn string
+	TemplateDigest  string
+	CreateProvider  bool
+	ResumeCommand   string
+	ProviderNote    string
+	CapabilityNote  string
+	Warnings        []string
 }
 
-// buildQuickCreatePlan assembles the two console links and the facts around
-// them. The console URL grammar is a query string carried inside the URL
-// fragment: everything after #/stacks/create/review is one opaque string to
-// the server and the console's client-side router reads it whole.
+// buildQuickCreatePlan assembles the console link and the facts around it.
+// The console URL grammar is a query string carried inside the URL fragment:
+// everything after #/stacks/create/review is one opaque string to the server
+// and the console's client-side router reads it whole. CreateProvider is
+// always explicit in the link, so the emitted URL never depends on the
+// template's default.
 func buildQuickCreatePlan(p connectPlatform, setup cloudapi.CloudConnectionSetup,
 	account, installationID string, opts options) quickCreatePlan {
 
@@ -72,32 +70,33 @@ func buildQuickCreatePlan(p connectPlatform, setup cloudapi.CloudConnectionSetup
 		}
 		return "&" + v.Encode()
 	}
-	roleStack := "formae-connect-" + installationID
+	stack := "formae-connect-" + installationID
+	createProvider := !opts.ProviderExists
 	return quickCreatePlan{
-		ProviderStackURL: quickCreateConsole +
-			"?templateURL=" + url.QueryEscape(templateURL(providerTemplateKey, providerTemplateVersionID)) +
-			frag(providerStackName, nil),
-		RoleStackURL: quickCreateConsole +
+		StackURL: quickCreateConsole +
 			"?templateURL=" + url.QueryEscape(templateURL(roleTemplateKey, roleTemplateVersionID)) +
-			frag(roleStack, map[string]string{
+			frag(stack, map[string]string{
 				"Subject":           setup.CloudSubject,
 				"RoleName":          setup.CloudRoleName,
 				"ExpectedAccountId": account,
+				"CreateProvider":    fmt.Sprintf("%t", createProvider),
 			}),
-		RoleStackName:   roleStack,
+		StackName:       stack,
 		ExpectedRoleArn: "arn:aws:iam::" + account + ":role/" + setup.CloudRoleName,
-		ProviderDigest:  providerTemplateSHA256,
-		RoleDigest:      roleTemplateSHA256,
+		TemplateDigest:  roleTemplateSHA256,
+		CreateProvider:  createProvider,
 		ResumeCommand:   resumeCommand(opts, account),
-		SkipStepOne:     "If this account was connected before, the identity provider already exists — skip step 1.",
-		CapabilityNote:  "Both stacks require the CAPABILITY_NAMED_IAM acknowledgement in the console.",
+		ProviderNote: "If this account was connected to formae before, re-run with --provider-exists: " +
+			"the shared identity provider already exists and the stack should create the role only.",
+		CapabilityNote: "The stack requires the CAPABILITY_NAMED_IAM acknowledgement in the console.",
 	}
 }
 
 // runQuickCreate is the --quick-create path: read the coordinates, assemble
-// the two console links, emit them, and stop. Nothing is registered — the
-// user comes back with the stack's RoleArn output and finishes with
-// --role-arn (or, interactively, pastes it into the in-sitting wait).
+// the console link, emit it, and — interactively — finish in the same
+// sitting: Enter registers the expected ARN once the stack is applied, a
+// pasted RoleArn wins when it differs. Non-interactively nothing is
+// registered; the user comes back with --role-arn.
 func runQuickCreate(cc *cobra.Command, opts options, consumer printer.Consumer, schema string) error {
 	if opts.Account == "" {
 		return clicmd.FlagErrorf("--quick-create requires --account")
@@ -124,11 +123,23 @@ func runQuickCreate(cc *cobra.Command, opts options, consumer printer.Consumer, 
 		return printLinksHuman(cc.OutOrStdout(), plan)
 	}
 
-	// The in-sitting completion: consent, print the links, wait for the
-	// pasted RoleArn, validate it exactly like --role-arn, and register.
+	// The in-sitting completion: consent, settle the provider question,
+	// print the link, wait for Enter or a pasted RoleArn, validate it exactly
+	// like --role-arn, and register.
 	th := clicmd.ResolveConfiguredTheme(cc)
 	if err := confirmInteractive(th, opts.Account, s.Setup.CloudSubject, permissionsProvisioned, elsewhere); err != nil {
 		return err
+	}
+	if !opts.ProviderExists && accountInHint(s.Setup.AccountsConnectedHint, opts.Account) {
+		exists, err := confirmProviderExistsFn(th, opts.Account)
+		if err != nil {
+			return err
+		}
+		if exists {
+			opts.ProviderExists = true
+			plan = buildQuickCreatePlan(s.Platform, s.Setup, opts.Account, s.InstallationID, opts)
+			plan.Warnings = warnings
+		}
 	}
 	if err := printLinksHuman(cc.OutOrStdout(), plan); err != nil {
 		return err
@@ -140,6 +151,11 @@ func runQuickCreate(cc *cobra.Command, opts options, consumer printer.Consumer, 
 		// the session from a fresh shell.
 		_, _ = fmt.Fprintln(cc.OutOrStdout(), "\nResume later with:\n  "+plan.ResumeCommand)
 		return err
+	}
+	if pasted == "" {
+		// Enter means "it applied and the output matches what you printed":
+		// register the expected ARN.
+		pasted = plan.ExpectedRoleArn
 	}
 	parsed, err := parseRoleArn(pasted, opts.Account)
 	if err != nil {
@@ -153,31 +169,31 @@ func runQuickCreate(cc *cobra.Command, opts options, consumer printer.Consumer, 
 	if err != nil {
 		return err
 	}
-	return printRegisteredHuman(cc.OutOrStdout(), registeredDocument(status, opts.Account, parsed.Arn, warnings), s.InstallationID)
+	return printRegisteredHuman(cc.OutOrStdout(), true, th, registeredDocument(status, opts.Account, parsed.Arn, warnings), s.InstallationID)
 }
 
-// printLinksHuman renders the plan as the two console steps.
+// printLinksHuman renders the plan as one console step.
 func printLinksHuman(w io.Writer, plan quickCreatePlan) error {
+	intro := "One CloudFormation stack establishes the trust. Open the link, review, and create the stack (" + plan.StackName + "):"
+	notes := []string{plan.CapabilityNote}
+	if plan.CreateProvider {
+		notes = append(notes, plan.ProviderNote)
+	}
 	lines := []string{
-		"Two CloudFormation stacks establish the trust. Open each link, review, and create the stack.",
+		intro,
+		"  " + plan.StackURL,
+		"  template sha256: " + plan.TemplateDigest,
 		"",
-		"Step 1 — the formae identity provider (once per account):",
-		"  " + plan.ProviderStackURL,
-		"  " + plan.SkipStepOne,
-		"  template sha256: " + plan.ProviderDigest,
+	}
+	lines = append(lines, notes...)
+	lines = append(lines,
 		"",
-		"Step 2 — the connect role (" + plan.RoleStackName + "):",
-		"  " + plan.RoleStackURL,
-		"  template sha256: " + plan.RoleDigest,
-		"",
-		plan.CapabilityNote,
-		"",
-		"When the role stack is applied, its RoleArn output should be:",
-		"  " + plan.ExpectedRoleArn,
+		"When the stack is applied, its RoleArn output should be:",
+		"  "+plan.ExpectedRoleArn,
 		"",
 		"Finish by registering it:",
-		"  " + plan.ResumeCommand,
-	}
+		"  "+plan.ResumeCommand,
+	)
 	for _, warning := range plan.Warnings {
 		lines = append(lines, "", "warning: "+warning)
 	}

--- a/internal/cli/connect/quickcreate.go
+++ b/internal/cli/connect/quickcreate.go
@@ -30,8 +30,8 @@ const (
 	// Template 0.2.0: the shared OIDC provider rides in the role template
 	// behind CreateProvider, so quick-create emits exactly one link.
 	roleTemplateKey       = "formae-connect-role.yaml"
-	roleTemplateVersionID = "PINNED_AT_PUBLICATION"
-	roleTemplateSHA256    = "PINNED_AT_PUBLICATION"
+	roleTemplateVersionID = "xxcZ8mU5TG82MLf5iyJrlmnB4i2wOZ_f"
+	roleTemplateSHA256    = "12fe0ff79a73387c2e591fb0348558406f5b085917d879b91dc9b21de2306ee2"
 
 	quickCreateConsole = "https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review"
 )

--- a/internal/cli/connect/quickcreate_release_test.go
+++ b/internal/cli/connect/quickcreate_release_test.go
@@ -14,10 +14,8 @@ import "testing"
 // the publication is pending, and a release cannot.
 func TestTemplateCoordinatesArePinned(t *testing.T) {
 	for name, value := range map[string]string{
-		"providerTemplateVersionID": providerTemplateVersionID,
-		"providerTemplateSHA256":    providerTemplateSHA256,
-		"roleTemplateVersionID":     roleTemplateVersionID,
-		"roleTemplateSHA256":        roleTemplateSHA256,
+		"roleTemplateVersionID": roleTemplateVersionID,
+		"roleTemplateSHA256":    roleTemplateSHA256,
 	} {
 		if value == "PINNED_AT_PUBLICATION" {
 			t.Errorf("%s still holds the placeholder; pin it from the infrastructure repo's publication before releasing", name)

--- a/internal/cli/connect/quickcreate_test.go
+++ b/internal/cli/connect/quickcreate_test.go
@@ -7,6 +7,8 @@
 package connect
 
 import (
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,42 +39,53 @@ func defaultPlatform(t *testing.T) connectPlatform {
 	return p
 }
 
-// The two console links, byte for byte. Everything after #/stacks/create/review
-// rides in the URL fragment, so the whole ?templateURL=...&stackName=... query
-// grammar is assembled inside the fragment string.
-func TestBuildQuickCreatePlan_GoldenURLs(t *testing.T) {
+// The single console link, byte for byte up to the pinned versionId (spliced
+// from the constant so pin swaps stay constants-only changes). Everything
+// after #/stacks/create/review rides in the URL fragment, so the whole
+// ?templateURL=...&stackName=... query grammar is assembled inside the
+// fragment string. CreateProvider is always explicit — the emitted link never
+// depends on the template's default.
+func TestBuildQuickCreatePlan_GoldenURL(t *testing.T) {
 	plan := buildQuickCreatePlan(defaultPlatform(t), testSetup(), testAccount, testInstallation, options{})
 
+	tplURL := "https://formae-connect-templates.s3.us-east-1.amazonaws.com/formae-connect-role.yaml?versionId=" +
+		url.QueryEscape(roleTemplateVersionID)
 	assert.Equal(t,
 		"https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review"+
-			"?templateURL=https%3A%2F%2Fformae-connect-templates.s3.us-east-1.amazonaws.com"+
-			"%2Fformae-oidc-provider.yaml%3FversionId%3DGCkhsMGjUAKV_qs7m7uYl6j5879bUjgu"+
-			"&stackName=formae-oidc-provider",
-		plan.ProviderStackURL)
-
-	assert.Equal(t,
-		"https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review"+
-			"?templateURL=https%3A%2F%2Fformae-connect-templates.s3.us-east-1.amazonaws.com"+
-			"%2Fformae-connect-role.yaml%3FversionId%3DNpQAD3Vxf_JcswPJ4VuSSBoUp0gY2.uq"+
+			"?templateURL="+url.QueryEscape(tplURL)+
+			"&param_CreateProvider=true"+
 			"&param_ExpectedAccountId="+testAccount+
 			"&param_RoleName=formae-connect-"+testInstallation+
 			"&param_Subject=fai%3Aacme%2F"+testInstallation+
 			"&stackName=formae-connect-"+testInstallation,
-		plan.RoleStackURL)
+		plan.StackURL)
+}
+
+// --provider-exists flips exactly the CreateProvider parameter.
+func TestBuildQuickCreatePlan_ProviderExistsFlipsTheParameter(t *testing.T) {
+	base := buildQuickCreatePlan(defaultPlatform(t), testSetup(), testAccount, testInstallation, options{})
+	flipped := buildQuickCreatePlan(defaultPlatform(t), testSetup(), testAccount, testInstallation,
+		options{ProviderExists: true})
+
+	assert.False(t, base.CreateProvider == flipped.CreateProvider)
+	assert.True(t, base.CreateProvider)
+	assert.False(t, flipped.CreateProvider)
+	assert.Equal(t,
+		strings.Replace(base.StackURL, "param_CreateProvider=true", "param_CreateProvider=false", 1),
+		flipped.StackURL)
 }
 
 func TestBuildQuickCreatePlan_CarriesTheFactsTheEmitNeeds(t *testing.T) {
 	plan := buildQuickCreatePlan(defaultPlatform(t), testSetup(), testAccount, testInstallation, options{})
 
-	assert.Equal(t, "formae-connect-"+testInstallation, plan.RoleStackName)
+	assert.Equal(t, "formae-connect-"+testInstallation, plan.StackName)
 	assert.Equal(t, "arn:aws:iam::"+testAccount+":role/"+testRoleName, plan.ExpectedRoleArn)
-	assert.Equal(t, providerTemplateSHA256, plan.ProviderDigest)
-	assert.Equal(t, roleTemplateSHA256, plan.RoleDigest)
-	assert.Contains(t, plan.SkipStepOne, "skip step 1")
+	assert.Equal(t, roleTemplateSHA256, plan.TemplateDigest)
+	assert.Contains(t, plan.ProviderNote, "--provider-exists")
 	assert.Contains(t, plan.CapabilityNote, "CAPABILITY_NAMED_IAM")
 }
 
-// The overridden template base flows into both links: the pair moves together.
+// The overridden template base flows into the link.
 func TestBuildQuickCreatePlan_UsesTheOverriddenBase(t *testing.T) {
 	clearConnectEnv(t)
 	t.Setenv("FORMAE_CONNECT_ISSUER", "https://oidc.test.example")
@@ -82,8 +95,7 @@ func TestBuildQuickCreatePlan_UsesTheOverriddenBase(t *testing.T) {
 
 	plan := buildQuickCreatePlan(p, testSetup(), testAccount, testInstallation, options{})
 
-	assert.Contains(t, plan.ProviderStackURL, "templates.test.example")
-	assert.Contains(t, plan.RoleStackURL, "templates.test.example")
+	assert.Contains(t, plan.StackURL, "templates.test.example")
 }
 
 // The resume hint carries the original profile selection verbatim: a fresh
@@ -124,4 +136,37 @@ func TestBuildQuickCreatePlan_ResumeCommandRidesThePlan(t *testing.T) {
 
 	assert.Contains(t, plan.ResumeCommand, "--profile staging")
 	assert.Contains(t, plan.ResumeCommand, "--account "+testAccount)
+}
+
+// The human emit is one step: a single link plus the provider note, never the
+// old two-step layout.
+func TestPrintLinksHuman_SingleStep(t *testing.T) {
+	plan := buildQuickCreatePlan(defaultPlatform(t), testSetup(), testAccount, testInstallation, options{})
+	var out strings.Builder
+
+	require.NoError(t, printLinksHuman(&out, plan))
+
+	got := out.String()
+	assert.Equal(t, 1, strings.Count(got, "#/stacks/create/review"), "exactly one console link")
+	assert.Contains(t, got, plan.StackURL)
+	assert.Contains(t, got, "--provider-exists")
+	assert.NotContains(t, got, "Step 1")
+	assert.NotContains(t, got, "Step 2")
+	assert.NotContains(t, got, "skip step 1")
+}
+
+// Registration success states the registration and nothing more: the
+// unverified nuance lives in the docs, not the happy-path output. The
+// outcome line rides the shared ack idiom (styled on a TTY, plain piped).
+func TestPrintRegisteredHuman_NoUnverifiedLine(t *testing.T) {
+	var out strings.Builder
+	v := registeredDocument(statusRegisteredUnverified, testAccount, "arn:aws:iam::"+testAccount+":role/r",
+		[]string{"careful"})
+
+	require.NoError(t, printRegisteredHuman(&out, false, nil, v, testInstallation))
+
+	assert.Contains(t, out.String(), "✓ registered aws account "+testAccount)
+	assert.Contains(t, out.String(), "! warning: careful")
+	assert.NotContains(t, out.String(), "not verified")
+	assert.NotContains(t, out.String(), "declared by you")
 }

--- a/internal/cli/connect/rolearn.go
+++ b/internal/cli/connect/rolearn.go
@@ -12,6 +12,8 @@ import (
 
 	clicmd "github.com/platform-engineering-labs/formae/internal/cli/cmd"
 	"github.com/platform-engineering-labs/formae/internal/cli/printer"
+	"github.com/platform-engineering-labs/formae/internal/cli/tui/components"
+	"github.com/platform-engineering-labs/formae/internal/cli/tui/theme"
 )
 
 // runRegisterOnly is the --role-arn path: trust already exists — an applied
@@ -56,26 +58,32 @@ func runRegisterOnly(cc *cobra.Command, opts options, consumer printer.Consumer,
 	if consumer == printer.ConsumerMachine {
 		return emitRegistered(cc.OutOrStdout(), schema, v)
 	}
-	return printRegisteredHuman(cc.OutOrStdout(), v, s.InstallationID)
+	return printRegisteredHuman(cc.OutOrStdout(), isInteractive(), clicmd.ResolveConfiguredTheme(cc), v, s.InstallationID)
 }
 
-// printRegisteredHuman renders the same facts as prose.
-func printRegisteredHuman(w io.Writer, v registeredView, installationID string) error {
+// printRegisteredHuman renders the same facts as prose. The outcome and
+// warning lines ride the shared ack idiom: styled on a TTY, plain when piped
+// so output stays ANSI-free.
+func printRegisteredHuman(w io.Writer, tty bool, th *theme.Theme, v registeredView, installationID string) error {
+	ack := func(m components.AckMarker, text string) string {
+		if tty {
+			return components.AckLine(th, m, text)
+		}
+		return components.AckLinePlain(m, text)
+	}
 	verb := "registered"
 	if v.Status == statusAlreadyRegistered {
 		verb = "already registered"
 	}
-	if _, err := fmt.Fprintf(w, "✓ %s aws account %s on installation %s\n", verb, v.Account, installationID); err != nil {
+	if _, err := fmt.Fprintln(w, ack(components.AckDone,
+		fmt.Sprintf("%s aws account %s on installation %s", verb, v.Account, installationID))); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintf(w, "  role: %s\n", v.RoleArn); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintln(w, "  The registration is declared by you, not verified by formae."); err != nil {
-		return err
-	}
 	for _, warning := range v.Warnings {
-		if _, err := fmt.Fprintf(w, "  warning: %s\n", warning); err != nil {
+		if _, err := fmt.Fprintln(w, ack(components.AckWarn, "warning: "+warning)); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/connect/structure_test.go
+++ b/internal/cli/connect/structure_test.go
@@ -49,7 +49,7 @@ func TestStructure_AwsFlagsLiveOnTheSubcommandOnly(t *testing.T) {
 	parent := ConnectCmd()
 	aws := findSub(t, parent, "aws")
 
-	for _, flag := range []string{"account", "quick-create", "profile-aws", "region", "role-arn", "no-input"} {
+	for _, flag := range []string{"account", "quick-create", "provider-exists", "profile-aws", "region", "role-arn", "no-input"} {
 		assert.NotNil(t, aws.Flags().Lookup(flag), "flag %q missing on connect aws", flag)
 		assert.Nil(t, parent.Flags().Lookup(flag), "flag %q must not exist on the parent", flag)
 	}


### PR DESCRIPTION
## Summary

- Quick-create emits a **single** CloudFormation console link: the shared identity provider rides in the role template behind an explicit `CreateProvider` parameter (infrastructure PR platform-engineering-labs/infrastructure#54 is the template side).
- `--provider-exists` flips the parameter for accounts connected before — the non-TTY mirror of the interactive question, which is only asked when the connection hint already knows the account; a fresh account gets one link and zero questions.
- Interactive completion: a bare **Enter** at the RoleArn prompt registers the expected ARN once the stack is applied; pasting still wins when the ARN differs (edited parameters, bring-your-own-role).
- The happy-path output drops the declared-not-verified line; outcome and warning lines render through the shared ack component (styled on TTY, plain piped).
- Machine links document: `stackUrl`/`templateSha256`/`createProvider` replace the provider fields; schema version bumps to 2.

Draft until the 0.2.0 template publication lands and the versionId/sha256 pins replace the placeholders (releasecheck gate enforces).