### PR TITLE
fix(resolver): follow reference chains to the value the chain root will hold

### DIFF
--- a/internal/metastructure/resolver/resolvable_properties.go
+++ b/internal/metastructure/resolver/resolvable_properties.go
@@ -8,10 +8,23 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/tidwall/gjson"
 )
+
+// ReferenceCycleError reports that plan-time resolution followed a chain of
+// references back onto itself. The cycle is rejected when the lookup runs,
+// before any changeset exists, because the execution DAG's cycle detection
+// cannot see references that resolve within the lookup itself.
+type ReferenceCycleError struct {
+	Chain []string // "<ksuid>#/<propertyPath>" hops in traversal order, first repeated hop last
+}
+
+func (e ReferenceCycleError) Error() string {
+	return fmt.Sprintf("reference cycle detected at plan time: %s", strings.Join(e.Chain, " -> "))
+}
 
 // AnswerKind classifies why a SourceAnswer's value may be trusted, or that it
 // carries none yet.
@@ -82,6 +95,17 @@ func (p *ResolvableProperties) Answer(ksuid, property string) (SourceAnswer, boo
 	return SourceAnswer{}, false
 }
 
+// LoadResolvablePropertiesFromStacks answers, for each resolvable URI on
+// resource, whether a value is available at plan time and what it is.
+//
+// Classification is recursive over the desired reference graph: a declared
+// source's effective desired value that is itself a non-opaque reference
+// envelope is resolved by following that reference in turn (applying any
+// nested $json extraction in memory), so a chain of references converges to
+// the value its root will hold after this command in a single pass, however
+// many hops deep. An opaque marker anywhere on a hop stops the recursion
+// there and keeps the persisted-row fallthrough unchanged. A reference cycle
+// is rejected as a ReferenceCycleError naming the chain.
 func LoadResolvablePropertiesFromStacks(resource pkgmodel.Resource, allResources map[string][]*pkgmodel.Resource, effective map[string]json.RawMessage) (ResolvableProperties, error) {
 	res := NewResolvableProperties()
 
@@ -97,50 +121,98 @@ func LoadResolvablePropertiesFromStacks(resource pkgmodel.Resource, allResources
 	uris := ExtractResolvableURIs(resource)
 
 	for _, uri := range uris {
-		ksuid := uri.KSUID()
-		propertyPath := uri.PropertyPath()
-
-		targetResource, exists := resourcesByKsuid[ksuid]
-		if !exists {
-			return res, fmt.Errorf("resource with KSUID %s not found", ksuid)
+		answer, err := classifySourceProperty(uri.KSUID(), uri.PropertyPath(), resourcesByKsuid, effective, nil)
+		if err != nil {
+			return res, err
 		}
-
-		if effDoc, declared := effective[ksuid]; declared {
-			effVal := gjson.GetBytes(effDoc, propertyPath)
-			if effVal.Exists() && !isReferenceEnvelope(effVal) && !containsHashedValue(effVal) &&
-				!containsOpaqueVisibility(effVal) && !isSourcePropertyOpaque(targetResource, propertyPath) {
-				res.AddAnswer(ksuid, propertyPath, SourceAnswer{Kind: AnswerResolved, Value: ExtractPropertyValue(effVal)})
-				continue
-			}
-			// Reference envelopes, hashed shapes, and opaque sources — persisted,
-			// schema-declared, or only ever inline-marked in the desired document
-			// itself — fall through to the persisted-row path unchanged: envelopes
-			// keep the cached value, opaque and hashed sources keep today's
-			// deferral.
-		}
-
-		if value, ok := resolvableValueFrom(targetResource.ReadOnlyProperties, propertyPath); ok {
-			res.Add(ksuid, propertyPath, value)
+		if answer.Kind == AnswerDeferred {
+			// Property not available yet — this happens for forward references to
+			// new resources whose read-only properties are assigned at creation
+			// time, and for a secret, whose value is only ever read live. The
+			// value will be resolved at execution time via RemainingResolvables.
+			slog.Debug("Skipping unresolvable property (will resolve at execution time)",
+				"property", uri.PropertyPath(), "ksuid", uri.KSUID())
 			continue
 		}
-
-		if value, ok := resolvableValueFrom(targetResource.Properties, propertyPath); ok {
-			res.Add(ksuid, propertyPath, value)
-			continue
-		}
-
-		// Property not available yet — this happens for forward references to
-		// new resources whose read-only properties are assigned at creation time,
-		// and for a secret, whose value is only ever read live. The value will be
-		// resolved at execution time via RemainingResolvables.
-		slog.Debug("Skipping unresolvable property (will resolve at execution time)",
-			"property", propertyPath,
-			"resource", targetResource.Label,
-			"ksuid", ksuid)
-		continue
+		res.AddAnswer(uri.KSUID(), uri.PropertyPath(), answer)
 	}
 
 	return res, nil
+}
+
+// classifySourceProperty answers whether propertyPath on the resource named
+// by ksuid has a value available at plan time, following a chain of
+// references recursively when the value is itself a non-opaque reference.
+//
+// visiting is the ordered chain of hops currently being classified, used both
+// to detect a cycle (linear membership check; chains here are short) and, on
+// a cycle, as the error's Chain.
+func classifySourceProperty(ksuid, propertyPath string, resourcesByKsuid map[string]*pkgmodel.Resource, effective map[string]json.RawMessage, visiting []string) (SourceAnswer, error) {
+	key := ksuid + "#/" + propertyPath
+	for _, v := range visiting {
+		if v == key {
+			return SourceAnswer{}, ReferenceCycleError{Chain: append(append([]string{}, visiting...), key)}
+		}
+	}
+	visiting = append(visiting, key)
+
+	targetResource, exists := resourcesByKsuid[ksuid]
+	if !exists {
+		return SourceAnswer{}, fmt.Errorf("resource with KSUID %s not found", ksuid)
+	}
+
+	if effDoc, declared := effective[ksuid]; declared {
+		effVal := gjson.GetBytes(effDoc, propertyPath)
+		if effVal.Exists() {
+			refused := containsHashedValue(effVal) || containsOpaqueVisibility(effVal) ||
+				isSourcePropertyOpaque(targetResource, propertyPath)
+			if !refused && !isReferenceEnvelope(effVal) {
+				return SourceAnswer{Kind: AnswerResolved, Value: ExtractPropertyValue(effVal)}, nil
+			}
+			if !refused && isReferenceEnvelope(effVal) {
+				nested := pkgmodel.FormaeURI(effVal.Get("$ref").String())
+				if nested != "" && nested.KSUID() != "" {
+					sub, err := classifySourceProperty(nested.KSUID(), nested.PropertyPath(), resourcesByKsuid, effective, visiting)
+					if err != nil {
+						return SourceAnswer{}, err
+					}
+					if sub.Kind == AnswerDeferred {
+						return SourceAnswer{Kind: AnswerDeferred}, nil
+					}
+					if sub.Kind == AnswerResolved && !sub.Opaque {
+						value := sub.Value
+						derivable := true
+						if jsonPath := effVal.Get("$json").String(); jsonPath != "" {
+							extracted, jerr := ExtractJSONPath(value, jsonPath)
+							if jerr != nil {
+								derivable = false // underivable extraction: fall through, execution resolves live
+							} else {
+								value = extracted
+							}
+						}
+						if derivable {
+							return SourceAnswer{Kind: AnswerResolved, Value: value}, nil
+						}
+					}
+					// AnswerStable (transitive source unmoved): the cached value on
+					// this hop's persisted envelope is the last applied resolution
+					// and remains valid. Fall through to the persisted path, which
+					// answers exactly that (or defers for a value-less envelope),
+					// preserving prior behavior. Resolved-but-opaque and an
+					// underivable extraction fall through the same way.
+				}
+			}
+			// refused shapes fall through to the persisted path unchanged
+		}
+	}
+
+	if value, ok := resolvableValueFrom(targetResource.ReadOnlyProperties, propertyPath); ok {
+		return SourceAnswer{Kind: AnswerStable, Value: value}, nil
+	}
+	if value, ok := resolvableValueFrom(targetResource.Properties, propertyPath); ok {
+		return SourceAnswer{Kind: AnswerStable, Value: value}, nil
+	}
+	return SourceAnswer{Kind: AnswerDeferred}, nil
 }
 
 // resolvableValueFrom reads propertyPath out of one persisted property

--- a/internal/metastructure/resolver/resolvable_properties_test.go
+++ b/internal/metastructure/resolver/resolvable_properties_test.go
@@ -8,6 +8,7 @@ package resolver
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -227,6 +228,13 @@ func TestLoadResolvableProperties_EffectiveDesiredLiteralWins(t *testing.T) {
 // opaque is never materialized by this rule: behavior stays byte-identical to
 // the persisted-row path (envelope: cached value; hashed/valueless: deferred).
 func TestLoadResolvableProperties_EnvelopeAndHashedKeepTodaysBehavior(t *testing.T) {
+	// The transitive root the "Chained" envelope points to: not declared in
+	// effective, so the chain is unmoved and the outer envelope's own cached
+	// value is what must answer — exercised recursively now, same as before.
+	root := &pkgmodel.Resource{
+		Label: "root", Ksuid: "k-root", Stack: "s",
+		Properties: json.RawMessage(`{"V": "root-value"}`),
+	}
 	source := &pkgmodel.Resource{
 		Label: "parent", Ksuid: "k-parent", Stack: "s",
 		Properties: json.RawMessage(`{
@@ -241,7 +249,7 @@ func TestLoadResolvableProperties_EnvelopeAndHashedKeepTodaysBehavior(t *testing
 			"B": {"$ref": "formae://k-parent#/Secret"}
 		}`),
 	}
-	all := map[string][]*pkgmodel.Resource{"s": {source}}
+	all := map[string][]*pkgmodel.Resource{"s": {source, root}}
 	effective := map[string]json.RawMessage{
 		"k-parent": json.RawMessage(`{
 			"Chained": {"$ref": "formae://k-root#/V"},
@@ -316,4 +324,231 @@ func TestLoadResolvableProperties_EffectiveDesiredSkipsInlineOpaqueNotYetPersist
 
 	_, ok := props.Get("k-parent", "Secret")
 	assert.False(t, ok, "an inline-opaque value that exists only in the effective desired document must never be materialized")
+}
+
+// A consumer references B, and B's own value is a reference to A. When the
+// command changes A's literal, the consumer must resolve the value B will
+// hold after this command: A's new literal, not B's stale cached value.
+func TestLoadResolvableProperties_ChainRootLiteralWins(t *testing.T) {
+	root := pkgmodel.Resource{
+		Label: "root", Ksuid: "k-root", Stack: "s",
+		Properties: json.RawMessage(`{"Name": "r", "Value": "blue"}`),
+	}
+	middle := pkgmodel.Resource{
+		Label: "middle", Ksuid: "k-middle", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Name": "m",
+			"Value": {"$ref": "formae://k-root#/Value", "$value": "blue"}
+		}`),
+	}
+	consumer := pkgmodel.Resource{
+		Label: "consumer", Ksuid: "k-consumer", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Ref": {"$ref": "formae://k-middle#/Value", "$value": "blue"}
+		}`),
+	}
+	all := map[string][]*pkgmodel.Resource{"s": {&root, &middle}}
+	effective := map[string]json.RawMessage{
+		"k-root":   json.RawMessage(`{"Name": "r", "Value": "green"}`),
+		"k-middle": json.RawMessage(`{"Name": "m", "Value": {"$ref": "formae://k-root#/Value"}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumer, all, effective)
+	require.NoError(t, err)
+
+	v, ok := props.Get("k-middle", "Value")
+	require.True(t, ok)
+	assert.Equal(t, "green", v, "the chain root's new literal is the resolution, not the middle hop's stale cached value")
+
+	a, _ := props.Answer("k-middle", "Value")
+	assert.Equal(t, AnswerResolved, a.Kind)
+}
+
+// When nothing in the chain moves (the transitive root is not declared in the
+// command), the middle resource's cached value is the last applied resolution
+// and remains the answer.
+func TestLoadResolvableProperties_ChainUnmovedKeepsCachedValue(t *testing.T) {
+	root := pkgmodel.Resource{
+		Label: "root", Ksuid: "k-root", Stack: "s",
+		Properties: json.RawMessage(`{"Name": "r", "Value": "blue"}`),
+	}
+	middle := pkgmodel.Resource{
+		Label: "middle", Ksuid: "k-middle", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Name": "m",
+			"Value": {"$ref": "formae://k-root#/Value", "$value": "blue"}
+		}`),
+	}
+	consumer := pkgmodel.Resource{
+		Label: "consumer", Ksuid: "k-consumer", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Ref": {"$ref": "formae://k-middle#/Value", "$value": "blue"}
+		}`),
+	}
+	all := map[string][]*pkgmodel.Resource{"s": {&root, &middle}}
+	effective := map[string]json.RawMessage{
+		"k-middle": json.RawMessage(`{"Name": "m", "Value": {"$ref": "formae://k-root#/Value"}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumer, all, effective)
+	require.NoError(t, err)
+
+	v, ok := props.Get("k-middle", "Value")
+	require.True(t, ok)
+	assert.Equal(t, "blue", v, "the undeclared root means the middle hop's cached value remains the answer")
+
+	a, _ := props.Answer("k-middle", "Value")
+	assert.Equal(t, AnswerStable, a.Kind)
+}
+
+// An opaque marker anywhere on the hop keeps today's behavior: no recursion,
+// the persisted fallthrough answers (cached value if present), and the raw
+// desired plaintext of the transitive root is never consulted.
+func TestLoadResolvableProperties_ChainOpaqueHopKeepsTodaysBehavior(t *testing.T) {
+	root := pkgmodel.Resource{
+		Label: "root", Ksuid: "k-root", Stack: "s",
+		Properties: json.RawMessage(`{"Name": "r", "Secret": {"$value": "digest", "$hashed": true}}`),
+	}
+	middle := pkgmodel.Resource{
+		Label: "middle", Ksuid: "k-middle", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Name": "m",
+			"Cred": {"$ref": "formae://k-root#/Secret", "$value": "cached-leaf", "$visibility": "Opaque"}
+		}`),
+	}
+	consumer := pkgmodel.Resource{
+		Label: "consumer", Ksuid: "k-consumer", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Ref": {"$ref": "formae://k-middle#/Cred", "$value": "cached-leaf", "$visibility": "Opaque"}
+		}`),
+	}
+	all := map[string][]*pkgmodel.Resource{"s": {&root, &middle}}
+	effective := map[string]json.RawMessage{
+		"k-root":   json.RawMessage(`{"Name": "r", "Secret": "rotated-plaintext"}`),
+		"k-middle": json.RawMessage(`{"Name": "m", "Cred": {"$ref": "formae://k-root#/Secret", "$visibility": "Opaque"}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumer, all, effective)
+	require.NoError(t, err)
+
+	v, ok := props.Get("k-middle", "Cred")
+	require.True(t, ok)
+	assert.Equal(t, "cached-leaf", v)
+	assert.NotContains(t, v, "rotated-plaintext", "an opaque hop must never surface the transitive root's live plaintext")
+}
+
+// A middle hop that extracts a key from a JSON document resolves the
+// extracted leaf of the root's new value, entirely in memory.
+func TestLoadResolvableProperties_ChainJSONHopExtractsLeaf(t *testing.T) {
+	root := pkgmodel.Resource{
+		Label: "root", Ksuid: "k-root", Stack: "s",
+		Properties: json.RawMessage(`{"Name": "r", "Doc": "{\"db\":{\"host\":\"old-host\"}}"}`),
+	}
+	middle := pkgmodel.Resource{
+		Label: "middle", Ksuid: "k-middle", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Name": "m",
+			"Host": {"$ref": "formae://k-root#/Doc", "$value": "old-host", "$json": "db.host"}
+		}`),
+	}
+	consumer := pkgmodel.Resource{
+		Label: "consumer", Ksuid: "k-consumer", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Ref": {"$ref": "formae://k-middle#/Host", "$value": "old-host"}
+		}`),
+	}
+	all := map[string][]*pkgmodel.Resource{"s": {&root, &middle}}
+	effective := map[string]json.RawMessage{
+		"k-root":   json.RawMessage(`{"Name": "r", "Doc": "{\"db\":{\"host\":\"new-host\"}}"}`),
+		"k-middle": json.RawMessage(`{"Name": "m", "Host": {"$ref": "formae://k-root#/Doc", "$json": "db.host"}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumer, all, effective)
+	require.NoError(t, err)
+
+	v, ok := props.Get("k-middle", "Host")
+	require.True(t, ok)
+	assert.Equal(t, "new-host", v, "the JSON hop resolves the extracted leaf of the root's new value")
+}
+
+// Two references whose chains meet at the same root resolve independently: a
+// diamond is not a cycle.
+func TestLoadResolvableProperties_DiamondResolves(t *testing.T) {
+	root := pkgmodel.Resource{
+		Label: "root", Ksuid: "k-root", Stack: "s",
+		Properties: json.RawMessage(`{"Name": "r", "Value": "blue"}`),
+	}
+	left := pkgmodel.Resource{
+		Label: "left", Ksuid: "k-left", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Name": "l",
+			"Value": {"$ref": "formae://k-root#/Value", "$value": "blue"}
+		}`),
+	}
+	right := pkgmodel.Resource{
+		Label: "right", Ksuid: "k-right", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Name": "rr",
+			"Value": {"$ref": "formae://k-root#/Value", "$value": "blue"}
+		}`),
+	}
+	consumer := pkgmodel.Resource{
+		Label: "consumer", Ksuid: "k-consumer", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Left":  {"$ref": "formae://k-left#/Value", "$value": "blue"},
+			"Right": {"$ref": "formae://k-right#/Value", "$value": "blue"}
+		}`),
+	}
+	all := map[string][]*pkgmodel.Resource{"s": {&root, &left, &right}}
+	effective := map[string]json.RawMessage{
+		"k-root":  json.RawMessage(`{"Name": "r", "Value": "green"}`),
+		"k-left":  json.RawMessage(`{"Name": "l", "Value": {"$ref": "formae://k-root#/Value"}}`),
+		"k-right": json.RawMessage(`{"Name": "rr", "Value": {"$ref": "formae://k-root#/Value"}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumer, all, effective)
+	require.NoError(t, err)
+
+	leftVal, ok := props.Get("k-left", "Value")
+	require.True(t, ok)
+	assert.Equal(t, "green", leftVal)
+
+	rightVal, ok := props.Get("k-right", "Value")
+	require.True(t, ok)
+	assert.Equal(t, "green", rightVal)
+}
+
+// A chain that loops back onto itself is a clean plan-time error naming the
+// cycle, not a hang and not a stale resolution.
+func TestLoadResolvableProperties_ReferenceCycleFails(t *testing.T) {
+	a := pkgmodel.Resource{
+		Label: "a", Ksuid: "k-a", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Value": {"$ref": "formae://k-b#/Value", "$value": "x"}
+		}`),
+	}
+	b := pkgmodel.Resource{
+		Label: "b", Ksuid: "k-b", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Value": {"$ref": "formae://k-a#/Value", "$value": "x"}
+		}`),
+	}
+	consumer := pkgmodel.Resource{
+		Label: "consumer", Ksuid: "k-consumer", Stack: "s",
+		Properties: json.RawMessage(`{
+			"Ref": {"$ref": "formae://k-a#/Value", "$value": "x"}
+		}`),
+	}
+	all := map[string][]*pkgmodel.Resource{"s": {&a, &b}}
+	effective := map[string]json.RawMessage{
+		"k-a": json.RawMessage(`{"Value": {"$ref": "formae://k-b#/Value"}}`),
+		"k-b": json.RawMessage(`{"Value": {"$ref": "formae://k-a#/Value"}}`),
+	}
+
+	_, err := LoadResolvablePropertiesFromStacks(consumer, all, effective)
+	require.Error(t, err)
+
+	var cycleErr ReferenceCycleError
+	require.True(t, errors.As(err, &cycleErr), "error must be a ReferenceCycleError")
+	assert.GreaterOrEqual(t, len(cycleErr.Chain), 2, "the chain must name at least the repeated hop and its first occurrence")
 }

--- a/internal/metastructure/resource_update/resource_update_generator_static_move_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_static_move_test.go
@@ -211,3 +211,145 @@ func TestGenerateResourceUpdates_ConsumerIgnoresResubmittedSetOnceProducerField(
 		}
 	}
 }
+
+// A literal move propagates through a two-hop chain in one command: the
+// root's field changes, the middle resource references it, and a consumer
+// references the middle resource. All three must be planned, with the
+// consumer's patch carrying the root's new value.
+func TestGenerateResourceUpdates_LiteralMovesThroughTwoHopChain(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	rootSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Value"},
+		Hints:      map[string]pkgmodel.FieldHint{"Name": {CreateOnly: true}},
+	}
+	middleSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "ParentRef"},
+		Hints:      map[string]pkgmodel.FieldHint{},
+	}
+	consumerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "ParentRef"},
+		Hints:      map[string]pkgmodel.FieldHint{},
+	}
+
+	rootKsuid := util.NewID()
+	middleKsuid := util.NewID()
+	consumerKsuid := util.NewID()
+
+	existingStack := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label:      "root",
+				Type:       "FakeAWS::Versioned::Parent",
+				Stack:      "test-stack",
+				Target:     "test-target",
+				Schema:     rootSchema,
+				Ksuid:      rootKsuid,
+				Properties: json.RawMessage(`{"Name": "root-1", "Value": "hello"}`),
+			},
+			{
+				Label:  "middle",
+				Type:   "FakeAWS::Versioned::Consumer",
+				Stack:  "test-stack",
+				Target: "test-target",
+				Schema: middleSchema,
+				Ksuid:  middleKsuid,
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Name": "middle-1", "ParentRef": {"$ref": "formae://%s#/Value", "$value": "hello"}}`,
+					rootKsuid)),
+			},
+			{
+				Label:  "consumer",
+				Type:   "FakeAWS::Versioned::Consumer",
+				Stack:  "test-stack",
+				Target: "test-target",
+				Schema: consumerSchema,
+				Ksuid:  consumerKsuid,
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Name": "consumer-1", "ParentRef": {"$ref": "formae://%s#/ParentRef", "$value": "hello"}}`,
+					middleKsuid)),
+			},
+		},
+	}
+
+	_, err := ds.StoreStack(existingStack, "previous-command")
+	require.NoError(t, err)
+
+	// Only the root's mutable field changes; its new value is a literal. The
+	// middle and consumer are resubmitted with the $res sugar, unchanged.
+	forma := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Targets: []pkgmodel.Target{
+			{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+		},
+		Resources: []pkgmodel.Resource{
+			{
+				Label:      "root",
+				Type:       "FakeAWS::Versioned::Parent",
+				Stack:      "test-stack",
+				Target:     "test-target",
+				Schema:     rootSchema,
+				Properties: json.RawMessage(`{"Name": "root-1", "Value": "world"}`),
+			},
+			{
+				Label:  "middle",
+				Type:   "FakeAWS::Versioned::Consumer",
+				Stack:  "test-stack",
+				Target: "test-target",
+				Schema: middleSchema,
+				Properties: json.RawMessage(`{
+					"Name": "middle-1",
+					"ParentRef": {
+						"$res":      true,
+						"$label":    "root",
+						"$type":     "FakeAWS::Versioned::Parent",
+						"$stack":    "test-stack",
+						"$property": "Value"
+					}
+				}`),
+			},
+			{
+				Label:  "consumer",
+				Type:   "FakeAWS::Versioned::Consumer",
+				Stack:  "test-stack",
+				Target: "test-target",
+				Schema: consumerSchema,
+				Properties: json.RawMessage(`{
+					"Name": "consumer-1",
+					"ParentRef": {
+						"$res":      true,
+						"$label":    "middle",
+						"$type":     "FakeAWS::Versioned::Consumer",
+						"$stack":    "test-stack",
+						"$property": "ParentRef"
+					}
+				}`),
+			},
+		},
+	}
+
+	existingTargets := []*pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+	}
+
+	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+		FormaCommandSourceUser, existingTargets, ds, nil, nil)
+	require.NoError(t, err)
+
+	planned := map[string]*ResourceUpdate{}
+	for i := range updates {
+		planned[updates[i].DesiredState.Label] = &updates[i]
+	}
+
+	require.Contains(t, planned, "root", "root whose field changed must be updated")
+	require.Contains(t, planned, "middle", "middle hop following the root's changed field must stay in the changeset")
+	require.Contains(t, planned, "consumer", "consumer at the end of the chain must stay in the changeset")
+
+	consumer := planned["consumer"]
+	assert.Contains(t, string(consumer.DesiredState.PatchDocument), "world",
+		"the consumer's patch must carry the root's new value through the two-hop chain")
+}

