### PR TITLE
fix(resolver): plan-time references resolve against effective desired state

### DIFF
--- a/internal/metastructure/resolver/resolvable_properties.go
+++ b/internal/metastructure/resolver/resolvable_properties.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/platform-engineering-labs/formae/internal/metastructure/transformations"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/tidwall/gjson"
 )
@@ -103,6 +104,18 @@ func LoadResolvablePropertiesFromStacks(resource pkgmodel.Resource, allResources
 			return res, fmt.Errorf("resource with KSUID %s not found", ksuid)
 		}
 
+		if effDoc, declared := effective[ksuid]; declared {
+			effVal := gjson.GetBytes(effDoc, propertyPath)
+			if effVal.Exists() && !isReferenceEnvelope(effVal) && !containsHashedValue(effVal) &&
+				!sourcePropertyIsOpaque(targetResource, propertyPath) {
+				res.AddAnswer(ksuid, propertyPath, SourceAnswer{Kind: AnswerResolved, Value: ExtractPropertyValue(effVal)})
+				continue
+			}
+			// Reference envelopes, hashed shapes, and opaque sources fall through to
+			// the persisted-row path unchanged: envelopes keep the cached value,
+			// opaque and hashed sources keep today's deferral.
+		}
+
 		if value, ok := resolvableValueFrom(targetResource.ReadOnlyProperties, propertyPath); ok {
 			res.Add(ksuid, propertyPath, value)
 			continue
@@ -125,6 +138,18 @@ func LoadResolvablePropertiesFromStacks(resource pkgmodel.Resource, allResources
 	}
 
 	return res, nil
+}
+
+// sourcePropertyIsOpaque reports whether the source marks propertyPath opaque:
+// an at-rest hashed shape, a $visibility marker, or the schema/known-opaque
+// table. An opaque source's desired plaintext is never materialized into the
+// plan-time lookup.
+func sourcePropertyIsOpaque(source *pkgmodel.Resource, propertyPath string) bool {
+	persisted := gjson.GetBytes(source.Properties, propertyPath)
+	if containsHashedValue(persisted) || persisted.Get("$visibility").String() == "Opaque" {
+		return true
+	}
+	return transformations.OpaqueFields(source.Schema, source.Type)[propertyPath]
 }
 
 // resolvableValueFrom reads propertyPath out of one persisted property

--- a/internal/metastructure/resolver/resolvable_properties.go
+++ b/internal/metastructure/resolver/resolvable_properties.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/platform-engineering-labs/formae/internal/metastructure/transformations"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/tidwall/gjson"
 )
