### PR TITLE
fix(cli): detect kitty graphics inside a herdr pane

### DIFF
--- a/internal/cli/tui/logo/detect.go
+++ b/internal/cli/tui/logo/detect.go
@@ -24,6 +24,7 @@ type envInfo struct {
 	Tmux    bool // inside tmux or screen
 	SSH     bool // inside an SSH session
 	Unicode bool // terminal supports Unicode (braille)
+	Herdr   bool // inside a herdr multiplexer pane
 
 	// Env hints — insufficient alone to enable graphics
 	KittyWindowID bool   // KITTY_WINDOW_ID is set
@@ -33,17 +34,42 @@ type envInfo struct {
 }
 
 // probeResult holds the results of the raw-mode escape-sequence query.
-// Both fields are false when the probe was skipped (tmux/ssh) or timed out.
+// Both fields are false when the probe was skipped or timed out.
 type probeResult struct {
 	Kitty  bool
 	ITerm2 bool
+}
+
+// probeAllowed reports whether the escape-sequence probe may be sent and its
+// answer believed.
+//
+// tmux and screen intercept the escape stream, and over a plain SSH link a
+// reply that arrives after the timeout leaks its bytes into the shell, so both
+// normally suppress the probe.
+//
+// A herdr pane is the exception to the SSH rule. herdr's server outlives the
+// client that started it, so SSH_CLIENT/SSH_CONNECTION/SSH_TTY inside a pane
+// describe how that server was launched rather than this pane's terminal: a
+// session started once over SSH leaves them set in every pane it spawns
+// afterwards, including panes attached locally. herdr also answers the graphics
+// query itself on behalf of the attached client, so the reply is immediate and
+// cannot arrive late enough to leak. Its answer is better evidence than the
+// inherited variables.
+//
+// A tmux inside a herdr pane still suppresses the probe: the innermost
+// multiplexer owns the escape stream.
+func probeAllowed(env envInfo) bool {
+	if env.Tmux {
+		return false
+	}
+	return !env.SSH || env.Herdr
 }
 
 // decide is a pure function: given env signals and probe results it returns
 // the appropriate Capability.  The layered, fail-safe order is:
 //
 //  1. Hard disqualifiers → CapText
-//  2. Probe results (trusted only when NOT inside tmux/screen/ssh)
+//  2. Probe results (trusted only when probeAllowed says the probe is sound)
 //     probe.Kitty → CapKitty; probe.ITerm2 → CapITerm2
 //  3. Env hints are NOT sufficient to enable graphics; they only confirm
 //     braille is a safe choice
@@ -54,8 +80,8 @@ func decide(env envInfo, probe probeResult) Capability {
 		return CapText
 	}
 
-	// Layer 2: probe results — only trust them outside tmux/screen/ssh
-	if !env.Tmux && !env.SSH {
+	// Layer 2: probe results — only trust them where the probe is meaningful
+	if probeAllowed(env) {
 		if probe.Kitty {
 			return CapKitty
 		}
@@ -105,7 +131,7 @@ func parseKittyProbe(resp []byte) bool {
 
 // probe is the seam for raw-mode escape-sequence queries. It is a var so
 // tests can replace it without performing real terminal I/O.
-// Under tmux/ssh the seam returns an empty probeResult immediately.
+// Where probeAllowed is false the seam returns an empty probeResult immediately.
 //
 // Fail-safe invariant: any error, timeout, or uncertainty leaves all fields
 // false — decide() then lands on braille/text.  The probe only ever *adds*
@@ -113,9 +139,9 @@ func parseKittyProbe(resp []byte) bool {
 //
 //nolint:gochecknoglobals
 var probe = func(env envInfo) probeResult {
-	// Skip the escape-sequence probe entirely when inside tmux/screen/ssh —
+	// Skip the escape-sequence probe entirely where it cannot be trusted —
 	// a garbled escape in the banner is worse than no logo graphics.
-	if env.Tmux || env.SSH {
+	if !probeAllowed(env) {
 		return probeResult{}
 	}
 
@@ -272,6 +298,10 @@ func gatherEnv() envInfo {
 	profile := termenv.ColorProfile()
 	unicode := profile != termenv.Ascii
 
+	// herdr sets HERDR_ENV=1 in every pane it spawns; this is the marker herdr
+	// documents for detecting that a process runs inside one of its panes.
+	herdr := os.Getenv("HERDR_ENV") == "1"
+
 	kittyWindowID := os.Getenv("KITTY_WINDOW_ID") != ""
 	wezterm := os.Getenv("WEZTERM_EXECUTABLE") != "" ||
 		os.Getenv("WEZTERM_PANE") != ""
@@ -283,6 +313,7 @@ func gatherEnv() envInfo {
 		Tmux:          tmux,
 		SSH:           ssh,
 		Unicode:       unicode,
+		Herdr:         herdr,
 		KittyWindowID: kittyWindowID,
 		WezTerm:       wezterm,
 		TermProgram:   termProgram,

--- a/internal/cli/tui/logo/detect_test.go
+++ b/internal/cli/tui/logo/detect_test.go
@@ -7,6 +7,7 @@
 package logo
 
 import (
+	"os"
 	"sync"
 	"testing"
 )
@@ -90,6 +91,31 @@ func TestDecide(t *testing.T) {
 			name:  "probe.ITerm2 but SSH → CapBraille (probe ignored)",
 			env:   envInfo{IsTTY: true, SSH: true, Unicode: true},
 			probe: probeResult{ITerm2: true},
+			want:  CapBraille,
+		},
+		// ── herdr panes: inherited SSH_* must not suppress the probe ─────────
+		{
+			name:  "probe.Kitty, SSH inherited inside a herdr pane → CapKitty",
+			env:   envInfo{IsTTY: true, SSH: true, Herdr: true, Unicode: true},
+			probe: probeResult{Kitty: true},
+			want:  CapKitty,
+		},
+		{
+			name:  "probe.ITerm2, SSH inherited inside a herdr pane → CapITerm2",
+			env:   envInfo{IsTTY: true, SSH: true, Herdr: true, Unicode: true},
+			probe: probeResult{ITerm2: true},
+			want:  CapITerm2,
+		},
+		{
+			name:  "probe.Kitty, tmux inside a herdr pane → CapBraille (tmux wins)",
+			env:   envInfo{IsTTY: true, Tmux: true, Herdr: true, Unicode: true},
+			probe: probeResult{Kitty: true},
+			want:  CapBraille,
+		},
+		{
+			name:  "herdr pane with no probe result → CapBraille",
+			env:   envInfo{IsTTY: true, Herdr: true, Unicode: true},
+			probe: probeResult{},
 			want:  CapBraille,
 		},
 		// ── Env hints insufficient for graphics (no probe) ────────────────────
@@ -207,5 +233,85 @@ func TestDetect_Stable(t *testing.T) {
 
 	if first != second {
 		t.Errorf("Detect() not stable: first=%v second=%v", first, second)
+	}
+}
+
+// TestProbeAllowed covers the gate shared by probe() and decide().
+//
+// tmux always owns the escape stream, so it always suppresses the probe. SSH
+// suppresses it too, except inside a herdr pane: herdr's server outlives the
+// client that started it, so SSH_* there describes the server's launch rather
+// than the pane's terminal, and herdr answers the query itself.
+func TestProbeAllowed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		env  envInfo
+		want bool
+	}{
+		{name: "plain terminal", env: envInfo{}, want: true},
+		{name: "tmux", env: envInfo{Tmux: true}, want: false},
+		{name: "ssh", env: envInfo{SSH: true}, want: false},
+		{name: "herdr alone", env: envInfo{Herdr: true}, want: true},
+		{name: "herdr with inherited ssh", env: envInfo{SSH: true, Herdr: true}, want: true},
+		{name: "tmux inside herdr", env: envInfo{Tmux: true, Herdr: true}, want: false},
+		{name: "tmux and ssh inside herdr", env: envInfo{Tmux: true, SSH: true, Herdr: true}, want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := probeAllowed(tt.env); got != tt.want {
+				t.Errorf("probeAllowed(%+v) = %v; want %v", tt.env, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestProbeSeam_SkippedWhenNotAllowed asserts the real probe seam returns an
+// empty result without touching the terminal whenever probeAllowed is false.
+func TestProbeSeam_SkippedWhenNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	for _, env := range []envInfo{
+		{Tmux: true},
+		{SSH: true},
+		{Tmux: true, Herdr: true},
+	} {
+		if got := probe(env); got != (probeResult{}) {
+			t.Errorf("probe(%+v) = %+v; want empty probeResult", env, got)
+		}
+	}
+}
+
+// TestGatherEnv_Herdr checks that HERDR_ENV, the marker herdr documents for
+// detecting one of its panes, is the signal gatherEnv reads.
+func TestGatherEnv_Herdr(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		set   bool
+		want  bool
+	}{
+		{name: "unset", set: false, want: false},
+		{name: "empty", value: "", set: true, want: false},
+		{name: "one", value: "1", set: true, want: true},
+		{name: "zero", value: "0", set: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv("HERDR_ENV", tt.value)
+			} else {
+				t.Setenv("HERDR_ENV", "1")
+				os.Unsetenv("HERDR_ENV")
+			}
+			if got := gatherEnv().Herdr; got != tt.want {
+				t.Errorf("gatherEnv().Herdr = %v; want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Inside a herdr pane the startup banner fell back to braille even though the outer terminal renders kitty graphics.

herdr's server outlives the client that started it. A session started once over SSH leaves `SSH_CLIENT`/`SSH_CONNECTION`/`SSH_TTY` set in that server's environment, and every pane it spawns afterwards inherits them, including panes attached locally. The banner's SSH heuristic read those variables as a live remote session and skipped the escape-sequence probe, so the kitty capability was never detected and `decide()` fell through to braille.

Those variables describe how the server was launched, not the pane's terminal. Measured inside a pane whose environment carries them, herdr answers the kitty `a=q` capability query itself, immediately, and in the correct order relative to the DA1 reply.

- Gate the probe on a single `probeAllowed()` helper used by both the probe seam and `decide()`, so the two copies of the condition cannot drift apart.
- A herdr pane ignores SSH. herdr answers the query on behalf of the attached client, so the reply cannot arrive late enough to leak escape bytes into the shell, which is the risk the SSH guard exists to prevent.
- tmux still wins inside a herdr pane, since the innermost multiplexer owns the escape stream.
