### PR TITLE
fix(patch,resolver,resource-update): close the cross-change gaps in reference planning

### DIFF
--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -4083,12 +4083,14 @@ func (d *DatastoreAuroraDataAPI) BulkStoreResourceUpdates(commandID string, upda
 				retries, remaining, version, stack_label, group_id, source,
 				resource, resource_target, existing_resource, existing_target,
 				progress_result, most_recent_progress,
-				remaining_resolvables, reference_labels, previous_properties
+				remaining_resolvables, reference_labels, previous_properties,
+				failure_reason
 			) VALUES (:command_id, :ksuid, :operation, :state, :start_ts::timestamp, :modified_ts::timestamp,
 				:retries, :remaining, :version, :stack_label, :group_id, :source,
 				:resource, :resource_target, :existing_resource, :existing_target,
 				:progress_result, :most_recent_progress,
-				:remaining_resolvables, :reference_labels, :previous_properties)
+				:remaining_resolvables, :reference_labels, :previous_properties,
+				:failure_reason)
 			ON CONFLICT (command_id, ksuid, operation) DO UPDATE SET
 				state = EXCLUDED.state,
 				modified_ts = EXCLUDED.modified_ts,
@@ -4096,7 +4098,8 @@ func (d *DatastoreAuroraDataAPI) BulkStoreResourceUpdates(commandID string, upda
 				existing_resource = EXCLUDED.existing_resource,
 				previous_properties = EXCLUDED.previous_properties,
 				progress_result = EXCLUDED.progress_result,
-				most_recent_progress = EXCLUDED.most_recent_progress
+				most_recent_progress = EXCLUDED.most_recent_progress,
+				failure_reason = EXCLUDED.failure_reason
 		`
 
 		params := []types.SqlParameter{
@@ -4121,6 +4124,7 @@ func (d *DatastoreAuroraDataAPI) BulkStoreResourceUpdates(commandID string, upda
 			{Name: aws.String("remaining_resolvables"), Value: &types.FieldMemberStringValue{Value: string(remainingResolvablesJSON)}},
 			{Name: aws.String("reference_labels"), Value: &types.FieldMemberStringValue{Value: string(referenceLabelsJSON)}},
 			{Name: aws.String("previous_properties"), Value: &types.FieldMemberStringValue{Value: string(previousPropertiesJSON)}},
+			{Name: aws.String("failure_reason"), Value: &types.FieldMemberStringValue{Value: ru.FailureReason}},
 		}
 
 		_, err = d.executeStatementInTransaction(ctx, txID, query, params)
@@ -4145,7 +4149,8 @@ func (d *DatastoreAuroraDataAPI) LoadResourceUpdates(commandID string) ([]resour
 		retries, remaining, version, stack_label, group_id, source,
 		resource, resource_target, existing_resource, existing_target,
 		progress_result, most_recent_progress,
-		remaining_resolvables, reference_labels, previous_properties
+		remaining_resolvables, reference_labels, previous_properties,
+		failure_reason
 	FROM resource_updates
 	WHERE command_id = :command_id
 	ORDER BY ksuid ASC
@@ -4185,6 +4190,10 @@ func (d *DatastoreAuroraDataAPI) LoadResourceUpdates(commandID string) ([]resour
 		remainingResolvablesJSON, _ := getStringField(record[17])
 		referenceLabelsJSON, _ := getStringField(record[18])
 		previousPropertiesJSON, _ := getStringField(record[19])
+		var failureReason string
+		if len(record) > 20 {
+			failureReason, _ = getStringField(record[20])
+		}
 
 		var desiredState pkgmodel.Resource
 		var resourceTarget pkgmodel.Target
@@ -4231,6 +4240,7 @@ func (d *DatastoreAuroraDataAPI) LoadResourceUpdates(commandID string) ([]resour
 			RemainingResolvables:     remainingResolvables,
 			ReferenceLabels:          referenceLabels,
 			PreviousProperties:       previousProperties,
+			FailureReason:            failureReason,
 		})
 	}
 

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -125,6 +125,7 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunMonotonicTerminalityTest(t, newDS)
 	RunMonotonicTerminalityRaceTest(t, newDS)
 	RunForceCancelResourceUpdatesTest(t, newDS)
+	RunResourceUpdateFailureReasonRoundTrip(t, newDS)
 
 	RunRecordAgentBoot(t, newDS)
 	RunAgentBootsAreAppendOnly(t, newDS)

--- a/internal/datastore/dstest/suite_forma_commands.go
+++ b/internal/datastore/dstest/suite_forma_commands.go
@@ -1414,3 +1414,57 @@ func RunCommandSourceRoundTrip(t *testing.T, newDS func(t *testing.T) TestDatast
 			"Source must survive a store/load round-trip")
 	})
 }
+
+// RunResourceUpdateFailureReasonRoundTrip verifies that a failure reason
+// recorded on a resource update with no plugin progress survives both the
+// command store/load round trip and a bulk resource-update store, so the
+// persisted command's error message surfaces it instead of coming back blank.
+func RunResourceUpdateFailureReasonRoundTrip(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("ResourceUpdateFailureReasonRoundTrip", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		reason := "resource update failed before any plugin operation ran"
+		cmd := &forma_command.FormaCommand{
+			ID:          util.NewID(),
+			Description: pkgmodel.Description{},
+			ResourceUpdates: []resource_update.ResourceUpdate{
+				{
+					ResourceTarget: pkgmodel.Target{Label: "target1", Namespace: "default", Config: json.RawMessage("{}")},
+					DesiredState:   pkgmodel.Resource{Ksuid: util.NewID(), Properties: json.RawMessage("{}")},
+					Operation:      types.OperationUpdate,
+					State:          resource_update.ResourceUpdateStateFailed,
+					FailureReason:  reason,
+				},
+			},
+			Command: pkgmodel.CommandApply,
+			State:   forma_command.CommandStateFailed,
+		}
+		err := ds.StoreFormaCommand(cmd, cmd.ID)
+		assert.NoError(t, err)
+
+		commands, err := ds.LoadFormaCommands()
+		assert.NoError(t, err)
+		if !assert.Len(t, commands, 1) {
+			return
+		}
+		loaded := commands[0].ResourceUpdates[0]
+		assert.Equal(t, reason, loaded.FailureReason, "the failure reason must survive the command round trip")
+		assert.Equal(t, reason, loaded.MostRecentFailureMessage())
+
+		// The bulk path is the one completion handling actually writes through.
+		bulkReason := "a different reason recorded at completion"
+		loaded.FailureReason = bulkReason
+		err = ds.BulkStoreResourceUpdates(cmd.ID, []resource_update.ResourceUpdate{loaded})
+		assert.NoError(t, err)
+
+		commands, err = ds.LoadFormaCommands()
+		assert.NoError(t, err)
+		if !assert.Len(t, commands, 1) {
+			return
+		}
+		assert.Equal(t, bulkReason, commands[0].ResourceUpdates[0].FailureReason,
+			"the failure reason must survive the bulk resource-update store")
+	})
+}

--- a/internal/datastore/migrations_mssql/00021_resource_update_failure_reason.sql
+++ b/internal/datastore/migrations_mssql/00021_resource_update_failure_reason.sql
@@ -1,0 +1,14 @@
+-- © 2026 Platform Engineering Labs Inc.
+--
+-- SPDX-License-Identifier: FSL-1.1-ALv2
+
+-- +goose Up
+-- Persist the failure reason recorded for a resource update that fails
+-- before any plugin operation runs (e.g. a terminal resolve failure), so the
+-- command's error message survives a reload instead of coming back blank.
+-- Nullable: rows written before this migration, and successful updates, have
+-- no reason to record.
+ALTER TABLE resource_updates ADD failure_reason nvarchar(max) NULL;
+
+-- +goose Down
+ALTER TABLE resource_updates DROP COLUMN failure_reason;

--- a/internal/datastore/migrations_postgres/00022_resource_update_failure_reason.sql
+++ b/internal/datastore/migrations_postgres/00022_resource_update_failure_reason.sql
@@ -1,0 +1,14 @@
+-- © 2026 Platform Engineering Labs Inc.
+--
+-- SPDX-License-Identifier: FSL-1.1-ALv2
+
+-- +goose Up
+-- Persist the failure reason recorded for a resource update that fails
+-- before any plugin operation runs (e.g. a terminal resolve failure), so the
+-- command's error message survives a reload instead of coming back blank.
+-- Nullable: rows written before this migration, and successful updates, have
+-- no reason to record.
+ALTER TABLE resource_updates ADD COLUMN failure_reason TEXT;
+
+-- +goose Down
+ALTER TABLE resource_updates DROP COLUMN failure_reason;

--- a/internal/datastore/migrations_sqlite/00021_resource_update_failure_reason.sql
+++ b/internal/datastore/migrations_sqlite/00021_resource_update_failure_reason.sql
@@ -1,0 +1,16 @@
+-- © 2026 Platform Engineering Labs Inc.
+--
+-- SPDX-License-Identifier: FSL-1.1-ALv2
+
+-- +goose Up
+-- Persist the failure reason recorded for a resource update that fails
+-- before any plugin operation runs (e.g. a terminal resolve failure), so the
+-- command's error message survives a reload instead of coming back blank.
+-- Nullable: rows written before this migration, and successful updates, have
+-- no reason to record.
+ALTER TABLE resource_updates ADD COLUMN failure_reason TEXT;
+
+-- +goose Down
+-- SQLite doesn't support DROP COLUMN before 3.35.0; leaving the column in
+-- place on rollback is safe (the application ignores extra columns).
+SELECT 1;

--- a/internal/datastore/mssql/mssql_datastore.go
+++ b/internal/datastore/mssql/mssql_datastore.go
@@ -226,7 +226,7 @@ SELECT
 	ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
 	ru.progress_result, ru.most_recent_progress,
 	ru.remaining_resolvables, ru.reference_labels, ru.previous_properties,
-	ru.is_cascade, ru.cascade_source
+	ru.is_cascade, ru.cascade_source, ru.failure_reason
 FROM forma_commands fc
 LEFT JOIN resource_updates ru ON fc.command_id = ru.command_id`
 
@@ -256,6 +256,7 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 	var remainingResolvablesJSON, referenceLabelsJSON, previousPropertiesJSON []byte
 	var ruIsCascade *bool
 	var ruCascadeSource *string
+	var ruFailureReason *string
 
 	err := rows.Scan(
 		&commandID, &fcTimestamp, &fcCommand, &fcState, &fcClientID,
@@ -266,7 +267,7 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 		&resourceJSON, &resourceTargetJSON, &existingResourceJSON, &existingTargetJSON,
 		&progressResultJSON, &mostRecentProgressJSON,
 		&remainingResolvablesJSON, &referenceLabelsJSON, &previousPropertiesJSON,
-		&ruIsCascade, &ruCascadeSource,
+		&ruIsCascade, &ruCascadeSource, &ruFailureReason,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -403,6 +404,9 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 	}
 	if ruCascadeSource != nil {
 		ru.CascadeSource = *ruCascadeSource
+	}
+	if ruFailureReason != nil {
+		ru.FailureReason = *ruFailureReason
 	}
 
 	return &cmd, &ru, nil
@@ -804,14 +808,14 @@ func (d *DatastoreMSSQL) BulkStoreResourceUpdates(commandID string, updates []re
 		return fmt.Errorf("failed to clear existing resource updates: %w", err)
 	}
 
-	const colsPerRow = 23
+	const colsPerRow = 24
 	insertPrefix := `INSERT INTO resource_updates (
 		command_id, ksuid, operation, state, start_ts, modified_ts,
 		retries, remaining, version, stack_label, group_id, source,
 		resource, resource_target, existing_resource, existing_target,
 		progress_result, most_recent_progress,
 		remaining_resolvables, reference_labels, previous_properties,
-		is_cascade, cascade_source
+		is_cascade, cascade_source, failure_reason
 	) VALUES `
 
 	// Dedupe by (ksuid, operation) keeping the last — last-wins, matching the
@@ -906,6 +910,7 @@ func (d *DatastoreMSSQL) BulkStoreResourceUpdates(commandID string, updates []re
 			previousProperties,
 			ru.IsCascade,
 			ru.CascadeSource,
+			ru.FailureReason,
 		}
 		stmt := insertPrefix + "(" + placeholders(1, colsPerRow) + ")"
 		if _, err = tx.ExecContext(ctx, stmt, args...); err != nil {

--- a/internal/datastore/mssql/mssql_resourceupdates.go
+++ b/internal/datastore/mssql/mssql_resourceupdates.go
@@ -293,7 +293,7 @@ func (d *DatastoreMSSQL) LoadResourceUpdates(commandID string) ([]resource_updat
 			resource, resource_target, existing_resource, existing_target,
 			progress_result, most_recent_progress,
 			remaining_resolvables, reference_labels, previous_properties,
-			is_cascade, cascade_source
+			is_cascade, cascade_source, failure_reason
 		FROM resource_updates
 		WHERE command_id = @p1
 		ORDER BY ksuid ASC`
@@ -316,6 +316,7 @@ func (d *DatastoreMSSQL) LoadResourceUpdates(commandID string) ([]resource_updat
 		var remainingResolvablesJSON, referenceLabelsJSON, previousPropertiesJSON []byte
 		var ruIsCascade *bool
 		var ruCascadeSource *string
+		var ruFailureReason *string
 
 		err := rows.Scan(
 			&ksuid, &operation, &state, &startTs, &modifiedTs,
@@ -323,7 +324,7 @@ func (d *DatastoreMSSQL) LoadResourceUpdates(commandID string) ([]resource_updat
 			&resourceJSON, &resourceTargetJSON, &existingResourceJSON, &existingTargetJSON,
 			&progressResultJSON, &mostRecentProgressJSON,
 			&remainingResolvablesJSON, &referenceLabelsJSON, &previousPropertiesJSON,
-			&ruIsCascade, &ruCascadeSource,
+			&ruIsCascade, &ruCascadeSource, &ruFailureReason,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan resource update: %w", err)
@@ -405,6 +406,9 @@ func (d *DatastoreMSSQL) LoadResourceUpdates(commandID string) ([]resource_updat
 		}
 		if ruCascadeSource != nil {
 			ru.CascadeSource = *ruCascadeSource
+		}
+		if ruFailureReason != nil {
+			ru.FailureReason = *ruFailureReason
 		}
 
 		updates = append(updates, ru)

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -266,7 +266,7 @@ SELECT
 	ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
 	ru.progress_result, ru.most_recent_progress,
 	ru.remaining_resolvables, ru.reference_labels, ru.previous_properties,
-	ru.is_cascade, ru.cascade_source
+	ru.is_cascade, ru.cascade_source, ru.failure_reason
 FROM forma_commands fc
 LEFT JOIN resource_updates ru ON fc.command_id = ru.command_id`
 
@@ -300,6 +300,7 @@ func scanJoinedRowPostgres(rows pgx.Rows) (*forma_command.FormaCommand, *resourc
 	var remainingResolvablesJSON, referenceLabelsJSON, previousPropertiesJSON []byte
 	var ruIsCascade *bool
 	var ruCascadeSource *string
+	var ruFailureReason *string
 
 	err := rows.Scan(
 		// FormaCommand columns
@@ -312,7 +313,7 @@ func scanJoinedRowPostgres(rows pgx.Rows) (*forma_command.FormaCommand, *resourc
 		&resourceJSON, &resourceTargetJSON, &existingResourceJSON, &existingTargetJSON,
 		&progressResultJSON, &mostRecentProgressJSON,
 		&remainingResolvablesJSON, &referenceLabelsJSON, &previousPropertiesJSON,
-		&ruIsCascade, &ruCascadeSource,
+		&ruIsCascade, &ruCascadeSource, &ruFailureReason,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -457,6 +458,9 @@ func scanJoinedRowPostgres(rows pgx.Rows) (*forma_command.FormaCommand, *resourc
 	}
 	if ruCascadeSource != nil {
 		ru.CascadeSource = *ruCascadeSource
+	}
+	if ruFailureReason != nil {
+		ru.FailureReason = *ruFailureReason
 	}
 
 	return &cmd, &ru, nil
@@ -710,7 +714,7 @@ func (d DatastorePostgres) QueryFormaCommands(query *datastore.StatusQuery) ([]*
 			ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
 			ru.progress_result, ru.most_recent_progress,
 			ru.remaining_resolvables, ru.reference_labels, ru.previous_properties,
-	ru.is_cascade, ru.cascade_source
+	ru.is_cascade, ru.cascade_source, ru.failure_reason
 		FROM forma_commands fc
 		LEFT JOIN resource_updates ru ON fc.command_id = ru.command_id
 		WHERE fc.command_id IN (%s)
@@ -4644,8 +4648,8 @@ func (d DatastorePostgres) BulkStoreResourceUpdates(commandID string, updates []
 				resource, resource_target, existing_resource, existing_target,
 				progress_result, most_recent_progress,
 				remaining_resolvables, reference_labels, previous_properties,
-				is_cascade, cascade_source
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
+				is_cascade, cascade_source, failure_reason
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)
 			ON CONFLICT (command_id, ksuid, operation) DO UPDATE SET
 				state = EXCLUDED.state,
 				start_ts = EXCLUDED.start_ts,
@@ -4666,7 +4670,8 @@ func (d DatastorePostgres) BulkStoreResourceUpdates(commandID string, updates []
 				reference_labels = EXCLUDED.reference_labels,
 				previous_properties = EXCLUDED.previous_properties,
 				is_cascade = EXCLUDED.is_cascade,
-				cascade_source = EXCLUDED.cascade_source
+				cascade_source = EXCLUDED.cascade_source,
+				failure_reason = EXCLUDED.failure_reason
 		`,
 			commandID,
 			ru.DesiredState.Ksuid,
@@ -4691,6 +4696,7 @@ func (d DatastorePostgres) BulkStoreResourceUpdates(commandID string, updates []
 			ru.PreviousProperties,
 			ru.IsCascade,
 			ru.CascadeSource,
+			ru.FailureReason,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to insert resource update: %w", err)
@@ -4716,7 +4722,7 @@ func (d DatastorePostgres) LoadResourceUpdates(commandID string) ([]resource_upd
 			resource, resource_target, existing_resource, existing_target,
 			progress_result, most_recent_progress,
 			remaining_resolvables, reference_labels, previous_properties,
-			is_cascade, cascade_source
+			is_cascade, cascade_source, failure_reason
 		FROM resource_updates
 		WHERE command_id = $1
 		ORDER BY ksuid ASC
@@ -4739,6 +4745,7 @@ func (d DatastorePostgres) LoadResourceUpdates(commandID string) ([]resource_upd
 		var remainingResolvablesJSON, referenceLabelsJSON, previousPropertiesJSON []byte
 		var ruIsCascade *bool
 		var ruCascadeSource *string
+		var ruFailureReason *string
 
 		err := rows.Scan(
 			&ksuid,
@@ -4763,6 +4770,7 @@ func (d DatastorePostgres) LoadResourceUpdates(commandID string) ([]resource_upd
 			&previousPropertiesJSON,
 			&ruIsCascade,
 			&ruCascadeSource,
+			&ruFailureReason,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan resource update: %w", err)
@@ -4829,6 +4837,9 @@ func (d DatastorePostgres) LoadResourceUpdates(commandID string) ([]resource_upd
 		}
 		if ruCascadeSource != nil {
 			ru.CascadeSource = *ruCascadeSource
+		}
+		if ruFailureReason != nil {
+			ru.FailureReason = *ruFailureReason
 		}
 
 		updates = append(updates, ru)

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -216,7 +216,7 @@ SELECT
 	ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
 	ru.progress_result, ru.most_recent_progress,
 	ru.remaining_resolvables, ru.reference_labels, ru.previous_properties,
-	ru.is_cascade, ru.cascade_source
+	ru.is_cascade, ru.cascade_source, ru.failure_reason
 FROM forma_commands fc
 LEFT JOIN resource_updates ru ON fc.command_id = ru.command_id`
 
@@ -250,6 +250,7 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 	var remainingResolvablesJSON, referenceLabelsJSON, previousPropertiesJSON []byte
 	var ruIsCascade sql.NullInt64
 	var ruCascadeSource sql.NullString
+	var ruFailureReason sql.NullString
 
 	err := rows.Scan(
 		// FormaCommand columns
@@ -262,7 +263,7 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 		&resourceJSON, &resourceTargetJSON, &existingResourceJSON, &existingTargetJSON,
 		&progressResultJSON, &mostRecentProgressJSON,
 		&remainingResolvablesJSON, &referenceLabelsJSON, &previousPropertiesJSON,
-		&ruIsCascade, &ruCascadeSource,
+		&ruIsCascade, &ruCascadeSource, &ruFailureReason,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -421,6 +422,9 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 	if ruCascadeSource.Valid {
 		ru.CascadeSource = ruCascadeSource.String
 	}
+	if ruFailureReason.Valid {
+		ru.FailureReason = ruFailureReason.String
+	}
 
 	return &cmd, &ru, nil
 }
@@ -548,7 +552,7 @@ func (d DatastoreSQLite) GetMostRecentFormaCommandByClientID(clientID string) (*
 			ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
 			ru.progress_result, ru.most_recent_progress,
 			ru.remaining_resolvables, ru.reference_labels, ru.previous_properties,
-	ru.is_cascade, ru.cascade_source
+	ru.is_cascade, ru.cascade_source, ru.failure_reason
 		FROM forma_commands fc
 		LEFT JOIN resource_updates ru ON fc.command_id = ru.command_id
 		WHERE fc.command_id = (
@@ -924,7 +928,7 @@ func (d DatastoreSQLite) QueryFormaCommands(query *datastore.StatusQuery) ([]*fo
 			ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
 			ru.progress_result, ru.most_recent_progress,
 			ru.remaining_resolvables, ru.reference_labels, ru.previous_properties,
-	ru.is_cascade, ru.cascade_source
+	ru.is_cascade, ru.cascade_source, ru.failure_reason
 		FROM forma_commands fc
 		LEFT JOIN resource_updates ru ON fc.command_id = ru.command_id
 		WHERE fc.command_id IN (%s)
@@ -4809,8 +4813,8 @@ func (d DatastoreSQLite) BulkStoreResourceUpdates(commandID string, updates []re
 			resource, resource_target, existing_resource, existing_target,
 			progress_result, most_recent_progress,
 			remaining_resolvables, reference_labels, previous_properties,
-			is_cascade, cascade_source
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			is_cascade, cascade_source, failure_reason
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement: %w", err)
@@ -4901,6 +4905,7 @@ func (d DatastoreSQLite) BulkStoreResourceUpdates(commandID string, updates []re
 			ru.PreviousProperties,
 			ru.IsCascade,
 			ru.CascadeSource,
+			ru.FailureReason,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to insert resource update: %w", err)

--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -989,6 +989,12 @@ func (f *FormaCommandPersister) markResourceUpdateAsComplete(msg *messages.MarkR
 		res.State = msg.FinalState
 		res.StartTs = msg.ResourceStartTs
 		res.ModifiedTs = msg.ResourceModifiedTs
+		// Guarded copy: a successful completion carries no reason (the updater
+		// clears it on success), and an empty incoming reason must not erase
+		// one already recorded for this row.
+		if msg.FailureReason != "" {
+			res.FailureReason = msg.FailureReason
+		}
 
 		// Hash read/actual-state properties at this write choke point, same as
 		// updateCommandFromProgress does for intermediate progress. This matters most

--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -989,12 +989,13 @@ func (f *FormaCommandPersister) markResourceUpdateAsComplete(msg *messages.MarkR
 		res.State = msg.FinalState
 		res.StartTs = msg.ResourceStartTs
 		res.ModifiedTs = msg.ResourceModifiedTs
-		// Guarded copy: a successful completion carries no reason (the updater
-		// clears it on success), and an empty incoming reason must not erase
-		// one already recorded for this row.
-		if msg.FailureReason != "" {
-			res.FailureReason = msg.FailureReason
-		}
+		// Unconditional copy: the updater owns the reason's lifecycle (it
+		// records one per failing pass and clears it on success), so the
+		// completion's value is authoritative either way. An empty value on a
+		// successful retry MUST overwrite a reason persisted by an earlier
+		// failed attempt, or a succeeded update keeps reporting an obsolete
+		// error.
+		res.FailureReason = msg.FailureReason
 
 		// Hash read/actual-state properties at this write choke point, same as
 		// updateCommandFromProgress does for intermediate progress. This matters most

--- a/internal/metastructure/forma_persister/forma_command_persister_test.go
+++ b/internal/metastructure/forma_persister/forma_command_persister_test.go
@@ -1497,3 +1497,42 @@ func TestFormaCommandPersister_MarkCompleteRecordsFailureReason(t *testing.T) {
 	assert.Equal(t, reason, loaded.ResourceUpdates[0].FailureReason)
 	assert.Equal(t, reason, loaded.ResourceUpdates[0].MostRecentFailureMessage())
 }
+
+// A retry that succeeds after a failed attempt must clear the failure reason
+// persisted by that earlier attempt: the completion's (empty) reason is
+// authoritative, so a succeeded update never reports an obsolete error. The
+// stored row carries the stale reason (as it does when a command is reloaded
+// mid-retry after a crash) while its state is still non-terminal.
+func TestFormaCommandPersister_SuccessfulRetryClearsPersistedFailureReason(t *testing.T) {
+	formaCommand := newFormaCommandWithCreateResourceUpdate()
+	formaCommand.ResourceUpdates[0].FailureReason = "resource update failed before any plugin operation ran"
+	formaPersister, sender, err := newFormaCommandPersisterForTest(t)
+	assert.NoError(t, err)
+
+	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
+	assert.NoError(t, storeResult.Error)
+	assert.True(t, storeResult.Response.(bool))
+
+	resourceURI := formaCommand.ResourceUpdates[0].DesiredState.URI()
+
+	succeeded := messages.MarkResourceUpdateAsComplete{
+		CommandID:          formaCommand.ID,
+		ResourceURI:        resourceURI,
+		Operation:          resource_update.OperationCreate,
+		FinalState:         resource_update.ResourceUpdateStateSuccess,
+		ResourceStartTs:    util.TimeNow(),
+		ResourceModifiedTs: util.TimeNow(),
+	}
+	res := formaPersister.Call(sender, succeeded)
+	assert.NoError(t, res.Error)
+	assert.True(t, res.Response.(bool))
+
+	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
+	assert.NoError(t, loadResult.Error)
+	loaded, ok := loadResult.Response.(*forma_command.FormaCommand)
+	assert.True(t, ok)
+
+	assert.Empty(t, loaded.ResourceUpdates[0].FailureReason)
+	assert.Empty(t, loaded.ResourceUpdates[0].MostRecentFailureMessage(),
+		"a succeeded update must not report a reason from an earlier failed attempt")
+}

--- a/internal/metastructure/forma_persister/forma_command_persister_test.go
+++ b/internal/metastructure/forma_persister/forma_command_persister_test.go
@@ -1460,3 +1460,40 @@ func newFormaCommandPersisterWithDatastore(t *testing.T, ds datastore.Datastore)
 
 	return operator, sender, nil
 }
+
+// A completion that carries a failure reason (a failure recorded before any
+// plugin operation ran, so no progress entry holds a message) must land on the
+// persisted resource update, where the command's error surfaces read it.
+func TestFormaCommandPersister_MarkCompleteRecordsFailureReason(t *testing.T) {
+	formaCommand := newFormaCommandWithCreateResourceUpdate()
+	formaPersister, sender, err := newFormaCommandPersisterForTest(t)
+	assert.NoError(t, err)
+
+	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
+	assert.NoError(t, storeResult.Error)
+	assert.True(t, storeResult.Response.(bool))
+
+	resourceURI := formaCommand.ResourceUpdates[0].DesiredState.URI()
+	reason := "resource update failed before any plugin operation ran"
+
+	markComplete := messages.MarkResourceUpdateAsComplete{
+		CommandID:          formaCommand.ID,
+		ResourceURI:        resourceURI,
+		Operation:          resource_update.OperationCreate,
+		FinalState:         resource_update.ResourceUpdateStateFailed,
+		ResourceStartTs:    util.TimeNow(),
+		ResourceModifiedTs: util.TimeNow(),
+		FailureReason:      reason,
+	}
+	markRes := formaPersister.Call(sender, markComplete)
+	assert.NoError(t, markRes.Error)
+	assert.True(t, markRes.Response.(bool))
+
+	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
+	assert.NoError(t, loadResult.Error)
+	loaded, ok := loadResult.Response.(*forma_command.FormaCommand)
+	assert.True(t, ok)
+
+	assert.Equal(t, reason, loaded.ResourceUpdates[0].FailureReason)
+	assert.Equal(t, reason, loaded.ResourceUpdates[0].MostRecentFailureMessage())
+}

--- a/internal/metastructure/messages/forma_persister.go
+++ b/internal/metastructure/messages/forma_persister.go
@@ -25,6 +25,10 @@ type MarkResourceUpdateAsComplete struct {
 	ResourceProperties         json.RawMessage
 	ResourceReadOnlyProperties json.RawMessage
 	Version                    string
+	// FailureReason carries a human-readable explanation for a failure that
+	// was not recorded as plugin progress (e.g. a terminal resolve miss), so
+	// the persisted command's error message survives a reload.
+	FailureReason string
 }
 
 type UpdateResourceProgress struct {

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/canonicalize"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
-	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/jsonpatch"
 	"github.com/tidwall/gjson"
@@ -149,26 +148,16 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 	createOnlyOps := extractCreateOnlyFields(patchOps, createOnlyFields)
 	mutableOps := filterCreateOnlyFields(patchOps, createOnlyFields)
 
-	// Member-level ops under an array are ambiguous between a member swap and
-	// an immutable-field change: set-based array comparison emits whole-element
-	// remove/add pairs, so a change to a createOnly subfield never appears at
-	// the subfield's own path. The hinted subfield's values are the
-	// disambiguator: when their multiset differs between stored and desired,
-	// the element ops under that field escalate to createOnly (a replacement);
-	// when it is unchanged, sibling-only member changes stay mutable.
-	if replacementFields := arrayCreateOnlyChangedFields(flattenedDocument, flattenedPatch, createOnlyFields); len(replacementFields) > 0 {
-		stillMutable := make([]jsonpatch.JsonPatchOperation, 0, len(mutableOps))
-		for _, op := range mutableOps {
-			root, _, _ := strings.Cut(cleanPath(op.Path), "/")
-			if replacementFields[root] {
-				createOnlyOps = append(createOnlyOps, op)
-			} else {
-				stillMutable = append(stillMutable, op)
-			}
-		}
-		mutableOps = stillMutable
-	}
-
+	// Member-level ops on an UNKEYED collection (whole-element remove/add
+	// pairs from set-based comparison) deliberately stay mutable, even when
+	// the element carries a createOnly-hinted subfield: without member
+	// identity, a changed immutable value is byte-identical to one member
+	// leaving and another arriving, and the provider-appropriate remedy for
+	// such collections is member replacement (e.g. detach/re-attach), not a
+	// whole-resource replacement. A collection whose members ARE identity-
+	// bearing declares an EntitySet indexField; its diff pairs members and
+	// emits subfield-level ops, which the index-transparent matching above
+	// classifies as createOnly and escalates correctly.
 	if len(mutableOps) == 0 && len(createOnlyOps) == 0 {
 		return nil, nil, false, nil
 	}
@@ -939,115 +928,6 @@ func extractCreateOnlyFields(patchOps []jsonpatch.JsonPatchOperation, createOnly
 // ("Items.Token") must catch the op at its indexed path ("/Items/0/Token").
 func isCreateOnlyPath(path string, createOnlyFields []string) bool {
 	return pathMatchesFieldThroughArrays(path, createOnlyFields)
-}
-
-// arrayCreateOnlyChangedFields returns the set of top-level fields whose
-// member-level ops must escalate to createOnly: fields with a createOnly
-// descendant hint reached through an array where an immutable value changed
-// on a RETAINED member. Set-based array comparison has no member identity, so
-// retention is inferred structurally (see
-// createOnlyChangeWithinRetainedMembers). A membership edit — a member added,
-// removed, or replaced — stays mutable: a leaf-value comparison alone cannot
-// make that distinction, since a new member carries new leaf values without
-// changing any existing member. Object-nested createOnly paths are excluded —
-// their changes surface at the subfield's own op path and classify there, so
-// escalating sibling ops under the same container would over-trigger
-// replacements.
-func arrayCreateOnlyChangedFields(document, patch []byte, createOnlyFields []string) map[string]bool {
-	changed := map[string]bool{}
-	if len(createOnlyFields) == 0 {
-		return changed
-	}
-	var docMap, patchMap map[string]any
-	if err := json.Unmarshal(document, &docMap); err != nil {
-		return changed
-	}
-	if err := json.Unmarshal(patch, &patchMap); err != nil {
-		return changed
-	}
-	arrayFieldsByRoot := map[string][]string{}
-	for _, field := range createOnlyFields {
-		segments := strings.Split(field, ".")
-		if len(segments) < 2 {
-			continue
-		}
-		_, docViaArray := collectNestedFieldValues(docMap, segments)
-		_, patchViaArray := collectNestedFieldValues(patchMap, segments)
-		if !docViaArray && !patchViaArray {
-			continue
-		}
-		arrayFieldsByRoot[segments[0]] = append(arrayFieldsByRoot[segments[0]], field)
-	}
-	for root, fields := range arrayFieldsByRoot {
-		if createOnlyChangeWithinRetainedMembers(document, patch, root, fields) {
-			changed[root] = true
-		}
-	}
-	return changed
-}
-
-// createOnlyChangeWithinRetainedMembers reports whether the subtrees under
-// root differ with the createOnly leaves present but compare equal
-// (order-insensitively) once every such leaf is stripped from both sides: the
-// signature of an immutable value changing, or being re-associated, within a
-// membership that is otherwise unchanged. A membership or sibling change
-// leaves the stripped sides different too and stays mutable. The rule is
-// deliberately conservative in the non-destructive direction: a combined edit
-// (membership change plus an immutable change on a retained member) stays
-// mutable rather than forcing a replacement the membership half never needed.
-func createOnlyChangeWithinRetainedMembers(document, patch []byte, root string, createOnlyArrayFields []string) bool {
-	docField := gjson.GetBytes(document, root)
-	patchField := gjson.GetBytes(patch, root)
-	if !docField.Exists() || !patchField.Exists() {
-		return false
-	}
-	same, err := util.JsonEqualIgnoreArrayOrder(json.RawMessage(docField.Raw), json.RawMessage(patchField.Raw))
-	if err != nil || same {
-		return false
-	}
-	strippedDoc, err := removeWriteOnlyFields(document, createOnlyArrayFields)
-	if err != nil {
-		return false
-	}
-	strippedPatch, err := removeWriteOnlyFields(patch, createOnlyArrayFields)
-	if err != nil {
-		return false
-	}
-	docResidual := gjson.GetBytes(strippedDoc, root)
-	patchResidual := gjson.GetBytes(strippedPatch, root)
-	residualSame, err := util.JsonEqualIgnoreArrayOrder(json.RawMessage(docResidual.Raw), json.RawMessage(patchResidual.Raw))
-	return err == nil && residualSame
-}
-
-// collectNestedFieldValues resolves the dot-path in obj, traversing arrays
-// like removeNestedField (the remaining path is applied to every map
-// element), and reports whether the traversal crossed an array — the signal
-// arrayCreateOnlyChangedFields keys on.
-func collectNestedFieldValues(obj map[string]any, path []string) ([]any, bool) {
-	if len(path) == 0 {
-		return nil, false
-	}
-	val, exists := obj[path[0]]
-	if !exists {
-		return nil, false
-	}
-	if len(path) == 1 {
-		return []any{val}, false
-	}
-	if nestedObj, ok := val.(map[string]any); ok {
-		return collectNestedFieldValues(nestedObj, path[1:])
-	}
-	if arr, ok := val.([]any); ok {
-		var out []any
-		for _, elem := range arr {
-			if elemMap, ok := elem.(map[string]any); ok {
-				vals, _ := collectNestedFieldValues(elemMap, path[1:])
-				out = append(out, vals...)
-			}
-		}
-		return out, true
-	}
-	return nil, false
 }
 
 // pathMatchesField reports whether a JSON Pointer path (without its leading

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/canonicalize"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/jsonpatch"
 	"github.com/tidwall/gjson"
@@ -943,11 +944,16 @@ func isCreateOnlyPath(path string, createOnlyFields []string) bool {
 
 // arrayCreateOnlyChangedFields returns the set of top-level fields whose
 // member-level ops must escalate to createOnly: fields with a createOnly
-// descendant hint reached through an array whose value multiset differs
-// between the stored document and the desired patch. Object-nested createOnly
-// paths are excluded — their changes surface at the subfield's own op path and
-// classify there, so escalating sibling ops under the same container would
-// over-trigger replacements.
+// descendant hint reached through an array whose values changed between the
+// stored document and the desired patch. Two signals, either escalates:
+// the hinted subfield's value multiset differs, or — with the multiset
+// unchanged — the two sides become EQUAL once the hinted leaves are stripped
+// while differing with them present, meaning the only change is which member
+// holds which createOnly value (values exchanged between members: an
+// immutable change per member, not a membership edit). Object-nested
+// createOnly paths are excluded — their changes surface at the subfield's own
+// op path and classify there, so escalating sibling ops under the same
+// container would over-trigger replacements.
 func arrayCreateOnlyChangedFields(document, patch []byte, createOnlyFields []string) map[string]bool {
 	changed := map[string]bool{}
 	if len(createOnlyFields) == 0 {
@@ -960,6 +966,7 @@ func arrayCreateOnlyChangedFields(document, patch []byte, createOnlyFields []str
 	if err := json.Unmarshal(patch, &patchMap); err != nil {
 		return changed
 	}
+	arrayFieldsByRoot := map[string][]string{}
 	for _, field := range createOnlyFields {
 		segments := strings.Split(field, ".")
 		if len(segments) < 2 {
@@ -970,11 +977,49 @@ func arrayCreateOnlyChangedFields(document, patch []byte, createOnlyFields []str
 		if !docViaArray && !patchViaArray {
 			continue
 		}
+		arrayFieldsByRoot[segments[0]] = append(arrayFieldsByRoot[segments[0]], field)
 		if multisetKey(docValues) != multisetKey(patchValues) {
 			changed[segments[0]] = true
 		}
 	}
+	for root, fields := range arrayFieldsByRoot {
+		if changed[root] {
+			continue
+		}
+		if createOnlyValuesExchanged(document, patch, root, fields) {
+			changed[root] = true
+		}
+	}
 	return changed
+}
+
+// createOnlyValuesExchanged reports whether the subtrees under root differ
+// with the createOnly leaves present but compare equal (order-insensitively)
+// once every such leaf is stripped from both sides: the re-association
+// signature. A genuine membership or sibling change leaves the stripped sides
+// different and stays mutable.
+func createOnlyValuesExchanged(document, patch []byte, root string, createOnlyArrayFields []string) bool {
+	docField := gjson.GetBytes(document, root)
+	patchField := gjson.GetBytes(patch, root)
+	if !docField.Exists() || !patchField.Exists() {
+		return false
+	}
+	same, err := util.JsonEqualIgnoreArrayOrder(json.RawMessage(docField.Raw), json.RawMessage(patchField.Raw))
+	if err != nil || same {
+		return false
+	}
+	strippedDoc, err := removeWriteOnlyFields(document, createOnlyArrayFields)
+	if err != nil {
+		return false
+	}
+	strippedPatch, err := removeWriteOnlyFields(patch, createOnlyArrayFields)
+	if err != nil {
+		return false
+	}
+	docResidual := gjson.GetBytes(strippedDoc, root)
+	patchResidual := gjson.GetBytes(strippedPatch, root)
+	residualSame, err := util.JsonEqualIgnoreArrayOrder(json.RawMessage(docResidual.Raw), json.RawMessage(patchResidual.Raw))
+	return err == nil && residualSame
 }
 
 // collectNestedFieldValues returns every value the dot-path resolves to in

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"sort"
 	"strings"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/canonicalize"
@@ -944,16 +943,16 @@ func isCreateOnlyPath(path string, createOnlyFields []string) bool {
 
 // arrayCreateOnlyChangedFields returns the set of top-level fields whose
 // member-level ops must escalate to createOnly: fields with a createOnly
-// descendant hint reached through an array whose values changed between the
-// stored document and the desired patch. Two signals, either escalates:
-// the hinted subfield's value multiset differs, or — with the multiset
-// unchanged — the two sides become EQUAL once the hinted leaves are stripped
-// while differing with them present, meaning the only change is which member
-// holds which createOnly value (values exchanged between members: an
-// immutable change per member, not a membership edit). Object-nested
-// createOnly paths are excluded — their changes surface at the subfield's own
-// op path and classify there, so escalating sibling ops under the same
-// container would over-trigger replacements.
+// descendant hint reached through an array where an immutable value changed
+// on a RETAINED member. Set-based array comparison has no member identity, so
+// retention is inferred structurally (see
+// createOnlyChangeWithinRetainedMembers). A membership edit — a member added,
+// removed, or replaced — stays mutable: a leaf-value comparison alone cannot
+// make that distinction, since a new member carries new leaf values without
+// changing any existing member. Object-nested createOnly paths are excluded —
+// their changes surface at the subfield's own op path and classify there, so
+// escalating sibling ops under the same container would over-trigger
+// replacements.
 func arrayCreateOnlyChangedFields(document, patch []byte, createOnlyFields []string) map[string]bool {
 	changed := map[string]bool{}
 	if len(createOnlyFields) == 0 {
@@ -972,33 +971,31 @@ func arrayCreateOnlyChangedFields(document, patch []byte, createOnlyFields []str
 		if len(segments) < 2 {
 			continue
 		}
-		docValues, docViaArray := collectNestedFieldValues(docMap, segments)
-		patchValues, patchViaArray := collectNestedFieldValues(patchMap, segments)
+		_, docViaArray := collectNestedFieldValues(docMap, segments)
+		_, patchViaArray := collectNestedFieldValues(patchMap, segments)
 		if !docViaArray && !patchViaArray {
 			continue
 		}
 		arrayFieldsByRoot[segments[0]] = append(arrayFieldsByRoot[segments[0]], field)
-		if multisetKey(docValues) != multisetKey(patchValues) {
-			changed[segments[0]] = true
-		}
 	}
 	for root, fields := range arrayFieldsByRoot {
-		if changed[root] {
-			continue
-		}
-		if createOnlyValuesExchanged(document, patch, root, fields) {
+		if createOnlyChangeWithinRetainedMembers(document, patch, root, fields) {
 			changed[root] = true
 		}
 	}
 	return changed
 }
 
-// createOnlyValuesExchanged reports whether the subtrees under root differ
-// with the createOnly leaves present but compare equal (order-insensitively)
-// once every such leaf is stripped from both sides: the re-association
-// signature. A genuine membership or sibling change leaves the stripped sides
-// different and stays mutable.
-func createOnlyValuesExchanged(document, patch []byte, root string, createOnlyArrayFields []string) bool {
+// createOnlyChangeWithinRetainedMembers reports whether the subtrees under
+// root differ with the createOnly leaves present but compare equal
+// (order-insensitively) once every such leaf is stripped from both sides: the
+// signature of an immutable value changing, or being re-associated, within a
+// membership that is otherwise unchanged. A membership or sibling change
+// leaves the stripped sides different too and stays mutable. The rule is
+// deliberately conservative in the non-destructive direction: a combined edit
+// (membership change plus an immutable change on a retained member) stays
+// mutable rather than forcing a replacement the membership half never needed.
+func createOnlyChangeWithinRetainedMembers(document, patch []byte, root string, createOnlyArrayFields []string) bool {
 	docField := gjson.GetBytes(document, root)
 	patchField := gjson.GetBytes(patch, root)
 	if !docField.Exists() || !patchField.Exists() {
@@ -1022,9 +1019,10 @@ func createOnlyValuesExchanged(document, patch []byte, root string, createOnlyAr
 	return err == nil && residualSame
 }
 
-// collectNestedFieldValues returns every value the dot-path resolves to in
-// obj, traversing arrays like removeNestedField (the remaining path is
-// applied to every map element), and whether the traversal crossed an array.
+// collectNestedFieldValues resolves the dot-path in obj, traversing arrays
+// like removeNestedField (the remaining path is applied to every map
+// element), and reports whether the traversal crossed an array — the signal
+// arrayCreateOnlyChangedFields keys on.
 func collectNestedFieldValues(obj map[string]any, path []string) ([]any, bool) {
 	if len(path) == 0 {
 		return nil, false
@@ -1050,21 +1048,6 @@ func collectNestedFieldValues(obj map[string]any, path []string) ([]any, bool) {
 		return out, true
 	}
 	return nil, false
-}
-
-// multisetKey renders values as an order-insensitive comparison key: the
-// sorted JSON forms joined with a separator that cannot appear in JSON.
-func multisetKey(values []any) string {
-	keys := make([]string, 0, len(values))
-	for _, v := range values {
-		b, err := json.Marshal(v)
-		if err != nil {
-			continue
-		}
-		keys = append(keys, string(b))
-	}
-	sort.Strings(keys)
-	return strings.Join(keys, "\x00")
 }
 
 // pathMatchesField reports whether a JSON Pointer path (without its leading

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -91,28 +91,9 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 		return nil, nil, false, fmt.Errorf("unable to generate patch document for apply mode: %s", mode)
 	}
 
-	// Strip a field that is both writeOnly AND createOnly from the desired
-	// state (patch) before comparison, but only when the stored document holds
-	// no value for it. The provider's Read never returns writeOnly fields, so a
-	// document sourced from a Read alone (import, discovery) lacks them; the
-	// "add" op jsonpatch would generate for the declared value lands on a
-	// createOnly path and triggers a resource replacement even though nothing
-	// changed. When the document does hold a last-applied value, the ordinary
-	// comparison is the truth: an unchanged value converges to no op, and a
-	// changed value is a genuine createOnly change that must plan a
-	// replacement rather than be dropped.
-	writeOnlyCreateOnly := intersectFields(schema.WriteOnly(), schema.CreateOnly())
-	if len(writeOnlyCreateOnly) > 0 {
-		var withoutBaseline []string
-		for _, field := range writeOnlyCreateOnly {
-			if !gjson.GetBytes(flattenedDocument, field).Exists() {
-				withoutBaseline = append(withoutBaseline, field)
-			}
-		}
-		flattenedPatch, err = removeWriteOnlyFields(flattenedPatch, withoutBaseline)
-		if err != nil {
-			return nil, nil, false, fmt.Errorf("failed to strip writeOnly+createOnly fields from desired state: %w", err)
-		}
+	flattenedPatch, err = StripFieldsWithoutBaseline(flattenedPatch, flattenedDocument, schema)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("failed to strip writeOnly+createOnly fields from desired state: %w", err)
 	}
 
 	requiredOnUpdateFields := schema.RequiredOnUpdate()
@@ -284,6 +265,75 @@ func intersectFields(a, b []string) []string {
 
 // removeWriteOnlyFields removes writeOnly fields from the document.
 // WriteOnly field paths can be nested (e.g., "LoginProfile.Password").
+// StripFieldsWithoutBaseline removes from desired every field that is both
+// writeOnly AND createOnly in the schema and for which storedDocument holds no
+// baseline value. The provider's Read never returns writeOnly fields, so a
+// document sourced from a Read alone (import, discovery) lacks them; keeping
+// the declared value would land an "add" op on a createOnly path and trigger a
+// resource replacement even though nothing changed. When the document does
+// hold a last-applied value, the ordinary comparison is the truth: an
+// unchanged value converges to no op, and a changed value is a genuine
+// createOnly change that must plan a replacement rather than be dropped.
+//
+// Exported because the effective-desired computation must apply the SAME strip
+// as patch generation: if the two decide differently, reference consumers are
+// planned against values the producer's own patch never writes.
+func StripFieldsWithoutBaseline(desired, storedDocument []byte, schema pkgmodel.Schema) ([]byte, error) {
+	writeOnlyCreateOnly := intersectFields(schema.WriteOnly(), schema.CreateOnly())
+	if len(writeOnlyCreateOnly) == 0 {
+		return desired, nil
+	}
+	var withoutBaseline []string
+	for _, field := range writeOnlyCreateOnly {
+		if !hasStoredBaseline(storedDocument, field) {
+			withoutBaseline = append(withoutBaseline, field)
+		}
+	}
+	return removeWriteOnlyFields(desired, withoutBaseline)
+}
+
+// hasStoredBaseline reports whether the dot-separated fieldPath resolves to at
+// least one value in document, traversing arrays the same way removeNestedField
+// does: at an array, the remaining path is probed in every map element, and any
+// hit counts. The predicate decides per FIELD, not per element — one member
+// holding a baseline keeps the whole field, and mixed-baseline members are left
+// to ordinary member comparison.
+func hasStoredBaseline(document []byte, fieldPath string) bool {
+	var deserialized map[string]any
+	if err := json.Unmarshal(document, &deserialized); err != nil {
+		return false
+	}
+	return nestedFieldExists(deserialized, strings.Split(fieldPath, "."))
+}
+
+// nestedFieldExists is hasStoredBaseline's traversal: the read-side mirror of
+// removeNestedField.
+func nestedFieldExists(obj map[string]any, path []string) bool {
+	if len(path) == 0 {
+		return false
+	}
+	val, exists := obj[path[0]]
+	if !exists {
+		return false
+	}
+	if len(path) == 1 {
+		return true
+	}
+	if nested, ok := val.(map[string]any); ok {
+		return nestedFieldExists(nested, path[1:])
+	}
+	if arr, ok := val.([]any); ok {
+		for _, elem := range arr {
+			if elemMap, ok := elem.(map[string]any); ok {
+				if nestedFieldExists(elemMap, path[1:]) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 func removeWriteOnlyFields(document []byte, writeOnlyFields []string) ([]byte, error) {
 	if len(writeOnlyFields) == 0 {
 		return document, nil

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/canonicalize"
@@ -147,6 +148,26 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 	createOnlyFields := schema.CreateOnly()
 	createOnlyOps := extractCreateOnlyFields(patchOps, createOnlyFields)
 	mutableOps := filterCreateOnlyFields(patchOps, createOnlyFields)
+
+	// Member-level ops under an array are ambiguous between a member swap and
+	// an immutable-field change: set-based array comparison emits whole-element
+	// remove/add pairs, so a change to a createOnly subfield never appears at
+	// the subfield's own path. The hinted subfield's values are the
+	// disambiguator: when their multiset differs between stored and desired,
+	// the element ops under that field escalate to createOnly (a replacement);
+	// when it is unchanged, sibling-only member changes stay mutable.
+	if replacementFields := arrayCreateOnlyChangedFields(flattenedDocument, flattenedPatch, createOnlyFields); len(replacementFields) > 0 {
+		stillMutable := make([]jsonpatch.JsonPatchOperation, 0, len(mutableOps))
+		for _, op := range mutableOps {
+			root, _, _ := strings.Cut(cleanPath(op.Path), "/")
+			if replacementFields[root] {
+				createOnlyOps = append(createOnlyOps, op)
+			} else {
+				stillMutable = append(stillMutable, op)
+			}
+		}
+		mutableOps = stillMutable
+	}
 
 	if len(mutableOps) == 0 && len(createOnlyOps) == 0 {
 		return nil, nil, false, nil
@@ -913,8 +934,92 @@ func extractCreateOnlyFields(patchOps []jsonpatch.JsonPatchOperation, createOnly
 // normalization the check silently no-ops for any path deeper than a
 // top-level field — which leaves createOnly violations on nested
 // fields undetected until the cloud API rejects them at apply time.
+// Matching is array-index-transparent for the same reason as the
+// requiredOnUpdate matcher: a hint on a field inside an array element
+// ("Items.Token") must catch the op at its indexed path ("/Items/0/Token").
 func isCreateOnlyPath(path string, createOnlyFields []string) bool {
-	return pathMatchesField(path, createOnlyFields)
+	return pathMatchesFieldThroughArrays(path, createOnlyFields)
+}
+
+// arrayCreateOnlyChangedFields returns the set of top-level fields whose
+// member-level ops must escalate to createOnly: fields with a createOnly
+// descendant hint reached through an array whose value multiset differs
+// between the stored document and the desired patch. Object-nested createOnly
+// paths are excluded — their changes surface at the subfield's own op path and
+// classify there, so escalating sibling ops under the same container would
+// over-trigger replacements.
+func arrayCreateOnlyChangedFields(document, patch []byte, createOnlyFields []string) map[string]bool {
+	changed := map[string]bool{}
+	if len(createOnlyFields) == 0 {
+		return changed
+	}
+	var docMap, patchMap map[string]any
+	if err := json.Unmarshal(document, &docMap); err != nil {
+		return changed
+	}
+	if err := json.Unmarshal(patch, &patchMap); err != nil {
+		return changed
+	}
+	for _, field := range createOnlyFields {
+		segments := strings.Split(field, ".")
+		if len(segments) < 2 {
+			continue
+		}
+		docValues, docViaArray := collectNestedFieldValues(docMap, segments)
+		patchValues, patchViaArray := collectNestedFieldValues(patchMap, segments)
+		if !docViaArray && !patchViaArray {
+			continue
+		}
+		if multisetKey(docValues) != multisetKey(patchValues) {
+			changed[segments[0]] = true
+		}
+	}
+	return changed
+}
+
+// collectNestedFieldValues returns every value the dot-path resolves to in
+// obj, traversing arrays like removeNestedField (the remaining path is
+// applied to every map element), and whether the traversal crossed an array.
+func collectNestedFieldValues(obj map[string]any, path []string) ([]any, bool) {
+	if len(path) == 0 {
+		return nil, false
+	}
+	val, exists := obj[path[0]]
+	if !exists {
+		return nil, false
+	}
+	if len(path) == 1 {
+		return []any{val}, false
+	}
+	if nestedObj, ok := val.(map[string]any); ok {
+		return collectNestedFieldValues(nestedObj, path[1:])
+	}
+	if arr, ok := val.([]any); ok {
+		var out []any
+		for _, elem := range arr {
+			if elemMap, ok := elem.(map[string]any); ok {
+				vals, _ := collectNestedFieldValues(elemMap, path[1:])
+				out = append(out, vals...)
+			}
+		}
+		return out, true
+	}
+	return nil, false
+}
+
+// multisetKey renders values as an order-insensitive comparison key: the
+// sorted JSON forms joined with a separator that cannot appear in JSON.
+func multisetKey(values []any) string {
+	keys := make([]string, 0, len(values))
+	for _, v := range values {
+		b, err := json.Marshal(v)
+		if err != nil {
+			continue
+		}
+		keys = append(keys, string(b))
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, "\x00")
 }
 
 // pathMatchesField reports whether a JSON Pointer path (without its leading

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -930,22 +930,6 @@ func isCreateOnlyPath(path string, createOnlyFields []string) bool {
 	return pathMatchesFieldThroughArrays(path, createOnlyFields)
 }
 
-// pathMatchesField reports whether a JSON Pointer path (without its leading
-// "/", see cleanPath) targets one of the given dot-separated schema field
-// paths, or a nested path within it. Schema Hints use dot-separated keys for
-// nested fields ("Spec.Selector"), while jsonpatch operation paths use slash
-// separators per RFC 6902 ("Spec/Selector/MatchLabels/foo"); the field side is
-// normalized to slash form before comparing.
-func pathMatchesField(path string, fields []string) bool {
-	for _, field := range fields {
-		f := strings.ReplaceAll(field, ".", "/")
-		if path == f || strings.HasPrefix(path, f+"/") {
-			return true
-		}
-	}
-	return false
-}
-
 // onlyForceResentNoops reports whether every op in ops is a force-resent
 // no-op: an "add" on a requiredOnUpdate path whose value merely restates what
 // originalDocument already held there before force-resend stripped it out (see

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -3953,7 +3953,10 @@ func TestGeneratePatch_ArrayNestedWriteOnlyCreateOnly_NoBaselineStillStripped(t 
 	assert.NotContains(t, string(patchDoc)+string(createOnlyPatch), "Token")
 }
 
-func TestGeneratePatch_ArrayNestedCreateOnlyChange_TriggersReplacement(t *testing.T) {
+func TestGeneratePatch_UnkeyedArrayCreateOnlyChange_DeliveredAsMemberSwap(t *testing.T) {
+	// Without member identity a changed immutable value is indistinguishable
+	// from one member leaving and another arriving; the collection remedy is
+	// member replacement, never a whole-resource replacement.
 	document := []byte(`{"Name": "x", "Entries": [{"Token": "old", "Weight": 1}]}`)
 	desired := []byte(`{"Name": "x", "Entries": [{"Token": "new", "Weight": 1}]}`)
 	schema := pkgmodel.Schema{
@@ -3963,10 +3966,35 @@ func TestGeneratePatch_ArrayNestedCreateOnlyChange_TriggersReplacement(t *testin
 	props := resolver.NewResolvableProperties()
 	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
-	assert.NotEmpty(t, createOnlyPatch,
-		"a changed createOnly value nested under an array must classify as a createOnly diff")
-	assert.JSONEq(t, "[]", string(patchDoc),
-		"the member swap must not additionally be sent as a mutable patch")
+	assert.Empty(t, createOnlyPatch,
+		"an unkeyed member change must not trigger a resource replacement")
+	assert.Contains(t, string(patchDoc), "new",
+		"the member swap must carry the new value")
+	assert.Contains(t, string(patchDoc), `"add"`,
+		"the removed member must be re-added with the new value, not merely removed")
+}
+
+// A KEYED collection (EntitySet with an indexField) pairs members, so a
+// changed createOnly subfield surfaces at its own path and escalates to a
+// replacement, while a mutable sibling changed in the same edit stays in the
+// mutable patch.
+func TestGeneratePatch_EntitySetCreateOnlyChange_TriggersReplacement(t *testing.T) {
+	document := []byte(`{"Name":"x","Entries":[{"Id":"A","Token":"old","Weight":1}]}`)
+	desired := []byte(`{"Name":"x","Entries":[{"Id":"A","Token":"new","Weight":5}]}`)
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Entries"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Entries":       {UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Id"},
+			"Entries.Token": {CreateOnly: true},
+		},
+	}
+	props := resolver.NewResolvableProperties()
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Contains(t, string(createOnlyPatch), "/Entries/0/Token",
+		"a changed createOnly subfield on a paired member must classify as a createOnly diff")
+	assert.Contains(t, string(patchDoc), "/Entries/0/Weight",
+		"the mutable sibling change stays in the mutable patch")
 }
 
 func TestGeneratePatch_ArrayMemberSiblingChange_StaysMutable(t *testing.T) {
@@ -3983,9 +4011,9 @@ func TestGeneratePatch_ArrayMemberSiblingChange_StaysMutable(t *testing.T) {
 	assert.NotEmpty(t, patchDoc)
 }
 
-func TestGeneratePatch_ArrayCreateOnlyValuesExchangedBetweenMembers_TriggersReplacement(t *testing.T) {
-	// The Token multiset is unchanged, but each member's immutable value
-	// changed: this is an immutable change per member, not a membership edit.
+func TestGeneratePatch_UnkeyedArrayCreateOnlyValuesExchanged_DeliveredAsMemberSwaps(t *testing.T) {
+	// Values exchanged between unkeyed members read as members leaving and
+	// arriving; the swap is delivered mutably like any other membership edit.
 	document := []byte(`{"Name":"x","Entries":[{"Id":"A","Token":"t1"},{"Id":"B","Token":"t2"}]}`)
 	desired := []byte(`{"Name":"x","Entries":[{"Id":"A","Token":"t2"},{"Id":"B","Token":"t1"}]}`)
 	schema := pkgmodel.Schema{
@@ -3995,9 +4023,8 @@ func TestGeneratePatch_ArrayCreateOnlyValuesExchangedBetweenMembers_TriggersRepl
 	props := resolver.NewResolvableProperties()
 	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
-	assert.NotEmpty(t, createOnlyPatch,
-		"createOnly values exchanged between members must classify as a createOnly diff")
-	assert.JSONEq(t, "[]", string(patchDoc))
+	assert.Empty(t, createOnlyPatch)
+	assert.NotEmpty(t, patchDoc)
 }
 
 func TestGeneratePatch_ArrayMembershipChange_StaysMutable(t *testing.T) {

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -3952,3 +3952,33 @@ func TestGeneratePatch_ArrayNestedWriteOnlyCreateOnly_NoBaselineStillStripped(t 
 	require.NoError(t, err)
 	assert.NotContains(t, string(patchDoc)+string(createOnlyPatch), "Token")
 }
+
+func TestGeneratePatch_ArrayNestedCreateOnlyChange_TriggersReplacement(t *testing.T) {
+	document := []byte(`{"Name": "x", "Entries": [{"Token": "old", "Weight": 1}]}`)
+	desired := []byte(`{"Name": "x", "Entries": [{"Token": "new", "Weight": 1}]}`)
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Entries"},
+		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
+	}
+	props := resolver.NewResolvableProperties()
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.NotEmpty(t, createOnlyPatch,
+		"a changed createOnly value nested under an array must classify as a createOnly diff")
+	assert.JSONEq(t, "[]", string(patchDoc),
+		"the member swap must not additionally be sent as a mutable patch")
+}
+
+func TestGeneratePatch_ArrayMemberSiblingChange_StaysMutable(t *testing.T) {
+	document := []byte(`{"Name": "x", "Entries": [{"Token": "same", "Weight": 1}]}`)
+	desired := []byte(`{"Name": "x", "Entries": [{"Token": "same", "Weight": 2}]}`)
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Entries"},
+		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
+	}
+	props := resolver.NewResolvableProperties()
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, createOnlyPatch, "a sibling-only member change must not trigger a replacement")
+	assert.NotEmpty(t, patchDoc)
+}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -3912,3 +3912,43 @@ func TestGeneratePatch_AtomicObjectWithNumericRef_EmitsNumber(t *testing.T) {
 	assert.Contains(t, string(patchDoc), "443")
 	assert.NotContains(t, string(patchDoc), `"443"`, "a numeric reference must not be written back as text")
 }
+
+func TestHasStoredBaseline_ProjectsThroughArrays(t *testing.T) {
+	doc := []byte(`{"Name":"x","Entries":[{"Token":"old"},{"Other":1}],"Nested":{"Deep":[{"Key":"v"}]}}`)
+	assert.True(t, hasStoredBaseline(doc, "Entries.Token"))
+	assert.True(t, hasStoredBaseline(doc, "Nested.Deep.Key"))
+	assert.True(t, hasStoredBaseline(doc, "Name"))
+	assert.False(t, hasStoredBaseline(doc, "Entries.Missing"))
+	assert.False(t, hasStoredBaseline(doc, "Absent"))
+	assert.False(t, hasStoredBaseline(doc, "Absent.Token"))
+}
+
+func TestGeneratePatch_ArrayNestedWriteOnlyCreateOnly_ChangeSurvivesTheStrip(t *testing.T) {
+	document := []byte(`{"Name": "x", "Entries": [{"Token": "old"}]}`)
+	desired := []byte(`{"Name": "x", "Entries": [{"Token": "new"}]}`)
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Entries"},
+		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
+	}
+	props := resolver.NewResolvableProperties()
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	combined := string(patchDoc) + string(createOnlyPatch)
+	assert.Contains(t, combined, "new",
+		"a genuine change to an array-nested writeOnly+createOnly field with a stored baseline must survive into the diff, not be silently stripped")
+}
+
+func TestGeneratePatch_ArrayNestedWriteOnlyCreateOnly_NoBaselineStillStripped(t *testing.T) {
+	// Import-shaped: the stored document has no Token anywhere; the declared
+	// value must be stripped so an add op cannot trigger a false replacement.
+	document := []byte(`{"Name": "x", "Entries": [{"Weight": 1}]}`)
+	desired := []byte(`{"Name": "x", "Entries": [{"Weight": 1, "Token": "t"}]}`)
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Entries"},
+		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
+	}
+	props := resolver.NewResolvableProperties()
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.NotContains(t, string(patchDoc)+string(createOnlyPatch), "Token")
+}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -4016,3 +4016,33 @@ func TestGeneratePatch_ArrayMembershipChange_StaysMutable(t *testing.T) {
 	assert.Empty(t, createOnlyPatch, "a membership change must not trigger a replacement")
 	assert.NotEmpty(t, patchDoc)
 }
+
+func TestGeneratePatch_ArrayMemberAdded_StaysMutable(t *testing.T) {
+	// Adding a member (carrying its own createOnly value) is a membership
+	// edit: no existing member's immutable field changed.
+	document := []byte(`{"Name":"x","Entries":[{"Id":"A","Token":"t1"}]}`)
+	desired := []byte(`{"Name":"x","Entries":[{"Id":"A","Token":"t1"},{"Id":"B","Token":"t2"}]}`)
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Entries"},
+		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
+	}
+	props := resolver.NewResolvableProperties()
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, createOnlyPatch, "adding a member must not trigger a resource replacement")
+	assert.NotEmpty(t, patchDoc)
+}
+
+func TestGeneratePatch_ArrayMemberRemoved_StaysMutable(t *testing.T) {
+	document := []byte(`{"Name":"x","Entries":[{"Id":"A","Token":"t1"},{"Id":"B","Token":"t2"}]}`)
+	desired := []byte(`{"Name":"x","Entries":[{"Id":"A","Token":"t1"}]}`)
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Entries"},
+		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
+	}
+	props := resolver.NewResolvableProperties()
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, createOnlyPatch, "removing a member must not trigger a resource replacement")
+	assert.NotEmpty(t, patchDoc)
+}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -3982,3 +3982,37 @@ func TestGeneratePatch_ArrayMemberSiblingChange_StaysMutable(t *testing.T) {
 	assert.Empty(t, createOnlyPatch, "a sibling-only member change must not trigger a replacement")
 	assert.NotEmpty(t, patchDoc)
 }
+
+func TestGeneratePatch_ArrayCreateOnlyValuesExchangedBetweenMembers_TriggersReplacement(t *testing.T) {
+	// The Token multiset is unchanged, but each member's immutable value
+	// changed: this is an immutable change per member, not a membership edit.
+	document := []byte(`{"Name":"x","Entries":[{"Id":"A","Token":"t1"},{"Id":"B","Token":"t2"}]}`)
+	desired := []byte(`{"Name":"x","Entries":[{"Id":"A","Token":"t2"},{"Id":"B","Token":"t1"}]}`)
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Entries"},
+		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
+	}
+	props := resolver.NewResolvableProperties()
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.NotEmpty(t, createOnlyPatch,
+		"createOnly values exchanged between members must classify as a createOnly diff")
+	assert.JSONEq(t, "[]", string(patchDoc))
+}
+
+func TestGeneratePatch_ArrayMembershipChange_StaysMutable(t *testing.T) {
+	// Replacing one member with a different member (same Token value carried
+	// by a new member identity) is a collection membership edit, not an
+	// immutable-field change.
+	document := []byte(`{"Name":"x","Entries":[{"Id":"A","Token":"t1"}]}`)
+	desired := []byte(`{"Name":"x","Entries":[{"Id":"C","Token":"t1"}]}`)
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Entries"},
+		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
+	}
+	props := resolver.NewResolvableProperties()
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, createOnlyPatch, "a membership change must not trigger a replacement")
+	assert.NotEmpty(t, patchDoc)
+}

--- a/internal/metastructure/resolver/resolvable_properties_test.go
+++ b/internal/metastructure/resolver/resolvable_properties_test.go
@@ -552,3 +552,107 @@ func TestLoadResolvableProperties_ReferenceCycleFails(t *testing.T) {
 	require.True(t, errors.As(err, &cycleErr), "error must be a ReferenceCycleError")
 	assert.GreaterOrEqual(t, len(cycleErr.Chain), 2, "the chain must name at least the repeated hop and its first occurrence")
 }
+
+const middleKsuid = "2middleghijklmnopqrstuvwxyz"
+
+// A reference to a container field whose SCHEMA marks a nested descendant
+// opaque (e.g. a hint on Config.Password while the reference names Config)
+// must refuse plan-time materialization: the container holds a credential, so
+// the whole referenced subtree is a credential for materialization purposes.
+// This covers the first appearance of the value, before any inline
+// $hashed/$visibility markers exist for the value-level walks to catch.
+func TestLoadResolvableProperties_ContainerReference_RefusesDescendantOpaqueHint(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Ksuid: sourceKsuid,
+		Label: "holder",
+		Type:  "Test::Config::Holder",
+		Stack: "default",
+		Schema: pkgmodel.Schema{
+			Fields: []string{"Name", "Config"},
+			Hints:  map[string]pkgmodel.FieldHint{"Config.Password": {Opaque: true}},
+		},
+		Properties: json.RawMessage(`{"Name":"s","Config":{"User":"u"}}`),
+	}
+	effective := map[string]json.RawMessage{
+		sourceKsuid: json.RawMessage(`{"Name":"s","Config":{"User":"u","Password":"hunter2"}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("Config"), stacksWith(source), effective)
+	require.NoError(t, err)
+
+	value, found := props.Get(sourceKsuid, "Config")
+	if found {
+		assert.NotContains(t, value, "hunter2",
+			"a reference to a container with an opaque descendant hint must not materialize the descendant's plaintext")
+	}
+}
+
+// The same rule one hop out: a middle resource's reference envelope resolves
+// the container and extracts the secret leaf via $json; the extracted
+// plaintext must not reach a consumer referencing the middle's property.
+func TestLoadResolvableProperties_ChainHopJSONExtraction_RefusesDescendantOpaqueHint(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Ksuid: sourceKsuid,
+		Label: "holder",
+		Type:  "Test::Config::Holder",
+		Stack: "default",
+		Schema: pkgmodel.Schema{
+			Fields: []string{"Name", "Config"},
+			Hints:  map[string]pkgmodel.FieldHint{"Config.Password": {Opaque: true}},
+		},
+		Properties: json.RawMessage(`{"Name":"s","Config":{"User":"u"}}`),
+	}
+	middle := &pkgmodel.Resource{
+		Ksuid: middleKsuid,
+		Label: "middle",
+		Type:  "Test::Config::Middle",
+		Stack: "default",
+		Properties: json.RawMessage(`{"Ref":{"$ref":"formae://` + sourceKsuid + `#/Config"}}`),
+	}
+	consumer := pkgmodel.Resource{
+		Label:      "consumer",
+		Type:       "Test::Consumer",
+		Stack:      "default",
+		Properties: json.RawMessage(`{"Password":{"$ref":"formae://` + middleKsuid + `#/Ref"}}`),
+	}
+	all := map[string][]*pkgmodel.Resource{"default": {source, middle}}
+	effective := map[string]json.RawMessage{
+		sourceKsuid: json.RawMessage(`{"Name":"s","Config":{"User":"u","Password":"hunter2"}}`),
+		middleKsuid: json.RawMessage(`{"Ref":{"$ref":"formae://` + sourceKsuid + `#/Config","$json":"Password"}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumer, all, effective)
+	require.NoError(t, err)
+
+	value, found := props.Get(middleKsuid, "Ref")
+	if found {
+		assert.NotContains(t, value, "hunter2",
+			"a chain hop's JSON extraction must not isolate an opaque descendant's plaintext")
+	}
+}
+
+// A sibling field with no opaque descendant still resolves from effective
+// desired state: the descendant rule must not over-refuse.
+func TestLoadResolvableProperties_SiblingOfOpaqueDescendant_StillResolves(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Ksuid: sourceKsuid,
+		Label: "holder",
+		Type:  "Test::Config::Holder",
+		Stack: "default",
+		Schema: pkgmodel.Schema{
+			Fields: []string{"Name", "Config"},
+			Hints:  map[string]pkgmodel.FieldHint{"Config.Password": {Opaque: true}},
+		},
+		Properties: json.RawMessage(`{"Name":"old","Config":{"User":"u"}}`),
+	}
+	effective := map[string]json.RawMessage{
+		sourceKsuid: json.RawMessage(`{"Name":"new","Config":{"User":"u","Password":"hunter2"}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("Name"), stacksWith(source), effective)
+	require.NoError(t, err)
+
+	value, found := props.Get(sourceKsuid, "Name")
+	require.True(t, found, "a sibling of an opaque descendant must still resolve")
+	assert.Equal(t, "new", value)
+}

--- a/internal/metastructure/resolver/resolvable_properties_test.go
+++ b/internal/metastructure/resolver/resolvable_properties_test.go
@@ -656,3 +656,58 @@ func TestLoadResolvableProperties_SiblingOfOpaqueDescendant_StillResolves(t *tes
 	require.True(t, found, "a sibling of an opaque descendant must still resolve")
 	assert.Equal(t, "new", value)
 }
+
+// A reference BELOW a nested opaque hint (the hint on Config.Password, the
+// reference into Config.Password.value) is a key into a nested map-shaped
+// secret: every ancestor of the referenced path must be consulted, not only
+// its top-level root.
+func TestLoadResolvableProperties_ReferenceBelowNestedOpaqueHint_Refused(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Ksuid: sourceKsuid,
+		Label: "holder",
+		Type:  "Test::Config::Holder",
+		Stack: "default",
+		Schema: pkgmodel.Schema{
+			Fields: []string{"Name", "Config"},
+			Hints:  map[string]pkgmodel.FieldHint{"Config.Password": {Opaque: true}},
+		},
+		Properties: json.RawMessage(`{"Name":"s","Config":{"User":"u"}}`),
+	}
+	effective := map[string]json.RawMessage{
+		sourceKsuid: json.RawMessage(`{"Name":"s","Config":{"User":"u","Password":{"value":"hunter2"}}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("Config.Password.value"), stacksWith(source), effective)
+	require.NoError(t, err)
+
+	value, found := props.Get(sourceKsuid, "Config.Password.value")
+	if found {
+		assert.NotContains(t, value, "hunter2",
+			"a reference below a nested opaque hint must not materialize the secret")
+	}
+}
+
+// A reference below a NON-opaque sibling of the hinted field still resolves.
+func TestLoadResolvableProperties_ReferenceBelowNonOpaqueSibling_StillResolves(t *testing.T) {
+	source := &pkgmodel.Resource{
+		Ksuid: sourceKsuid,
+		Label: "holder",
+		Type:  "Test::Config::Holder",
+		Stack: "default",
+		Schema: pkgmodel.Schema{
+			Fields: []string{"Name", "Config"},
+			Hints:  map[string]pkgmodel.FieldHint{"Config.Password": {Opaque: true}},
+		},
+		Properties: json.RawMessage(`{"Name":"s","Config":{"Meta":{"region":"old"}}}`),
+	}
+	effective := map[string]json.RawMessage{
+		sourceKsuid: json.RawMessage(`{"Name":"s","Config":{"Meta":{"region":"new"},"Password":{"value":"hunter2"}}}`),
+	}
+
+	props, err := LoadResolvablePropertiesFromStacks(consumerOf("Config.Meta.region"), stacksWith(source), effective)
+	require.NoError(t, err)
+
+	value, found := props.Get(sourceKsuid, "Config.Meta.region")
+	require.True(t, found, "a reference below a non-opaque sibling must still resolve")
+	assert.Equal(t, "new", value)
+}

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -263,14 +263,19 @@ func isSourcePropertyOpaque(source *pkgmodel.Resource, propertyName string) bool
 	if source == nil || propertyName == "" {
 		return false
 	}
-	// Check the property path itself and its top-level field. A ref into a
+	// Check the property path itself and every ancestor prefix. A ref into a
 	// MAP-shaped opaque secret (e.g. "decodedData.password", produced by
 	// secret.res.secretValue.at("password")) is opaque by virtue of its opaque
 	// parent field: the field is stored as a single hashed envelope with no
 	// per-key sub-structure, so the leaf path has no $visibility of its own.
+	// The parent may itself be nested (a hint on "Config.Password" with a ref
+	// into "Config.Password.value"), so every ancestor is a candidate, not
+	// only the top-level root.
 	candidates := []string{propertyName}
-	if root, _, found := strings.Cut(propertyName, "."); found {
-		candidates = append(candidates, root)
+	for i := len(propertyName) - 1; i > 0; i-- {
+		if propertyName[i] == '.' {
+			candidates = append(candidates, propertyName[:i])
+		}
 	}
 	for _, p := range candidates {
 		// A value stored hashed at rest is a SHA-256 digest; refused wherever it

--- a/internal/metastructure/resolver/resolver.go
+++ b/internal/metastructure/resolver/resolver.go
@@ -297,6 +297,17 @@ func isSourcePropertyOpaque(source *pkgmodel.Resource, propertyName string) bool
 			return true
 		}
 	}
+	// A hint on a field nested under the referenced path makes the whole
+	// referenced subtree opaque: a container holding a credential is itself a
+	// credential for materialization purposes, whether the reference names the
+	// leaf, the container, or any ancestor. The value-level walks above already
+	// refuse persisted descendants ($hashed / $visibility inside the subtree);
+	// this covers the schema-declared case before anything is persisted.
+	for key := range opaqueFields {
+		if strings.HasPrefix(key, propertyName+".") {
+			return true
+		}
+	}
 	return false
 }
 

--- a/internal/metastructure/resource_update/effective_desired.go
+++ b/internal/metastructure/resource_update/effective_desired.go
@@ -8,15 +8,20 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/platform-engineering-labs/formae/internal/metastructure/patch"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
 // EffectiveDesired maps an existing resource's KSUID to the desired properties
 // document this command will drive it to: the forma declaration after the same
-// SetOnce filtering that decides the resource's own patch. It is computed once
-// per command, ahead of the resolvable lookup, and the same artifact feeds both
-// the lookup and the update factory, so the filtering is never re-derived in
-// two places.
+// value-strategy filtering that decides the resource's own patch — SetOnce
+// substitution AND the no-baseline writeOnly+createOnly strip. The lookup must
+// never advertise a value the producer's pipeline will not write: a consumer
+// resolving such a value would be planned (and for a createOnly destination,
+// destructively replaced) against state that never materializes. It is
+// computed once per command, ahead of the resolvable lookup, and the same
+// artifact feeds both the lookup and the update factory, so the filtering is
+// never re-derived in two places.
 type EffectiveDesired map[string]json.RawMessage
 
 // ComputeEffectiveDesired builds the map for every forma resource whose KSUID
@@ -44,6 +49,14 @@ func ComputeEffectiveDesired(forma *pkgmodel.Forma, allResourcesByStack map[stri
 		filtered, err := filterSetOnceProps(row.Properties, r.Properties, r.Label)
 		if err != nil {
 			return nil, fmt.Errorf("failed to compute effective desired properties for %s: %w", r.Label, err)
+		}
+		// The baseline is probed against the persisted row's properties, while
+		// patch generation probes the flattened document; for the fields in
+		// question (writeOnly+createOnly, schema-hinted) presence in the
+		// persisted row is the baseline in both pipelines.
+		filtered, err = patch.StripFieldsWithoutBaseline(filtered, row.Properties, r.Schema)
+		if err != nil {
+			return nil, fmt.Errorf("failed to strip no-baseline fields from effective desired properties for %s: %w", r.Label, err)
 		}
 		eff[r.Ksuid] = filtered
 	}

--- a/internal/metastructure/resource_update/effective_desired_test.go
+++ b/internal/metastructure/resource_update/effective_desired_test.go
@@ -12,55 +12,135 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
-// The effective desired document for an existing resource is the forma
-// declaration after SetOnce filtering: a populated SetOnce property keeps its
-// persisted value no matter what the forma resubmits. Resources with no
-// persisted row (creates) get no entry.
-func TestComputeEffectiveDesired_SetOncePreservedCreatesAbsent(t *testing.T) {
-	existing := &pkgmodel.Resource{
-		Label: "parent",
-		Ksuid: "ksuid-parent",
-		Stack: "test-stack",
-		Properties: json.RawMessage(`{
-			"Name": "parent-1",
-			"Value": {"$value": "hello", "$strategy": "SetOnce"}
-		}`),
+func effectiveDesiredTokenSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"Name", "Token"},
+		Hints:  map[string]pkgmodel.FieldHint{"Token": {WriteOnly: true, CreateOnly: true}},
 	}
-	forma := &pkgmodel.Forma{
+}
+
+// A declared writeOnly+createOnly value with no stored baseline is not part of
+// the state this command drives the producer to: the producer's own patch
+// generation strips it, so the effective desired document must strip it too,
+// or reference consumers would be planned against a value that is never
+// written.
+func TestComputeEffectiveDesired_StripsDeclaredWriteOnlyCreateOnlyWithoutBaseline(t *testing.T) {
+	schema := effectiveDesiredTokenSchema()
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Label: "s", Ksuid: "2sourceghijklmnopqrstuvwxyz", Type: "Test::Source", Schema: schema,
+		Properties: json.RawMessage(`{"Name":"s","Token":"t"}`),
+	}}}
+	persisted := map[string][]*pkgmodel.Resource{"default": {{
+		Label: "s", Ksuid: "2sourceghijklmnopqrstuvwxyz", Type: "Test::Source", Schema: schema,
+		Properties: json.RawMessage(`{"Name":"s"}`),
+	}}}
+
+	eff, err := ComputeEffectiveDesired(forma, persisted)
+	require.NoError(t, err)
+	assert.False(t, gjson.GetBytes(eff["2sourceghijklmnopqrstuvwxyz"], "Token").Exists(),
+		"a declared writeOnly+createOnly value with no stored baseline is not part of the state this command drives to")
+	assert.Equal(t, "s", gjson.GetBytes(eff["2sourceghijklmnopqrstuvwxyz"], "Name").String())
+}
+
+// With a stored baseline the declared value is a genuine immutable change and
+// must stay visible to the lookup, so the coordinated source and consumer
+// replacement still plans.
+func TestComputeEffectiveDesired_KeepsWriteOnlyCreateOnlyWithBaseline(t *testing.T) {
+	schema := effectiveDesiredTokenSchema()
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Label: "s", Ksuid: "2sourceghijklmnopqrstuvwxyz", Type: "Test::Source", Schema: schema,
+		Properties: json.RawMessage(`{"Name":"s","Token":"t"}`),
+	}}}
+	persisted := map[string][]*pkgmodel.Resource{"default": {{
+		Label: "s", Ksuid: "2sourceghijklmnopqrstuvwxyz", Type: "Test::Source", Schema: schema,
+		Properties: json.RawMessage(`{"Name":"s","Token":"t-old"}`),
+	}}}
+
+	eff, err := ComputeEffectiveDesired(forma, persisted)
+	require.NoError(t, err)
+	assert.Equal(t, "t", gjson.GetBytes(eff["2sourceghijklmnopqrstuvwxyz"], "Token").String())
+}
+
+// An import-shaped source (writeOnly+createOnly field stored without a
+// baseline) declared with a value must not drive a consumer whose createOnly
+// field references it into a replacement: the source's own patch strips the
+// undeliverable value and the effective desired document strips it
+// identically, so the consumer is not planned against a value that is never
+// written and nothing is destroyed.
+func TestGenerateResourceUpdates_ImportShapedWriteOnlySource_ConsumerIsNotReplaced(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	sourceSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Token"},
+		Hints:      map[string]pkgmodel.FieldHint{"Token": {WriteOnly: true, CreateOnly: true}, "Name": {CreateOnly: true}},
+	}
+	consumerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "SourceToken"},
+		Hints:      map[string]pkgmodel.FieldHint{"SourceToken": {CreateOnly: true}, "Name": {CreateOnly: true}},
+	}
+
+	existingStack := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
 		Resources: []pkgmodel.Resource{
 			{
-				Label: "parent",
-				Ksuid: "ksuid-parent",
-				Stack: "test-stack",
-				Properties: json.RawMessage(`{
-					"Name": "parent-1",
-					"Value": {"$value": "world-resubmitted", "$strategy": "SetOnce"}
-				}`),
+				Label: "s", Type: "Test::Source", Stack: "test-stack", Target: "test-target",
+				Schema: sourceSchema, Ksuid: util.NewID(),
+				Properties: json.RawMessage(`{"Name":"s"}`),
 			},
 			{
-				Label:      "brand-new",
-				Ksuid:      "ksuid-new",
-				Stack:      "test-stack",
-				Properties: json.RawMessage(`{"Name": "n"}`),
+				Label: "c", Type: "Test::Consumer", Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema, Ksuid: util.NewID(),
+				Properties: json.RawMessage(`{"Name":"c","SourceToken":"old"}`),
 			},
 		},
 	}
-	all := map[string][]*pkgmodel.Resource{"test-stack": {existing}}
-
-	eff, err := ComputeEffectiveDesired(forma, all)
+	_, err := ds.StoreStack(existingStack, "previous-command")
 	require.NoError(t, err)
 
-	filtered, ok := eff["ksuid-parent"]
-	require.True(t, ok, "an existing declared resource must have an effective desired entry")
-	assert.JSONEq(t, `{
-		"Name": "parent-1",
-		"Value": {"$value": "hello", "$strategy": "SetOnce"}
-	}`, string(filtered), "a populated SetOnce property keeps its persisted value")
+	forma := &pkgmodel.Forma{
+		Stacks:  []pkgmodel.Stack{{Label: "test-stack"}},
+		Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test", Config: json.RawMessage(`{}`)}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "s", Type: "Test::Source", Stack: "test-stack", Target: "test-target",
+				Schema:     sourceSchema,
+				Properties: json.RawMessage(`{"Name":"s","Token":"t"}`),
+			},
+			{
+				Label: "c", Type: "Test::Consumer", Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema,
+				Properties: json.RawMessage(`{
+					"Name": "c",
+					"SourceToken": {
+						"$res": true,
+						"$label": "s",
+						"$type": "Test::Source",
+						"$stack": "test-stack",
+						"$property": "Token"
+					}
+				}`),
+			},
+		},
+	}
+	existingTargets := []*pkgmodel.Target{{Label: "test-target", Namespace: "test", Config: json.RawMessage(`{}`)}}
 
-	_, ok = eff["ksuid-new"]
-	assert.False(t, ok, "a resource with no persisted row has no entry")
+	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, existingTargets, ds, nil, nil)
+	require.NoError(t, err)
+
+	for _, u := range updates {
+		label := u.DesiredState.Label
+		if label == "" {
+			label = u.PriorState.Label
+		}
+		assert.NotEqual(t, OperationDelete, u.Operation,
+			"nothing may be planned for deletion over a value the source never writes (got delete for %q)", label)
+	}
 }

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -2465,8 +2465,14 @@ func referencesOpaqueProperty(opaque map[string]bool, propertyName string) bool 
 			return true
 		}
 	}
-	root, _, nested := strings.Cut(propertyName, ".")
-	return nested && opaque[root]
+	// Every ancestor prefix, not only the top-level root: the opaque parent of
+	// a map-shaped secret may itself be nested.
+	for i := len(propertyName) - 1; i > 0; i-- {
+		if propertyName[i] == '.' && opaque[propertyName[:i]] {
+			return true
+		}
+	}
+	return false
 }
 
 // collectOpaqueResolvablePaths records the gjson/sjson path of every $res envelope

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -2448,12 +2448,22 @@ func markOpaqueResolvablesInProps(propsJSON string, opaqueByTriplet map[pkgmodel
 // leaf path is never in the set and matching it alone would leave the reference
 // un-marked and its resolved value unhashed at rest. Test the top-level field too,
 // mirroring resolver.isSourcePropertyOpaque.
+//
+// The converse direction also holds: a hint nested under the referenced path
+// (an opaque descendant) makes the referenced container opaque, since resolving
+// the container would materialize the descendant. Same rule as the resolver's
+// oracle; keep the two in sync.
 func referencesOpaqueProperty(opaque map[string]bool, propertyName string) bool {
 	if propertyName == "" {
 		return false
 	}
 	if opaque[propertyName] {
 		return true
+	}
+	for key := range opaque {
+		if strings.HasPrefix(key, propertyName+".") {
+			return true
+		}
 	}
 	root, _, nested := strings.Cut(propertyName, ".")
 	return nested && opaque[root]

--- a/internal/metastructure/resource_update/resource_update_generator_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_test.go
@@ -1827,6 +1827,8 @@ func TestReferencesOpaqueProperty_DescendantHint(t *testing.T) {
 		{"sibling under the same container", nested, "Config.User", false},
 		{"unrelated field", nested, "Name", false},
 		{"key into a map-shaped secret", mapSecret, "data.token", true},
+		{"key below a nested opaque hint", nested, "Config.Password.value", true},
+		{"key below a non-opaque sibling", nested, "Config.Other.sub", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/metastructure/resource_update/resource_update_generator_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_test.go
@@ -1808,3 +1808,29 @@ func TestSynthesizeCascadeUpdatePatch_ReplacedParentIndexedProviderField(t *test
 	assert.NotContains(t, patchStr, `"value":"arn:`,
 		"stale cached value must not be emitted as a bare concrete replace value outside the cascade marker")
 }
+
+// A reference names an opaque property when the opaque set holds the exact
+// path, the path's map-secret root, or any hint nested under the referenced
+// path: a container holding a credential is itself a credential.
+func TestReferencesOpaqueProperty_DescendantHint(t *testing.T) {
+	nested := map[string]bool{"Config.Password": true}
+	mapSecret := map[string]bool{"data": true}
+
+	cases := []struct {
+		name     string
+		opaque   map[string]bool
+		property string
+		want     bool
+	}{
+		{"container with opaque descendant", nested, "Config", true},
+		{"exact descendant path", nested, "Config.Password", true},
+		{"sibling under the same container", nested, "Config.User", false},
+		{"unrelated field", nested, "Name", false},
+		{"key into a map-shaped secret", mapSecret, "data.token", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, referencesOpaqueProperty(tc.opaque, tc.property))
+		})
+	}
+}

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -362,6 +362,7 @@ func onStateChange(oldState gen.Atom, newState gen.Atom, data ResourceUpdateData
 				ResourceProperties:         data.resourceUpdate.DesiredState.Properties,
 				ResourceReadOnlyProperties: data.resourceUpdate.DesiredState.ReadOnlyProperties,
 				Version:                    data.resourceUpdate.Version,
+				FailureReason:              data.resourceUpdate.FailureReason,
 			},
 		)
 		if err != nil {

--- a/internal/workflow_tests/local/apply_forma/failure_reason_test.go
+++ b/internal/workflow_tests/local/apply_forma/failure_reason_test.go
@@ -1,0 +1,108 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// A resource update that fails at execution-time reference resolution (no
+// plugin operation ever runs, so no progress entry carries a message) must
+// surface its failure reason on the command loaded from the datastore, not
+// come back with a blank error.
+func TestApplyForma_TerminalResolveFailure_PersistsFailureReason(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationCreate,
+					OperationStatus: resource.OperationStatusSuccess,
+					RequestID:       req.Label + "-create",
+					NativeID:        req.Label,
+					// The source never reports the referenced field, so the
+					// consumer's live resolution cannot succeed.
+					ResourceProperties: json.RawMessage(`{"Name":"` + req.Label + `"}`),
+				}}, nil
+			},
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{
+					ResourceType: req.ResourceType,
+					Properties:   `{"Name":"` + req.NativeID + `"}`,
+				}, nil
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		schema := pkgmodel.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "Token", "SourceToken"},
+			Hints:      map[string]pkgmodel.FieldHint{"Name": {CreateOnly: true}},
+		}
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label: "source", Type: "FakeAWS::Resolve::Source", Stack: "test-stack", Target: "test-target",
+					Managed: true, Schema: schema,
+					Properties: json.RawMessage(`{"Name":"source"}`),
+				},
+				{
+					Label: "consumer", Type: "FakeAWS::Resolve::Consumer", Stack: "test-stack", Target: "test-target",
+					Managed: true, Schema: schema,
+					Properties: json.RawMessage(`{
+						"Name": "consumer",
+						"SourceToken": {
+							"$res": true,
+							"$label": "source",
+							"$type": "FakeAWS::Resolve::Source",
+							"$stack": "test-stack",
+							"$property": "Token"
+						}
+					}`),
+				},
+			},
+			Targets: []pkgmodel.Target{{Label: "test-target"}},
+		}
+
+		_, err = m.ApplyForma(forma, defaultApplyConfig(), "test", "", "")
+		require.NoError(t, err)
+
+		var cmds []*forma_command.FormaCommand
+		require.Eventually(t, func() bool {
+			cmds, err = m.Datastore.LoadFormaCommands()
+			require.NoError(t, err)
+			return len(cmds) > 0 && cmds[0].State != forma_command.CommandStateInProgress
+		}, 60*time.Second, 200*time.Millisecond, "the apply must reach a terminal state")
+
+		var consumerUpdate *resource_update.ResourceUpdate
+		for i := range cmds[0].ResourceUpdates {
+			if cmds[0].ResourceUpdates[i].DesiredState.Label == "consumer" {
+				consumerUpdate = &cmds[0].ResourceUpdates[i]
+			}
+		}
+		require.NotNil(t, consumerUpdate)
+		require.Equal(t, resource_update.ResourceUpdateStateFailed, consumerUpdate.State,
+			"the consumer's live resolution must fail terminally")
+		require.NotEmpty(t, consumerUpdate.MostRecentFailureMessage(),
+			"the resolve failure's reason must survive into the persisted command")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/reconcile_after_patch_test.go
+++ b/internal/workflow_tests/local/apply_forma/reconcile_after_patch_test.go
@@ -1,0 +1,418 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+const (
+	admissionProducerType = "FakeAWS::Admission::Producer"
+	admissionConsumerType = "FakeAWS::Admission::Consumer"
+)
+
+// admissionState is a mutex-guarded string: the last value a fake resource
+// reported as its cloud state.
+type admissionState struct {
+	mu    sync.Mutex
+	value string
+}
+
+func (s *admissionState) get() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.value
+}
+
+func (s *admissionState) set(v string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.value = v
+}
+
+// admissionFieldValue reads a named top-level property, unwrapping a resolved
+// {"$ref":...,"$value":...} envelope if the field arrives that way.
+func admissionFieldValue(raw json.RawMessage, field string) (string, bool) {
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return "", false
+	}
+	v, ok := m[field]
+	if !ok {
+		return "", false
+	}
+	switch val := v.(type) {
+	case string:
+		return val, true
+	case map[string]any:
+		if s, ok := val["$value"].(string); ok {
+			return s, true
+		}
+	}
+	return "", false
+}
+
+func admissionProps(resourceType, value string) json.RawMessage {
+	switch resourceType {
+	case admissionProducerType:
+		return json.RawMessage(fmt.Sprintf(`{"Name":"producer","Color":"%s"}`, value))
+	case admissionConsumerType:
+		return json.RawMessage(fmt.Sprintf(`{"Name":"consumer","ProducerColor":"%s"}`, value))
+	}
+	return nil
+}
+
+func admissionSchema(field string) pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", field},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Name": {CreateOnly: true},
+		},
+	}
+}
+
+// admissionFullForma declares the producer with the given literal and the
+// consumer referencing the producer's Color field.
+func admissionFullForma(producerColor string) *pkgmodel.Forma {
+	return &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label:      "producer",
+				Type:       admissionProducerType,
+				Properties: json.RawMessage(fmt.Sprintf(`{"Name":"producer","Color":"%s"}`, producerColor)),
+				Stack:      "test-stack",
+				Target:     "test-target",
+				Managed:    true,
+				Schema:     admissionSchema("Color"),
+			},
+			{
+				Label: "consumer",
+				Type:  admissionConsumerType,
+				Properties: json.RawMessage(`{
+					"Name": "consumer",
+					"ProducerColor": {
+						"$res": true,
+						"$label": "producer",
+						"$type": "` + admissionProducerType + `",
+						"$stack": "test-stack",
+						"$property": "Color"
+					}
+				}`),
+				Stack:   "test-stack",
+				Target:  "test-target",
+				Managed: true,
+				Schema:  admissionSchema("ProducerColor"),
+			},
+		},
+		Targets: []pkgmodel.Target{{Label: "test-target"}},
+	}
+}
+
+// admissionProducerOnlyForma declares only the producer, for a patch that
+// changes just the referenced field.
+func admissionProducerOnlyForma(producerColor string) *pkgmodel.Forma {
+	return &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label:      "producer",
+				NativeID:   "producer",
+				Type:       admissionProducerType,
+				Properties: json.RawMessage(fmt.Sprintf(`{"Name":"producer","Color":"%s"}`, producerColor)),
+				Stack:      "test-stack",
+				Target:     "test-target",
+				Managed:    true,
+				Schema:     admissionSchema("Color"),
+			},
+		},
+		Targets: []pkgmodel.Target{{Label: "test-target"}},
+	}
+}
+
+// A reconcile submitted after a patch changed a referenced producer field must
+// be admitted without force when the forma already reflects the patched value:
+// the producer's modification is absorbed (its declaration matches current
+// state), and the consumer's pending convergence is explained by its own
+// reference edge, not out-of-band drift. The reconcile then converges the
+// consumer to the referenced value.
+func TestApplyForma_ReconcileAfterPatchOnReferencedField_AdmittedAndConvergesConsumer(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		producer := &admissionState{value: "blue"}
+		consumer := &admissionState{value: "blue"}
+
+		stateFor := func(resourceType string) (*admissionState, string) {
+			switch resourceType {
+			case admissionProducerType:
+				return producer, "Color"
+			case admissionConsumerType:
+				return consumer, "ProducerColor"
+			}
+			return nil, ""
+		}
+
+		var mu sync.Mutex
+		consumerUpdateValues := []string{}
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				state, field := stateFor(req.ResourceType)
+				if state == nil {
+					return nil, nil
+				}
+				if v, ok := admissionFieldValue(req.Properties, field); ok {
+					state.set(v)
+				}
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          req.Label + "-create",
+					NativeID:           req.Label,
+					ResourceProperties: admissionProps(req.ResourceType, state.get()),
+				}}, nil
+			},
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				state, _ := stateFor(req.ResourceType)
+				if state == nil {
+					return nil, nil
+				}
+				return &resource.ReadResult{
+					ResourceType: req.ResourceType,
+					Properties:   string(admissionProps(req.ResourceType, state.get())),
+				}, nil
+			},
+			Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				state, field := stateFor(req.ResourceType)
+				if state == nil {
+					return nil, nil
+				}
+				if v, ok := admissionFieldValue(req.DesiredProperties, field); ok {
+					state.set(v)
+					if req.ResourceType == admissionConsumerType {
+						mu.Lock()
+						consumerUpdateValues = append(consumerUpdateValues, v)
+						mu.Unlock()
+					}
+				}
+				return &resource.UpdateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationUpdate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          req.Label + "-update",
+					NativeID:           req.NativeID,
+					ResourceProperties: admissionProps(req.ResourceType, state.get()),
+				}}, nil
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		// Command 1: reconcile creates producer and consumer.
+		_, err = m.ApplyForma(admissionFullForma("blue"), defaultApplyConfig(), "test", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		// Command 2: patch mode changes only the producer's referenced field.
+		_, err = m.ApplyForma(
+			admissionProducerOnlyForma("green"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch, Simulate: false},
+			"test", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		// Command 3: reconcile with the forma as it stands after the patch
+		// (producer already declares green; the consumer's reference is
+		// textually unchanged). Must be admitted without force.
+		_, err = m.ApplyForma(admissionFullForma("green"), defaultApplyConfig(), "test", "", "")
+		var rejected apimodel.FormaReconcileRejectedError
+		if errors.As(err, &rejected) {
+			t.Fatalf("reconcile after a patch on a referenced field was rejected for modifications its reference edge explains: %+v", rejected.ModifiedStacks)
+		}
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		require.NotEmpty(t, cmds)
+		require.Equal(t, forma_command.CommandStateSuccess, cmds[0].State, "the reconcile must succeed")
+
+		// The reconcile must have converged the consumer to the patched value.
+		mu.Lock()
+		values := append([]string{}, consumerUpdateValues...)
+		mu.Unlock()
+		require.Contains(t, values, "green", "the consumer's plugin must receive the referenced field's patched value")
+		require.Equal(t, "green", consumer.get(), "the consumer's cloud state must converge to the referenced value")
+	})
+}
+
+// admissionCrossStackForma declares only the consumer's stack; the consumer
+// references the producer's field across stacks.
+func admissionCrossStackConsumerForma() *pkgmodel.Forma {
+	return &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "consumer-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "consumer",
+				Type:  admissionConsumerType,
+				Properties: json.RawMessage(`{
+					"Name": "consumer",
+					"ProducerColor": {
+						"$res": true,
+						"$label": "producer",
+						"$type": "` + admissionProducerType + `",
+						"$stack": "producer-stack",
+						"$property": "Color"
+					}
+				}`),
+				Stack:   "consumer-stack",
+				Target:  "test-target",
+				Managed: true,
+				Schema:  admissionSchema("ProducerColor"),
+			},
+		},
+		Targets: []pkgmodel.Target{{Label: "test-target"}},
+	}
+}
+
+func admissionCrossStackProducerForma(color string) *pkgmodel.Forma {
+	return &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "producer-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label:      "producer",
+				Type:       admissionProducerType,
+				Properties: json.RawMessage(fmt.Sprintf(`{"Name":"producer","Color":"%s"}`, color)),
+				Stack:      "producer-stack",
+				Target:     "test-target",
+				Managed:    true,
+				Schema:     admissionSchema("Color"),
+			},
+		},
+		Targets: []pkgmodel.Target{{Label: "test-target"}},
+	}
+}
+
+// A reconcile of the consumer's stack after a patch changed the producer in a
+// DIFFERENT stack: admission consults only the stacks the forma declares, so
+// the producer-stack modification does not reject the consumer-stack
+// reconcile, and the consumer still converges to the referenced value.
+func TestApplyForma_ReconcileConsumerStack_AfterCrossStackProducerPatch_Admitted(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		producer := &admissionState{value: "blue"}
+		consumer := &admissionState{value: "blue"}
+
+		stateFor := func(resourceType string) (*admissionState, string) {
+			switch resourceType {
+			case admissionProducerType:
+				return producer, "Color"
+			case admissionConsumerType:
+				return consumer, "ProducerColor"
+			}
+			return nil, ""
+		}
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				state, field := stateFor(req.ResourceType)
+				if state == nil {
+					return nil, nil
+				}
+				if v, ok := admissionFieldValue(req.Properties, field); ok {
+					state.set(v)
+				}
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          req.Label + "-create",
+					NativeID:           req.Label,
+					ResourceProperties: admissionProps(req.ResourceType, state.get()),
+				}}, nil
+			},
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				state, _ := stateFor(req.ResourceType)
+				if state == nil {
+					return nil, nil
+				}
+				return &resource.ReadResult{
+					ResourceType: req.ResourceType,
+					Properties:   string(admissionProps(req.ResourceType, state.get())),
+				}, nil
+			},
+			Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				state, field := stateFor(req.ResourceType)
+				if state == nil {
+					return nil, nil
+				}
+				if v, ok := admissionFieldValue(req.DesiredProperties, field); ok {
+					state.set(v)
+				}
+				return &resource.UpdateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationUpdate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          req.Label + "-update",
+					NativeID:           req.NativeID,
+					ResourceProperties: admissionProps(req.ResourceType, state.get()),
+				}}, nil
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		// Create the producer, then the consumer referencing it cross-stack.
+		_, err = m.ApplyForma(admissionCrossStackProducerForma("blue"), defaultApplyConfig(), "test", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		_, err = m.ApplyForma(admissionCrossStackConsumerForma(), defaultApplyConfig(), "test", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		// Patch the producer's referenced field in its own stack.
+		patchForma := admissionCrossStackProducerForma("green")
+		patchForma.Resources[0].NativeID = "producer"
+		_, err = m.ApplyForma(
+			patchForma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch, Simulate: false},
+			"test", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		// Reconcile the consumer's stack only. Must be admitted without force.
+		_, err = m.ApplyForma(admissionCrossStackConsumerForma(), defaultApplyConfig(), "test", "", "")
+		var rejected apimodel.FormaReconcileRejectedError
+		if errors.As(err, &rejected) {
+			t.Fatalf("consumer-stack reconcile was rejected for a producer-stack modification: %+v", rejected.ModifiedStacks)
+		}
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		require.NotEmpty(t, cmds)
+		require.Equal(t, forma_command.CommandStateSuccess, cmds[0].State, "the consumer-stack reconcile must succeed")
+		require.Equal(t, "green", consumer.get(), "the consumer must converge to the cross-stack referenced value")
+	})
+}


