### PR TITLE
fix(login): harden the hosted fallthrough and make id-file creation dir-safe

### DIFF
--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -66,6 +66,11 @@ func (cliconfig) EnsureId(id string) error {
 
 	idFile := filepath.Join(configPath, id)
 	if _, err := os.Stat(idFile); os.IsNotExist(err) {
+		// A fresh machine has no data directory yet; the id file must not be
+		// the thing that discovers that.
+		if err := os.MkdirAll(configPath, 0o755); err != nil {
+			return fmt.Errorf("failed to create data directory: %w", err)
+		}
 		err := os.WriteFile(idFile, []byte(ksuid.New().String()), 0600)
 		if err != nil {
 			return fmt.Errorf("failed to create ID file: %w", err)

--- a/internal/cli/config/ensure_id_test.go
+++ b/internal/cli/config/ensure_id_test.go
@@ -1,0 +1,31 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A fresh machine has no ~/.pel/formae yet; ensuring an id must create the
+// directory rather than fail on the missing parent.
+func TestEnsureId_CreatesTheDataDirectory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := Config.EnsureClientID(); err != nil {
+		t.Fatalf("EnsureClientID on a fresh home: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".pel/formae", "cli_client_id"))
+	if err != nil {
+		t.Fatalf("id file not written: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("id file is empty")
+	}
+}

--- a/internal/cli/login/active_test.go
+++ b/internal/cli/login/active_test.go
@@ -184,3 +184,22 @@ func TestActive_AppliesToAProfileSignInToo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, cloudProfileName(), active)
 }
+
+// The pointer pick is independent of the order the control plane returned
+// installations in: identical grants activate the same profile on every
+// machine, not whichever came first off the wire this time.
+func TestActive_PickIsIndependentOfPublicationOrder(t *testing.T) {
+	picks := map[string]bool{}
+	for _, order := range [][]Installation{
+		{installation(installOne, "prod", stateActive), installation(installTwo, "staging", stateActive)},
+		{installation(installTwo, "staging", stateActive), installation(installOne, "prod", stateActive)},
+	} {
+		f := cleanStoreFixture(t)
+		f.answer(order...)
+		require.NoError(t, runLoginAndSync(context.Background(), signedIn(), cloudStep(t, f), false))
+		active, err := f.store.Active()
+		require.NoError(t, err)
+		picks[active] = true
+	}
+	assert.Len(t, picks, 1, "the pick varied with response order: %v", picks)
+}

--- a/internal/cli/login/cloud_clean_test.go
+++ b/internal/cli/login/cloud_clean_test.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/platform-engineering-labs/formae/internal/cli/app"
 	"github.com/platform-engineering-labs/formae/internal/cli/profile/store"
+	"io"
+	"path/filepath"
 )
 
 // The gate on the whole hosted sign-in path: a machine that has never been
@@ -158,12 +160,23 @@ func TestCleanDirectory_WithoutHostedTheDefaultIsCreated(t *testing.T) {
 		"the profile path no longer bootstraps, so the hosted assertion proves nothing")
 }
 
+// forceTTY makes the command believe it runs on a terminal: the fallthrough
+// is interactive-only, so its happy path needs one.
+func forceTTY(t *testing.T) {
+	t.Helper()
+	restore := loginIsTerminal
+	loginIsTerminal = func(io.Writer) bool { return true }
+	t.Cleanup(func() { loginIsTerminal = restore })
+}
+
 // A classic active profile with no auth plugin no longer dead-ends bare
-// `formae login`: the only sign-in formae offers in that state is the hosted
-// platform, so the command falls through to it — and the synced installation
-// profile becomes active, exactly as if --hosted had been passed.
+// `formae login` on a terminal: the only sign-in formae offers in that state
+// is the hosted platform, so the command falls through to it — and the
+// synced installation profile becomes active, exactly as if --hosted had
+// been passed.
 func TestCleanDirectory_BareLoginFallsThroughToHosted(t *testing.T) {
 	dir := stubCloudSignIn(t, installation(installOne, "prod", stateActive))
+	forceTTY(t)
 
 	cmd := LoginCmd()
 	cmd.SetArgs(nil)
@@ -176,4 +189,41 @@ func TestCleanDirectory_BareLoginFallsThroughToHosted(t *testing.T) {
 	active, err := s.Active()
 	require.NoError(t, err)
 	assert.Equal(t, cloudProfileName(), active)
+}
+
+// An explicitly selected --config is an explicit scope: falling through to
+// the hosted flow would write profiles and move the pointer in the default
+// config directory, outside what the caller named. The dead end stays, with
+// the remedy in the message.
+func TestCleanDirectory_ExplicitConfigDoesNotFallThrough(t *testing.T) {
+	dir := stubCloudSignIn(t, installation(installOne, "prod", stateActive))
+	cfg := filepath.Join(t.TempDir(), "authless.pkl")
+	require.NoError(t, os.WriteFile(cfg, []byte(store.StubTemplate), 0o644))
+
+	cmd := LoginCmd()
+	cmd.SetArgs([]string{"--config", cfg})
+	cmd.SilenceUsage = true
+	err := cmd.ExecuteContext(cliContext())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--hosted")
+	assert.NoFileExists(t, store.New(dir).ProfilePath(cloudProfileName()),
+		"the fallthrough escaped the explicitly selected config scope")
+}
+
+// Without a TTY the fallthrough would turn a promptly detectable
+// configuration failure into a process waiting on a browser nobody is
+// watching. Scripts get the old immediate error, with the remedy named.
+func TestCleanDirectory_NoTTYDoesNotFallThrough(t *testing.T) {
+	// go test runs non-TTY by default; nothing to stub.
+	dir := stubCloudSignIn(t, installation(installOne, "prod", stateActive))
+
+	cmd := LoginCmd()
+	cmd.SetArgs(nil)
+	cmd.SilenceUsage = true
+	err := cmd.ExecuteContext(cliContext())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--hosted")
+	assert.NoFileExists(t, store.New(dir).ProfilePath(cloudProfileName()))
 }

--- a/internal/cli/login/login.go
+++ b/internal/cli/login/login.go
@@ -173,12 +173,19 @@ touched.`,
 				// A profile with no auth plugin has exactly one sign-in formae
 				// offers: the hosted platform. Falling through beats a dead end
 				// that tells the user to re-run with a flag (decision
-				// 2026-08-22).
+				// 2026-08-22) — but only interactively and only for the default
+				// config: an explicit --config is an explicit scope the hosted
+				// flow's default-directory writes would escape, and a script
+				// without a TTY wants the prompt failure, not a process parked
+				// on a browser URL nobody is watching.
 				var noPlugin *app.NoAuthPluginError
 				if errors.As(err, &noPlugin) {
-					ackLine(out, loginIsTerminal(out), themeFor(a), components.AckSkip,
-						"the active profile has no auth plugin; signing in to the hosted platform")
-					return runHosted()
+					if configFile == "" && loginIsTerminal(out) {
+						ackLine(out, true, themeFor(a), components.AckSkip,
+							"the active profile has no auth plugin; signing in to the hosted platform")
+						return runHosted()
+					}
+					return run(fmt.Errorf("%w; run `formae login --hosted` to sign in to the hosted platform", err))
 				}
 				return run(err)
 			}
@@ -573,7 +580,10 @@ func activatePublished(st *store.Store, result syncResult, out io.Writer, tty bo
 		return existing
 	}
 
-	name := published[0]
+	// The lexicographic minimum, not published[0]: publication order follows
+	// the control plane's response order, and identical grants must activate
+	// the same profile on every machine.
+	name := slices.Min(published)
 	if err := st.Use(name); err != nil {
 		ackLine(out, tty, th, components.AckSkip, fmt.Sprintf(
 			"profile %s was created but could not be made the active one (%v); "+


### PR DESCRIPTION
## Summary

Review follow-ups on the login activation/fallthrough changes:

- **Deterministic activation pick**: the pointer moves to the lexicographic minimum of the published profiles, not `published[0]` — identical grants now activate the same profile on every machine regardless of control-plane response ordering.
- **Fallthrough is interactive-only and default-config-only**: `formae login --config x.pkl` with an authless config no longer falls through to the hosted flow (which would write profiles and move the active pointer in the *default* config directory, outside the explicitly selected scope), and a non-TTY bare `login` fails fast again instead of parking on a browser URL. Both errors name `formae login --hosted` as the remedy.
- **`EnsureId` creates the data directory**: the first formae command on a machine with no `~/.pel/formae` failed with "failed to create ID file"; this is also what broke the mutation-test coverage phase on the previous login PR.

Each fix test-first; all three new behavior tests verified to fail without their implementation.