### PR TITLE
fix(resource-update): classify absent referenced properties by cause, reject dangling removals, and stop requiredOnUpdate churn

### DIFF
--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -106,7 +106,8 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 		}
 	}
 
-	patchOps, err := createPatchDocument(flattenedDocument, flattenedPatch, schema.Fields, schema.RequiredOnUpdate(), schema.HasProviderDefault(), entitySetProviderDefaultsFromHints(schema.Hints), collectionSemanticsFromFieldHints(schema.Hints), defaultIgnoredFields, strategy)
+	requiredOnUpdateFields := schema.RequiredOnUpdate()
+	patchOps, err := createPatchDocument(flattenedDocument, flattenedPatch, schema.Fields, requiredOnUpdateFields, schema.HasProviderDefault(), entitySetProviderDefaultsFromHints(schema.Hints), collectionSemanticsFromFieldHints(schema.Hints), defaultIgnoredFields, strategy)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create patch document: %w", err)
 	}
@@ -130,7 +131,17 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 	// reaches the plugin nor triggers a replacement.
 	patchOps = dropCanonicallyEqualHintedOps(patchOps, flattenedDocument, flattenedPatch, schema)
 
-	if len(patchOps) == 0 {
+	// A requiredOnUpdate field is force-resent by stripping it from the document
+	// side before the diff (see the documentForceResent step in
+	// createPatchDocument), so its own "add" op reappears even when nothing
+	// changed. That reappearance must never itself decide that an update is
+	// sent — patch emptiness is never a decision input. If every remaining op
+	// is such a no-op restatement of the field's own stored value, there is no
+	// real change and no patch is planned, exactly as for a genuinely empty
+	// diff. When a real change is present alongside it, the force-resent op
+	// stays in the patch unchanged: the provider still requires the field in
+	// every update payload it actually receives.
+	if onlyForceResentNoops(patchOps, flattenedDocument, requiredOnUpdateFields) {
 		return nil, nil, nil
 	}
 
@@ -840,13 +851,58 @@ func extractCreateOnlyFields(patchOps []jsonpatch.JsonPatchOperation, createOnly
 // top-level field — which leaves createOnly violations on nested
 // fields undetected until the cloud API rejects them at apply time.
 func isCreateOnlyPath(path string, createOnlyFields []string) bool {
-	for _, field := range createOnlyFields {
+	return pathMatchesField(path, createOnlyFields)
+}
+
+// pathMatchesField reports whether a JSON Pointer path (without its leading
+// "/", see cleanPath) targets one of the given dot-separated schema field
+// paths, or a nested path within it. Schema Hints use dot-separated keys for
+// nested fields ("Spec.Selector"), while jsonpatch operation paths use slash
+// separators per RFC 6902 ("Spec/Selector/MatchLabels/foo"); the field side is
+// normalized to slash form before comparing.
+func pathMatchesField(path string, fields []string) bool {
+	for _, field := range fields {
 		f := strings.ReplaceAll(field, ".", "/")
 		if path == f || strings.HasPrefix(path, f+"/") {
 			return true
 		}
 	}
 	return false
+}
+
+// onlyForceResentNoops reports whether every op in ops is a force-resent
+// no-op: an "add" on a requiredOnUpdate path whose value merely restates what
+// originalDocument already held there before force-resend stripped it out (see
+// createPatchDocument). An empty ops slice trivially satisfies this, matching
+// the emptiness this check replaces.
+func onlyForceResentNoops(ops []jsonpatch.JsonPatchOperation, originalDocument []byte, requiredOnUpdateFields []string) bool {
+	for _, op := range ops {
+		if !isForceResentNoop(op, originalDocument, requiredOnUpdateFields) {
+			return false
+		}
+	}
+	return true
+}
+
+// isForceResentNoop reports whether op is an "add" operation on a
+// requiredOnUpdate path whose value equals what originalDocument already held
+// at that path — i.e. the op exists solely because createPatchDocument strips
+// requiredOnUpdate fields from the document side to guarantee they ride along
+// in a genuine update, not because the field's value actually changed.
+func isForceResentNoop(op jsonpatch.JsonPatchOperation, originalDocument []byte, requiredOnUpdateFields []string) bool {
+	if op.Operation != "add" || len(requiredOnUpdateFields) == 0 {
+		return false
+	}
+	path := cleanPath(op.Path)
+	if !pathMatchesField(path, requiredOnUpdateFields) {
+		return false
+	}
+	gjsonPath := strings.ReplaceAll(path, "/", ".")
+	original := gjson.GetBytes(originalDocument, gjsonPath)
+	if !original.Exists() {
+		return false
+	}
+	return reflect.DeepEqual(original.Value(), op.Value)
 }
 
 func hasValue(val any) bool {

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -28,9 +28,18 @@ var defaultIgnoredFields = []jsonpatch.Path{}
 //     fields. When non-empty, the caller must plan a destroy+create rather
 //     than an update; the ops are used purely for CLI rendering ("because
 //     these immutable properties changed: …") and are never sent to plugins.
+//   - onlyForceResent reports whether patchDocument's ops (and any
+//     createOnlyPatch ops) consist ENTIRELY of requiredOnUpdate fields
+//     force-resent to guarantee the provider sees them, with no op reflecting
+//     an actual change. patchDocument itself is never stripped of these ops —
+//     content is never dropped here, only reported. A caller deciding whether
+//     to PLAN an update at all should treat this the same as an empty patch; a
+//     caller regenerating the payload for an update that is already happening
+//     must ignore this and send patchDocument as returned, because the
+//     provider still requires the force-resent field in that payload.
 //
 // The two slices are disjoint. Either can be nil.
-func GeneratePatch(document []byte, patch []byte, storedEnvelopes []byte, desiredEnvelopes []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, error) {
+func GeneratePatch(document []byte, patch []byte, storedEnvelopes []byte, desiredEnvelopes []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, bool, error) {
 	return generatePatch(document, patch, storedEnvelopes, desiredEnvelopes, properties, schema, mode)
 }
 
@@ -66,10 +75,10 @@ func entitySetProviderDefaultsFromHints(hints map[string]pkgmodel.FieldHint) map
 	return result
 }
 
-func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desiredEnvelopes []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, error) {
+func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desiredEnvelopes []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, bool, error) {
 	flattenedDocument, flattenedPatch, err := flattenAndResolveRefs(document, patch, storedEnvelopes, desiredEnvelopes, properties)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to flatten and resolve refs: %w", err)
+		return nil, nil, false, fmt.Errorf("failed to flatten and resolve refs: %w", err)
 	}
 
 	var strategy jsonpatch.PatchStrategy
@@ -79,7 +88,7 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 	case pkgmodel.FormaApplyModePatch:
 		strategy = jsonpatch.PatchStrategyEnsureExists
 	default:
-		return nil, nil, fmt.Errorf("unable to generate patch document for apply mode: %s", mode)
+		return nil, nil, false, fmt.Errorf("unable to generate patch document for apply mode: %s", mode)
 	}
 
 	// Strip a field that is both writeOnly AND createOnly from the desired
@@ -102,14 +111,14 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 		}
 		flattenedPatch, err = removeWriteOnlyFields(flattenedPatch, withoutBaseline)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to strip writeOnly+createOnly fields from desired state: %w", err)
+			return nil, nil, false, fmt.Errorf("failed to strip writeOnly+createOnly fields from desired state: %w", err)
 		}
 	}
 
 	requiredOnUpdateFields := schema.RequiredOnUpdate()
 	patchOps, err := createPatchDocument(flattenedDocument, flattenedPatch, schema.Fields, requiredOnUpdateFields, schema.HasProviderDefault(), entitySetProviderDefaultsFromHints(schema.Hints), collectionSemanticsFromFieldHints(schema.Hints), defaultIgnoredFields, strategy)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create patch document: %w", err)
+		return nil, nil, false, fmt.Errorf("failed to create patch document: %w", err)
 	}
 
 	// Remove spurious patch operations that add empty arrays or maps.
@@ -131,19 +140,23 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 	// reaches the plugin nor triggers a replacement.
 	patchOps = dropCanonicallyEqualHintedOps(patchOps, flattenedDocument, flattenedPatch, schema)
 
+	if len(patchOps) == 0 {
+		return nil, nil, false, nil
+	}
+
 	// A requiredOnUpdate field is force-resent by stripping it from the document
 	// side before the diff (see the documentForceResent step in
 	// createPatchDocument), so its own "add" op reappears even when nothing
 	// changed. That reappearance must never itself decide that an update is
-	// sent — patch emptiness is never a decision input. If every remaining op
-	// is such a no-op restatement of the field's own stored value, there is no
-	// real change and no patch is planned, exactly as for a genuinely empty
-	// diff. When a real change is present alongside it, the force-resent op
-	// stays in the patch unchanged: the provider still requires the field in
-	// every update payload it actually receives.
-	if onlyForceResentNoops(patchOps, flattenedDocument, requiredOnUpdateFields) {
-		return nil, nil, nil
-	}
+	// sent — patch emptiness is never a decision input. onlyForceResent reports
+	// whether every remaining op is such a no-op restatement of a field's own
+	// stored value, so a caller PLANNING whether to send an update at all can
+	// treat this the same as an empty patch. It must NOT be used to strip
+	// content here: a caller regenerating the payload for an update that is
+	// already happening still needs the force-resent op in what this function
+	// returns, because the provider requires the field in every update payload
+	// it actually receives.
+	onlyForceResent := onlyForceResentNoops(patchOps, flattenedDocument, requiredOnUpdateFields)
 
 	// Separate createOnly operations from mutable operations. CreateOnly
 	// fields cannot be updated in-place via the cloud API — if they changed,
@@ -155,24 +168,24 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 	mutableOps := filterCreateOnlyFields(patchOps, createOnlyFields)
 
 	if len(mutableOps) == 0 && len(createOnlyOps) == 0 {
-		return nil, nil, nil
+		return nil, nil, false, nil
 	}
 
 	patchJson, err := json.Marshal(mutableOps)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to serialize patch document: %w", err)
+		return nil, nil, false, fmt.Errorf("failed to serialize patch document: %w", err)
 	}
 
 	var createOnlyJson json.RawMessage
 	if len(createOnlyOps) > 0 {
 		createOnlyBytes, err := json.Marshal(createOnlyOps)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to serialize createOnly patch: %w", err)
+			return nil, nil, false, fmt.Errorf("failed to serialize createOnly patch: %w", err)
 		}
 		createOnlyJson = json.RawMessage(createOnlyBytes)
 	}
 