--- a/internal/workflow_tests/local/apply_forma/reference_chain_test.go
+++ b/internal/workflow_tests/local/apply_forma/reference_chain_test.go
@@ -1,0 +1,323 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+const (
+	chainRefRootType     = "FakeAWS::Chain::Root"
+	chainRefMiddleType   = "FakeAWS::Chain::Middle"
+	chainRefConsumerType = "FakeAWS::Chain::Consumer"
+)
+
+// chainRefUpdateCall records one plugin Update request: which resource it
+// targeted and the full desired document it carried.
+type chainRefUpdateCall struct {
+	ResourceType      string
+	Label             string
+	DesiredProperties json.RawMessage
+}
+
+// chainRefUpdateCapture accumulates every plugin Update call across a test run.
+type chainRefUpdateCapture struct {
+	mu    sync.Mutex
+	calls []chainRefUpdateCall
+}
+
+func (c *chainRefUpdateCapture) add(call chainRefUpdateCall) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls = append(c.calls, call)
+}
+
+// forLabel returns the last captured Update call for the given resource
+// label, if any.
+func (c *chainRefUpdateCapture) forLabel(label string) (chainRefUpdateCall, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var found chainRefUpdateCall
+	ok := false
+	for _, call := range c.calls {
+		if call.Label == label {
+			found = call
+			ok = true
+		}
+	}
+	return found, ok
+}
+
+// chainRefFieldValue reads a named top-level property out of a resource
+// properties document, unwrapping a resolved {"$ref":...,"$value":...}
+// envelope if the field arrives that way instead of as a plain scalar.
+func chainRefFieldValue(raw json.RawMessage, field string) (string, bool) {
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return "", false
+	}
+	v, ok := m[field]
+	if !ok {
+		return "", false
+	}
+	switch val := v.(type) {
+	case string:
+		return val, true
+	case map[string]any:
+		if s, ok := val["$value"].(string); ok {
+			return s, true
+		}
+	}
+	return "", false
+}
+
+// chainRefProps builds the properties document a FakeAWS chain resource
+// reports as its cloud state, given the single value it carries.
+func chainRefProps(resourceType, value string) json.RawMessage {
+	switch resourceType {
+	case chainRefRootType:
+		return json.RawMessage(fmt.Sprintf(`{"Name":"root","Color":"%s"}`, value))
+	case chainRefMiddleType:
+		return json.RawMessage(fmt.Sprintf(`{"Name":"middle","RootColor":"%s"}`, value))
+	case chainRefConsumerType:
+		return json.RawMessage(fmt.Sprintf(`{"Name":"consumer","MiddleColor":"%s"}`, value))
+	}
+	return nil
+}
+
+// chainRefStateFor returns the state cell holding the last-known value for a
+// resource type, and the name of the field that value lives under.
+func chainRefStateFor(resourceType string, root, middle, consumer *chainRefState) (*chainRefState, string) {
+	switch resourceType {
+	case chainRefRootType:
+		return root, "Color"
+	case chainRefMiddleType:
+		return middle, "RootColor"
+	case chainRefConsumerType:
+		return consumer, "MiddleColor"
+	}
+	return nil, ""
+}
+
+// chainRefState is a mutex-guarded string: the last value a FakeAWS chain
+// resource reported as its cloud state.
+type chainRefState struct {
+	mu    sync.Mutex
+	value string
+}
+
+func newChainRefState(initial string) *chainRefState {
+	return &chainRefState{value: initial}
+}
+
+func (s *chainRefState) get() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.value
+}
+
+func (s *chainRefState) set(v string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.value = v
+}
+
+// chainRefSchema returns the schema for a chain resource whose only mutable
+// field is named field.
+func chainRefSchema(field string) pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", field},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Name": {CreateOnly: true},
+		},
+	}
+}
+
+// chainRefForma builds the three-resource chain (root -> middle -> consumer)
+// for the given root literal. middle references root's Color field via $res
+// sugar; consumer references middle's RootColor field via $res sugar, so
+// consumer is two hops from the literal that changes.
+func chainRefForma(rootColor string) *pkgmodel.Forma {
+	return &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label:      "root",
+				Type:       chainRefRootType,
+				Properties: json.RawMessage(fmt.Sprintf(`{"Name":"root","Color":"%s"}`, rootColor)),
+				Stack:      "test-stack",
+				Target:     "test-target",
+				Managed:    true,
+				Schema:     chainRefSchema("Color"),
+			},
+			{
+				Label: "middle",
+				Type:  chainRefMiddleType,
+				Properties: json.RawMessage(`{
+					"Name": "middle",
+					"RootColor": {
+						"$res": true,
+						"$label": "root",
+						"$type": "` + chainRefRootType + `",
+						"$stack": "test-stack",
+						"$property": "Color"
+					}
+				}`),
+				Stack:   "test-stack",
+				Target:  "test-target",
+				Managed: true,
+				Schema:  chainRefSchema("RootColor"),
+			},
+			{
+				Label: "consumer",
+				Type:  chainRefConsumerType,
+				Properties: json.RawMessage(`{
+					"Name": "consumer",
+					"MiddleColor": {
+						"$res": true,
+						"$label": "middle",
+						"$type": "` + chainRefMiddleType + `",
+						"$stack": "test-stack",
+						"$property": "RootColor"
+					}
+				}`),
+				Stack:   "test-stack",
+				Target:  "test-target",
+				Managed: true,
+				Schema:  chainRefSchema("MiddleColor"),
+			},
+		},
+		Targets: []pkgmodel.Target{{Label: "test-target"}},
+	}
+}
+
+// TestApplyForma_LiteralMove_ConvergesTwoHopChainInOneApply pins the
+// user-visible outcome of plan-time reference classification being
+// recursive: a literal change on a chain root reaches every transitive
+// follower in the same apply. The middle resource and the consumer both
+// receive the new value, and a subsequent simulate plans no changes.
+func TestApplyForma_LiteralMove_ConvergesTwoHopChainInOneApply(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		root := newChainRefState("blue")
+		middle := newChainRefState("blue")
+		consumer := newChainRefState("blue")
+
+		updates := &chainRefUpdateCapture{}
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				state, field := chainRefStateFor(req.ResourceType, root, middle, consumer)
+				if state == nil {
+					return nil, nil
+				}
+				if v, ok := chainRefFieldValue(req.Properties, field); ok {
+					state.set(v)
+				}
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          req.Label + "-create",
+					NativeID:           req.Label,
+					ResourceProperties: chainRefProps(req.ResourceType, state.get()),
+				}}, nil
+			},
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				state, _ := chainRefStateFor(req.ResourceType, root, middle, consumer)
+				if state == nil {
+					return nil, nil
+				}
+				return &resource.ReadResult{
+					ResourceType: req.ResourceType,
+					Properties:   string(chainRefProps(req.ResourceType, state.get())),
+				}, nil
+			},
+			Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				state, field := chainRefStateFor(req.ResourceType, root, middle, consumer)
+				if state == nil {
+					return nil, nil
+				}
+				updates.add(chainRefUpdateCall{
+					ResourceType:      req.ResourceType,
+					Label:             req.Label,
+					DesiredProperties: req.DesiredProperties,
+				})
+				if v, ok := chainRefFieldValue(req.DesiredProperties, field); ok {
+					state.set(v)
+				}
+				return &resource.UpdateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationUpdate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          req.Label + "-update",
+					NativeID:           req.NativeID,
+					ResourceProperties: chainRefProps(req.ResourceType, state.get()),
+				}}, nil
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		// ── Apply #1: create the chain with root's literal "blue" ────────────
+		_, err = m.ApplyForma(chainRefForma("blue"), defaultApplyConfig(), "test", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		require.NotEmpty(t, cmds)
+		require.Equal(t, forma_command.CommandStateSuccess, cmds[0].State, "initial apply (create chain) must succeed")
+
+		// ── Apply #2: move only root's literal from "blue" to "green" ────────
+		_, err = m.ApplyForma(chainRefForma("green"), defaultApplyConfig(), "test", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err = m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		require.NotEmpty(t, cmds)
+		require.Equal(t, forma_command.CommandStateSuccess, cmds[0].State, "the literal move must succeed")
+
+		middleUpdate, ok := updates.forLabel("middle")
+		require.True(t, ok, "the middle resource must receive a plugin Update in the same apply")
+		middleValue, ok := chainRefFieldValue(middleUpdate.DesiredProperties, "RootColor")
+		require.True(t, ok, "middle's Update must carry a RootColor value")
+		assert.Equal(t, "green", middleValue,
+			"the middle resource's plugin Update must carry the new root literal")
+
+		consumerUpdate, ok := updates.forLabel("consumer")
+		require.True(t, ok, "the consumer resource must receive a plugin Update in the same apply")
+		consumerValue, ok := chainRefFieldValue(consumerUpdate.DesiredProperties, "MiddleColor")
+		require.True(t, ok, "consumer's Update must carry a MiddleColor value")
+		assert.Equal(t, "green", consumerValue,
+			"the consumer, two hops from the literal, must also converge in the same apply")
+
+		// ── Simulate #3: same forma, chain is already converged ──────────────
+		simConfig := defaultApplyConfig()
+		simConfig.Simulate = true
+		simResp, err := m.ApplyForma(chainRefForma("green"), simConfig, "test", "", "")
+		require.NoError(t, err)
+		assert.False(t, simResp.Simulation.ChangesRequired,
+			"a converged chain must plan no changes")
+		assert.Empty(t, simResp.Simulation.Command.ResourceUpdates,
+			"a converged chain must plan zero resource updates")
+	})
+}


