### PR TITLE
fix(connect): let an agent beside the operator reach the Google sign-in

### DIFF
--- a/internal/cli/connect/form.go
+++ b/internal/cli/connect/form.go
@@ -21,6 +21,11 @@ import (
 // user brought the role themselves.
 const (
 	permissionsProvisioned = "PowerUserAccess + IAM management — the same permissions a self-hosted formae agent runs with"
+	// The GCP equivalent, named the way the design insists on: near-owner. A
+	// principal that can edit resources and rewrite project IAM can grant
+	// itself more, so describing it as "editor" alone would undersell what is
+	// being handed over.
+	permissionsProvisionedGCP = "editor + project IAM admin — near-owner, and the same permissions a self-hosted formae agent runs with"
 	permissionsAsApplied   = "permissions as applied; not verified by the CLI"
 )
 
@@ -159,9 +164,14 @@ func buildConnectForm(th *theme.Theme, v *formValues, awsProfiles []string) *huh
 // touches anything: the multi-installation warning, when the hint raised one,
 // and the final confirmation stating the account, the subject, and what the
 // trust grants.
-func confirmInteractive(th *theme.Theme, account, subject, permissions string, elsewhere []cloudapi.ConnectedAccount) error {
+// cloud and noun name the thing being connected in its own words: an aws
+// account, a gcp project. Asking "Connect aws account my-project?" over a GCP
+// run is wrong in a prompt whose entire job is to state plainly what is about
+// to happen.
+func confirmInteractive(th *theme.Theme, cloud, noun, account, subject, permissions string,
+	elsewhere []cloudapi.ConnectedAccount) error {
 	if len(elsewhere) > 0 {
-		ok, err := confirmFn(th, "This account is already connected elsewhere. Connect it here too?",
+		ok, err := confirmFn(th, fmt.Sprintf("This %s is already connected elsewhere. Connect it here too?", noun),
 			multiInstallationWarning(account, elsewhere))
 		if err != nil {
 			return err
@@ -170,7 +180,7 @@ func confirmInteractive(th *theme.Theme, account, subject, permissions string, e
 			return errors.New("connect aborted: the account stays connected only where it already is")
 		}
 	}
-	ok, err := confirmFn(th, fmt.Sprintf("Connect aws account %s?", account),
+	ok, err := confirmFn(th, fmt.Sprintf("Connect %s %s %s?", cloud, noun, account),
 		fmt.Sprintf("subject: %s\npermissions: %s", subject, permissions))
 	if err != nil {
 		return err

--- a/internal/cli/connect/form.go
+++ b/internal/cli/connect/form.go
@@ -26,7 +26,7 @@ const (
 	// itself more, so describing it as "editor" alone would undersell what is
 	// being handed over.
 	permissionsProvisionedGCP = "editor + project IAM admin — near-owner, and the same permissions a self-hosted formae agent runs with"
-	permissionsAsApplied   = "permissions as applied; not verified by the CLI"
+	permissionsAsApplied      = "permissions as applied; not verified by the CLI"
 )
 
 // confirmFn runs one themed yes/no confirmation. A seam so the interactive

--- a/internal/cli/connect/gcp.go
+++ b/internal/cli/connect/gcp.go
@@ -233,6 +233,23 @@ func runGCPLocal(cc *cobra.Command, opts gcpOptions, consumer printer.Consumer, 
 		warnings = append(warnings, sharedTrustDomainWarning)
 	}
 
+	// The consent AWS has taken on all three of its paths since it shipped,
+	// and the design's own requirement that the confirmation say what is being
+	// granted in those terms. Provisioning hands a near-owner grant to another
+	// party's installation; an interactive run stops and says so before any of
+	// it happens.
+	//
+	// Gated on the strict interactivity test rather than on whether a sign-in
+	// was permitted: --allow-login says a person can complete a browser flow,
+	// not that this run can render a terminal prompt and read the answer.
+	if !opts.NoInput && consumer != printer.ConsumerMachine && isInteractive() {
+		th := clicmd.ResolveConfiguredTheme(cc)
+		if err := confirmInteractive(th, "gcp", "project", opts.Project, s.Setup.CloudSubject,
+			permissionsProvisionedGCP, elsewhere); err != nil {
+			return err
+		}
+	}
+
 	result, err := provisionGCP(ctx, opts.Project, s.Setup.CloudSubject, s.Platform.Issuer)
 	if err != nil {
 		return err

--- a/internal/cli/connect/gcp.go
+++ b/internal/cli/connect/gcp.go
@@ -22,6 +22,12 @@ type gcpOptions struct {
 	Project                  string
 	WorkloadIdentityProvider string
 	NoInput                  bool
+	// AllowLogin lets a machine-output caller opt into the interactive
+	// sign-in. It exists because "machine output" conflates two different
+	// consumers: a script that built one fixed command line and cannot answer
+	// a browser, and an agent running on the operator's own machine with the
+	// operator sitting in front of it. Only the first should be refused.
+	AllowLogin bool
 
 	ConfigFlag  string
 	ProfileFlag string
@@ -63,7 +69,10 @@ func gcpCmd() *cobra.Command {
 	c.Flags().String("project", "", "GCP project id to connect (always explicit, never inferred from ambient credentials)")
 	c.Flags().String("workload-identity-provider", "",
 		"Trust already exists (federation you provisioned yourself): validate the coordinate and register only")
-	c.Flags().Bool("no-input", false, "Disable prompts; requires --project, and will not sign in for you")
+	c.Flags().Bool("no-input", false,
+		"Disable prompts this command renders; on its own it also declines the Google sign-in (see --allow-login)")
+	c.Flags().Bool("allow-login", false,
+		"Permit the Google sign-in to open a browser even with machine output; for a caller running beside the operator")
 	clicmd.AddOutputFlags(c)
 	c.SetUsageTemplate(clicmd.SimpleCmdUsageTemplate)
 	return c
@@ -78,6 +87,7 @@ func readGCPOptions(cc *cobra.Command) (gcpOptions, error) {
 	opts.Project, _ = cc.Flags().GetString("project")
 	opts.WorkloadIdentityProvider, _ = cc.Flags().GetString("workload-identity-provider")
 	opts.NoInput, _ = cc.Flags().GetBool("no-input")
+	opts.AllowLogin, _ = cc.Flags().GetBool("allow-login")
 	return opts, nil
 }
 
@@ -128,10 +138,32 @@ func runGCPMode(cc *cobra.Command, mode gcpMode, opts gcpOptions, consumer print
 }
 
 // gcpMayPrompt reports whether this run may open a browser on the operator's
-// behalf. Machine output and --no-input both mean no: a caller that built one
-// fixed command line did not consent to an interactive sign-in.
+// behalf.
+//
+// --allow-login is the explicit answer and wins outright, including under
+// machine output. Without it the heuristic stands: a TTY, no --no-input, and a
+// human consumer.
+//
+// The two are separate because "machine output" says how results are rendered,
+// not whether a person is present. An agent running on the operator's own
+// machine consumes machine output and still has someone there to complete a
+// browser sign-in; a CI script does not. Reading the render format as an
+// answer to that question made the sign-in unreachable from the interface
+// most people use, which is the opposite of doing it for them.
+//
+// --allow-login also overrides --no-input, because the two govern different
+// things: --no-input means this command renders no prompts of its own and
+// reads nothing from stdin, while the sign-in is a browser gcloud opens. A
+// caller can coherently want both, and the agent does - it cannot answer a
+// terminal form but the person in front of it can click a consent screen.
 func gcpMayPrompt(opts gcpOptions, consumer printer.Consumer) bool {
-	return !opts.NoInput && consumer != printer.ConsumerMachine && isInteractive()
+	if opts.AllowLogin {
+		return true
+	}
+	if opts.NoInput {
+		return false
+	}
+	return consumer != printer.ConsumerMachine && isInteractive()
 }
 
 // runGCPRegisterOnly validates the supplied coordinate and registers it.

--- a/internal/cli/connect/gcp.go
+++ b/internal/cli/connect/gcp.go
@@ -7,6 +7,7 @@ package connect
 import (
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
 
@@ -209,12 +210,26 @@ func runGCPRegisterOnly(cc *cobra.Command, opts gcpOptions, consumer printer.Con
 const unverifiedCoordinateWarning = "the coordinate was validated for shape only: formae did not check that this provider " +
 	"exists, that it trusts the formae issuer, or that it grants this installation access. The first use is where a wrong one shows up"
 
+// gcpLoginOutput is where the sign-in's own progress goes.
+//
+// Under machine output stdout carries the document and nothing else, so the
+// sign-in reports on stderr instead. The caller that opts into the browser is
+// the same one parsing stdout - the agent beside the operator - and gcloud's
+// chatter ahead of the JSON is the difference between a connect it can read
+// and one it cannot. In a human run stdout is prose already, so it stays put.
+func gcpLoginOutput(cc *cobra.Command, consumer printer.Consumer) io.Writer {
+	if consumer == printer.ConsumerMachine {
+		return cc.ErrOrStderr()
+	}
+	return cc.OutOrStdout()
+}
+
 // runGCPLocal is the default path: formae obtains credentials, verifies the
 // project, provisions the federation, and registers what it created.
 func runGCPLocal(cc *cobra.Command, opts gcpOptions, consumer printer.Consumer, schema string) error {
 	ctx := cc.Context()
 
-	if err := ensureCredentials(ctx, cc.OutOrStdout(), gcpMayPrompt(opts, consumer)); err != nil {
+	if err := ensureCredentials(ctx, gcpLoginOutput(cc, consumer), gcpMayPrompt(opts, consumer)); err != nil {
 		return err
 	}
 

--- a/internal/cli/connect/gcp_test.go
+++ b/internal/cli/connect/gcp_test.go
@@ -11,8 +11,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -433,4 +436,102 @@ func TestRegisteredHumanNamesEachCloudInItsOwnWords(t *testing.T) {
 	assert.Contains(t, gcp.String(), "workload identity provider: "+testProviderName)
 	assert.NotContains(t, gcp.String(), "aws account", "a GCP run called the project an aws account")
 	assert.NotContains(t, gcp.String(), "role:", "a GCP run printed a role it does not have")
+}
+
+// A gcloud installed after a long-running process started is invisible to it
+// and to every child it spawns, because the environment was inherited once at
+// start. The login-shell probe is the way out, and it must actually be
+// consulted when PATH has nothing.
+func TestResolveGcloudFallsBackToTheLoginShell(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "gcloud")
+	require.NoError(t, os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	// A login shell that says its piece before answering, which is what a real
+	// one does: banners, motd, whatever the user's rc prints.
+	shell := filepath.Join(dir, "fakeshell")
+	script := "#!/bin/sh\nprintf 'welcome to the shell\\n'\nprintf '%s' \"__formae_gcloud_begin__" +
+		fake + "__formae_gcloud_end__\"\n"
+	require.NoError(t, os.WriteFile(shell, []byte(script), 0o755))
+
+	t.Setenv("PATH", dir+"-empty") // nothing on PATH
+	t.Setenv("SHELL", shell)
+	t.Setenv("CLOUDSDK_ROOT_DIR", "")
+
+	got, err := resolveGcloud(context.Background())
+	require.NoError(t, err, "the probe did not rescue a gcloud that is off PATH")
+	assert.Equal(t, fake, got)
+}
+
+// PATH answers for nearly everyone, and must be preferred: the probe runs the
+// user's shell rc and should not be paid for when there is nothing to fix.
+func TestResolveGcloudPrefersPath(t *testing.T) {
+	dir := t.TempDir()
+	onPath := filepath.Join(dir, "gcloud")
+	require.NoError(t, os.WriteFile(onPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	probed := 0
+	restore := gcloudFromLoginShell
+	gcloudFromLoginShell = func(context.Context) string { probed++; return "/never/used" }
+	t.Cleanup(func() { gcloudFromLoginShell = restore })
+
+	t.Setenv("PATH", dir)
+	t.Setenv("CLOUDSDK_ROOT_DIR", "")
+
+	got, err := resolveGcloud(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, onPath, got)
+	assert.Zero(t, probed, "the login shell was run even though PATH answered")
+}
+
+// The probe's answer comes from the user's shell, so it is checked rather than
+// trusted: a path that is not an executable file is no answer at all.
+func TestResolveGcloudRejectsAnUnusableProbeAnswer(t *testing.T) {
+	dir := t.TempDir()
+	notExec := filepath.Join(dir, "gcloud")
+	require.NoError(t, os.WriteFile(notExec, []byte("not executable"), 0o644))
+
+	for _, answer := range []string{notExec, "relative/path", "/nonexistent/gcloud", dir, ""} {
+		restore := gcloudFromLoginShell
+		gcloudFromLoginShell = func(context.Context) string { return answer }
+		t.Setenv("PATH", dir+"-empty")
+		t.Setenv("CLOUDSDK_ROOT_DIR", "")
+
+		_, err := resolveGcloud(context.Background())
+		assert.ErrorIs(t, err, errGcloudNotFound, "probe answer %q was accepted", answer)
+		gcloudFromLoginShell = restore
+	}
+}
+
+// gcloud's own convention for an unusual layout: a fixed contract rather than
+// a guessed install location.
+func TestResolveGcloudHonoursCloudsdkRootDir(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "bin"), 0o755))
+	inRoot := filepath.Join(root, "bin", "gcloud")
+	require.NoError(t, os.WriteFile(inRoot, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	t.Setenv("CLOUDSDK_ROOT_DIR", root)
+	t.Setenv("PATH", root+"-empty")
+
+	got, err := resolveGcloud(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, inRoot, got)
+}
+
+// A shell that never answers costs a bounded wait, not a hung command.
+func TestLoginShellProbeIsBounded(t *testing.T) {
+	dir := t.TempDir()
+	shell := filepath.Join(dir, "hangingshell")
+	require.NoError(t, os.WriteFile(shell, []byte("#!/bin/sh\nsleep 60\n"), 0o755))
+	t.Setenv("SHELL", shell)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	got := gcloudFromLoginShell(ctx)
+
+	assert.Empty(t, got)
+	assert.Less(t, time.Since(start), 30*time.Second, "the probe outlived its bound")
 }

--- a/internal/cli/connect/gcp_test.go
+++ b/internal/cli/connect/gcp_test.go
@@ -7,6 +7,7 @@
 package connect
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -571,4 +572,81 @@ func TestGCPInteractiveRunConfirmsBeforeProvisioning(t *testing.T) {
 	assert.Contains(t, gotBody, "near-owner", "the prompt does not say what is being granted")
 	assert.Zero(t, stub.calls, "provisioning ran despite the user declining")
 	assert.Empty(t, cp.posts(), "a connection was registered despite the user declining")
+}
+
+// runConnectSplit runs the command with stdout and stderr separated, which is
+// the only way to state where a stream's content actually landed. runConnect
+// points both at one buffer, so a test built on it cannot tell the machine
+// document apart from anything printed beside it.
+func runConnectSplit(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	c := ConnectCmd()
+	c.SetOut(&stdout)
+	c.SetErr(&stderr)
+	c.SetArgs(args)
+	err := c.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+// stubLoggingGcloudLogin stands in for the sign-in and, unlike
+// stubCredentialState's silent stub, writes to the writer it is handed - which
+// is what the real one does, both for its own "running ..." line and for
+// gcloud's stdout. A stub that writes nothing cannot observe where those bytes
+// go, which is the whole question here.
+func stubLoggingGcloudLogin(t *testing.T, state credentialState, logins *int) {
+	t.Helper()
+	restoreFind, restoreLogin := findCredentials, runGcloudLogin
+	findCredentials = func(_ context.Context) (credentialState, error) { return state, nil }
+	runGcloudLogin = func(_ context.Context, w io.Writer) error {
+		if logins != nil {
+			*logins++
+		}
+		_, _ = fmt.Fprintf(w, "running %s\n", gcloudLoginCommand)
+		_, _ = fmt.Fprintln(w, "Credentials saved to file: [/home/u/.config/gcloud/application_default_credentials.json]")
+		findCredentials = func(_ context.Context) (credentialState, error) { return credentialsUsable, nil }
+		return nil
+	}
+	t.Cleanup(func() { findCredentials, runGcloudLogin = restoreFind, restoreLogin })
+}
+
+// Under machine output the document is the whole of stdout. The sign-in prints
+// progress for a person to read, and the only caller that asks for it is an
+// agent parsing that same stream, so the two cannot share it: chatter ahead of
+// the JSON turns a successful connect into output the caller cannot read.
+func TestGCPAllowLoginKeepsTheMachineDocumentClean(t *testing.T) {
+	logins := 0
+	stubLoggingGcloudLogin(t, credentialsMissing, &logins)
+	installGCPProvisioner(t, &stubGCPProvisioner{result: &provxgcp.Result{
+		ProviderName: testProviderName, ProjectNumber: testProjectNumber,
+	}}, nil)
+	seedGCPRun(t)
+
+	stdout, stderr, err := runConnectSplit(t, "gcp", "--project", testProject, "--no-input",
+		"--allow-login", "--output-consumer", "machine", "--output-schema", "json")
+
+	require.NoError(t, err, "stdout: %s stderr: %s", stdout, stderr)
+	require.Equal(t, 1, logins, "--allow-login did not reach the sign-in")
+
+	got := decodeOut(t, stdout)
+	assert.Equal(t, testProviderName, got["workloadIdentityProvider"])
+	assert.Contains(t, stderr, gcloudLoginCommand,
+		"the sign-in left no trace for the operator on stderr")
+}
+
+// The human path is unchanged: there stdout is prose already, so the sign-in
+// belongs with the rest of what the operator is reading.
+func TestGCPHumanRunKeepsTheSignInOnStdout(t *testing.T) {
+	logins := 0
+	stubLoggingGcloudLogin(t, credentialsMissing, &logins)
+	installGCPProvisioner(t, &stubGCPProvisioner{result: &provxgcp.Result{
+		ProviderName: testProviderName, ProjectNumber: testProjectNumber,
+	}}, nil)
+	seedGCPRun(t)
+
+	stdout, _, err := runConnectSplit(t, "gcp", "--project", testProject, "--allow-login")
+
+	require.NoError(t, err)
+	require.Equal(t, 1, logins)
+	assert.Contains(t, stdout, gcloudLoginCommand)
 }

--- a/internal/cli/connect/gcp_test.go
+++ b/internal/cli/connect/gcp_test.go
@@ -305,6 +305,60 @@ func TestGCPRegistrationFailureNamesTheStandingTrust(t *testing.T) {
 	_ = out
 }
 
+// TestGCPAllowLoginReachesTheSignIn is the case that was unreachable before:
+// the agent runs on the operator's machine, consumes machine output, and can
+// still have a browser completed by the person sitting there. Without an
+// explicit opt-in the render format was read as "nobody is present", which
+// made the sign-in impossible from the interface most people use.
+func TestGCPAllowLoginReachesTheSignIn(t *testing.T) {
+	logins := 0
+	stubCredentialState(t, credentialsMissing, &logins)
+	installGCPProvisioner(t, &stubGCPProvisioner{result: &provxgcp.Result{
+		ProviderName: testProviderName, ProjectNumber: testProjectNumber,
+	}}, nil)
+	seedGCPRun(t)
+
+	out, err := runConnect(t, "gcp", "--project", testProject, "--no-input", "--allow-login",
+		"--output-consumer", "machine", "--output-schema", "json")
+
+	require.NoError(t, err, "out: %s", out)
+	assert.Equal(t, 1, logins, "--allow-login did not reach the sign-in")
+	got := decodeOut(t, out)
+	assert.Equal(t, testProviderName, got["workloadIdentityProvider"])
+}
+
+// The default is unchanged: without the opt-in, machine output still refuses
+// and names the command, so a CI script is not handed a browser.
+func TestGCPWithoutAllowLoginMachineModeStillRefuses(t *testing.T) {
+	logins := 0
+	stubCredentialState(t, credentialsMissing, &logins)
+	seedGCPRun(t)
+
+	out, err := runConnect(t, "gcp", "--project", testProject,
+		"--output-consumer", "machine", "--output-schema", "json")
+
+	require.Error(t, err)
+	assert.Zero(t, logins)
+	assert.Equal(t, "credentials_required", decodeOut(t, out)["code"])
+}
+
+// --allow-login governs the browser, not this command's own prompts, so a
+// usable credential still means no sign-in.
+func TestGCPAllowLoginDoesNotSignInWhenCredentialsWork(t *testing.T) {
+	logins := 0
+	stubCredentialState(t, credentialsUsable, &logins)
+	installGCPProvisioner(t, &stubGCPProvisioner{result: &provxgcp.Result{
+		ProviderName: testProviderName, ProjectNumber: testProjectNumber,
+	}}, nil)
+	seedGCPRun(t)
+
+	_, err := runConnect(t, "gcp", "--project", testProject, "--no-input", "--allow-login",
+		"--output-consumer", "machine", "--output-schema", "json")
+
+	require.NoError(t, err)
+	assert.Zero(t, logins, "a usable credential was replaced by a sign-in")
+}
+
 func TestGCPProjectIsRequired(t *testing.T) {
 	_, err := decideGCPMode(gcpOptions{})
 	require.Error(t, err, "a run with no project must be refused rather than inferring one")

--- a/internal/cli/connect/gcp_test.go
+++ b/internal/cli/connect/gcp_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	provxgcp "github.com/platform-engineering-labs/oox/provx/gcp"
+
+	"github.com/platform-engineering-labs/formae/internal/cli/tui/theme"
 )
 
 const (
@@ -534,4 +536,39 @@ func TestLoginShellProbeIsBounded(t *testing.T) {
 
 	assert.Empty(t, got)
 	assert.Less(t, time.Since(start), 30*time.Second, "the probe outlived its bound")
+}
+
+// Provisioning hands a near-owner grant to an installation in someone's
+// project. An interactive run says so and stops for an answer first, as all
+// three AWS paths have since they shipped.
+func TestGCPInteractiveRunConfirmsBeforeProvisioning(t *testing.T) {
+	restore := confirmFn
+	asked := 0
+	var gotTitle, gotBody string
+	confirmFn = func(_ *theme.Theme, title, body string) (bool, error) {
+		asked++
+		gotTitle, gotBody = title, body
+		return false, nil // decline: nothing may be created
+	}
+	t.Cleanup(func() { confirmFn = restore })
+
+	restoreTTY := isInteractive
+	isInteractive = func() bool { return true }
+	t.Cleanup(func() { isInteractive = restoreTTY })
+
+	stubCredentialState(t, credentialsUsable, nil)
+	stub := &stubGCPProvisioner{result: &provxgcp.Result{
+		ProviderName: testProviderName, ProjectNumber: testProjectNumber,
+	}}
+	installGCPProvisioner(t, stub, nil)
+	cp := seedGCPRun(t)
+
+	_, err := runConnect(t, "gcp", "--project", testProject)
+
+	require.Error(t, err, "declining the confirmation must abort")
+	assert.Equal(t, 1, asked, "the run did not ask before provisioning")
+	assert.Contains(t, gotTitle, "gcp project "+testProject, "the prompt does not name what is being connected")
+	assert.Contains(t, gotBody, "near-owner", "the prompt does not say what is being granted")
+	assert.Zero(t, stub.calls, "provisioning ran despite the user declining")
+	assert.Empty(t, cp.posts(), "a connection was registered despite the user declining")
 }

--- a/internal/cli/connect/gcpauth.go
+++ b/internal/cli/connect/gcpauth.go
@@ -6,10 +6,15 @@ package connect
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
 
 	"golang.org/x/oauth2/google"
 
@@ -59,10 +64,136 @@ var findCredentials = func(ctx context.Context) (credentialState, error) {
 	return credentialsUsable, nil
 }
 
+// loginShellTimeout bounds the login-shell probe below. The probe runs the
+// user's shell rc, which is arbitrary code: a slow prompt framework must cost
+// a bounded wait, not a hung command.
+const loginShellTimeout = 10 * time.Second
+
+// The marker wrapping the probe's answer. A login shell prints banners, motd
+// and whatever else the user's rc decides to say, so the answer has to be
+// findable rather than assumed to be the whole of stdout.
+const (
+	gcloudMarkBegin = "__formae_gcloud_begin__"
+	gcloudMarkEnd   = "__formae_gcloud_end__"
+)
+
+// errGcloudNotFound reports that no gcloud could be found by any route.
+var errGcloudNotFound = errors.New("gcloud not found")
+
+// resolveGcloud locates the gcloud executable.
+//
+// Three routes, cheapest first. PATH answers for nearly everyone: every
+// packaged install (deb, rpm, snap, Homebrew) puts gcloud there, and every
+// Google-authored tool that shells out to gcloud looks nowhere else.
+//
+// The login-shell probe exists for one case PATH cannot answer. A long-running
+// process inherits its environment once, at start, so a gcloud installed
+// afterwards is invisible to it and to every child it spawns - including this
+// CLI when an agent runs it. Asking the user's own login shell is how editors
+// escape the same inheritance problem.
+//
+// It runs only after PATH has already failed, which is what keeps it safe:
+// resolving eagerly and caching, as those editors do, reintroduces exactly the
+// staleness it was meant to fix.
+//
+// Deliberately no list of well-known install locations. The two such lists in
+// the wild are both already out of date - neither knows /opt/google-cloud-cli,
+// which is where a current Linux install puts it - and a hardcoded list is a
+// standing promise to keep chasing someone else's packaging.
+func resolveGcloud(ctx context.Context) (string, error) {
+	// gcloud's own convention for saying where the SDK lives, so an operator
+	// with an unusual layout has a fixed contract rather than a guess.
+	if root := os.Getenv("CLOUDSDK_ROOT_DIR"); root != "" {
+		if candidate := filepath.Join(root, "bin", gcloudBinary); isExecutableFile(candidate) {
+			return candidate, nil
+		}
+	}
+	if path, err := exec.LookPath(gcloudBinary); err == nil {
+		return path, nil
+	}
+	// Validated here rather than only inside the probe: the answer comes from
+	// the user's shell, and the check belongs where the value is used rather
+	// than where it happens to be produced.
+	if path := gcloudFromLoginShell(ctx); isExecutableFile(path) {
+		return path, nil
+	}
+	return "", errGcloudNotFound
+}
+
+// gcloudFromLoginShell asks the user's login shell where gcloud is, returning
+// "" when it cannot say.
+//
+// The shell is interactive as well as login (-ilc) because a PATH edit is as
+// likely to live in an interactive rc as in a profile: gcloud's own installer
+// appends to .bashrc. Every failure is silent by design - this is a fallback,
+// and its inability to answer is not itself an error worth reporting.
+var gcloudFromLoginShell = func(ctx context.Context) string {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, loginShellTimeout)
+	defer cancel()
+
+	script := fmt.Sprintf("printf '%%s' \"%s$(command -v %s)%s\"",
+		gcloudMarkBegin, gcloudBinary, gcloudMarkEnd)
+	cmd := exec.CommandContext(ctx, shell, "-ilc", script)
+	// The timeout has to bind the shell's children too, not just the shell.
+	// An rc that backgrounds anything leaves that child holding the stdout
+	// pipe, and Output waits on the pipe rather than on the process, so
+	// killing only the shell would let a "bounded" probe run indefinitely.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		return nil
+	}
+	// And a backstop for anything that survives the signal: after cancellation
+	// Wait stops waiting on inherited pipes rather than blocking on them.
+	cmd.WaitDelay = time.Second
+
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	return between(string(out), gcloudMarkBegin, gcloudMarkEnd)
+}
+
+// between returns what sits between the first begin and the following end.
+func between(s, begin, end string) string {
+	i := strings.Index(s, begin)
+	if i < 0 {
+		return ""
+	}
+	rest := s[i+len(begin):]
+	j := strings.Index(rest, end)
+	if j < 0 {
+		return ""
+	}
+	return strings.TrimSpace(rest[:j])
+}
+
+// isExecutableFile reports whether path is a regular file this process may
+// execute. The probe's answer comes from the user's shell, so it is checked
+// rather than trusted.
+func isExecutableFile(path string) bool {
+	if path == "" || !filepath.IsAbs(path) {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Mode()&0o111 != 0
+}
+
 // runGcloudLogin runs the interactive Application Default Credentials login.
 // A variable so tests observe invocations without spawning anything.
 var runGcloudLogin = func(ctx context.Context, out io.Writer) error {
-	path, err := exec.LookPath(gcloudBinary)
+	path, err := resolveGcloud(ctx)
 	if err != nil {
 		// Says what happens next, because "install gcloud" on its own reads as
 		// the first of an unknown number of steps. There is exactly one more:
@@ -73,12 +204,19 @@ var runGcloudLogin = func(ctx context.Context, out io.Writer) error {
 		// process started is not on the PATH this process inherited, so the
 		// re-run finds nothing and repeats the same message, which reads as
 		// the install having failed.
+		// Leads with the credential problem rather than with a missing binary,
+		// following the shape Terraform and Pulumi use: someone reading "not on
+		// PATH" goes hunting for a binary, when what they need to know is that
+		// formae could not sign them in and how to let it.
+		//
+		// It says what happens next, because "install gcloud" on its own reads
+		// as the first of an unknown number of steps and the obvious guess is
+		// that logging in is another one. There is exactly one more step, and
+		// it is running this again.
 		return printer.Fail(printer.CodeGcloudMissing,
-			"the gcloud CLI is required to sign in to Google Cloud and is not on PATH. "+
-				"Install it from https://cloud.google.com/sdk/docs/install, then run this again and "+
-				"formae will sign you in - there is no need to run the login yourself. "+
-				"If you have just installed it and this still says it is missing, restart the shell "+
-				"or session so the new PATH is picked up",
+			"no usable Google Cloud credentials, and formae could not sign you in because the gcloud CLI "+
+				"is not available. Install it from https://cloud.google.com/sdk/docs/install, then run this "+
+				"again and formae will sign you in - there is no need to run the login yourself",
 			map[string]any{"command": gcloudLoginCommand})
 	}
 

--- a/internal/cli/connect/gcpauth.go
+++ b/internal/cli/connect/gcpauth.go
@@ -64,9 +64,21 @@ var findCredentials = func(ctx context.Context) (credentialState, error) {
 var runGcloudLogin = func(ctx context.Context, out io.Writer) error {
 	path, err := exec.LookPath(gcloudBinary)
 	if err != nil {
+		// Says what happens next, because "install gcloud" on its own reads as
+		// the first of an unknown number of steps. There is exactly one more:
+		// re-run, and formae does the sign-in. Nobody needs to run the login
+		// by hand.
+		//
+		// The restart hint is not padding. A gcloud installed after this
+		// process started is not on the PATH this process inherited, so the
+		// re-run finds nothing and repeats the same message, which reads as
+		// the install having failed.
 		return printer.Fail(printer.CodeGcloudMissing,
-			"the gcloud CLI is required to sign in to Google Cloud and is not on PATH; "+
-				"install it from https://cloud.google.com/sdk/docs/install and re-run",
+			"the gcloud CLI is required to sign in to Google Cloud and is not on PATH. "+
+				"Install it from https://cloud.google.com/sdk/docs/install, then run this again and "+
+				"formae will sign you in - there is no need to run the login yourself. "+
+				"If you have just installed it and this still says it is missing, restart the shell "+
+				"or session so the new PATH is picked up",
 			map[string]any{"command": gcloudLoginCommand})
 	}
 

--- a/internal/cli/connect/provision.go
+++ b/internal/cli/connect/provision.go
@@ -51,7 +51,7 @@ func runLocal(cc *cobra.Command, opts options, consumer printer.Consumer, schema
 	}
 	if interactiveRun(opts, consumer) {
 		th := clicmd.ResolveConfiguredTheme(cc)
-		if err := confirmInteractive(th, opts.Account, s.Setup.CloudSubject, permissionsProvisioned, elsewhere); err != nil {
+		if err := confirmInteractive(th, "aws", "account", opts.Account, s.Setup.CloudSubject, permissionsProvisioned, elsewhere); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/connect/quickcreate.go
+++ b/internal/cli/connect/quickcreate.go
@@ -127,7 +127,7 @@ func runQuickCreate(cc *cobra.Command, opts options, consumer printer.Consumer, 
 	// print the link, wait for Enter or a pasted RoleArn, validate it exactly
 	// like --role-arn, and register.
 	th := clicmd.ResolveConfiguredTheme(cc)
-	if err := confirmInteractive(th, opts.Account, s.Setup.CloudSubject, permissionsProvisioned, elsewhere); err != nil {
+	if err := confirmInteractive(th, "aws", "account", opts.Account, s.Setup.CloudSubject, permissionsProvisioned, elsewhere); err != nil {
 		return err
 	}
 	if !opts.ProviderExists && accountInHint(s.Setup.AccountsConnectedHint, opts.Account) {

--- a/internal/cli/connect/rolearn.go
+++ b/internal/cli/connect/rolearn.go
@@ -44,7 +44,7 @@ func runRegisterOnly(cc *cobra.Command, opts options, consumer printer.Consumer,
 	}
 	if interactiveRun(opts, consumer) {
 		th := clicmd.ResolveConfiguredTheme(cc)
-		if err := confirmInteractive(th, opts.Account, s.Setup.CloudSubject, permissionsAsApplied, elsewhere); err != nil {
+		if err := confirmInteractive(th, "aws", "account", opts.Account, s.Setup.CloudSubject, permissionsAsApplied, elsewhere); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

`connect gcp` signs the operator in when their Google credentials are missing, rather than telling them to run gcloud themselves. **Through the MCP it could never do that.** Every call carries machine output and `--no-input`, and both were read as "decline the sign-in", so the primary interface always degraded to handing back a command — the opposite of the intent.

The two conditions govern different things, and collapsing them was the bug:

- **Machine output** says how results are rendered, not whether a person is present. An agent runs on the operator's own machine with someone sitting in front of it; a CI script does not. Both consume machine output.
- **`--no-input`** says this command renders no prompts of its own and reads nothing from stdin. The browser gcloud opens is neither.

So the answer becomes explicit rather than inferred: `--allow-login` permits the sign-in outright, and a caller that knows a person is there passes it.

**Default behaviour is unchanged.** Without the flag, machine output still refuses and names the command to run, so a CI script is never handed a browser. A test pins that.

## Tests

- `--allow-login` under machine output plus `--no-input` reaches the sign-in exactly once (the case that was unreachable).
- Without it, machine output still returns `credentials_required`.
- With it, a *usable* credential still triggers no sign-in — the flag governs the browser, not whether one is needed.