-	return json.RawMessage(patchJson), createOnlyJson, nil
+	return json.RawMessage(patchJson), createOnlyJson, onlyForceResent, nil
 }
 
 func createPatchDocument(document []byte, patch []byte, schemaFields []string, requiredOnUpdateFields []string, hasProviderDefaultFields []string, entitySetProviderDefaults map[string]string, collections jsonpatch.Collections, ignoredFields []jsonpatch.Path, strategy jsonpatch.PatchStrategy) ([]jsonpatch.JsonPatchOperation, error) {
@@ -894,7 +907,7 @@ func isForceResentNoop(op jsonpatch.JsonPatchOperation, originalDocument []byte,
 		return false
 	}
 	path := cleanPath(op.Path)
-	if !pathMatchesField(path, requiredOnUpdateFields) {
+	if !pathMatchesFieldThroughArrays(path, requiredOnUpdateFields) {
 		return false
 	}
 	gjsonPath := strings.ReplaceAll(path, "/", ".")
@@ -903,6 +916,64 @@ func isForceResentNoop(op jsonpatch.JsonPatchOperation, originalDocument []byte,
 		return false
 	}
 	return reflect.DeepEqual(original.Value(), op.Value)
+}
+
+// pathMatchesFieldThroughArrays is pathMatchesField's array-index-aware
+// counterpart, used only for matching a force-resent op's path against
+// requiredOnUpdate fields. A requiredOnUpdate hint on a field nested inside an
+// array (e.g. "Items.Token") is stripped from every array element by
+// removeNestedField, so its "add" op lands at an array-indexed path (e.g.
+// "/Items/0/Token") that plain segment-by-segment comparison against
+// "Items/Token" would never match. Mirrors removeNestedField's own traversal:
+// a numeric path segment is transparent (an array index, not a field name)
+// and is skipped rather than consumed against the field's segments.
+func pathMatchesFieldThroughArrays(path string, fields []string) bool {
+	pathSegments := strings.Split(path, "/")
+	for _, field := range fields {
+		if matchesFieldThroughArrays(pathSegments, strings.Split(field, ".")) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesFieldThroughArrays reports whether pathSegments targets fieldSegments
+// (or a nested path within it), skipping any pathSegments entry that is a
+// numeric array index rather than consuming it against a field segment.
+func matchesFieldThroughArrays(pathSegments, fieldSegments []string) bool {
+	fi := 0
+	for _, segment := range pathSegments {
+		if isArrayIndexSegment(segment) {
+			continue
+		}
+		if fi >= len(fieldSegments) {
+			// Every field segment already matched; what remains is a nested
+			// path within the field, which still counts as a match.
+			return true
+		}
+		if segment != fieldSegments[fi] {
+			return false
+		}
+		fi++
+	}
+	return fi == len(fieldSegments)
+}
+
+// isArrayIndexSegment reports whether a JSON Pointer path segment is a
+// non-negative integer (an array index per RFC 6901), the same shape
+// removeNestedField's array traversal produces. A schema field literally
+// named with all-digit keys is indistinguishable from an index here — the
+// same ambiguity the resolver's own dotted-path convention already accepts.
+func isArrayIndexSegment(segment string) bool {
+	if segment == "" {
+		return false
+	}
+	for _, r := range segment {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func hasValue(val any) bool {

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -359,7 +359,7 @@ func TestGeneratePatch(t *testing.T) {
 	resProps := resolver.NewResolvableProperties()
 	resProps.Add(resourceKsuid, "id", "def")
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, resProps, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, resProps, schema, pkgmodel.FormaApplyModePatch)
 
 	assert.NoError(t, err)
 	// val2 is createOnly and changed → a non-empty createOnlyPatch is returned
@@ -431,7 +431,7 @@ func TestGeneratePatch_NestedCreateOnlyTriggersReplacement(t *testing.T) {
 		},
 	}
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	require.NotEmpty(t, createOnlyPatch, "nested createOnly change must produce a non-empty createOnlyPatch")
 
@@ -482,7 +482,7 @@ func TestGeneratePatch_ShouldResolveRefs(t *testing.T) {
 	props.Add(resourceKsuid, "other-id", "def")
 	props.Add(resourceKsuid, "notha-id", "ghi")
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	assert.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -519,7 +519,7 @@ func TestGeneratePatch_ListResolvableMatchingLiveValue_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "ValidationRecords.0.Values", `["_7a296.acm-validations.aws"]`)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "an unchanged list-valued resolvable must reconcile to a no-op")
@@ -543,7 +543,7 @@ func TestGeneratePatch_MultiValueListResolvableMatchingLiveValue_NoPatch(t *test
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "Values", `["10.0.0.1","10.0.0.2"]`)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc)
@@ -567,7 +567,7 @@ func TestGeneratePatch_ListResolvableGenuineChange_EmitsReplace(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "ValidationRecords.0.Values", `["new.acm-validations.aws"]`)
 
-	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "a genuine list change must still emit a patch")
 
@@ -598,7 +598,7 @@ func TestGeneratePatch_ObjectResolvableMatchingLiveValue_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "Endpoints", `{"host":"db.internal","port":5432,"tls":true,"aliases":["a","b"],"fallback":null}`)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc)
@@ -624,7 +624,7 @@ func TestGeneratePatch_JsonStringScalarResolvable_StaysString_NoPatch(t *testing
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "PolicyDocument", `{"Version":"2012-10-17"}`)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "a JSON-string scalar must not be reparsed into a native structure")
@@ -650,7 +650,7 @@ func TestGeneratePatch_ArrayElementObjectResolvableMatchingLiveValue_NoPatch(t *
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "Endpoints.0", `{"host":"db.internal","port":5432}`)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "an unchanged array of object-valued resolvables must reconcile to a no-op")
@@ -676,7 +676,7 @@ func TestGeneratePatch_StringNullResolvableAgainstArray_StaysString(t *testing.T
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "Polymorphic", "null")
 
-	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc)
 	assert.Contains(t, string(patchDoc), `"value":"null"`, "the literal string \"null\" must not be rewritten to JSON null")
@@ -833,7 +833,7 @@ func TestGeneratePatch_MixedNestedAndFlattenedStructures(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 
 	assert.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
@@ -919,7 +919,7 @@ func TestGeneratePatch_RequiredOnUpdateFieldsGenerateAddOperation(t *testing.T) 
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -987,7 +987,7 @@ func TestGeneratePatch_WriteOnlyCreateOnlyFieldsNoPhantomReplacement(t *testing.
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "writeOnly+createOnly field should NOT trigger replacement")
 	assert.Nil(t, patchDoc, "No patch should be generated when only writeOnly+createOnly fields differ")
@@ -1027,7 +1027,7 @@ func TestGeneratePatch_WriteOnlyFieldUnchanged_NoAddOperation(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "writeOnly-only field unchanged should not force an add op")
@@ -1069,7 +1069,7 @@ func TestGeneratePatch_AddTagsWhileRetainingExisting(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1134,7 +1134,7 @@ func TestGeneratePatch_HasProviderDefaultFieldsNotRemoved(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1177,7 +1177,7 @@ func TestGeneratePatch_HasProviderDefaultFieldsOverridden(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1370,7 +1370,7 @@ func TestGeneratePatch_ReconcileRemovesOOBTagsWhenDesiredIsEmptyArray(t *testing
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1396,7 +1396,7 @@ func TestGeneratePatch_ReconcileRemovesOOBTagsWhenDesiredIsNull(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	require.NotNil(t, patchDoc, "expected a patch to handle the OOB tag, got nil")
@@ -1436,7 +1436,7 @@ func TestGeneratePatch_AbsentDesiredVsEmptyActualArray_NoPatch(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "expected no patch ops when desired is absent and actual is empty array")
@@ -1539,7 +1539,7 @@ func TestGeneratePatch_OuterWithOnlyNestedEmpties_NoSpuriousSuppression(t *testi
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "expected nil patch; pinning current jsonpatch behavior for {Outer:{}}-vs-{} so any future change surfaces here, not as silent drift")
 }
@@ -1565,7 +1565,7 @@ func TestGeneratePatch_AbsentDesiredVsEmptyActualArray_PatchMode_NoPatch(t *test
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "expected no patch ops in Patch mode either")
 }
@@ -1598,7 +1598,7 @@ func TestGeneratePatch_AbsentDesiredVsEmptyActual_EntitySetField_NotAWSSpecific_
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc)
 }
@@ -1745,7 +1745,7 @@ func TestGeneratePatch_ProviderDefaultInsideArray_NoPatch(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "Expected no patch when only difference is provider default Cpu inside array")
 }
@@ -1782,7 +1782,7 @@ func TestGeneratePatch_AtomicField_SingleReplace(t *testing.T) {
 		},
 	}
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1808,7 +1808,7 @@ func TestGeneratePatch_AtomicField_NoDiffNoPatch(t *testing.T) {
 		},
 	}
 
