### PR TITLE
feat(connect): list the cloud connections registered on an installation

### DIFF
--- a/internal/cli/cloudapi/client.go
+++ b/internal/cli/cloudapi/client.go
@@ -125,7 +125,7 @@ type Client interface {
 		registration CloudConnectionRegistration) (RegisterOutcome, error)
 	// ListCloudConnections reads the connections registered on the
 	// installation, with a warning for every record it had to drop.
-	ListCloudConnections(ctx context.Context, bearer, installationID string) ([]CloudConnection, []string, error)
+	ListCloudConnections(ctx context.Context, bearer, installationID string) (ConnectionsSnapshot, error)
 }
 
 // AuthError reports that the control plane refused the credentials

--- a/internal/cli/cloudapi/connections.go
+++ b/internal/cli/cloudapi/connections.go
@@ -223,51 +223,141 @@ func (c *httpCloudClient) RegisterCloudConnection(ctx context.Context, bearer, i
 	}
 }
 
+// ConnectionsSnapshot is a connections listing and whether it may be believed
+// completely.
+//
+// Complete is the difference between "this installation has no connections" and
+// "this response could not be read", which a caller branching on absence cannot
+// otherwise tell apart. It mirrors Snapshot.Authoritative, for the same reason
+// and with the same discipline: a consumer that ignores it decides on a list it
+// only partly received.
+type ConnectionsSnapshot struct {
+	Connections []CloudConnection
+	Complete    bool
+	Warnings    []string
+}
+
+// knownClouds is the closed set the control plane's own discriminated union
+// admits. A record naming anything else is one this build cannot interpret, so
+// it is dropped rather than guessed at, and dropping it costs completeness.
+var knownClouds = map[string]bool{"aws": true, "gcp": true, "azure": true}
+
+// SessionLapsedError is a sign-in that is no longer good.
+type SessionLapsedError struct{ Cause error }
+
+func (e *SessionLapsedError) Error() string { return e.Cause.Error() }
+func (e *SessionLapsedError) Unwrap() error { return e.Cause }
+
+// InstallationForbiddenError is a caller the control plane knows and will not
+// serve for this installation.
+//
+// It says nothing about membership. The server answers a caller with no grant on
+// the owning organization with 404, so 403 means a member whose explicit tenant
+// list does not include this installation.
+type InstallationForbiddenError struct{ Cause error }
+
+func (e *InstallationForbiddenError) Error() string { return e.Cause.Error() }
+func (e *InstallationForbiddenError) Unwrap() error { return e.Cause }
+
 // ListCloudConnections reads the connections registered on the installation.
 // Broken records are dropped with a warning, never aborting the body: the
