### PR TITLE
fix(resource-update): execution-time patch regeneration is mode-faithful and fails loudly on late createOnly diffs

### DIFF
--- a/internal/metastructure/auto_reconciler.go
+++ b/internal/metastructure/auto_reconciler.go
@@ -382,7 +382,7 @@ func prepareReconcile(ds datastore.Datastore, stackLabel string, clientID string
 	if err != nil {
 		return nil, fmt.Errorf("failed to create changeset: %w", err)
 	}
-	cs, err := changeset.NewChangeset(resourceUpdates, synth, reconcileCommand.ID, pkgmodel.CommandApply)
+	cs, err := changeset.NewChangeset(resourceUpdates, synth, reconcileCommand.ID, pkgmodel.CommandApply, reconcileCommand.Config.Mode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create changeset: %w", err)
 	}

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -40,8 +40,13 @@ type Update interface {
 }
 
 type Changeset struct {
-	CommandID      string
-	DAG            *ExecutionDAG
+	CommandID string
+	DAG       *ExecutionDAG
+	// Mode is the apply mode the owning command was planned under (reconcile
+	// vs patch). Execution-time patch regeneration (a resolvable resolving
+	// after planning) must derive its diff under this same mode, or a
+	// reconcile-planned removal can silently vanish under patch semantics.
+	Mode           pkgmodel.FormaApplyMode
 	trackedUpdates map[string]bool
 }
 
@@ -74,10 +79,12 @@ func NewChangeset(
 	targetUpdates []target_update.TargetUpdate,
 	commandID string,
 	command pkgmodel.Command,
+	mode pkgmodel.FormaApplyMode,
 ) (Changeset, error) {
 	changeset := Changeset{
 		CommandID:      commandID,
 		DAG:            NewExecutionDAG(),
+		Mode:           mode,
 		trackedUpdates: make(map[string]bool),
 	}
 

--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -320,7 +320,7 @@ func resume(from gen.PID, state gen.Atom, data ChangesetData, message Resume, pr
 			finished = false
 		}
 		updates := data.changeset.GetExecutableUpdates(namespace, n)
-		err = startUpdates(updates, data.changeset.CommandID, proc)
+		err = startUpdates(updates, data.changeset.CommandID, data.changeset.Mode, proc)
 		if err != nil {
 			proc.Log().Error("Failed to start executable updates for changeset commandID=%s: %v", data.changeset.CommandID, err)
 			return StateFinishedWithError, data, nil, nil
@@ -634,11 +634,11 @@ func handleUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, even
 	return resume(from, state, data, Resume{}, proc)
 }
 
-func startUpdates(updates []Update, commandID string, proc gen.Process) error {
+func startUpdates(updates []Update, commandID string, mode pkgmodel.FormaApplyMode, proc gen.Process) error {
 	for _, update := range updates {
 		switch u := update.(type) {
 		case *resource_update.ResourceUpdate:
-			if err := startResourceUpdate(u, commandID, proc); err != nil {
+			if err := startResourceUpdate(u, commandID, mode, proc); err != nil {
 				return err
 			}
 		case *target_update.TargetUpdate:
@@ -653,7 +653,7 @@ func startUpdates(updates []Update, commandID string, proc gen.Process) error {
 	return nil
 }
 
-func startResourceUpdate(ru *resource_update.ResourceUpdate, commandID string, proc gen.Process) error {
+func startResourceUpdate(ru *resource_update.ResourceUpdate, commandID string, mode pkgmodel.FormaApplyMode, proc gen.Process) error {
 	proc.Log().Debug("Starting resource updater uri=%v operation=%s", ru.URI(), ru.Operation)
 
 	// Sync exclusion is handled in bulk by registerAllResourcesWithSynchronizer
@@ -678,6 +678,7 @@ func startResourceUpdate(ru *resource_update.ResourceUpdate, commandID string, p
 		resource_update.StartResourceUpdate{
 			ResourceUpdate: *ru,
 			CommandID:      commandID,
+			Mode:           mode,
 		})
 	if err != nil {
 		proc.Log().Error("Failed to send start message to resource updater: %v", err)

--- a/internal/metastructure/changeset/resolve_test_helper_test.go
+++ b/internal/metastructure/changeset/resolve_test_helper_test.go
@@ -17,6 +17,11 @@ import (
 // call shape so the many existing tests port with a mechanical rename, and it
 // preserves their assertions: a reject error surfaces from the synthesis step,
 // a dependency-cycle error from NewChangeset.
+//
+// Mode is fixed at Reconcile: none of this package's tests exercise
+// ResolveValue/patch regeneration (they assert DAG structure), so no test
+// caller here has a command config to thread a real mode from, and the fixed
+// value has no effect on what they assert.
 func buildChangesetForTest(
 	resourceUpdates []resource_update.ResourceUpdate,
 	targetUpdates []target_update.TargetUpdate,
@@ -31,5 +36,5 @@ func buildChangesetForTest(
 	if err != nil {
 		return Changeset{}, err
 	}
-	return NewChangeset(resourceUpdates, append(targetUpdates, synth...), commandID, command)
+	return NewChangeset(resourceUpdates, append(targetUpdates, synth...), commandID, command, pkgmodel.FormaApplyModeReconcile)
 }

--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -797,7 +797,7 @@ func synchronizeResources(op ListOperation, namespace string, target pkgmodel.Ta
 		finalizeFailedSyncCommand(syncCommand, proc)
 		return "", fmt.Errorf("failed to build changeset: %w", err)
 	}
-	cs, err := changeset.NewChangeset(syncCommand.ResourceUpdates, synth, syncCommand.ID, pkgmodel.CommandSync)
+	cs, err := changeset.NewChangeset(syncCommand.ResourceUpdates, synth, syncCommand.ID, pkgmodel.CommandSync, syncCommand.Config.Mode)
 	if err != nil {
 		slog.Error("failed to build changeset for discovery sync command", "commandID", syncCommand.ID, "error", err)
 		finalizeFailedSyncCommand(syncCommand, proc)

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -361,7 +361,7 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 		if synthErr != nil {
 			return nil, synthErr
 		}
-		cs, err = changeset.NewChangeset(fa.ResourceUpdates, append(fa.TargetUpdates, synth...), fa.ID, fa.Command)
+		cs, err = changeset.NewChangeset(fa.ResourceUpdates, append(fa.TargetUpdates, synth...), fa.ID, fa.Command, config.Mode)
 		if err != nil {
 			return nil, err
 		}
@@ -831,7 +831,7 @@ func (m *Metastructure) DestroyForma(forma *pkgmodel.Forma, config *config.Forma
 		if synthErr != nil {
 			return nil, synthErr
 		}
-		cs, err := changeset.NewChangeset(fa.ResourceUpdates, append(fa.TargetUpdates, synth...), fa.ID, pkgmodel.CommandDestroy)
+		cs, err := changeset.NewChangeset(fa.ResourceUpdates, append(fa.TargetUpdates, synth...), fa.ID, pkgmodel.CommandDestroy, config.Mode)
 		if err != nil {
 			return nil, err
 		}
@@ -1431,7 +1431,7 @@ func (m *Metastructure) ReRunIncompleteCommands() error {
 			slog.Error("Failed to build changeset for incomplete forma command, skipping", "commandID", fa.ID, "error", synthErr)
 			continue
 		}
-		cs, err := changeset.NewChangeset(pendingUpdates, append(pendingTargetUpdates, synth...), fa.ID, pkgmodel.CommandApply)
+		cs, err := changeset.NewChangeset(pendingUpdates, append(pendingTargetUpdates, synth...), fa.ID, pkgmodel.CommandApply, fa.Config.Mode)
 		if err != nil {
 			slog.Error("Failed to build changeset for incomplete forma command, skipping", "commandID", fa.ID, "error", err)
 			continue

--- a/internal/metastructure/resource_update/regenerate_createonly_test.go
+++ b/internal/metastructure/resource_update/regenerate_createonly_test.go
@@ -1,0 +1,94 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// A createOnly diff that only appears when a reference resolves at execution
+// time means plan-time classification missed a replacement. The update must
+// fail with a typed error naming the field: never silently dropped, never an
+// undeclared replacement.
+func TestResolveValue_LateCreateOnlyDiff_FailsLoudly(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Anchor"},
+		Hints:      map[string]pkgmodel.FieldHint{"Anchor": {CreateOnly: true}},
+	}
+	ru := ResourceUpdate{
+		Operation: OperationUpdate,
+		PriorState: pkgmodel.Resource{
+			Label: "consumer", Type: "Test::Config::Entry", Schema: schema,
+			Properties: json.RawMessage(`{"Name": "c1", "Anchor": "old-anchor"}`),
+		},
+		DesiredState: pkgmodel.Resource{
+			Label: "consumer", Type: "Test::Config::Entry", Schema: schema,
+			Properties: json.RawMessage(`{"Name": "c1", "Anchor": {"$ref": "formae://k-src#/Anchor"}}`),
+		},
+		RemainingResolvables: []pkgmodel.FormaeURI{"formae://k-src#/Anchor"},
+	}
+
+	err := ru.ResolveValue("formae://k-src#/Anchor", "new-anchor", pkgmodel.FormaApplyModeReconcile)
+	require.Error(t, err)
+	var late LateCreateOnlyChangeError
+	require.True(t, errors.As(err, &late), "the failure must be the typed late-createOnly error")
+	assert.Contains(t, late.Fields, "Anchor")
+	assert.Equal(t, "consumer", late.ResourceLabel)
+}
+
+// The state machine's resolve-completion handler must not just fail the
+// update: an operator reading the resource update's status afterward has to
+// be able to see WHY it failed. This drives the same late-createOnly diff
+// through resourceResolved (the StateResolving message handler that calls
+// ResolveValue) and asserts the reason lands on the surface the status query
+// reads — MostRecentFailureMessage — naming both the category and the field.
+func TestResourceResolved_LateCreateOnlyDiff_PersistsReason(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Anchor"},
+		Hints:      map[string]pkgmodel.FieldHint{"Anchor": {CreateOnly: true}},
+	}
+	ru := &ResourceUpdate{
+		Operation: OperationUpdate,
+		PriorState: pkgmodel.Resource{
+			Label: "consumer", Type: "Test::Config::Entry", Schema: schema,
+			Properties: json.RawMessage(`{"Name": "c1", "Anchor": "old-anchor"}`),
+		},
+		DesiredState: pkgmodel.Resource{
+			Label: "consumer", Type: "Test::Config::Entry", Schema: schema,
+			Properties: json.RawMessage(`{"Name": "c1", "Anchor": {"$ref": "formae://k-src#/Anchor"}}`),
+		},
+		RemainingResolvables: []pkgmodel.FormaeURI{"formae://k-src#/Anchor"},
+	}
+	data := ResourceUpdateData{
+		resourceUpdate:           ru,
+		commandID:                "cmd-1",
+		applyMode:                pkgmodel.FormaApplyModeReconcile,
+		originalResourceKsuidURI: ru.DesiredState.URI(),
+	}
+	proc := newOperationCapturingProcess()
+
+	state, _, _, err := resourceResolved(gen.PID{}, StateResolving, data,
+		messages.ValueResolved{ResourceURI: "formae://k-src#/Anchor", Value: "new-anchor"}, proc)
+	require.NoError(t, err, "resourceResolved reports the failure on the resource update, not as a Go error")
+	assert.Equal(t, StateFinishedWithError, state)
+
+	message := ru.MostRecentFailureMessage()
+	require.NotEmpty(t, message, "a late createOnly diff must still surface a reason")
+	assert.Contains(t, message, "createOnly")
+	assert.Contains(t, message, "Anchor")
+}

--- a/internal/metastructure/resource_update/regenerate_mode_test.go
+++ b/internal/metastructure/resource_update/regenerate_mode_test.go
@@ -1,0 +1,64 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// Execution-time patch regeneration must derive the patch under the same
+// apply-mode semantics the command was planned with: under reconcile, an
+// EntitySet member present in the prior state and absent from the desired
+// state produces a remove op; under patch mode, absence means "leave
+// unchanged" and no remove op may appear.
+//
+// A plain scalar field dropped from the desired state does not diff under
+// either strategy (jsonpatch only emits removes for EntitySet-hinted
+// collections — see jsonpatch.diff), so it cannot distinguish the two modes.
+// The fixture uses an EntitySet-hinted Tags field losing a member instead,
+// alongside a still-unresolved Endpoint reference, to exercise regeneration
+// after a resolve while keeping the mode-sensitive removal observable.
+func TestResolveValue_RegeneratesUnderCommandMode(t *testing.T) {
+	newUpdate := func() ResourceUpdate {
+		schema := pkgmodel.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "Endpoint", "Tags"},
+			Hints: map[string]pkgmodel.FieldHint{
+				"Tags": {UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Key"},
+			},
+		}
+		return ResourceUpdate{
+			Operation: OperationUpdate,
+			PriorState: pkgmodel.Resource{
+				Label: "consumer", Type: "Test::Config::Entry", Schema: schema,
+				Properties: json.RawMessage(`{"Name": "c1", "Endpoint": "old-endpoint", "Tags": [{"Key": "env", "Value": "prod"}, {"Key": "legacy", "Value": "true"}]}`),
+			},
+			DesiredState: pkgmodel.Resource{
+				Label: "consumer", Type: "Test::Config::Entry", Schema: schema,
+				Properties: json.RawMessage(`{"Name": "c1", "Endpoint": {"$ref": "formae://k-src#/Endpoint"}, "Tags": [{"Key": "env", "Value": "prod"}]}`),
+			},
+			RemainingResolvables: []pkgmodel.FormaeURI{"formae://k-src#/Endpoint"},
+		}
+	}
+
+	reconcile := newUpdate()
+	require.NoError(t, reconcile.ResolveValue("formae://k-src#/Endpoint", "new-endpoint", pkgmodel.FormaApplyModeReconcile))
+	assert.Contains(t, string(reconcile.DesiredState.PatchDocument), "remove",
+		"reconcile regeneration must keep the remove op for the dropped Tags member")
+	assert.Contains(t, string(reconcile.DesiredState.PatchDocument), "Tags")
+
+	patchMode := newUpdate()
+	require.NoError(t, patchMode.ResolveValue("formae://k-src#/Endpoint", "new-endpoint", pkgmodel.FormaApplyModePatch))
+	assert.NotContains(t, string(patchMode.DesiredState.PatchDocument), "remove",
+		"patch-mode regeneration must leave the undeclared Tags member unchanged")
+}

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -115,10 +115,15 @@ func (ru *ResourceUpdate) ListResolvables() []pkgmodel.FormaeURI {
 // plugin call sees a diff that matches reality. ResolveValue is the only
 // apply-time mutator of DesiredState.Properties, so it owns the regen.
 //
+// mode is the command's configured apply mode (reconcile vs patch), the
+// same mode planning used to derive the original patch — regeneration must
+// use identical semantics or a reconcile-planned removal can silently
+// vanish when a resolvable resolves at execution time.
+//
 // Only Updates need a fresh patch — Create/Delete/Replace carry full
 // desired/prior state to the provider rather than a diff. Patch regen is
 // also a no-op when no Schema is available (sync/discovery paths).
-func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value string) error {
+func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value string, mode pkgmodel.FormaApplyMode) error {
 	properties, err := resolver.ResolvePropertyReferences(formaeUri, ru.DesiredState.Properties, value)
 	if err != nil {
 		slog.Error("Failed to resolve dynamic properties", "error", err)
@@ -127,10 +132,14 @@ func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value strin
 	ru.DesiredState.Properties = properties
 
 	if ru.Operation == OperationUpdate && len(ru.DesiredState.Schema.Fields) > 0 {
-		patchDoc, derr := ru.regeneratePatchDocument()
+		patchDoc, createOnlyPatch, derr := ru.regeneratePatchDocument(mode)
 		if derr != nil {
 			return fmt.Errorf("failed to re-derive patch document after resolving %s: %w", formaeUri, derr)
 		}
+		// createOnlyPatch (ops against createOnly fields newly triggered by
+		// this resolve) is deliberately ignored here — loud failure on a late
+		// createOnly diff is handled by a follow-up change, not this one.
+		_ = createOnlyPatch
 		ru.DesiredState.PatchDocument = patchDoc
 	}
 
@@ -148,11 +157,17 @@ func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value strin
 // patch op, and resource_updater.go's update() forwards PatchDocument to the
 // plugin unconverted, so any hash material in it would reach the plugin
 // unguarded.
-func (ru *ResourceUpdate) regeneratePatchDocument() (json.RawMessage, error) {
+//
+// mode must match the apply mode the command was planned under (reconcile ->
+// ExactMatch, patch -> EnsureExists) — see patch.GeneratePatch — so a
+// reconcile-planned removal is not silently dropped by regenerating under
+// patch semantics. Returns (patch, createOnlyPatch, err); the caller decides
+// what to do with a createOnly diff surfaced this late.
+func (ru *ResourceUpdate) regeneratePatchDocument(mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, error) {
 	existingForPatch, desiredForPatch, err := SuppressUnchangedOpaqueValues(
 		ru.PriorState.Properties, ru.DesiredState.Properties, ru.DesiredState.Schema, ru.DesiredState.Type)
 	if err != nil {
-		return nil, fmt.Errorf("failed to suppress unchanged opaque values: %w", err)
+		return nil, nil, fmt.Errorf("failed to suppress unchanged opaque values: %w", err)
 	}
 
 	// Read-safe/comparison conversion: existingPluginProps is only used as the
@@ -162,7 +177,7 @@ func (ru *ResourceUpdate) regeneratePatchDocument() (json.RawMessage, error) {
 	// generation.
 	existingPluginProps, err := resolver.ConvertExistingStateForComparison(existingForPatch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert existing properties to plugin format: %w", err)
+		return nil, nil, fmt.Errorf("failed to convert existing properties to plugin format: %w", err)
 	}
 
 	// Guarded conversion: desiredForPatch is the "after" side and, once an
@@ -171,23 +186,23 @@ func (ru *ResourceUpdate) regeneratePatchDocument() (json.RawMessage, error) {
 	// is broken, and that must fail loudly rather than silently reach a plugin.
 	newPluginProps, err := resolver.ConvertToPluginFormat(desiredForPatch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert desired properties to plugin format: %w", err)
+		return nil, nil, fmt.Errorf("failed to convert desired properties to plugin format: %w", err)
 	}
 
-	patchDoc, _, err := patch.GeneratePatch(
+	patchDoc, createOnlyPatch, err := patch.GeneratePatch(
 		existingPluginProps,
 		newPluginProps,
 		existingForPatch,
 		desiredForPatch,
 		resolver.NewResolvableProperties(),
 		ru.DesiredState.Schema,
-		pkgmodel.FormaApplyModePatch,
+		mode,
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return patchDoc, nil
+	return patchDoc, createOnlyPatch, nil
 }
 
 func (ru *ResourceUpdate) RequiresDelete() bool {

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -55,6 +55,19 @@ const (
 	ResourceUpdateStateRejected   = types.ResourceUpdateStateRejected
 )
 
+// LateCreateOnlyChangeError reports that resolving a reference at execution
+// time produced a diff on createOnly fields that plan-time classification did
+// not declare. The update must fail rather than silently drop the diff or
+// escalate to an undeclared replacement.
+type LateCreateOnlyChangeError struct {
+	ResourceLabel string
+	Fields        []string
+}
+
+func (e LateCreateOnlyChangeError) Error() string {
+	return fmt.Sprintf("resolving references at execution time changed createOnly fields %v on %s; a replacement was not planned, refusing to proceed", e.Fields, e.ResourceLabel)
+}
+
 // ResourceUpdate represents an update to a resource in the system. A ResourceUpdate is a logical operation
 // that may involve multiple plugin operations. For example a replace operation will involve two plugin
 // operations: a delete and a create.
@@ -136,10 +149,13 @@ func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value strin
 		if derr != nil {
 			return fmt.Errorf("failed to re-derive patch document after resolving %s: %w", formaeUri, derr)
 		}
-		// createOnlyPatch (ops against createOnly fields newly triggered by
-		// this resolve) is deliberately ignored here — loud failure on a late
-		// createOnly diff is handled by a follow-up change, not this one.
-		_ = createOnlyPatch
+		if len(createOnlyPatch) > 0 {
+			fields, ferr := createOnlyPatchFields(createOnlyPatch)
+			if ferr != nil {
+				return fmt.Errorf("failed to inspect createOnly patch after resolving %s: %w", formaeUri, ferr)
+			}
+			return LateCreateOnlyChangeError{ResourceLabel: ru.DesiredState.Label, Fields: fields}
+		}
 		ru.DesiredState.PatchDocument = patchDoc
 	}
 
@@ -203,6 +219,34 @@ func (ru *ResourceUpdate) regeneratePatchDocument(mode pkgmodel.FormaApplyMode) 
 	}
 
 	return patchDoc, createOnlyPatch, nil
+}
+
+// createOnlyPatchFields extracts the distinct top-level field names touched
+// by a createOnly patch document, in first-seen order, so
+// LateCreateOnlyChangeError can name what changed without exposing the raw
+// JSON-patch op shape to callers.
+func createOnlyPatchFields(createOnlyPatch json.RawMessage) ([]string, error) {
+	var ops []struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(createOnlyPatch, &ops); err != nil {
+		return nil, fmt.Errorf("failed to parse createOnly patch ops: %w", err)
+	}
+
+	seen := make(map[string]struct{}, len(ops))
+	var fields []string
+	for _, op := range ops {
+		field, _, _ := strings.Cut(strings.TrimPrefix(op.Path, "/"), "/")
+		if field == "" {
+			continue
+		}
+		if _, ok := seen[field]; ok {
+			continue
+		}
+		seen[field] = struct{}{}
+		fields = append(fields, field)
+	}
+	return fields, nil
 }
 
 func (ru *ResourceUpdate) RequiresDelete() bool {

--- a/internal/metastructure/resource_update/resource_update_test.go
+++ b/internal/metastructure/resource_update/resource_update_test.go
@@ -278,7 +278,7 @@ func TestResolveValue_UpdatesResolvedValueInProperties(t *testing.T) {
 			Properties: json.RawMessage(fmt.Sprintf(`{"resolvable": {"$ref":"formae://%s#/Id"}}`, resourceKsuid)),
 		},
 	}
-	err := resourceUpdate.ResolveValue(resolvableUri, "12345")
+	err := resourceUpdate.ResolveValue(resolvableUri, "12345", pkgmodel.FormaApplyModeReconcile)
 	assert.NoError(t, err)
 
 	expectedJson := fmt.Sprintf(`{"resolvable":{"$ref":"formae://%s#/Id","$value":"12345"}}`, resourceKsuid)

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -625,6 +625,18 @@ func resourceResolved(from gen.PID, state gen.Atom, data ResourceUpdateData, mes
 	err := data.resourceUpdate.ResolveValue(message.ResourceURI, message.Value, data.applyMode)
 	if err != nil {
 		proc.Log().Error("failed to resolve value for resource update resourceURI=%v: %v", message.ResourceURI, err)
+		// LateCreateOnlyChangeError is already a fixed, redacted text (it names
+		// only the changed field, never a value) — record it verbatim. Every
+		// other resolve/regen failure can carry error detail built from
+		// user-authored property paths (see updateRequestFailureReason's
+		// doc), so it must route through the same redaction mapping the rest
+		// of the update path uses rather than recording the raw error.
+		var late LateCreateOnlyChangeError
+		if errors.As(err, &late) {
+			data.resourceUpdate.FailureReason = late.Error()
+		} else {
+			data.resourceUpdate.FailureReason = updateRequestFailureReason(err)
+		}
 		data.resourceUpdate.MarkAsFailed()
 		return StateFinishedWithError, data, nil, nil
 	}

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -153,6 +153,11 @@ type StartResourceUpdate struct {
 	ResourceUpdate ResourceUpdate
 	CommandID      string
 	UpdateId       string
+	// Mode is the apply mode the owning command was planned under (reconcile
+	// vs patch). It flows into ResourceUpdateData.applyMode so a resolvable
+	// that resolves after planning regenerates its patch under the same
+	// semantics the command was planned with.
+	Mode pkgmodel.FormaApplyMode
 }
 
 type PluginOperatorMissingInAction struct{}
@@ -206,6 +211,12 @@ type ResourceUpdateData struct {
 	retryConfig     pkgmodel.RetryConfig
 	requestedBy     gen.PID
 	commandSource   FormaCommandSource
+
+	// applyMode is the apply mode the owning command was planned under
+	// (reconcile vs patch), set from StartResourceUpdate.Mode in start().
+	// resourceResolved passes it to ResolveValue so execution-time patch
+	// regeneration derives its diff under the same semantics planning used.
+	applyMode pkgmodel.FormaApplyMode
 
 	// operatorRetryConfig is the retry config the PluginCoordinator spawned the
 	// watched plugin operator with, which is the per-plugin override wherever
@@ -388,6 +399,7 @@ func start(from gen.PID, state gen.Atom, data ResourceUpdateData, message StartR
 	data.resourceUpdate = &message.ResourceUpdate
 	data.commandID = message.CommandID
 	data.commandSource = message.ResourceUpdate.Source
+	data.applyMode = message.Mode
 	data.resourceUpdate.StartTs = util.TimeNow()
 	data.resourceUpdate.ModifiedTs = data.resourceUpdate.StartTs
 	data.originalResourceKsuidURI = data.resourceUpdate.DesiredState.URI()
@@ -610,7 +622,7 @@ func resolve(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Ato
 }
 
 func resourceResolved(from gen.PID, state gen.Atom, data ResourceUpdateData, message messages.ValueResolved, proc gen.Process) (gen.Atom, ResourceUpdateData, []statemachine.Action, error) {
-	err := data.resourceUpdate.ResolveValue(message.ResourceURI, message.Value)
+	err := data.resourceUpdate.ResolveValue(message.ResourceURI, message.Value, data.applyMode)
 	if err != nil {
 		proc.Log().Error("failed to resolve value for resource update resourceURI=%v: %v", message.ResourceURI, err)
 		data.resourceUpdate.MarkAsFailed()

--- a/internal/metastructure/resource_update/resource_updater_test.go
+++ b/internal/metastructure/resource_update/resource_updater_test.go
@@ -92,7 +92,7 @@ func TestResolveValue_KeepsPatchDocumentInSync(t *testing.T) {
 		},
 	}
 
-	err := ru.ResolveValue(parentURI, "arn:aws:ecs:us-east-1:0:task-definition/test:2")
+	err := ru.ResolveValue(parentURI, "arn:aws:ecs:us-east-1:0:task-definition/test:2", pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotEmpty(t, ru.DesiredState.PatchDocument, "ResolveValue must populate PatchDocument when DesiredState changes")
 	patchStr := string(ru.DesiredState.PatchDocument)
@@ -132,7 +132,7 @@ func TestResolveValue_NoChangeProducesEmptyPatch(t *testing.T) {
 			Schema:     schema,
 		},
 	}
-	err := ru.ResolveValue(parentURI, "v1")
+	err := ru.ResolveValue(parentURI, "v1", pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	if len(ru.DesiredState.PatchDocument) > 0 {
 		assert.Equal(t, "[]", string(ru.DesiredState.PatchDocument),
@@ -164,7 +164,7 @@ func TestResolveValue_NonUpdateLeavesPatchDocumentUntouched(t *testing.T) {
 					PatchDocument: json.RawMessage(`["pre-existing-untouched"]`),
 				},
 			}
-			err := ru.ResolveValue(parentURI, "v2")
+			err := ru.ResolveValue(parentURI, "v2", pkgmodel.FormaApplyModeReconcile)
 			require.NoError(t, err)
 			assert.Equal(t, `["pre-existing-untouched"]`, string(ru.DesiredState.PatchDocument),
 				"non-Update operations must not re-derive PatchDocument")
@@ -221,7 +221,7 @@ func TestResolveValue_SuppressesUnchangedHashedOpaqueField(t *testing.T) {
 		},
 	}
 
-	err := ru.ResolveValue(parentURI, "v2")
+	err := ru.ResolveValue(parentURI, "v2", pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 
 	patchStr := string(ru.DesiredState.PatchDocument)

--- a/internal/metastructure/stack_expirer.go
+++ b/internal/metastructure/stack_expirer.go
@@ -274,7 +274,7 @@ func prepareDestroyExpiredStack(ds datastore.Datastore, stackInfo datastore.Expi
 	if err != nil {
 		return nil, fmt.Errorf("failed to create changeset: %w", err)
 	}
-	cs, err := changeset.NewChangeset(resourceUpdates, synth, destroyCommand.ID, pkgmodel.CommandDestroy)
+	cs, err := changeset.NewChangeset(resourceUpdates, synth, destroyCommand.ID, pkgmodel.CommandDestroy, destroyCommand.Config.Mode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create changeset: %w", err)
 	}

--- a/internal/metastructure/synchronizer.go
+++ b/internal/metastructure/synchronizer.go
@@ -343,7 +343,7 @@ func synchronizeAllResources(state gen.Atom, data SynchronizerData, proc gen.Pro
 		finalizeFailedCommand(syncCommand, proc)
 		return StateIdle, data, rescheduleAction(data), nil
 	}
-	cs, err := changeset.NewChangeset(allResourceUpdates, synth, syncCommand.ID, pkgmodel.CommandSync)
+	cs, err := changeset.NewChangeset(allResourceUpdates, synth, syncCommand.ID, pkgmodel.CommandSync, syncCommand.Config.Mode)
 	if err != nil {
 		proc.Log().Error("Synchronizer: failed to build changeset, skipping sync cycle commandID=%s: %v", syncCommand.ID, err)
 		finalizeFailedCommand(syncCommand, proc)

--- a/internal/workflow_tests/local/apply_forma/regeneration_mode_test.go
+++ b/internal/workflow_tests/local/apply_forma/regeneration_mode_test.go
@@ -1,0 +1,199 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// TestApplyForma_ReconcileRemoval_SurvivesLiveReferenceResolution pins that a
+// reconcile-planned removal reaches the provider even when the same update
+// also carries a reference that only resolves at execution time.
+//
+// The consumer both references the producer's Name (forcing a live resolve
+// on every apply, per the executor's re-resolve-before-dispatch path — see
+// TestApplyForma_UnchangedReference_IsAbsentFromTheExecutedPatch) and
+// declares an EntitySet-hinted Tags list. A plain scalar field dropped from
+// a desired state produces no diff under either apply mode (jsonpatch only
+// emits removes for EntitySet-hinted collections), so an EntitySet member is
+// the shape that actually distinguishes reconcile from patch semantics; see
+// regenerate_mode_test.go in the resource_update package for the same
+// finding at the unit level.
+//
+// Before threading the command's apply mode into execution-time patch
+// regeneration, the live reference resolve regenerated the patch under
+// hardcoded patch-mode (EnsureExists) semantics regardless of how the
+// command was actually planned, so a reconcile-planned Tags removal never
+// reached the provider.
+func TestApplyForma_ReconcileRemoval_SurvivesLiveReferenceResolution(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		echoForm := func(name string) string { return "arn:fake:producer/" + name }
+
+		var consumerState atomic.Value // current provider-side consumer properties (JSON string)
+		var consumerUpdatePatch atomic.Value
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				var props string
+				switch req.ResourceType {
+				case "FakeAWS::Tagged::Producer":
+					props = `{"Name":"producer-1","Value":"hello"}`
+				case "FakeAWS::Tagged::Consumer":
+					props = fmt.Sprintf(
+						`{"Name":"consumer-1","ParentRef":"%s","Tags":[{"Key":"env","Value":"prod"},{"Key":"legacy","Value":"true"}]}`,
+						echoForm("producer-1"))
+					consumerState.Store(props)
+				}
+				return &resource.CreateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:          resource.OperationCreate,
+						OperationStatus:    resource.OperationStatusSuccess,
+						NativeID:           req.Label,
+						ResourceProperties: json.RawMessage(props),
+					},
+				}, nil
+			},
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				switch req.ResourceType {
+				case "FakeAWS::Tagged::Producer":
+					return &resource.ReadResult{
+						ResourceType: req.ResourceType,
+						Properties:   `{"Name":"producer-1","Value":"hello"}`,
+					}, nil
+				case "FakeAWS::Tagged::Consumer":
+					if stored, ok := consumerState.Load().(string); ok {
+						return &resource.ReadResult{ResourceType: req.ResourceType, Properties: stored}, nil
+					}
+				}
+				return nil, nil
+			},
+			Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				if req.ResourceType == "FakeAWS::Tagged::Consumer" && req.PatchDocument != nil {
+					consumerUpdatePatch.Store(*req.PatchDocument)
+					// Reflect the applied removal so a subsequent Read (e.g. the
+					// next apply's plan) sees the post-update state.
+					consumerState.Store(fmt.Sprintf(
+						`{"Name":"consumer-1","ParentRef":"%s","Tags":[{"Key":"env","Value":"prod"}]}`,
+						echoForm("producer-1")))
+				}
+				return &resource.UpdateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationUpdate,
+						OperationStatus: resource.OperationStatusSuccess,
+						RequestID:       "update-req-1",
+						NativeID:        req.NativeID,
+					},
+				}, nil
+			},
+		}
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		producerSchema := pkgmodel.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "Value"},
+			Hints:      map[string]pkgmodel.FieldHint{"Name": {CreateOnly: true}},
+		}
+		consumerSchema := pkgmodel.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "ParentRef", "Tags"},
+			Hints: map[string]pkgmodel.FieldHint{
+				"Name":      {CreateOnly: true},
+				"ParentRef": {CreateOnly: false},
+				"Tags":      {UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Key"},
+			},
+		}
+
+		formaFor := func(tagsJSON string) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+				Resources: []pkgmodel.Resource{
+					{
+						Label:      "producer",
+						Type:       "FakeAWS::Tagged::Producer",
+						Properties: json.RawMessage(`{"Name":"producer-1","Value":"hello"}`),
+						Stack:      "test-stack",
+						Target:     "test-target",
+						Managed:    true,
+						Schema:     producerSchema,
+					},
+					{
+						Label: "consumer",
+						Type:  "FakeAWS::Tagged::Consumer",
+						Properties: json.RawMessage(fmt.Sprintf(`{
+							"Name": "consumer-1",
+							"ParentRef": {
+								"$res": true,
+								"$label": "producer",
+								"$type": "FakeAWS::Tagged::Producer",
+								"$stack": "test-stack",
+								"$property": "Name"
+							},
+							"Tags": %s
+						}`, tagsJSON)),
+						Stack:   "test-stack",
+						Target:  "test-target",
+						Managed: true,
+						Schema:  consumerSchema,
+					},
+				},
+				Targets: []pkgmodel.Target{{Label: "test-target"}},
+			}
+		}
+
+		v1Tags := `[{"Key":"env","Value":"prod"},{"Key":"legacy","Value":"true"}]`
+		v2Tags := `[{"Key":"env","Value":"prod"}]`
+
+		_, err = m.ApplyForma(formaFor(v1Tags), &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test", "", "")
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			fas, _ := m.Datastore.LoadFormaCommands()
+			return len(fas) > 0 && (fas[0].State == forma_command.CommandStateSuccess || fas[0].State == forma_command.CommandStateFailed)
+		}, 10*time.Second, 100*time.Millisecond, "v1 should reach terminal state")
+		fas, _ := m.Datastore.LoadFormaCommands()
+		require.Equal(t, forma_command.CommandStateSuccess, fas[0].State, "v1 apply should succeed")
+
+		// v2 drops the "legacy" Tags member from the declaration while the
+		// ParentRef reference to producer is unchanged (still requires a live
+		// resolve at execution — see the executor's re-resolve-before-dispatch
+		// path exercised by TestApplyForma_UnchangedReference_IsAbsentFromTheExecutedPatch).
+		_, err = m.ApplyForma(formaFor(v2Tags), &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test", "", "")
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			fas, _ := m.Datastore.LoadFormaCommands()
+			return len(fas) >= 2 && (fas[0].State == forma_command.CommandStateSuccess || fas[0].State == forma_command.CommandStateFailed)
+		}, 30*time.Second, 100*time.Millisecond, "v2 should reach terminal state")
+		fas, _ = m.Datastore.LoadFormaCommands()
+		require.Equal(t, forma_command.CommandStateSuccess, fas[0].State, "v2 apply should succeed")
+
+		executed := consumerUpdatePatch.Load()
+		require.NotNil(t, executed, "the provider must receive the consumer's update")
+		patchStr := executed.(string)
+		assert.Contains(t, patchStr, "remove", "the executed patch must carry the reconcile-planned removal")
+		assert.Contains(t, patchStr, "Tags", "the removal must target the dropped Tags member")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/regeneration_mode_test.go
+++ b/internal/workflow_tests/local/apply_forma/regeneration_mode_test.go
@@ -38,12 +38,6 @@ import (
 // the shape that actually distinguishes reconcile from patch semantics; see
 // regenerate_mode_test.go in the resource_update package for the same
 // finding at the unit level.
-//
-// Before threading the command's apply mode into execution-time patch
-// regeneration, the live reference resolve regenerated the patch under
-// hardcoded patch-mode (EnsureExists) semantics regardless of how the
-// command was actually planned, so a reconcile-planned Tags removal never
-// reached the provider.
 func TestApplyForma_ReconcileRemoval_SurvivesLiveReferenceResolution(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		echoForm := func(name string) string { return "arn:fake:producer/" + name }

--- a/internal/workflow_tests/local/changeset_resolve_helper_test.go
+++ b/internal/workflow_tests/local/changeset_resolve_helper_test.go
@@ -17,6 +17,11 @@ import (
 // generate synthetic Resolve target ops via target_update.SynthesizeResolveTargetUpdates,
 // then build the (ds-free) changeset. Keeps the old changeset.NewChangeset call
 // shape so existing tests port with a mechanical rename.
+//
+// Mode is fixed at Reconcile: this helper's callers exercise DAG/executor
+// wiring, not ResolveValue/patch regeneration, so no test caller here has a
+// command config to thread a real mode from, and the fixed value has no
+// effect on what they assert.
 func buildChangesetWithResolves(
 	resourceUpdates []resource_update.ResourceUpdate,
 	targetUpdates []target_update.TargetUpdate,
@@ -31,5 +36,5 @@ func buildChangesetWithResolves(
 	if err != nil {
 		return changeset.Changeset{}, err
 	}
-	return changeset.NewChangeset(resourceUpdates, append(targetUpdates, synth...), commandID, command)
+	return changeset.NewChangeset(resourceUpdates, append(targetUpdates, synth...), commandID, command, pkgmodel.FormaApplyModeReconcile)
 }


### PR DESCRIPTION
## Summary

Two pre-existing defects in execution-time patch regeneration. Whenever an update carries a resolvable, execution resolves it live and regenerates the patch; that regeneration diverged from what was planned in two ways.

- **Regeneration ran under hardcoded patch-mode semantics** while planning selects exact-match for reconcile, so a reconcile update that both carried a resolvable and removed part of its declaration (e.g. an EntitySet member such as a tag) silently lost the removal at execution: simulate showed it, the provider never received it. The command's configured apply mode now threads from the persisted command config through `NewChangeset` → the changeset executor → the updater FSM into `ResolveValue`/`regeneratePatchDocument`, and recovery re-threads it from the reloaded command. The new workflow test fails at the base commit (provider receives an empty patch) and passes at head with the remove op present.
- **Regeneration discarded the createOnly patch it computed**, so a createOnly diff surfacing only at execution (live-resolved value differing on an immutable field the plan did not classify as a replacement) was silently ignored. It now fails the update with a typed `LateCreateOnlyChangeError` naming the resource and fields — never silently dropped, and never escalated into a replacement the plan did not declare — and the reason is recorded on the resource update so its failure message names the fields. Non-typed resolve failures route through the existing redacted failure-reason mapping.

Deliberately unchanged: destroy paths (destroy changesets contain no update operations, verified), and everything about opaque/secret resolution.

Verified: `resource_update`, `changeset`, `patch` unit suites and the full local workflow suites green; the mode-fidelity test verified red-at-base/green-at-head; build and vet clean.