### PR TITLE
fix(agent): report plugin output at the level the plugin chose

### DIFF
--- a/internal/metastructure/plugin_process_supervisor/plugin_log_level_test.go
+++ b/internal/metastructure/plugin_process_supervisor/plugin_log_level_test.go
@@ -1,0 +1,48 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package plugin_process_supervisor
+
+import "testing"
+
+// Plugins do not agree on a log format. Ergo-based ones emit the runtime's
+// bracketed format; anything built on log/slog emits logfmt with an uppercase
+// level. Both name a level, and the supervisor has to read either to report a
+// line at the severity its author chose.
+func TestPluginLevel(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{"ergo info", "1764458575429677244 [info] <79F4473F.0.1004>: hello", "info"},
+		{"ergo error", "1764458575429677244 [error] <79F4473F.0.1004>: boom", "error"},
+		{"ergo warning", "1764458575429677244 [warning] <79F4473F.0.1004>: hmm", "warning"},
+
+		// The shape the oidc auth plugin actually emits.
+		{
+			"slog warn",
+			`time=2026-08-25T20:52:51.539Z level=WARN msg="rejected credential" plugin=oidc`,
+			"warning",
+		},
+		{"slog error", `time=2026-08-25T20:52:51.539Z level=ERROR msg="broker died"`, "error"},
+		{"slog info", `time=2026-08-25T20:52:51.539Z level=INFO msg="started"`, "info"},
+		{"slog debug", `time=2026-08-25T20:52:51.539Z level=DEBUG msg="dialing"`, "debug"},
+
+		// A level is only a level when it is its own field.
+		{"level inside a quoted message", `time=1 level=INFO msg="set level=ERROR on the thing"`, "info"},
+
+		// Nothing recognisable: the caller decides what to do with that.
+		{"unstructured", "something fell over", ""},
+		{"empty", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pluginLevel(tc.output); got != tc.want {
+				t.Fatalf("pluginLevel(%q) = %q, want %q", tc.output, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/metastructure/plugin_process_supervisor/plugin_process_supervisor.go
+++ b/internal/metastructure/plugin_process_supervisor/plugin_process_supervisor.go
@@ -164,40 +164,76 @@ func (p *PluginProcessSupervisor) getPluginName(namespace string) string {
 	return namespace
 }
 
-// logPluginOutput parses Ergo's log format and logs with appropriate level
-// Format: "timestamp [level] rest_of_message" e.g. "1764458575429677244 [info] <79F4473F.0.1004>: message"
-var pluginLogRegex = regexp.MustCompile(`^\d+\s+\[(trace|debug|info|warning|error)\]\s+(.*)$`)
+// Plugins do not agree on a log format, so two are recognised.
+//
+// Ergo's runtime writes "timestamp [level] rest_of_message", e.g.
+// "1764458575429677244 [info] <79F4473F.0.1004>: message". Anything built on
+// log/slog writes logfmt with an uppercase level, e.g.
+// `time=... level=WARN msg="rejected credential"`, which is what the auth
+// plugins emit. Reading only the first left every slog line unclassified.
+var (
+	pluginLogRegex = regexp.MustCompile(`^\d+\s+\[(trace|debug|info|warning|error)\]\s+(.*)$`)
+	// The level must start a token, so one quoted inside a message is not
+	// mistaken for the line's own.
+	pluginLogfmtLevelRegex = regexp.MustCompile(`(?:^|\s)level=([A-Za-z]+)`)
+)
+
+// pluginLevel reports the level a plugin gave one of its own log lines,
+// normalised to the names Log() uses, or "" when the line names none.
+func pluginLevel(output string) string {
+	if matches := pluginLogRegex.FindStringSubmatch(output); matches != nil {
+		return matches[1]
+	}
+	if matches := pluginLogfmtLevelRegex.FindStringSubmatch(output); matches != nil {
+		switch strings.ToLower(matches[1]) {
+		case "trace":
+			return "trace"
+		case "debug":
+			return "debug"
+		case "info":
+			return "info"
+		case "warn", "warning":
+			return "warning"
+		case "error":
+			return "error"
+		}
+	}
+	return ""
+}
+
+// logAtPluginLevel reports a plugin's line at the level the plugin chose,
+// deferring to fallback when it named none.
+//
+// The message travels as an argument, never as the format string: it is text
+// the plugin wrote, and a stray verb in it would garble the line.
+func (p *PluginProcessSupervisor) logAtPluginLevel(level, message string, fallback func(string, ...any)) {
+	switch level {
+	case "trace":
+		p.Log().Trace("%s", message)
+	case "debug":
+		p.Log().Debug("%s", message)
+	case "info":
+		p.Log().Info("%s", message)
+	case "warning":
+		p.Log().Warning("%s", message)
+	case "error":
+		p.Log().Error("%s", message)
+	default:
+		fallback("%s", message)
+	}
+}
 
 func (p *PluginProcessSupervisor) logPluginOutput(pluginName, output string) {
 	if output == "" {
 		return
 	}
 
-	matches := pluginLogRegex.FindStringSubmatch(output)
-	if matches == nil {
-		// No level found, log as info
-		p.Log().Info("[%s] %s", pluginName, output)
-		return
+	message := output
+	if matches := pluginLogRegex.FindStringSubmatch(output); matches != nil {
+		message = matches[2]
 	}
 
-	level := matches[1]
-	message := matches[2]
-	formattedMsg := fmt.Sprintf("[%s] %s", pluginName, message)
-
-	switch level {
-	case "trace":
-		p.Log().Trace(formattedMsg)
-	case "debug":
-		p.Log().Debug(formattedMsg)
-	case "info":
-		p.Log().Info(formattedMsg)
-	case "warning":
-		p.Log().Warning(formattedMsg)
-	case "error":
-		p.Log().Error(formattedMsg)
-	default:
-		p.Log().Info(formattedMsg)
-	}
+	p.logAtPluginLevel(pluginLevel(output), fmt.Sprintf("[%s] %s", pluginName, message), p.Log().Info)
 }
 
 func (p *PluginProcessSupervisor) HandleMessage(from gen.PID, message any) error {
@@ -244,8 +280,20 @@ func (p *PluginProcessSupervisor) HandleMessage(from gen.PID, message any) error
 		}
 
 	case meta.MessagePortError:
-		// Plugin error output
-		p.Log().Error("Plugin error tag=%s: %v", msg.Tag, msg.Error)
+		// The port is named for the channel, not the severity: a plugin's whole
+		// log stream arrives here at whatever level its author chose. Reporting
+		// all of it at Error made an ordinary rejected credential
+		// indistinguishable from a fault, and an installation's "error logs
+		// occurring" alert fired on a mistyped password.
+		//
+		// A line naming no level stays at Error: on the error port, assuming
+		// the worst is the right default. The wording is unchanged because it
+		// names the port, and operators filter alert queries on it.
+		p.logAtPluginLevel(
+			pluginLevel(fmt.Sprint(msg.Error)),
+			fmt.Sprintf("Plugin error tag=%s: %v", msg.Tag, msg.Error),
+			p.Log().Error,
+		)
 
 	case meta.MessagePortTerminate:
 		switch {


### PR DESCRIPTION
## Summary

A plugin's entire log stream arrives on its error port, at whatever level the plugin assigned. The supervisor logged all of it at `Error`. The visible consequence: the oidc plugin emits `level=WARN msg="rejected credential"` for an ordinary bad credential, the agent recorded that as an ERROR, and the installation `error logs occurring` alert fired. One unauthenticated request is enough to trip it.

An alert that reports a mistyped password as an error is one operators learn to ignore, which costs us the signal it exists to carry.

Two defects, not one:

- `meta.MessagePortError` bypassed the level dispatch that already existed for text and data output.
- That dispatch would not have helped: `pluginLogRegex` only matched Ergo's `<nanos> [level] rest` format. Anything built on `log/slog` emits logfmt with an uppercase level, so every line the auth plugins write was unclassified.

Both formats are now recognised by a small `pluginLevel` helper, and the error port dispatches through the same path. A line that names no level still logs at `Error` — on the error port that is the right default. The logfmt match requires the level to start a token, so one quoted inside a message is not mistaken for the line's own.

The message wording is deliberately unchanged: it names the port rather than the severity, and operators filter alert queries on message text.

Also fixes a latent issue in the same function: plugin-written text was passed as a format string, so a stray verb in plugin output garbled the line.