### PR TITLE
fix(metastructure): reject dangling refs to deleted resources, and deconflict cascade destroys

### DIFF
--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -3889,12 +3889,19 @@ func (d *DatastoreAuroraDataAPI) Stats() (*stats.Stats, error) {
 func (d *DatastoreAuroraDataAPI) GetKSUIDByTriplet(stack, label, resourceType string) (string, error) {
 	ctx := context.Background()
 
+	// Only the triplet's latest version counts: a resource whose newest row is
+	// a delete/reaped tombstone is gone, and an older live version must not
+	// resurrect its ksuid. Mirrors BatchGetKSUIDsByTriplets.
 	query := `
 	SELECT ksuid
-	FROM resources
-	WHERE stack = :stack AND label = :label AND LOWER(type) = LOWER(:type)
-	AND operation != :operation AND operation != 'reaped'
-	ORDER BY version COLLATE "C" DESC
+	FROM resources r1
+	WHERE r1.stack = :stack AND r1.label = :label AND LOWER(r1.type) = LOWER(:type)
+	AND r1.operation != :operation AND r1.operation != 'reaped'
+	AND NOT EXISTS (
+		SELECT 1 FROM resources r2
+		WHERE r1.stack = r2.stack AND r1.label = r2.label AND r1.type = r2.type
+		AND r2.version COLLATE "C" > r1.version COLLATE "C"
+	)
 	LIMIT 1
 	`
 	params := []types.SqlParameter{

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -142,6 +142,7 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunLoadResourceByNativeIDDifferentTypes(t, newDS)
 	RunBatchGetKSUIDsByTriplets(t, newDS)
 	RunBatchGetKSUIDsByTripletsPatchScenario(t, newDS)
+	RunGetKSUIDByTriplet(t, newDS)
 	RunDifferentResourceTypesSameNativeId(t, newDS)
 	RunGetResourceModificationsSinceLastReconcile(t, newDS)
 	RunStoreResourceAfterDeleteWithSameNativeID(t, newDS)

--- a/internal/datastore/dstest/suite_resources.go
+++ b/internal/datastore/dstest/suite_resources.go
@@ -675,6 +675,71 @@ func RunBatchGetKSUIDsByTriplets(t *testing.T, newDS func(t *testing.T) TestData
 	})
 }
 
+// GetKSUIDByTriplet must agree with BatchGetKSUIDsByTriplets on liveness: a
+// resource whose latest version is a delete tombstone is gone, and its triplet
+// must not resolve to the ksuid of an older version. A re-created resource
+// resolves to the new row's ksuid.
+func RunGetKSUIDByTriplet(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetKSUIDByTriplet", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		resource := &pkgmodel.Resource{
+			Stack:      "test-stack",
+			Label:      "resource-1",
+			Type:       "AWS::S3::Bucket",
+			NativeID:   "bucket-1",
+			Properties: json.RawMessage(`{"BucketName": "test-bucket-1"}`),
+			Managed:    true,
+		}
+		_, err := ds.StoreResource(resource, "test-command-1")
+		assert.NoError(t, err)
+
+		stored, err := ds.LoadResourceByNativeID("bucket-1", "AWS::S3::Bucket")
+		assert.NoError(t, err)
+		assert.NotNil(t, stored)
+
+		ksuid, err := ds.GetKSUIDByTriplet("test-stack", "resource-1", "AWS::S3::Bucket")
+		assert.NoError(t, err)
+		assert.Equal(t, stored.Ksuid, ksuid)
+
+		// Missing triplet resolves to nothing.
+		ksuid, err = ds.GetKSUIDByTriplet("test-stack", "no-such-resource", "AWS::S3::Bucket")
+		assert.NoError(t, err)
+		assert.Empty(t, ksuid)
+
+		// A deleted resource's triplet resolves to nothing: the latest version
+		// is the tombstone, and the older live version must not resurrect.
+		_, err = ds.DeleteResource(stored, "delete-command")
+		assert.NoError(t, err)
+
+		ksuid, err = ds.GetKSUIDByTriplet("test-stack", "resource-1", "AWS::S3::Bucket")
+		assert.NoError(t, err)
+		assert.Empty(t, ksuid, "a deleted resource must not resolve via an older version")
+
+		// Re-creating the triplet resolves to the new row's ksuid.
+		recreated := &pkgmodel.Resource{
+			Stack:      "test-stack",
+			Label:      "resource-1",
+			Type:       "AWS::S3::Bucket",
+			NativeID:   "bucket-2",
+			Properties: json.RawMessage(`{"BucketName": "test-bucket-2"}`),
+			Managed:    true,
+		}
+		_, err = ds.StoreResource(recreated, "recreate-command")
+		assert.NoError(t, err)
+
+		restored, err := ds.LoadResourceByNativeID("bucket-2", "AWS::S3::Bucket")
+		assert.NoError(t, err)
+		assert.NotNil(t, restored)
+
+		ksuid, err = ds.GetKSUIDByTriplet("test-stack", "resource-1", "AWS::S3::Bucket")
+		assert.NoError(t, err)
+		assert.Equal(t, restored.Ksuid, ksuid)
+	})
+}
+
 func RunBatchGetKSUIDsByTripletsPatchScenario(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	t.Run("BatchGetKSUIDsByTriplets_PatchScenario", func(t *testing.T) {
 		td := newDS(t)

--- a/internal/datastore/mssql/mssql_resourceupdates.go
+++ b/internal/datastore/mssql/mssql_resourceupdates.go
@@ -159,12 +159,19 @@ func (d *DatastoreMSSQL) GetKSUIDByTriplet(stack, label, resourceType string) (s
 	ctx, span := mssqlTracer.Start(context.Background(), "GetKSUIDByTriplet")
 	defer span.End()
 
+	// Only the triplet's latest version counts: a resource whose newest row is
+	// a delete/reaped tombstone is gone, and an older live version must not
+	// resurrect its ksuid. Mirrors BatchGetKSUIDsByTriplets.
 	query := `
 		SELECT TOP (1) ksuid
-		FROM resources
-		WHERE stack = @p1 AND label = @p2 AND LOWER(type) = LOWER(@p3)
-		AND operation != @p4 AND operation != 'reaped'
-		ORDER BY version COLLATE Latin1_General_BIN2 DESC`
+		FROM resources r1
+		WHERE r1.stack = @p1 AND r1.label = @p2 AND LOWER(r1.type) = LOWER(@p3)
+		AND r1.operation != @p4 AND r1.operation != 'reaped'
+		AND NOT EXISTS (
+			SELECT 1 FROM resources r2
+			WHERE r1.stack = r2.stack AND r1.label = r2.label AND r1.type = r2.type
+			AND r2.version COLLATE Latin1_General_BIN2 > r1.version COLLATE Latin1_General_BIN2
+		)`
 	var ksuid string
 	err := d.conn.QueryRowContext(ctx, query, stack, label, resourceType, string(types.OperationDelete)).Scan(&ksuid)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/internal/datastore/mssql/resourceupdates_integration_test.go
+++ b/internal/datastore/mssql/resourceupdates_integration_test.go
@@ -296,16 +296,15 @@ func TestMSSQLResourceUpdatesKSUIDTriplet(t *testing.T) {
 		t.Errorf("GetKSUIDByTriplet = %q, want k1", got)
 	}
 
-	// k2's latest version is a delete, but GetKSUIDByTriplet (like
-	// postgres/sqlite) returns the latest NON-deleted version (v001 -> k2)
-	// rather than excluding the triplet entirely. The NOT-EXISTS-based Batch
-	// variant below is the one that drops it.
+	// k2's latest version is a delete: the triplet is excluded entirely, the
+	// same semantics as the Batch variant. Resolving through an older live
+	// version is how a dangling reference to a deleted resource is minted.
 	got, err = ds.GetKSUIDByTriplet("stack-a", "label-2", "AWS::EC2::Instance")
 	if err != nil {
 		t.Fatalf("GetKSUIDByTriplet(deleted): %v", err)
 	}
-	if got != "k2" {
-		t.Errorf("GetKSUIDByTriplet(deleted) = %q, want k2 (latest non-deleted)", got)
+	if got != "" {
+		t.Errorf("GetKSUIDByTriplet(deleted) = %q, want excluded (empty)", got)
 	}
 
 	// Missing triplet returns empty string, no error.

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -726,12 +726,19 @@ func (d DatastorePostgres) GetKSUIDByTriplet(stack, label, resourceType string) 
 	ctx, span := tracer.Start(context.Background(), "GetKSUIDByTriplet")
 	defer span.End()
 
+	// Only the triplet's latest version counts: a resource whose newest row is
+	// a delete/reaped tombstone is gone, and an older live version must not
+	// resurrect its ksuid. Mirrors BatchGetKSUIDsByTriplets.
 	query := `
 	SELECT ksuid
-	FROM resources
-	WHERE stack = $1 AND label = $2 AND LOWER(type) = LOWER($3)
-	AND operation != $4 AND operation != 'reaped'
-	ORDER BY version COLLATE "C" DESC
+	FROM resources r1
+	WHERE r1.stack = $1 AND r1.label = $2 AND LOWER(r1.type) = LOWER($3)
+	AND r1.operation != $4 AND r1.operation != 'reaped'
+	AND NOT EXISTS (
+		SELECT 1 FROM resources r2
+		WHERE r1.stack = r2.stack AND r1.label = r2.label AND r1.type = r2.type
+		AND r2.version COLLATE "C" > r1.version COLLATE "C"
+	)
 	LIMIT 1
 	`
 	row := d.pool.QueryRow(ctx, query, stack, label, resourceType, resource_update.OperationDelete)

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -4643,12 +4643,19 @@ func (d DatastoreSQLite) GetKSUIDByTriplet(stack, label, resourceType string) (s
 	_, span := sqliteTracer.Start(context.Background(), "GetKSUIDByTriplet")
 	defer span.End()
 
+	// Only the triplet's latest version counts: a resource whose newest row is
+	// a delete/reaped tombstone is gone, and an older live version must not
+	// resurrect its ksuid. Mirrors BatchGetKSUIDsByTriplets.
 	query := `
 	SELECT ksuid
-	FROM resources
-	WHERE stack = ? AND label = ? AND LOWER(type) = LOWER(?)
-	AND operation != ? AND operation != 'reaped'
-	ORDER BY version DESC
+	FROM resources r1
+	WHERE r1.stack = ? AND r1.label = ? AND LOWER(r1.type) = LOWER(?)
+	AND r1.operation != ? AND r1.operation != 'reaped'
+	AND NOT EXISTS (
+		SELECT 1 FROM resources r2
+		WHERE r1.stack = r2.stack AND r1.label = r2.label AND r1.type = r2.type
+		AND r2.version > r1.version
+	)
 	LIMIT 1
 	`
 	row := d.conn.QueryRow(query, stack, label, resourceType, resource_update.OperationDelete)

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1564,10 +1564,27 @@ func stackLabelsFromForma(forma *pkgmodel.Forma) []string {
 // deletes for the given forma's resources. It queries the datastore for
 // cross-stack dependents of resources being destroyed.
 func (m *Metastructure) findCascadeStackLabels(forma *pkgmodel.Forma) ([]string, error) {
+	// Client-submitted formas carry no ksuids, only (stack, label, type)
+	// triplets — resolve those against the datastore so the dependents walk
+	// actually has roots. Without this the walk is empty for every destroy
+	// that arrives over the API, and the admission conflict check never sees
+	// the stacks a cascade delete will touch.
 	currentLevel := make([]string, 0)
+	var unresolved []pkgmodel.TripletKey
 	for _, r := range forma.Resources {
 		if r.Ksuid != "" {
 			currentLevel = append(currentLevel, r.Ksuid)
+			continue
+		}
+		unresolved = append(unresolved, pkgmodel.TripletKey{Stack: r.Stack, Label: r.Label, Type: r.Type})
+	}
+	if len(unresolved) > 0 {
+		resolved, err := m.Datastore.BatchGetKSUIDsByTriplets(unresolved)
+		if err != nil {
+			return nil, err
+		}
+		for _, ksuid := range resolved {
+			currentLevel = append(currentLevel, ksuid)
 		}
 	}
 	if len(currentLevel) == 0 {

--- a/internal/metastructure/metastructure_test.go
+++ b/internal/metastructure/metastructure_test.go
@@ -607,3 +607,48 @@ func TestForceReconcileCommandIsVisibleThroughCommandStatus(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, hidden.Commands, "a scheduled reconcile stays out of the user-facing command history")
 }
+
+// A client-submitted destroy forma carries no ksuids, only (stack, label,
+// type) triplets. The cascade-stack walk must resolve those triplets against
+// the datastore before seeding the dependents BFS; a walk seeded only from
+// forma-supplied ksuids finds nothing, and the admission conflict check never
+// sees the stacks a cascade delete will touch.
+func TestFindCascadeStackLabels_ResolvesKsuidlessFormaResources(t *testing.T) {
+	ds := newSQLiteTestDatastore(t)
+
+	parent := &pkgmodel.Resource{
+		Stack:      "stack-0",
+		Label:      "res-a",
+		Type:       "Test::Generic::Resource",
+		NativeID:   "native-parent",
+		Properties: json.RawMessage(`{"Name":"res-a"}`),
+		Managed:    true,
+	}
+	_, err := ds.StoreResource(parent, "create-parent")
+	require.NoError(t, err)
+	stored, err := ds.LoadResourceByNativeID("native-parent", "Test::Generic::Resource")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+
+	child := &pkgmodel.Resource{
+		Stack:    "stack-1",
+		Label:    "child-xstack",
+		Type:     "Test::Generic::ChildResource",
+		NativeID: "native-child",
+		Properties: json.RawMessage(
+			`{"Name":"child-xstack","ParentId":{"$ref":"formae://` + stored.Ksuid + `#/Name"}}`),
+		Managed: true,
+	}
+	_, err = ds.StoreResource(child, "create-child")
+	require.NoError(t, err)
+
+	m := &Metastructure{Datastore: ds}
+	stacks, err := m.findCascadeStackLabels(&pkgmodel.Forma{
+		Resources: []pkgmodel.Resource{
+			{Stack: "stack-0", Label: "res-a", Type: "Test::Generic::Resource"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"stack-1"}, stacks,
+		"the cross-stack dependent's stack must surface for admission deconfliction")
+}

--- a/internal/metastructure/resource_update/resource_update_generator_deleted_ref_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_deleted_ref_test.go
@@ -1,0 +1,107 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// A forma resource whose $res reference points at a resource that has been
+// deleted (its latest datastore version is a tombstone) must be rejected with
+// FormaReferencedResourcesNotFoundError. The triplet must not translate via an
+// older version of the deleted row: that produces a dangling $ref whose ksuid
+// no live-view lookup can resolve, surfacing as an internal error on every
+// subsequent apply touching the stack.
+func TestGenerateResourceUpdates_ReferenceToDeletedResourceIsRejected(t *testing.T) {
+	ds, err := dssqlite.NewDatastoreSQLite(context.Background(), &pkgmodel.DatastoreConfig{
+		DatastoreType: pkgmodel.SqliteDatastore,
+		Sqlite:        pkgmodel.SqliteConfig{FilePath: ":memory:"},
+	}, "test")
+	require.NoError(t, err)
+
+	target := &pkgmodel.Target{Label: "test-target", Namespace: "Test", Config: json.RawMessage(`{}`)}
+
+	parent := &pkgmodel.Resource{
+		Stack:      "stack-1",
+		Label:      "res-a",
+		Type:       "Test::Generic::Resource",
+		Target:     "test-target",
+		NativeID:   "native-parent",
+		Properties: json.RawMessage(`{"Name":"res-a"}`),
+		Managed:    true,
+	}
+	_, err = ds.StoreResource(parent, "create-command")
+	require.NoError(t, err)
+
+	child := &pkgmodel.Resource{
+		Stack:      "stack-1",
+		Label:      "child-a",
+		Type:       "Test::Generic::ChildResource",
+		Target:     "test-target",
+		NativeID:   "native-child",
+		Properties: json.RawMessage(`{"Name":"child-a","ParentId":"res-a"}`),
+		Managed:    true,
+	}
+	_, err = ds.StoreResource(child, "create-command")
+	require.NoError(t, err)
+
+	// The parent is deleted (e.g. an absorbed out-of-band deletion): its
+	// latest version is now a tombstone.
+	stored, err := ds.LoadResourceByNativeID("native-parent", "Test::Generic::Resource")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	_, err = ds.DeleteResource(stored, "delete-command")
+	require.NoError(t, err)
+
+	// An apply carrying only the child, whose ParentId references the
+	// now-deleted parent.
+	forma := &pkgmodel.Forma{
+		Resources: []pkgmodel.Resource{
+			{
+				Stack:  "stack-1",
+				Label:  "child-a",
+				Type:   "Test::Generic::ChildResource",
+				Target: "test-target",
+				Properties: json.RawMessage(`{
+					"Name": "child-a",
+					"ParentId": {
+						"$res": true,
+						"$label": "res-a",
+						"$type": "Test::Generic::Resource",
+						"$stack": "stack-1",
+						"$property": "Name"
+					}
+				}`),
+			},
+		},
+	}
+
+	_, err = resource_update.GenerateResourceUpdates(
+		forma,
+		pkgmodel.CommandApply,
+		pkgmodel.FormaApplyModePatch,
+		resource_update.FormaCommandSourceUser,
+		[]*pkgmodel.Target{target},
+		ds,
+		nil, nil,
+	)
+
+	require.Error(t, err)
+	var notFound apimodel.FormaReferencedResourcesNotFoundError
+	require.True(t, errors.As(err, &notFound),
+		"expected FormaReferencedResourcesNotFoundError, got: %v", err)
+}


### PR DESCRIPTION
## Summary

Root cause of the twin `TestProperty_FullChaos` failures on the rebased PR branches (runs 32623792180 / 32623882130). Two agent-side defects, one causal chain, reachable now that the label-collision hang no longer kills sequences early:

- **A deleted resource's triplet still resolved to its old ksuid.** `GetKSUIDByTriplet` filtered tombstones out and took the newest survivor, so a resource whose latest version is a delete tombstone resolved via an older live version — contradicting `BatchGetKSUIDsByTriplets`' pinned semantics. Consequence: after sync absorbs an out-of-band deletion, dependents' `$res` references translate into dangling `$ref`s instead of a clean `FormaReferencedResourcesNotFoundError`; updates then 500 ("failed to load resolvable properties: resource with KSUID … not found") and creates are admitted only to fail mid-execution. Fixed in all four backends (latest-version-must-be-live subquery, mirroring the batch lookup).
- **Cascade-stack deconfliction was dead code for real destroys.** `findCascadeStackLabels` seeded its dependents walk from `forma.Resources[].Ksuid` — client-submitted formas carry no ksuids, so the walk always returned nil and cascading destroys bypassed the admission overlap check entirely, letting a cascade delete a resource a concurrent in-flight command was creating. Fixed by resolving ksuid-less resources via `BatchGetKSUIDsByTriplets` before seeding the walk.

**Production impact:** an out-of-band deletion of any referenced resource (e.g. a VPC removed in the console) turned every subsequent apply/patch/policy change on that stack into an internal 500; and user destroys with cross-stack cascade dependents were never deconflicted against in-flight commands.

**Evidence:** every fix red-then-green — the dstest triplet test (red on sqlite, green on sqlite + real postgres + real mssql containers; aurora shares the postgres dialect, not run locally), the deleted-ref generator test reproducing the exact CI 500 message, and the cascade-walk test (red: nil, green: the dependent stack). Full datastore + metastructure unit suites green; `TestProperty_FullChaos` 100 checks PASS (1155.8s, zero BUG/500/mismatch lines); `TestProperty_Concurrent` 30-check smoke PASS.

**Stated residual (deliberately not addressed):** the cascade walk reads dependent rows at admission; a dependent whose creating command has not yet persisted is invisible — the same accepted class as the documented target-config admission TOCTOU, needing pending-update-aware admission to close fully.