### PR TITLE
fix(connection): isolate plugin discovery in the contract tests

### DIFF
--- a/internal/cli/connection/contract_test.go
+++ b/internal/cli/connection/contract_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -62,7 +63,18 @@ func seed(t *testing.T, active string, profiles map[string]string) string {
 			t.Fatal(err)
 		}
 	}
+	// Isolating the config directory alone is not enough. Plugin discovery reads
+	// pluginDir, which defaults to a path under the caller's home, so a test whose
+	// premise is "no auth plugin is installed" is answered by whatever the
+	// developer running it happens to have installed: it passes in CI and fails on
+	// any machine carrying the oidc plugin, for a reason unrelated to the
+	// behaviour under test.
+	empty := filepath.Join(root, "empty-plugins")
+	if err := os.MkdirAll(empty, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	for name, body := range profiles {
+		body += "\npluginDir = " + strconv.Quote(empty) + "\n"
 		if err := os.WriteFile(filepath.Join(root, "profiles", name+".pkl"), []byte(body), 0o600); err != nil {
 			t.Fatal(err)
 		}
@@ -185,13 +197,13 @@ func TestContractAuthFailure(t *testing.T) {
 
 	out, err := run(t, machine("resolve", "--profile", "prod")...)
 	if err == nil {
-		t.Fatalf("expected a failure without an auth plugin: %s", out)
+		t.Fatalf("expected a failure without an auth plugin: %s", redactCredentials(out))
 	}
 	if got := decode(t, out); got["code"] != "auth_failed" {
-		t.Fatalf("code: %s", out)
+		t.Fatalf("code: %s", redactCredentials(out))
 	}
 	if strings.Contains(out, "Bearer") {
-		t.Fatalf("a failure must never carry a credential: %s", out)
+		t.Fatal("a failure must never carry a credential")
 	}
 }
 

--- a/internal/cli/connection/redact.go
+++ b/internal/cli/connection/redact.go
@@ -1,0 +1,22 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package connection
+
+import "regexp"
+
+// bearerToken matches a bearer credential as it appears in resolved output.
+var bearerToken = regexp.MustCompile(`Bearer [A-Za-z0-9._~+/=-]+`)
+
+// redactCredentials removes bearer tokens from text that is about to be shown.
+//
+// It exists for failure messages. A test asserting that resolution fails will,
+// on the day resolution unexpectedly succeeds, print the successful result -
+// and a successful hosted resolution carries a live credential. The assertion
+// guarding against exactly that sits below the one that prints it, and is
+// unreachable on the path where a credential exists, so the guard alone was
+// never enough.
+func redactCredentials(s string) string {
+	return bearerToken.ReplaceAllString(s, "Bearer [redacted]")
+}

--- a/internal/cli/connection/redact_helpers_test.go
+++ b/internal/cli/connection/redact_helpers_test.go
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: FSL-1.1-ALv2
 
+//go:build unit
+
 package connection
 
 import "regexp"

--- a/internal/cli/connection/redact_test.go
+++ b/internal/cli/connection/redact_test.go
@@ -1,3 +1,7 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
 //go:build unit
 
 package connection

--- a/internal/cli/connection/redact_test.go
+++ b/internal/cli/connection/redact_test.go
@@ -1,0 +1,32 @@
+//go:build unit
+
+package connection
+
+import (
+	"strings"
+	"testing"
+)
+
+// A test that fails because it found a credential must not print the credential
+// while saying so, and neither must one that fails because it did not expect to
+// find one at all.
+func TestRedactCredentials_RemovesTheTokenAndKeepsTheRest(t *testing.T) {
+	out := `{"profile":"prod","credential":"Bearer eyJhbGciOiJSUzI1NiJ9.payload.signature"}`
+
+	got := redactCredentials(out)
+
+	if strings.Contains(got, "eyJhbGciOiJSUzI1NiJ9") {
+		t.Errorf("the token survived redaction: %s", got)
+	}
+	if !strings.Contains(got, `"profile":"prod"`) {
+		t.Errorf("redaction removed the context a reader needs: %s", got)
+	}
+}
+
+// Output with no credential in it is worth reading in full.
+func TestRedactCredentials_LeavesOrdinaryOutputAlone(t *testing.T) {
+	out := `{"schemaVersion":1,"code":"auth_failed"}`
+	if got := redactCredentials(out); got != out {
+		t.Errorf("ordinary output was altered: %s", got)
+	}
+}


### PR DESCRIPTION
## Summary

Two defects in `internal/cli/connection`'s contract tests, one of which prints a live credential.

**The tests isolate the config directory but not the plugin directory.** `seed` points `FORMAE_CONFIG_DIR` at a temp dir, but plugin discovery reads `pluginDir`, which defaults to a path under the caller's home. So `TestContractAuthFailure`, whose premise is that no auth plugin is installed, is actually answered by whatever the developer running it happens to have installed. It is green in CI and red on any machine carrying the oidc plugin, for a reason unrelated to the behaviour under test.

**When that premise fails, the failure message prints a bearer token.** Resolution succeeds instead of failing, and `t.Fatalf("expected a failure without an auth plugin: %s", out)` interpolates the resolved connection, which on a hosted profile carries a live credential.

The assertion that exists to stop this sits below the one that does it:

```go
if err == nil {
    t.Fatalf("expected a failure without an auth plugin: %s", out)   // prints out
}
...
if strings.Contains(out, "Bearer") {
    t.Fatalf("a failure must never carry a credential: %s", out)     // the guard
}
```

The guard is unreachable in exactly the case where a credential exists: a successful resolve aborts above it, and a failed resolve has no credential to find. Fixing only the isolation leaves that armed for the next thing that makes resolution succeed.

`seed` now points every profile it writes at an empty plugin directory, and failure messages render through a redaction pass. The guard reports that a credential was present without reproducing it.

Verified both ways: the previously failing test now passes against a real `HOME` carrying the oidc plugin, and still passes against a bare one.