-	patchDoc, createOnlyPatch, err := generatePatch(doc, doc, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(doc, doc, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Empty(t, patchDoc, "Expected no patch when atomic field is identical")
@@ -1838,7 +1838,7 @@ func TestGeneratePatch_EmptyArrayOnCreateOnlyField_NoPatch(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "Empty arrays on createOnly fields should not trigger replacement")
 	assert.Empty(t, patchDoc, "Expected no patch when only difference is empty arrays on createOnly fields")
@@ -1863,7 +1863,7 @@ func TestGeneratePatch_NonEmptyArrayOnCreateOnlyField_TriggersReplacement(t *tes
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.NotEmpty(t, createOnlyPatch, "Non-empty change to createOnly field should trigger replacement")
 	assert.NotEmpty(t, patchDoc)
@@ -1889,7 +1889,7 @@ func TestGeneratePatch_EmptyArrayOnNonCreateOnlyField_NoPatch(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "Expected no patch when only difference is empty arrays on non-createOnly fields")
 }
@@ -1913,7 +1913,7 @@ func TestGeneratePatch_ReplaceNonEmptyArrayPreserved(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.NotEmpty(t, patchDoc, "Expected patch when user clears a collection via replace")
 }
@@ -2052,7 +2052,7 @@ func TestGeneratePatch_EntitySetProviderDefaults_PatchMode(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Empty(t, patchDoc, "Expected no patch when user-specified attribute matches actual")
@@ -2089,7 +2089,7 @@ func TestGeneratePatch_EntitySetProviderDefaults_WithUserChange(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	require.NotEmpty(t, patchDoc)
@@ -2138,7 +2138,7 @@ func TestGeneratePatch_ProviderDefaultInsideArray_SingleElement_NoReplace(t *tes
 		},
 	}
 
-	patchDoc, createOnlyPatch, err := generatePatch(
+	patchDoc, createOnlyPatch, _, err := generatePatch(
 		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
@@ -2178,7 +2178,7 @@ func TestGeneratePatch_ProviderDefaultInsideArray_MixedElements_NoReplace(t *tes
 		},
 	}
 
-	patchDoc, createOnlyPatch, err := generatePatch(
+	patchDoc, createOnlyPatch, _, err := generatePatch(
 		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
@@ -2235,7 +2235,7 @@ func TestGeneratePatch_ProviderDefaultInsideNestedArray_PortMappingHostPort_Mixe
 		},
 	}
 
-	patchDoc, createOnlyPatch, err := generatePatch(
+	patchDoc, createOnlyPatch, _, err := generatePatch(
 		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
@@ -2291,7 +2291,7 @@ func TestGeneratePatch_ProviderDefaultInsideNestedArray_PortMappingHostPort(t *t
 		},
 	}
 
-	patchDoc, createOnlyPatch, err := generatePatch(
+	patchDoc, createOnlyPatch, _, err := generatePatch(
 		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
@@ -2334,7 +2334,7 @@ func TestGeneratePatch_UserChangedFieldInsideArray_StillReplaces(t *testing.T) {
 		},
 	}
 
-	_, createOnlyPatch, err := generatePatch(
+	_, createOnlyPatch, _, err := generatePatch(
 		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
@@ -2364,7 +2364,7 @@ func TestGeneratePatch_TopLevelProviderDefaultOverride_StillDiffs(t *testing.T) 
 		},
 	}
 
-	patchDoc, _, err := generatePatch(
+	patchDoc, _, _, err := generatePatch(
 		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
@@ -2403,7 +2403,7 @@ func TestGeneratePatch_EntitySetProviderDefaults_ReconcileMode(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "Expected no patch when only provider-default elements differ in reconcile mode")
 }
@@ -2461,7 +2461,7 @@ func TestGeneratePatch_NestedListOrderingInsideArrayElement_NoReplace(t *testing
 		},
 	}
 
-	patchDoc, createOnlyPatch, err := generatePatch(
+	patchDoc, createOnlyPatch, _, err := generatePatch(
 		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
@@ -2511,7 +2511,7 @@ func TestGeneratePatch_NestedPortMappingsOrderInsideArrayElement_NoReplace(t *te
 		},
 	}
 
-	patchDoc, createOnlyPatch, err := generatePatch(
+	patchDoc, createOnlyPatch, _, err := generatePatch(
 		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
@@ -2552,7 +2552,7 @@ func TestGeneratePatch_NestedListContentChange_StillReplaces(t *testing.T) {
 		},
 	}
 
-	_, createOnlyPatch, err := generatePatch(
+	_, createOnlyPatch, _, err := generatePatch(
 		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
 		pkgmodel.FormaApplyModeReconcile,
 	)
@@ -2587,7 +2587,7 @@ func TestGeneratePatch_HasProviderDefault_PlainListing_OmittedDesired(t *testing
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "user omitted hasProviderDefault Listing — strip pass must suppress remove ops for runtime-registered entries")
 }
@@ -2606,7 +2606,7 @@ func TestGeneratePatch_HasProviderDefault_NullDesired_Defensive(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc)
 }
@@ -2640,7 +2640,7 @@ func TestGeneratePatch_HasProviderDefault_PlainListing_PR269Rendering(t *testing
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 
 	// Document the bug shape: explicit empty Listing in patch + runtime entry
@@ -2695,7 +2695,7 @@ func TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserOmits_PostRevert(t 
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "characterization: with hasProviderDefault on an EntitySet, OOB-added entries are NOT removed when user omits — see test docstring for the open question")
 }
@@ -2732,7 +2732,7 @@ func TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserDeclaresOne(t *test
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "characterization: with hasProviderDefault on an EntitySet, OOB-added entries are tolerated even when user declares others")
 }
@@ -2765,7 +2765,7 @@ func TestGeneratePatch_AtomicNestedArrayProducesReplace(t *testing.T) {
 		},
 	}
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -2798,7 +2798,7 @@ func TestGeneratePatch_BundledUpdate_DropsSerializationOnlyHintedOp(t *testing.T
 	document := []byte(`{"folderUid":"a","configJson":"{\"x\":1,\"y\":2}"}`)
 	patch := []byte(`{"folderUid":"b","configJson":"{\n  \"y\": 2,\n  \"x\": 1\n}"}`)
 
-	mutable, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, _, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2816,7 +2816,7 @@ func TestGeneratePatch_GenuineHintedChange_KeepsOp(t *testing.T) {
 	document := []byte(`{"configJson":"{\"x\":1}"}`)
 	patch := []byte(`{"configJson":"{\"x\":2}"}`)
 
-	mutable, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, _, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2830,7 +2830,7 @@ func TestGeneratePatch_FallbackKeepsOpOnInvalidJSON(t *testing.T) {
 	document := []byte(`{"configJson":"{\"x\":1}"}`)
 	patch := []byte(`{"configJson":"not json"}`)
 
-	mutable, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, _, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2843,7 +2843,7 @@ func TestGeneratePatch_CreateOnlyHinted_SerializationOnly_NoReplacement(t *testi
 	schema := pkgmodel.Schema{Fields: []string{"configJson"}, Hints: map[string]pkgmodel.FieldHint{"configJson": {Format: "json", CreateOnly: true}}}
 	document := []byte(`{"configJson":"{\"x\":1,\"y\":2}"}`)
 	patch := []byte(`{"configJson":"{\"y\":2,\"x\":1}"}`)
-	mutable, createOnly, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, createOnly, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2860,7 +2860,7 @@ func TestGeneratePatch_ArrayPathNeverDropped(t *testing.T) {
 	schema := pkgmodel.Schema{Fields: []string{"tags"}, Hints: map[string]pkgmodel.FieldHint{"tags": {Format: "json"}}}
 	document := []byte(`{"tags":["a","b"]}`)
 	patch := []byte(`{"tags":["a","c"]}`)
-	mutable, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, _, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2883,7 +2883,7 @@ func TestGeneratePatch_RefResolutionMatchesApplied_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "an unchanged reference must reconcile to a no-op regardless of echo form")
@@ -2904,7 +2904,7 @@ func TestGeneratePatch_CreateOnlyRefMatchesApplied_NoReplacement(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "unchanged createOnly reference must not trigger replacement")
 	var ops []jsonpatch.JsonPatchOperation
@@ -2926,7 +2926,7 @@ func TestGeneratePatch_RefResolutionDiffersFromApplied_PlansUpdate(t *testing.T)
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", newArn)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	var ops []jsonpatch.JsonPatchOperation
@@ -2948,7 +2948,7 @@ func TestGeneratePatch_AppliedWithoutStoredEcho_FallsBackToFresh(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3035,7 +3035,7 @@ func TestGeneratePatch_LegacyRowWithoutApplied_KeepsFreshVsEcho(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3053,7 +3053,7 @@ func TestGeneratePatch_OpaqueRefIgnoresApplied(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Value", "sent")
 
-	patchDoc, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3073,7 +3073,7 @@ func TestGeneratePatch_NumericRefMatchesApplied_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Port", "443")
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "numeric ref matching $applied must reconcile to no-op")
@@ -3091,7 +3091,7 @@ func TestGeneratePatch_NumericRefDiffersFromApplied_PlansUpdate(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Port", "8443")
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	var ops []jsonpatch.JsonPatchOperation
@@ -3120,7 +3120,7 @@ func TestGeneratePatch_ArrayRefCounterpartMatchedByURI_NotIndex(t *testing.T) {
 	props.Add(ksuid, "ArnA", arnA)
 	props.Add(ksuid, "ArnB", arnB)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "reordered echoes of unchanged references must reconcile to a no-op")
@@ -3144,7 +3144,7 @@ func TestGeneratePatch_ArrayRefDuplicateURIs_FailsClosed(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "ArnA", arn)
 
-	patchDoc, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3165,7 +3165,7 @@ func TestGeneratePatch_ResolvedRefMatchingApplied_NoPatch(t *testing.T) {
 	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
 	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "a resolved reference matching the applied baseline must not be rewritten")
@@ -3182,7 +3182,7 @@ func TestGeneratePatch_ResolvedRefDifferingFromApplied_PlansUpdate(t *testing.T)
 	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, newArn)
 	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3203,7 +3203,7 @@ func TestGeneratePatch_LiteralReplacingRefMatchingApplied_PlansUpdate(t *testing
 	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
 	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3223,7 +3223,7 @@ func TestGeneratePatch_ResolvedRefWithDifferentURI_PlansUpdate(t *testing.T) {
 	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
 	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3239,7 +3239,7 @@ func TestGeneratePatch_ResolvedOpaqueRefIgnoresApplied(t *testing.T) {
 	patch := []byte(`{"Secret": "sent"}`)
 	schema := pkgmodel.Schema{Fields: []string{"Secret"}}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3257,7 +3257,7 @@ func TestGeneratePatch_ResolvedStructuredRefMatchingApplied_NoPatch(t *testing.T
 	patch := []byte(`{"Hosts": ["a", "b"]}`)
 	schema := pkgmodel.Schema{Fields: []string{"Hosts"}}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "a structured resolution matching its baseline must not be rewritten")
 }
@@ -3280,7 +3280,7 @@ func TestGeneratePatch_ResolvedArrayRefsMatchingApplied_NoPatch(t *testing.T) {
 	patch := fmt.Appendf(nil, `{"Topics": [%q, %q]}`, arnA, arnB)
 	schema := pkgmodel.Schema{Fields: []string{"Topics"}}
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "resolved array references matching their baselines must not be rewritten")
@@ -3305,7 +3305,7 @@ func TestGeneratePatch_ResolvedArrayRefPartiallyRepointed_PlansOnlyTheChange(t *
 	patch := fmt.Appendf(nil, `{"Topics": [%q, %q]}`, arnA, arnC)
 	schema := pkgmodel.Schema{Fields: []string{"Topics"}}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc)
 	assert.Contains(t, string(patchDoc), arnC, "the repointed element must be written")
@@ -3329,7 +3329,7 @@ func TestGeneratePatch_ResolvedArrayRefsAmbiguousStored_FailsClosed(t *testing.T
 	patch := fmt.Appendf(nil, `{"Topics": [%q, %q]}`, arn, arn)
 	schema := pkgmodel.Schema{Fields: []string{"Topics"}}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3353,7 +3353,7 @@ func TestGeneratePatch_ResolvedRefWithStaleValue_PlansFreshResolution(t *testing
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", freshArn)
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3377,7 +3377,7 @@ func TestGeneratePatch_CreateOnlyResolvedRefWithStaleValue_PlansReplacement(t *t
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", freshArn)
 
-	_, createOnlyPatch, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	_, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotEmpty(t, createOnlyPatch, "a moved reference on an immutable field must still force a replacement")
 	assert.Contains(t, string(createOnlyPatch), freshArn)
@@ -3396,7 +3396,7 @@ func TestGeneratePatch_ResolvedRefFreshlyMatchingApplied_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "an unchanged reference stays suppressed under fresh resolution")
@@ -3424,7 +3424,7 @@ func TestGeneratePatch_ResolvedArrayRefWithStaleValue_PlansFreshResolution(t *te
 	props.Add(ksuid, "ArnA", arnA)
 	props.Add(ksuid, "ArnB", arnBMoved)
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "a moved array reference must be planned")
 	assert.Contains(t, string(patchDoc), arnBMoved, "the moved element carries its current resolution")
@@ -3447,7 +3447,7 @@ func TestGeneratePatch_ResolvedRefWithUnreadableJSONPath_Fails(t *testing.T) {
 	// The source resolves, but no longer carries the path the reference reads.
 	props.Add(ksuid, "Config", `{"host":"10.0.0.2"}`)
 
-	_, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	_, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.Error(t, err, "a reference that cannot be read through its path must not be treated as unchanged")
 	assert.Contains(t, err.Error(), "address")
 }
@@ -3468,7 +3468,7 @@ func TestGeneratePatch_CreateOnlyResolvedRefWithUnreadableJSONPath_Fails(t *test
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Config", `{"name":"fn-v2"}`)
 
-	_, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	_, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.Error(t, err, "an unreadable reference on an immutable field must not silently suppress the replacement")
 }
 
@@ -3484,7 +3484,7 @@ func TestGeneratePatch_ResolvedArrayRefWithUnreadableJSONPath_Fails(t *testing.T
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Config", `{"host":"10.0.0.2"}`)
 
-	_, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	_, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.Error(t, err, "an unreadable array reference must not be treated as unchanged")
 }
 
@@ -3500,7 +3500,7 @@ func TestGeneratePatch_ResolvedRefWithUnresolvableSource_UsesRecordedValue(t *te
 	patch := fmt.Appendf(nil, `{"Endpoint": %q}`, applied)
 	schema := pkgmodel.Schema{Fields: []string{"Endpoint"}}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "an unavailable source leaves the recorded resolution standing")
 }
@@ -3519,7 +3519,7 @@ func TestGeneratePatch_ResolvedArrayRefChangingShape_PlansFreshResolution(t *tes
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Cfg", "h2")
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "a reference resolving to a new shape must be planned")
 	assert.Contains(t, string(patchDoc), "h2", "the plan must carry the current resolution")
@@ -3539,7 +3539,7 @@ func TestGeneratePatch_CreateOnlyResolvedArrayRefChangingShape_PlansReplacement(
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Cfg", "h2")
 
-	_, createOnlyPatch, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	_, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotEmpty(t, createOnlyPatch, "a shape-changing reference on an immutable field must still force a replacement")
 }
@@ -3556,7 +3556,7 @@ func TestGeneratePatch_ResolvedArrayRefObjectMatchingApplied_NoPatch(t *testing.
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Cfg", `{"host":"h1"}`)
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "an unchanged object-valued reference must not be rewritten")
 }
@@ -3579,7 +3579,7 @@ func TestGeneratePatch_AtomicObjectWithUnchangedRef_EmitsWriteForm(t *testing.T)
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "the sibling change must be planned")
 	assert.Contains(t, string(patchDoc), arn,
@@ -3613,7 +3613,7 @@ func TestGeneratePatch_OrderedArrayReorderedRefs_EmitWriteForm(t *testing.T) {
 	props.Add(ksuid, "ArnA", arnA)
 	props.Add(ksuid, "ArnB", arnB)
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "reordering an ordered list is a change")
 	assert.Contains(t, string(patchDoc), arnA)
@@ -3636,7 +3636,7 @@ func TestGeneratePatch_AtomicObjectWithResolvedRef_EmitsWriteForm(t *testing.T) 
 		Hints:  map[string]pkgmodel.FieldHint{"Cfg": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic}},
 	}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "the sibling change must be planned")
 	assert.Contains(t, string(patchDoc), arn)
@@ -3659,7 +3659,7 @@ func TestGeneratePatch_AtomicObjectFullyUnchanged_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "an unchanged atomic object must still reconcile to a no-op")
 }
@@ -3679,7 +3679,7 @@ func TestGeneratePatch_UnchangedRefWithDriftedLiveValue_PlansRepair(t *testing.T
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3703,7 +3703,7 @@ func TestGeneratePatch_CreateOnlyUnchangedRefWithDriftedLiveValue_PlansReplaceme
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	_, createOnlyPatch, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	_, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotEmpty(t, createOnlyPatch, "drift on an immutable reference-fed field must still force a replacement")
 }
@@ -3719,7 +3719,7 @@ func TestGeneratePatch_ResolvedRefWithDriftedLiveValue_PlansRepair(t *testing.T)
 	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
 	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3748,7 +3748,7 @@ func TestGeneratePatch_ArrayRefWithDriftedLiveElement_PlansRepair(t *testing.T) 
 	props.Add(ksuid, "ArnA", arnA)
 	props.Add(ksuid, "ArnB", arnB)
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "a drifted array element must be repaired")
 	assert.Contains(t, string(patchDoc), arnB, "the repair carries the written form")
@@ -3769,7 +3769,7 @@ func TestGeneratePatch_AtomicObjectWithUnresolvableRef_EmitsWriteForm(t *testing
 		Hints:  map[string]pkgmodel.FieldHint{"Cfg": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic}},
 	}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "the sibling change must be planned")
 	assert.Contains(t, string(patchDoc), arn, "the emitted object must carry the last written form")
@@ -3796,7 +3796,7 @@ func TestGeneratePatch_OrderedArrayUnresolvableRefsReordered_EmitWriteForm(t *te
 		Hints:  map[string]pkgmodel.FieldHint{"Topics": {UpdateMethod: pkgmodel.FieldUpdateMethodArray}},
 	}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "reordering an ordered list is a change")
 	assert.NotContains(t, string(patchDoc), "name-a", "the provider's read form must not be sent back as a write")
@@ -3816,7 +3816,7 @@ func TestGeneratePatch_UnresolvableRefUnchanged_NoPatch(t *testing.T) {
 	patch := desired
 	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "an unchanged reference must still reconcile to a no-op")
 }
@@ -3841,7 +3841,7 @@ func TestGeneratePatch_NumericArrayRefsUnchanged_NoPatch(t *testing.T) {
 	props.Add(ksuid, "PortA", "443")
 	props.Add(ksuid, "PortB", "8080")
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "unchanged numeric references must not be rewritten")
 }
@@ -3868,7 +3868,7 @@ func TestGeneratePatch_NumericOrderedArrayRefsReordered_EmitNumbers(t *testing.T
 	props.Add(ksuid, "PortA", "443")
 	props.Add(ksuid, "PortB", "8080")
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "reordering an ordered list is a change")
 	assert.NotContains(t, string(patchDoc), `"443"`, "a numeric reference must not be written back as text")
@@ -3886,7 +3886,7 @@ func TestGeneratePatch_BooleanRefUnchanged_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Flag", "true")
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "an unchanged boolean reference must not be rewritten")
 }
