### PR TITLE
fix(metastructure): unique unmanaged labels, and one sync update per resource

### DIFF
--- a/internal/metastructure/resource_update/resource_labeler.go
+++ b/internal/metastructure/resource_update/resource_labeler.go
@@ -133,19 +133,28 @@ func (l *ResourceLabeler) extractLabelFromLegacyTagKeys(properties json.RawMessa
 	return ""
 }
 
-// ensureUnique checks if a label already exists and increments the version if needed.
+// ensureUnique returns a label that no existing resource holds, incrementing
+// the version suffix as often as needed. A single increment is not enough:
+// when the base label itself ends in "-<number>" ("server-1"), incrementing it
+// lands on a neighboring label ("server-2") that another resource may already
+// hold as its natural name, and the minted variant is invisible to a later
+// lookup for the original base — so every candidate is re-checked until one
+// is free.
 func (l *ResourceLabeler) ensureUnique(label string) string {
-	res, err := l.datastore.LatestLabelForResource(label)
-	if err != nil {
-		return label
-	}
+	candidate := label
+	for {
+		res, err := l.datastore.LatestLabelForResource(candidate)
+		if err != nil {
+			return candidate
+		}
 
-	// No existing resource on the unmanaged stack with this label
-	if res == "" {
-		return label
-	}
+		// No existing resource with this label or a versioned variant of it
+		if res == "" {
+			return candidate
+		}
 
-	return incrementVersion(res)
+		candidate = incrementVersion(res)
+	}
 }
 
 func incrementVersion(version string) string {

--- a/internal/metastructure/resource_update/resource_labeler_test.go
+++ b/internal/metastructure/resource_update/resource_labeler_test.go
@@ -190,6 +190,54 @@ func TestLabelForUnmanagedResource_IncrementsExistingVersion(t *testing.T) {
 	assert.Equal(t, "MyInstance-6", label)
 }
 
+// A discovered name that itself ends in "-<number>" must not be deduplicated
+// into a neighboring label that another resource already holds: incrementing
+// "server-1" lands on "server-2", which is a natural name in its own right.
+func TestLabelForUnmanagedResource_DoesNotMintTakenNumericNeighbor(t *testing.T) {
+	properties := json.RawMessage(`{"Tags":[{"Key":"Name","Value":"server-1"}]}`)
+	labelConfig := pkgmodel.LabelConfig{
+		DefaultQuery: `$.Tags[?(@.Key=='Name')].Value`,
+	}
+
+	l := newResourceLabelerForTest(t, func(ds datastore.Datastore) {
+		for _, label := range []string{"server-1", "server-2"} {
+			_, err := ds.StoreResource(&pkgmodel.Resource{Stack: "$unmanaged", Label: label, Type: "AWS::EC2::Instance"}, "test-command-id")
+			assert.NoError(t, err)
+		}
+	})
+
+	label := l.LabelForUnmanagedResource("i-00000000000000002", "AWS::EC2::Instance", properties, labelConfig, nil)
+	assert.NotEqual(t, "server-1", label)
+	assert.NotEqual(t, "server-2", label)
+}
+
+// The same name discovered repeatedly (each mint persisted before the next)
+// must yield a distinct label every time. The minted variant of a numeric
+// name ("server-1" -> "server-2") is not itself found by a later lookup for
+// the original name, so without an existence check on the minted label the
+// third discovery repeats the second's label.
+func TestLabelForUnmanagedResource_RepeatedDuplicateNamesStayUnique(t *testing.T) {
+	properties := json.RawMessage(`{"Tags":[{"Key":"Name","Value":"server-1"}]}`)
+	labelConfig := pkgmodel.LabelConfig{
+		DefaultQuery: `$.Tags[?(@.Key=='Name')].Value`,
+	}
+
+	var store datastore.Datastore
+	l := newResourceLabelerForTest(t, func(ds datastore.Datastore) {
+		store = ds
+	})
+
+	seen := make(map[string]bool)
+	for i := 0; i < 3; i++ {
+		label := l.LabelForUnmanagedResource("i-00000000000000000", "AWS::EC2::Instance", properties, labelConfig, nil)
+		assert.False(t, seen[label], "label %q minted twice", label)
+		seen[label] = true
+
+		_, err := store.StoreResource(&pkgmodel.Resource{Stack: "$unmanaged", Label: label, Type: "AWS::EC2::Instance"}, "test-command-id")
+		require.NoError(t, err)
+	}
+}
+
 // Tests for LabelConfig priority (JSONPath query takes precedence over legacy tag keys)
 
 func TestLabelForUnmanagedResource_JSONPathQueryTakesPrecedenceOverLegacyTagKeys(t *testing.T) {

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -691,8 +691,14 @@ func generateResourceUpdatesForSync(
 		// envelopes so the merge drops any stale $hashed and persist re-hashes.
 		markInheritedOpaqueResolvables(existingResources)
 
-		// Normal sync - create read resource updates for existing resources
+		// Normal sync - create one read resource update per existing resource.
+		// The match against forma resources is by (stack, label, type), which is
+		// NOT unique: discovery labeling can leave two rows sharing a label. Emit
+		// at most one update per row — a second update for the same ksuid would
+		// collide downstream (the changeset DAG keeps one node per operation URI
+		// and the command never terminalizes the dropped duplicate).
 		for _, existingResource := range existingResources {
+			matched := false
 			for _, resource := range forma.Resources {
 				if resource.Stack == stack.SingleStackLabel() &&
 					resource.Label == existingResource.Label &&
@@ -701,26 +707,31 @@ func generateResourceUpdatesForSync(
 					// Use the schema from the forma resource (which may have been refreshed
 					// from the plugin) rather than the stale schema stored in the DB
 					existingResource.Schema = resource.Schema
-
-					// See comment above: pass empty sentinel when target is gone.
-					target := existingTargetMap[existingResource.Target]
-					if target == nil {
-						target = &pkgmodel.Target{Label: existingResource.Target}
-					}
-					if skipResurrectionForReapedTarget(source, target) {
-						continue
-					}
-					resourceUpdate, err := NewResourceUpdateForSync(
-						*existingResource,
-						*target,
-						source,
-					)
-					if err != nil {
-						return nil, fmt.Errorf("failed to create resource update sync for %s: %w", existingResource.Label, err)
-					}
-					resourceUpdates = append(resourceUpdates, resourceUpdate)
+					matched = true
+					break
 				}
 			}
+			if !matched {
+				continue
+			}
+
+			// See comment above: pass empty sentinel when target is gone.
+			target := existingTargetMap[existingResource.Target]
+			if target == nil {
+				target = &pkgmodel.Target{Label: existingResource.Target}
+			}
+			if skipResurrectionForReapedTarget(source, target) {
+				continue
+			}
+			resourceUpdate, err := NewResourceUpdateForSync(
+				*existingResource,
+				*target,
+				source,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create resource update sync for %s: %w", existingResource.Label, err)
+			}
+			resourceUpdates = append(resourceUpdates, resourceUpdate)
 		}
 	}
 

--- a/internal/metastructure/resource_update/resource_update_generator_sync_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_sync_test.go
@@ -1,0 +1,71 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/constants"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// Two rows in the same stack can share (label, type) while being distinct
+// resources (distinct ksuids, distinct native ids) — discovery labeling does
+// not guarantee label uniqueness. A sync must emit exactly one read update per
+// resource row: emitting more than one produces duplicate ksuid:operation keys
+// downstream, where the changeset DAG keeps only one node per operation URI and
+// the command's remaining resource updates can never reach a terminal state.
+func TestGenerateResourceUpdatesForSync_DuplicateLabelsEmitOneUpdatePerResource(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	target := &pkgmodel.Target{
+		Label:     "test-target",
+		Namespace: "Test",
+		Config:    json.RawMessage(`{}`),
+	}
+
+	rowA := pkgmodel.Resource{
+		Ksuid:      "ksuidAAAAAAAAAAAAAAAAAAAAAA",
+		Label:      "shared-label",
+		Type:       "Test::Generic::Resource",
+		Stack:      constants.UnmanagedStack,
+		Target:     "test-target",
+		NativeID:   "native-a",
+		Properties: json.RawMessage(`{"Name":"shared-label"}`),
+	}
+	rowB := rowA
+	rowB.Ksuid = "ksuidBBBBBBBBBBBBBBBBBBBBBB"
+	rowB.NativeID = "native-b"
+
+	_, err := ds.StoreStack(&pkgmodel.Forma{Resources: []pkgmodel.Resource{rowA, rowB}}, "test-command")
+	require.NoError(t, err)
+
+	forma := pkgmodel.FormaFromResources([]*pkgmodel.Resource{&rowA, &rowB})
+
+	updates, err := GenerateResourceUpdates(
+		forma,
+		pkgmodel.CommandSync,
+		pkgmodel.FormaApplyModePatch,
+		FormaCommandSourceSynchronize,
+		[]*pkgmodel.Target{target},
+		ds,
+		nil, nil,
+	)
+	require.NoError(t, err)
+
+	seen := make(map[string]bool, len(updates))
+	for _, u := range updates {
+		key := u.DesiredState.Ksuid + ":" + string(u.Operation)
+		assert.False(t, seen[key], "duplicate resource update generated for %s (label %s)", key, u.DesiredState.Label)
+		seen[key] = true
+	}
+	assert.Len(t, updates, 2)
+}

--- a/tests/blackbox/executor.go
+++ b/tests/blackbox/executor.go
@@ -1837,12 +1837,15 @@ func (h *TestHarness) forceSyncAndAwait(t *testing.T, model *StateModel, appeara
 func (h *TestHarness) executeTriggerDiscovery(t *testing.T, model *StateModel) {
 	t.Helper()
 	// The model knows exactly what discovery will ingest: cloud resources it
-	// created out-of-band that are not yet in inventory. Everything else the
-	// plugin lists is either already tracked (known native id) or absent.
+	// created out-of-band that are not yet in inventory AND that discovery
+	// can reach (a child orphaned by a parent rename is not listable — see
+	// discoverableUnmanaged). Everything else the plugin lists is either
+	// already tracked (known native id) or absent.
 	expectIngest := false
 	if model != nil {
-		for _, res := range model.UnmanagedResources {
-			if res.PresentInCloud && !res.PresentInInventory {
+		discoverable := model.discoverableUnmanaged()
+		for nativeID, res := range model.UnmanagedResources {
+			if res.PresentInCloud && !res.PresentInInventory && discoverable[nativeID] {
 				expectIngest = true
 				break
 			}

--- a/tests/blackbox/state_model.go
+++ b/tests/blackbox/state_model.go
@@ -392,9 +392,65 @@ func (m *StateModel) ApplyUnmanagedCloudDelete(nativeID string) {
 	res.CloudProperties = ""
 }
 
-func (m *StateModel) ApplyDiscoveryToUnmanaged() {
+// unmanagedParentTypeOf mirrors the test plugin's parent-child list mapping:
+// child resources are listed by filtering their ParentId against a parent
+// row's current Name.
+var unmanagedParentTypeOf = map[string]string{
+	"Test::Generic::ChildResource":      "Test::Generic::Resource",
+	"Test::Generic::GrandchildResource": "Test::Generic::ChildResource",
+}
+
+// discoverableUnmanaged returns the native ids discovery can actually reach.
+// Top-level resources are always listable. A child or grandchild is listable
+// only while some already-ingested or reachable resource of its parent type
+// still carries the Name its ParentId references: the plugin lists children
+// by ParentId == parent.Name, so a parent renamed out-of-band before its
+// children were ingested orphans them (and their descendants, transitively).
+func (m *StateModel) discoverableUnmanaged() map[string]bool {
+	// Names offered per resource type by rows discovery can consult as parents.
+	availableNames := make(map[string]map[string]bool)
+	addName := func(resType, properties string) {
+		var p struct{ Name string }
+		if properties == "" || json.Unmarshal([]byte(properties), &p) != nil || p.Name == "" {
+			return
+		}
+		if availableNames[resType] == nil {
+			availableNames[resType] = make(map[string]bool)
+		}
+		availableNames[resType][p.Name] = true
+	}
 	for _, res := range m.UnmanagedResources {
-		if !res.PresentInCloud {
+		if res.PresentInInventory {
+			addName(res.ResourceType, res.InventoryProperties)
+		}
+	}
+
+	reachable := make(map[string]bool)
+	for changed := true; changed; {
+		changed = false
+		for nativeID, res := range m.UnmanagedResources {
+			if reachable[nativeID] || !res.PresentInCloud {
+				continue
+			}
+			if parentType, isChild := unmanagedParentTypeOf[res.ResourceType]; isChild {
+				var p struct{ ParentId string }
+				if json.Unmarshal([]byte(res.CloudProperties), &p) != nil ||
+					!availableNames[parentType][p.ParentId] {
+					continue
+				}
+			}
+			reachable[nativeID] = true
+			addName(res.ResourceType, res.CloudProperties)
+			changed = true
+		}
+	}
+	return reachable
+}
+
+func (m *StateModel) ApplyDiscoveryToUnmanaged() {
+	discoverable := m.discoverableUnmanaged()
+	for nativeID, res := range m.UnmanagedResources {
+		if !res.PresentInCloud || !discoverable[nativeID] {
 			continue
 		}
 		res.PresentInInventory = true

--- a/tests/blackbox/state_model_test.go
+++ b/tests/blackbox/state_model_test.go
@@ -439,6 +439,33 @@ func TestStateModel_UnmanagedLifecycle(t *testing.T) {
 	assert.False(t, res.PresentInCloud)
 }
 
+// Discovery reaches children by filtering ParentId against the parent's
+// current Name. Renaming a parent before its children were ingested makes
+// them (and their descendants) unreachable; renaming it back restores them.
+func TestStateModel_DiscoverySkipsChildrenOrphanedByParentRename(t *testing.T) {
+	model := NewStateModel(1, 1)
+	model.ApplyUnmanagedCloudCreate("cloud-1", "Test::Generic::Resource", `{"Name":"p1","Value":"v1"}`)
+	model.ApplyUnmanagedCloudCreate("cloud-1-child-0", "Test::Generic::ChildResource", `{"Name":"c1","ParentId":"p1","Value":"v1"}`)
+	model.ApplyUnmanagedCloudCreate("cloud-1-gc-0", "Test::Generic::GrandchildResource", `{"Name":"g1","ParentId":"c1","Value":"v1"}`)
+
+	model.ApplyUnmanagedCloudModify("cloud-1", `{"Name":"p1-renamed","Value":"v2"}`)
+	model.ApplyDiscoveryToUnmanaged()
+
+	assert.True(t, model.UnmanagedResources["cloud-1"].PresentInInventory)
+	assert.False(t, model.UnmanagedResources["cloud-1-child-0"].PresentInInventory,
+		"child pointing at the old parent name is unreachable")
+	assert.False(t, model.UnmanagedResources["cloud-1-gc-0"].PresentInInventory,
+		"grandchild under an unreachable child is transitively unreachable")
+
+	model.ApplyUnmanagedCloudModify("cloud-1", `{"Name":"p1","Value":"v3"}`)
+	model.ApplyDiscoveryToUnmanaged()
+
+	assert.True(t, model.UnmanagedResources["cloud-1-child-0"].PresentInInventory,
+		"renaming the parent back makes the child reachable again")
+	assert.True(t, model.UnmanagedResources["cloud-1-gc-0"].PresentInInventory,
+		"the grandchild follows once the child is reachable")
+}
+
 // An out-of-band modify of a managed resource is absorbed by sync: inventory
 // converges on the cloud properties. The model computes that end state
 // directly at the drift operation.

--- a/tests/blackbox/unmanaged_orphan_test.go
+++ b/tests/blackbox/unmanaged_orphan_test.go
@@ -1,0 +1,58 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build integration || property
+
+package blackbox
+
+import (
+	"testing"
+	"time"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// Discovery lists child resources by filtering their ParentId against the
+// parent's current Name. Renaming a parent out-of-band BEFORE its children
+// were ever ingested therefore orphans them: the child list runs with the
+// new name, the children still carry the old one, and no discovery pass can
+// reach them. The model must predict exactly that — parent ingested, orphaned
+// children never ingested — and inventory must still converge.
+func TestCloudModify_RenamedParentOrphansUndiscoveredChildren(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		h := NewTestHarness(t, 30*time.Second)
+		defer h.Cleanup()
+		h.ResetAgentState(t)
+		config := PropertyTestConfig{ResourceCount: 10, StackCount: 1}
+		model := NewStateModel(config.StackCount, config.ResourceCount)
+		h.SetupStacks(t, model, config)
+
+		create := Operation{Kind: OpCloudCreate, NativeID: "cloud-1",
+			ResourceType: "Test::Generic::Resource",
+			Properties:   `{"Name":"cp-parent","Value":"v1","SetTags":[],"EntityTags":[],"OrderedItems":[]}`,
+			CloudChildren: []CloudChildResource{
+				{NativeID: "cloud-1-child-0", ResourceType: "Test::Generic::ChildResource",
+					Properties: `{"Name":"cp-child","ParentId":"cp-parent","Value":"v1"}`},
+				{NativeID: "cloud-1-gc-0", ResourceType: "Test::Generic::GrandchildResource",
+					Properties: `{"Name":"cp-gc","ParentId":"cp-child","Value":"v1"}`},
+			}}
+		h.ExecuteOperation(t, &create, model)
+
+		modify := Operation{Kind: OpCloudModify, CloudTargetManaged: false, NativeID: "cloud-1",
+			Properties: `{"Name":"cp-renamed","Value":"v2","SetTags":[],"EntityTags":[],"OrderedItems":[]}`}
+		h.ExecuteOperation(t, &modify, model)
+
+		h.executeTriggerDiscovery(t, model)
+
+		require.True(t, model.UnmanagedResources["cloud-1"].PresentInInventory,
+			"the renamed parent itself is top-level listable and must ingest")
+		require.False(t, model.UnmanagedResources["cloud-1-child-0"].PresentInInventory,
+			"a child pointing at the parent's old name is unreachable for discovery")
+		require.False(t, model.UnmanagedResources["cloud-1-gc-0"].PresentInInventory,
+			"a grandchild under an unreachable child is transitively unreachable")
+		require.True(t, h.waitForUnmanagedInventoryExpectations(t, model, 10*time.Second),
+			"inventory must converge on the parent alone")
+	})
+}


### PR DESCRIPTION
## Summary

Root cause of the recurring `TestProperty_FullChaos` failures (two independent seeds, both CI runs carry the agent's own `BUG:` guard logs). Two chained agent-side defects:

- **Discovery's label dedup can mint an already-taken label.** `ensureUnique` increments the latest matching label once without re-checking the result: a discovered name ending in `-<number>` (e.g. `server-1`, `server-2` — a completely normal naming scheme) can increment into a label another resource already holds, or mint the same increment twice, leaving two `$unmanaged` rows with the same (label, type). KSUID timestamps in both CI runs prove the second mint happened minutes after the first, against a fully persisted store. Fixed: the increment loops until the candidate is actually free.
- **The sync generator amplifies a duplicate label into duplicate updates.** It emits one update per (row × matching forma entry), and the synchronizer builds the forma from the same rows — two rows sharing a label produce four updates (A,A,B,B), the changeset DAG dedups them by `ksuid//operation` and silently drops half, and the command persister then waits forever on completions that can never arrive: **every subsequent sync command hangs InProgress permanently**. Fixed: at most one read update per existing row.

Each fix landed test-first with the failing test reproducing the exact CI signature (`label "server-2" minted twice`; `duplicate resource update generated for <ksuid>:read`). Full metastructure unit suite green; a FullChaos smoke run passes.

Known residual, deliberately out of scope: two same-name resources in the *same* discovery batch can still race the mint across concurrent ResourceUpdater actors (provably not what CI hit — the duplicate mints were minutes apart); the sync-generator fix keeps sync terminal even if that occurs. Serializing mint+persist is a larger change for a follow-up.