### PR TITLE
feat(connect): list local AWS profiles and their resolved accounts

### DIFF
--- a/internal/cli/connect/aws.go
+++ b/internal/cli/connect/aws.go
@@ -46,6 +46,7 @@ func awsCmd() *cobra.Command {
 	c.Flags().Bool("no-input", false, "Disable prompts; requires --account and one of --quick-create, --profile-aws, --role-arn")
 	clicmd.AddOutputFlags(c)
 	c.SetUsageTemplate(clicmd.SimpleCmdUsageTemplate)
+	c.AddCommand(profilesCmd())
 	return c
 }
 

--- a/internal/cli/connect/machine.go
+++ b/internal/cli/connect/machine.go
@@ -124,3 +124,29 @@ func emitRegistered(w io.Writer, schema string, v registeredView) error {
 func emitConnections(w io.Writer, schema string, v connectionsView) error {
 	return printer.NewMachineReadablePrinter[connectionsView](w, schema).Print(&v)
 }
+
+// profileResolution is one local AWS profile's resolution: either the
+// account its credentials authenticate to, or why that could not be
+// determined. Never both, never neither.
+type profileResolution struct {
+	Name        string `json:"name" yaml:"name"`
+	Account     string `json:"account,omitempty" yaml:"account,omitempty"`
+	Unavailable string `json:"unavailable,omitempty" yaml:"unavailable,omitempty"`
+}
+
+// profilesView is the `connect aws profiles` emit: every profile the local
+// shared AWS config names, alongside the account it resolves to. Profiles is
+// always a slice, never nil, for the same reason Connections is on
+// connectionsView. Warnings is always present too, even empty: this document
+// carries no Complete flag to hedge against, so there is nothing else to
+// signal a partial read with.
+type profilesView struct {
+	SchemaVersion int                 `json:"schemaVersion" yaml:"schemaVersion"`
+	Phase         string              `json:"phase" yaml:"phase"` // "awsProfiles"
+	Profiles      []profileResolution `json:"profiles" yaml:"profiles"`
+	Warnings      []string            `json:"warnings" yaml:"warnings"`
+}
+
+func emitProfiles(w io.Writer, schema string, v profilesView) error {
+	return printer.NewMachineReadablePrinter[profilesView](w, schema).Print(&v)
+}

--- a/internal/cli/connect/profiles.go
+++ b/internal/cli/connect/profiles.go
@@ -1,0 +1,143 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package connect
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	clicmd "github.com/platform-engineering-labs/formae/internal/cli/cmd"
+	"github.com/platform-engineering-labs/formae/internal/cli/printer"
+)
+
+// profileResolveTimeout bounds a single profile's resolution, so one dead
+// SSO session cannot hang the read of the rest. A var, not a const, so a
+// test can shrink it rather than waiting out the real duration.
+var profileResolveTimeout = 5 * time.Second
+
+// profilesFallbackMessage is the internal-code text an undeclared error gets
+// on the profiles path.
+const profilesFallbackMessage = "formae could not list AWS profiles; run it without --output-consumer machine to see why"
+
+func profilesCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:           "profiles",
+		Short:         "List local AWS profiles and the account each authenticates to",
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cc *cobra.Command, args []string) error {
+			return runConnectAWSProfiles(cc)
+		},
+	}
+	clicmd.AddOutputFlags(c)
+	c.SetUsageTemplate(clicmd.SimpleCmdUsageTemplate)
+	return c
+}
+
+// runConnectAWSProfiles reads the local shared AWS config and reports every
+// profile it names, each with the account its credentials resolve to. It is
+// a local read: no cloud credentials of its own beyond the profile it is
+// reading, and no control-plane session, so it works with no formae profile
+// configured at all.
+func runConnectAWSProfiles(cc *cobra.Command) error {
+	consumer, schema, err := resolveOutputOrHuman(cc)
+	if err != nil {
+		return err
+	}
+
+	v, err := readAWSProfilesView(cc)
+	if err != nil {
+		return report(cc.OutOrStdout(), consumer, schema, err, profilesFallbackMessage)
+	}
+
+	if consumer == printer.ConsumerMachine {
+		return emitProfiles(cc.OutOrStdout(), schema, v)
+	}
+	return printProfilesHuman(cc.OutOrStdout(), v)
+}
+
+// readAWSProfilesView enumerates the local AWS profiles and resolves each
+// one's account. Enumeration failing outright (the shared config could not
+// be read at all) fails the whole command: there is no profile list to build
+// a partial document from. Once profiles are named, one being unresolvable
+// is never fatal to the rest — it is reported alongside them, never in
+// place of them.
+func readAWSProfilesView(cc *cobra.Command) (profilesView, error) {
+	names, err := listAWSProfiles()
+	if err != nil {
+		return profilesView{}, err
+	}
+
+	return profilesView{
+		SchemaVersion: connectSchemaVersion,
+		Phase:         "awsProfiles",
+		Profiles:      resolveAWSProfiles(cc.Context(), names),
+		Warnings:      []string{},
+	}, nil
+}
+
+// resolveAWSProfiles resolves every named profile's account concurrently.
+// Each goroutine owns a distinct index, so no coordination is needed beyond
+// waiting for all of them; concurrency does not complicate the error
+// handling here, since a per-profile failure only ever affects that
+// profile's own row.
+func resolveAWSProfiles(ctx context.Context, names []string) []profileResolution {
+	results := make([]profileResolution, len(names))
+	var wg sync.WaitGroup
+	for i, name := range names {
+		wg.Add(1)
+		go func(i int, name string) {
+			defer wg.Done()
+			results[i] = resolveOneAWSProfile(ctx, name)
+		}(i, name)
+	}
+	wg.Wait()
+	return results
+}
+
+// resolveOneAWSProfile resolves one profile's account, bounded by its own
+// timeout so a dead SSO session cannot hang the rest of the read. It asks no
+// stated account of resolveCaller: this is a report, not a confirmation.
+func resolveOneAWSProfile(ctx context.Context, name string) profileResolution {
+	callCtx, cancel := context.WithTimeout(ctx, profileResolveTimeout)
+	defer cancel()
+	_, account, _, err := resolveCaller(callCtx, name, "")
+	if err != nil {
+		return profileResolution{Name: name, Unavailable: unavailableReason(err)}
+	}
+	return profileResolution{Name: name, Account: account}
+}
+
+// printProfilesHuman renders one line per profile: the account for one that
+// resolved, or its reason for one that did not. No profiles at all gets the
+// plain sentence rather than an empty listing.
+func printProfilesHuman(w io.Writer, v profilesView) error {
+	if len(v.Profiles) == 0 {
+		_, err := fmt.Fprintln(w, "No AWS profiles were found in the local shared config.")
+		return err
+	}
+
+	if _, err := fmt.Fprintln(w, "AWS profiles:"); err != nil {
+		return err
+	}
+	for _, p := range v.Profiles {
+		line := "  " + p.Name + "  "
+		if p.Unavailable != "" {
+			line += "unavailable: " + p.Unavailable
+		} else {
+			line += p.Account
+		}
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cli/connect/profiles_test.go
+++ b/internal/cli/connect/profiles_test.go
@@ -1,0 +1,250 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package connect
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials/ssocreds"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/cli/printer"
+)
+
+// `connect aws profiles` is a local, read-only listing: every profile the
+// shared AWS config names, plus the account its credentials resolve to (or
+// why that could not be determined). It takes no cloud credentials of its
+// own beyond the profile it is reading, and no control-plane session: these
+// tests never seed a formae profile, so a run that reached openControlPlane
+// would fail for lack of one.
+
+// seedProfilesConfig writes a shared config naming the given profiles and
+// isolates the run from the machine's own AWS environment. body is the
+// config file verbatim (`[profile x]` sections); credentials pairs a profile
+// name with a distinct static access key, so a profile that should reach the
+// stub STS server has something to sign with.
+func seedProfilesConfig(t *testing.T, body string, credentialProfiles ...string) {
+	t.Helper()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config")
+	require.NoError(t, os.WriteFile(configPath, []byte(body), 0o600))
+
+	var creds string
+	for i, p := range credentialProfiles {
+		creds += fmt.Sprintf("[%s]\naws_access_key_id = AKIAEXAMPLE%02d\naws_secret_access_key = examplesecretexamplesecretexample%02d\n\n", p, i, i)
+	}
+	credentialsPath := filepath.Join(dir, "credentials")
+	require.NoError(t, os.WriteFile(credentialsPath, []byte(creds), 0o600))
+
+	t.Setenv("AWS_CONFIG_FILE", configPath)
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", credentialsPath)
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	for _, k := range []string{"AWS_REGION", "AWS_DEFAULT_REGION", "AWS_PROFILE", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"} {
+		k := k
+		if old, ok := os.LookupEnv(k); ok {
+			t.Cleanup(func() { _ = os.Setenv(k, old) })
+		}
+		require.NoError(t, os.Unsetenv(k))
+	}
+}
+
+// runAWSProfiles runs `connect aws profiles` with args appended.
+func runAWSProfiles(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	return runConnect(t, append([]string{"aws", "profiles"}, args...)...)
+}
+
+// The document a consumer branches on: three profiles, one resolved, one
+// unavailable for lacking a region, one unavailable for an expired SSO
+// session (simulated through the loadAWSConfig seam, since a real expired
+// token cache is not something a hermetic test can seed). Order mirrors
+// listAWSProfiles' own sort.
+func TestConnectAWSProfiles_MachineDocument(t *testing.T) {
+	seedProfilesConfig(t, `[profile blue-admin]
+region = eu-west-1
+
+[profile no-region]
+
+[profile sandbox]
+region = eu-west-1
+`, "blue-admin", "sandbox")
+
+	fakeSTS(t, testAccount, "arn:aws:iam::"+testAccount+":user/dev")
+
+	restoreLoad := loadAWSConfig
+	loadAWSConfig = func(ctx context.Context, profile, region string) (aws.Config, error) {
+		if profile == "sandbox" {
+			return aws.Config{}, &ssocreds.InvalidTokenError{}
+		}
+		return restoreLoad(ctx, profile, region)
+	}
+	t.Cleanup(func() { loadAWSConfig = restoreLoad })
+
+	out, err := runAWSProfiles(t, machineArgs()...)
+	require.NoError(t, err, "out: %s", out)
+
+	doc := decodeDoc(t, out)
+	assert.Equal(t, "awsProfiles", doc["phase"])
+	assert.Equal(t, float64(2), doc["schemaVersion"])
+	assert.Equal(t, []any{}, doc["warnings"])
+
+	rows, ok := doc["profiles"].([]any)
+	require.True(t, ok, "profiles is not an array: %s", out)
+	require.Len(t, rows, 3)
+
+	blueAdmin := rows[0].(map[string]any)
+	assert.Equal(t, "blue-admin", blueAdmin["name"])
+	assert.Equal(t, testAccount, blueAdmin["account"])
+	_, unavailablePresent := blueAdmin["unavailable"]
+	assert.False(t, unavailablePresent, "a resolved profile must not carry an unavailable key")
+
+	noRegion := rows[1].(map[string]any)
+	assert.Equal(t, "no-region", noRegion["name"])
+	assert.Equal(t, "no region is configured for this profile", noRegion["unavailable"])
+	_, accountPresent := noRegion["account"]
+	assert.False(t, accountPresent, "an unavailable profile must not carry an account key")
+
+	sandbox := rows[2].(map[string]any)
+	assert.Equal(t, "sandbox", sandbox["name"])
+	assert.Equal(t, "the SSO session has expired", sandbox["unavailable"])
+}
+
+// No profiles at all is not an empty array pretending to be a listing: the
+// human path says so plainly, and the machine document still carries a
+// non-null (empty) array rather than omitting the field.
+func TestConnectAWSProfiles_NoProfilesAtAll(t *testing.T) {
+	seedProfilesConfig(t, "")
+
+	out, err := runAWSProfiles(t)
+	require.NoError(t, err, "out: %s", out)
+	assert.Equal(t, "No AWS profiles were found in the local shared config.\n", out)
+
+	out, err = runAWSProfiles(t, machineArgs()...)
+	require.NoError(t, err, "out: %s", out)
+	doc := decodeDoc(t, out)
+	rows, ok := doc["profiles"].([]any)
+	require.True(t, ok, "profiles must be an array, not null: %s", out)
+	assert.Empty(t, rows)
+}
+
+// Human output names each profile with its account, and marks an unavailable
+// one clearly with its reason, rather than a bare name or a raw AWS error.
+func TestConnectAWSProfiles_HumanOutput(t *testing.T) {
+	seedProfilesConfig(t, `[profile blue-admin]
+region = eu-west-1
+
+[profile sandbox]
+region = eu-west-1
+`, "blue-admin")
+
+	fakeSTS(t, testAccount, "arn:aws:iam::"+testAccount+":user/dev")
+
+	restoreLoad := loadAWSConfig
+	loadAWSConfig = func(ctx context.Context, profile, region string) (aws.Config, error) {
+		if profile == "sandbox" {
+			return aws.Config{}, &ssocreds.InvalidTokenError{}
+		}
+		return restoreLoad(ctx, profile, region)
+	}
+	t.Cleanup(func() { loadAWSConfig = restoreLoad })
+
+	out, err := runAWSProfiles(t)
+	require.NoError(t, err, "out: %s", out)
+
+	assert.Contains(t, out, "blue-admin  "+testAccount)
+	assert.Contains(t, out, "sandbox  unavailable: the SSO session has expired")
+	assert.NotContains(t, out, "schemaVersion")
+}
+
+// A single dead profile must not hang the whole read: its resolution gets
+// its own bounded timeout, so the run finishes and reports that one profile
+// as unavailable rather than blocking on it.
+func TestConnectAWSProfiles_APerProfileTimeoutBoundsAHungResolution(t *testing.T) {
+	seedProfilesConfig(t, `[profile slow]
+region = eu-west-1
+`, "slow")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = w.Write([]byte(`<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetCallerIdentityResult><Arn>arn:aws:iam::` + testAccount + `:user/dev</Arn><UserId>x</UserId><Account>` + testAccount + `</Account></GetCallerIdentityResult>
+  <ResponseMetadata><RequestId>r</RequestId></ResponseMetadata>
+</GetCallerIdentityResponse>`))
+	}))
+	t.Cleanup(srv.Close)
+	restoreEndpoint := stsEndpoint
+	stsEndpoint = srv.URL
+	t.Cleanup(func() { stsEndpoint = restoreEndpoint })
+
+	restoreTimeout := profileResolveTimeout
+	profileResolveTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { profileResolveTimeout = restoreTimeout })
+
+	start := time.Now()
+	out, err := runAWSProfiles(t, machineArgs()...)
+	elapsed := time.Since(start)
+	require.NoError(t, err, "out: %s", out)
+
+	assert.Less(t, elapsed, 250*time.Millisecond, "the hung profile must not make the whole read wait for it")
+
+	doc := decodeDoc(t, out)
+	rows := doc["profiles"].([]any)
+	require.Len(t, rows, 1)
+	row := rows[0].(map[string]any)
+	assert.Equal(t, "slow", row["name"])
+	assert.Equal(t, "could not resolve this profile's credentials", row["unavailable"])
+}
+
+// The reason text a consumer sees is derived from the failure's kind, never
+// the raw AWS SDK error: an undeclared error gets the same generic reason as
+// any other unclassified failure, not its own message echoed onto the wire.
+func TestUnavailableReason(t *testing.T) {
+	assert.Equal(t, "the SSO session has expired",
+		unavailableReason(printer.Fail(printer.CodeSSOLoginRequired, "the AWS SSO session for this profile has expired", nil)))
+	assert.Equal(t, "no region is configured for this profile",
+		unavailableReason(printer.Fail(printer.CodeProvisionFailed, "no region: pass --region or set one on the AWS profile", nil)))
+	assert.Equal(t, "the credentials belong to a non-commercial AWS partition",
+		unavailableReason(printer.Fail(printer.CodeUnsupportedPartition, "the credentials belong to a non-commercial AWS partition, which connect does not support", nil)))
+	assert.Equal(t, "could not resolve this profile's credentials",
+		unavailableReason(fmt.Errorf("operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: abc, api error InvalidClientTokenId: secret-looking-value")))
+}
+
+// The command is nested under `aws`, since profiles are AWS-specific while
+// connect itself is not, and it carries only the shared output flags: no
+// account/quick-create/role-arn/profile-aws/region/no-input, which belong to
+// provisioning, not a local read.
+func TestStructure_ProfilesIsRegisteredUnderAWSAndCarriesNoProvisioningFlags(t *testing.T) {
+	parent := ConnectCmd()
+	aws := findSub(t, parent, "aws")
+	profiles := findSub(t, aws, "profiles")
+
+	assert.NotNil(t, profiles.Flags().Lookup("output-consumer"), "profiles must own the output-consumer flag")
+	assert.NotNil(t, profiles.Flags().Lookup("output-schema"), "profiles must own the output-schema flag")
+
+	for _, flag := range []string{"account", "quick-create", "provider-exists", "role-arn", "profile-aws", "region", "no-input"} {
+		assert.Nil(t, profiles.Flags().Lookup(flag), "flag %q must not exist on connect aws profiles", flag)
+	}
+}
+
+// A positional argument is rejected: profiles takes none.
+func TestStructure_ProfilesTakesNoPositionalArguments(t *testing.T) {
+	out, err := runAWSProfiles(t, "unexpected-arg")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected-arg")
+	assert.NotContains(t, out, "schemaVersion")
+}