@@ -3906,7 +3906,7 @@ func TestGeneratePatch_AtomicObjectWithNumericRef_EmitsNumber(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "PortA", "443")
 
-	patchDoc, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "the sibling change must be planned")
 	assert.Contains(t, string(patchDoc), "443")

--- a/internal/metastructure/patch/required_on_update_decision_test.go
+++ b/internal/metastructure/patch/required_on_update_decision_test.go
@@ -1,0 +1,83 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package patch
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/jsonpatch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A requiredOnUpdate field is force-resent by stripping it from the document
+// side before the diff, so its own value always reappears as an "add" op. When
+// the document and the desired state agree on every field, that reappearance
+// is the only op the diff would otherwise produce — and it must not itself
+// decide that an update is sent.
+func TestGeneratePatch_UnchangedRequiredOnUpdateField_ProducesNilPatch(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Token"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Token": {RequiredOnUpdate: true},
+		},
+	}
+
+	document := []byte(`{"Name": "n1", "Token": "t1"}`)
+	desired := []byte(`{"Name": "n1", "Token": "t1"}`)
+
+	patchDoc, createOnlyPatch, err := generatePatch(document, desired, nil, nil,
+		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	require.NoError(t, err)
+
+	assert.Empty(t, createOnlyPatch)
+	assert.Empty(t, patchDoc, "a requiredOnUpdate field's own force-resent add must not conjure a patch when nothing changed")
+}
+
+// When a real change is present elsewhere in the same resource, the
+// requiredOnUpdate field's force-resent op rides along unchanged: the
+// provider still requires it in every update payload it actually receives.
+func TestGeneratePatch_ChangedFieldAlongsideRequiredOnUpdateField_KeepsForceResentAdd(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Token"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Token": {RequiredOnUpdate: true},
+		},
+	}
+
+	document := []byte(`{"Name": "n1", "Token": "t1"}`)
+	desired := []byte(`{"Name": "n2", "Token": "t1"}`)
+
+	patchDoc, createOnlyPatch, err := generatePatch(document, desired, nil, nil,
+		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	require.NoError(t, err)
+	assert.Empty(t, createOnlyPatch)
+
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	require.Len(t, ops, 2, "expected one op for the real Name change and one force-resent op for Token")
+
+	var nameOp, tokenOp *jsonpatch.JsonPatchOperation
+	for i := range ops {
+		switch ops[i].Path {
+		case "/Name":
+			nameOp = &ops[i]
+		case "/Token":
+			tokenOp = &ops[i]
+		}
+	}
+
+	require.NotNil(t, nameOp, "the real Name change must be present")
+	assert.Equal(t, "n2", nameOp.Value)
+
+	require.NotNil(t, tokenOp, "the force-resent Token op must still ride along with the real change")
+	assert.Equal(t, "add", tokenOp.Operation, "requiredOnUpdate fields are force-resent as an add")
+	assert.Equal(t, "t1", tokenOp.Value)
+}

