### PR TITLE
fix(patch): only strip writeOnly+createOnly fields lacking a stored baseline

### DIFF
--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -82,15 +82,25 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 		return nil, nil, fmt.Errorf("unable to generate patch document for apply mode: %s", mode)
 	}
 
-	// Strip fields that are both writeOnly AND createOnly from the desired
-	// state (patch) before comparison. writeOnly fields are never returned by
-	// the provider's Read, so they're always absent from the document. If the
-	// field is also createOnly, the "add" op that jsonpatch generates triggers
-	// a resource replacement even though nothing actually changed. Stripping
-	// them from the patch prevents phantom replacements on re-apply.
+	// Strip a field that is both writeOnly AND createOnly from the desired
+	// state (patch) before comparison, but only when the stored document holds
+	// no value for it. The provider's Read never returns writeOnly fields, so a
+	// document sourced from a Read alone (import, discovery) lacks them; the
+	// "add" op jsonpatch would generate for the declared value lands on a
+	// createOnly path and triggers a resource replacement even though nothing
+	// changed. When the document does hold a last-applied value, the ordinary
+	// comparison is the truth: an unchanged value converges to no op, and a
+	// changed value is a genuine createOnly change that must plan a
+	// replacement rather than be dropped.
 	writeOnlyCreateOnly := intersectFields(schema.WriteOnly(), schema.CreateOnly())
 	if len(writeOnlyCreateOnly) > 0 {
-		flattenedPatch, err = removeWriteOnlyFields(flattenedPatch, writeOnlyCreateOnly)
+		var withoutBaseline []string
+		for _, field := range writeOnlyCreateOnly {
+			if !gjson.GetBytes(flattenedDocument, field).Exists() {
+				withoutBaseline = append(withoutBaseline, field)
+			}
+		}
+		flattenedPatch, err = removeWriteOnlyFields(flattenedPatch, withoutBaseline)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to strip writeOnly+createOnly fields from desired state: %w", err)
 		}

--- a/internal/metastructure/patch/writeonly_createonly_baseline_test.go
+++ b/internal/metastructure/patch/writeonly_createonly_baseline_test.go
@@ -1,0 +1,70 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package patch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func writeOnlyCreateOnlySchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"ClusterName", "AccessConfig"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"AccessConfig": {WriteOnly: true, CreateOnly: true},
+		},
+	}
+}
+
+// A writeOnly+createOnly field whose last-applied value is in the stored
+// document, and whose desired value differs, is a genuine createOnly change:
+// it must surface in the createOnly patch so the plan declares a replacement,
+// not be silently dropped.
+func TestGeneratePatch_WriteOnlyCreateOnlyChanged_StoredBaseline_PlansReplacement(t *testing.T) {
+	document := []byte(`{
+		"ClusterName": "my-cluster",
+		"AccessConfig": {"AuthenticationMode": "API_AND_CONFIG_MAP"}
+	}`)
+	patch := []byte(`{
+		"ClusterName": "my-cluster",
+		"AccessConfig": {"AuthenticationMode": "API"}
+	}`)
+	props := resolver.NewResolvableProperties()
+
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, writeOnlyCreateOnlySchema(), pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	if len(patchDoc) > 0 {
+		assert.JSONEq(t, "[]", string(patchDoc), "a createOnly change belongs in the createOnly patch, not the update patch")
+	}
+	require.NotEmpty(t, createOnlyPatch, "a changed writeOnly+createOnly field with a stored baseline must plan a replacement")
+	assert.Contains(t, string(createOnlyPatch), "API", "the replacement patch must carry the new value")
+}
+
+// The same field with a stored baseline and an unchanged desired value plans
+// nothing: equality against the stored last-applied value converges without
+// any op or replacement.
+func TestGeneratePatch_WriteOnlyCreateOnlyUnchanged_StoredBaseline_NoOp(t *testing.T) {
+	document := []byte(`{
+		"ClusterName": "my-cluster",
+		"AccessConfig": {"AuthenticationMode": "API_AND_CONFIG_MAP"}
+	}`)
+	patch := []byte(`{
+		"ClusterName": "my-cluster",
+		"AccessConfig": {"AuthenticationMode": "API_AND_CONFIG_MAP"}
+	}`)
+	props := resolver.NewResolvableProperties()
+
+	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, writeOnlyCreateOnlySchema(), pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, createOnlyPatch, "an unchanged writeOnly+createOnly field must not plan a replacement")
+	assert.Nil(t, patchDoc, "an unchanged writeOnly+createOnly field must not plan any op")
+}


### PR DESCRIPTION
## Summary

- A field hinted both `writeOnly` and `createOnly` was stripped from the desired state unconditionally before patch comparison (introduced in 7d39a9cc to stop phantom replacements, #21). Since 69041eb3 split force-resend off `writeOnly`, stored rows retain the last-applied value for these fields, so the unconditional strip now discards real information: **a genuine change to such a field was silently dropped** — no op, no replacement, apply reported Success while the cloud kept the old value. 386 fields across the published plugin schemas carry both hints.
- The strip is still needed where it was invented: a stored document sourced from `Read` alone (import, discovery) never contains writeOnly fields, and the declared value would diff as an `add` op on a createOnly path, planning a phantom replacement.
- Fix: strip the desired-side value **only when the stored document holds no value at the field's path**. With a baseline present, the ordinary comparison decides — an unchanged value converges to no op, a changed value routes to the createOnly patch and plans a declared replacement.

The sync/drift path is unaffected: `DriftPatch` diffs old vs current cloud state (where the provider never returns these fields), and the merge keeps stored values on unobservable reads; the strip in `generatePatch` is the `WriteOnly` hint's only consumer.

Verified with new unit tests pinning both directions (changed-with-baseline plans a replacement; unchanged-with-baseline plans nothing), the pre-existing no-baseline test unchanged, and green runs of the `patch`, `resource_update`, `resolver`, and `apply_forma` workflow suites.