-// caller compares against what it can read.
-func (c *httpCloudClient) ListCloudConnections(ctx context.Context, bearer, installationID string) ([]CloudConnection, []string, error) {
+// caller compares against what it can read, and Complete tells it whether what
+// it read was everything.
+func (c *httpCloudClient) ListCloudConnections(ctx context.Context, bearer, installationID string) (ConnectionsSnapshot, error) {
 	status, data, err := c.request(ctx, http.MethodGet, bearer, nil,
 		"cloud connections response", "api", "v1", "installations", installationID, "cloud-connections")
 	if err != nil {
-		return nil, nil, err
+		return ConnectionsSnapshot{}, err
 	}
 	if status != http.StatusOK {
-		if err := classifyStatus(status, "cloud connections"); err != nil {
-			return nil, nil, err
+		// Split before classifyStatus, which collapses 401 and 403 into one
+		// AuthError that retains no status. The two mean different things to a
+		// user and only this layer still knows which happened.
+		switch status {
+		case http.StatusUnauthorized:
+			return ConnectionsSnapshot{}, &SessionLapsedError{Cause: errors.New(
+				"your formae session has lapsed; sign in again")}
+		case http.StatusForbidden:
+			return ConnectionsSnapshot{}, &InstallationForbiddenError{Cause: errors.New(
+				"you do not have access to this installation")}
 		}
-		return nil, nil, fmt.Errorf(
+		if err := classifyStatus(status, "cloud connections"); err != nil {
+			return ConnectionsSnapshot{}, err
+		}
+		return ConnectionsSnapshot{}, fmt.Errorf(
 			"the control plane returned unexpected HTTP %d for the cloud-connections request", status)
 	}
 
-	envelope, _, err := decodeEnvelope(data, "cloud connections response")
+	envelope, repeated, err := decodeEnvelope(data, "cloud connections response")
 	if err != nil {
-		return nil, nil, err
+		return ConnectionsSnapshot{}, err
 	}
+
+	snapshot := ConnectionsSnapshot{Complete: true}
+
+	for _, key := range repeated {
+		snapshot.Complete = false
+		snapshot.Warnings = append(snapshot.Warnings, fmt.Sprintf(
+			"the cloud connections response carries the %q field more than once, so this run has at most "+
+				"one of the lists it was sent", clip(key, maxWarnedRunes)))
+	}
+
+	// An absent or null list is not an empty one. Reading either as "there are
+	// none" is what turns an unreadable response into a decision.
+	raw, present := envelope["results"]
 	var results []json.RawMessage
-	if raw, ok := envelope["results"]; ok {
+	switch {
+	case !present:
+		snapshot.Complete = false
+		snapshot.Warnings = append(snapshot.Warnings,
+			"the cloud connections response carries no list where one was expected")
+	default:
 		if err := json.Unmarshal(raw, &results); err != nil {
-			return nil, nil, errors.New("the cloud connections response carries no list where one was expected")
+			return ConnectionsSnapshot{}, errors.New(
+				"the cloud connections response carries no list where one was expected")
+		}
+		if results == nil {
+			snapshot.Complete = false
+			snapshot.Warnings = append(snapshot.Warnings,
+				"the cloud connections response carries an empty list where one was expected")
 		}
 	}
-	var connections []CloudConnection
-	var warnings []string
+
 	for i, record := range results {
 		var connection CloudConnection
 		if err := json.Unmarshal(record, &connection); err != nil {
-			warnings = append(warnings, fmt.Sprintf(
+			snapshot.Complete = false
+			snapshot.Warnings = append(snapshot.Warnings, fmt.Sprintf(
 				"ignoring record %d of the cloud connections response: it could not be read (%q)",
 				i+1, clip(err.Error(), maxWarnedRunes)))
 			continue
 		}
-		if connection.Cloud == "" || connection.Account == "" || connection.RoleArn == "" {
-			warnings = append(warnings, fmt.Sprintf(
-				"ignoring record %d of the cloud connections response: it names no cloud, account, or role", i+1))
+		if reason := invalidConnection(connection); reason != "" {
+			snapshot.Complete = false
+			snapshot.Warnings = append(snapshot.Warnings, fmt.Sprintf(
+				"ignoring record %d of the cloud connections response: %s", i+1, reason))
 			continue
 		}
-		connections = append(connections, connection)
+		snapshot.Connections = append(snapshot.Connections, connection)
 	}
-	return connections, warnings, nil
+	return snapshot, nil
+}
+
+// invalidConnection names why a record cannot be used, or returns "".
+//
+// The role ARN is required of AWS alone. GCP and Azure carry their own trust
+// coordinates and no role, so requiring it of every cloud dropped valid records
+// and reported an installation that has connections as having none.
+func invalidConnection(c CloudConnection) string {
+	switch {
+	case !knownClouds[c.Cloud]:
+		return "it names a cloud this formae does not understand"
+	case c.Account == "":
+		return "it names no account"
+	case c.Cloud == "aws" && c.RoleArn == "":
+		return "it names no role"
+	}
+	return ""
 }
 
 // classifyStatus maps the statuses every connect call classifies the same way:

--- a/internal/cli/cloudapi/connections_test.go
+++ b/internal/cli/cloudapi/connections_test.go
@@ -368,7 +368,8 @@ func connectionsBody(t *testing.T, records ...any) string {
 
 func listConnectionsFrom(t *testing.T, srv *httptest.Server) ([]CloudConnection, []string, error) {
 	t.Helper()
-	return NewClient(srv.URL).ListCloudConnections(context.Background(), testBearer, testInstallationA)
+	snap, err := NewClient(srv.URL).ListCloudConnections(context.Background(), testBearer, testInstallationA)
+	return snap.Connections, snap.Warnings, err
 }
 
 func TestListCloudConnections_DecodesRecordsAndSendsTheBearerOnly(t *testing.T) {
@@ -409,8 +410,8 @@ func TestListCloudConnections_DropsABrokenRecordWithAWarning(t *testing.T) {
 func TestListCloudConnections_ClassifiesFailuresAndRefusesRedirects(t *testing.T) {
 	srv, _ := serveBody(t, http.StatusForbidden, nil, "")
 	_, _, err := listConnectionsFrom(t, srv)
-	var authErr *AuthError
-	require.True(t, errors.As(err, &authErr))
+	var forbidden *InstallationForbiddenError
+	require.True(t, errors.As(err, &forbidden))
 
 	srv2, _ := serveBody(t, http.StatusServiceUnavailable, nil, "")
 	_, _, err = listConnectionsFrom(t, srv2)
@@ -447,5 +448,87 @@ func TestConnectCalls_WarningsAreBoundedAndLeakNothing(t *testing.T) {
 	_, err = setupFrom(t, badIssuer)
 	if err != nil {
 		assert.Less(t, len(err.Error()), 1000, "an error must not flood the terminal with text the far end chose")
+	}
+}
+
+// listAgainst serves body as a connections listing and returns the snapshot.
+func listAgainst(t *testing.T, body string) ConnectionsSnapshot {
+	t.Helper()
+	srv, _ := serveBody(t, http.StatusOK, nil, body)
+	snap, err := NewClient(srv.URL).ListCloudConnections(context.Background(), testBearer, testInstallationA)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	return snap
+}
+
+// listStatus answers the listing with code and returns the resulting error.
+func listStatus(t *testing.T, code int) error {
+	t.Helper()
+	srv, _ := serveBody(t, code, nil, "")
+	_, err := NewClient(srv.URL).ListCloudConnections(context.Background(), testBearer, testInstallationA)
+	return err
+}
+
+// A clean empty listing is complete, which is the branch a consumer acts on.
+func TestListCloudConnections_EmptyIsComplete(t *testing.T) {
+	snap := listAgainst(t, `{"results":[]}`)
+	if !snap.Complete || len(snap.Connections) != 0 {
+		t.Fatalf("complete=%v n=%d", snap.Complete, len(snap.Connections))
+	}
+}
+
+// Each of these means the full set could not be established, so a caller must
+// not read the short list as "these are all of them".
+func TestListCloudConnections_IncompleteTriggers(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"missing results", `{}`},
+		{"null results", `{"results":null}`},
+		{"repeated results", `{"results":[],"results":[]}`},
+		{"dropped record", `{"results":[{"cloud":"aws","account":"1"}]}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			snap := listAgainst(t, tc.body)
+			if snap.Complete {
+				t.Error("reports complete when the full set was not established")
+			}
+			if len(snap.Warnings) == 0 {
+				t.Error("nothing told the caller why")
+			}
+		})
+	}
+}
+
+// GCP and Azure rows carry no role ARN and are valid. An AWS row without one is
+// not, an unknown cloud is not, a mis-cased one is not, and neither is a record
+// with no account.
+func TestListCloudConnections_ClosedUnion(t *testing.T) {
+	snap := listAgainst(t, `{"results":[
+		{"cloud":"gcp","account":"proj"},
+		{"cloud":"azure","account":"sub"},
+		{"cloud":"aws","account":"1","roleArn":"arn:aws:iam::1:role/r"},
+		{"cloud":"aws","account":"2"},
+		{"cloud":"AWS","account":"3"},
+		{"cloud":"future","account":"4"},
+		{"cloud":"gcp"}]}`)
+
+	if len(snap.Connections) != 3 {
+		t.Fatalf("kept %d records, want the three valid ones", len(snap.Connections))
+	}
+	if snap.Complete {
+		t.Error("records were dropped, so the snapshot is not complete")
+	}
+}
+
+// 401 and 403 mean different things to a user and must not collapse: 401 is a
+// lapsed session, 403 is a member whose tenant grant excludes this installation.
+func TestListCloudConnections_DistinguishesLapsedFromForbidden(t *testing.T) {
+	var lapsed *SessionLapsedError
+	if err := listStatus(t, http.StatusUnauthorized); !errors.As(err, &lapsed) {
+		t.Errorf("401 did not report a lapsed session: %v", err)
+	}
+	var denied *InstallationForbiddenError
+	if err := listStatus(t, http.StatusForbidden); !errors.As(err, &denied) {
+		t.Errorf("403 did not report denied access: %v", err)
 	}
 }

--- a/internal/cli/connect/aws.go
+++ b/internal/cli/connect/aws.go
@@ -83,7 +83,7 @@ func runConnectAWS(cc *cobra.Command, opts options) error {
 			// one fixed command line and gets the exit status.
 			return err
 		}
-		return report(cc.OutOrStdout(), consumer, schema, err)
+		return report(cc.OutOrStdout(), consumer, schema, err, awsFallbackMessage)
 	}
 	if m == modeForm && consumer == printer.ConsumerMachine {
 		// Machine mode never reaches a form: flags are consent.
@@ -92,10 +92,14 @@ func runConnectAWS(cc *cobra.Command, opts options) error {
 	}
 
 	if err := runMode(cc, m, opts, consumer, schema); err != nil {
-		return report(cc.OutOrStdout(), consumer, schema, err)
+		return report(cc.OutOrStdout(), consumer, schema, err, awsFallbackMessage)
 	}
 	return nil
 }
+
+// awsFallbackMessage is the internal-code text an undeclared error gets on
+// the aws paths.
+const awsFallbackMessage = "formae could not connect the account; run it without --output-consumer machine to see why"
 
 // runMode runs the decided path. The paths land slice by slice; one that has
 // not landed yet says so rather than pretending.
@@ -137,8 +141,10 @@ func resolveOutputOrHuman(cc *cobra.Command) (printer.Consumer, string, error) {
 // ones the flow declares: a consumer parses one protocol or it parses none,
 // and the paths where that matters most are the degraded ones nobody
 // anticipated. An error we did not declare is reported as internal rather
-// than given a code that would imply we understood it.
-func report(w io.Writer, consumer printer.Consumer, schema string, err error) error {
+// than given a code that would imply we understood it. fallbackMessage is
+// the text for that case; each caller names its own, since "could not connect
+// the account" is wrong for a run that only reads.
+func report(w io.Writer, consumer printer.Consumer, schema string, err error, fallbackMessage string) error {
 	if consumer != printer.ConsumerMachine {
 		return err
 	}
@@ -151,8 +157,7 @@ func report(w io.Writer, consumer printer.Consumer, schema string, err error) er
 		// can quote configuration source, and a Pkl failure quotes the line it
 		// failed on — which can be the line holding an inline password.
 		if _, perr := printer.PrintFailure(w, schema, printer.Fail(printer.CodeInternal,
-			"formae could not connect the account; run it without --output-consumer machine to see why",
-			nil)); perr != nil {
+			fallbackMessage, nil)); perr != nil {
 			return perr
 		}
 	}

--- a/internal/cli/connect/connect.go
+++ b/internal/cli/connect/connect.go
@@ -47,6 +47,7 @@ func ConnectCmd() *cobra.Command {
 	command.PersistentFlags().String("config", "", "Path to config file")
 	command.PersistentFlags().String("profile", "", "Named profile to use (see `formae profile list`)")
 	command.AddCommand(awsCmd())
+	command.AddCommand(listCmd())
 	command.SetUsageTemplate(clicmd.SimpleCmdUsageTemplate)
 	return command
 }

--- a/internal/cli/connect/contract_test.go
+++ b/internal/cli/connect/contract_test.go
@@ -7,6 +7,7 @@
 package connect
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -255,6 +256,27 @@ func stubCredentials(t *testing.T, answers ...func() (*pkgauth.GetAuthHeaderResp
 	newCredentials = func(_ *app.App) credentialProvider { return creds }
 	t.Cleanup(func() { newCredentials = restore })
 	return creds
+}
+
+// hostedOpts seeds a hosted profile against a stub control plane and stubs a
+// credential, returning the options an authenticated control-plane call
+// needs. The stub control plane and credential are not asserted on here; the
+// point is a run that authenticates cleanly.
+func hostedOpts(t *testing.T) options {
+	t.Helper()
+	cp := newControlPlane(t)
+	seedProfile(t, cp, hostedProfile(contractInstallation))
+	stubCredentials(t, bearerAnswer("t1"))
+	return options{}
+}
+
+// Listing is a control-plane read and must not depend on the AWS-side template
+// and issuer pin, which only the provisioning paths use.
+func TestOpenControlPlane_IgnoresConnectPlatformOverrides(t *testing.T) {
+	t.Setenv("FORMAE_CONNECT_ISSUER", "not a url")
+	if _, err := openControlPlane(context.Background(), hostedOpts(t)); err != nil {
+		t.Fatalf("a malformed AWS-side override broke a control-plane read: %v", err)
+	}
 }
 
 func registerOnlyArgs() []string {

--- a/internal/cli/connect/contract_test.go
+++ b/internal/cli/connect/contract_test.go
@@ -780,6 +780,46 @@ func TestContractRegistrationConflict(t *testing.T) {
 	})
 }
 
+// The connections document is pinned the same way links and registered are:
+// command-level, against the shared control-plane fixture, so the assertion
+// proves the command reads the fixture's connections route and selects the
+// machine emit, not merely that the serializer round-trips a struct. A
+// serializer-level test in machine_test.go could not prove either.
+func TestContractListEmitsTheConnectionsDocument(t *testing.T) {
+	cp := newControlPlane(t)
+	cp.connectionsBody = `{"results":[` +
+		`{"cloud":"aws","account":"` + testAccount + `","roleArn":"` + contractRoleArn + `"},` +
+		`{"cloud":"gcp","account":"some-gcp-project"}]}`
+	seedProfile(t, cp, hostedProfile(contractInstallation))
+	stubCredentials(t, bearerAnswer("t1"))
+
+	out, err := runConnect(t, "list", "--output-consumer", "machine", "--output-schema", "json")
+
+	require.NoError(t, err, "out: %s", out)
+	got := decodeOut(t, out)
+	assert.Equal(t, float64(2), got["schemaVersion"])
+	assert.Equal(t, "connections", got["phase"])
+	assert.Equal(t, contractInstallation, got["installation"])
+	assert.Equal(t, true, got["complete"])
+
+	rows, ok := got["connections"].([]any)
+	require.True(t, ok, "connections is not an array: %s", out)
+	require.Len(t, rows, 2)
+
+	aws, ok := rows[0].(map[string]any)
+	require.True(t, ok, "row 0 is not an object: %s", out)
+	assert.Equal(t, "aws", aws["cloud"])
+	assert.Equal(t, testAccount, aws["account"])
+	assert.Equal(t, contractRoleArn, aws["roleArn"])
+
+	gcp, ok := rows[1].(map[string]any)
+	require.True(t, ok, "row 1 is not an object: %s", out)
+	assert.Equal(t, "gcp", gcp["cloud"])
+	assert.Equal(t, "some-gcp-project", gcp["account"])
+	_, present := gcp["roleArn"]
+	assert.False(t, present, "a GCP row must not carry a roleArn key, empty or otherwise")
+}
+
 // registerAgainstConflict runs a registration the control plane refuses with
 // 409, against a connections listing built by one of the listingXWithout
 // helpers below, and returns the error the run finished with.

--- a/internal/cli/connect/contract_test.go
+++ b/internal/cli/connect/contract_test.go
@@ -8,6 +8,7 @@ package connect
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/platform-engineering-labs/formae/internal/cli/app"
 	"github.com/platform-engineering-labs/formae/internal/cli/connection"
+	"github.com/platform-engineering-labs/formae/internal/cli/printer"
 	"github.com/platform-engineering-labs/formae/internal/cli/profile/store"
 	pkgauth "github.com/platform-engineering-labs/formae/pkg/auth"
 )
@@ -754,4 +756,76 @@ func TestContractRegistrationConflict(t *testing.T) {
 		assert.Equal(t, other, details["registeredRoleArn"])
 		assert.Equal(t, contractRoleArn, details["statedRoleArn"])
 	})
+}
+
+// registerAgainstConflict runs a registration the control plane refuses with
+// 409, against a connections listing built by one of the listingXWithout
+// helpers below, and returns the error the run finished with.
+func registerAgainstConflict(t *testing.T, connectionsBody string) error {
+	t.Helper()
+	cp := newControlPlane(t)
+	cp.registerStatus = http.StatusConflict
+	cp.registerBody = `{"error":{"code":"cloud_connection_exists"}}`
+	cp.connectionsBody = connectionsBody
+	seedProfile(t, cp, hostedProfile(contractInstallation))
+	stubCredentials(t, bearerAnswer("t1"))
+
+	_, err := runConnect(t, registerOnlyArgs()...)
+	return err
+}
+
+// listingIncompleteWithout is a connections listing that carries no
+// connection for account and dropped a record along the way, so Complete is
+// false: this run cannot tell "not registered" from "not fully read".
+func listingIncompleteWithout(account string) string {
+	other := otherAccount(account)
+	return `{"results":[{"cloud":"aws","account":"` + other + `","roleArn":"arn:aws:iam::` + other + `:role/other"},` +
+		`{"cloud":"digitalocean","account":"555555555555"}]}`
+}
+
+// listingCompleteWithout is a connections listing that was read in full (so
+// Complete is true) and still carries no connection for account.
+func listingCompleteWithout(account string) string {
+	other := otherAccount(account)
+	return `{"results":[{"cloud":"aws","account":"` + other + `","roleArn":"arn:aws:iam::` + other + `:role/other"}]}`
+}
+
+// otherAccount is any account distinct from the one passed in, so a listing
+// can carry a real, non-matching connection rather than an empty list.
+func otherAccount(account string) string {
+	if account == "999999999999" {
+		return "888888888888"
+	}
+	return "999999999999"
+}
+
+// Absence from a listing that is known to be partial settles nothing, so the
+// caller is told it could not compare rather than that the row conflicts. It
+// must not carry the registration_conflict code either: that code says the
+// control plane's refusal has been corroborated, which a partial listing
+// cannot do.
+func TestRegister_IncompleteAndUnmatchedCannotCompare(t *testing.T) {
+	err := registerAgainstConflict(t, listingIncompleteWithout("123456789012"))
+	if err == nil || !strings.Contains(err.Error(), "not visible to compare") {
+		t.Fatalf("got %v", err)
+	}
+	var fail *printer.Failure
+	if errors.As(err, &fail) {
+		t.Fatalf("an incomplete listing must not be reported as a corroborated conflict, got code %q", fail.Code)
+	}
+}
+
+// Absence from a complete listing is conclusive: the control plane refused the
+// registration as a duplicate and the existing row is genuinely not there. The
+// message must not claim it "could not compare": the listing was read in
+// full, so the absence is evidence, not a gap.
+func TestRegister_CompleteAndUnmatchedIsADuplicate(t *testing.T) {
+	err := registerAgainstConflict(t, listingCompleteWithout("123456789012"))
+	var fail *printer.Failure
+	if !errors.As(err, &fail) || fail.Code != printer.CodeRegistrationConflict {
+		t.Fatalf("got %v", err)
+	}
+	if strings.Contains(err.Error(), "not visible to compare") {
+		t.Fatalf("a complete listing settles the question; the message must not hedge: %v", err)
+	}
 }

--- a/internal/cli/connect/contract_test.go
+++ b/internal/cli/connect/contract_test.go
@@ -273,8 +273,14 @@ func hostedOpts(t *testing.T) options {
 // Listing is a control-plane read and must not depend on the AWS-side template
 // and issuer pin, which only the provisioning paths use.
 func TestOpenControlPlane_IgnoresConnectPlatformOverrides(t *testing.T) {
+	opts := hostedOpts(t)
+	// Set after seeding: seedProfile clears the FORMAE_CONNECT_* pair, so
+	// setting it first would be wiped before openControlPlane ever runs.
+	// Both variables are set, not just the issuer, because a half-set pair
+	// is refused before either value is parsed as a URL.
 	t.Setenv("FORMAE_CONNECT_ISSUER", "not a url")
-	if _, err := openControlPlane(context.Background(), hostedOpts(t)); err != nil {
+	t.Setenv("FORMAE_CONNECT_TEMPLATE_BASE", "also not a url")
+	if _, err := openControlPlane(context.Background(), opts); err != nil {
 		t.Fatalf("a malformed AWS-side override broke a control-plane read: %v", err)
 	}
 }

--- a/internal/cli/connect/list.go
+++ b/internal/cli/connect/list.go
@@ -143,10 +143,24 @@ func classifyListError(ctx context.Context, client cloudapi.Client, bearer, inst
 // printConnectionsHuman renders the listing as prose: one line per registered
 // connection, naming the installation so a run against a non-default profile
 // says which installation it read.
+//
+// Empty-and-complete gets the one required sentence and nothing else: no
+// header, no warning, because none was raised. Every other case (rows to
+// show, or a listing that could not be read in full) shares the general path
+// below, which never presents the rows it did read as though they were the
+// whole count: the count itself is never stated, complete or not.
 func printConnectionsHuman(w io.Writer, v connectionsView) error {
-	lines := []string{fmt.Sprintf("cloud connections registered on installation %s:", v.Installation)}
-	if len(v.Connections) == 0 {
-		lines = append(lines, "  (none)")
+	if len(v.Connections) == 0 && v.Complete {
+		_, err := fmt.Fprintf(w, "No cloud accounts are registered on %s.\n", v.Installation)
+		return err
+	}
+
+	var lines []string
+	if v.Complete {
+		lines = append(lines, fmt.Sprintf("cloud accounts registered on %s:", v.Installation))
+	} else {
+		lines = append(lines, fmt.Sprintf(
+			"cloud accounts registered on %s (this list is partial; it could not be read in full):", v.Installation))
 	}
 	for _, c := range v.Connections {
 		line := "  " + c.Cloud + "  " + c.Account
@@ -154,9 +168,6 @@ func printConnectionsHuman(w io.Writer, v connectionsView) error {
 			line += "  " + c.RoleArn
 		}
 		lines = append(lines, line)
-	}
-	if !v.Complete {
-		lines = append(lines, "", "warning: this listing could not be read in full; some connections may be missing")
 	}
 	for _, warning := range v.Warnings {
 		lines = append(lines, "warning: "+warning)

--- a/internal/cli/connect/list.go
+++ b/internal/cli/connect/list.go
@@ -1,0 +1,170 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package connect
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/platform-engineering-labs/formae/internal/cli/cloudapi"
+	clicmd "github.com/platform-engineering-labs/formae/internal/cli/cmd"
+	"github.com/platform-engineering-labs/formae/internal/cli/printer"
+)
+
+// listFallbackMessage is the internal-code text an undeclared error gets on
+// the list path.
+const listFallbackMessage = "formae could not list the cloud connections; run it without --output-consumer machine to see why"
+
+func listCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:           "list",
+		Short:         "List the cloud accounts registered on this installation",
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cc *cobra.Command, args []string) error {
+			opts, err := readSelection(cc)
+			if err != nil {
+				return err
+			}
+			return runConnectList(cc, opts)
+		},
+	}
+	clicmd.AddOutputFlags(c)
+	c.SetUsageTemplate(clicmd.SimpleCmdUsageTemplate)
+	return c
+}
+
+// runConnectList reads the connections registered on the active installation
+// and reports them. It is member-readable: it opens the control plane the way
+// any read does, through openControlPlane, and never calls openSession or the
+// admin-gated setup endpoint that only provisioning needs.
+func runConnectList(cc *cobra.Command, opts options) error {
+	consumer, schema, err := resolveOutputOrHuman(cc)
+	if err != nil {
+		return err
+	}
+
+	v, err := readConnections(cc, opts)
+	if err != nil {
+		return report(cc.OutOrStdout(), consumer, schema, err, listFallbackMessage)
+	}
+
+	if consumer == printer.ConsumerMachine {
+		return emitConnections(cc.OutOrStdout(), schema, v)
+	}
+	return printConnectionsHuman(cc.OutOrStdout(), v)
+}
+
+// readConnections opens the control plane, reads the connections listing, and
+// maps it onto the document a consumer sees. Connections is built as a
+// non-nil slice regardless of how many rows the listing carried, so an empty
+// listing and one that could not be read stay distinguishable only through
+// Complete, never through null-versus-empty.
+func readConnections(cc *cobra.Command, opts options) (connectionsView, error) {
+	cp, err := openControlPlane(cc.Context(), opts)
+	if err != nil {
+		return connectionsView{}, err
+	}
+
+	snapshot, err := cp.Client.ListCloudConnections(cc.Context(), cp.Bearer, cp.InstallationID)
+	if err != nil {
+		return connectionsView{}, classifyListError(cc.Context(), cp.Client, cp.Bearer, cp.InstallationID, err)
+	}
+
+	connections := make([]connectionView, 0, len(snapshot.Connections))
+	for _, c := range snapshot.Connections {
+		connections = append(connections, connectionView{Cloud: c.Cloud, Account: c.Account, RoleArn: c.RoleArn})
+	}
+
+	return connectionsView{
+		SchemaVersion: connectSchemaVersion,
+		Phase:         "connections",
+		Installation:  cp.InstallationID,
+		Complete:      snapshot.Complete,
+		Connections:   connections,
+		Warnings:      snapshot.Warnings,
+	}, nil
+}
+
+// classifyListError maps a connections-listing failure onto the declared
+// codes.
+//
+// A 404 is ambiguous on its own, the same way the setup read's is: no grant
+// and a control plane too old to carry the route answer identically, so the
+// installations listing this run can already fetch disambiguates it, and only
+// an authoritative listing may conclude anything about visibility.
+func classifyListError(ctx context.Context, client cloudapi.Client, bearer, installationID string, err error) error {
+	var lapsed *cloudapi.SessionLapsedError
+	if errors.As(err, &lapsed) {
+		return printer.Fail(printer.CodeAuthFailed, lapsed.Error(), nil)
+	}
+
+	var forbidden *cloudapi.InstallationForbiddenError
+	if errors.As(err, &forbidden) {
+		return printer.Fail(printer.CodeNotAuthorized, forbidden.Error(), nil)
+	}
+
+	var notFound *cloudapi.NotFoundError
+	if errors.As(err, &notFound) {
+		snapshot, lerr := client.ListInstallations(ctx, bearer)
+		if lerr != nil || !snapshot.Authoritative {
+			// An incomplete listing licenses no claim about visibility.
+			return fmt.Errorf("the control plane answered 404 for the cloud connections request, "+
+				"and the installations listing could not settle whether this installation is visible to you; try again: %w", err)
+		}
+		for _, installation := range snapshot.Installations {
+			if installation.InstallationID == installationID {
+				return printer.Fail(printer.CodeControlPlaneTooOld,
+					"this installation is visible to you, but its control plane predates listing cloud connections; "+
+						"upgrade it and re-run", nil)
+			}
+		}
+		return printer.Fail(printer.CodeNotAuthorized,
+			"this installation is not among the ones your grants cover; if you were granted access recently, "+
+				"run `formae login` to refresh your session and try again",
+			map[string]any{"reason": "not_visible"})
+	}
+
+	var transient *cloudapi.TransientError
+	if errors.As(err, &transient) {
+		return fmt.Errorf("the control plane could not answer the cloud connections request; try again: %w", err)
+	}
+
+	return err
+}
+
+// printConnectionsHuman renders the listing as prose: one line per registered
+// connection, naming the installation so a run against a non-default profile
+// says which installation it read.
+func printConnectionsHuman(w io.Writer, v connectionsView) error {
+	lines := []string{fmt.Sprintf("cloud connections registered on installation %s:", v.Installation)}
+	if len(v.Connections) == 0 {
+		lines = append(lines, "  (none)")
+	}
+	for _, c := range v.Connections {
+		line := "  " + c.Cloud + "  " + c.Account
+		if c.RoleArn != "" {
+			line += "  " + c.RoleArn
+		}
+		lines = append(lines, line)
+	}
+	if !v.Complete {
+		lines = append(lines, "", "warning: this listing could not be read in full; some connections may be missing")
+	}
+	for _, warning := range v.Warnings {
+		lines = append(lines, "warning: "+warning)
+	}
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cli/connect/list_test.go
+++ b/internal/cli/connect/list_test.go
@@ -312,10 +312,14 @@ func TestConnectList_IncompleteListingReportsNotCompleteWithAWarning(t *testing.
 	assert.NotEmpty(t, warnings)
 }
 
-// Human output names the installation and never carries the machine document.
+// Human output names the installation, carries the cloud, account, and role
+// for an AWS row, never carries the machine document, and never claims a
+// connection was "verified" (formae never verifies that a registration's
+// trust is actually usable).
 func TestConnectList_HumanOutputNamesTheInstallation(t *testing.T) {
+	roleArn := "arn:aws:iam::" + testAccount + ":role/r"
 	stub := newListStub()
-	stub.connectionsBody = snapshotOf(conn("aws", testAccount, "arn:aws:iam::"+testAccount+":role/r"))
+	stub.connectionsBody = snapshotOf(conn("aws", testAccount, roleArn))
 	url := stub.start(t)
 	seedListProfile(t, url)
 	stubCredentials(t, bearerAnswer("t1"))
@@ -323,6 +327,49 @@ func TestConnectList_HumanOutputNamesTheInstallation(t *testing.T) {
 	out, err := runList(t)
 	require.NoError(t, err, "out: %s", out)
 	assert.Contains(t, out, contractInstallation)
+	assert.Contains(t, out, "aws")
 	assert.Contains(t, out, testAccount)
+	assert.Contains(t, out, roleArn)
 	assert.NotContains(t, out, "schemaVersion")
+	assert.NotContains(t, strings.ToLower(out), "verified")
+}
+
+// The spec pins the empty-and-complete sentence exactly: no more, no less,
+// and no claim hedged by an unrelated warning that was never raised.
+func TestConnectList_HumanOutputEmptyAndCompleteIsTheExactSentence(t *testing.T) {
+	stub := newListStub()
+	stub.connectionsBody = snapshotOf()
+	url := stub.start(t)
+	seedListProfile(t, url)
+	stubCredentials(t, bearerAnswer("t1"))
+
+	out, err := runList(t)
+	require.NoError(t, err, "out: %s", out)
+	assert.Equal(t, "No cloud accounts are registered on "+contractInstallation+".\n", out)
+}
+
+// An incomplete listing says plainly that it may be partial, prints the
+// warnings that explain why, and never presents the rows it did read as if
+// they were the whole count.
+func TestConnectList_HumanOutputIncompleteSaysPartialAndNeverACount(t *testing.T) {
+	stub := newListStub()
+	// One valid AWS row plus one record missing its role: the second is
+	// dropped with a warning, so the listing is one row short of complete.
+	stub.connectionsBody = `{"results":[` +
+		`{"cloud":"aws","account":"` + testAccount + `","roleArn":"arn:aws:iam::` + testAccount + `:role/r"},` +
+		`{"cloud":"aws","account":"999999999999"}]}`
+	url := stub.start(t)
+	seedListProfile(t, url)
+	stubCredentials(t, bearerAnswer("t1"))
+
+	out, err := runList(t)
+	require.NoError(t, err, "out: %s", out)
+
+	lower := strings.ToLower(out)
+	assert.Contains(t, lower, "partial", "an incomplete listing must say plainly that it may be partial")
+	assert.NotContains(t, lower, "no cloud accounts are registered",
+		"a partial listing must not read as the empty-and-complete sentence")
+	assert.NotRegexp(t, `\b1\s+(cloud account|connection)s?\b`, lower,
+		"the one row read must not be presented as if it were the total count")
+	assert.Contains(t, out, testAccount, "the row that was read is still shown")
 }

--- a/internal/cli/connect/list_test.go
+++ b/internal/cli/connect/list_test.go
@@ -327,9 +327,9 @@ func TestConnectList_HumanOutputNamesTheInstallation(t *testing.T) {
 	out, err := runList(t)
 	require.NoError(t, err, "out: %s", out)
 	assert.Contains(t, out, contractInstallation)
-	assert.Contains(t, out, "aws")
-	assert.Contains(t, out, testAccount)
-	assert.Contains(t, out, roleArn)
+	// Assert the row's own shape, not just substrings the role ARN alone
+	// would also satisfy (it embeds both "aws" and the account number).
+	assert.Contains(t, out, "  aws  "+testAccount+"  "+roleArn)
 	assert.NotContains(t, out, "schemaVersion")
 	assert.NotContains(t, strings.ToLower(out), "verified")
 }

--- a/internal/cli/connect/list_test.go
+++ b/internal/cli/connect/list_test.go
@@ -1,0 +1,328 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package connect
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/cli/printer"
+)
+
+// `connect list` is a read: it authenticates and reads the connections
+// registered on the installation, and never touches the admin-gated setup
+// endpoint that only provisioning needs. These pin the machine document, the
+// route it must (and must not) reach, and how a refusal is classified.
+
+// listStub is a minimal control-plane double for the routes list drives: the
+// connections listing and the installations listing its 404 disambiguates
+// against. It records every path seen, so a test can assert the setup route
+// was never reached.
+type listStub struct {
+	mu    sync.Mutex
+	paths []string
+
+	connectionsStatus int
+	connectionsBody   string
+
+	installationsStatus int
+	installationsBody   string
+}
+
+func newListStub() *listStub {
+	return &listStub{
+		connectionsStatus:   http.StatusOK,
+		connectionsBody:     `{"results":[]}`,
+		installationsStatus: http.StatusOK,
+		installationsBody:   `{"results":[]}`,
+	}
+}
+
+func (s *listStub) start(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		s.paths = append(s.paths, r.URL.Path)
+		status, body := s.route(r)
+		s.mu.Unlock()
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func (s *listStub) route(r *http.Request) (int, string) {
+	switch {
+	case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/cloud-connections"):
+		return s.connectionsStatus, s.connectionsBody
+	case r.Method == http.MethodGet && r.URL.Path == "/api/v1/me/installations":
+		return s.installationsStatus, s.installationsBody
+	default:
+		return http.StatusNotFound, `{"error":{"code":"not_found"}}`
+	}
+}
+
+func (s *listStub) recordedPaths() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.paths...)
+}
+
+// seedListProfile writes a hosted profile naming contractInstallation and
+// points the connect env at url, the way seedProfile does for the contract
+// tests, but against listStub rather than the contract controlPlane.
+func seedListProfile(t *testing.T, url string) {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "profiles"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "profiles", "prod.pkl"), []byte(hostedProfile(contractInstallation)), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "active"), []byte("prod\n"), 0o600))
+	t.Setenv("FORMAE_CONFIG_DIR", dir)
+	clearConnectEnv(t)
+	t.Setenv("FORMAE_CLOUD_URL", url)
+	t.Setenv("FORMAE_CLOUD_ISSUER", "https://auth.formae.ai")
+}
+
+// runList runs `connect list` with args appended, and returns what it wrote
+// and the error it finished with.
+func runList(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	c := ConnectCmd()
+	c.SetOut(&out)
+	c.SetErr(&out)
+	c.SetArgs(append([]string{"list"}, args...))
+	err := c.Execute()
+	return out.String(), err
+}
+
+func machineArgs() []string {
+	return []string{"--output-consumer", "machine", "--output-schema", "json"}
+}
+
+// conn builds one row of a stub connections response. An empty roleArn omits
+// the field, the way a non-AWS cloud's record does on the real control plane.
+func conn(cloud, account, roleArn string) map[string]any {
+	m := map[string]any{"cloud": cloud, "account": account}
+	if roleArn != "" {
+		m["roleArn"] = roleArn
+	}
+	return m
+}
+
+// snapshotOf renders a cloud-connections response body carrying exactly the
+// given rows; called with none, it renders a legitimate empty list rather
+// than a null one.
+func snapshotOf(rows ...map[string]any) string {
+	if rows == nil {
+		rows = []map[string]any{}
+	}
+	data, err := json.Marshal(map[string]any{"results": rows})
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}
+
+// installationsSnapshot describes the /me/installations answer a 404
+// disambiguates against: whether it may be believed completely, and whether
+// it lists the installation being read.
+type installationsSnapshot struct {
+	Authoritative bool
+	Listed        bool
+}
+
+// runListNotFound runs list against a connections endpoint that 404s, with
+// the installations listing built from snap, and returns the run's error.
+func runListNotFound(t *testing.T, snap installationsSnapshot) error {
+	t.Helper()
+	stub := newListStub()
+	stub.connectionsStatus = http.StatusNotFound
+	stub.connectionsBody = `{"error":{"code":"not_found"}}`
+	switch {
+	case !snap.Authoritative:
+		stub.installationsBody = `{"results":[],"nextPageToken":"abc"}` // one page of several
+	case snap.Listed:
+		stub.installationsBody = meBodyListing(t, contractInstallation)
+	default:
+		stub.installationsBody = meBodyListing(t, otherInstallation)
+	}
+	url := stub.start(t)
+	seedListProfile(t, url)
+	stubCredentials(t, bearerAnswer("t1"))
+
+	_, err := runList(t, machineArgs()...)
+	return err
+}
+
+// runListStatus runs list against a connections endpoint answering status,
+// and returns the run's error.
+func runListStatus(t *testing.T, status int) error {
+	t.Helper()
+	stub := newListStub()
+	stub.connectionsStatus = status
+	stub.connectionsBody = `{"error":{"code":"denied"}}`
+	url := stub.start(t)
+	seedListProfile(t, url)
+	stubCredentials(t, bearerAnswer("t1"))
+
+	_, err := runList(t, machineArgs()...)
+	return err
+}
+
+// The document a consumer branches on: connections always present, and a
+// non-AWS row carries no empty role ARN.
+func TestConnectList_MachineDocument(t *testing.T) {
+	stub := newListStub()
+	stub.connectionsBody = snapshotOf(
+		conn("aws", testAccount, "arn:aws:iam::"+testAccount+":role/r"),
+		conn("gcp", "my-project", ""),
+	)
+	url := stub.start(t)
+	seedListProfile(t, url)
+	stubCredentials(t, bearerAnswer("t1"))
+
+	out, err := runList(t, machineArgs()...)
+	require.NoError(t, err, "out: %s", out)
+
+	doc := decodeDoc(t, out)
+	assert.Equal(t, "connections", doc["phase"])
+	assert.Equal(t, float64(2), doc["schemaVersion"])
+	assert.Equal(t, true, doc["complete"])
+	assert.Equal(t, contractInstallation, doc["installation"])
+
+	rows, ok := doc["connections"].([]any)
+	require.True(t, ok, "connections is not an array: %s", out)
+	require.Len(t, rows, 2)
+	if _, present := rows[1].(map[string]any)["roleArn"]; present {
+		t.Error("a GCP row carries a roleArn key")
+	}
+}
+
+// A nil slice would encode as null, and a consumer must never have to tell
+// absent from empty.
+func TestConnectList_EmptyIsAnArray(t *testing.T) {
+	stub := newListStub()
+	stub.connectionsBody = snapshotOf()
+	url := stub.start(t)
+	seedListProfile(t, url)
+	stubCredentials(t, bearerAnswer("t1"))
+
+	out, err := runList(t, machineArgs()...)
+	require.NoError(t, err, "out: %s", out)
+	assert.Contains(t, out, `"connections":[]`)
+}
+
+// The list is member-readable, so it must reach the connections endpoint
+// without ever touching the admin-gated setup endpoint. Asserting only the
+// absence would also pass if the command failed before authenticating.
+func TestConnectList_ReachesConnectionsAndNotSetup(t *testing.T) {
+	stub := newListStub()
+	url := stub.start(t)
+	seedListProfile(t, url)
+	stubCredentials(t, bearerAnswer("t1"))
+
+	out, err := runList(t, machineArgs()...)
+	require.NoError(t, err, "the run failed, so the path assertions prove nothing: out=%s", out)
+
+	paths := stub.recordedPaths()
+	assert.True(t, slices.ContainsFunc(paths, func(p string) bool { return strings.Contains(p, "/cloud-connections") }),
+		"never called the connections endpoint")
+	for _, p := range paths {
+		assert.NotContains(t, p, "cloud-connection-setup", "called the admin-gated setup endpoint")
+	}
+}
+
+// 403 means a member whose tenant grant excludes this installation. The
+// server answers non-membership with 404, so this message must claim
+// neither.
+func TestConnectList_ForbiddenMessageClaimsNothingAboutMembership(t *testing.T) {
+	err := runListStatus(t, http.StatusForbidden)
+	failureCode(t, err, printer.CodeNotAuthorized)
+	msg := strings.ToLower(err.Error())
+	for _, word := range []string{"member", "admin"} {
+		assert.NotContains(t, msg, word)
+	}
+}
+
+// A 401 means the session itself has lapsed, distinct from a 403.
+func TestConnectList_SessionLapsedIsAuthFailed(t *testing.T) {
+	err := runListStatus(t, http.StatusUnauthorized)
+	failureCode(t, err, printer.CodeAuthFailed)
+}
+
+// Absence from a non-authoritative installations snapshot is not evidence the
+// installation does not exist.
+func TestConnectList_NotFoundAgainstAPartialSnapshotCannotDecide(t *testing.T) {
+	err := runListNotFound(t, installationsSnapshot{Authoritative: false})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not", "a partial snapshot produced a definite answer: %v", err)
+
+	var fail *printer.Failure
+	assert.False(t, errors.As(err, &fail), "a partial snapshot must not be reported as a declared, definite code")
+}
+
+// Listed in the installations listing but 404 on connections means the
+// control plane predates the route.
+func TestConnectList_NotFoundButListedIsControlPlaneTooOld(t *testing.T) {
+	err := runListNotFound(t, installationsSnapshot{Authoritative: true, Listed: true})
+	failureCode(t, err, printer.CodeControlPlaneTooOld)
+}
+
+// Unlisted against an authoritative listing means genuinely not visible.
+func TestConnectList_NotFoundAndUnlistedIsNotVisible(t *testing.T) {
+	err := runListNotFound(t, installationsSnapshot{Authoritative: true, Listed: false})
+	failureCode(t, err, printer.CodeNotAuthorized)
+}
+
+// A record a cloud understands but that carries an anomaly (here, no role
+// ARN for an AWS record) is dropped rather than aborting the body, and its
+// absence is reported through Complete rather than silently.
+func TestConnectList_IncompleteListingReportsNotCompleteWithAWarning(t *testing.T) {
+	stub := newListStub()
+	stub.connectionsBody = `{"results":[{"cloud":"aws","account":"` + testAccount + `"}]}`
+	url := stub.start(t)
+	seedListProfile(t, url)
+	stubCredentials(t, bearerAnswer("t1"))
+
+	out, err := runList(t, machineArgs()...)
+	require.NoError(t, err, "out: %s", out)
+
+	doc := decodeDoc(t, out)
+	assert.Equal(t, false, doc["complete"])
+	warnings, ok := doc["warnings"].([]any)
+	require.True(t, ok, "the drop is reported through a warning: %s", out)
+	assert.NotEmpty(t, warnings)
+}
+
+// Human output names the installation and never carries the machine document.
+func TestConnectList_HumanOutputNamesTheInstallation(t *testing.T) {
+	stub := newListStub()
+	stub.connectionsBody = snapshotOf(conn("aws", testAccount, "arn:aws:iam::"+testAccount+":role/r"))
+	url := stub.start(t)
+	seedListProfile(t, url)
+	stubCredentials(t, bearerAnswer("t1"))
+
+	out, err := runList(t)
+	require.NoError(t, err, "out: %s", out)
+	assert.Contains(t, out, contractInstallation)
+	assert.Contains(t, out, testAccount)
+	assert.NotContains(t, out, "schemaVersion")
+}

--- a/internal/cli/connect/machine.go
+++ b/internal/cli/connect/machine.go
@@ -10,9 +10,10 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/cli/printer"
 )
 
-// The machine protocol for a connect run: one stream, one document per run —
-// a `links` document when quick-create emits and stops, a `registered`
-// document when a registration happened — or a failure envelope through
+// The machine protocol for a connect run: one stream, one document per run,
+// either a `links` document when quick-create emits and stops, a
+// `registered` document when a registration happened, a `connections`
+// document when list reads what is registered, or a failure envelope through
 // printer.PrintFailure. No free prose crosses: a consumer gets the fields
 // declared here and renders its own text, and no document ever carries a
 // credential.
@@ -90,10 +91,36 @@ func registeredDocument(status, account, roleArn string, warnings []string) regi
 	}
 }
 
+// connectionView is one registered connection as reported to a consumer.
+// RoleArn is omitted for a cloud that carries no role (GCP, Azure), so a
+// consumer never mistakes an absent field for an empty one.
+type connectionView struct {
+	Cloud   string `json:"cloud" yaml:"cloud"`
+	Account string `json:"account" yaml:"account"`
+	RoleArn string `json:"roleArn,omitempty" yaml:"roleArn,omitempty"`
+}
+
+// connectionsView is the list emit. Connections is always a slice, never
+// nil: a consumer branches on empty versus absent, and a null value would
+// erase that distinction. Complete says whether the listing was read in
+// full, mirroring cloudapi.ConnectionsSnapshot.Complete.
+type connectionsView struct {
+	SchemaVersion int              `json:"schemaVersion" yaml:"schemaVersion"`
+	Phase         string           `json:"phase" yaml:"phase"` // "connections"
+	Installation  string           `json:"installation" yaml:"installation"`
+	Complete      bool             `json:"complete" yaml:"complete"`
+	Connections   []connectionView `json:"connections" yaml:"connections"`
+	Warnings      []string         `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+}
+
 func emitLinks(w io.Writer, schema string, v linksView) error {
 	return printer.NewMachineReadablePrinter[linksView](w, schema).Print(&v)
 }
 
 func emitRegistered(w io.Writer, schema string, v registeredView) error {
 	return printer.NewMachineReadablePrinter[registeredView](w, schema).Print(&v)
+}
+
+func emitConnections(w io.Writer, schema string, v connectionsView) error {
+	return printer.NewMachineReadablePrinter[connectionsView](w, schema).Print(&v)
 }

--- a/internal/cli/connect/machine_test.go
+++ b/internal/cli/connect/machine_test.go
@@ -101,7 +101,7 @@ func TestDocuments_SupportYAML(t *testing.T) {
 func TestReport_MapsUndeclaredErrorsToInternal(t *testing.T) {
 	var out bytes.Buffer
 
-	err := report(&out, printer.ConsumerMachine, "json", errors.New("pkl: inline password hunter2"))
+	err := report(&out, printer.ConsumerMachine, "json", errors.New("pkl: inline password hunter2"), awsFallbackMessage)
 
 	require.Error(t, err)
 	got := decodeDoc(t, out.String())
@@ -113,7 +113,7 @@ func TestReport_PassesDeclaredFailuresThrough(t *testing.T) {
 	var out bytes.Buffer
 
 	err := report(&out, printer.ConsumerMachine, "json",
-		printer.Fail(printer.CodeHostedRequired, "only a hosted installation can be connected", nil))
+		printer.Fail(printer.CodeHostedRequired, "only a hosted installation can be connected", nil), awsFallbackMessage)
 
 	require.Error(t, err)
 	got := decodeDoc(t, out.String())
@@ -124,7 +124,7 @@ func TestReport_PassesDeclaredFailuresThrough(t *testing.T) {
 func TestReport_HumanConsumerGetsNoEnvelope(t *testing.T) {
 	var out bytes.Buffer
 
-	err := report(&out, printer.ConsumerHuman, "json", errors.New("plain"))
+	err := report(&out, printer.ConsumerHuman, "json", errors.New("plain"), awsFallbackMessage)
 
 	require.Error(t, err)
 	assert.Zero(t, out.Len())

--- a/internal/cli/connect/setup.go
+++ b/internal/cli/connect/setup.go
@@ -291,8 +291,13 @@ func (s *session) register(ctx context.Context, account, roleArn string) (string
 			"a different role is already registered for this account on this installation",
 			map[string]any{"registeredRoleArn": connection.RoleArn, "statedRoleArn": roleArn})
 	}
+	if !snapshot.Complete {
+		return "", fmt.Errorf("a cloud connection for this account already exists, and the connections listing " +
+			"used to compare it was incomplete, so the existing registration is not visible to compare")
+	}
 	return "", printer.Fail(printer.CodeRegistrationConflict,
-		"the control plane refused this registration as a duplicate, and the existing registration is not visible to compare",
+		"the control plane refused this registration as a duplicate, but no connection for this account "+
+			"appears in the installation's full listing",
 		map[string]any{"statedRoleArn": roleArn})
 }
 

--- a/internal/cli/connect/setup.go
+++ b/internal/cli/connect/setup.go
@@ -274,13 +274,13 @@ func (s *session) register(ctx context.Context, account, roleArn string) (string
 
 	// 409: read the listing and compare. The same ARN is the idempotent
 	// success; a different one is a conflict the user has to resolve.
-	connections, warnings, lerr := s.client.ListCloudConnections(ctx, bearer, s.InstallationID)
-	s.Warnings = append(s.Warnings, warnings...)
+	snapshot, lerr := s.client.ListCloudConnections(ctx, bearer, s.InstallationID)
+	s.Warnings = append(s.Warnings, snapshot.Warnings...)
 	if lerr != nil {
 		return "", fmt.Errorf("a cloud connection for this account already exists, and the existing "+
 			"registration could not be read to compare: %w", lerr)
 	}
-	for _, connection := range connections {
+	for _, connection := range snapshot.Connections {
 		if connection.Cloud != "aws" || connection.Account != account {
 			continue
 		}

--- a/internal/cli/connect/setup.go
+++ b/internal/cli/connect/setup.go
@@ -128,29 +128,31 @@ func selectWithoutBootstrap(configFlag, profileFlag string) (selection, error) {
 	}
 }
 
-// session is an authenticated connect run whose coordinates have been read
-// and whose issuer has passed the pin. Everything path-specific happens on
-// top of one of these.
-type session struct {
+// cpContext is an authenticated handle to the control plane: a profile has
+// been resolved, the login-issuer gate has passed, and a credential has been
+// force-refreshed. It touches nothing AWS-side, so a read that only lists or
+// looks up state can build on it without inheriting the provisioning paths'
+// template and issuer pin.
+type cpContext struct {
+	Client         cloudapi.Client
+	Bearer         string
 	InstallationID string
-	Setup          cloudapi.CloudConnectionSetup
-	Platform       connectPlatform
-	Warnings       []string
 
-	client    cloudapi.Client
-	validated login.ValidatedHosted
-	creds     credentialProvider
+	// Validated and Creds are not optional: openSession's registration path
+	// force-refreshes the credential a second time before registering
+	// (boundary two), and both are needed to do that without authenticating
+	// again from scratch.
+	Validated login.ValidatedHosted
+	Creds     credentialProvider
 }
 
-// openSession resolves the profile, force-refreshes the credential (boundary
-// one), reads the setup coordinates, and holds them against the issuer pin.
-func openSession(ctx context.Context, opts options) (*session, error) {
+// openControlPlane resolves the profile, requires it to be hosted, holds the
+// bearer to the login-issuer gate, and force-refreshes the credential
+// (boundary one). Nothing here depends on FORMAE_CONNECT_*: that pair governs
+// only the AWS-side trust artifacts, which a control-plane read never
+// touches.
+func openControlPlane(ctx context.Context, opts options) (*cpContext, error) {
 	conn, a, _, err := resolveHosted(opts.ConfigFlag, opts.ProfileFlag)
-	if err != nil {
-		return nil, err
-	}
-
-	p, err := resolveConnectPlatform()
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +170,7 @@ func openSession(ctx context.Context, opts options) (*session, error) {
 		return nil, authFailure(err)
 	}
 
-	// The control-plane origin comes from the login platform pair — that is
+	// The control-plane origin comes from the login platform pair: that is
 	// where the bearer goes; FORMAE_CONNECT_* governs only the AWS-side
 	// issuer/template pin.
 	origin, _, err := cloudapi.ResolvePlatform("", "")
@@ -177,9 +179,45 @@ func openSession(ctx context.Context, opts options) (*session, error) {
 	}
 	client := newCloudAPI(origin)
 
-	setup, err := client.GetCloudConnectionSetup(ctx, bearer, conn.Installation)
+	return &cpContext{
+		Client:         client,
+		Bearer:         bearer,
+		InstallationID: conn.Installation,
+		Validated:      validated,
+		Creds:          creds,
+	}, nil
+}
+
+// session is an authenticated connect run whose coordinates have been read
+// and whose issuer has passed the pin. Everything path-specific happens on
+// top of one of these.
+type session struct {
+	InstallationID string
+	Setup          cloudapi.CloudConnectionSetup
+	Platform       connectPlatform
+	Warnings       []string
+
+	client    cloudapi.Client
+	validated login.ValidatedHosted
+	creds     credentialProvider
+}
+
+// openSession resolves the profile, force-refreshes the credential (boundary
+// one), reads the setup coordinates, and holds them against the issuer pin.
+func openSession(ctx context.Context, opts options) (*session, error) {
+	cp, err := openControlPlane(ctx, opts)
 	if err != nil {
-		return nil, classifySetupError(ctx, client, bearer, conn.Installation, err)
+		return nil, err
+	}
+
+	p, err := resolveConnectPlatform()
+	if err != nil {
+		return nil, err
+	}
+
+	setup, err := cp.Client.GetCloudConnectionSetup(ctx, cp.Bearer, cp.InstallationID)
+	if err != nil {
+		return nil, classifySetupError(ctx, cp.Client, cp.Bearer, cp.InstallationID, err)
 	}
 
 	// F6: the server's spelling is canonicalised before the comparison, so a
@@ -191,13 +229,13 @@ func openSession(ctx context.Context, opts options) (*session, error) {
 	}
 
 	return &session{
-		InstallationID: conn.Installation,
+		InstallationID: cp.InstallationID,
 		Setup:          setup,
 		Platform:       p,
 		Warnings:       setup.Warnings,
-		client:         client,
-		validated:      validated,
-		creds:          creds,
+		client:         cp.Client,
+		validated:      cp.Validated,
+		creds:          cp.Creds,
 	}, nil
 }
 

--- a/internal/cli/connect/structure_test.go
+++ b/internal/cli/connect/structure_test.go
@@ -60,6 +60,30 @@ func TestStructure_AwsFlagsLiveOnTheSubcommandOnly(t *testing.T) {
 	assert.NotNil(t, parent.PersistentFlags().Lookup("profile"))
 }
 
+// `connect list` is a member-readable listing, not a provisioning flow: it
+// owns the shared output flags, takes no positional arguments, and carries
+// none of the AWS-only flags that only `connect aws` needs.
+func TestStructure_ListIsRegisteredAndCarriesNoAWSOnlyFlags(t *testing.T) {
+	parent := ConnectCmd()
+	list := findSub(t, parent, "list")
+
+	assert.NotNil(t, list.Flags().Lookup("output-consumer"), "list must own the output-consumer flag")
+	assert.NotNil(t, list.Flags().Lookup("output-schema"), "list must own the output-schema flag")
+
+	for _, flag := range []string{"account", "quick-create", "provider-exists", "role-arn", "profile-aws", "region", "no-input"} {
+		assert.Nil(t, list.Flags().Lookup(flag), "flag %q must not exist on connect list", flag)
+	}
+}
+
+// A positional argument is rejected: list takes none.
+func TestStructure_ListTakesNoPositionalArguments(t *testing.T) {
+	out, err := runConnect(t, "list", "unexpected-arg")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected-arg")
+	assert.NotContains(t, out, "schemaVersion")
+}
+
 func TestStructure_ConnectIsAnAuthCommand(t *testing.T) {
 	c := ConnectCmd()
 	assert.Equal(t, "Auth", c.Annotations["type"])

--- a/internal/cli/printer/failure.go
+++ b/internal/cli/printer/failure.go
@@ -69,8 +69,12 @@ const (
 	// CodeRegistrationConflict: a different role ARN is already registered for
 	// this account on this installation.
 	CodeRegistrationConflict Code = "registration_conflict"
-	// CodeNotAuthorized: the control plane answered 403; the caller is not an
-	// admin of this installation. Terminal, not retried.
+	// CodeNotAuthorized: the caller lacks the access this operation needs on
+	// this installation. Provisioning uses it for a 403 meaning the caller is
+	// not an admin; listing uses it both for a 403 meaning a member's tenant
+	// grant excludes this installation, and for a 404 meaning the
+	// installation is not visible to the caller at all. Terminal, not
+	// retried.
 	CodeNotAuthorized Code = "not_authorized"
 	// CodeUnsupportedPartition: a non-commercial region, ARN, or STS caller.
 	CodeUnsupportedPartition Code = "unsupported_partition"


### PR DESCRIPTION
## Summary

Adds `formae connect list`, a read-only command reporting which cloud accounts are registered on the active hosted installation. Nothing outside `internal/cli/connect` could read that before: `ListCloudConnections` existed with a single caller and no command surface.

The consumer is an MCP server deciding whether to offer a user the cloud-account connection flow, so both the machine document and its completeness semantics are a contract rather than a convenience.

## The listing now says whether it was read in full

`ListCloudConnections` returned an empty slice from three situations that are not "there are none": `results` absent, `results` null, and every record dropped as unreadable. A caller branching on absence could not tell those apart from a genuinely empty installation, and the branch it feeds decides whether to provision.

It now returns a `ConnectionsSnapshot` carrying `Complete`, in the same shape `Snapshot.Authoritative` already uses for the installations listing and for the same reason.

Scoped deliberately to what can occur: a dropped record, an absent or null list, and a repeated top-level key. Pagination and unrecognised response fields were considered and left out, because the endpoint has neither and the installations listing guards them only because missing a page makes it delete profiles.

## Non-AWS rows survive

`CloudConnection` required a role ARN of every record, but the control-plane collection is a discriminated union where GCP carries `workloadIdentityProvider` and Azure carries `azureTenantId`. Their rows were dropped as broken, so an installation with only a GCP connection listed as empty. Validation is now per cloud over the closed set, and an unknown cloud is a dropped record that costs completeness.

## Smaller pieces

The 409 comparison in `register` consults `Complete` only after no matching record is found, so a partial listing that still contains the account settles the question. Only absence from an incomplete listing is inconclusive.

`openControlPlane` splits the authenticated control-plane context out of `openSession`, so a read-only list does not depend on the AWS-side template and issuer pin, and does not touch the admin-gated setup endpoint it has no need for.

401 and 403 no longer collapse into one error. The status is only in hand inside the client, and the two mean different things: a lapsed session, or a member whose tenant grant does not include this installation. The 403 wording asserts nothing about membership, since the server answers that with 404.