--- a/internal/metastructure/patch/required_on_update_decision_test.go
+++ b/internal/metastructure/patch/required_on_update_decision_test.go
@@ -20,9 +20,12 @@ import (
 // A requiredOnUpdate field is force-resent by stripping it from the document
 // side before the diff, so its own value always reappears as an "add" op. When
 // the document and the desired state agree on every field, that reappearance
-// is the only op the diff would otherwise produce — and it must not itself
-// decide that an update is sent.
-func TestGeneratePatch_UnchangedRequiredOnUpdateField_ProducesNilPatch(t *testing.T) {
+// is the only op the diff would otherwise produce. generatePatch reports this
+// via onlyForceResent rather than nilling patchDoc out: the decision of
+// whether to plan an update at all belongs to the caller (planning drops it;
+// execution-time regeneration must not), so the op itself is never stripped
+// from what this function returns.
+func TestGeneratePatch_UnchangedRequiredOnUpdateField_ReportsOnlyForceResent(t *testing.T) {
 	schema := pkgmodel.Schema{
 		Fields: []string{"Name", "Token"},
 		Hints: map[string]pkgmodel.FieldHint{
@@ -33,12 +36,19 @@ func TestGeneratePatch_UnchangedRequiredOnUpdateField_ProducesNilPatch(t *testin
 	document := []byte(`{"Name": "n1", "Token": "t1"}`)
 	desired := []byte(`{"Name": "n1", "Token": "t1"}`)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, desired, nil, nil,
+	patchDoc, createOnlyPatch, onlyForceResent, err := generatePatch(document, desired, nil, nil,
 		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 
 	assert.Empty(t, createOnlyPatch)
-	assert.Empty(t, patchDoc, "a requiredOnUpdate field's own force-resent add must not conjure a patch when nothing changed")
+	assert.True(t, onlyForceResent, "nothing real changed, so the decision must report force-resent-only")
+
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	require.Len(t, ops, 1, "the force-resent Token op is still content this function returns")
+	assert.Equal(t, "/Token", ops[0].Path)
+	assert.Equal(t, "add", ops[0].Operation)
+	assert.Equal(t, "t1", ops[0].Value)
 }
 
 // When a real change is present elsewhere in the same resource, the
@@ -55,10 +65,11 @@ func TestGeneratePatch_ChangedFieldAlongsideRequiredOnUpdateField_KeepsForceRese
 	document := []byte(`{"Name": "n1", "Token": "t1"}`)
 	desired := []byte(`{"Name": "n2", "Token": "t1"}`)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, desired, nil, nil,
+	patchDoc, createOnlyPatch, onlyForceResent, err := generatePatch(document, desired, nil, nil,
 		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
+	assert.False(t, onlyForceResent, "a real change is present, so the decision must not report force-resent-only")
 
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -95,10 +106,11 @@ func TestGeneratePatch_ChangedRequiredOnUpdateFieldItself_PlansUpdate(t *testing
 	document := []byte(`{"Name": "n1", "Token": "t1"}`)
 	desired := []byte(`{"Name": "n1", "Token": "t2"}`)
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, desired, nil, nil,
+	patchDoc, createOnlyPatch, onlyForceResent, err := generatePatch(document, desired, nil, nil,
 		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
+	assert.False(t, onlyForceResent, "the Token change itself is real, so the decision must not report force-resent-only")
 
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -108,4 +120,64 @@ func TestGeneratePatch_ChangedRequiredOnUpdateFieldItself_PlansUpdate(t *testing
 	assert.Equal(t, "/Token", tokenOp.Path)
 	assert.Equal(t, "add", tokenOp.Operation, "requiredOnUpdate fields are force-resent as an add")
 	assert.Equal(t, "t2", tokenOp.Value, "the op must carry the new value, not the stored one")
+}
+
+// A requiredOnUpdate hint on a field nested inside an array ("Items.Token")
+// is force-resent the same way a top-level field is: stripping happens inside
+// every array element, so the resulting "add" op lands at an array-indexed
+// path ("/Items/0/Token"). That path must still be recognized as force-resent
+// when nothing about it actually changed.
+func TestGeneratePatch_UnchangedArrayNestedRequiredOnUpdateField_ReportsOnlyForceResent(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Items"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Items":       {UpdateMethod: pkgmodel.FieldUpdateMethodArray},
+			"Items.Token": {RequiredOnUpdate: true},
+		},
+	}
+
+	document := []byte(`{"Name": "n1", "Items": [{"Token": "same"}]}`)
+	desired := []byte(`{"Name": "n1", "Items": [{"Token": "same"}]}`)
+
+	patchDoc, createOnlyPatch, onlyForceResent, err := generatePatch(document, desired, nil, nil,
+		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	require.NoError(t, err)
+
+	assert.Empty(t, createOnlyPatch)
+	assert.True(t, onlyForceResent, "the array-nested Token op is unchanged, so the decision must report force-resent-only")
+
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	require.Len(t, ops, 1, "the force-resent Items.0.Token op is still content this function returns")
+	assert.Equal(t, "/Items/0/Token", ops[0].Path)
+	assert.Equal(t, "add", ops[0].Operation)
+	assert.Equal(t, "same", ops[0].Value)
+}
+
+// The changed direction for an array-nested requiredOnUpdate field: a genuine
+// change still plans an update like any other change.
+func TestGeneratePatch_ChangedArrayNestedRequiredOnUpdateField_PlansUpdate(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Items"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Items":       {UpdateMethod: pkgmodel.FieldUpdateMethodArray},
+			"Items.Token": {RequiredOnUpdate: true},
+		},
+	}
+
+	document := []byte(`{"Name": "n1", "Items": [{"Token": "old"}]}`)
+	desired := []byte(`{"Name": "n1", "Items": [{"Token": "new"}]}`)
+
+	patchDoc, createOnlyPatch, onlyForceResent, err := generatePatch(document, desired, nil, nil,
+		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	require.NoError(t, err)
+
+	assert.Empty(t, createOnlyPatch)
+	assert.False(t, onlyForceResent, "the Items.0.Token change itself is real, so the decision must not report force-resent-only")
+
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	require.Len(t, ops, 1, "expected exactly one op for the genuine array-nested Token change")
+	assert.Equal(t, "/Items/0/Token", ops[0].Path)
+	assert.Equal(t, "new", ops[0].Value)
 }

--- a/internal/metastructure/patch/required_on_update_decision_test.go
+++ b/internal/metastructure/patch/required_on_update_decision_test.go
@@ -81,3 +81,31 @@ func TestGeneratePatch_ChangedFieldAlongsideRequiredOnUpdateField_KeepsForceRese
 	assert.Equal(t, "add", tokenOp.Operation, "requiredOnUpdate fields are force-resent as an add")
 	assert.Equal(t, "t1", tokenOp.Value)
 }
+
+// A genuine change to a requiredOnUpdate field plans an update like any other
+// change.
+func TestGeneratePatch_ChangedRequiredOnUpdateFieldItself_PlansUpdate(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Token"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Token": {RequiredOnUpdate: true},
+		},
+	}
+
+	document := []byte(`{"Name": "n1", "Token": "t1"}`)
+	desired := []byte(`{"Name": "n1", "Token": "t2"}`)
+
+	patchDoc, createOnlyPatch, err := generatePatch(document, desired, nil, nil,
+		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	require.NoError(t, err)
+	assert.Empty(t, createOnlyPatch)
+
+	var ops []jsonpatch.JsonPatchOperation
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	require.Len(t, ops, 1, "expected exactly one op for the genuine Token change")
+
+	tokenOp := ops[0]
+	assert.Equal(t, "/Token", tokenOp.Path)
+	assert.Equal(t, "add", tokenOp.Operation, "requiredOnUpdate fields are force-resent as an add")
+	assert.Equal(t, "t2", tokenOp.Value, "the op must carry the new value, not the stored one")
+}

--- a/internal/metastructure/patch/writeonly_createonly_baseline_test.go
+++ b/internal/metastructure/patch/writeonly_createonly_baseline_test.go
@@ -40,7 +40,7 @@ func TestGeneratePatch_WriteOnlyCreateOnlyChanged_StoredBaseline_PlansReplacemen
 	}`)
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, writeOnlyCreateOnlySchema(), pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, writeOnlyCreateOnlySchema(), pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	if len(patchDoc) > 0 {
 		assert.JSONEq(t, "[]", string(patchDoc), "a createOnly change belongs in the createOnly patch, not the update patch")
@@ -63,7 +63,7 @@ func TestGeneratePatch_WriteOnlyCreateOnlyUnchanged_StoredBaseline_NoOp(t *testi
 	}`)
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, err := generatePatch(document, patch, nil, nil, props, writeOnlyCreateOnlySchema(), pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, writeOnlyCreateOnlySchema(), pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "an unchanged writeOnly+createOnly field must not plan a replacement")
 	assert.Nil(t, patchDoc, "an unchanged writeOnly+createOnly field must not plan any op")

--- a/internal/metastructure/resource_update/absence_semantics_test.go
+++ b/internal/metastructure/resource_update/absence_semantics_test.go
@@ -410,3 +410,149 @@ func TestGenerateResourceUpdates_ForwardReferenceDefers(t *testing.T) {
 	}
 	assert.True(t, found, "the producer's Arn URI must remain as a resolvable, expected among: %v", consumer.RemainingResolvables)
 }
+
+// Removing a property together with the resource that references it is not a
+// dangling reference: both leave in the same command.
+func TestGenerateResourceUpdates_RemovedPropertyWithDeletedConsumer_NoError(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	producerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Name": {CreateOnly: true},
+			"Tags": {UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Key"},
+		},
+	}
+	consumerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Ref"},
+	}
+
+	producerKsuid := util.NewID()
+	consumerKsuid := util.NewID()
+
+	existingStack := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Absence::Producer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: producerSchema, Ksuid: producerKsuid,
+				Properties: json.RawMessage(`{"Name": "p", "Tags": [{"Key": "team", "Value": "x"}]}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Absence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema, Ksuid: consumerKsuid,
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Name": "c", "Ref": {"$ref": "formae://%s#/Tags", "$value": "[{\"Key\":\"team\",\"Value\":\"x\"}]"}}`,
+					producerKsuid)),
+			},
+		},
+	}
+	_, err := ds.StoreStack(existingStack, "previous-command")
+	require.NoError(t, err)
+
+	// Reconcile: the producer no longer declares Tags at all, and the
+	// consumer is dropped from the forma entirely — it is being deleted in
+	// this same command, not left dangling.
+	forma := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Targets: []pkgmodel.Target{
+			{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+		},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Absence::Producer",
+				Stack: "test-stack", Target: "test-target",
+				Schema:     producerSchema,
+				Properties: json.RawMessage(`{"Name": "p"}`),
+			},
+		},
+	}
+	existingTargets := []*pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+	}
+
+	_, err = GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+		FormaCommandSourceUser, existingTargets, ds, nil, nil)
+	require.NoError(t, err)
+}
+
+// Removing one member of a collection does not dangle a reference to the
+// collection itself.
+func TestGenerateResourceUpdates_MemberRemovalDoesNotDangleCollectionReference(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	producerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Name": {CreateOnly: true},
+			"Tags": {UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Key"},
+		},
+	}
+	consumerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Ref"},
+	}
+
+	producerKsuid := util.NewID()
+	consumerKsuid := util.NewID()
+
+	existingStack := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Absence::Producer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: producerSchema, Ksuid: producerKsuid,
+				Properties: json.RawMessage(`{"Name": "p", "Tags": [{"Key": "team", "Value": "x"}, {"Key": "env", "Value": "prod"}]}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Absence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema, Ksuid: consumerKsuid,
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Name": "c", "Ref": {"$ref": "formae://%s#/Tags", "$value": "[{\"Key\":\"team\",\"Value\":\"x\"},{\"Key\":\"env\",\"Value\":\"prod\"}]"}}`,
+					producerKsuid)),
+			},
+		},
+	}
+	_, err := ds.StoreStack(existingStack, "previous-command")
+	require.NoError(t, err)
+
+	// Reconcile: Tags stays declared, but only one of the two persisted
+	// members survives — the other is dropped. The consumer references the
+	// collection root, not the dropped member.
+	forma := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Targets: []pkgmodel.Target{
+			{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+		},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Absence::Producer",
+				Stack: "test-stack", Target: "test-target",
+				Schema:     producerSchema,
+				Properties: json.RawMessage(`{"Name": "p", "Tags": [{"Key": "team", "Value": "x"}]}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Absence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema,
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Name": "c", "Ref": {"$ref": "formae://%s#/Tags", "$value": "[{\"Key\":\"team\",\"Value\":\"x\"},{\"Key\":\"env\",\"Value\":\"prod\"}]"}}`,
+					producerKsuid)),
+			},
+		},
+	}
+	existingTargets := []*pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+	}
+
+	_, err = GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+		FormaCommandSourceUser, existingTargets, ds, nil, nil)
+	require.NoError(t, err)
+}

