### PR TITLE
fix(query): drop the dead managed key from the command grammar

### DIFF
--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -53,7 +53,6 @@ type StatusQuery struct {
 	Command     *QueryItem[string]
 	Status      *QueryItem[string]
 	Stack       *QueryItem[string]
-	Managed     *QueryItem[bool]
 	Subject     *QueryItem[string]
 	SubjectName *QueryItem[string]
 	// Source restricts results to a FormaCommand source (forma_command.Source,

--- a/internal/metastructure/querier/bluge_querier.go
+++ b/internal/metastructure/querier/bluge_querier.go
@@ -165,8 +165,6 @@ func (b *BlugeQuerier) assignTermToStatusQuery(field string, value any, sq *data
 		sq.Status = appendStringValue(sq.Status, value.(string), constraint)
 	case "stack":
 		sq.Stack = appendStringValue(sq.Stack, value.(string), constraint)
-	case "managed":
-		sq.Managed = queryItem(value.(bool), constraint)
 	default:
 		return apimodel.InvalidQueryError{Reason: fmt.Sprintf("unknown field for StatusQuery: '%s'", field)}
 	}

--- a/internal/metastructure/querier/bluge_querier_test.go
+++ b/internal/metastructure/querier/bluge_querier_test.go
@@ -303,6 +303,20 @@ func TestBlugeQuerier_statusQuery_ComplexStackWithOtherFields(t *testing.T) {
 	assert.Equal(t, expectedStatusQuery, statusQuery)
 }
 
+func TestBlugeQuerier_statusQuery_UnknownFieldIsInvalidQuery(t *testing.T) {
+	querier := &BlugeQuerier{}
+
+	queryString := "managed:true"
+
+	statusQuery, err := querier.statusQuery(queryString, Caller{ClientID: "test-client-id"}, 0)
+	assert.Nil(t, statusQuery)
+	require.Error(t, err)
+
+	var invalidQueryErr apimodel.InvalidQueryError
+	assert.ErrorAs(t, err, &invalidQueryErr)
+	assert.Contains(t, invalidQueryErr.Reason, "unknown field for StatusQuery: 'managed'")
+}
+
 func TestBlugeQuerier_resourceQuery_ManagedResources(t *testing.T) {
 	querier := &BlugeQuerier{}
 


### PR DESCRIPTION
## Summary

- The command branch of the query grammar accepted a `managed:` key it could never serve: it did a bare `bool` type assertion on a value the parser always delivers as a string, so any command query using it (`command list`, `cancel`, and the other `--query` surfaces on the command path) panicked instead of erroring. Even parsed, it would have done nothing: no datastore backend renders `StatusQuery.Managed`.
- "Managed" is a resource concept; the key leaked into the command grammar from the resource grammar. This removes the case (the key now falls through to the same typed unknown-field error every other bogus key gets) and deletes the never-rendered `StatusQuery.Managed` field, with a regression test pinning error-not-panic.
- The resource grammar's `managed:` (legitimate, `strconv.ParseBool`-based) and the destroy grammar's explicit rejection are untouched.