### PR DESCRIPTION
## Summary

- A reference to a resource whose own value is a reference resolved the middle hop's stale cached value when the chain root changed in the same command: a two-hop chain converged one hop per apply, each apply reporting success while downstream resources kept old values. Plan-time classification is now recursive over the desired reference graph: an unmoved transitive source keeps the cached last-applied resolution, a moved plan-derivable source answers the derived value (applying a nested `$json` extraction in memory for non-opaque values), and any underivable hop defers to execution-time live resolution.
- Opaque behavior is byte-identical: any opaque marker on a hop (`$hashed`, `$visibility`, schema/known-table) skips recursion and keeps the previous fallthrough, pinned by a dedicated test plus the existing opacity suite.
- **Behavior change:** a set of resources whose persisted references form a cycle is now rejected at plan generation with a typed error naming the chain. Previous versions accepted such cycles and silently resolved them to stale cached values (and could create them); the lookup runs before any changeset exists, so the execution DAG's cycle detection cannot see this path. Destroys are unaffected, and an undeclared persisted cycle does not error; breaking a declared cycle is a forma edit (declare one hop as a literal). Diamonds (two chains meeting at one root) resolve normally.
- End-to-end pin: changing a chain root's literal reaches the middle resource and its consumer's plugin in the same apply, and a subsequent simulate plans zero changes. The workflow test was verified to fail on the pre-change code and pass at head.

Verified: full `resolver`, `resource_update`, `patch` suites and the `apply_forma` workflow suite green; vet and gofmt clean.