--- a/internal/cli/connect/sts.go
+++ b/internal/cli/connect/sts.go
@@ -45,12 +45,30 @@ var stsEndpoint string
 // verifyCaller confirms, before any IAM call, that the profile's credentials
 // authenticate to the stated account in the commercial partition.
 func verifyCaller(ctx context.Context, profile, region, statedAccount string) (verifiedCaller, error) {
+	cfg, account, arn, err := resolveCaller(ctx, profile, region)
+	if err != nil {
+		return verifiedCaller{}, err
+	}
+	if account != statedAccount {
+		return verifiedCaller{}, printer.Fail(printer.CodeAccountMismatch,
+			fmt.Sprintf("profile %q authenticates to account %s, not the stated %s",
+				profile, account, statedAccount), nil)
+	}
+	return verifiedCaller{Account: statedAccount, Arn: arn, Cfg: cfg}, nil
+}
+
+// resolveCaller loads the profile's config and asks STS who its credentials
+// belong to, without comparing against any stated account. It is the part
+// verifyCaller shares with a resolve-only reader (the profiles listing),
+// which reports the account rather than confirms it: the client construction
+// and the classification of what can go wrong along the way live here once.
+func resolveCaller(ctx context.Context, profile, region string) (aws.Config, string, string, error) {
 	cfg, err := loadAWSConfig(ctx, profile, region)
 	if err != nil {
-		return verifiedCaller{}, classifySSO(err, profile)
+		return aws.Config{}, "", "", classifySSO(err, profile)
 	}
 	if cfg.Region == "" {
-		return verifiedCaller{}, printer.Fail(printer.CodeProvisionFailed,
+		return aws.Config{}, "", "", printer.Fail(printer.CodeProvisionFailed,
 			"no region: pass --region or set one on the AWS profile", nil)
 	}
 	client := sts.NewFromConfig(cfg, func(o *sts.Options) {
@@ -60,18 +78,34 @@ func verifyCaller(ctx context.Context, profile, region, statedAccount string) (v
 	})
 	out, err := client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
-		return verifiedCaller{}, classifySSO(err, profile)
+		return aws.Config{}, "", "", classifySSO(err, profile)
 	}
 	if !strings.HasPrefix(aws.ToString(out.Arn), "arn:aws:") {
-		return verifiedCaller{}, printer.Fail(printer.CodeUnsupportedPartition,
+		return aws.Config{}, "", "", printer.Fail(printer.CodeUnsupportedPartition,
 			"the credentials belong to a non-commercial AWS partition, which connect does not support", nil)
 	}
-	if aws.ToString(out.Account) != statedAccount {
-		return verifiedCaller{}, printer.Fail(printer.CodeAccountMismatch,
-			fmt.Sprintf("profile %q authenticates to account %s, not the stated %s",
-				profile, aws.ToString(out.Account), statedAccount), nil)
+	return cfg, aws.ToString(out.Account), aws.ToString(out.Arn), nil
+}
+
+// unavailableReason turns a resolveCaller failure into the text the profiles
+// listing reports beside a profile it could not resolve. It is derived from
+// the failure's kind, never the failure's own message: the message on an
+// undeclared error can quote request detail from the AWS SDK, so only the
+// codes we ourselves classified get their own wording, and everything else
+// (including a resolution that timed out) shares one generic reason.
+func unavailableReason(err error) string {
+	var f *printer.Failure
+	if errors.As(err, &f) {
+		switch f.Code {
+		case printer.CodeSSOLoginRequired:
+			return "the SSO session has expired"
+		case printer.CodeProvisionFailed:
+			return "no region is configured for this profile"
+		case printer.CodeUnsupportedPartition:
+			return "the credentials belong to a non-commercial AWS partition"
+		}
 	}
-	return verifiedCaller{Account: statedAccount, Arn: aws.ToString(out.Arn), Cfg: cfg}, nil
+	return "could not resolve this profile's credentials"
 }
 
 // classifySSO turns an expired SSO session into the one failure whose remedy


### PR DESCRIPTION
## Summary

Adds `formae connect aws profiles`, listing each local AWS profile alongside the account its credentials authenticate to. Follows #681, now merged.

## Why the account is resolved here rather than at connect time

A user picks credentials, not an account. A profile name is intent about which keys to use and says nothing about which account they reach: profiles get renamed, copied between machines, or point somewhere they did six months ago.

Showing the account beside the name at selection time makes the selection itself the informed choice about where trust gets provisioned. That preserves the property `--account` exists for, without asking anyone to type twelve digits they may not know.

So `--account` stays mandatory and `verifyCaller` keeps comparing rather than sourcing. An earlier shape that made `--account` optional when `--profile-aws` was given got dropped: it resolved the account during the connect run, which is after the point where a human has to affirm the target.

## What it emits

```json
{"schemaVersion":2,"phase":"awsProfiles",
 "profiles":[{"name":"blue-admin","account":"123456789012"},
             {"name":"sandbox","unavailable":"the SSO session has expired"}],
 "warnings":[]}
```

A profile carries either an account or a reason it could not be resolved, never both and never neither. `profiles` is always present and never null.

## Per-profile failure is ordinary

Resolving N profiles is N `GetCallerIdentity` calls, and an expired SSO session is a normal state on a developer machine rather than an exceptional one. An unresolvable profile is reported as unavailable beside the ones that resolved and never sinks the document, and each resolution carries its own timeout so a single dead session cannot hang the read.

The reason text is ours, derived from the failure kind. No raw SDK error string crosses, for the same reason the rest of this package does not let producer prose reach a consumer.

## Reuse

`listAWSProfiles` and the STS call both already existed and were reachable only from the interactive form. `verifyCaller`'s stated-account comparison and its `account_mismatch` failure are unchanged; the resolution step was factored out from underneath it.