### PR TITLE
fix(login): activate what you signed in to, and fall through to hosted

### DIFF
--- a/internal/cli/login/active_test.go
+++ b/internal/cli/login/active_test.go
@@ -25,9 +25,12 @@ import (
 // finished sign-in with a profile on disk, no pointer, and the next command
 // bootstrapping a classic default beside it.
 //
-// The rule is narrow. An existing pointer is never moved — a user with profiles
-// already has an answer to "which one", and a sign-in is not a request to change
-// it.
+// The rule (2026-08-22): a sign-in that publishes profiles points the pointer at
+// what it published — signing in IS the request to use what you signed in to.
+// Before this, a hosted sign-in on a machine with a classic active profile left
+// that profile active, and the next connect resolved the classic profile and
+// refused. The pointer stays put only when it already names a published profile,
+// and a switch always says what it moved from.
 
 // cleanStoreFixture is a sync fixture whose store has no profiles and no active
 // pointer, which is the state a machine that has never run formae is in.
@@ -82,9 +85,10 @@ func TestActive_NoClassicDefaultIsCreated(t *testing.T) {
 	assert.NoFileExists(t, f.store.ProfilePath("default"))
 }
 
-// A pointer the user already has is not moved. Reaching around the rename path's
-// own refusal to touch the active profile would be the same mistake one level up.
-func TestActive_AnExistingPointerIsNeverMoved(t *testing.T) {
+// A sign-in moves the pointer onto what it published, naming what it moved
+// from: signing in is the request to use what you signed in to. The profile
+// the pointer left behind is untouched on disk.
+func TestActive_TheSignedInProfileBecomesActive(t *testing.T) {
 	f := cleanStoreFixture(t)
 	require.NoError(t, os.MkdirAll(f.store.ProfilesDir(), 0o755))
 	require.NoError(t, os.WriteFile(f.store.ProfilePath("mine"), []byte(store.StubTemplate), 0o644))
@@ -93,12 +97,41 @@ func TestActive_AnExistingPointerIsNeverMoved(t *testing.T) {
 	f.answer(installation(installOne, "prod", stateActive))
 	require.NoError(t, runLoginAndSync(context.Background(), signedIn(), cloudStep(t, f), false))
 
-	// The profile was still published; only the pointer stayed put.
-	assert.FileExists(t, f.store.ProfilePath(cloudProfileName()))
+	active, err := f.store.Active()
+	require.NoError(t, err)
+	assert.Equal(t, cloudProfileName(), active)
+	assert.Contains(t, f.out.String(), "was mine", "the switch names what it moved from")
+	assert.FileExists(t, f.store.ProfilePath("mine"), "the previous profile is untouched on disk")
+}
+
+// A pointer already naming a published profile stays put: re-signing in to what
+// you already use is a no-op, not a switch to the run's first published profile.
+func TestActive_AnActivePublishedProfileStaysActive(t *testing.T) {
+	f := cleanStoreFixture(t)
+	f.answer(
+		installation(installOne, "prod", stateActive),
+		installation(installTwo, "staging", stateActive),
+	)
+	require.NoError(t, runLoginAndSync(context.Background(), signedIn(), cloudStep(t, f), false))
+
+	// Point at the other published profile, then sign in again.
+	published, err := f.store.Active()
+	require.NoError(t, err)
+	other := nameTwo
+	if published == other {
+		other = nameOne
+	}
+	require.NoError(t, f.store.Use(other))
+
+	f.answer(
+		installation(installOne, "prod", stateActive),
+		installation(installTwo, "staging", stateActive),
+	)
+	require.NoError(t, runLoginAndSync(context.Background(), signedIn(), cloudStep(t, f), false))
 
 	active, err := f.store.Active()
 	require.NoError(t, err)
-	assert.Equal(t, "mine", active)
+	assert.Equal(t, other, active, "an active published profile is never yanked to the run's first")
 }
 
 // A run that published nothing writes no pointer. There is nothing to point at,

--- a/internal/cli/login/cloud_clean_test.go
+++ b/internal/cli/login/cloud_clean_test.go
@@ -157,3 +157,23 @@ func TestCleanDirectory_WithoutHostedTheDefaultIsCreated(t *testing.T) {
 	assert.FileExists(t, store.New(dir).ProfilePath("default"),
 		"the profile path no longer bootstraps, so the hosted assertion proves nothing")
 }
+
+// A classic active profile with no auth plugin no longer dead-ends bare
+// `formae login`: the only sign-in formae offers in that state is the hosted
+// platform, so the command falls through to it — and the synced installation
+// profile becomes active, exactly as if --hosted had been passed.
+func TestCleanDirectory_BareLoginFallsThroughToHosted(t *testing.T) {
+	dir := stubCloudSignIn(t, installation(installOne, "prod", stateActive))
+
+	cmd := LoginCmd()
+	cmd.SetArgs(nil)
+	cmd.SilenceUsage = true
+	require.NoError(t, cmd.ExecuteContext(cliContext()))
+
+	s := store.New(dir)
+	assert.FileExists(t, s.ProfilePath(cloudProfileName()))
+
+	active, err := s.Active()
+	require.NoError(t, err)
+	assert.Equal(t, cloudProfileName(), active)
+}

--- a/internal/cli/login/login.go
+++ b/internal/cli/login/login.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/platform-engineering-labs/formae/internal/cli/app"
@@ -136,7 +137,7 @@ touched.`,
 			// creates one — a classic localhost default, for a user who may have
 			// come here precisely to use the hosted platform. Signing in cannot
 			// be reached through a step that decides the question it is asking.
-			if hosted {
+			runHosted := func() error {
 				return run(runCloudLoginAndSync(cmd.Context(), cloudLogin{
 					Cloud:     cloud,
 					Issuer:    cloudIssuer,
@@ -153,6 +154,9 @@ touched.`,
 					Emit:      emit,
 				}))
 			}
