### PR TITLE
test(blackbox): never resurrect an incarnation a folded delete already removed

### DIFF
--- a/tests/blackbox/executor.go
+++ b/tests/blackbox/executor.go
@@ -1014,6 +1014,16 @@ func correctModelFromCommandOutcome(t *testing.T, cmd *apimodel.Command, model *
 		if ru.State == "Success" {
 			switch ru.Operation {
 			case "create":
+				// A delete can only succeed on an incarnation that already
+				// existed, so a create RU carrying the NativeID a folded
+				// delete removed predates that delete — regardless of which
+				// command completed first. Folding it would resurrect a slot
+				// the agent has already destroyed.
+				if ru.NativeID != "" && model.DeletedNativeID(stackIdx, slotIdx) == ru.NativeID {
+					t.Logf("correctModelFromCommandOutcome: skipping stale create stack=%s slot=%d (incarnation %s already deleted by a previously folded command)",
+						model.Stack(stackIdx).Label, slotIdx, ru.NativeID)
+					goto markDone
+				}
 				model.ClearAuthoritativeSlot(stackIdx, slotIdx)
 				props := ""
 				if ru.Properties != nil {
@@ -1025,6 +1035,7 @@ func correctModelFromCommandOutcome(t *testing.T, cmd *apimodel.Command, model *
 			case "delete":
 				model.ApplyDestroyed(stackIdx, []int{slotIdx})
 				model.MarkAuthoritativeSlot(stackIdx, slotIdx)
+				model.SetDeletedNativeID(stackIdx, slotIdx, ru.NativeID)
 				model.ClearNativeID(stackIdx, slotIdx)
 				model.ClearKsuid(stackIdx, slotIdx)
 			case "update":
@@ -2400,6 +2411,7 @@ func (h *TestHarness) SetupStacks(t *testing.T, model *StateModel, config Proper
 	// slots authoritative, which must be cleared before the new iteration
 	// creates resources on those slots.
 	model.AuthoritativeSlots = make(map[string]bool)
+	model.DeletedNativeIDs = make(map[string]string)
 
 	// Create a single resource on each stack to ensure the stack exists.
 	for stackIdx := range model.Stacks {

--- a/tests/blackbox/state_model.go
+++ b/tests/blackbox/state_model.go
@@ -80,6 +80,13 @@ type StateModel struct {
 	// expected to have been ingested into the unmanaged inventory.
 	UnmanagedResources map[string]*ExpectedUnmanagedResource
 	AuthoritativeSlots map[string]bool
+	// DeletedNativeIDs maps "stackIdx:slotIdx" → the NativeID of the
+	// incarnation whose folded delete RU made the slot authoritative. A
+	// create RU carrying the same NativeID predates that delete (a delete
+	// can only succeed on an incarnation that already existed), so it must
+	// not resurrect the slot however late its command drains. Cleared with
+	// the slot's authoritative mark.
+	DeletedNativeIDs map[string]string
 	// NativeIDs maps "stackIdx:slotIdx" → cloud native ID (e.g. "test-42").
 	// Populated from command response ResourceUpdate.NativeID on successful
 	// creates/updates. Cleared on successful deletes.
@@ -152,6 +159,7 @@ func NewStateModel(stackCount, resourcesPerStack int) *StateModel {
 		ProviderStackLabel:  providerLabel,
 		UnmanagedResources:  make(map[string]*ExpectedUnmanagedResource),
 		AuthoritativeSlots:  make(map[string]bool),
+		DeletedNativeIDs:    make(map[string]string),
 		NativeIDs:           make(map[string]string),
 		Ksuids:              make(map[string]string),
 		DriftExcludedStacks: make(map[int]bool),
@@ -299,6 +307,18 @@ func (m *StateModel) MarkAuthoritativeSlot(stackIdx, slotIdx int) {
 
 func (m *StateModel) ClearAuthoritativeSlot(stackIdx, slotIdx int) {
 	delete(m.AuthoritativeSlots, slotKeyString(stackIdx, slotIdx))
+	delete(m.DeletedNativeIDs, slotKeyString(stackIdx, slotIdx))
+}
+
+func (m *StateModel) SetDeletedNativeID(stackIdx, slotIdx int, nativeID string) {
+	if nativeID == "" {
+		return
+	}
+	m.DeletedNativeIDs[slotKeyString(stackIdx, slotIdx)] = nativeID
+}
+
+func (m *StateModel) DeletedNativeID(stackIdx, slotIdx int) string {
+	return m.DeletedNativeIDs[slotKeyString(stackIdx, slotIdx)]
 }
 
 func (m *StateModel) IsAuthoritativeSlot(stackIdx, slotIdx int) bool {

--- a/tests/blackbox/state_model_test.go
+++ b/tests/blackbox/state_model_test.go
@@ -748,6 +748,69 @@ func TestCorrectModelFromCommandOutcome_TTLSupersededSlotStaysDestroyed(t *testi
 		"the TTL destroy's authoritative mark must survive the stale correction")
 }
 
+// Commands fold into the model in completion order, which can invert the
+// order the agent actually executed per-resource operations in. A cascade
+// delete that succeeded proves the deleted incarnation existed when it ran,
+// so a create RU carrying that same NativeID predates the delete no matter
+// which command completed first. When such a create drains after the delete
+// was already folded, it must not resurrect the slot: the deterministic end
+// state is NotExist.
+func TestCorrectModelFromCommandOutcome_CreateOfDeletedIncarnationDoesNotResurrect(t *testing.T) {
+	model := NewStateModel(3, 10)
+	require.NotNil(t, model.Pool)
+	xslot := -1
+	for i := range model.Pool.Slots {
+		if model.Pool.IsCrossStack(i) {
+			xslot = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, xslot, "pool must have a cross-stack slot")
+
+	// An apply optimistically created the cross-stack slot.
+	model.ApplyCreated(1, []int{xslot}, "")
+	label := model.LabelForResource(1, xslot)
+
+	// A destroy of the provider stack cascade-deleted the slot and completed
+	// (Canceled overall) before the apply did, so its outcome folds first.
+	destroyCmd := &apimodel.Command{
+		CommandID: "cmd-destroy",
+		State:     "Canceled",
+		ResourceUpdates: []apimodel.ResourceUpdate{{
+			StackName:     "stack-1",
+			ResourceLabel: label,
+			Operation:     "delete",
+			State:         "Success",
+			IsCascade:     true,
+			NativeID:      "test-101",
+		}},
+	}
+	corrected := map[struct{ stackIdx, slotIdx int }]bool{}
+	correctModelFromCommandOutcome(t, destroyCmd, model, model.Pool, nil, corrected, false, nil, nil)
+	require.Equal(t, StateNotExist, model.Resource(1, xslot).State)
+
+	// The apply completes later (Failed overall) and drains with a create
+	// Success RU for the incarnation the cascade delete already removed.
+	applyCmd := &apimodel.Command{
+		CommandID: "cmd-apply",
+		State:     "Failed",
+		ResourceUpdates: []apimodel.ResourceUpdate{{
+			StackName:     "stack-1",
+			ResourceLabel: label,
+			Operation:     "create",
+			State:         "Success",
+			NativeID:      "test-101",
+		}},
+	}
+	corrected = map[struct{ stackIdx, slotIdx int }]bool{}
+	correctModelFromCommandOutcome(t, applyCmd, model, model.Pool, nil, corrected, true, nil, nil)
+
+	require.Equal(t, StateNotExist, model.Resource(1, xslot).State,
+		"a create RU for an incarnation a folded delete already removed must not resurrect the slot")
+	require.True(t, model.IsAuthoritativeSlot(1, xslot),
+		"the delete's authoritative mark must survive the stale create")
+}
+
 // A failed command's unmentioned slot was never touched by the agent, so an
 // optimistic property prediction for it must roll back even when the slot's
 // State never changed. A patch that fails on a sibling before reaching the


### PR DESCRIPTION
## Summary

- `TestProperty_FullChaos` intermittently reported `inventory=NotExist but model expects Exists` for a cross-stack child slot. The agent's inventory was correct; the harness state model was wrong.
- Command outcomes fold into the model in completion order, which can invert the order the agent actually executed per-resource operations in: a destroy admitted after an apply can cascade-delete a resource the apply created and still reach a terminal state first (e.g. by being canceled after its cascade half succeeded). The late-draining apply's `create Success` RU then cleared the delete's authoritative mark and resurrected the slot. The two folds happen in separate drain invocations, so the existing reverse-order `corrected` protection never applies.
- The correction stays deterministic and uses only command-response data: a delete can only succeed on an incarnation that already existed, so a create RU carrying the NativeID a folded delete removed necessarily predates that delete. The model now records the deleted NativeID alongside the authoritative mark and skips folding such stale creates. A genuine re-create carries a fresh NativeID and folds exactly as before; no invariant is loosened.
- Adds a unit test mirroring the TTL-superseded variant of the same resurrect problem; `TestProperty_FullChaos` passes 100 checks with the change.