### PR TITLE
fix(login): refresh the credential when no sign-in produced it

### DIFF
--- a/internal/cli/login/login.go
+++ b/internal/cli/login/login.go
@@ -244,7 +244,7 @@ func runLoginAndSync(ctx context.Context, c authClient, s syncStep, device bool)
 		return err
 	}
 
-	result, active, syncErr := runSync(ctx, s)
+	result, active, syncErr := runSync(ctx, s, report.Status == statusAlreadyAuthenticated)
 	if syncErr != nil {
 		// Typed, because a consumer has to tell this apart from a sign-in that
 		// failed: the user IS authenticated here, and their session is saved, so
@@ -478,7 +478,10 @@ func syncFromFlags(block cliAuthBlock) syncEntry { return syncFromFlagsEntry{blo
 // A sign-in and a sync are separate facts, and every message here keeps them
 // apart: the user is signed in whatever the sync did, so nothing this function
 // prints may read as a login that failed.
-func runSync(ctx context.Context, s syncStep) (syncResult, string, error) {
+// forceRefresh asks the auth plugin for a freshly minted credential rather
+// than the one it already holds. Set on the already-authenticated branch, and
+// only there: see credential's own comment for why the distinction matters.
+func runSync(ctx context.Context, s syncStep, forceRefresh bool) (syncResult, string, error) {
 	tty := loginIsTerminal(s.Out)
 
 	p, err := resolvePlatform(s.CloudFlag, s.IssuerFlag)
@@ -507,7 +510,7 @@ func runSync(ctx context.Context, s syncStep) (syncResult, string, error) {
 		return syncResult{}, "", nil
 	}
 
-	hdr, err := credential(s.Creds)
+	hdr, err := credential(s.Creds, forceRefresh)
 	if err != nil {
 		return syncResult{}, "", fmt.Errorf("%s: %w", syncIncomplete(""), err)
 	}
@@ -611,8 +614,21 @@ func activatePublished(st *store.Store, result syncResult, out io.Writer, tty bo
 // unauthenticated request — the same fail-closed reading of a header the API
 // path takes, and for the same reason. Only the canonical Authorization key
 // is read, because it is the only key this CLI ever sends.
-func credential(c credentialProvider) (http.Header, error) {
-	resp, err := c.GetAuthHeader(false)
+// credential asks the auth plugin for the credential this sign-in produced.
+//
+// forceRefresh is false after a flow has just completed: that credential is
+// current by construction and a refresh buys nothing. It is true on the
+// already-authenticated short-circuit, where no flow ran and the plugin is
+// holding a token of unknown age.
+//
+// The distinction is load-bearing rather than cosmetic. The credential carries
+// the caller's grants as claims, resolved by the control plane when the token
+// is minted, so a token minted before the user was granted an installation
+// keeps reporting that they have none for as long as it stays valid. Signing
+// in and only then being granted an installation is the ordinary onboarding
+// order, so this is the common path, not an edge case.
+func credential(c credentialProvider, forceRefresh bool) (http.Header, error) {
+	resp, err := c.GetAuthHeader(forceRefresh)
 	if err != nil {
 		return nil, fmt.Errorf("ask the auth plugin for the credential this sign-in produced: %w", err)
 	}

--- a/internal/cli/login/login_test.go
+++ b/internal/cli/login/login_test.go
@@ -422,6 +422,31 @@ func TestLoginSyncsOnTheAlreadyAuthenticatedBranch(t *testing.T) {
 	}, lines(f.out))
 }
 
+// TestLoginForcesARefreshOnTheAlreadyAuthenticatedBranch verifies that a login
+// which short-circuits on an existing session asks the auth plugin to refresh
+// the credential rather than reusing the one it holds.
+//
+// The credential carries the caller's grants as claims, and the control plane
+// resolves them at mint time, so a token minted before the user's access
+// changed reports the old answer for as long as it stays valid. That is not a
+// hypothetical ordering: signing in and only then being granted an
+// installation is the ordinary onboarding sequence, and reusing the cached
+// token there enumerates nothing and writes no profile.
+//
+// This is the branch where no sign-in has just happened, which is what
+// separates it from TestLoginSyncsAfterASignIn: a credential a flow has only
+// now produced is current by construction and refreshing it buys nothing.
+func TestLoginForcesARefreshOnTheAlreadyAuthenticatedBranch(t *testing.T) {
+	f := newSyncFixture(t)
+	f.answer(installation(installOne, "prod", stateActive))
+	step := f.loginStep()
+
+	require.NoError(t, runLoginAndSync(context.Background(), alreadySignedIn(), step, false))
+
+	assert.Equal(t, []bool{true}, step.Creds.(*stubCredentials).forced,
+		"no sign-in produced this credential, so its grants may predate the user's access")
+}
+
 // TestLoginDoesNotSyncWhenTheSignInFails verifies that a failed sign-in ends
 // the command before anything is asked or written.
 func TestLoginDoesNotSyncWhenTheSignInFails(t *testing.T) {
@@ -625,7 +650,7 @@ func TestLoginFailsWhenAnotherProcessHoldsTheLedger(t *testing.T) {
 func TestLoginFailsWhenNoDesiredInstallationGotAProfile(t *testing.T) {
 	f := newSyncFixture(t)
 	f.answer(installation(installTwo, "staging", stateActive))
-	_, _, syncErr := runSync(context.Background(), f.loginStep())
+	_, _, syncErr := runSync(context.Background(), f.loginStep(), false)
 	require.NoError(t, syncErr)
 	require.True(t, f.exists(nameTwo))
 
@@ -635,7 +660,7 @@ func TestLoginFailsWhenNoDesiredInstallationGotAProfile(t *testing.T) {
 		installation(installTwo, "staging", "warping"),
 	)
 
-	_, _, err := runSync(context.Background(), f.loginStep())
+	_, _, err := runSync(context.Background(), f.loginStep(), false)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "you are signed in")


### PR DESCRIPTION
## What

A `login` that short-circuits on an existing session reused the credential the auth plugin was already holding. It now asks for a refreshed one — **only** on that branch.

## Why

The credential carries the caller's grants as claims, and the control plane resolves them at mint time. A token minted before the user was granted an installation therefore keeps reporting that they have none, for as long as it stays valid.

That ordering is the ordinary onboarding one, not an edge case:

1. User signs in. They have no organization yet, so the token is minted with no grants.
2. They create an organization and provision an agent.
3. They run `login` again to pick up the profile.

Step 3 is exactly the branch that short-circuits, so it enumerated nothing and wrote no profile — while the console showed the agent the whole time, because the dashboard authenticates by cookie and resolves grants live rather than from token claims.

It resolved itself once the access token aged out and the plugin refreshed, which is why it only bites inside the roughly half-hour window a new signup sits in. That is also why it was not caught earlier: testing slowly hides it.

## Scope

Forced **only** on the already-authenticated branch. A credential a completed flow has just produced is current by construction, and refreshing it buys nothing. The pre-existing test asserting that path does not force a refresh is kept exactly as it was — it is the guard that this stayed surgical rather than becoming a blanket refresh.

## Testing

- New: `TestLoginForcesARefreshOnTheAlreadyAuthenticatedBranch`, confirmed failing before the change (`expected [true], actual [false]`) and passing after.
- Unchanged and still passing: `TestLoginSyncsAfterASignIn`, which pins the fresh-sign-in path to no refresh.
- `go build ./...`, `go vet -tags=unit ./internal/cli/...`, and `go test -tags=unit ./internal/cli/...` (39 packages) all clean.