+			if hosted {
+				return runHosted()
+			}
 
 			configFile, _ := cmd.Flags().GetString("config")
 
@@ -166,6 +170,16 @@ touched.`,
 
 			client, err := a.AuthClient()
 			if err != nil {
+				// A profile with no auth plugin has exactly one sign-in formae
+				// offers: the hosted platform. Falling through beats a dead end
+				// that tells the user to re-run with a flag (decision
+				// 2026-08-22).
+				var noPlugin *app.NoAuthPluginError
+				if errors.As(err, &noPlugin) {
+					ackLine(out, loginIsTerminal(out), themeFor(a), components.AckSkip,
+						"the active profile has no auth plugin; signing in to the hosted platform")
+					return runHosted()
+				}
 				return run(err)
 			}
 
@@ -516,45 +530,47 @@ func runSync(ctx context.Context, s syncStep) (syncResult, string, error) {
 		Theme:    s.Theme,
 	}, p, gate.Bearer, gate.Auth, s.Entry.sourceAuth())
 
-	active := activateFirstIfNone(st, result, s.Out, tty, s.Theme)
+	active := activatePublished(st, result, s.Out, tty, s.Theme)
 
 	printWarnings(s.Out, tty, s.Theme, result.Warnings)
 	return result, active, syncExit(result)
 }
 
-// activateFirstIfNone points the active profile at one this run published, but
-// only when the store has no active profile at all.
+// activatePublished points the active profile at what this run published:
+// signing in is the request to use what you signed in to (decision 2026-08-22;
+// before this, a hosted sign-in on a machine with a classic active profile left
+// that profile active, and the next connect resolved the classic profile and
+// refused).
 //
-// A machine that has just signed in for the first time has profiles and no
-// pointer, and nothing else in this package writes one — the sync reads the
-// active profile only to protect it from rename and prune. Left without one, the
-// next formae command bootstraps a classic localhost default beside the hosted
-// profile that was just created, which is the outcome the whole hosted sign-in
-// path exists to avoid.
-//
-// An existing pointer is never moved. A user with profiles already has an answer
-// to "which one", and signing in is not a request to change it; the rename path
-// refuses to touch the active profile for the same reason, and reaching around
-// that here would be the same mistake one level up.
+// The pointer stays put only when it already names a profile this run
+// published — re-signing in to what you already use is a no-op, never a yank
+// to the run's first profile. A switch always names what it moved from, and
+// the profile left behind is untouched on disk; `formae profile use` reverses
+// it in one command.
 //
 // It runs after publication, and that ordering matters: store.Use runs the
 // store's initialization, which on a store with no profiles at all bootstraps
-// the very default this avoids. With a published profile present, initialization
-// stops at "orphaned profiles, no default" and only the pointer is written.
+// the classic localhost default this whole path exists to avoid. With a
+// published profile present, initialization stops at "orphaned profiles, no
+// default" and only the pointer is written.
 //
-// Failing to write the pointer is a warning, never a failed sign-in. The user is
-// signed in and their profiles exist either way, which is the rule every message
-// in this file follows.
-// It returns the active profile a caller's next request would use, which is
-// whatever the pointer names when this is done — the one it just wrote, the one
-// that was already there, or empty when there is none.
-func activateFirstIfNone(st *store.Store, result syncResult, out io.Writer, tty bool, th *theme.Theme) string {
-	if existing, err := st.Active(); err == nil {
-		return existing
-	}
+// Failing to write the pointer is a warning, never a failed sign-in. The user
+// is signed in and their profiles exist either way, which is the rule every
+// message in this file follows. It returns the active profile a caller's next
+// request would use: the one it just wrote, the published one that was
+// already active, or empty when nothing was published and no pointer exists.
+func activatePublished(st *store.Store, result syncResult, out io.Writer, tty bool, th *theme.Theme) string {
+	existing, existingErr := st.Active()
+
 	published := result.published()
 	if len(published) == 0 {
+		if existingErr == nil {
+			return existing
+		}
 		return "" // nothing to point at, and no pointer is better than a dangling one.
+	}
+	if existingErr == nil && slices.Contains(published, existing) {
+		return existing
 	}
 
 	name := published[0]
@@ -562,9 +578,16 @@ func activateFirstIfNone(st *store.Store, result syncResult, out io.Writer, tty 
 		ackLine(out, tty, th, components.AckSkip, fmt.Sprintf(
 			"profile %s was created but could not be made the active one (%v); "+
 				"run `formae profile use %s` to select it", name, err, name))
+		if existingErr == nil {
+			return existing
+		}
 		return ""
 	}
-	ackLine(out, tty, th, components.AckDone, "made profile "+name+" active")
+	switched := "made profile " + name + " active"
+	if existingErr == nil && existing != name {
+		switched += " (was " + existing + "; `formae profile use " + existing + "` switches back)"
+	}
+	ackLine(out, tty, th, components.AckDone, switched)
 	return name
 }
 

--- a/internal/cli/login/login_test.go
+++ b/internal/cli/login/login_test.go
@@ -393,6 +393,7 @@ func TestLoginSyncsAfterASignIn(t *testing.T) {
 		"  https://issuer.example/authorize?req=abc",
 		"✓ signed in as jane",
 		"✓ created profile " + nameOne,
+		"✓ made profile " + nameOne + " active (was default; `formae profile use default` switches back)",
 	}, lines(f.out))
 	assert.Equal(t, 1, f.client.calls)
 	assert.True(t, f.exists(nameOne))
@@ -417,6 +418,7 @@ func TestLoginSyncsOnTheAlreadyAuthenticatedBranch(t *testing.T) {
 	assert.Equal(t, []string{
 		"✓ already signed in as jane",
 		"✓ created profile " + nameOne,
+		"✓ made profile " + nameOne + " active (was default; `formae profile use default` switches back)",
 	}, lines(f.out))
 }
 


### PR DESCRIPTION
## Summary

- A sign-in now points the active profile at what it published. Previously `login --hosted` on a machine with a classic active profile synced the installation profile but left the classic one active, so the next `connect` resolved the classic profile and refused with `hosted_required`. The pointer stays put when it already names a published profile (re-login is a no-op), a switch always names what it moved from, and `formae profile use <previous>` reverses it in one command.
- Bare `formae login` on a profile with no auth plugin falls through to the hosted sign-in instead of dead-ending with "no auth plugin configured for the active profile" — the hosted platform is the only sign-in formae offers in that state.

Both were hit in live use of the hosted journey on 2026-08-22; behavior decisions recorded on the Slice C review ledger.