### PR DESCRIPTION
## Summary

Four defects found by the cross-model review of the reference-convergence family, plus the fixes from this branch's own adversarial review passes:

- **A schema hint on a nested field now protects references to its container.** A hint marking `Config.Password` opaque previously did not refuse plan-time materialization of a reference to `Config`, so the whole container — secret included — could resolve as plaintext on the value's first appearance, and a chain hop's JSON extraction could isolate the secret. Both opacity oracles (the resolver's and its generator mirror) now treat any hint equal to or nested under the referenced path as opaque; siblings still resolve.
- **The effective desired document applies the same no-baseline writeOnly+createOnly strip as patch generation**, through a shared, array-aware baseline predicate. Previously an import-shaped source (writeOnly+createOnly field with no stored baseline) declared with a value had that value stripped from its own patch but still advertised to reference consumers, which were planned as a destructive delete+create chasing a value the producer never writes. Now nothing is planned and nothing is destroyed.
- **Stored baselines nested under array elements are visible to the strip probe.** The probe used a dotted path that never projects through arrays, so a genuine immutable change under an array was silently stripped and surfaced only as a bare member-removal op. The probe now uses the same array-projecting traversal as the strip helper, so the change survives into the diff.
- **CreateOnly classification is array-aware, split by member identity.** Keyed collections (EntitySet with an indexField) pair members and surface a changed createOnly subfield at its own path; index-transparent matching classifies it as a createOnly diff and plans the replacement, while mutable siblings changed in the same edit stay in the mutable patch. Unkeyed collections have no member identity — a changed immutable value is byte-identical to one member leaving and another arriving — so member changes deliberately stay mutable member swaps carrying the new value (the provider-appropriate remedy, e.g. detach/re-attach), never a whole-resource replacement. Grounded in a scan of the shipped plugin schemas: the unkeyed shape is real (17 collections across gcp and azure, e.g. `compute.Instance.disks` with createOnly `deviceName`), and escalating it would have turned a disk re-attach into a VM replacement.
- **A terminal resolve failure's reason now reaches the persisted command.** The reason was recorded only on the updater's in-memory copy; the completion message and the `resource_updates` table had no carrier, so operators saw a blank error. New nullable `failure_reason` column (sqlite/postgres/mssql migrations; aurora shares the postgres migrations) wired through every dialect's insert and load, the completion message, and the persister. The copy is unconditional, so a successful retry clears a stale persisted reason.

Also pins the reconcile admission behavior after a patch on a referenced field (same-stack and cross-stack): admitted without force, consumer converges to the patched value.

## Verification

Every fix landed test-first with its RED verified against merged main, and each non-trivial link was reversal-checked (fix stashed, test fails). Full `-tags=unit` tree green locally except `internal/schema/pkl`, which fails identically on clean main in this environment. Five adversarial review passes ran on this branch; every finding is dispositioned, with the unkeyed-collection classification settled by maintainer ruling against the shipped plugin schemas.

## Residuals

- Aurora still omits `is_cascade`/`cascade_source` from its resource-update SQL (pre-existing parity gap, untouched); `failure_reason` is wired on aurora.
- The sqlite migration's no-op down follows the existing sqlite migration convention in this repo.