--- a/internal/metastructure/resource_update/absence_semantics_test.go
+++ b/internal/metastructure/resource_update/absence_semantics_test.go
@@ -1,0 +1,412 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// A reconcile that removes a property another resource references is
+// rejected at plan time: the reference would dangle the moment the removal
+// executes.
+func TestGenerateResourceUpdates_ReferenceToRemovedPropertyFails(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	producerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Name": {CreateOnly: true},
+			"Tags": {UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Key"},
+		},
+	}
+	consumerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Ref"},
+	}
+
+	producerKsuid := util.NewID()
+	consumerKsuid := util.NewID()
+
+	existingStack := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Absence::Producer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: producerSchema, Ksuid: producerKsuid,
+				Properties: json.RawMessage(`{"Name": "p", "Tags": [{"Key": "team", "Value": "x"}]}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Absence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema, Ksuid: consumerKsuid,
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Name": "c", "Ref": {"$ref": "formae://%s#/Tags", "$value": "[{\"Key\":\"team\",\"Value\":\"x\"}]"}}`,
+					producerKsuid)),
+			},
+		},
+	}
+	_, err := ds.StoreStack(existingStack, "previous-command")
+	require.NoError(t, err)
+
+	// Reconcile: the producer no longer declares Tags at all (whole EntitySet
+	// property removed), while the consumer's declaration is unchanged.
+	forma := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Targets: []pkgmodel.Target{
+			{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+		},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Absence::Producer",
+				Stack: "test-stack", Target: "test-target",
+				Schema:     producerSchema,
+				Properties: json.RawMessage(`{"Name": "p"}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Absence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema,
+				Properties: json.RawMessage(`{
+					"Name": "c",
+					"Ref": {
+						"$res":      true,
+						"$label":    "producer",
+						"$type":     "FakeAWS::Absence::Producer",
+						"$stack":    "test-stack",
+						"$property": "Tags"
+					}
+				}`),
+			},
+		},
+	}
+	existingTargets := []*pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+	}
+
+	_, err = GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+		FormaCommandSourceUser, existingTargets, ds, nil, nil)
+	require.Error(t, err)
+
+	var refErr ReferenceToRemovedPropertyError
+	require.True(t, errors.As(err, &refErr), "expected ReferenceToRemovedPropertyError, got: %v", err)
+	assert.Equal(t, "consumer", refErr.ConsumerLabel)
+	assert.Equal(t, "producer", refErr.SourceLabel)
+	assert.Equal(t, "Tags", refErr.PropertyPath)
+}
+
+// In patch mode, omitting a property means leave it unchanged: a reference
+// to it resolves the persisted value and nothing is removed.
+func TestGenerateResourceUpdates_PatchModeOmission_LeavesReferenceUndisturbed(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	producerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Name": {CreateOnly: true},
+			"Tags": {UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Key"},
+		},
+	}
+	consumerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Ref"},
+	}
+
+	producerKsuid := util.NewID()
+	consumerKsuid := util.NewID()
+
+	existingStack := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Absence::Producer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: producerSchema, Ksuid: producerKsuid,
+				Properties: json.RawMessage(`{"Name": "p", "Tags": [{"Key": "team", "Value": "x"}]}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Absence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema, Ksuid: consumerKsuid,
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Name": "c", "Ref": {"$ref": "formae://%s#/Tags", "$value": "[{\"Key\":\"team\",\"Value\":\"x\"}]"}}`,
+					producerKsuid)),
+			},
+		},
+	}
+	_, err := ds.StoreStack(existingStack, "previous-command")
+	require.NoError(t, err)
+
+	// Patch mode: producer omits Tags, but patch semantics leave omitted
+	// fields untouched rather than removing them.
+	forma := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Targets: []pkgmodel.Target{
+			{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+		},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Absence::Producer",
+				Stack: "test-stack", Target: "test-target",
+				Schema:     producerSchema,
+				Properties: json.RawMessage(`{"Name": "p"}`),
+			},
+		},
+	}
+	existingTargets := []*pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+	}
+
+	_, err = GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModePatch,
+		FormaCommandSourceUser, existingTargets, ds, nil, nil)
+	require.NoError(t, err)
+}
+
+// Reconcile omission of a plain property is not removal: no remove op is
+// minted, the persisted value stands, and the reference stays quiet.
+func TestGenerateResourceUpdates_ReconcileOmissionWithoutRemoval_KeepsPersistedResolution(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	producerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Note"},
+	}
+	consumerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Ref"},
+	}
+
+	producerKsuid := util.NewID()
+	consumerKsuid := util.NewID()
+
+	existingStack := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Absence::PlainProducer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: producerSchema, Ksuid: producerKsuid,
+				Properties: json.RawMessage(`{"Name": "p", "Note": "n1"}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Absence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema, Ksuid: consumerKsuid,
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Name": "c", "Ref": {"$ref": "formae://%s#/Note", "$value": "n1"}}`,
+					producerKsuid)),
+			},
+		},
+	}
+	_, err := ds.StoreStack(existingStack, "previous-command")
+	require.NoError(t, err)
+
+	// Reconcile: the producer's forma declaration simply omits Note (a plain
+	// scalar field with no collection hint); the consumer is unchanged.
+	forma := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Targets: []pkgmodel.Target{
+			{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+		},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Absence::PlainProducer",
+				Stack: "test-stack", Target: "test-target",
+				Schema:     producerSchema,
+				Properties: json.RawMessage(`{"Name": "p"}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Absence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema,
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Name": "c", "Ref": {"$ref": "formae://%s#/Note", "$value": "n1"}}`,
+					producerKsuid)),
+			},
+		},
+	}
+	existingTargets := []*pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+	}
+
+	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+		FormaCommandSourceUser, existingTargets, ds, nil, nil)
+	require.NoError(t, err)
+
+	for i := range updates {
+		if updates[i].DesiredState.Label == "consumer" {
+			assert.Empty(t, string(updates[i].DesiredState.PatchDocument),
+				"no consumer change should be planned for an omitted-but-not-removed property")
+		}
+	}
+}
+
+// A provider-computed output is never declared; a reference to it resolves
+// the persisted value.
+func TestGenerateResourceUpdates_ReadOnlyOutputResolvesFromPersisted(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	producerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Mutable", "Arn"},
+	}
+	consumerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Ref"},
+	}
+
+	producerKsuid := util.NewID()
+	consumerKsuid := util.NewID()
+
+	existingStack := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Absence::OutputProducer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: producerSchema, Ksuid: producerKsuid,
+				Properties:         json.RawMessage(`{"Name": "p", "Mutable": "m1"}`),
+				ReadOnlyProperties: json.RawMessage(`{"Arn": "arn:probe"}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Absence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema, Ksuid: consumerKsuid,
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Name": "c", "Ref": {"$ref": "formae://%s#/Arn", "$value": "arn:probe"}}`,
+					producerKsuid)),
+			},
+		},
+	}
+	_, err := ds.StoreStack(existingStack, "previous-command")
+	require.NoError(t, err)
+
+	// Reconcile changes an unrelated mutable field on the producer; Arn is
+	// never declared (it is provider-computed) and the consumer is unchanged.
+	forma := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Targets: []pkgmodel.Target{
+			{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+		},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Absence::OutputProducer",
+				Stack: "test-stack", Target: "test-target",
+				Schema:     producerSchema,
+				Properties: json.RawMessage(`{"Name": "p", "Mutable": "m2"}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Absence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema,
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Name": "c", "Ref": {"$ref": "formae://%s#/Arn", "$value": "arn:probe"}}`,
+					producerKsuid)),
+			},
+		},
+	}
+	existingTargets := []*pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+	}
+
+	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+		FormaCommandSourceUser, existingTargets, ds, nil, nil)
+	require.NoError(t, err)
+
+	for i := range updates {
+		if updates[i].DesiredState.Label == "consumer" {
+			assert.NotContains(t, string(updates[i].DesiredState.PatchDocument), "Arn",
+				"consumer must not be spuriously planned on the Arn path")
+		}
+	}
+}
+
+// A forward reference to a resource created in this command defers to
+// execution-time resolution.
+func TestGenerateResourceUpdates_ForwardReferenceDefers(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	producerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Arn"},
+	}
+	consumerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Ref"},
+	}
+
+	// No persisted rows: both resources are brand new.
+	forma := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Targets: []pkgmodel.Target{
+			{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+		},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Absence::NewProducer",
+				Stack: "test-stack", Target: "test-target",
+				Schema:     producerSchema,
+				Properties: json.RawMessage(`{"Name": "p"}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Absence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema,
+				Properties: json.RawMessage(`{
+					"Name": "c",
+					"Ref": {
+						"$res":      true,
+						"$label":    "producer",
+						"$type":     "FakeAWS::Absence::NewProducer",
+						"$stack":    "test-stack",
+						"$property": "Arn"
+					}
+				}`),
+			},
+		},
+	}
+	existingTargets := []*pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+	}
+
+	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+		FormaCommandSourceUser, existingTargets, ds, nil, nil)
+	require.NoError(t, err)
+
+	planned := map[string]*ResourceUpdate{}
+	for i := range updates {
+		planned[updates[i].DesiredState.Label] = &updates[i]
+	}
+
+	producer, ok := planned["producer"]
+	require.True(t, ok, "producer must be planned")
+	assert.Equal(t, OperationCreate, producer.Operation)
+
+	consumer, ok := planned["consumer"]
+	require.True(t, ok, "consumer must be planned")
+	assert.Equal(t, OperationCreate, consumer.Operation)
+
+	require.NotEmpty(t, consumer.RemainingResolvables, "the forward reference must defer to execution-time resolution")
+	found := false
+	for _, uri := range consumer.RemainingResolvables {
+		if uri.PropertyPath() == "Arn" {
+			found = true
+		}
+	}
+	assert.True(t, found, "the producer's Arn URI must remain as a resolvable, expected among: %v", consumer.RemainingResolvables)
+}

--- a/internal/metastructure/resource_update/occurrence_extraction_test.go
+++ b/internal/metastructure/resource_update/occurrence_extraction_test.go
@@ -1,0 +1,272 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// Two references to the same source property with different JSON extractions
+// each receive their own extracted value.
+func TestGenerateResourceUpdates_TwoExtractionsOfOneProperty_DoNotCollide(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	producerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Doc"},
+		Hints:      map[string]pkgmodel.FieldHint{"Name": {CreateOnly: true}},
+	}
+	consumerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "User", "Pass"},
+	}
+
+	producerKsuid := util.NewID()
+	consumerKsuid := util.NewID()
+
+	existingStack := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Occurrence::Producer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: producerSchema, Ksuid: producerKsuid,
+				Properties: json.RawMessage(`{"Name": "p", "Doc": "{\"user\":\"u1\",\"pass\":\"p1\"}"}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Occurrence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema, Ksuid: consumerKsuid,
+				Properties: json.RawMessage(fmt.Sprintf(`{
+					"Name": "c",
+					"User": {"$ref": "formae://%[1]s#/Doc", "$value": "u1", "$json": "user"},
+					"Pass": {"$ref": "formae://%[1]s#/Doc", "$value": "p1", "$json": "pass"}
+				}`, producerKsuid)),
+			},
+		},
+	}
+	_, err := ds.StoreStack(existingStack, "previous-command")
+	require.NoError(t, err)
+
+	// Reconcile: the producer's Doc changes; the consumer's declaration is
+	// unchanged, expressed via $res sugar with each occurrence carrying its
+	// own $json extraction path.
+	forma := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Targets: []pkgmodel.Target{
+			{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+		},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "producer", Type: "FakeAWS::Occurrence::Producer",
+				Stack: "test-stack", Target: "test-target",
+				Schema:     producerSchema,
+				Properties: json.RawMessage(`{"Name": "p", "Doc": "{\"user\":\"u2\",\"pass\":\"p2\"}"}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Occurrence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema,
+				Properties: json.RawMessage(`{
+					"Name": "c",
+					"User": {
+						"$res":      true,
+						"$label":    "producer",
+						"$type":     "FakeAWS::Occurrence::Producer",
+						"$stack":    "test-stack",
+						"$property": "Doc",
+						"$json":     "user"
+					},
+					"Pass": {
+						"$res":      true,
+						"$label":    "producer",
+						"$type":     "FakeAWS::Occurrence::Producer",
+						"$stack":    "test-stack",
+						"$property": "Doc",
+						"$json":     "pass"
+					}
+				}`),
+			},
+		},
+	}
+	existingTargets := []*pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+	}
+
+	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+		FormaCommandSourceUser, existingTargets, ds, nil, nil)
+	require.NoError(t, err)
+
+	planned := map[string]*ResourceUpdate{}
+	for i := range updates {
+		planned[updates[i].DesiredState.Label] = &updates[i]
+	}
+
+	consumer, ok := planned["consumer"]
+	require.True(t, ok, "consumer following the producer's changed Doc must stay in the changeset")
+	patch := string(consumer.DesiredState.PatchDocument)
+	assert.Contains(t, patch, "u2", "the User occurrence must extract its own leaf")
+	assert.Contains(t, patch, "p2", "the Pass occurrence must extract its own leaf")
+}
+
+// A consumer declaring a requiredOnUpdate field follows a changed reference
+// exactly like any other consumer, and an unchanged reference does not plan
+// it.
+func TestGenerateResourceUpdates_RequiredOnUpdateConsumer_BehavesIdentically(t *testing.T) {
+	producerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Value"},
+		Hints:      map[string]pkgmodel.FieldHint{"Name": {CreateOnly: true}},
+	}
+	consumerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "ParentRef", "Token"},
+		Hints:      map[string]pkgmodel.FieldHint{"Token": {RequiredOnUpdate: true}},
+	}
+
+	buildExistingStack := func(producerKsuid string) *pkgmodel.Forma {
+		return &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label: "parent", Type: "FakeAWS::Occurrence::Parent",
+					Stack: "test-stack", Target: "test-target",
+					Schema: producerSchema, Ksuid: producerKsuid,
+					Properties: json.RawMessage(`{"Name": "parent-1", "Value": "hello"}`),
+				},
+				{
+					Label: "consumer", Type: "FakeAWS::Occurrence::Consumer",
+					Stack: "test-stack", Target: "test-target",
+					Schema: consumerSchema, Ksuid: util.NewID(),
+					Properties: json.RawMessage(fmt.Sprintf(
+						`{"Name": "consumer-1", "Token": "t1", "ParentRef": {"$ref": "formae://%s#/Value", "$value": "hello"}}`,
+						producerKsuid)),
+				},
+			},
+		}
+	}
+
+	existingTargets := []*pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+	}
+	targets := []pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+	}
+
+	// Scenario A: the producer's Value changes, consumer declaration
+	// (including the requiredOnUpdate Token) is unchanged -> consumer
+	// follows the changed reference like any other consumer.
+	t.Run("changed root plans the consumer", func(t *testing.T) {
+		ds, _ := GetDeps(t)
+		producerKsuid := util.NewID()
+
+		_, err := ds.StoreStack(buildExistingStack(producerKsuid), "previous-command")
+		require.NoError(t, err)
+
+		forma := &pkgmodel.Forma{
+			Stacks:  []pkgmodel.Stack{{Label: "test-stack"}},
+			Targets: targets,
+			Resources: []pkgmodel.Resource{
+				{
+					Label: "parent", Type: "FakeAWS::Occurrence::Parent",
+					Stack: "test-stack", Target: "test-target",
+					Schema:     producerSchema,
+					Properties: json.RawMessage(`{"Name": "parent-1", "Value": "world"}`),
+				},
+				{
+					Label: "consumer", Type: "FakeAWS::Occurrence::Consumer",
+					Stack: "test-stack", Target: "test-target",
+					Schema: consumerSchema,
+					Properties: json.RawMessage(`{
+						"Name": "consumer-1",
+						"Token": "t1",
+						"ParentRef": {
+							"$res":      true,
+							"$label":    "parent",
+							"$type":     "FakeAWS::Occurrence::Parent",
+							"$stack":    "test-stack",
+							"$property": "Value"
+						}
+					}`),
+				},
+			},
+		}
+
+		updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+			FormaCommandSourceUser, existingTargets, ds, nil, nil)
+		require.NoError(t, err)
+
+		planned := map[string]*ResourceUpdate{}
+		for i := range updates {
+			planned[updates[i].DesiredState.Label] = &updates[i]
+		}
+
+		consumer, ok := planned["consumer"]
+		require.True(t, ok, "consumer following the producer's changed field must stay in the changeset")
+		assert.Contains(t, string(consumer.DesiredState.PatchDocument), "world",
+			"the consumer's patch must carry the producer's new value")
+	})
+
+	// Scenario B: the producer's Value is resubmitted unchanged, consumer
+	// declaration is unchanged -> requiredOnUpdate alone must not conjure an
+	// update for an otherwise unchanged consumer.
+	t.Run("unchanged root plans nothing", func(t *testing.T) {
+		ds, _ := GetDeps(t)
+		producerKsuid := util.NewID()
+
+		_, err := ds.StoreStack(buildExistingStack(producerKsuid), "previous-command")
+		require.NoError(t, err)
+
+		forma := &pkgmodel.Forma{
+			Stacks:  []pkgmodel.Stack{{Label: "test-stack"}},
+			Targets: targets,
+			Resources: []pkgmodel.Resource{
+				{
+					Label: "parent", Type: "FakeAWS::Occurrence::Parent",
+					Stack: "test-stack", Target: "test-target",
+					Schema:     producerSchema,
+					Properties: json.RawMessage(`{"Name": "parent-1", "Value": "hello"}`),
+				},
+				{
+					Label: "consumer", Type: "FakeAWS::Occurrence::Consumer",
+					Stack: "test-stack", Target: "test-target",
+					Schema: consumerSchema,
+					Properties: json.RawMessage(`{
+						"Name": "consumer-1",
+						"Token": "t1",
+						"ParentRef": {
+							"$res":      true,
+							"$label":    "parent",
+							"$type":     "FakeAWS::Occurrence::Parent",
+							"$stack":    "test-stack",
+							"$property": "Value"
+						}
+					}`),
+				},
+			},
+		}
+
+		updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+			FormaCommandSourceUser, existingTargets, ds, nil, nil)
+		require.NoError(t, err)
+
+		for i := range updates {
+			if updates[i].DesiredState.Label == "consumer" {
+				assert.Empty(t, string(updates[i].DesiredState.PatchDocument),
+					"requiredOnUpdate alone must not conjure an update for an otherwise unchanged consumer")
+			}
+		}
+	})
+}

--- a/internal/metastructure/resource_update/reference_removed_property.go
+++ b/internal/metastructure/resource_update/reference_removed_property.go
@@ -100,7 +100,14 @@ func validateReferencesAgainstRemovals(updates []ResourceUpdate, forma *pkgmodel
 			if !ok {
 				continue
 			}
-			refPath := "/" + uri.PropertyPath()
+			// Reference property paths use the resolver's dotted nesting
+			// convention ("Config.Endpoint", "Subnets.0"), while removal paths
+			// are JSON Pointers ("/Config", "/Subnets/0"). Normalize dots to
+			// slashes before comparing so a nested or array-indexed reference
+			// into a removed path is recognized. This adopts the resolver's
+			// own convention, including its known ambiguity with a literal
+			// dotted key — the same trade the resolver already makes.
+			refPath := "/" + strings.ReplaceAll(uri.PropertyPath(), ".", "/")
 			for _, rp := range removed {
 				if refPath == rp.Path || strings.HasPrefix(refPath, rp.Path+"/") {
 					return ReferenceToRemovedPropertyError{

--- a/internal/metastructure/resource_update/reference_removed_property.go
+++ b/internal/metastructure/resource_update/reference_removed_property.go
@@ -1,0 +1,116 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package resource_update
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// ReferenceToRemovedPropertyError reports that a resource references a
+// property that this command's reconcile removes from its source: the
+// reference would dangle the moment the producer's update executes. The plan
+// is rejected so the author either keeps the property declared or removes the
+// reference.
+type ReferenceToRemovedPropertyError struct {
+	ConsumerLabel string
+	SourceLabel   string
+	PropertyPath  string
+}
+
+func (e ReferenceToRemovedPropertyError) Error() string {
+	return fmt.Sprintf("resource %q references property %q of %q, which this command removes; keep the property declared or remove the reference", e.ConsumerLabel, e.PropertyPath, e.SourceLabel)
+}
+
+// removedProperty records that a reconcile-generated update removes the
+// JSON-pointer path Path from the resource this update targets, along with
+// that resource's label (for error reporting).
+type removedProperty struct {
+	Label string
+	Path  string
+}
+
+// jsonPatchRemoveOp is the shape this package needs out of a PatchDocument
+// entry to detect a "remove" op — decoupled from the jsonpatch package's own
+// operation type so an unrelated field added there can't break decoding here.
+type jsonPatchRemoveOp struct {
+	Op   string `json:"op"`
+	Path string `json:"path"`
+}
+
+// validateReferencesAgainstRemovals rejects a reconcile plan in which one
+// resource's generated update removes a property that another declared
+// resource still references. Absence has more than one cause — a
+// provider-computed output that was never declared, a patch-mode omission
+// that leaves the field untouched, a reconcile omission that mints no remove
+// op — and none of those dangle a reference. Only an actual "remove" op in a
+// generated PatchDocument does, so this pass keys off that op alone.
+//
+// Removes are read off the generated updates (only an OperationUpdate's
+// PatchDocument can carry one). Consumers are read off the forma's own
+// declared resources rather than the generated updates: a resource whose own
+// declaration is unchanged, and therefore never receives a ResourceUpdate,
+// still holds the dangling reference once its source is removed, and the
+// forma sweep is what makes that consumer visible.
+func validateReferencesAgainstRemovals(updates []ResourceUpdate, forma *pkgmodel.Forma) error {
+	// First sweep: collect every "remove" op's JSON-pointer path, keyed by
+	// the KSUID of the resource the removal executes against.
+	removedByKsuid := make(map[string][]removedProperty)
+	for _, u := range updates {
+		if u.Operation != OperationUpdate {
+			continue
+		}
+		if len(u.DesiredState.PatchDocument) == 0 {
+			continue
+		}
+		var ops []jsonPatchRemoveOp
+		if err := json.Unmarshal(u.DesiredState.PatchDocument, &ops); err != nil {
+			// Malformed patch documents are caught elsewhere; this pass only
+			// cares about well-formed "remove" ops.
+			continue
+		}
+		for _, op := range ops {
+			if op.Op != "remove" {
+				continue
+			}
+			removedByKsuid[u.DesiredState.Ksuid] = append(removedByKsuid[u.DesiredState.Ksuid], removedProperty{
+				Label: u.DesiredState.Label,
+				Path:  op.Path,
+			})
+		}
+	}
+	if len(removedByKsuid) == 0 {
+		return nil
+	}
+
+	// Second sweep: every resource the forma declares — whether it ends up
+	// unchanged, updated, or created — must not reference a path removed
+	// above (an exact match, or a nested path under it — a removal of a
+	// member within a collection, e.g. /Tags/1, does not dangle a reference
+	// to the collection itself, /Tags).
+	for _, r := range forma.Resources {
+		for _, uri := range resolver.ExtractResolvableURIs(r) {
+			removed, ok := removedByKsuid[uri.KSUID()]
+			if !ok {
+				continue
+			}
+			refPath := "/" + uri.PropertyPath()
+			for _, rp := range removed {
+				if refPath == rp.Path || strings.HasPrefix(refPath, rp.Path+"/") {
+					return ReferenceToRemovedPropertyError{
+						ConsumerLabel: r.Label,
+						SourceLabel:   rp.Label,
+						PropertyPath:  uri.PropertyPath(),
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/internal/metastructure/resource_update/reference_removed_property_test.go
+++ b/internal/metastructure/resource_update/reference_removed_property_test.go
@@ -1,0 +1,124 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// A reference expressed in the resolver's dotted-nesting convention
+// ("Config.Endpoint") into a property whose whole top-level path a generated
+// update removes ("/Config") dangles just as much as a reference to the
+// top-level property itself, and must be rejected.
+func TestValidateReferencesAgainstRemovals_DottedNestedReferenceIntoRemovedPath_Fails(t *testing.T) {
+	producerKsuid := util.NewID()
+
+	updates := []ResourceUpdate{
+		{
+			Operation: OperationUpdate,
+			DesiredState: pkgmodel.Resource{
+				Label:         "producer",
+				Ksuid:         producerKsuid,
+				PatchDocument: json.RawMessage(`[{"op":"remove","path":"/Config"}]`),
+			},
+		},
+	}
+	forma := &pkgmodel.Forma{
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "consumer",
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Ref": {"$ref": "formae://%s#/Config.Endpoint", "$value": "e1"}}`,
+					producerKsuid)),
+			},
+		},
+	}
+
+	err := validateReferencesAgainstRemovals(updates, forma)
+	require.Error(t, err)
+
+	var refErr ReferenceToRemovedPropertyError
+	require.True(t, errors.As(err, &refErr), "expected ReferenceToRemovedPropertyError, got: %v", err)
+	assert.Equal(t, "consumer", refErr.ConsumerLabel)
+	assert.Equal(t, "producer", refErr.SourceLabel)
+	assert.Equal(t, "Config.Endpoint", refErr.PropertyPath)
+}
+
+// A dotted array-index reference ("Subnets.0") into a property whose whole
+// top-level path a generated update removes ("/Subnets") dangles the same
+// way, and must be rejected.
+func TestValidateReferencesAgainstRemovals_DottedArrayIndexReferenceIntoRemovedPath_Fails(t *testing.T) {
+	producerKsuid := util.NewID()
+
+	updates := []ResourceUpdate{
+		{
+			Operation: OperationUpdate,
+			DesiredState: pkgmodel.Resource{
+				Label:         "producer",
+				Ksuid:         producerKsuid,
+				PatchDocument: json.RawMessage(`[{"op":"remove","path":"/Subnets"}]`),
+			},
+		},
+	}
+	forma := &pkgmodel.Forma{
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "consumer",
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Ref": {"$ref": "formae://%s#/Subnets.0", "$value": "subnet-a"}}`,
+					producerKsuid)),
+			},
+		},
+	}
+
+	err := validateReferencesAgainstRemovals(updates, forma)
+	require.Error(t, err)
+
+	var refErr ReferenceToRemovedPropertyError
+	require.True(t, errors.As(err, &refErr), "expected ReferenceToRemovedPropertyError, got: %v", err)
+	assert.Equal(t, "Subnets.0", refErr.PropertyPath)
+}
+
+// Removing one member of a collection (a "remove" op scoped to a single
+// element, e.g. "/Tags/1") does not dangle a reference to the collection as a
+// whole ("Tags"): the collection itself still exists after the removal.
+func TestValidateReferencesAgainstRemovals_MemberRemovalDoesNotDangleCollectionReference(t *testing.T) {
+	producerKsuid := util.NewID()
+
+	updates := []ResourceUpdate{
+		{
+			Operation: OperationUpdate,
+			DesiredState: pkgmodel.Resource{
+				Label:         "producer",
+				Ksuid:         producerKsuid,
+				PatchDocument: json.RawMessage(`[{"op":"remove","path":"/Tags/1"}]`),
+			},
+		},
+	}
+	forma := &pkgmodel.Forma{
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "consumer",
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Ref": {"$ref": "formae://%s#/Tags", "$value": "[{\"Key\":\"team\",\"Value\":\"x\"}]"}}`,
+					producerKsuid)),
+			},
+		},
+	}
+
+	err := validateReferencesAgainstRemovals(updates, forma)
+	assert.NoError(t, err, "a member removal must not be mistaken for removal of the collection it belongs to")
+}