@@ -107,7 +106,7 @@ func LoadResolvablePropertiesFromStacks(resource pkgmodel.Resource, allResources
 		if effDoc, declared := effective[ksuid]; declared {
 			effVal := gjson.GetBytes(effDoc, propertyPath)
 			if effVal.Exists() && !isReferenceEnvelope(effVal) && !containsHashedValue(effVal) &&
-				!sourcePropertyIsOpaque(targetResource, propertyPath) {
+				!isSourcePropertyOpaque(targetResource, propertyPath) {
 				res.AddAnswer(ksuid, propertyPath, SourceAnswer{Kind: AnswerResolved, Value: ExtractPropertyValue(effVal)})
 				continue
 			}
@@ -138,18 +137,6 @@ func LoadResolvablePropertiesFromStacks(resource pkgmodel.Resource, allResources
 	}
 
 	return res, nil
-}
-
-// sourcePropertyIsOpaque reports whether the source marks propertyPath opaque:
-// an at-rest hashed shape, a $visibility marker, or the schema/known-opaque
-// table. An opaque source's desired plaintext is never materialized into the
-// plan-time lookup.
-func sourcePropertyIsOpaque(source *pkgmodel.Resource, propertyPath string) bool {
-	persisted := gjson.GetBytes(source.Properties, propertyPath)
-	if containsHashedValue(persisted) || persisted.Get("$visibility").String() == "Opaque" {
-		return true
-	}
-	return transformations.OpaqueFields(source.Schema, source.Type)[propertyPath]
 }
 
 // resolvableValueFrom reads propertyPath out of one persisted property

--- a/internal/metastructure/resolver/resolvable_properties.go
+++ b/internal/metastructure/resolver/resolvable_properties.go
@@ -13,35 +13,74 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-// ResolvableProperties is a map of KSUIDs to property names to values
+// AnswerKind classifies why a SourceAnswer's value may be trusted, or that it
+// carries none yet.
+type AnswerKind int
+
+const (
+	// AnswerResolved: the value is derivable at plan time from effective
+	// desired state (a literal this command declares).
+	AnswerResolved AnswerKind = iota
+	// AnswerStable: the persisted value is valid because nothing this
+	// command does moves the source property.
+	AnswerStable
+	// AnswerDeferred: not derivable at plan time; execution-time resolution
+	// through RemainingResolvables answers it.
+	AnswerDeferred
+)
+
+// SourceAnswer is the resolver's answer for one property on one source
+// resource: whether, and why, a value is available at plan time.
+type SourceAnswer struct {
+	Kind   AnswerKind
+	Value  string // Resolved and Stable only
+	Opaque bool   // the source property is opaque; consumers of the seam decide what that means
+}
+
+// ResolvableProperties is a map of KSUIDs to property names to answers.
 // This can include resource.Properties and resource.ReadOnlyProperties
 type ResolvableProperties struct {
-	props map[string]map[string]string // ksuid -> property -> value
+	props map[string]map[string]SourceAnswer // ksuid -> property -> answer
 }
 
 func NewResolvableProperties() ResolvableProperties {
 	return ResolvableProperties{
-		props: make(map[string]map[string]string),
+		props: make(map[string]map[string]SourceAnswer),
 	}
 }
 
 func (p *ResolvableProperties) Add(ksuid, property, value string) {
+	p.AddAnswer(ksuid, property, SourceAnswer{Kind: AnswerStable, Value: value})
+}
+
+func (p *ResolvableProperties) AddAnswer(ksuid, property string, a SourceAnswer) {
 	if _, ok := p.props[ksuid]; !ok {
-		p.props[ksuid] = make(map[string]string)
+		p.props[ksuid] = make(map[string]SourceAnswer)
 	}
-	p.props[ksuid][property] = value
+	p.props[ksuid][property] = a
 }
 
 func (p *ResolvableProperties) Get(ksuid, property string) (string, bool) {
 	if resourceProps, ok := p.props[ksuid]; ok {
-		if value, ok := resourceProps[property]; ok {
-			return value, true
+		if answer, ok := resourceProps[property]; ok {
+			if answer.Kind == AnswerResolved || answer.Kind == AnswerStable {
+				return answer.Value, true
+			}
 		}
 	}
 	return "", false
 }
 
-func LoadResolvablePropertiesFromStacks(resource pkgmodel.Resource, allResources map[string][]*pkgmodel.Resource) (ResolvableProperties, error) {
+func (p *ResolvableProperties) Answer(ksuid, property string) (SourceAnswer, bool) {
+	if resourceProps, ok := p.props[ksuid]; ok {
+		if answer, ok := resourceProps[property]; ok {
+			return answer, true
+		}
+	}
+	return SourceAnswer{}, false
+}
+
+func LoadResolvablePropertiesFromStacks(resource pkgmodel.Resource, allResources map[string][]*pkgmodel.Resource, effective map[string]json.RawMessage) (ResolvableProperties, error) {
 	res := NewResolvableProperties()
 
 	resourcesByKsuid := make(map[string]*pkgmodel.Resource)

--- a/internal/metastructure/resolver/resolvable_properties.go
+++ b/internal/metastructure/resolver/resolvable_properties.go
@@ -18,15 +18,17 @@ import (
 type AnswerKind int
 
 const (
+	// AnswerDeferred: not derivable at plan time; execution-time resolution
+	// through RemainingResolvables answers it. Zero value on purpose: a
+	// missing or forgotten answer must read as the least-trusting kind, never
+	// the most.
+	AnswerDeferred AnswerKind = iota
 	// AnswerResolved: the value is derivable at plan time from effective
 	// desired state (a literal this command declares).
-	AnswerResolved AnswerKind = iota
+	AnswerResolved
 	// AnswerStable: the persisted value is valid because nothing this
 	// command does moves the source property.
 	AnswerStable
-	// AnswerDeferred: not derivable at plan time; execution-time resolution
-	// through RemainingResolvables answers it.
-	AnswerDeferred
 )
 
 // SourceAnswer is the resolver's answer for one property on one source
@@ -106,13 +108,15 @@ func LoadResolvablePropertiesFromStacks(resource pkgmodel.Resource, allResources
 		if effDoc, declared := effective[ksuid]; declared {
 			effVal := gjson.GetBytes(effDoc, propertyPath)
 			if effVal.Exists() && !isReferenceEnvelope(effVal) && !containsHashedValue(effVal) &&
-				!isSourcePropertyOpaque(targetResource, propertyPath) {
+				!containsOpaqueVisibility(effVal) && !isSourcePropertyOpaque(targetResource, propertyPath) {
 				res.AddAnswer(ksuid, propertyPath, SourceAnswer{Kind: AnswerResolved, Value: ExtractPropertyValue(effVal)})
 				continue
 			}
-			// Reference envelopes, hashed shapes, and opaque sources fall through to
-			// the persisted-row path unchanged: envelopes keep the cached value,
-			// opaque and hashed sources keep today's deferral.
+			// Reference envelopes, hashed shapes, and opaque sources — persisted,
+			// schema-declared, or only ever inline-marked in the desired document
+			// itself — fall through to the persisted-row path unchanged: envelopes
+			// keep the cached value, opaque and hashed sources keep today's
+			// deferral.
 		}
 
 		if value, ok := resolvableValueFrom(targetResource.ReadOnlyProperties, propertyPath); ok {
@@ -185,6 +189,31 @@ func containsHashedValue(value gjson.Result) bool {
 	found := false
 	value.ForEach(func(_, child gjson.Result) bool {
 		if containsHashedValue(child) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// containsOpaqueVisibility reports whether value is, or contains anywhere
+// within it, an inline $visibility: Opaque marker. This is the desired
+// document's own spelling of opacity — a plain {"$value": ..., "$visibility":
+// "Opaque"} envelope the command submits before that property has ever been
+// persisted or hashed, so neither a persisted shape check nor the
+// schema/known-opaque table sees it. The structural sibling of
+// containsHashedValue: same recursive shape, different marker.
+func containsOpaqueVisibility(value gjson.Result) bool {
+	if !value.IsObject() && !value.IsArray() {
+		return false
+	}
+	if value.Get("$visibility").String() == pkgmodel.VisibilityOpaque {
+		return true
+	}
+	found := false
+	value.ForEach(func(_, child gjson.Result) bool {
+		if containsOpaqueVisibility(child) {
 			found = true
 			return false
 		}

--- a/internal/metastructure/resolver/resolvable_properties_test.go
+++ b/internal/metastructure/resolver/resolvable_properties_test.go
@@ -292,3 +292,28 @@ func TestLoadResolvableProperties_EffectiveDesiredSkipsSourceOpaqueOnlyInReadOnl
 	a, _ := props.Answer("k-parent", "Token")
 	assert.Equal(t, AnswerStable, a.Kind, "fallthrough resolves via the persisted-row path, not the case-1 rule")
 }
+
+// A property that is inline-opaque only in the effective desired document —
+// the persisted row lacks the property entirely, and the schema carries no
+// opaque hint — must still never be materialized: the case-1 rule refuses it
+// by the desired document's own $visibility marker.
+func TestLoadResolvableProperties_EffectiveDesiredSkipsInlineOpaqueNotYetPersisted(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Label: "parent", Ksuid: "k-parent", Stack: "s",
+		Properties: json.RawMessage(`{"Name": "p"}`),
+	}
+	consumer := pkgmodel.Resource{
+		Label: "consumer", Ksuid: "k-consumer", Stack: "s",
+		Properties: json.RawMessage(`{"Ref": {"$ref": "formae://k-parent#/Secret"}}`),
+	}
+	all := map[string][]*pkgmodel.Resource{"s": {source}}
+	effective := map[string]json.RawMessage{
+		"k-parent": json.RawMessage(`{"Name": "p", "Secret": {"$value": "brand-new-plaintext", "$visibility": "Opaque"}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumer, all, effective)
+	require.NoError(t, err)
+
+	_, ok := props.Get("k-parent", "Secret")
+	assert.False(t, ok, "an inline-opaque value that exists only in the effective desired document must never be materialized")
+}

--- a/internal/metastructure/resolver/resolvable_properties_test.go
+++ b/internal/metastructure/resolver/resolvable_properties_test.go
@@ -49,7 +49,7 @@ func TestLoadResolvableProperties_SkipsHashedValue(t *testing.T) {
 			`"$visibility":"Opaque","$strategy":"Update","$hashed":true}}`),
 	}
 
-	props, err := LoadResolvablePropertiesFromStacks(consumerOf("SecretString"), stacksWith(source))
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("SecretString"), stacksWith(source), nil)
 	require.NoError(t, err)
 
 	_, found := props.Get(sourceKsuid, "SecretString")
@@ -70,7 +70,7 @@ func TestLoadResolvableProperties_SkipsHashedReadOnlyValue(t *testing.T) {
 			`"$visibility":"Opaque","$hashed":true}}`),
 	}
 
-	props, err := LoadResolvablePropertiesFromStacks(consumerOf("GeneratedToken"), stacksWith(source))
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("GeneratedToken"), stacksWith(source), nil)
 	require.NoError(t, err)
 
 	_, found := props.Get(sourceKsuid, "GeneratedToken")
@@ -89,7 +89,7 @@ func TestLoadResolvableProperties_UsesOpaqueValueThatIsNotHashed(t *testing.T) {
 		Properties: json.RawMessage(`{"SecretString":{"$value":"live-value","$visibility":"Opaque"}}`),
 	}
 
-	props, err := LoadResolvablePropertiesFromStacks(consumerOf("SecretString"), stacksWith(source))
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("SecretString"), stacksWith(source), nil)
 	require.NoError(t, err)
 
 	value, found := props.Get(sourceKsuid, "SecretString")
@@ -111,7 +111,7 @@ func TestLoadResolvableProperties_SkipsStructureHoldingAHashedValue(t *testing.T
 			`"$visibility":"Opaque","$hashed":true}}}`),
 	}
 
-	props, err := LoadResolvablePropertiesFromStacks(consumerOf("Connection"), stacksWith(source))
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("Connection"), stacksWith(source), nil)
 	require.NoError(t, err)
 
 	_, found := props.Get(sourceKsuid, "Connection")
@@ -131,7 +131,7 @@ func TestLoadResolvableProperties_SkipsValuelessReferenceEnvelope(t *testing.T) 
 		Properties: json.RawMessage(`{"Token":{"$ref":"formae://someotherksuid#/Value","$visibility":"Opaque"}}`),
 	}
 
-	props, err := LoadResolvablePropertiesFromStacks(consumerOf("Token"), stacksWith(source))
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("Token"), stacksWith(source), nil)
 	require.NoError(t, err)
 
 	_, found := props.Get(sourceKsuid, "Token")
@@ -150,7 +150,7 @@ func TestLoadResolvableProperties_UsesResolvedReferenceEnvelope(t *testing.T) {
 		Properties: json.RawMessage(`{"VpcId":{"$ref":"formae://someotherksuid#/VpcId","$value":"vpc-123"}}`),
 	}
 
-	props, err := LoadResolvablePropertiesFromStacks(consumerOf("VpcId"), stacksWith(source))
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("VpcId"), stacksWith(source), nil)
 	require.NoError(t, err)
 
 	value, found := props.Get(sourceKsuid, "VpcId")
@@ -169,10 +169,26 @@ func TestLoadResolvableProperties_UsesPlainValue(t *testing.T) {
 		ReadOnlyProperties: json.RawMessage(`{"VpcId":"vpc-123"}`),
 	}
 
-	props, err := LoadResolvablePropertiesFromStacks(consumerOf("VpcId"), stacksWith(source))
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("VpcId"), stacksWith(source), nil)
 	require.NoError(t, err)
 
 	value, found := props.Get(sourceKsuid, "VpcId")
 	require.True(t, found)
 	assert.Equal(t, "vpc-123", value)
+}
+
+// A persisted literal the command does not move answers Stable and keeps the
+// same value the string lookup returns, so both surfaces agree.
+func TestResolvableProperties_AnswerAgreesWithGet(t *testing.T) {
+	props := NewResolvableProperties()
+	props.AddAnswer("k1", "Value", SourceAnswer{Kind: AnswerStable, Value: "hello"})
+
+	v, ok := props.Get("k1", "Value")
+	require.True(t, ok)
+	assert.Equal(t, "hello", v)
+
+	a, ok := props.Answer("k1", "Value")
+	require.True(t, ok)
+	assert.Equal(t, AnswerStable, a.Kind)
+	assert.Equal(t, "hello", a.Value)
 }

--- a/internal/metastructure/resolver/resolvable_properties_test.go
+++ b/internal/metastructure/resolver/resolvable_properties_test.go
@@ -259,3 +259,36 @@ func TestLoadResolvableProperties_EnvelopeAndHashedKeepTodaysBehavior(t *testing
 	_, ok = props.Get("k-parent", "Secret")
 	assert.False(t, ok, "a hashed-at-rest source stays deferred; the raw desired plaintext must never be materialized")
 }
+
+// A source that marks the referenced property Opaque only in ReadOnlyProperties
+// (never in Properties) must still be caught: the effective desired document's
+// plain literal is not materialized, and resolution falls through to the
+// persisted-row path instead.
+func TestLoadResolvableProperties_EffectiveDesiredSkipsSourceOpaqueOnlyInReadOnlyProperties(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Label: "parent", Ksuid: "k-parent", Stack: "s",
+		Properties:         json.RawMessage(`{"Name": "p"}`),
+		ReadOnlyProperties: json.RawMessage(`{"Token": {"$value": "persisted-token", "$visibility": "Opaque"}}`),
+	}
+	consumer := pkgmodel.Resource{
+		Label: "consumer", Ksuid: "k-consumer", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Ref": {"$ref": "formae://k-parent#/Token", "$value": "persisted-token"}
+		}`),
+	}
+	all := map[string][]*pkgmodel.Resource{"s": {source}}
+	effective := map[string]json.RawMessage{
+		"k-parent": json.RawMessage(`{"Name": "p", "Token": "resubmitted-token"}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumer, all, effective)
+	require.NoError(t, err)
+
+	v, ok := props.Get("k-parent", "Token")
+	require.True(t, ok, "the persisted-row path still resolves the opaque-but-not-hashed value")
+	assert.Equal(t, "persisted-token", v,
+		"the resubmitted effective plaintext must never be materialized for a source opaque only in ReadOnlyProperties")
+
+	a, _ := props.Answer("k-parent", "Token")
+	assert.Equal(t, AnswerStable, a.Kind, "fallthrough resolves via the persisted-row path, not the case-1 rule")
+}

--- a/internal/metastructure/resolver/resolvable_properties_test.go
+++ b/internal/metastructure/resolver/resolvable_properties_test.go
@@ -192,3 +192,70 @@ func TestResolvableProperties_AnswerAgreesWithGet(t *testing.T) {
 	assert.Equal(t, AnswerStable, a.Kind)
 	assert.Equal(t, "hello", a.Value)
 }
+
+// When the command declares the source and its effective desired document
+// carries a plain literal for the referenced property, that literal is the
+// plan-time resolution, not the persisted row's stale value.
+func TestLoadResolvableProperties_EffectiveDesiredLiteralWins(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Label: "parent", Ksuid: "k-parent", Stack: "s",
+		Properties: json.RawMessage(`{"Name": "p", "Value": "hello"}`),
+	}
+	consumer := pkgmodel.Resource{
+		Label: "consumer", Ksuid: "k-consumer", Stack: "s",
+		Properties: json.RawMessage(`{
+			"ParentRef": {"$ref": "formae://k-parent#/Value", "$value": "hello"}
+		}`),
+	}
+	all := map[string][]*pkgmodel.Resource{"s": {source}}
+	effective := map[string]json.RawMessage{
+		"k-parent": json.RawMessage(`{"Name": "p", "Value": "world"}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumer, all, effective)
+	require.NoError(t, err)
+
+	v, ok := props.Get("k-parent", "Value")
+	require.True(t, ok)
+	assert.Equal(t, "world", v, "the effective desired literal is the resolution")
+
+	a, _ := props.Answer("k-parent", "Value")
+	assert.Equal(t, AnswerResolved, a.Kind)
+}
+
+// An effective desired value that is a reference envelope, hashed at rest, or
+// opaque is never materialized by this rule: behavior stays byte-identical to
+// the persisted-row path (envelope: cached value; hashed/valueless: deferred).
+func TestLoadResolvableProperties_EnvelopeAndHashedKeepTodaysBehavior(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Label: "parent", Ksuid: "k-parent", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Chained": {"$ref": "formae://k-root#/V", "$value": "cached"},
+			"Secret":  {"$value": "digest-at-rest", "$hashed": true}
+		}`),
+	}
+	consumer := pkgmodel.Resource{
+		Label: "consumer", Ksuid: "k-consumer", Stack: "s",
+		Properties: json.RawMessage(`{
+			"A": {"$ref": "formae://k-parent#/Chained"},
+			"B": {"$ref": "formae://k-parent#/Secret"}
+		}`),
+	}
+	all := map[string][]*pkgmodel.Resource{"s": {source}}
+	effective := map[string]json.RawMessage{
+		"k-parent": json.RawMessage(`{
+			"Chained": {"$ref": "formae://k-root#/V"},
+			"Secret":  "raw-new-secret-plaintext"
+		}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumer, all, effective)
+	require.NoError(t, err)
+
+	v, ok := props.Get("k-parent", "Chained")
+	require.True(t, ok)
+	assert.Equal(t, "cached", v, "an envelope source keeps the persisted cached value in this plan")
+
+	_, ok = props.Get("k-parent", "Secret")
+	assert.False(t, ok, "a hashed-at-rest source stays deferred; the raw desired plaintext must never be materialized")
+}

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
+	"github.com/platform-engineering-labs/formae/internal/metastructure/transformations"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
@@ -249,11 +250,15 @@ func ExtractOpaqueResolvableURIsFromJSON(data json.RawMessage) []pkgmodel.Formae
 }
 
 // isSourcePropertyOpaque reports whether propertyName on a source resource is an
-// opaque value — a secret stored hashed-at-rest with Opaque visibility. Used to
-// decide, from the SOURCE side, whether an otherwise Clear consumer ref is really
-// a credential. It checks Properties first then ReadOnlyProperties, mirroring
-// Resource property precedence: an opaque value (e.g. a plugin-generated token)
-// may be persisted in either collection.
+// opaque value: a value stored hashed at rest, one carrying an Opaque
+// $visibility marker, or a field the schema (or the agent-side known-opaque
+// table) marks opaque even before anything is persisted. Used to decide, from
+// the SOURCE side, whether an otherwise Clear consumer ref is really a
+// credential — and, by the same rule, whether a plan-time literal drawn from
+// the source's effective desired state is safe to materialize. It checks
+// Properties first then ReadOnlyProperties, mirroring Resource property
+// precedence: an opaque value (e.g. a plugin-generated token) may be
+// persisted in either collection.
 func isSourcePropertyOpaque(source *pkgmodel.Resource, propertyName string) bool {
 	if source == nil || propertyName == "" {
 		return false
@@ -268,10 +273,27 @@ func isSourcePropertyOpaque(source *pkgmodel.Resource, propertyName string) bool
 		candidates = append(candidates, root)
 	}
 	for _, p := range candidates {
+		// A value stored hashed at rest is a SHA-256 digest; refused wherever it
+		// sits, including nested inside the structure a path names as a whole.
+		if containsHashedValue(gjson.GetBytes(source.Properties, p)) {
+			return true
+		}
+		if containsHashedValue(gjson.GetBytes(source.ReadOnlyProperties, p)) {
+			return true
+		}
 		if gjson.GetBytes(source.Properties, p).Get("$visibility").String() == pkgmodel.VisibilityOpaque {
 			return true
 		}
 		if gjson.GetBytes(source.ReadOnlyProperties, p).Get("$visibility").String() == pkgmodel.VisibilityOpaque {
+			return true
+		}
+	}
+	// Fall back to the schema/known-opaque table (the same union PersistValueTransformer
+	// hashes against): a property that has never been persisted yet — or whose
+	// plugin schema drops FieldHint.Opaque — still classifies as opaque here.
+	opaqueFields := transformations.OpaqueFields(source.Schema, source.Type)
+	for _, p := range candidates {
+		if opaqueFields[p] {
 			return true
 		}
 	}

--- a/internal/metastructure/resolver/resolver_test.go
+++ b/internal/metastructure/resolver/resolver_test.go
@@ -1119,7 +1119,7 @@ func TestLoadResolvablePropertiesFromStacks(t *testing.T) {
 			Resources: []pkgmodel.Resource{vpc, subnet},
 		}
 
-		resolvables, err := LoadResolvablePropertiesFromStacks(subnet, formaToResourcesMap(forma))
+		resolvables, err := LoadResolvablePropertiesFromStacks(subnet, formaToResourcesMap(forma), nil)
 
 		require.NoError(t, err)
 		value, found := resolvables.Get(vpcKsuid, "VpcId")
@@ -1164,7 +1164,7 @@ func TestLoadResolvablePropertiesFromStacks(t *testing.T) {
 			Resources: []pkgmodel.Resource{compartment, vcn, subnet},
 		}
 
-		resolvables, err := LoadResolvablePropertiesFromStacks(subnet, formaToResourcesMap(forma))
+		resolvables, err := LoadResolvablePropertiesFromStacks(subnet, formaToResourcesMap(forma), nil)
 
 		require.NoError(t, err)
 		value, found := resolvables.Get(vcnKsuid, "CompartmentId")
@@ -1196,7 +1196,7 @@ func TestLoadResolvablePropertiesFromStacks(t *testing.T) {
 			Resources: []pkgmodel.Resource{vpc, subnet},
 		}
 
-		resolvables, err := LoadResolvablePropertiesFromStacks(subnet, formaToResourcesMap(forma))
+		resolvables, err := LoadResolvablePropertiesFromStacks(subnet, formaToResourcesMap(forma), nil)
 
 		require.NoError(t, err)
 		value, found := resolvables.Get(vpcKsuid, "CidrBlock")
@@ -1222,7 +1222,7 @@ func TestLoadResolvablePropertiesFromStacks(t *testing.T) {
 			Resources: []pkgmodel.Resource{subnet},
 		}
 
-		_, err := LoadResolvablePropertiesFromStacks(subnet, formaToResourcesMap(forma))
+		_, err := LoadResolvablePropertiesFromStacks(subnet, formaToResourcesMap(forma), nil)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
@@ -1252,7 +1252,7 @@ func TestLoadResolvablePropertiesFromStacks(t *testing.T) {
 			Resources: []pkgmodel.Resource{vpc, subnet},
 		}
 
-		props, err := LoadResolvablePropertiesFromStacks(subnet, formaToResourcesMap(forma))
+		props, err := LoadResolvablePropertiesFromStacks(subnet, formaToResourcesMap(forma), nil)
 
 		assert.NoError(t, err)
 		// Property not resolved — will be resolved at execution time

--- a/internal/metastructure/resolver/resolver_test.go
+++ b/internal/metastructure/resolver/resolver_test.go
@@ -1660,4 +1660,24 @@ func TestExtractSourceOpaqueResolvableURIsFromJSON(t *testing.T) {
 		json.RawMessage(`{"password":{"$ref":"`+string(missingURI)+`","$visibility":"Clear"}}`), load)
 	require.NoError(t, err)
 	assert.Empty(t, got)
+
+	// A schema-opaque source (FieldHint.Opaque) whose persisted value is still
+	// plain — no $hashed, no $visibility, never yet transformed at rest — is a
+	// credential by virtue of the schema/known-opaque table fallback.
+	schemaOpaqueKsuid := util.NewID()
+	schemaOpaqueURI := pkgmodel.NewFormaeURI(schemaOpaqueKsuid, "ApiKey")
+	sources[schemaOpaqueKsuid] = &pkgmodel.Resource{
+		Ksuid: schemaOpaqueKsuid,
+		Type:  "Test::SchemaOpaqueSource",
+		Schema: pkgmodel.Schema{
+			Fields: []string{"ApiKey"},
+			Hints:  map[string]pkgmodel.FieldHint{"ApiKey": {Opaque: true}},
+		},
+		Properties: json.RawMessage(`{"ApiKey":"plain-not-yet-hashed"}`),
+	}
+	got, err = ExtractSourceOpaqueResolvableURIsFromJSON(
+		json.RawMessage(`{"key":{"$ref":"`+string(schemaOpaqueURI)+`","$visibility":"Clear"}}`), load)
+	require.NoError(t, err)
+	assert.Equal(t, []pkgmodel.FormaeURI{schemaOpaqueURI}, got,
+		"a schema-declared Opaque field classifies opaque even when persisted as a plain value")
 }

--- a/internal/metastructure/resource_update/effective_desired.go
+++ b/internal/metastructure/resource_update/effective_desired.go
@@ -1,0 +1,51 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package resource_update
+
+import (
+	"encoding/json"
+	"fmt"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// EffectiveDesired maps an existing resource's KSUID to the desired properties
+// document this command will drive it to: the forma declaration after the same
+// SetOnce filtering that decides the resource's own patch. It is computed once
+// per command, ahead of the resolvable lookup, and the same artifact feeds both
+// the lookup and the update factory, so the filtering is never re-derived in
+// two places.
+type EffectiveDesired map[string]json.RawMessage
+
+// ComputeEffectiveDesired builds the map for every forma resource whose KSUID
+// matches a persisted row. A resource with no persisted row (a create) has no
+// entry: its declaration is already effective as written.
+func ComputeEffectiveDesired(forma *pkgmodel.Forma, allResourcesByStack map[string][]*pkgmodel.Resource) (EffectiveDesired, error) {
+	persisted := make(map[string]*pkgmodel.Resource)
+	for _, resources := range allResourcesByStack {
+		for _, r := range resources {
+			if r.Ksuid != "" {
+				persisted[r.Ksuid] = r
+			}
+		}
+	}
+	eff := make(EffectiveDesired)
+	for i := range forma.Resources {
+		r := &forma.Resources[i]
+		if r.Ksuid == "" {
+			continue
+		}
+		row, ok := persisted[r.Ksuid]
+		if !ok {
+			continue
+		}
+		filtered, err := filterSetOnceProps(row.Properties, r.Properties, r.Label)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute effective desired properties for %s: %w", r.Label, err)
+		}
+		eff[r.Ksuid] = filtered
+	}
+	return eff, nil
+}

--- a/internal/metastructure/resource_update/effective_desired_test.go
+++ b/internal/metastructure/resource_update/effective_desired_test.go
@@ -1,0 +1,66 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// The effective desired document for an existing resource is the forma
+// declaration after SetOnce filtering: a populated SetOnce property keeps its
+// persisted value no matter what the forma resubmits. Resources with no
+// persisted row (creates) get no entry.
+func TestComputeEffectiveDesired_SetOncePreservedCreatesAbsent(t *testing.T) {
+	existing := &pkgmodel.Resource{
+		Label: "parent",
+		Ksuid: "ksuid-parent",
+		Stack: "test-stack",
+		Properties: json.RawMessage(`{
+			"Name": "parent-1",
+			"Value": {"$value": "hello", "$strategy": "SetOnce"}
+		}`),
+	}
+	forma := &pkgmodel.Forma{
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "parent",
+				Ksuid: "ksuid-parent",
+				Stack: "test-stack",
+				Properties: json.RawMessage(`{
+					"Name": "parent-1",
+					"Value": {"$value": "world-resubmitted", "$strategy": "SetOnce"}
+				}`),
+			},
+			{
+				Label:      "brand-new",
+				Ksuid:      "ksuid-new",
+				Stack:      "test-stack",
+				Properties: json.RawMessage(`{"Name": "n"}`),
+			},
+		},
+	}
+	all := map[string][]*pkgmodel.Resource{"test-stack": {existing}}
+
+	eff, err := ComputeEffectiveDesired(forma, all)
+	require.NoError(t, err)
+
+	filtered, ok := eff["ksuid-parent"]
+	require.True(t, ok, "an existing declared resource must have an effective desired entry")
+	assert.JSONEq(t, `{
+		"Name": "parent-1",
+		"Value": {"$value": "hello", "$strategy": "SetOnce"}
+	}`, string(filtered), "a populated SetOnce property keeps its persisted value")
+
+	_, ok = eff["ksuid-new"]
+	assert.False(t, ok, "a resource with no persisted row has no entry")
+}

--- a/internal/metastructure/resource_update/opaque_suppression_test.go
+++ b/internal/metastructure/resource_update/opaque_suppression_test.go
@@ -57,7 +57,7 @@ func planUpdates(t *testing.T, existing, desired pkgmodel.Resource) []ResourceUp
 	t.Helper()
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
 	updates, err := NewResourceUpdateForExisting(
-		resolver.ResolvableProperties{}, existing, desired,
+		resolver.ResolvableProperties{}, nil, existing, desired,
 		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser)
 	require.NoError(t, err)
 	return updates

--- a/internal/metastructure/resource_update/resource_comparison.go
+++ b/internal/metastructure/resource_update/resource_comparison.go
@@ -26,33 +26,44 @@ func EnforceSetOnceAndCompareResourceForUpdate(existing, new *pkgmodel.Resource,
 	if err != nil {
 		return false, nil, err
 	}
+	hasChanges, err := CompareFilteredResourceForUpdate(existing, new, schema, filteredRawProps)
+	if err != nil {
+		return false, nil, err
+	}
+	return hasChanges, filteredRawProps, nil
+}
 
+// CompareFilteredResourceForUpdate reports whether filteredProps - the
+// effective desired document, i.e. the forma declaration after SetOnce
+// filtering - meaningfully differs from the existing row. The caller supplies
+// the filtered document so the filtering is computed exactly once per command.
+func CompareFilteredResourceForUpdate(existing, new *pkgmodel.Resource, schema pkgmodel.Schema, filteredProps json.RawMessage) (bool, error) {
 	// Hash the filtered properties ONLY for comparison (like verses like).
 	// The temp resource carries the schema so schema-keyed opaque fields
 	// (PersistValueTransformer) are hashed here the same way they are hashed
 	// on persist — otherwise a stored-hashed secret compares unequal to the
 	// re-submitted desired plaintext and produces a spurious update.
 	transformer := transformations.NewPersistValueTransformer()
-	tempResource := &pkgmodel.Resource{Type: new.Type, Schema: new.Schema, Properties: filteredRawProps}
+	tempResource := &pkgmodel.Resource{Type: new.Type, Schema: new.Schema, Properties: filteredProps}
 	// Comparison-only: nothing here is persisted, and the same values are hashed
 	// again on the persist path, which surfaces the opaque-match diagnostics with
 	// the resource identity attached. Reporting them here too would only double
 	// every warning.
 	hashedForComparison, _, err := transformer.ApplyToResource(tempResource)
 	if err != nil {
-		return false, nil, err
+		return false, err
 	}
 
 	// Canonicalize Format-hinted serialized fields on BOTH sides, for comparison
-	// only — never feeds the returned filteredRawProps.
+	// only — never feeds the returned filteredProps.
 	existingForCompare := canonicalizeHintedFields(existing.Properties, schema)
 	newForCompare := canonicalizeHintedFields(hashedForComparison.Properties, schema)
 
 	equal, err := util.JsonEqualIgnoreArrayOrder(existingForCompare, newForCompare)
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to compare properties: %w", err)
+		return false, fmt.Errorf("failed to compare properties: %w", err)
 	}
-	return !equal, filteredRawProps, nil
+	return !equal, nil
 }
 
 // canonicalizeHintedFields returns a copy of props in which each Format-hinted

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -19,6 +19,7 @@ import (
 
 func NewResourceUpdateForExisting(
 	resolvableProperties resolver.ResolvableProperties,
+	effectiveDesired json.RawMessage,
 	existingResource pkgmodel.Resource,
 	newResource pkgmodel.Resource,
 	existingTarget pkgmodel.Target,
@@ -47,7 +48,15 @@ func NewResourceUpdateForExisting(
 	// the properties might be identical
 	stackChanged := existingResource.Stack != newResource.Stack
 
-	hasChanges, filteredProps, err := EnforceSetOnceAndCompareResourceForUpdate(&existingResource, &newResource, newResource.Schema)
+	var err error
+	filteredProps := effectiveDesired
+	if filteredProps == nil {
+		filteredProps, err = filterSetOnceProps(existingResource.Properties, newResource.Properties, newResource.Label)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute effective desired properties: %w", err)
+		}
+	}
+	hasChanges, err := CompareFilteredResourceForUpdate(&existingResource, &newResource, newResource.Schema, filteredProps)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compare resources: %w", err)
 	}

--- a/internal/metastructure/resource_update/resource_update_factory_list_resolvable_test.go
+++ b/internal/metastructure/resource_update/resource_update_factory_list_resolvable_test.go
@@ -68,7 +68,7 @@ func TestNewResourceUpdateForExisting_ListResolvableMatchingLiveValue_NoUpdate(t
 
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
 
-	updates, err := NewResourceUpdateForExisting(resolvableProps, existing, newResource, target, target,
+	updates, err := NewResourceUpdateForExisting(resolvableProps, nil, existing, newResource, target, target,
 		pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser)
 	require.NoError(t, err)
 	assert.Empty(t, updates, "an unchanged list-valued resolvable must reconcile to a no-op")

--- a/internal/metastructure/resource_update/resource_update_factory_stack_transition_test.go
+++ b/internal/metastructure/resource_update/resource_update_factory_stack_transition_test.go
@@ -102,7 +102,7 @@ func requireSingleUpdate(t *testing.T, existing, new pkgmodel.Resource) Resource
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
 	resolvableProps := resolver.ResolvableProperties{}
 
-	updates, err := NewResourceUpdateForExisting(resolvableProps, existing, new, target, target,
+	updates, err := NewResourceUpdateForExisting(resolvableProps, nil, existing, new, target, target,
 		pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser)
 	require.NoError(t, err)
 

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -805,6 +805,11 @@ func generateResourceUpdatesForReconcile(
 	// This allows forward references to new resources in the same command.
 	resolvableLookup := resourcesForResolvables(forma, allResourcesByStack)
 
+	effectiveDesired, err := ComputeEffectiveDesired(forma, allResourcesByStack)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute effective desired state: %w", err)
+	}
+
 	for _, stack := range forma.SplitByStack() {
 		existingResources, err := ds.LoadResourcesByStack(stack.SingleStackLabel())
 		if err != nil {
@@ -826,6 +831,7 @@ func generateResourceUpdatesForReconcile(
 
 					resourceUpdate, err := NewResourceUpdateForExisting(
 						readOnlyProperties,
+						effectiveDesired[existingUnmanaged.Ksuid],
 						existingUnmanaged,
 						newResource,
 						*existingTargetMap[existingUnmanaged.Target],
@@ -879,6 +885,7 @@ func generateResourceUpdatesForReconcile(
 					}
 					existingResourceUpdates, err := NewResourceUpdateForExisting(
 						readOnlyProperties,
+						effectiveDesired[existingResource.Ksuid],
 						*existingResource,
 						newResource,
 						*existingTargetMap[existingResource.Target],
@@ -957,6 +964,7 @@ func generateResourceUpdatesForReconcile(
 
 					resourceUpdate, err := NewResourceUpdateForExisting(
 						readOnlyProperties,
+						effectiveDesired[existingUnmanaged.Ksuid],
 						existingUnmanaged,
 						newResource,
 						*existingTargetMap[existingUnmanaged.Target],
@@ -1265,6 +1273,11 @@ func generateResourceUpdatesForPatch(
 	// This allows forward references to new resources in the same command.
 	resolvableLookup := resourcesForResolvables(forma, allResourcesByStack)
 
+	effectiveDesired, err := ComputeEffectiveDesired(forma, allResourcesByStack)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute effective desired state: %w", err)
+	}
+
 	for _, stack := range forma.SplitByStack() {
 		stackResources, err := ds.LoadResourcesByStack(stack.SingleStackLabel())
 		if err != nil {
@@ -1307,6 +1320,7 @@ func generateResourceUpdatesForPatch(
 
 				existingResourceUpdates, err := NewResourceUpdateForExisting(
 					readOnlyProperties,
+					effectiveDesired[matched.Ksuid],
 					*matched,
 					newResource,
 					*existingTargetMap[matched.Target],

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -824,7 +824,7 @@ func generateResourceUpdatesForReconcile(
 					continue
 				}
 				if existingUnmanaged, ok := findUnmanagedResource(newResource, allResourcesByStack); ok {
-					readOnlyProperties, err := resolver.LoadResolvablePropertiesFromStacks(newResource, resolvableLookup)
+					readOnlyProperties, err := resolver.LoadResolvablePropertiesFromStacks(newResource, resolvableLookup, effectiveDesired)
 					if err != nil {
 						return nil, fmt.Errorf("failed to load resolvable properties: %w", err)
 					}
@@ -878,7 +878,7 @@ func generateResourceUpdatesForReconcile(
 
 					found = true
 
-					readOnlyProperties, err := resolver.LoadResolvablePropertiesFromStacks(newResource, resolvableLookup)
+					readOnlyProperties, err := resolver.LoadResolvablePropertiesFromStacks(newResource, resolvableLookup, effectiveDesired)
 
 					if err != nil {
 						return nil, fmt.Errorf("failed to load resolvable properties: %w", err)
@@ -957,7 +957,7 @@ func generateResourceUpdatesForReconcile(
 				}
 				// Check if this resource exists as an unmanaged resource
 				if existingUnmanaged, ok := findUnmanagedResource(newResource, allResourcesByStack); ok {
-					readOnlyProperties, err := resolver.LoadResolvablePropertiesFromStacks(newResource, resolvableLookup)
+					readOnlyProperties, err := resolver.LoadResolvablePropertiesFromStacks(newResource, resolvableLookup, effectiveDesired)
 					if err != nil {
 						return nil, fmt.Errorf("failed to load resolvable properties: %w", err)
 					}
@@ -1313,7 +1313,7 @@ func generateResourceUpdatesForPatch(
 
 			if matched != nil {
 				// Use NewResourceUpdateForExisting to handle all the logic
-				readOnlyProperties, err := resolver.LoadResolvablePropertiesFromStacks(newResource, resolvableLookup)
+				readOnlyProperties, err := resolver.LoadResolvablePropertiesFromStacks(newResource, resolvableLookup, effectiveDesired)
 				if err != nil {
 					return nil, fmt.Errorf("failed to load resolvable properties: %w", err)
 				}

--- a/internal/metastructure/resource_update/resource_update_generator_static_move_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_static_move_test.go
@@ -1,0 +1,213 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// A consumer follows a producer's plain mutable field through a resolvable.
+// The producer's field changes to a value that is fully known at plan time (it
+// is a literal in the forma). The consumer's declaration is untouched.
+//
+// The consumer must stay in the changeset with a patch that moves it to the
+// producer's new value: its declared intent is "follow that field", and the
+// field's post-apply value is right there in the forma.
+func TestGenerateResourceUpdates_ConsumerFollowsChangedProducerField(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	producerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Value"},
+		Hints:      map[string]pkgmodel.FieldHint{"Name": {CreateOnly: true}},
+	}
+	consumerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "ParentRef"},
+		Hints:      map[string]pkgmodel.FieldHint{},
+	}
+
+	producerKsuid := util.NewID()
+	consumerKsuid := util.NewID()
+
+	existingStack := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label:      "parent",
+				Type:       "FakeAWS::Versioned::Parent",
+				Stack:      "test-stack",
+				Target:     "test-target",
+				Schema:     producerSchema,
+				Ksuid:      producerKsuid,
+				Properties: json.RawMessage(`{"Name": "parent-1", "Value": "hello"}`),
+			},
+			{
+				Label:  "consumer",
+				Type:   "FakeAWS::Versioned::Consumer",
+				Stack:  "test-stack",
+				Target: "test-target",
+				Schema: consumerSchema,
+				Ksuid:  consumerKsuid,
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Name": "consumer-1", "ParentRef": {"$ref": "formae://%s#/Value", "$value": "hello"}}`,
+					producerKsuid)),
+			},
+		},
+	}
+
+	_, err := ds.StoreStack(existingStack, "previous-command")
+	require.NoError(t, err)
+
+	// Only the producer's mutable field changes; its new value is a literal.
+	forma := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Targets: []pkgmodel.Target{
+			{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+		},
+		Resources: []pkgmodel.Resource{
+			{
+				Label:      "parent",
+				Type:       "FakeAWS::Versioned::Parent",
+				Stack:      "test-stack",
+				Target:     "test-target",
+				Schema:     producerSchema,
+				Properties: json.RawMessage(`{"Name": "parent-1", "Value": "world"}`),
+			},
+			{
+				Label:  "consumer",
+				Type:   "FakeAWS::Versioned::Consumer",
+				Stack:  "test-stack",
+				Target: "test-target",
+				Schema: consumerSchema,
+				Properties: json.RawMessage(`{
+					"Name": "consumer-1",
+					"ParentRef": {
+						"$res":      true,
+						"$label":    "parent",
+						"$type":     "FakeAWS::Versioned::Parent",
+						"$stack":    "test-stack",
+						"$property": "Value"
+					}
+				}`),
+			},
+		},
+	}
+
+	existingTargets := []*pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+	}
+
+	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+		FormaCommandSourceUser, existingTargets, ds, nil, nil)
+	require.NoError(t, err)
+
+	planned := map[string]*ResourceUpdate{}
+	for i := range updates {
+		planned[updates[i].DesiredState.Label] = &updates[i]
+	}
+
+	require.Contains(t, planned, "parent", "producer whose field changed must be updated")
+
+	consumer, ok := planned["consumer"]
+	require.True(t, ok, "consumer following the producer's changed field must stay in the changeset")
+	assert.Contains(t, string(consumer.DesiredState.PatchDocument), "world",
+		"the consumer's patch must carry the producer's new value")
+}
+
+// A populated SetOnce property keeps its persisted value regardless of what
+// the forma resubmits, so a consumer referencing it must NOT be scheduled for
+// the resubmitted value: classification runs on effective desired state.
+func TestGenerateResourceUpdates_ConsumerIgnoresResubmittedSetOnceProducerField(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	producerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Value"},
+		Hints:      map[string]pkgmodel.FieldHint{"Name": {CreateOnly: true}},
+	}
+	consumerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "ParentRef"},
+		Hints:      map[string]pkgmodel.FieldHint{},
+	}
+
+	producerKsuid := util.NewID()
+	consumerKsuid := util.NewID()
+
+	existingStack := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "parent", Type: "FakeAWS::Versioned::Parent",
+				Stack: "test-stack", Target: "test-target",
+				Schema: producerSchema, Ksuid: producerKsuid,
+				Properties: json.RawMessage(`{"Name": "parent-1", "Value": {"$value": "hello", "$strategy": "SetOnce"}}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Versioned::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema, Ksuid: consumerKsuid,
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Name": "consumer-1", "ParentRef": {"$ref": "formae://%s#/Value", "$value": "hello"}}`,
+					producerKsuid)),
+			},
+		},
+	}
+	_, err := ds.StoreStack(existingStack, "previous-command")
+	require.NoError(t, err)
+
+	forma := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Targets: []pkgmodel.Target{
+			{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+		},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "parent", Type: "FakeAWS::Versioned::Parent",
+				Stack: "test-stack", Target: "test-target",
+				Schema:     producerSchema,
+				Properties: json.RawMessage(`{"Name": "parent-1", "Value": {"$value": "world-resubmitted", "$strategy": "SetOnce"}}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Versioned::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema,
+				Properties: json.RawMessage(`{
+					"Name": "consumer-1",
+					"ParentRef": {
+						"$res": true, "$label": "parent",
+						"$type": "FakeAWS::Versioned::Parent",
+						"$stack": "test-stack", "$property": "Value"
+					}
+				}`),
+			},
+		},
+	}
+	existingTargets := []*pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+	}
+
+	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+		FormaCommandSourceUser, existingTargets, ds, nil, nil)
+	require.NoError(t, err)
+
+	for i := range updates {
+		if updates[i].DesiredState.Label == "consumer" {
+			assert.NotContains(t, string(updates[i].DesiredState.PatchDocument), "world-resubmitted",
+				"the consumer must not be scheduled for a value the producer never adopts")
+		}
+	}
+}

--- a/internal/metastructure/resource_update/resource_update_rename_test.go
+++ b/internal/metastructure/resource_update/resource_update_rename_test.go
@@ -45,7 +45,7 @@ func TestRename_PreservesExistingKsuidNotNewResourceKsuid(t *testing.T) {
 	newResource.Ksuid = strayKsuid // simulate a stale/wrong KSUID from upstream
 
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
-	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, existing, newResource,
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newResource,
 		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser)
 	require.NoError(t, err)
 	require.Len(t, updates, 1)
@@ -80,7 +80,7 @@ func TestRename_PureLabelChange_AliasDriven(t *testing.T) {
 	newResource.Alias = "web-server"
 
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
-	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, existing, newResource,
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newResource,
 		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser)
 	require.NoError(t, err)
 	require.Len(t, updates, 1, "pure label rename must emit one update, got %d", len(updates))
@@ -114,7 +114,7 @@ func TestRename_LabelAndProperties_AliasDriven(t *testing.T) {
 	newResource.Properties = json.RawMessage(`{"InstanceType": "t3.medium"}`)
 
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
-	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, existing, newResource,
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newResource,
 		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser)
 	require.NoError(t, err)
 	require.Len(t, updates, 1)
@@ -141,7 +141,7 @@ func TestRename_LabelMismatchWithoutAlias_Rejected(t *testing.T) {
 	// no Alias
 
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
-	_, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, existing, newResource,
+	_, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newResource,
 		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser)
 	require.Error(t, err, "label mismatch without alias must be a generator bug")
 }
@@ -161,7 +161,7 @@ func TestRename_AliasDoesNotMatchExisting_Rejected(t *testing.T) {
 	newResource.Alias = "some-unrelated-name"
 
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
-	_, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, existing, newResource,
+	_, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newResource,
 		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser)
 	require.Error(t, err, "alias mismatch is a generator bug")
 }
@@ -197,7 +197,7 @@ func TestRename_BringingUnderManagementAndRename(t *testing.T) {
 	newResource.Managed = true
 
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
-	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, existing, newResource,
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newResource,
 		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser)
 	require.NoError(t, err)
 	require.Len(t, updates, 1, "combined import+rename must emit one update")


### PR DESCRIPTION
## Summary

- A consumer following a producer's mutable field through a resolvable was **dropped from the changeset** when the same command changed that field: plan-time resolution read only the persisted row, resolved the stale value, the patch compared empty, and apply reported Success while the consumer kept the old value in the cloud. The new generator-level test pins the failure and now passes.
- The fix introduces one shared per-command precomputation of **effective desired state** (the forma declaration after SetOnce filtering, computed once and fed to both the resolvable lookup and the update factory, so the filtering is never derived twice), and a per-property resolution rule: when the command declares the source and its effective desired document holds a **plain literal** for the referenced property, that literal is the plan-time resolution.
- The lookup's per-property answer is now typed (`deferred` zero-value / `resolved` / `stable`, plus an opacity flag), giving later work a seam without behavior change: `Get` semantics are preserved for all existing readers.
- **Opaque safety is fail-closed on the desired side**: values that are reference envelopes, hashed at rest, schema/known-table opaque, `$visibility`-marked on the persisted row, or inline-`$visibility`-marked in the desired document itself are never materialized into the lookup — they keep today's behavior exactly (envelopes answer the cached value; opaque sources defer to execution-time live resolution). The previously-duplicated opacity checks were unified into the existing `isSourcePropertyOpaque` oracle, which now also covers hashed shapes and the schema fallback; new tests pin each refusal, including opacity present only in `ReadOnlyProperties` and opacity present only in the not-yet-persisted desired document.
- A populated SetOnce property keeps its persisted value regardless of what the forma resubmits, and consumers referencing it are not scheduled for a value the producer never adopts (pinned by test).

Out of scope, unchanged here: recursive reference chains, absence semantics, execution-time regeneration fixes, and any change to opaque resolution behavior (the create-path inline-opaque lookup behavior is pre-existing and deliberately untouched, pinned by its existing test).

Verified: full `resource_update`, `resolver`, `patch`, and `target_update` unit suites plus the `apply_forma` workflow suite green; `go vet` clean.