### PR TITLE
fix(connect): default the AWS region rather than refusing a profile without one

### DIFF
--- a/internal/cli/connect/aws.go
+++ b/internal/cli/connect/aws.go
@@ -42,7 +42,6 @@ func awsCmd() *cobra.Command {
 	c.Flags().Bool("provider-exists", false, "The account was connected to formae before: the shared OIDC identity provider already exists, so the stack creates the role only")
 	c.Flags().String("role-arn", "", "Trust already exists (an applied quick-create stack, or a role you made yourself): validate and register only")
 	c.Flags().String("profile-aws", "", "Provision directly with a local AWS shared-config profile, then register")
-	c.Flags().String("region", "", "AWS region for the local path (flag > profile region > us-east-1; quick-create has no region input)")
 	c.Flags().Bool("no-input", false, "Disable prompts; requires --account and one of --quick-create, --profile-aws, --role-arn")
 	clicmd.AddOutputFlags(c)
 	c.SetUsageTemplate(clicmd.SimpleCmdUsageTemplate)
@@ -62,7 +61,6 @@ func readOptions(cc *cobra.Command) (options, error) {
 	opts.ProviderExists, _ = cc.Flags().GetBool("provider-exists")
 	opts.ProfileAWS, _ = cc.Flags().GetString("profile-aws")
 	opts.RoleArn, _ = cc.Flags().GetString("role-arn")
-	opts.Region, _ = cc.Flags().GetString("region")
 	opts.NoInput, _ = cc.Flags().GetBool("no-input")
 	return opts, nil
 }

--- a/internal/cli/connect/aws.go
+++ b/internal/cli/connect/aws.go
@@ -42,7 +42,7 @@ func awsCmd() *cobra.Command {
 	c.Flags().Bool("provider-exists", false, "The account was connected to formae before: the shared OIDC identity provider already exists, so the stack creates the role only")
 	c.Flags().String("role-arn", "", "Trust already exists (an applied quick-create stack, or a role you made yourself): validate and register only")
 	c.Flags().String("profile-aws", "", "Provision directly with a local AWS shared-config profile, then register")
-	c.Flags().String("region", "", "AWS region for the local path (flag > profile region; quick-create has no region input)")
+	c.Flags().String("region", "", "AWS region for the local path (flag > profile region > us-east-1; quick-create has no region input)")
 	c.Flags().Bool("no-input", false, "Disable prompts; requires --account and one of --quick-create, --profile-aws, --role-arn")
 	clicmd.AddOutputFlags(c)
 	c.SetUsageTemplate(clicmd.SimpleCmdUsageTemplate)

--- a/internal/cli/connect/flow.go
+++ b/internal/cli/connect/flow.go
@@ -28,7 +28,6 @@ type options struct {
 	ProviderExists bool
 	ProfileAWS     string
 	RoleArn        string
-	Region         string
 	NoInput        bool
 
 	// ConfigFlag and ProfileFlag are carried verbatim into the resume hint:
@@ -58,9 +57,6 @@ func decideMode(opts options, tty bool) (mode, error) {
 	}
 	if set > 1 {
 		return 0, cmd.FlagErrorf("--quick-create, --profile-aws, and --role-arn are mutually exclusive; pass exactly one")
-	}
-	if opts.Region != "" && opts.ProfileAWS == "" {
-		return 0, cmd.FlagErrorf("--region applies only to the local path; pass it with --profile-aws")
 	}
 	if opts.ProviderExists && !opts.QuickCreate {
 		return 0, cmd.FlagErrorf("--provider-exists answers a question only quick-create asks; pass it with --quick-create")

--- a/internal/cli/connect/flow_test.go
+++ b/internal/cli/connect/flow_test.go
@@ -79,24 +79,6 @@ func TestDecideMode_NoInputRequiresAccountAndExactlyOneTrustFlag(t *testing.T) {
 	assert.Equal(t, modeQuickCreate, mode)
 }
 
-// --region belongs to the local path alone: quick-create has no region input
-// and register-only touches no AWS API.
-func TestDecideMode_RegionIsRefusedOffTheLocalPath(t *testing.T) {
-	for _, opts := range []options{
-		{Account: testAccount, QuickCreate: true, Region: "eu-west-1"},
-		{Account: testAccount, RoleArn: "arn:aws:iam::" + testAccount + ":role/r", Region: "eu-west-1"},
-		{Account: testAccount, Region: "eu-west-1"},
-	} {
-		_, err := decideMode(opts, true)
-		flagError(t, err)
-		assert.Contains(t, err.Error(), "--profile-aws")
-	}
-
-	mode, err := decideMode(options{Account: testAccount, ProfileAWS: "dev", Region: "eu-west-1"}, true)
-	require.NoError(t, err)
-	assert.Equal(t, modeLocal, mode)
-}
-
 // --provider-exists answers a question only quick-create asks.
 func TestDecideMode_ProviderExistsIsRefusedOffQuickCreate(t *testing.T) {
 	for _, opts := range []options{

--- a/internal/cli/connect/profiles.go
+++ b/internal/cli/connect/profiles.go
@@ -109,7 +109,7 @@ func resolveAWSProfiles(ctx context.Context, names []string) []profileResolution
 func resolveOneAWSProfile(ctx context.Context, name string) profileResolution {
 	callCtx, cancel := context.WithTimeout(ctx, profileResolveTimeout)
 	defer cancel()
-	_, account, _, err := resolveCaller(callCtx, name, "")
+	_, account, _, err := resolveCaller(callCtx, name)
 	if err != nil {
 		return profileResolution{Name: name, Unavailable: unavailableReason(err)}
 	}

--- a/internal/cli/connect/profiles_test.go
+++ b/internal/cli/connect/profiles_test.go
@@ -67,11 +67,11 @@ func runAWSProfiles(t *testing.T, args ...string) (string, error) {
 	return runConnect(t, append([]string{"aws", "profiles"}, args...)...)
 }
 
-// The document a consumer branches on: three profiles, one resolved, one
-// unavailable for lacking a region, one unavailable for an expired SSO
-// session (simulated through the loadAWSConfig seam, since a real expired
-// token cache is not something a hermetic test can seed). Order mirrors
-// listAWSProfiles' own sort.
+// The document a consumer branches on: three profiles, one resolved with a
+// region of its own, one resolved without any region configured at all, and
+// one unavailable for an expired SSO session (simulated through the
+// loadAWSConfig seam, since a real expired token cache is not something a
+// hermetic test can seed). Order mirrors listAWSProfiles' own sort.
 func TestConnectAWSProfiles_MachineDocument(t *testing.T) {
 	seedProfilesConfig(t, `[profile blue-admin]
 region = eu-west-1
@@ -80,7 +80,7 @@ region = eu-west-1
 
 [profile sandbox]
 region = eu-west-1
-`, "blue-admin", "sandbox")
+`, "blue-admin", "no-region", "sandbox")
 
 	fakeSTS(t, testAccount, "arn:aws:iam::"+testAccount+":user/dev")
 
@@ -113,9 +113,10 @@ region = eu-west-1
 
 	noRegion := rows[1].(map[string]any)
 	assert.Equal(t, "no-region", noRegion["name"])
-	assert.Equal(t, "no region is configured for this profile", noRegion["unavailable"])
-	_, accountPresent := noRegion["account"]
-	assert.False(t, accountPresent, "an unavailable profile must not carry an account key")
+	assert.Equal(t, testAccount, noRegion["account"],
+		"a profile with credentials resolves even with no region configured anywhere")
+	_, noRegionUnavailable := noRegion["unavailable"]
+	assert.False(t, noRegionUnavailable, "a resolved profile must not carry an unavailable key")
 
 	sandbox := rows[2].(map[string]any)
 	assert.Equal(t, "sandbox", sandbox["name"])
@@ -215,8 +216,6 @@ region = eu-west-1
 func TestUnavailableReason(t *testing.T) {
 	assert.Equal(t, "the SSO session has expired",
 		unavailableReason(printer.Fail(printer.CodeSSOLoginRequired, "the AWS SSO session for this profile has expired", nil)))
-	assert.Equal(t, "no region is configured for this profile",
-		unavailableReason(printer.Fail(printer.CodeProvisionFailed, "no region: pass --region or set one on the AWS profile", nil)))
 	assert.Equal(t, "the credentials belong to a non-commercial AWS partition",
 		unavailableReason(printer.Fail(printer.CodeUnsupportedPartition, "the credentials belong to a non-commercial AWS partition, which connect does not support", nil)))
 	assert.Equal(t, "could not resolve this profile's credentials",

--- a/internal/cli/connect/profiles_test.go
+++ b/internal/cli/connect/profiles_test.go
@@ -224,7 +224,7 @@ func TestUnavailableReason(t *testing.T) {
 
 // The command is nested under `aws`, since profiles are AWS-specific while
 // connect itself is not, and it carries only the shared output flags: no
-// account/quick-create/role-arn/profile-aws/region/no-input, which belong to
+// account/quick-create/role-arn/profile-aws/no-input, which belong to
 // provisioning, not a local read.
 func TestStructure_ProfilesIsRegisteredUnderAWSAndCarriesNoProvisioningFlags(t *testing.T) {
 	parent := ConnectCmd()
@@ -234,7 +234,7 @@ func TestStructure_ProfilesIsRegisteredUnderAWSAndCarriesNoProvisioningFlags(t *
 	assert.NotNil(t, profiles.Flags().Lookup("output-consumer"), "profiles must own the output-consumer flag")
 	assert.NotNil(t, profiles.Flags().Lookup("output-schema"), "profiles must own the output-schema flag")
 
-	for _, flag := range []string{"account", "quick-create", "provider-exists", "role-arn", "profile-aws", "region", "no-input"} {
+	for _, flag := range []string{"account", "quick-create", "provider-exists", "role-arn", "profile-aws", "no-input"} {
 		assert.Nil(t, profiles.Flags().Lookup(flag), "flag %q must not exist on connect aws profiles", flag)
 	}
 }

--- a/internal/cli/connect/profiles_test.go
+++ b/internal/cli/connect/profiles_test.go
@@ -85,11 +85,11 @@ region = eu-west-1
 	fakeSTS(t, testAccount, "arn:aws:iam::"+testAccount+":user/dev")
 
 	restoreLoad := loadAWSConfig
-	loadAWSConfig = func(ctx context.Context, profile, region string) (aws.Config, error) {
+	loadAWSConfig = func(ctx context.Context, profile string) (aws.Config, error) {
 		if profile == "sandbox" {
 			return aws.Config{}, &ssocreds.InvalidTokenError{}
 		}
-		return restoreLoad(ctx, profile, region)
+		return restoreLoad(ctx, profile)
 	}
 	t.Cleanup(func() { loadAWSConfig = restoreLoad })
 
@@ -154,11 +154,11 @@ region = eu-west-1
 	fakeSTS(t, testAccount, "arn:aws:iam::"+testAccount+":user/dev")
 
 	restoreLoad := loadAWSConfig
-	loadAWSConfig = func(ctx context.Context, profile, region string) (aws.Config, error) {
+	loadAWSConfig = func(ctx context.Context, profile string) (aws.Config, error) {
 		if profile == "sandbox" {
 			return aws.Config{}, &ssocreds.InvalidTokenError{}
 		}
-		return restoreLoad(ctx, profile, region)
+		return restoreLoad(ctx, profile)
 	}
 	t.Cleanup(func() { loadAWSConfig = restoreLoad })
 

--- a/internal/cli/connect/provision.go
+++ b/internal/cli/connect/provision.go
@@ -34,7 +34,7 @@ var newProvisioner = func(ctx context.Context, caller verifiedCaller,
 // runLocal is the --profile-aws path: verify the caller with STS, provision
 // the trust through provx, and register the resulting role.
 func runLocal(cc *cobra.Command, opts options, consumer printer.Consumer, schema string) error {
-	caller, err := verifyCaller(cc.Context(), opts.ProfileAWS, opts.Region, opts.Account)
+	caller, err := verifyCaller(cc.Context(), opts.ProfileAWS, opts.Account)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/connect/structure_test.go
+++ b/internal/cli/connect/structure_test.go
@@ -49,7 +49,7 @@ func TestStructure_AwsFlagsLiveOnTheSubcommandOnly(t *testing.T) {
 	parent := ConnectCmd()
 	aws := findSub(t, parent, "aws")
 
-	for _, flag := range []string{"account", "quick-create", "provider-exists", "profile-aws", "region", "role-arn", "no-input"} {
+	for _, flag := range []string{"account", "quick-create", "provider-exists", "profile-aws", "role-arn", "no-input"} {
 		assert.NotNil(t, aws.Flags().Lookup(flag), "flag %q missing on connect aws", flag)
 		assert.Nil(t, parent.Flags().Lookup(flag), "flag %q must not exist on the parent", flag)
 	}
@@ -70,7 +70,7 @@ func TestStructure_ListIsRegisteredAndCarriesNoAWSOnlyFlags(t *testing.T) {
 	assert.NotNil(t, list.Flags().Lookup("output-consumer"), "list must own the output-consumer flag")
 	assert.NotNil(t, list.Flags().Lookup("output-schema"), "list must own the output-schema flag")
 
-	for _, flag := range []string{"account", "quick-create", "provider-exists", "role-arn", "profile-aws", "region", "no-input"} {
+	for _, flag := range []string{"account", "quick-create", "provider-exists", "role-arn", "profile-aws", "no-input"} {
 		assert.Nil(t, list.Flags().Lookup(flag), "flag %q must not exist on connect list", flag)
 	}
 }

--- a/internal/cli/connect/sts.go
+++ b/internal/cli/connect/sts.go
@@ -26,24 +26,16 @@ type verifiedCaller struct {
 	Cfg     aws.Config // carried into the provisioner
 }
 
-// loadAWSConfig loads the shared config for the profile. The region option is
-// added only when the flag was passed: an unconditional WithRegion("") would
-// clobber the region the profile itself carries.
-var loadAWSConfig = func(ctx context.Context, profile, region string) (aws.Config, error) {
-	loadOptions := []func(*config.LoadOptions) error{
-		config.WithSharedConfigProfile(profile),
-	}
-	if region != "" {
-		loadOptions = append(loadOptions, config.WithRegion(region))
-	}
-	return config.LoadDefaultConfig(ctx, loadOptions...)
+// loadAWSConfig loads the shared config for the profile, region included when
+// the profile carries one.
+var loadAWSConfig = func(ctx context.Context, profile string) (aws.Config, error) {
+	return config.LoadDefaultConfig(ctx, config.WithSharedConfigProfile(profile))
 }
 
 // stsEndpoint overrides where GetCallerIdentity is sent; empty in production.
 var stsEndpoint string
 
-// defaultRegion is what the local path uses when neither the flag nor the
-// profile names a region.
+// defaultRegion is what the local path uses when the profile names no region.
 //
 // Nothing this path touches is regional. It asks STS which account the
 // credentials belong to, then creates an IAM role and the account-global OIDC
@@ -60,8 +52,8 @@ const defaultRegion = "us-east-1"
 
 // verifyCaller confirms, before any IAM call, that the profile's credentials
 // authenticate to the stated account in the commercial partition.
-func verifyCaller(ctx context.Context, profile, region, statedAccount string) (verifiedCaller, error) {
-	cfg, account, arn, err := resolveCaller(ctx, profile, region)
+func verifyCaller(ctx context.Context, profile, statedAccount string) (verifiedCaller, error) {
+	cfg, account, arn, err := resolveCaller(ctx, profile)
 	if err != nil {
 		return verifiedCaller{}, err
 	}
@@ -78,8 +70,8 @@ func verifyCaller(ctx context.Context, profile, region, statedAccount string) (v
 // verifyCaller shares with a resolve-only reader (the profiles listing),
 // which reports the account rather than confirms it: the client construction
 // and the classification of what can go wrong along the way live here once.
-func resolveCaller(ctx context.Context, profile, region string) (aws.Config, string, string, error) {
-	cfg, err := loadAWSConfig(ctx, profile, region)
+func resolveCaller(ctx context.Context, profile string) (aws.Config, string, string, error) {
+	cfg, err := loadAWSConfig(ctx, profile)
 	if err != nil {
 		return aws.Config{}, "", "", classifySSO(err, profile)
 	}

--- a/internal/cli/connect/sts.go
+++ b/internal/cli/connect/sts.go
@@ -42,6 +42,22 @@ var loadAWSConfig = func(ctx context.Context, profile, region string) (aws.Confi
 // stsEndpoint overrides where GetCallerIdentity is sent; empty in production.
 var stsEndpoint string
 
+// defaultRegion is what the local path uses when neither the flag nor the
+// profile names a region.
+//
+// Nothing this path touches is regional. It asks STS which account the
+// credentials belong to, then creates an IAM role and the account-global OIDC
+// provider that role trusts: STS answers identically from any region, and IAM
+// has one global endpoint. A region is required only because an SDK client
+// cannot be constructed without one.
+//
+// So it is defaulted rather than demanded. Credentials in the shared
+// credentials file with no region beside them is an ordinary setup, and
+// refusing it reports every such profile as unavailable — which withdraws the
+// direct-provision path from the connect flow entirely and leaves the console
+// link as the only way through, for a preference nothing downstream reads.
+const defaultRegion = "us-east-1"
+
 // verifyCaller confirms, before any IAM call, that the profile's credentials
 // authenticate to the stated account in the commercial partition.
 func verifyCaller(ctx context.Context, profile, region, statedAccount string) (verifiedCaller, error) {
@@ -68,8 +84,7 @@ func resolveCaller(ctx context.Context, profile, region string) (aws.Config, str
 		return aws.Config{}, "", "", classifySSO(err, profile)
 	}
 	if cfg.Region == "" {
-		return aws.Config{}, "", "", printer.Fail(printer.CodeProvisionFailed,
-			"no region: pass --region or set one on the AWS profile", nil)
+		cfg.Region = defaultRegion
 	}
 	client := sts.NewFromConfig(cfg, func(o *sts.Options) {
 		if stsEndpoint != "" {
@@ -99,8 +114,6 @@ func unavailableReason(err error) string {
 		switch f.Code {
 		case printer.CodeSSOLoginRequired:
 			return "the SSO session has expired"
-		case printer.CodeProvisionFailed:
-			return "no region is configured for this profile"
 		case printer.CodeUnsupportedPartition:
 			return "the credentials belong to a non-commercial AWS partition"
 		}

--- a/internal/cli/connect/sts_test.go
+++ b/internal/cli/connect/sts_test.go
@@ -91,14 +91,20 @@ func TestVerifyCaller_TheRegionFlagBeatsTheProfileRegion(t *testing.T) {
 	assert.Equal(t, "us-east-1", caller.Cfg.Region)
 }
 
-func TestVerifyCaller_NoRegionAnywhereIsARefusal(t *testing.T) {
+// Credentials with no region configured anywhere is an ordinary AWS setup, and
+// nothing this path touches is regional: it asks STS who the credentials belong
+// to and then creates an IAM role, both global. A region is defaulted so such a
+// profile still resolves, rather than being refused over a preference no call
+// downstream ever reads.
+func TestVerifyCaller_NoRegionAnywhereDefaultsRatherThanRefusing(t *testing.T) {
 	seedAWSConfig(t, "[profile test]\n")
 	fakeSTS(t, testAccount, "arn:aws:iam::"+testAccount+":user/dev")
 
-	_, err := verifyCaller(context.Background(), "test", "", testAccount)
+	caller, err := verifyCaller(context.Background(), "test", "", testAccount)
 
-	failureCode(t, err, printer.CodeProvisionFailed)
-	assert.Contains(t, err.Error(), "region")
+	require.NoError(t, err)
+	assert.Equal(t, testAccount, caller.Account)
+	assert.Equal(t, defaultRegion, caller.Cfg.Region)
 }
 
 func TestVerifyCaller_AMismatchNamesStatedAndActual(t *testing.T) {

--- a/internal/cli/connect/sts_test.go
+++ b/internal/cli/connect/sts_test.go
@@ -73,22 +73,12 @@ func TestVerifyCaller_AcceptsAMatchingCommercialCaller(t *testing.T) {
 	seedAWSConfig(t, "[profile test]\nregion = eu-west-1\n")
 	fakeSTS(t, testAccount, "arn:aws:iam::"+testAccount+":user/dev")
 
-	caller, err := verifyCaller(context.Background(), "test", "", testAccount)
+	caller, err := verifyCaller(context.Background(), "test", testAccount)
 
 	require.NoError(t, err)
 	assert.Equal(t, testAccount, caller.Account)
 	assert.Equal(t, "arn:aws:iam::"+testAccount+":user/dev", caller.Arn)
-	assert.Equal(t, "eu-west-1", caller.Cfg.Region, "the profile's region loads when no flag is passed")
-}
-
-func TestVerifyCaller_TheRegionFlagBeatsTheProfileRegion(t *testing.T) {
-	seedAWSConfig(t, "[profile test]\nregion = eu-west-1\n")
-	fakeSTS(t, testAccount, "arn:aws:iam::"+testAccount+":user/dev")
-
-	caller, err := verifyCaller(context.Background(), "test", "us-east-1", testAccount)
-
-	require.NoError(t, err)
-	assert.Equal(t, "us-east-1", caller.Cfg.Region)
+	assert.Equal(t, "eu-west-1", caller.Cfg.Region, "the profile's own region is what loads")
 }
 
 // Credentials with no region configured anywhere is an ordinary AWS setup, and
@@ -100,7 +90,7 @@ func TestVerifyCaller_NoRegionAnywhereDefaultsRatherThanRefusing(t *testing.T) {
 	seedAWSConfig(t, "[profile test]\n")
 	fakeSTS(t, testAccount, "arn:aws:iam::"+testAccount+":user/dev")
 
-	caller, err := verifyCaller(context.Background(), "test", "", testAccount)
+	caller, err := verifyCaller(context.Background(), "test", testAccount)
 
 	require.NoError(t, err)
 	assert.Equal(t, testAccount, caller.Account)
@@ -111,7 +101,7 @@ func TestVerifyCaller_AMismatchNamesStatedAndActual(t *testing.T) {
 	seedAWSConfig(t, "[profile test]\nregion = eu-west-1\n")
 	fakeSTS(t, "999999999999", "arn:aws:iam::999999999999:user/dev")
 
-	_, err := verifyCaller(context.Background(), "test", "", testAccount)
+	_, err := verifyCaller(context.Background(), "test", testAccount)
 
 	failureCode(t, err, printer.CodeAccountMismatch)
 	assert.Contains(t, err.Error(), testAccount)
@@ -122,7 +112,7 @@ func TestVerifyCaller_ANonCommercialCallerIsRefused(t *testing.T) {
 	seedAWSConfig(t, "[profile test]\nregion = us-gov-west-1\n")
 	fakeSTS(t, testAccount, "arn:aws-us-gov:iam::"+testAccount+":user/dev")
 
-	_, err := verifyCaller(context.Background(), "test", "", testAccount)
+	_, err := verifyCaller(context.Background(), "test", testAccount)
 
 	failureCode(t, err, printer.CodeUnsupportedPartition)
 }


### PR DESCRIPTION
## Summary

`connect aws profiles` reported every local AWS profile as unavailable on any machine whose credentials live in `~/.aws/credentials` with no region configured beside them. That is an ordinary AWS setup, and the effect was to withdraw the direct-provision path from the connect flow entirely: the profile listing had nothing to offer, so the CloudFormation console link became the only way through, with nothing on screen to explain why.

Nothing on this path is regional. `resolveCaller` asks STS which account the credentials belong to, and the provisioner it feeds creates an IAM role plus the account-global OIDC provider that role trusts. STS answers identically from any region and IAM has a single global endpoint, so a region was required only to construct an SDK client. It is now defaulted rather than demanded.

Two things follow from that:

- The reason table's `CodeProvisionFailed` case is dropped. Nothing in `resolveCaller` emits that code any more, so an unclassified failure falls to the generic reason instead of being reported as a missing region.
- `--region` on `connect aws` goes with it (second commit). Once the region is understood as an endpoint choice rather than a placement choice, the flag had nothing left to decide: nothing is created in a region, nothing outside the package referenced it, the MCP server's `provision_cloud_role` never passed one, and no documentation mentions it. It also carried a validation rule that existed only to police itself, plus a parameter threaded through three functions. A profile that names a region still uses it; only the explicit override is gone. It has shipped under no stable tag, so nothing can depend on it yet.

Net effect is 24 lines removed.

With no region configured anywhere:

```
$ formae connect aws profiles     # before
AWS profiles:
  blue     unavailable: no region is configured for this profile
  ci-test  unavailable: no region is configured for this profile

$ formae connect aws profiles     # after
AWS profiles:
  blue     <account id>
  ci-test  <account id>
```