--- a/internal/metastructure/resource_update/regenerate_force_resent_test.go
+++ b/internal/metastructure/resource_update/regenerate_force_resent_test.go
@@ -1,0 +1,57 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// Execution-time patch regeneration must never strip a requiredOnUpdate
+// field's force-resent op, even when it is the ONLY op the regenerated diff
+// would otherwise produce. This update is already in flight (Operation is
+// OperationUpdate): dropping the op here — rather than at planning, before
+// the update was ever created — would send the plugin an Update whose
+// PatchDocument is missing a field the provider mandates in every update
+// payload.
+func TestResolveValue_RegeneratesForceResentFieldEvenWhenNothingElseChanged(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "ParentRef", "Token"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Token": {RequiredOnUpdate: true},
+		},
+	}
+
+	ru := ResourceUpdate{
+		Operation: OperationUpdate,
+		PriorState: pkgmodel.Resource{
+			Label: "consumer", Type: "Test::Config::Entry", Schema: schema,
+			Properties: json.RawMessage(`{"Name": "c1", "ParentRef": "hello", "Token": "t1"}`),
+		},
+		DesiredState: pkgmodel.Resource{
+			Label: "consumer", Type: "Test::Config::Entry", Schema: schema,
+			Properties: json.RawMessage(`{"Name": "c1", "ParentRef": {"$ref": "formae://k-src#/Value"}, "Token": "t1"}`),
+		},
+		RemainingResolvables: []pkgmodel.FormaeURI{"formae://k-src#/Value"},
+	}
+
+	// The reference resolves back to exactly the stored value: nothing about
+	// this resource actually changes. Token is unchanged too. The only op a
+	// regenerated diff can produce is Token's force-resent "add".
+	require.NoError(t, ru.ResolveValue("formae://k-src#/Value", "hello", pkgmodel.FormaApplyModeReconcile))
+
+	assert.NotEmpty(t, ru.DesiredState.PatchDocument,
+		"regeneration must not overwrite an in-flight update's patch with empty when only the force-resent op remains")
+	assert.Contains(t, string(ru.DesiredState.PatchDocument), "Token")
+	assert.Contains(t, string(ru.DesiredState.PatchDocument), "t1")
+}

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -205,7 +205,14 @@ func (ru *ResourceUpdate) regeneratePatchDocument(mode pkgmodel.FormaApplyMode) 
 		return nil, nil, fmt.Errorf("failed to convert desired properties to plugin format: %w", err)
 	}
 
-	patchDoc, createOnlyPatch, err := patch.GeneratePatch(
+	// The onlyForceResent decision is deliberately ignored here: this call
+	// regenerates the payload for an update that is already happening, so a
+	// requiredOnUpdate field's force-resent op must ride along in patchDoc as
+	// returned — dropping it would send the plugin an Update with the
+	// provider-mandated field missing. Only planning (whether to create this
+	// ResourceUpdate at all) may treat a force-resent-only patch as empty; see
+	// resource_update_factory.go.
+	patchDoc, createOnlyPatch, _, err := patch.GeneratePatch(
 		existingPluginProps,
 		newPluginProps,
 		existingForPatch,

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -66,6 +66,7 @@ func NewResourceUpdateForExisting(
 
 	var patchDocument json.RawMessage
 	var createOnlyPatch json.RawMessage
+	var onlyForceResent bool
 
 	if hasChanges {
 		// Drop opaque values that are unchanged from what is stored so a sibling
@@ -94,7 +95,7 @@ func NewResourceUpdateForExisting(
 			return nil, fmt.Errorf("failed to convert new properties to plugin format: %w", err)
 		}
 
-		patchDocument, createOnlyPatch, err = patch.GeneratePatch(
+		patchDocument, createOnlyPatch, onlyForceResent, err = patch.GeneratePatch(
 			existingPluginProps,
 			newPluginProps,
 			existingForPatch,
@@ -107,7 +108,13 @@ func NewResourceUpdateForExisting(
 			return nil, fmt.Errorf("failed to create patch document for resource %s: %w", existingResource.Label, err)
 		}
 
-		if patchDocument == nil && len(createOnlyPatch) == 0 && !stackChanged && !labelChanged {
+		// A patch that is empty, or whose only ops are requiredOnUpdate fields
+		// force-resent to guarantee the provider sees them (no op reflecting an
+		// actual change), carries nothing for the plugin to do. Planning is the
+		// one place that decision is allowed to drop the update outright —
+		// regeneratePatchDocument at execution time must never do the same, or
+		// an in-flight update would lose the force-resent field from its payload.
+		if (patchDocument == nil || onlyForceResent) && len(createOnlyPatch) == 0 && !stackChanged && !labelChanged {
 			return []ResourceUpdate{}, nil
 		}
 	} else {

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -1102,6 +1102,11 @@ func generateResourceUpdatesForReconcile(
 	// represented by a user-driven update/create or by an existing
 	// delete (those paths already cover the dependent).
 	finalResourceUpdates = appendCascadeUpdatesIfAbsent(finalResourceUpdates, cascadeUpdates)
+
+	if err := validateReferencesAgainstRemovals(finalResourceUpdates, forma); err != nil {
+		return nil, err
+	}
+
 	return finalResourceUpdates, nil
 }
 


### PR DESCRIPTION
## Summary

- **A reconcile that removes a property another declared resource references is now rejected at plan time** with a typed error naming the consumer, the source, and the path — instead of silently resolving a value the command is deleting. The check consults the producer's actual generated operation (remove ops in planned update patches), sweeps the forma's declared resources for references (including consumers whose own diff is empty), normalizes the resolver's dotted reference paths to JSON-Pointer form so nested and array-index references are caught, and excludes the safe shapes: removing one collection member does not dangle a reference to the collection, and a resource deleted in the same command cannot dangle. Reconcile-only; patch mode and destroys are untouched.
- **The other three meanings of an absent referenced property are pinned as deliberate behavior:** a provider-computed output resolves from the persisted row; patch-mode omission means leave-unchanged; reconcile omission that mints no remove op keeps the persisted value; a forward reference to a resource created in the same command defers to execution-time resolution.
- **An unchanged resource declaring a `requiredOnUpdate` field is no longer planned on every reconcile.** The force-resend add op (restating the stored value so the provider receives its mandated field) no longer counts toward whether a patch is empty — but it is a planning decision only: execution-time regeneration always preserves full patch content, so an in-flight update never reaches the plugin missing its required field. Array-nested hints (`Items.Token`) are matched index-transparently, so the fix covers collection shapes too. Three directions pinned: unchanged plans nothing, changed-elsewhere carries the force-resent field, a genuine change to the field itself plans normally.
- Occurrence-extraction identity is pinned: two references to one source property with different JSON extractions each receive their own extracted value.

Documented residuals: consumers not declared in the forma (cross-stack references from stacks outside the command) are not swept by the dangling-reference check, matching the declared-desired-state contract; and path matching adopts the resolver's existing dotted-nesting convention, including its known ambiguity for literal dotted map keys and all-digit field names.

Verified: full `resource_update`, `resolver`, `patch` suites, the `apply_forma` workflow suite, and the entire `workflow_tests` tree green; build and vet clean; the branch merges cleanly with current main (verified on a scratch merge including the chain-recursion interaction, where a chain-mediated dangling reference is caught at its direct hop).