### PR TITLE
feat(metastructure,datastore,cli): surface suppressed out-of-band drift on reconcile submissions

### DIFF
--- a/internal/cli/apply/apply.go
+++ b/internal/cli/apply/apply.go
@@ -228,6 +228,9 @@ func runApplyInteractive(a *app.App, opts *ApplyOptions) error {
 		fmt.Printf("%s\n\n%s\n\n",
 			lipgloss.NewStyle().Foreground(th.Palette.Done).Render("No changes needed:"),
 			lipgloss.NewStyle().Foreground(th.Palette.TextSubtle).Render("The specified forma resources are up to date."))
+		if block := simview.RenderSuppressedDrift(th, res.Simulation.SuppressedDrift, legacyWidth(os.Stdout)); block != "" {
+			fmt.Print(block + "\n")
+		}
 		return nil
 	}
 
@@ -297,6 +300,9 @@ func runApplyLegacy(a *app.App, opts *ApplyOptions) error {
 		fmt.Printf("%s\n\n%s\n\n",
 			lipgloss.NewStyle().Foreground(a.Theme().Palette.Done).Render("No changes needed:"),
 			lipgloss.NewStyle().Foreground(a.Theme().Palette.TextSubtle).Render("The specified forma resources are up to date."))
+		if block := simview.RenderSuppressedDrift(a.Theme(), res.Simulation.SuppressedDrift, legacyWidth(os.Stdout)); block != "" {
+			fmt.Print(block + "\n")
+		}
 		return nil
 	}
 

--- a/internal/cli/tui/simview/print.go
+++ b/internal/cli/tui/simview/print.go
@@ -57,5 +57,80 @@ func RenderSimulationPlain(th *theme.Theme, sim *apimodel.Simulation, width int)
 			}
 		}
 	}
+
+	if len(sim.SuppressedDrift) > 0 {
+		sb.WriteString("\n")
+		sb.WriteString(RenderSuppressedDrift(th, sim.SuppressedDrift, width))
+	}
+	return sb.String()
+}
+
+// suppressedDriftLines renders one text line per suppressed-drift note plus a
+// trailing explainer chosen by disposition. Values are compacted and
+// truncated for display; an opaque note names the path and the fact of
+// movement only.
+func suppressedDriftLines(notes []apimodel.SuppressedDriftNote) []string {
+	compact := func(raw []byte) string {
+		s := string(raw)
+		s = strings.Join(strings.Fields(s), " ")
+		if len(s) > 48 {
+			s = s[:45] + "..."
+		}
+		return s
+	}
+
+	var lines []string
+	remaining := false
+	for _, n := range notes {
+		if n.Disposition == "remaining" {
+			remaining = true
+		}
+		if n.Opaque {
+			lines = append(lines, fmt.Sprintf("%s/%s %s: changed (opaque value)", n.Stack, n.Label, n.Path))
+			continue
+		}
+		from := "unset"
+		if len(n.From) > 0 {
+			from = compact(n.From)
+		}
+		to := "unset"
+		if len(n.To) > 0 {
+			to = compact(n.To)
+		}
+		lines = append(lines, fmt.Sprintf("%s/%s %s: %s -> %s", n.Stack, n.Label, n.Path, from, to))
+	}
+	if remaining {
+		lines = append(lines, "This apply will not modify them and nothing else changes, so they stay pending in the drift list.")
+	} else {
+		lines = append(lines, "This apply will not modify them; completing it absorbs them into the baseline.")
+	}
+	lines = append(lines, "To manage such a field, declare it in the forma.")
+	return lines
+}
+
+// RenderSuppressedDrift renders the suppressed-drift notes as a styled,
+// non-interactive block: out-of-band changes on provider-defaulted fields
+// the forma does not declare, which the plan cannot address.
+func RenderSuppressedDrift(th *theme.Theme, notes []apimodel.SuppressedDriftNote, width int) string {
+	if len(notes) == 0 {
+		return ""
+	}
+	p := th.Palette
+	var sb strings.Builder
+	sb.WriteString("  ")
+	sb.WriteString(lipgloss.NewStyle().Foreground(p.Warning).Render("Out-of-band changes on provider-defaulted fields this forma does not declare:"))
+	sb.WriteString("\n")
+	lines := suppressedDriftLines(notes)
+	bodySt := lipgloss.NewStyle().Foreground(p.TextPrimary)
+	subtleSt := lipgloss.NewStyle().Foreground(p.TextSubtle)
+	for i, line := range lines {
+		st := bodySt
+		if i >= len(notes) {
+			st = subtleSt
+		}
+		sb.WriteString("    ")
+		sb.WriteString(st.Render(line))
+		sb.WriteString("\n")
+	}
 	return sb.String()
 }

--- a/internal/cli/tui/simview/print_test.go
+++ b/internal/cli/tui/simview/print_test.go
@@ -107,3 +107,59 @@ func TestRenderSimulationPlain_Content(t *testing.T) {
 	// Non-empty output
 	assert.Greater(t, len(strings.TrimSpace(stripped)), 0, "output must be non-empty")
 }
+
+func TestRenderSuppressedDrift_ListsMovementAndDisposition(t *testing.T) {
+	th := theme.New("formae")
+	notes := []apimodel.SuppressedDriftNote{
+		{
+			Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key",
+			Path: "EnableKeyRotation", From: []byte(`false`), To: []byte(`true`),
+			Disposition: "absorbed",
+		},
+		{
+			Stack: "prod", Type: "X::Y::Z", Label: "vault",
+			Path: "MasterSecret", Opaque: true,
+			Disposition: "absorbed",
+		},
+	}
+
+	out := plain(RenderSuppressedDrift(th, notes, 100))
+
+	assert.Contains(t, out, "signing-key")
+	assert.Contains(t, out, "EnableKeyRotation")
+	assert.Contains(t, out, "false")
+	assert.Contains(t, out, "true")
+	assert.Contains(t, out, "vault")
+	assert.Contains(t, out, "MasterSecret")
+	assert.Contains(t, out, "opaque", "an opaque note names the fact, not the values")
+	assert.NotContains(t, out, "$hashed")
+	assert.Contains(t, strings.ToLower(out), "will not modify")
+	assert.Contains(t, strings.ToLower(out), "absorb")
+}
+
+func TestRenderSuppressedDrift_RemainingDisposition_SaysPending(t *testing.T) {
+	th := theme.New("formae")
+	notes := []apimodel.SuppressedDriftNote{{
+		Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key",
+		Path: "EnableKeyRotation", From: []byte(`false`), To: []byte(`true`),
+		Disposition: "remaining",
+	}}
+
+	out := strings.ToLower(plain(RenderSuppressedDrift(th, notes, 100)))
+	assert.Contains(t, out, "pending")
+	assert.NotContains(t, out, "absorbs")
+}
+
+func TestRenderSimulationPlain_IncludesSuppressedDrift(t *testing.T) {
+	th := theme.New("formae")
+	sim := makePlainFixtureSim()
+	sim.SuppressedDrift = []apimodel.SuppressedDriftNote{{
+		Stack: "staging", Type: "AWS::KMS::Key", Label: "signing-key",
+		Path: "EnableKeyRotation", From: []byte(`false`), To: []byte(`true`),
+		Disposition: "absorbed",
+	}}
+
+	out := plain(RenderSimulationPlain(th, sim, 100))
+	assert.Contains(t, out, "EnableKeyRotation")
+	assert.Contains(t, out, "signing-key")
+}

--- a/internal/cli/tui/simview/render.go
+++ b/internal/cli/tui/simview/render.go
@@ -50,6 +50,31 @@ func (m Model) renderBody() (string, int) {
 	// lookup per row.
 	navIdx := 0
 
+	// Suppressed-drift banner: out-of-band changes on provider-defaulted
+	// fields the forma does not declare. The plan cannot address them; the
+	// user sees them before deciding.
+	if len(m.cmd.SuppressedDrift) > 0 {
+		innerW := m.width - 8
+		if innerW < 20 {
+			innerW = 20
+		}
+		var panelLines []string
+		for _, line := range suppressedDriftLines(m.cmd.SuppressedDrift) {
+			panelLines = append(panelLines, strings.Split(wrapText(line, innerW), "\n")...)
+		}
+		panelW := m.width - 4
+		if panelW < 24 {
+			panelW = 24
+		}
+		panel := components.Panel(m.th, m.th.Palette.Warning, "Out-of-band changes not addressed by this apply", panelLines, panelW)
+		body.WriteString("\n")
+		lineCount++
+		for _, pl := range strings.Split(panel, "\n") {
+			body.WriteString("  " + pl + "\n")
+			lineCount++
+		}
+	}
+
 	// Destroy cascade warning banner: shown at the top of the viewport when
 	// KindDestroy and any resource row has cascade=true.
 	if m.opts.Kind == KindDestroy {

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -753,10 +753,12 @@ func (d *DatastoreAuroraDataAPI) StoreFormaCommand(fa *forma_command.FormaComman
 	query := fmt.Sprintf(`
 	INSERT INTO %s (command_id, timestamp, command, state, agent_version, client_id, agent_id,
 		description_text, description_confirm, config_mode, config_force, config_simulate,
-		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name)
+		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name,
+		suppressed_drift_notes)
 	VALUES (:command_id, :timestamp::timestamp, :command, :state, :agent_version, :client_id, :agent_id,
 		:description_text, :description_confirm, :config_mode, :config_force, :config_simulate,
-		:target_updates, :stack_updates, :policy_updates, :modified_ts::timestamp, :source, :subject, :subject_name)
+		:target_updates, :stack_updates, :policy_updates, :modified_ts::timestamp, :source, :subject, :subject_name,
+		:suppressed_drift_notes)
 	ON CONFLICT (command_id) DO UPDATE
 	SET timestamp = EXCLUDED.timestamp,
 	command = EXCLUDED.command,
@@ -775,7 +777,8 @@ func (d *DatastoreAuroraDataAPI) StoreFormaCommand(fa *forma_command.FormaComman
 	modified_ts = EXCLUDED.modified_ts,
 	source = EXCLUDED.source,
 	subject = EXCLUDED.subject,
-	subject_name = EXCLUDED.subject_name
+	subject_name = EXCLUDED.subject_name,
+	suppressed_drift_notes = EXCLUDED.suppressed_drift_notes
 	`, datastore.CommandsTable)
 
 	params := []types.SqlParameter{
@@ -798,6 +801,15 @@ func (d *DatastoreAuroraDataAPI) StoreFormaCommand(fa *forma_command.FormaComman
 		{Name: aws.String("source"), Value: &types.FieldMemberStringValue{Value: string(fa.Source)}},
 		{Name: aws.String("subject"), Value: &types.FieldMemberStringValue{Value: fa.Subject}},
 		{Name: aws.String("subject_name"), Value: &types.FieldMemberStringValue{Value: fa.SubjectName}},
+	}
+	if len(fa.SuppressedDriftNotes) > 0 {
+		notesJSON, merr := json.Marshal(fa.SuppressedDriftNotes)
+		if merr != nil {
+			return fmt.Errorf("failed to marshal suppressed drift notes: %w", merr)
+		}
+		params = append(params, types.SqlParameter{Name: aws.String("suppressed_drift_notes"), Value: &types.FieldMemberStringValue{Value: string(notesJSON)}})
+	} else {
+		params = append(params, types.SqlParameter{Name: aws.String("suppressed_drift_notes"), Value: &types.FieldMemberIsNull{Value: true}})
 	}
 
 	_, err = d.executeStatement(ctx, query, params)
@@ -823,7 +835,8 @@ func (d *DatastoreAuroraDataAPI) LoadFormaCommands() ([]*forma_command.FormaComm
 	query := `
 	SELECT command_id, timestamp, command, state, client_id,
 		description_text, description_confirm, config_mode, config_force, config_simulate,
-		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name
+		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name,
+		suppressed_drift_notes
 	FROM forma_commands
 	ORDER BY timestamp DESC
 	`
@@ -859,7 +872,8 @@ func (d *DatastoreAuroraDataAPI) LoadIncompleteFormaCommands() ([]*forma_command
 	query := `
 	SELECT command_id, timestamp, command, state, client_id,
 		description_text, description_confirm, config_mode, config_force, config_simulate,
-		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name
+		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name,
+		suppressed_drift_notes
 	FROM forma_commands
 	WHERE command != :sync_command AND state IN (:state_not_started, :state_in_progress)
 	ORDER BY timestamp DESC
@@ -918,6 +932,10 @@ func (d *DatastoreAuroraDataAPI) parseFormaCommandRecord(record []types.Field) (
 	source, _ := getStringField(record[14])
 	subject, _ := getStringField(record[15])
 	subjectName, _ := getStringField(record[16])
+	suppressedDriftNotesJSON := ""
+	if len(record) > 17 {
+		suppressedDriftNotesJSON, _ = getStringField(record[17])
+	}
 
 	var targetUpdates []target_update.TargetUpdate
 	if targetUpdatesJSON != "" {
@@ -932,6 +950,11 @@ func (d *DatastoreAuroraDataAPI) parseFormaCommandRecord(record []types.Field) (
 	var policyUpdates []policy_update.PolicyUpdate
 	if policyUpdatesJSON != "" {
 		_ = json.Unmarshal([]byte(policyUpdatesJSON), &policyUpdates)
+	}
+
+	var suppressedDriftNotes []forma_command.SuppressedDriftNote
+	if suppressedDriftNotesJSON != "" {
+		_ = json.Unmarshal([]byte(suppressedDriftNotesJSON), &suppressedDriftNotes)
 	}
 
 	return &forma_command.FormaCommand{
@@ -956,6 +979,8 @@ func (d *DatastoreAuroraDataAPI) parseFormaCommandRecord(record []types.Field) (
 		Source:        forma_command.Source(source),
 		Subject:       subject,
 		SubjectName:   subjectName,
+
+		SuppressedDriftNotes: suppressedDriftNotes,
 	}, nil
 }
 
@@ -984,7 +1009,8 @@ func (d *DatastoreAuroraDataAPI) GetFormaCommandByCommandID(commandID string) (*
 	query := `
 	SELECT command_id, timestamp, command, state, client_id,
 		description_text, description_confirm, config_mode, config_force, config_simulate,
-		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name
+		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name,
+		suppressed_drift_notes
 	FROM forma_commands
 	WHERE command_id = :command_id
 	`
@@ -1022,7 +1048,8 @@ func (d *DatastoreAuroraDataAPI) GetMostRecentFormaCommandByClientID(clientID st
 	query := `
 	SELECT command_id, timestamp, command, state, client_id,
 		description_text, description_confirm, config_mode, config_force, config_simulate,
-		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name
+		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name,
+		suppressed_drift_notes
 	FROM forma_commands
 	WHERE client_id = :client_id AND source = 'user'
 	ORDER BY timestamp DESC
@@ -1215,7 +1242,8 @@ func (d *DatastoreAuroraDataAPI) QueryFormaCommands(statusQuery *datastore.Statu
 	queryStr := `
 	SELECT command_id, timestamp, command, state, client_id,
 		description_text, description_confirm, config_mode, config_force, config_simulate,
-		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name
+		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name,
+		suppressed_drift_notes
 	FROM forma_commands
 	WHERE 1=1
 	`

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -110,6 +110,7 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunStoreAndLoadFormaCommandOptionalFields(t, newDS)
 	RunStoreAndLoadFormaCommandEmptySubject(t, newDS)
 	RunFormaCommandSubjectNullRoundTrip(t, newDS)
+	RunFormaCommandSuppressedDriftNotesRoundTrip(t, newDS)
 	RunStoreFormaCommandSyncSkipsResourceUpdates(t, newDS)
 	RunCommandSourceRoundTrip(t, newDS)
 	RunGetMostRecentFormaCommandByClientID(t, newDS)

--- a/internal/datastore/dstest/suite_forma_commands.go
+++ b/internal/datastore/dstest/suite_forma_commands.go
@@ -1550,3 +1550,62 @@ func RunResourceUpdateProvenanceRoundTrip(t *testing.T, newDS func(t *testing.T)
 		}
 	})
 }
+
+// RunFormaCommandSuppressedDriftNotesRoundTrip verifies that a command's
+// suppressed-drift notes survive store and reload with values, opacity, and
+// disposition intact, and that a command without notes reads back empty.
+func RunFormaCommandSuppressedDriftNotesRoundTrip(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("StoreAndLoad_FormaCommand_SuppressedDriftNotes", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		cmd := &forma_command.FormaCommand{
+			ID:      util.NewID(),
+			Command: pkgmodel.CommandApply,
+			State:   forma_command.CommandStatePending,
+			Config:  config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
+			SuppressedDriftNotes: []forma_command.SuppressedDriftNote{
+				{
+					Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key",
+					Path:        "EnableKeyRotation",
+					From:        json.RawMessage(`false`),
+					To:          json.RawMessage(`true`),
+					Disposition: forma_command.SuppressedDriftAbsorbed,
+				},
+				{
+					Stack: "prod", Type: "X::Y::Z", Label: "r",
+					Path:        "MasterSecret",
+					Opaque:      true,
+					Disposition: forma_command.SuppressedDriftAbsorbed,
+				},
+			},
+		}
+
+		err := ds.StoreFormaCommand(cmd, cmd.ID)
+		assert.NoError(t, err)
+
+		loaded, err := ds.GetFormaCommandByCommandID(cmd.ID)
+		assert.NoError(t, err)
+		if assert.Len(t, loaded.SuppressedDriftNotes, 2) {
+			assert.Equal(t, "EnableKeyRotation", loaded.SuppressedDriftNotes[0].Path)
+			assert.JSONEq(t, `false`, string(loaded.SuppressedDriftNotes[0].From))
+			assert.JSONEq(t, `true`, string(loaded.SuppressedDriftNotes[0].To))
+			assert.Equal(t, forma_command.SuppressedDriftAbsorbed, loaded.SuppressedDriftNotes[0].Disposition)
+			assert.True(t, loaded.SuppressedDriftNotes[1].Opaque)
+			assert.Nil(t, loaded.SuppressedDriftNotes[1].From)
+			assert.Nil(t, loaded.SuppressedDriftNotes[1].To)
+		}
+
+		bare := &forma_command.FormaCommand{
+			ID:      util.NewID(),
+			Command: pkgmodel.CommandApply,
+			State:   forma_command.CommandStatePending,
+		}
+		err = ds.StoreFormaCommand(bare, bare.ID)
+		assert.NoError(t, err)
+		loaded, err = ds.GetFormaCommandByCommandID(bare.ID)
+		assert.NoError(t, err)
+		assert.Empty(t, loaded.SuppressedDriftNotes)
+	})
+}

--- a/internal/datastore/migrations_mssql/00023_forma_command_suppressed_drift_notes.sql
+++ b/internal/datastore/migrations_mssql/00023_forma_command_suppressed_drift_notes.sql
@@ -1,0 +1,13 @@
+-- © 2026 Platform Engineering Labs Inc.
+--
+-- SPDX-License-Identifier: FSL-1.1-ALv2
+
+-- +goose Up
+-- Persist the suppressed-drift notes computed at submission: the record of
+-- out-of-band movement on provider-default fields the command's plan could
+-- not see, whose completion advances the drift window past that movement.
+-- Nullable: commands without suppressed movement store nothing.
+ALTER TABLE forma_commands ADD suppressed_drift_notes nvarchar(max) NULL;
+
+-- +goose Down
+ALTER TABLE forma_commands DROP COLUMN suppressed_drift_notes;

--- a/internal/datastore/migrations_postgres/00024_forma_command_suppressed_drift_notes.sql
+++ b/internal/datastore/migrations_postgres/00024_forma_command_suppressed_drift_notes.sql
@@ -1,0 +1,13 @@
+-- © 2026 Platform Engineering Labs Inc.
+--
+-- SPDX-License-Identifier: FSL-1.1-ALv2
+
+-- +goose Up
+-- Persist the suppressed-drift notes computed at submission: the record of
+-- out-of-band movement on provider-default fields the command's plan could
+-- not see, whose completion advances the drift window past that movement.
+-- Nullable: commands without suppressed movement store nothing.
+ALTER TABLE forma_commands ADD COLUMN suppressed_drift_notes TEXT;
+
+-- +goose Down
+ALTER TABLE forma_commands DROP COLUMN suppressed_drift_notes;

--- a/internal/datastore/migrations_sqlite/00023_forma_command_suppressed_drift_notes.sql
+++ b/internal/datastore/migrations_sqlite/00023_forma_command_suppressed_drift_notes.sql
@@ -1,0 +1,15 @@
+-- © 2026 Platform Engineering Labs Inc.
+--
+-- SPDX-License-Identifier: FSL-1.1-ALv2
+
+-- +goose Up
+-- Persist the suppressed-drift notes computed at submission: the record of
+-- out-of-band movement on provider-default fields the command's plan could
+-- not see, whose completion advances the drift window past that movement.
+-- Nullable: commands without suppressed movement store nothing.
+ALTER TABLE forma_commands ADD COLUMN suppressed_drift_notes TEXT;
+
+-- +goose Down
+-- SQLite doesn't support DROP COLUMN before 3.35.0; leaving the column in
+-- place on rollback is safe (the application ignores extra columns).
+SELECT 1;

--- a/internal/datastore/mssql/mssql_datastore.go
+++ b/internal/datastore/mssql/mssql_datastore.go
@@ -220,7 +220,7 @@ const formaCommandWithResourceUpdatesQueryBase = `
 SELECT
 	fc.command_id, fc.timestamp, fc.command, fc.state, fc.client_id,
 	fc.description_text, fc.description_confirm, fc.config_mode, fc.config_force, fc.config_simulate,
-	fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name,
+	fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name, fc.suppressed_drift_notes,
 	ru.ksuid, ru.operation, ru.state, ru.start_ts, ru.modified_ts,
 	ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 	ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
@@ -246,6 +246,7 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 	var fcModifiedTs *time.Time
 	var fcSource *string
 	var fcSubject, fcSubjectName *string
+	var fcSuppressedDriftNotesJSON []byte
 
 	var ruKsuid, ruOperation, ruState *string
 	var ruStartTs, ruModifiedTs *time.Time
@@ -263,6 +264,7 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 		&commandID, &fcTimestamp, &fcCommand, &fcState, &fcClientID,
 		&descriptionText, &descriptionConfirm, &configMode, &configForce, &configSimulate,
 		&targetUpdatesJSON, &stackUpdatesJSON, &policyUpdatesJSON, &fcModifiedTs, &fcSource, &fcSubject, &fcSubjectName,
+		&fcSuppressedDriftNotesJSON,
 		&ruKsuid, &ruOperation, &ruState, &ruStartTs, &ruModifiedTs,
 		&ruRetries, &ruRemaining, &ruVersion, &ruStackLabel, &ruGroupID, &ruSource,
 		&resourceJSON, &resourceTargetJSON, &existingResourceJSON, &existingTargetJSON,
@@ -317,6 +319,12 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 	if len(policyUpdatesJSON) > 0 {
 		if err := json.Unmarshal(policyUpdatesJSON, &cmd.PolicyUpdates); err != nil {
 			return nil, nil, fmt.Errorf("failed to unmarshal policy updates: %w", err)
+		}
+	}
+
+	if len(fcSuppressedDriftNotesJSON) > 0 {
+		if err := json.Unmarshal(fcSuppressedDriftNotesJSON, &cmd.SuppressedDriftNotes); err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal suppressed drift notes: %w", err)
 		}
 	}
 
@@ -491,12 +499,21 @@ func (d *DatastoreMSSQL) StoreFormaCommand(fa *forma_command.FormaCommand, comma
 		return fmt.Errorf("failed to marshal policy updates: %w", err)
 	}
 
+	var suppressedDriftNotesJSON any
+	if len(fa.SuppressedDriftNotes) > 0 {
+		notesJSON, merr := json.Marshal(fa.SuppressedDriftNotes)
+		if merr != nil {
+			return fmt.Errorf("failed to marshal suppressed drift notes: %w", merr)
+		}
+		suppressedDriftNotesJSON = string(notesJSON)
+	}
+
 	args := []any{
 		commandID, fa.StartTs.UTC(), string(fa.Command), string(fa.State), formae.Version,
 		fa.ClientID, d.agentID, fa.Description.Text, fa.Description.Confirm,
 		string(fa.Config.Mode), fa.Config.Force, fa.Config.Simulate,
 		string(targetUpdatesJSON), string(stackUpdatesJSON), string(policyUpdatesJSON), fa.ModifiedTs.UTC(),
-		string(fa.Source), fa.Subject, fa.SubjectName,
+		string(fa.Source), fa.Subject, fa.SubjectName, suppressedDriftNotesJSON,
 	}
 
 	tx, err := d.conn.BeginTx(ctx, nil)
@@ -517,7 +534,7 @@ func (d *DatastoreMSSQL) StoreFormaCommand(fa *forma_command.FormaCommand, comma
 		description_confirm = @p9, config_mode = @p10, config_force = @p11,
 		config_simulate = @p12, target_updates = @p13, stack_updates = @p14,
 		policy_updates = @p15, modified_ts = @p16, source = @p17,
-		subject = @p18, subject_name = @p19
+		subject = @p18, subject_name = @p19, suppressed_drift_notes = @p20
 	WHERE command_id = @p1`, datastore.CommandsTable)
 
 	res, err := tx.ExecContext(ctx, updateQuery, args...)
@@ -534,8 +551,9 @@ func (d *DatastoreMSSQL) StoreFormaCommand(fa *forma_command.FormaCommand, comma
 		INSERT INTO %[1]s
 			(command_id, timestamp, command, state, agent_version, client_id, agent_id,
 			 description_text, description_confirm, config_mode, config_force, config_simulate,
-			 target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name)
-		VALUES (@p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16, @p17, @p18, @p19)`,
+			 target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name,
+			 suppressed_drift_notes)
+		VALUES (@p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16, @p17, @p18, @p19, @p20)`,
 			datastore.CommandsTable)
 		if _, err := tx.ExecContext(ctx, insertQuery, args...); err != nil {
 			slog.Error("failed to store FormaCommand (insert)", "error", err)

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -207,12 +207,21 @@ func (d DatastorePostgres) StoreFormaCommand(fa *forma_command.FormaCommand, com
 		return fmt.Errorf("failed to marshal policy updates: %w", err)
 	}
 
+	var suppressedDriftNotesJSON []byte
+	if len(fa.SuppressedDriftNotes) > 0 {
+		suppressedDriftNotesJSON, err = json.Marshal(fa.SuppressedDriftNotes)
+		if err != nil {
+			return fmt.Errorf("failed to marshal suppressed drift notes: %w", err)
+		}
+	}
+
 	// We no longer store the forma JSON - Description and Config are stored as normalized columns
 	query := fmt.Sprintf(`
 	INSERT INTO %s (command_id, timestamp, command, state, agent_version, client_id, agent_id,
 		description_text, description_confirm, config_mode, config_force, config_simulate,
-		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+		target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name,
+		suppressed_drift_notes)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
 	ON CONFLICT (command_id) DO UPDATE
 	SET timestamp = EXCLUDED.timestamp,
 	command = EXCLUDED.command,
@@ -231,12 +240,14 @@ func (d DatastorePostgres) StoreFormaCommand(fa *forma_command.FormaCommand, com
 	modified_ts = EXCLUDED.modified_ts,
 	source = EXCLUDED.source,
 	subject = EXCLUDED.subject,
-	subject_name = EXCLUDED.subject_name
+	subject_name = EXCLUDED.subject_name,
+	suppressed_drift_notes = EXCLUDED.suppressed_drift_notes
 	`, datastore.CommandsTable)
 
 	_, err = d.pool.Exec(ctx, query, commandID, fa.StartTs.UTC(), fa.Command, fa.State, formae.Version, fa.ClientID, d.agentID,
 		fa.Description.Text, fa.Description.Confirm, fa.Config.Mode, fa.Config.Force, fa.Config.Simulate,
-		targetUpdatesJSON, stackUpdatesJSON, policyUpdatesJSON, fa.ModifiedTs.UTC(), string(fa.Source), fa.Subject, fa.SubjectName)
+		targetUpdatesJSON, stackUpdatesJSON, policyUpdatesJSON, fa.ModifiedTs.UTC(), string(fa.Source), fa.Subject, fa.SubjectName,
+		suppressedDriftNotesJSON)
 	if err != nil {
 		slog.Error("failed to store FormaCommand", "query", query, "error", err)
 		return err
@@ -260,7 +271,7 @@ const formaCommandWithResourceUpdatesQueryBasePostgres = `
 SELECT
 	fc.command_id, fc.timestamp, fc.command, fc.state, fc.client_id,
 	fc.description_text, fc.description_confirm, fc.config_mode, fc.config_force, fc.config_simulate,
-	fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name,
+	fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name, fc.suppressed_drift_notes,
 	ru.ksuid, ru.operation, ru.state, ru.start_ts, ru.modified_ts,
 	ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 	ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
@@ -289,6 +300,7 @@ func scanJoinedRowPostgres(rows pgx.Rows) (*forma_command.FormaCommand, *resourc
 	var fcModifiedTs *time.Time
 	var fcSource *string
 	var fcSubject, fcSubjectName *string
+	var fcSuppressedDriftNotesJSON []byte
 
 	// ResourceUpdate fields (all nullable due to LEFT JOIN)
 	var ruKsuid, ruOperation, ruState *string
@@ -308,6 +320,7 @@ func scanJoinedRowPostgres(rows pgx.Rows) (*forma_command.FormaCommand, *resourc
 		&commandID, &fcTimestamp, &fcCommand, &fcState, &fcClientID,
 		&descriptionText, &descriptionConfirm, &configMode, &configForce, &configSimulate,
 		&targetUpdatesJSON, &stackUpdatesJSON, &policyUpdatesJSON, &fcModifiedTs, &fcSource, &fcSubject, &fcSubjectName,
+		&fcSuppressedDriftNotesJSON,
 		// ResourceUpdate columns
 		&ruKsuid, &ruOperation, &ruState, &ruStartTs, &ruModifiedTs,
 		&ruRetries, &ruRemaining, &ruVersion, &ruStackLabel, &ruGroupID, &ruSource,
@@ -371,6 +384,12 @@ func scanJoinedRowPostgres(rows pgx.Rows) (*forma_command.FormaCommand, *resourc
 	if len(policyUpdatesJSON) > 0 {
 		if err := json.Unmarshal(policyUpdatesJSON, &cmd.PolicyUpdates); err != nil {
 			return nil, nil, fmt.Errorf("failed to unmarshal policy updates: %w", err)
+		}
+	}
+
+	if len(fcSuppressedDriftNotesJSON) > 0 {
+		if err := json.Unmarshal(fcSuppressedDriftNotesJSON, &cmd.SuppressedDriftNotes); err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal suppressed drift notes: %w", err)
 		}
 	}
 
@@ -720,7 +739,7 @@ func (d DatastorePostgres) QueryFormaCommands(query *datastore.StatusQuery) ([]*
 		SELECT
 			fc.command_id, fc.timestamp, fc.command, fc.state, fc.client_id,
 			fc.description_text, fc.description_confirm, fc.config_mode, fc.config_force, fc.config_simulate,
-			fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name,
+			fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name, fc.suppressed_drift_notes,
 			ru.ksuid, ru.operation, ru.state, ru.start_ts, ru.modified_ts,
 			ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 			ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -177,15 +177,26 @@ func (d DatastoreSQLite) StoreFormaCommand(fa *forma_command.FormaCommand, comma
 		configSimulate = 1
 	}
 
+	var suppressedDriftNotesJSON any
+	if len(fa.SuppressedDriftNotes) > 0 {
+		notesJSON, merr := json.Marshal(fa.SuppressedDriftNotes)
+		if merr != nil {
+			return fmt.Errorf("failed to marshal suppressed drift notes: %w", merr)
+		}
+		suppressedDriftNotesJSON = notesJSON
+	}
+
 	query := fmt.Sprintf(`INSERT OR REPLACE INTO %s
 		(command_id, timestamp, command, state, agent_version, client_id, agent_id,
 		 description_text, description_confirm, config_mode, config_force, config_simulate,
-		 target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, datastore.CommandsTable)
+		 target_updates, stack_updates, policy_updates, modified_ts, source, subject, subject_name,
+		 suppressed_drift_notes)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, datastore.CommandsTable)
 
 	_, err = d.conn.Exec(query, commandID, startTsUTC, fa.Command, fa.State, formae.Version, fa.ClientID, d.agentID,
 		fa.Description.Text, descriptionConfirm, fa.Config.Mode, configForce, configSimulate,
-		targetUpdatesJSON, stackUpdatesJSON, policyUpdatesJSON, modifiedTsUTC, string(fa.Source), fa.Subject, fa.SubjectName)
+		targetUpdatesJSON, stackUpdatesJSON, policyUpdatesJSON, modifiedTsUTC, string(fa.Source), fa.Subject, fa.SubjectName,
+		suppressedDriftNotesJSON)
 	if err != nil {
 		slog.Error("Query", "query", query, "error", err)
 		return err
@@ -210,7 +221,7 @@ const formaCommandWithResourceUpdatesQueryBase = `
 SELECT
 	fc.command_id, fc.timestamp, fc.command, fc.state, fc.client_id,
 	fc.description_text, fc.description_confirm, fc.config_mode, fc.config_force, fc.config_simulate,
-	fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name,
+	fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name, fc.suppressed_drift_notes,
 	ru.ksuid, ru.operation, ru.state, ru.start_ts, ru.modified_ts,
 	ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 	ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
@@ -239,6 +250,7 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 	var fcModifiedTs sql.NullString
 	var fcSource sql.NullString
 	var fcSubject, fcSubjectName sql.NullString
+	var fcSuppressedDriftNotesJSON []byte
 
 	// ResourceUpdate fields (all nullable due to LEFT JOIN)
 	var ruKsuid, ruOperation, ruState sql.NullString
@@ -258,6 +270,7 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 		&commandID, &fcTimestamp, &command, &fcState, &clientID,
 		&descriptionText, &descriptionConfirm, &configMode, &configForce, &configSimulate,
 		&targetUpdatesJSON, &stackUpdatesJSON, &policyUpdatesJSON, &fcModifiedTs, &fcSource, &fcSubject, &fcSubjectName,
+		&fcSuppressedDriftNotesJSON,
 		// ResourceUpdate columns
 		&ruKsuid, &ruOperation, &ruState, &ruStartTs, &ruModifiedTs,
 		&ruRetries, &ruRemaining, &ruVersion, &ruStackLabel, &ruGroupID, &ruSource,
@@ -333,6 +346,12 @@ func scanJoinedRow(rows *sql.Rows) (*forma_command.FormaCommand, *resource_updat
 	if len(policyUpdatesJSON) > 0 {
 		if err := json.Unmarshal(policyUpdatesJSON, &cmd.PolicyUpdates); err != nil {
 			return nil, nil, fmt.Errorf("failed to unmarshal policy updates: %w", err)
+		}
+	}
+
+	if len(fcSuppressedDriftNotesJSON) > 0 {
+		if err := json.Unmarshal(fcSuppressedDriftNotesJSON, &cmd.SuppressedDriftNotes); err != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal suppressed drift notes: %w", err)
 		}
 	}
 
@@ -558,7 +577,7 @@ func (d DatastoreSQLite) GetMostRecentFormaCommandByClientID(clientID string) (*
 		SELECT
 			fc.command_id, fc.timestamp, fc.command, fc.state, fc.client_id,
 			fc.description_text, fc.description_confirm, fc.config_mode, fc.config_force, fc.config_simulate,
-			fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name,
+			fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name, fc.suppressed_drift_notes,
 			ru.ksuid, ru.operation, ru.state, ru.start_ts, ru.modified_ts,
 			ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 			ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,
@@ -934,7 +953,7 @@ func (d DatastoreSQLite) QueryFormaCommands(query *datastore.StatusQuery) ([]*fo
 		SELECT
 			fc.command_id, fc.timestamp, fc.command, fc.state, fc.client_id,
 			fc.description_text, fc.description_confirm, fc.config_mode, fc.config_force, fc.config_simulate,
-			fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name,
+			fc.target_updates, fc.stack_updates, fc.policy_updates, fc.modified_ts, fc.source, fc.subject, fc.subject_name, fc.suppressed_drift_notes,
 			ru.ksuid, ru.operation, ru.state, ru.start_ts, ru.modified_ts,
 			ru.retries, ru.remaining, ru.version, ru.stack_label, ru.group_id, ru.source,
 			ru.resource, ru.resource_target, ru.existing_resource, ru.existing_target,

--- a/internal/metastructure/forma_command/forma_command.go
+++ b/internal/metastructure/forma_command/forma_command.go
@@ -5,6 +5,7 @@
 package forma_command
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
@@ -41,6 +42,35 @@ const (
 	SourceStackExpirer   Source = "stack-expirer"
 )
 
+// SuppressedDriftDisposition says what a command's submission did about a
+// suppressed-drift note's movement: nothing yet (the drift stays in the
+// changes-since-last-reconcile window) or absorbed (this command's completion
+// advances the window past it without having addressed it).
+type SuppressedDriftDisposition string
+
+const (
+	SuppressedDriftRemaining SuppressedDriftDisposition = "remaining"
+	SuppressedDriftAbsorbed  SuppressedDriftDisposition = "absorbed"
+)
+
+// SuppressedDriftNote records out-of-band movement on a provider-default
+// field the command's plan cannot see: the field is annotated
+// hasProviderDefault and the forma does not declare it (or, for a partially
+// declared EntitySet field, the moved elements carry undeclared keys), so
+// the strip passes hide the change from the diff and no operation is
+// planned for it. From and To carry the suppressed content on each side and
+// are absent for an opaque path, which records path and movement only.
+type SuppressedDriftNote struct {
+	Stack       string                     `json:"Stack"`
+	Type        string                     `json:"Type"`
+	Label       string                     `json:"Label"`
+	Path        string                     `json:"Path"`
+	From        json.RawMessage            `json:"From,omitempty"`
+	To          json.RawMessage            `json:"To,omitempty"`
+	Opaque      bool                       `json:"Opaque,omitempty"`
+	Disposition SuppressedDriftDisposition `json:"Disposition"`
+}
+
 type FormaCommand struct {
 	ID              string                           `json:"ID"`
 	Description     pkgmodel.Description             `json:"Description"`
@@ -57,6 +87,12 @@ type FormaCommand struct {
 	Subject         string                           `json:"Subject,omitempty"`
 	SubjectName     string                           `json:"SubjectName,omitempty"`
 	Source          Source                           `json:"Source,omitempty"`
+	// SuppressedDriftNotes is the durable record of out-of-band movement on
+	// provider-default fields this command's plan could not see: computed
+	// once at submission from the changes-since-last-reconcile window, and
+	// persisted with the command because its completion advances that window
+	// past the movement without having addressed it.
+	SuppressedDriftNotes []SuppressedDriftNote `json:"SuppressedDriftNotes,omitempty"`
 }
 
 type FormaCommandResult struct {

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -341,13 +341,49 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 		return nil, err
 	}
 
+	// One drift-window snapshot per reconcile submission, taken before the
+	// no-changes return and regardless of force: the same loaded
+	// modifications feed the rejection gate below and the suppressed-drift
+	// notes, so the response, any rejection, and the persisted command agree.
+	var modificationsByStack map[string][]datastore.ResourceModification
+	var suppressedNotes []forma_command.SuppressedDriftNote
+	if config.Mode == pkgmodel.FormaApplyModeReconcile {
+		modificationsByStack = make(map[string][]datastore.ResourceModification)
+		// The union covers both consumers: the rejection gate iterates the
+		// stacks with generated updates (fa.GetStackLabels(), its historical
+		// scope), while notes also cover declared stacks that produced no
+		// updates at all, which is exactly where purely suppressed drift
+		// lives.
+		seenStacks := map[string]bool{}
+		for _, stackLabel := range append(stackLabelsFromForma(forma), fa.GetStackLabels()...) {
+			if seenStacks[stackLabel] {
+				continue
+			}
+			seenStacks[stackLabel] = true
+			modifications, loadErr := m.Datastore.GetResourceModificationsSinceLastReconcile(stackLabel)
+			if loadErr != nil {
+				slog.Error("Failed to load modifications since last reconcile", "stack", stackLabel, "error", loadErr)
+				return nil, fmt.Errorf("failed to load modifications for stack %s: %w", stackLabel, loadErr)
+			}
+			if len(modifications) > 0 {
+				modificationsByStack[stackLabel] = modifications
+			}
+		}
+		suppressedNotes = computeSuppressedDriftNotes(modificationsByStack, forma, fa)
+	}
+
 	if !fa.HasChanges() {
+		// Nothing executes and no command is persisted, so the drift window
+		// does not advance: suppressed movement is NOT absorbed by a no-op
+		// apply. The notes say so (disposition remaining) and keep appearing
+		// until a reconcile with changes runs.
 		return &apimodel.SubmitCommandResponse{
 			CommandID:   fa.ID,
 			Description: apimodel.Description(fa.Description),
 			Simulation: apimodel.Simulation{
 				ChangesRequired: false,
 				Command:         apimodel.Command{},
+				SuppressedDrift: translateSuppressedDriftNotes(stampSuppressedDriftDisposition(suppressedNotes, forma_command.SuppressedDriftRemaining)),
 			},
 		}, nil
 	}
@@ -370,25 +406,25 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 
 	if config.Mode == pkgmodel.FormaApplyModeReconcile && !config.Force {
 		var modifiedStacks = make(map[string]apimodel.ModifiedStack)
+		// Rejection keeps its historical scope: only the stacks with
+		// generated updates are checked, from the same snapshot the notes
+		// were computed from.
 		for _, stackLabel := range fa.GetStackLabels() {
-			modifications, loadErr := m.Datastore.GetResourceModificationsSinceLastReconcile(stackLabel)
-			if loadErr != nil {
-				slog.Error("Failed to load most recent non-reconcile forma commands by stack", "stack", stackLabel, "error", loadErr)
-				return nil, fmt.Errorf("failed to load most recent forma commands for stack %s: %w", stackLabel, loadErr)
+			modifications := modificationsByStack[stackLabel]
+			if len(modifications) == 0 {
+				continue
 			}
-			if len(modifications) > 0 {
-				// Filter out modifications that have been absorbed into the forma.
-				// A modification is absorbed when the forma contains the resource
-				// and no resource update was generated for it (properties match current state).
-				unabsorbed := filterUnabsorbedModifications(modifications, forma, fa)
-				if len(unabsorbed) > 0 {
-					modifiedResources := make([]apimodel.ResourceModification, 0, len(unabsorbed))
-					for _, modification := range unabsorbed {
-						modifiedResources = append(modifiedResources, toAPIResourceModification(modification))
-					}
-					modifiedStacks[stackLabel] = apimodel.ModifiedStack{
-						ModifiedResources: modifiedResources,
-					}
+			// Filter out modifications that have been absorbed into the forma.
+			// A modification is absorbed when the forma contains the resource
+			// and no resource update was generated for it (properties match current state).
+			unabsorbed := filterUnabsorbedModifications(modifications, forma, fa)
+			if len(unabsorbed) > 0 {
+				modifiedResources := make([]apimodel.ResourceModification, 0, len(unabsorbed))
+				for _, modification := range unabsorbed {
+					modifiedResources = append(modifiedResources, toAPIResourceModification(modification))
+				}
+				modifiedStacks[stackLabel] = apimodel.ModifiedStack{
+					ModifiedResources: modifiedResources,
 				}
 			}
 		}
@@ -396,6 +432,12 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 			return nil, apimodel.FormaReconcileRejectedError{ModifiedStacks: modifiedStacks}
 		}
 	}
+
+	// This command executes (or simulates executing) and its completion
+	// advances the drift window past the suppressed movement without having
+	// addressed it; the notes ride the command as the durable record of that
+	// absorption.
+	fa.SuppressedDriftNotes = stampSuppressedDriftDisposition(suppressedNotes, forma_command.SuppressedDriftAbsorbed)
 
 	if config.Mode == pkgmodel.FormaApplyModePatch {
 		err = m.checkIfPatchCanBeApplied(fa)
@@ -445,6 +487,7 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 				ChangesRequired: fa.HasChanges(),
 				Command:         translateToAPICommand(fa),
 				Warnings:        warnings,
+				SuppressedDrift: translateSuppressedDriftNotes(fa.SuppressedDriftNotes),
 			},
 		}, nil
 	}
@@ -595,21 +638,23 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 		Simulation: apimodel.Simulation{
 			ChangesRequired: fa.HasChanges(),
 			Command:         translateToAPICommand(fa),
+			SuppressedDrift: translateSuppressedDriftNotes(fa.SuppressedDriftNotes),
 		},
 	}, nil
 }
 
 func translateToAPICommand(fa *forma_command.FormaCommand) apimodel.Command {
 	apiCommand := apimodel.Command{
-		CommandID:   fa.ID,
-		Command:     string(fa.Command),
-		Mode:        string(fa.Config.Mode),
-		Source:      string(fa.Source),
-		Subject:     fa.Subject,
-		SubjectName: fa.SubjectName,
-		State:       string(fa.State),
-		StartTs:     fa.StartTs,
-		EndTs:       fa.ModifiedTs,
+		CommandID:       fa.ID,
+		Command:         string(fa.Command),
+		Mode:            string(fa.Config.Mode),
+		Source:          string(fa.Source),
+		Subject:         fa.Subject,
+		SubjectName:     fa.SubjectName,
+		State:           string(fa.State),
+		StartTs:         fa.StartTs,
+		EndTs:           fa.ModifiedTs,
+		SuppressedDrift: translateSuppressedDriftNotes(fa.SuppressedDriftNotes),
 	}
 	for _, ru := range fa.ResourceUpdates {
 		var dur time.Duration = 0
@@ -1775,6 +1820,29 @@ func findCascadeTargetDeletes(
 // document describing the drift between the properties at the last reconcile
 // and the current (cloud) properties. A failed patch computation degrades to
 // label-only display — it never fails the caller.
+// translateSuppressedDriftNotes maps a command's suppressed-drift notes into
+// the API projection. Note values were sanitized at construction (opaque
+// paths carry no values), so this is a plain field mapping.
+func translateSuppressedDriftNotes(notes []forma_command.SuppressedDriftNote) []apimodel.SuppressedDriftNote {
+	if len(notes) == 0 {
+		return nil
+	}
+	out := make([]apimodel.SuppressedDriftNote, len(notes))
+	for i, n := range notes {
+		out[i] = apimodel.SuppressedDriftNote{
+			Stack:       n.Stack,
+			Type:        n.Type,
+			Label:       n.Label,
+			Path:        n.Path,
+			From:        n.From,
+			To:          n.To,
+			Opaque:      n.Opaque,
+			Disposition: string(n.Disposition),
+		}
+	}
+	return out
+}
+
 func toAPIResourceModification(modification datastore.ResourceModification) apimodel.ResourceModification {
 	patchDoc := json.RawMessage(nil)
 	if modification.Operation == "update" && len(modification.OldProperties) > 0 && len(modification.Properties) > 0 {

--- a/internal/metastructure/patch/suppressed_drift.go
+++ b/internal/metastructure/patch/suppressed_drift.go
@@ -1,0 +1,378 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package patch
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// SuppressedFieldDiff describes out-of-band movement on provider-default
+// content the patch pipeline's strip passes hide from the diff: a
+// hasProviderDefault field the user did not declare (or, for a partially
+// declared EntitySet field, the elements with undeclared keys) whose value
+// differs between two observations of the resource.
+//
+// From and To carry the suppressed content on each side, nil when the side
+// has no value for the path. For an opaque path both are nil: the diff
+// records the path and the fact of movement only, never values or digests,
+// because callers persist and display these records.
+type SuppressedFieldDiff struct {
+	Path   string
+	From   json.RawMessage
+	To     json.RawMessage
+	Opaque bool
+}
+
+// SuppressedFieldDiffs compares two stored property documents restricted to
+// the content the provider-default strip passes would hide from a diff
+// against the given desired properties. It reports one entry per suppressed
+// field whose content moved, sorted by path.
+//
+// The suppressed content per hasProviderDefault field is exactly what the
+// strip passes suppress: the whole field when desired omits it (absent or
+// null, the fieldExistsInMap semantics of removeProviderDefaultFieldsBoth),
+// and, for an EntitySet field with one or more declared keys, the elements
+// whose key is not among the declared keys (what
+// removeProviderDefaultEntitySetElements filters). An explicit empty
+// EntitySet declaration suppresses nothing: that is a user-initiated clear
+// the diff plans.
+//
+// Comparison is schema-aware so representation churn is not movement:
+// EntitySet content compares keyed by IndexField, collections without an
+// index compare as unordered multisets, Array-hinted fields compare ordered,
+// and array-nested dotted leaves (the ContainerDefinitions.Cpu shape, which
+// the strip removes from both sides unconditionally) compare as a multiset
+// of leaf values.
+func SuppressedFieldDiffs(oldProps, newProps, desired json.RawMessage, schema pkgmodel.Schema) ([]SuppressedFieldDiff, error) {
+	oldMap, err := unmarshalPropsObject(oldProps)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal old properties: %w", err)
+	}
+	newMap, err := unmarshalPropsObject(newProps)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal new properties: %w", err)
+	}
+	desiredMap, err := unmarshalPropsObject(desired)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal desired properties: %w", err)
+	}
+
+	paths := append([]string(nil), schema.HasProviderDefault()...)
+	sort.Strings(paths)
+
+	var diffs []SuppressedFieldDiff
+	for _, path := range paths {
+		parts := strings.Split(path, ".")
+		hint := schema.Hints[path]
+
+		var from, to json.RawMessage
+		var moved bool
+
+		if len(parts) > 1 {
+			if fieldExistsInMap(desiredMap, parts) {
+				continue
+			}
+			from, to, moved = compareLeafMultisets(oldMap, newMap, parts)
+		} else if !fieldExistsInMap(desiredMap, parts) {
+			from, to, moved = compareWholeField(oldMap, newMap, path, hint)
+		} else if hint.UpdateMethod == pkgmodel.FieldUpdateMethodEntitySet && hint.IndexField != "" {
+			declaredKeys := entitySetKeys(desiredMap[path], hint.IndexField)
+			if len(declaredKeys) == 0 {
+				// Explicit empty (or keyless) declaration: the diff plans
+				// the drain; nothing is suppressed.
+				continue
+			}
+			from, to, moved = compareEntitySetSubsets(oldMap[path], newMap[path], hint.IndexField, declaredKeys)
+		} else {
+			continue
+		}
+
+		if !moved {
+			continue
+		}
+
+		if pathOpaque(schema, path) || valueHasOpaqueMarker(oldMap[path]) || valueHasOpaqueMarker(newMap[path]) {
+			diffs = append(diffs, SuppressedFieldDiff{Path: path, Opaque: true})
+			continue
+		}
+		diffs = append(diffs, SuppressedFieldDiff{Path: path, From: from, To: to})
+	}
+
+	return diffs, nil
+}
+
+func unmarshalPropsObject(raw json.RawMessage) (map[string]any, error) {
+	if len(raw) == 0 {
+		return map[string]any{}, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	if m == nil {
+		m = map[string]any{}
+	}
+	return m, nil
+}
+
+// compareWholeField compares a fully suppressed field per its collection
+// semantics. A side where the field is absent renders as nil.
+func compareWholeField(oldMap, newMap map[string]any, path string, hint pkgmodel.FieldHint) (json.RawMessage, json.RawMessage, bool) {
+	oldVal, oldHas := oldMap[path]
+	newVal, newHas := newMap[path]
+	if !oldHas && !newHas {
+		return nil, nil, false
+	}
+
+	equal := false
+	switch {
+	case oldHas != newHas:
+		equal = false
+	case hint.UpdateMethod == pkgmodel.FieldUpdateMethodEntitySet && hint.IndexField != "":
+		oldArr, _ := oldVal.([]any)
+		newArr, _ := newVal.([]any)
+		equal = entitySetContentEqual(oldArr, newArr, hint.IndexField)
+	case hint.UpdateMethod == pkgmodel.FieldUpdateMethodArray:
+		equal = canonicalJSON(oldVal) == canonicalJSON(newVal)
+	default:
+		oldArr, oldIsArr := oldVal.([]any)
+		newArr, newIsArr := newVal.([]any)
+		if oldIsArr && newIsArr {
+			equal = multisetEqual(oldArr, newArr)
+		} else {
+			equal = canonicalJSON(oldVal) == canonicalJSON(newVal)
+		}
+	}
+	if equal {
+		return nil, nil, false
+	}
+
+	var from, to json.RawMessage
+	if oldHas {
+		from = json.RawMessage(canonicalJSON(oldVal))
+	}
+	if newHas {
+		to = json.RawMessage(canonicalJSON(newVal))
+	}
+	return from, to, true
+}
+
+// compareEntitySetSubsets compares only the elements whose key is not among
+// the declared keys: the portion removeProviderDefaultEntitySetElements
+// filters out of the diff. Keyless elements stay visible to the diff (the
+// filter keeps them), so they are not suppressed content here.
+func compareEntitySetSubsets(oldVal, newVal any, indexField string, declaredKeys map[string]struct{}) (json.RawMessage, json.RawMessage, bool) {
+	oldArr, _ := oldVal.([]any)
+	newArr, _ := newVal.([]any)
+	oldSub := suppressedEntitySetElements(oldArr, indexField, declaredKeys)
+	newSub := suppressedEntitySetElements(newArr, indexField, declaredKeys)
+	if entitySetContentEqual(oldSub, newSub, indexField) {
+		return nil, nil, false
+	}
+	return json.RawMessage(canonicalJSON(sortedByKey(oldSub, indexField))),
+		json.RawMessage(canonicalJSON(sortedByKey(newSub, indexField))),
+		true
+}
+
+func suppressedEntitySetElements(arr []any, indexField string, declaredKeys map[string]struct{}) []any {
+	var out []any
+	for _, elem := range arr {
+		elemMap, ok := elem.(map[string]any)
+		if !ok {
+			continue
+		}
+		keyVal, ok := elemMap[indexField]
+		if !ok {
+			continue
+		}
+		if _, declared := declaredKeys[fmt.Sprintf("%v", keyVal)]; declared {
+			continue
+		}
+		out = append(out, elem)
+	}
+	return out
+}
+
+func entitySetKeys(val any, indexField string) map[string]struct{} {
+	keys := map[string]struct{}{}
+	arr, _ := val.([]any)
+	for _, elem := range arr {
+		if elemMap, ok := elem.(map[string]any); ok {
+			if keyVal, ok := elemMap[indexField]; ok {
+				keys[fmt.Sprintf("%v", keyVal)] = struct{}{}
+			}
+		}
+	}
+	return keys
+}
+
+// entitySetContentEqual compares keyed elements by key and keyless elements
+// as an unordered multiset, so element order is never movement.
+func entitySetContentEqual(a, b []any, indexField string) bool {
+	aKeyed, aKeyless := partitionByKey(a, indexField)
+	bKeyed, bKeyless := partitionByKey(b, indexField)
+	if len(aKeyed) != len(bKeyed) {
+		return false
+	}
+	for k, v := range aKeyed {
+		if bKeyed[k] != v {
+			return false
+		}
+	}
+	return multisetEqual(aKeyless, bKeyless)
+}
+
+func partitionByKey(arr []any, indexField string) (map[string]string, []any) {
+	keyed := map[string]string{}
+	var keyless []any
+	for _, elem := range arr {
+		if elemMap, ok := elem.(map[string]any); ok {
+			if keyVal, ok := elemMap[indexField]; ok {
+				keyed[fmt.Sprintf("%v", keyVal)] = canonicalJSON(elem)
+				continue
+			}
+		}
+		keyless = append(keyless, elem)
+	}
+	return keyed, keyless
+}
+
+func sortedByKey(arr []any, indexField string) []any {
+	out := append([]any(nil), arr...)
+	sort.Slice(out, func(i, j int) bool {
+		ki, kj := "", ""
+		if m, ok := out[i].(map[string]any); ok {
+			ki = fmt.Sprintf("%v", m[indexField])
+		}
+		if m, ok := out[j].(map[string]any); ok {
+			kj = fmt.Sprintf("%v", m[indexField])
+		}
+		if ki != kj {
+			return ki < kj
+		}
+		return canonicalJSON(out[i]) < canonicalJSON(out[j])
+	})
+	if out == nil {
+		out = []any{}
+	}
+	return out
+}
+
+// compareLeafMultisets handles dotted provider-default paths. The strip
+// removes these leaves from both sides in every reachable array element, and
+// set-based array comparison has no stable element pairing, so the honest
+// comparison is the multiset of leaf values on each side.
+func compareLeafMultisets(oldMap, newMap map[string]any, parts []string) (json.RawMessage, json.RawMessage, bool) {
+	var oldLeaves, newLeaves []any
+	collectLeaves(oldMap, parts, &oldLeaves)
+	collectLeaves(newMap, parts, &newLeaves)
+	if multisetEqual(oldLeaves, newLeaves) {
+		return nil, nil, false
+	}
+	return renderLeafList(oldLeaves), renderLeafList(newLeaves), true
+}
+
+func renderLeafList(leaves []any) json.RawMessage {
+	if len(leaves) == 0 {
+		return nil
+	}
+	sorted := append([]any(nil), leaves...)
+	sort.Slice(sorted, func(i, j int) bool { return canonicalJSON(sorted[i]) < canonicalJSON(sorted[j]) })
+	return json.RawMessage(canonicalJSON(sorted))
+}
+
+// collectLeaves walks a dotted path, descending through arrays without
+// consuming a path segment, and appends every leaf value found.
+func collectLeaves(node any, parts []string, out *[]any) {
+	switch v := node.(type) {
+	case []any:
+		for _, elem := range v {
+			collectLeaves(elem, parts, out)
+		}
+	case map[string]any:
+		val, ok := v[parts[0]]
+		if !ok {
+			return
+		}
+		if len(parts) == 1 {
+			*out = append(*out, val)
+			return
+		}
+		collectLeaves(val, parts[1:], out)
+	}
+}
+
+func multisetEqual(a, b []any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := map[string]int{}
+	for _, v := range a {
+		counts[canonicalJSON(v)]++
+	}
+	for _, v := range b {
+		key := canonicalJSON(v)
+		counts[key]--
+		if counts[key] < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// canonicalJSON renders a decoded value deterministically (encoding/json
+// sorts map keys), so equality can be a string comparison.
+func canonicalJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%#v", v)
+	}
+	return string(b)
+}
+
+// pathOpaque reports whether an Opaque schema hint covers the path: the hint
+// on the path itself, on an ancestor (an opaque container makes its content
+// opaque), or on a descendant (an opaque leaf makes the container's content
+// unsafe to render).
+func pathOpaque(schema pkgmodel.Schema, path string) bool {
+	for _, op := range schema.Opaque() {
+		if op == path || strings.HasPrefix(path, op+".") || strings.HasPrefix(op, path+".") {
+			return true
+		}
+	}
+	return false
+}
+
+// valueHasOpaqueMarker reports whether a decoded value carries envelope
+// opacity anywhere within: a $visibility: Opaque marker or $hashed material.
+// Fails toward opaque so sanitization never depends on the schema alone.
+func valueHasOpaqueMarker(v any) bool {
+	switch node := v.(type) {
+	case map[string]any:
+		if vis, ok := node["$visibility"].(string); ok && vis == "Opaque" {
+			return true
+		}
+		if _, ok := node["$hashed"]; ok {
+			return true
+		}
+		for _, child := range node {
+			if valueHasOpaqueMarker(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range node {
+			if valueHasOpaqueMarker(child) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/metastructure/patch/suppressed_drift.go
+++ b/internal/metastructure/patch/suppressed_drift.go
@@ -47,9 +47,11 @@ type SuppressedFieldDiff struct {
 // Comparison is schema-aware so representation churn is not movement:
 // EntitySet content compares keyed by IndexField, collections without an
 // index compare as unordered multisets, Array-hinted fields compare ordered,
-// and array-nested dotted leaves (the ContainerDefinitions.Cpu shape, which
-// the strip removes from both sides unconditionally) compare as a multiset
-// of leaf values.
+// and dotted leaves compare as a multiset of leaf values collected with the
+// strip's own regime rules: a leaf reached through an array is suppressed
+// unconditionally (the ContainerDefinitions.Cpu shape, stripped from both
+// sides regardless of declaration), while a pure-object leaf is suppressed
+// only when desired omits it.
 func SuppressedFieldDiffs(oldProps, newProps, desired json.RawMessage, schema pkgmodel.Schema) ([]SuppressedFieldDiff, error) {
 	oldMap, err := unmarshalPropsObject(oldProps)
 	if err != nil {
@@ -74,14 +76,18 @@ func SuppressedFieldDiffs(oldProps, newProps, desired json.RawMessage, schema pk
 
 		var from, to json.RawMessage
 		var moved bool
+		// opacityProbe holds exactly the decoded content a note would carry,
+		// so envelope opacity markers anywhere within it force sanitization.
+		var opacityProbe []any
 
 		if len(parts) > 1 {
-			if fieldExistsInMap(desiredMap, parts) {
-				continue
-			}
-			from, to, moved = compareLeafMultisets(oldMap, newMap, parts)
+			oldLeaves := collectSuppressedLeaves(oldMap, desiredMap, parts)
+			newLeaves := collectSuppressedLeaves(newMap, desiredMap, parts)
+			from, to, moved = compareLeafMultisets(oldLeaves, newLeaves)
+			opacityProbe = append(append(opacityProbe, oldLeaves...), newLeaves...)
 		} else if !fieldExistsInMap(desiredMap, parts) {
 			from, to, moved = compareWholeField(oldMap, newMap, path, hint)
+			opacityProbe = []any{oldMap[path], newMap[path]}
 		} else if hint.UpdateMethod == pkgmodel.FieldUpdateMethodEntitySet && hint.IndexField != "" {
 			declaredKeys := entitySetKeys(desiredMap[path], hint.IndexField)
 			if len(declaredKeys) == 0 {
@@ -90,6 +96,7 @@ func SuppressedFieldDiffs(oldProps, newProps, desired json.RawMessage, schema pk
 				continue
 			}
 			from, to, moved = compareEntitySetSubsets(oldMap[path], newMap[path], hint.IndexField, declaredKeys)
+			opacityProbe = []any{oldMap[path], newMap[path]}
 		} else {
 			continue
 		}
@@ -98,7 +105,14 @@ func SuppressedFieldDiffs(oldProps, newProps, desired json.RawMessage, schema pk
 			continue
 		}
 
-		if pathOpaque(schema, path) || valueHasOpaqueMarker(oldMap[path]) || valueHasOpaqueMarker(newMap[path]) {
+		opaque := pathOpaque(schema, path)
+		for _, v := range opacityProbe {
+			if valueHasOpaqueMarker(v) {
+				opaque = true
+				break
+			}
+		}
+		if opaque {
 			diffs = append(diffs, SuppressedFieldDiff{Path: path, Opaque: true})
 			continue
 		}
@@ -265,14 +279,10 @@ func sortedByKey(arr []any, indexField string) []any {
 	return out
 }
 
-// compareLeafMultisets handles dotted provider-default paths. The strip
-// removes these leaves from both sides in every reachable array element, and
-// set-based array comparison has no stable element pairing, so the honest
-// comparison is the multiset of leaf values on each side.
-func compareLeafMultisets(oldMap, newMap map[string]any, parts []string) (json.RawMessage, json.RawMessage, bool) {
-	var oldLeaves, newLeaves []any
-	collectLeaves(oldMap, parts, &oldLeaves)
-	collectLeaves(newMap, parts, &newLeaves)
+// compareLeafMultisets compares two suppressed-leaf collections. Set-based
+// array comparison has no stable element pairing, so the honest comparison
+// is the multiset of leaf values on each side.
+func compareLeafMultisets(oldLeaves, newLeaves []any) (json.RawMessage, json.RawMessage, bool) {
 	if multisetEqual(oldLeaves, newLeaves) {
 		return nil, nil, false
 	}
@@ -288,25 +298,38 @@ func renderLeafList(leaves []any) json.RawMessage {
 	return json.RawMessage(canonicalJSON(sorted))
 }
 
-// collectLeaves walks a dotted path, descending through arrays without
-// consuming a path segment, and appends every leaf value found.
-func collectLeaves(node any, parts []string, out *[]any) {
-	switch v := node.(type) {
-	case []any:
-		for _, elem := range v {
-			collectLeaves(elem, parts, out)
+// collectSuppressedLeaves walks a dotted path with the strip's own regime
+// rules (see stripProviderDefaultPath): descending through an array switches
+// to the unconditional regime, where every reachable leaf is suppressed
+// content regardless of what desired declares; a walk that stays in objects
+// keeps the conditional regime, where the leaf is suppressed only when
+// desired omits the full path.
+func collectSuppressedLeaves(root any, desired map[string]any, parts []string) []any {
+	var out []any
+	declared := fieldExistsInMap(desired, parts)
+	var walk func(node any, rest []string, inArray bool)
+	walk = func(node any, rest []string, inArray bool) {
+		switch v := node.(type) {
+		case []any:
+			for _, elem := range v {
+				walk(elem, rest, true)
+			}
+		case map[string]any:
+			val, ok := v[rest[0]]
+			if !ok {
+				return
+			}
+			if len(rest) == 1 {
+				if inArray || !declared {
+					out = append(out, val)
+				}
+				return
+			}
+			walk(val, rest[1:], inArray)
 		}
-	case map[string]any:
-		val, ok := v[parts[0]]
-		if !ok {
-			return
-		}
-		if len(parts) == 1 {
-			*out = append(*out, val)
-			return
-		}
-		collectLeaves(val, parts[1:], out)
 	}
+	walk(root, parts, false)
+	return out
 }
 
 func multisetEqual(a, b []any) bool {

--- a/internal/metastructure/patch/suppressed_drift_test.go
+++ b/internal/metastructure/patch/suppressed_drift_test.go
@@ -316,3 +316,62 @@ func TestSuppressedFieldDiffs_MultipleFields_SortedByPath(t *testing.T) {
 	assert.Equal(t, "A", diffs[0].Path)
 	assert.Equal(t, "B", diffs[1].Path)
 }
+
+func TestSuppressedFieldDiffs_DottedLeafWithOpaqueEnvelope_PathOnlyNoValues(t *testing.T) {
+	// An opaque envelope nested inside array elements must sanitize the
+	// diff even though the schema hint carries no Opaque flag: the envelope
+	// marker is the authority.
+	schema := pkgmodel.Schema{
+		Fields: []string{"Family", "ContainerDefinitions"},
+		Hints:  map[string]pkgmodel.FieldHint{"ContainerDefinitions.Token": {HasProviderDefault: true}},
+	}
+	desired := `{"Family": "f", "ContainerDefinitions": [{"Name": "app"}]}`
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Family": "f", "ContainerDefinitions": [{"Name": "app", "Token": {"$value": "hash-one", "$visibility": "Opaque"}}]}`,
+		`{"Family": "f", "ContainerDefinitions": [{"Name": "app", "Token": {"$value": "hash-two", "$visibility": "Opaque"}}]}`,
+		desired, schema)
+
+	require.Len(t, diffs, 1)
+	assert.True(t, diffs[0].Opaque)
+	assert.Nil(t, diffs[0].From, "envelope-opaque leaf values must never appear in a note")
+	assert.Nil(t, diffs[0].To)
+}
+
+func TestSuppressedFieldDiffs_ArrayNestedLeaf_DeclaredElsewhere_StillCompared(t *testing.T) {
+	// The strip removes an array-nested provider-default leaf from every
+	// element on both sides regardless of desired declaring it somewhere,
+	// so the classifier must not skip the path just because one desired
+	// element declares the leaf: another element's suppressed movement is
+	// still invisible to the plan and must be noted.
+	schema := pkgmodel.Schema{
+		Fields: []string{"Family", "ContainerDefinitions"},
+		Hints:  map[string]pkgmodel.FieldHint{"ContainerDefinitions.Cpu": {HasProviderDefault: true}},
+	}
+	desired := `{"Family": "f", "ContainerDefinitions": [{"Name": "app", "Cpu": 512}, {"Name": "sidecar"}]}`
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Family": "f", "ContainerDefinitions": [{"Name": "app", "Cpu": 512}, {"Name": "sidecar", "Cpu": 0}]}`,
+		`{"Family": "f", "ContainerDefinitions": [{"Name": "app", "Cpu": 512}, {"Name": "sidecar", "Cpu": 256}]}`,
+		desired, schema)
+
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "ContainerDefinitions.Cpu", diffs[0].Path)
+}
+
+func TestSuppressedFieldDiffs_PureObjectDottedPath_DeclaredInDesired_NotReported(t *testing.T) {
+	// A dotted path that never traverses an array keeps the conditional
+	// strip semantics: declared in desired means plan territory, no note.
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Config"},
+		Hints:  map[string]pkgmodel.FieldHint{"Config.Encryption": {HasProviderDefault: true}},
+	}
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "r", "Config": {"Encryption": "aes"}}`,
+		`{"Name": "r", "Config": {"Encryption": "kms"}}`,
+		`{"Name": "r", "Config": {"Encryption": "kms"}}`,
+		schema)
+
+	assert.Empty(t, diffs)
+}

--- a/internal/metastructure/patch/suppressed_drift_test.go
+++ b/internal/metastructure/patch/suppressed_drift_test.go
@@ -1,0 +1,318 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package patch
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func suppressedDiffsForTest(t *testing.T, oldProps, newProps, desired string, schema pkgmodel.Schema) []SuppressedFieldDiff {
+	t.Helper()
+	diffs, err := SuppressedFieldDiffs(json.RawMessage(oldProps), json.RawMessage(newProps), json.RawMessage(desired), schema)
+	require.NoError(t, err)
+	return diffs
+}
+
+func TestSuppressedFieldDiffs_ScalarOmittedChanged_ReportsMovement(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "EnableKeyRotation"},
+		Hints:  map[string]pkgmodel.FieldHint{"EnableKeyRotation": {HasProviderDefault: true}},
+	}
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "k", "EnableKeyRotation": false}`,
+		`{"Name": "k", "EnableKeyRotation": true}`,
+		`{"Name": "k"}`,
+		schema)
+
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "EnableKeyRotation", diffs[0].Path)
+	assert.JSONEq(t, `false`, string(diffs[0].From))
+	assert.JSONEq(t, `true`, string(diffs[0].To))
+	assert.False(t, diffs[0].Opaque)
+}
+
+func TestSuppressedFieldDiffs_ScalarOmittedUnchanged_NoDiff(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "EnableKeyRotation"},
+		Hints:  map[string]pkgmodel.FieldHint{"EnableKeyRotation": {HasProviderDefault: true}},
+	}
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "k", "EnableKeyRotation": false}`,
+		`{"Name": "k", "EnableKeyRotation": false}`,
+		`{"Name": "k"}`,
+		schema)
+
+	assert.Empty(t, diffs)
+}
+
+func TestSuppressedFieldDiffs_DeclaredField_NeverReported(t *testing.T) {
+	// A field the user declares is plan territory, not suppressed content,
+	// no matter how it moved.
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "EnableKeyRotation"},
+		Hints:  map[string]pkgmodel.FieldHint{"EnableKeyRotation": {HasProviderDefault: true}},
+	}
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "k", "EnableKeyRotation": false}`,
+		`{"Name": "k", "EnableKeyRotation": true}`,
+		`{"Name": "k", "EnableKeyRotation": true}`,
+		schema)
+
+	assert.Empty(t, diffs)
+}
+
+func TestSuppressedFieldDiffs_NullDesired_TreatedAsOmitted(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "EnableKeyRotation"},
+		Hints:  map[string]pkgmodel.FieldHint{"EnableKeyRotation": {HasProviderDefault: true}},
+	}
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "k", "EnableKeyRotation": false}`,
+		`{"Name": "k", "EnableKeyRotation": true}`,
+		`{"Name": "k", "EnableKeyRotation": null}`,
+		schema)
+
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "EnableKeyRotation", diffs[0].Path)
+}
+
+func TestSuppressedFieldDiffs_EntitySetOmitted_OOBAddReported(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Tags": {HasProviderDefault: true, UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Key"},
+		},
+	}
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "r", "Tags": []}`,
+		`{"Name": "r", "Tags": [{"Key": "oob", "Value": "x"}]}`,
+		`{"Name": "r"}`,
+		schema)
+
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "Tags", diffs[0].Path)
+	assert.JSONEq(t, `[]`, string(diffs[0].From))
+	assert.JSONEq(t, `[{"Key": "oob", "Value": "x"}]`, string(diffs[0].To))
+}
+
+func TestSuppressedFieldDiffs_EntitySetPartialDeclaration_OnlySuppressedElementsCompared(t *testing.T) {
+	// Desired declares one key; the suppressed content is every element with
+	// an undeclared key. A change on a declared-key element is plan
+	// territory; a change on an undeclared-key element is suppressed
+	// movement and reported with only the suppressed elements as values.
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Tags": {HasProviderDefault: true, UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Key"},
+		},
+	}
+	desired := `{"Name": "r", "Tags": [{"Key": "mine", "Value": "v1"}]}`
+
+	// Declared element changed, suppressed element unchanged: no diff.
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "r", "Tags": [{"Key": "mine", "Value": "old"}, {"Key": "aws:sys", "Value": "s"}]}`,
+		`{"Name": "r", "Tags": [{"Key": "mine", "Value": "new"}, {"Key": "aws:sys", "Value": "s"}]}`,
+		desired, schema)
+	assert.Empty(t, diffs)
+
+	// Suppressed element changed: reported, and only suppressed elements
+	// appear in the values.
+	diffs = suppressedDiffsForTest(t,
+		`{"Name": "r", "Tags": [{"Key": "mine", "Value": "v1"}, {"Key": "aws:sys", "Value": "s1"}]}`,
+		`{"Name": "r", "Tags": [{"Key": "mine", "Value": "v1"}, {"Key": "aws:sys", "Value": "s2"}]}`,
+		desired, schema)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "Tags", diffs[0].Path)
+	assert.JSONEq(t, `[{"Key": "aws:sys", "Value": "s1"}]`, string(diffs[0].From))
+	assert.JSONEq(t, `[{"Key": "aws:sys", "Value": "s2"}]`, string(diffs[0].To))
+}
+
+func TestSuppressedFieldDiffs_EntitySetExplicitEmpty_NotSuppressed(t *testing.T) {
+	// An explicit empty declaration is a user-initiated clear: the drain is
+	// planned by the diff, so nothing here is suppressed content.
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Tags": {HasProviderDefault: true, UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Key"},
+		},
+	}
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "r", "Tags": []}`,
+		`{"Name": "r", "Tags": [{"Key": "oob", "Value": "x"}]}`,
+		`{"Name": "r", "Tags": []}`,
+		schema)
+
+	assert.Empty(t, diffs)
+}
+
+func TestSuppressedFieldDiffs_EntitySetReorderOnly_NoDiff(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Tags": {HasProviderDefault: true, UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Key"},
+		},
+	}
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "r", "Tags": [{"Key": "a", "Value": "1"}, {"Key": "b", "Value": "2"}]}`,
+		`{"Name": "r", "Tags": [{"Key": "b", "Value": "2"}, {"Key": "a", "Value": "1"}]}`,
+		`{"Name": "r"}`,
+		schema)
+
+	assert.Empty(t, diffs)
+}
+
+func TestSuppressedFieldDiffs_SetReorderOnly_NoDiff(t *testing.T) {
+	// Without an index field, an omitted provider-default collection compares
+	// as an unordered multiset: a provider returning the same members in a
+	// different order is not movement.
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Groups"},
+		Hints:  map[string]pkgmodel.FieldHint{"Groups": {HasProviderDefault: true}},
+	}
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "r", "Groups": ["sg-1", "sg-2"]}`,
+		`{"Name": "r", "Groups": ["sg-2", "sg-1"]}`,
+		`{"Name": "r"}`,
+		schema)
+
+	assert.Empty(t, diffs)
+}
+
+func TestSuppressedFieldDiffs_ArrayHint_OrderIsMovement(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Steps"},
+		Hints:  map[string]pkgmodel.FieldHint{"Steps": {HasProviderDefault: true, UpdateMethod: pkgmodel.FieldUpdateMethodArray}},
+	}
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "r", "Steps": ["a", "b"]}`,
+		`{"Name": "r", "Steps": ["b", "a"]}`,
+		`{"Name": "r"}`,
+		schema)
+
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "Steps", diffs[0].Path)
+}
+
+func TestSuppressedFieldDiffs_OpaqueField_PathOnlyNoValues(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "MasterPassword"},
+		Hints:  map[string]pkgmodel.FieldHint{"MasterPassword": {HasProviderDefault: true, Opaque: true}},
+	}
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "r", "MasterPassword": "hash-one"}`,
+		`{"Name": "r", "MasterPassword": "hash-two"}`,
+		`{"Name": "r"}`,
+		schema)
+
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "MasterPassword", diffs[0].Path)
+	assert.True(t, diffs[0].Opaque)
+	assert.Nil(t, diffs[0].From, "opaque movement must carry no values")
+	assert.Nil(t, diffs[0].To, "opaque movement must carry no values")
+}
+
+func TestSuppressedFieldDiffs_OpaqueEnvelopeValue_PathOnlyNoValues(t *testing.T) {
+	// Opacity can also arrive via the stored envelope, not only the schema
+	// hint. Either side carrying a $visibility: Opaque marker sanitizes the
+	// diff.
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Secret"},
+		Hints:  map[string]pkgmodel.FieldHint{"Secret": {HasProviderDefault: true}},
+	}
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "r", "Secret": {"$value": "h1", "$visibility": "Opaque"}}`,
+		`{"Name": "r", "Secret": {"$value": "h2", "$visibility": "Opaque"}}`,
+		`{"Name": "r"}`,
+		schema)
+
+	require.Len(t, diffs, 1)
+	assert.True(t, diffs[0].Opaque)
+	assert.Nil(t, diffs[0].From)
+	assert.Nil(t, diffs[0].To)
+}
+
+func TestSuppressedFieldDiffs_DottedArrayNestedLeaf_MultisetComparison(t *testing.T) {
+	// Array-nested provider-default leaves (the ContainerDefinitions.Cpu
+	// shape) compare as a multiset of leaf values: pairing across set-based
+	// array elements is unstable, so order and element identity are not
+	// movement, but a changed leaf value is.
+	schema := pkgmodel.Schema{
+		Fields: []string{"Family", "ContainerDefinitions"},
+		Hints:  map[string]pkgmodel.FieldHint{"ContainerDefinitions.Cpu": {HasProviderDefault: true}},
+	}
+	desired := `{"Family": "f", "ContainerDefinitions": [{"Name": "app"}]}`
+
+	// Same leaf values, different element order: no movement.
+	diffs := suppressedDiffsForTest(t,
+		`{"Family": "f", "ContainerDefinitions": [{"Name": "app", "Cpu": 0}, {"Name": "sidecar", "Cpu": 128}]}`,
+		`{"Family": "f", "ContainerDefinitions": [{"Name": "sidecar", "Cpu": 128}, {"Name": "app", "Cpu": 0}]}`,
+		desired, schema)
+	assert.Empty(t, diffs)
+
+	// A leaf value changed: movement.
+	diffs = suppressedDiffsForTest(t,
+		`{"Family": "f", "ContainerDefinitions": [{"Name": "app", "Cpu": 0}]}`,
+		`{"Family": "f", "ContainerDefinitions": [{"Name": "app", "Cpu": 256}]}`,
+		desired, schema)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "ContainerDefinitions.Cpu", diffs[0].Path)
+}
+
+func TestSuppressedFieldDiffs_FieldAppearsOrDisappears_ReportsMovement(t *testing.T) {
+	// A suppressed field present on only one side is movement between
+	// absence and a value.
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "KmsKeyId"},
+		Hints:  map[string]pkgmodel.FieldHint{"KmsKeyId": {HasProviderDefault: true}},
+	}
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "r"}`,
+		`{"Name": "r", "KmsKeyId": "key-123"}`,
+		`{"Name": "r"}`,
+		schema)
+
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "KmsKeyId", diffs[0].Path)
+	assert.Nil(t, diffs[0].From)
+	assert.JSONEq(t, `"key-123"`, string(diffs[0].To))
+}
+
+func TestSuppressedFieldDiffs_MultipleFields_SortedByPath(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "B", "A"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"B": {HasProviderDefault: true},
+			"A": {HasProviderDefault: true},
+		},
+	}
+
+	diffs := suppressedDiffsForTest(t,
+		`{"Name": "r", "A": 1, "B": 1}`,
+		`{"Name": "r", "A": 2, "B": 2}`,
+		`{"Name": "r"}`,
+		schema)
+
+	require.Len(t, diffs, 2)
+	assert.Equal(t, "A", diffs[0].Path)
+	assert.Equal(t, "B", diffs[1].Path)
+}

--- a/internal/metastructure/suppressed_drift_notes.go
+++ b/internal/metastructure/suppressed_drift_notes.go
@@ -1,0 +1,111 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package metastructure
+
+import (
+	"log/slog"
+	"sort"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/patch"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// computeSuppressedDriftNotes classifies out-of-band movement the plan cannot
+// see. It is strictly additive over the drift-rejection decision: candidates
+// are exactly the modifications filterUnabsorbedModifications absorbs (the
+// unabsorbed ones are rejection territory, displayed in full there), and for
+// each candidate the note carries the provider-default fields whose
+// suppressed content moved between the last reconcile and now. A candidate
+// that cannot be classified (a non-update operation, a missing property
+// blob, no matching forma declaration, or a diff error) produces no note:
+// every fallback is today's behavior, silence.
+//
+// The caller stamps the disposition: absorbed when a reconcile executes and
+// takes the drift out of the window, remaining when nothing executes and the
+// drift stays.
+func computeSuppressedDriftNotes(modificationsByStack map[string][]datastore.ResourceModification, forma *pkgmodel.Forma, fa *forma_command.FormaCommand) []forma_command.SuppressedDriftNote {
+	type modKey struct {
+		stack, typeName, label, operation string
+	}
+
+	stacks := make([]string, 0, len(modificationsByStack))
+	for stack := range modificationsByStack {
+		stacks = append(stacks, stack)
+	}
+	sort.Strings(stacks)
+
+	var notes []forma_command.SuppressedDriftNote
+	for _, stack := range stacks {
+		mods := modificationsByStack[stack]
+		unabsorbed := map[modKey]bool{}
+		for _, mod := range filterUnabsorbedModifications(mods, forma, fa) {
+			unabsorbed[modKey{mod.Stack, mod.Type, mod.Label, mod.Operation}] = true
+		}
+
+		for _, mod := range mods {
+			if unabsorbed[modKey{mod.Stack, mod.Type, mod.Label, mod.Operation}] {
+				continue
+			}
+			if mod.Operation != "update" || len(mod.OldProperties) == 0 || len(mod.Properties) == 0 {
+				continue
+			}
+			decl := findDeclarationForModification(forma, mod)
+			if decl == nil {
+				continue
+			}
+			diffs, err := patch.SuppressedFieldDiffs(mod.OldProperties, mod.Properties, decl.Properties, decl.Schema)
+			if err != nil {
+				slog.Warn("Failed to classify suppressed drift for resource; skipping note",
+					"stack", mod.Stack, "type", mod.Type, "label", mod.Label, "error", err)
+				continue
+			}
+			for _, d := range diffs {
+				notes = append(notes, forma_command.SuppressedDriftNote{
+					Stack:  mod.Stack,
+					Type:   mod.Type,
+					Label:  mod.Label,
+					Path:   d.Path,
+					From:   d.From,
+					To:     d.To,
+					Opaque: d.Opaque,
+				})
+			}
+		}
+	}
+	return notes
+}
+
+// findDeclarationForModification resolves a modification to its forma
+// declaration by current label or by the declaration's alias (a rename
+// records the modification under the old label), mirroring the matching
+// filterUnabsorbedModifications uses for absorption.
+func findDeclarationForModification(forma *pkgmodel.Forma, mod datastore.ResourceModification) *pkgmodel.Resource {
+	for i := range forma.Resources {
+		r := &forma.Resources[i]
+		if r.Stack != mod.Stack || r.Type != mod.Type {
+			continue
+		}
+		if r.Label == mod.Label || (r.Alias != "" && r.Alias == mod.Label) {
+			return r
+		}
+	}
+	return nil
+}
+
+// stampSuppressedDriftDisposition returns the notes with the given
+// disposition set on each.
+func stampSuppressedDriftDisposition(notes []forma_command.SuppressedDriftNote, disposition forma_command.SuppressedDriftDisposition) []forma_command.SuppressedDriftNote {
+	if len(notes) == 0 {
+		return nil
+	}
+	out := make([]forma_command.SuppressedDriftNote, len(notes))
+	for i, n := range notes {
+		n.Disposition = disposition
+		out[i] = n
+	}
+	return out
+}

--- a/internal/metastructure/suppressed_drift_notes_test.go
+++ b/internal/metastructure/suppressed_drift_notes_test.go
@@ -1,0 +1,243 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package metastructure
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func kmsSchemaForNotes() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"Name", "EnableKeyRotation"},
+		Hints:  map[string]pkgmodel.FieldHint{"EnableKeyRotation": {HasProviderDefault: true}},
+	}
+}
+
+func TestComputeSuppressedDriftNotes_AbsorbedSuppressedMovement_Noted(t *testing.T) {
+	mods := map[string][]datastore.ResourceModification{
+		"prod": {{
+			Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key", Operation: "update",
+			OldProperties: json.RawMessage(`{"Name": "k", "EnableKeyRotation": false}`),
+			Properties:    json.RawMessage(`{"Name": "k", "EnableKeyRotation": true}`),
+		}},
+	}
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key",
+		Properties: json.RawMessage(`{"Name": "k"}`),
+		Schema:     kmsSchemaForNotes(),
+	}}}
+	fa := &forma_command.FormaCommand{}
+
+	notes := computeSuppressedDriftNotes(mods, forma, fa)
+
+	require.Len(t, notes, 1)
+	assert.Equal(t, "prod", notes[0].Stack)
+	assert.Equal(t, "AWS::KMS::Key", notes[0].Type)
+	assert.Equal(t, "signing-key", notes[0].Label)
+	assert.Equal(t, "EnableKeyRotation", notes[0].Path)
+	assert.JSONEq(t, `false`, string(notes[0].From))
+	assert.JSONEq(t, `true`, string(notes[0].To))
+}
+
+func TestComputeSuppressedDriftNotes_UnabsorbedModification_NoNote(t *testing.T) {
+	// A modification with no matching forma declaration is unabsorbed: it is
+	// rejection territory (displayed in full there), never a note.
+	mods := map[string][]datastore.ResourceModification{
+		"prod": {{
+			Stack: "prod", Type: "AWS::KMS::Key", Label: "orphan", Operation: "update",
+			OldProperties: json.RawMessage(`{"EnableKeyRotation": false}`),
+			Properties:    json.RawMessage(`{"EnableKeyRotation": true}`),
+		}},
+	}
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key", Schema: kmsSchemaForNotes(),
+	}}}
+
+	notes := computeSuppressedDriftNotes(mods, forma, &forma_command.FormaCommand{})
+	assert.Empty(t, notes)
+}
+
+func TestComputeSuppressedDriftNotes_ModificationWithPendingUpdate_NoNote(t *testing.T) {
+	// A resource with a generated update keeps its modification unabsorbed
+	// (the rejection displays the full drift); the classifier must not
+	// produce a note for it.
+	mods := map[string][]datastore.ResourceModification{
+		"prod": {{
+			Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key", Operation: "update",
+			OldProperties: json.RawMessage(`{"Name": "k", "EnableKeyRotation": false}`),
+			Properties:    json.RawMessage(`{"Name": "k2", "EnableKeyRotation": true}`),
+		}},
+	}
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key",
+		Properties: json.RawMessage(`{"Name": "k2"}`),
+		Schema:     kmsSchemaForNotes(),
+	}}}
+	fa := &forma_command.FormaCommand{ResourceUpdates: []resource_update.ResourceUpdate{{
+		StackLabel:   "prod",
+		Operation:    resource_update.OperationUpdate,
+		DesiredState: pkgmodel.Resource{Type: "AWS::KMS::Key", Label: "signing-key"},
+	}}}
+
+	notes := computeSuppressedDriftNotes(mods, forma, fa)
+	assert.Empty(t, notes)
+}
+
+func TestComputeSuppressedDriftNotes_NonUpdateOperations_NeverNoted(t *testing.T) {
+	// Create/delete modifications carry no property blobs and are rejection
+	// territory; they must fail closed.
+	mods := map[string][]datastore.ResourceModification{
+		"prod": {
+			{Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key", Operation: "create"},
+			{Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key", Operation: "delete"},
+		},
+	}
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key",
+		Properties: json.RawMessage(`{"Name": "k"}`),
+		Schema:     kmsSchemaForNotes(),
+	}}}
+
+	notes := computeSuppressedDriftNotes(mods, forma, &forma_command.FormaCommand{})
+	assert.Empty(t, notes)
+}
+
+func TestComputeSuppressedDriftNotes_MissingPropertyBlobs_NoNote(t *testing.T) {
+	mods := map[string][]datastore.ResourceModification{
+		"prod": {{
+			Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key", Operation: "update",
+		}},
+	}
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key",
+		Properties: json.RawMessage(`{"Name": "k"}`),
+		Schema:     kmsSchemaForNotes(),
+	}}}
+
+	notes := computeSuppressedDriftNotes(mods, forma, &forma_command.FormaCommand{})
+	assert.Empty(t, notes)
+}
+
+func TestComputeSuppressedDriftNotes_AliasRename_ResolvesDeclaration(t *testing.T) {
+	// The modification is recorded under the old label; the forma renames
+	// the resource with alias. When no update was generated for it, the
+	// suppressed movement is still classified against the aliased
+	// declaration.
+	mods := map[string][]datastore.ResourceModification{
+		"prod": {{
+			Stack: "prod", Type: "AWS::KMS::Key", Label: "old-key", Operation: "update",
+			OldProperties: json.RawMessage(`{"Name": "k", "EnableKeyRotation": false}`),
+			Properties:    json.RawMessage(`{"Name": "k", "EnableKeyRotation": true}`),
+		}},
+	}
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "prod", Type: "AWS::KMS::Key", Label: "new-key", Alias: "old-key",
+		Properties: json.RawMessage(`{"Name": "k"}`),
+		Schema:     kmsSchemaForNotes(),
+	}}}
+
+	notes := computeSuppressedDriftNotes(mods, forma, &forma_command.FormaCommand{})
+	require.Len(t, notes, 1)
+	assert.Equal(t, "old-key", notes[0].Label, "the note names the modification's identity")
+	assert.Equal(t, "EnableKeyRotation", notes[0].Path)
+}
+
+func TestComputeSuppressedDriftNotes_DriftAbsorbedByDeclaration_NoNote(t *testing.T) {
+	// The user extracted the drifted values into the forma: the declared
+	// field is plan territory (and matches, so no update was generated).
+	// Nothing is suppressed.
+	mods := map[string][]datastore.ResourceModification{
+		"prod": {{
+			Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key", Operation: "update",
+			OldProperties: json.RawMessage(`{"Name": "k", "EnableKeyRotation": false}`),
+			Properties:    json.RawMessage(`{"Name": "k", "EnableKeyRotation": true}`),
+		}},
+	}
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key",
+		Properties: json.RawMessage(`{"Name": "k", "EnableKeyRotation": true}`),
+		Schema:     kmsSchemaForNotes(),
+	}}}
+
+	notes := computeSuppressedDriftNotes(mods, forma, &forma_command.FormaCommand{})
+	assert.Empty(t, notes)
+}
+
+func TestComputeSuppressedDriftNotes_ConvergenceOnlyUpdate_CoexistingSuppressedMovement_Noted(t *testing.T) {
+	// A convergence-only update does not block absorption (the existing
+	// filter's rule); suppressed movement on the same resource is still
+	// noted.
+	mods := map[string][]datastore.ResourceModification{
+		"prod": {{
+			Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key", Operation: "update",
+			OldProperties: json.RawMessage(`{"Name": "k", "EnableKeyRotation": false}`),
+			Properties:    json.RawMessage(`{"Name": "k", "EnableKeyRotation": true}`),
+		}},
+	}
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key",
+		Properties: json.RawMessage(`{"Name": "k"}`),
+		Schema:     kmsSchemaForNotes(),
+	}}}
+	fa := &forma_command.FormaCommand{ResourceUpdates: []resource_update.ResourceUpdate{{
+		StackLabel: "prod",
+		Operation:  resource_update.OperationUpdate,
+		DesiredState: pkgmodel.Resource{
+			Type: "AWS::KMS::Key", Label: "signing-key",
+			PatchDocument: json.RawMessage(`[{"op": "replace", "path": "/Secret", "value": "x"}]`),
+		},
+		ProvenanceRecords: []resource_update.OccurrenceRecord{{
+			DestinationPath:  "Secret",
+			Class:            resource_update.OccurrenceDeferredUpdate,
+			HasStoredWritten: true,
+			DesiredIdentity:  resource_update.OccurrenceIdentity{Ksuid: "id"},
+			StoredIdentity:   resource_update.OccurrenceIdentity{Ksuid: "id"},
+		}},
+	}}}
+
+	notes := computeSuppressedDriftNotes(mods, forma, fa)
+	require.Len(t, notes, 1)
+	assert.Equal(t, "EnableKeyRotation", notes[0].Path)
+}
+
+func TestComputeSuppressedDriftNotes_OpaquePath_NoValues(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "MasterSecret"},
+		Hints:  map[string]pkgmodel.FieldHint{"MasterSecret": {HasProviderDefault: true, Opaque: true}},
+	}
+	mods := map[string][]datastore.ResourceModification{
+		"prod": {{
+			Stack: "prod", Type: "X::Y::Z", Label: "r", Operation: "update",
+			OldProperties: json.RawMessage(`{"Name": "n", "MasterSecret": "h1"}`),
+			Properties:    json.RawMessage(`{"Name": "n", "MasterSecret": "h2"}`),
+		}},
+	}
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "prod", Type: "X::Y::Z", Label: "r",
+		Properties: json.RawMessage(`{"Name": "n"}`),
+		Schema:     schema,
+	}}}
+
+	notes := computeSuppressedDriftNotes(mods, forma, &forma_command.FormaCommand{})
+	require.Len(t, notes, 1)
+	assert.True(t, notes[0].Opaque)
+	assert.Nil(t, notes[0].From)
+	assert.Nil(t, notes[0].To)
+	raw, err := json.Marshal(notes[0])
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "h1")
+	assert.NotContains(t, string(raw), "h2")
+}

--- a/internal/metastructure/translate_test.go
+++ b/internal/metastructure/translate_test.go
@@ -52,3 +52,30 @@ func TestTranslateToAPICommand_Subject(t *testing.T) {
 	assert.Equal(t, "11111111-1111-4111-8111-111111111111", api.Subject)
 	assert.Equal(t, "dpanders", api.SubjectName)
 }
+
+// translateToAPICommand carries the command's suppressed-drift notes into the
+// API projection so status consumers read them from a typed field.
+func TestTranslateToAPICommand_SuppressedDriftNotes(t *testing.T) {
+	fa := &forma_command.FormaCommand{
+		ID:      "cmd-test-2",
+		Command: pkgmodel.CommandApply,
+		Config:  config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
+		SuppressedDriftNotes: []forma_command.SuppressedDriftNote{{
+			Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key",
+			Path: "EnableKeyRotation",
+			From: []byte(`false`), To: []byte(`true`),
+			Disposition: forma_command.SuppressedDriftAbsorbed,
+		}},
+	}
+
+	api := translateToAPICommand(fa)
+
+	if assert.Len(t, api.SuppressedDrift, 1) {
+		note := api.SuppressedDrift[0]
+		assert.Equal(t, "prod", note.Stack)
+		assert.Equal(t, "EnableKeyRotation", note.Path)
+		assert.JSONEq(t, `false`, string(note.From))
+		assert.JSONEq(t, `true`, string(note.To))
+		assert.Equal(t, "absorbed", note.Disposition)
+	}
+}

--- a/internal/workflow_tests/local/apply_forma/suppressed_drift_notes_test.go
+++ b/internal/workflow_tests/local/apply_forma/suppressed_drift_notes_test.go
@@ -1,0 +1,206 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// A hasProviderDefault field the user omits ("rotation") is set by the cloud
+// at create time and flipped out of band afterwards. The suppressed movement
+// must surface on every reconcile-mode response: as a disposition-remaining
+// note on a no-changes apply (which absorbs nothing), and as a
+// disposition-absorbed note persisted on a reconcile that executes with a
+// co-located change (whose completion advances the drift window past the
+// movement).
+func TestApplyForma_SuppressedDriftNotes_EndToEnd(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		providerDefaultSchema := pkgmodel.Schema{
+			Fields: []string{"foo", "rotation"},
+			Hints:  map[string]pkgmodel.FieldHint{"rotation": {HasProviderDefault: true}},
+		}
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				props := `{"foo":"bar","rotation":"off"}`
+				if request.Label == "resource-two" {
+					props = `{"foo":"new"}`
+				}
+				return &resource.CreateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:          resource.OperationCreate,
+						OperationStatus:    resource.OperationStatusSuccess,
+						NativeID:           request.Label,
+						ResourceProperties: json.RawMessage(props),
+					},
+				}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				// The cloud state after the out-of-band flip.
+				props := `{"foo":"bar","rotation":"on"}`
+				if request.NativeID == "resource-two" {
+					props = `{"foo":"new"}`
+				}
+				return &resource.ReadResult{
+					ResourceType: request.ResourceType,
+					Properties:   props,
+				}, nil
+			},
+		}
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		resourceOne := pkgmodel.Resource{
+			Label:      "resource-one",
+			Type:       "FakeAWS::Resource",
+			Stack:      "drift-stack",
+			Target:     "test-target1",
+			Schema:     providerDefaultSchema,
+			Properties: json.RawMessage(`{"foo":"bar"}`),
+		}
+		target := pkgmodel.Target{
+			Label:     "test-target1",
+			Namespace: "test-namespace1",
+			Config:    json.RawMessage(`{}`),
+		}
+		initial := &pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: "drift-stack"}},
+			Resources: []pkgmodel.Resource{resourceOne},
+			Targets:   []pkgmodel.Target{target},
+		}
+
+		_, err = m.ApplyForma(initial,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+
+		var commands []*forma_command.FormaCommand
+		require.Eventually(t, func() bool {
+			commands, err = m.Datastore.LoadFormaCommands()
+			assert.NoError(t, err)
+			return len(commands) == 1 && allCommandsSuccessful(commands)
+		}, 10*time.Second, 100*time.Millisecond, "initial reconcile should complete")
+
+		// Sync absorbs the out-of-band flip and records the modification.
+		require.NoError(t, m.ForceSync())
+		require.Eventually(t, func() bool {
+			drift, derr := m.ListDrift("drift-stack")
+			assert.NoError(t, derr)
+			return drift != nil && len(drift.ModifiedResources) == 1
+		}, 10*time.Second, 100*time.Millisecond, "sync should record the OOB modification")
+
+		// A simulate of the unchanged forma is a no-changes response that
+		// carries the suppressed movement, disposition remaining.
+		resp, err := m.ApplyForma(initial,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: true},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+		assert.False(t, resp.Simulation.ChangesRequired)
+		require.Len(t, resp.Simulation.SuppressedDrift, 1, "simulate must surface the suppressed movement")
+		note := resp.Simulation.SuppressedDrift[0]
+		assert.Equal(t, "drift-stack", note.Stack)
+		assert.Equal(t, "resource-one", note.Label)
+		assert.Equal(t, "rotation", note.Path)
+		assert.JSONEq(t, `"off"`, string(note.From))
+		assert.JSONEq(t, `"on"`, string(note.To))
+		assert.Equal(t, "remaining", note.Disposition)
+
+		// A non-simulate apply of the unchanged forma is a no-op: it
+		// persists no command, absorbs nothing, and the drift stays in the
+		// window.
+		resp, err = m.ApplyForma(initial,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+		assert.False(t, resp.Simulation.ChangesRequired)
+		require.Len(t, resp.Simulation.SuppressedDrift, 1)
+		assert.Equal(t, "remaining", resp.Simulation.SuppressedDrift[0].Disposition)
+
+		commands, err = m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		assert.Equal(t, 1, countApplyCommands(commands), "a no-op apply must not persist a command")
+
+		drift, err := m.ListDrift("drift-stack")
+		require.NoError(t, err)
+		require.NotNil(t, drift)
+		assert.Len(t, drift.ModifiedResources, 1, "a no-op apply must not advance the drift window")
+
+		// A reconcile with a co-located change executes; its response and
+		// its persisted command carry the note, disposition absorbed, and
+		// its completion advances the window.
+		withNewResource := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "drift-stack"}},
+			Resources: []pkgmodel.Resource{
+				resourceOne,
+				{
+					Label:      "resource-two",
+					Type:       "FakeAWS::Resource",
+					Stack:      "drift-stack",
+					Target:     "test-target1",
+					Schema:     pkgmodel.Schema{Fields: []string{"foo"}},
+					Properties: json.RawMessage(`{"foo":"new"}`),
+				},
+			},
+			Targets: []pkgmodel.Target{target},
+		}
+
+		resp, err = m.ApplyForma(withNewResource,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+		assert.True(t, resp.Simulation.ChangesRequired)
+		require.Len(t, resp.Simulation.SuppressedDrift, 1, "the executing reconcile must carry the note")
+		assert.Equal(t, "absorbed", resp.Simulation.SuppressedDrift[0].Disposition)
+
+		require.Eventually(t, func() bool {
+			commands, err = m.Datastore.LoadFormaCommands()
+			assert.NoError(t, err)
+			return countApplyCommands(commands) == 2 && allCommandsSuccessful(commands)
+		}, 10*time.Second, 100*time.Millisecond, "co-located reconcile should complete")
+
+		var absorbed *forma_command.FormaCommand
+		for _, cmd := range commands {
+			if len(cmd.SuppressedDriftNotes) > 0 {
+				absorbed = cmd
+			}
+		}
+		require.NotNil(t, absorbed, "the persisted command must carry the suppressed-drift note durably")
+		require.Len(t, absorbed.SuppressedDriftNotes, 1)
+		assert.Equal(t, "rotation", absorbed.SuppressedDriftNotes[0].Path)
+		assert.Equal(t, forma_command.SuppressedDriftAbsorbed, absorbed.SuppressedDriftNotes[0].Disposition)
+
+		require.Eventually(t, func() bool {
+			drift, derr := m.ListDrift("drift-stack")
+			assert.NoError(t, derr)
+			return drift != nil && len(drift.ModifiedResources) == 0
+		}, 10*time.Second, 100*time.Millisecond, "the completed reconcile advances the window past the drift")
+	})
+}
+
+func countApplyCommands(commands []*forma_command.FormaCommand) int {
+	n := 0
+	for _, cmd := range commands {
+		if cmd.Command == pkgmodel.CommandApply {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/workflow_tests/local/apply_forma/suppressed_drift_notes_test.go
+++ b/internal/workflow_tests/local/apply_forma/suppressed_drift_notes_test.go
@@ -204,3 +204,302 @@ func countApplyCommands(commands []*forma_command.FormaCommand) int {
 	}
 	return n
 }
+
+// A patch-mode submission never classifies drift: the suppressed-drift
+// machinery is reconcile-only.
+func TestApplyForma_SuppressedDriftNotes_PatchModeEmitsNone(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		schema := pkgmodel.Schema{
+			Fields: []string{"foo", "rotation"},
+			Hints:  map[string]pkgmodel.FieldHint{"rotation": {HasProviderDefault: true}},
+		}
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				return &resource.CreateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:          resource.OperationCreate,
+						OperationStatus:    resource.OperationStatusSuccess,
+						NativeID:           request.Label,
+						ResourceProperties: json.RawMessage(`{"foo":"bar","rotation":"off"}`),
+					},
+				}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{ResourceType: request.ResourceType, Properties: `{"foo":"bar","rotation":"on"}`}, nil
+			},
+			Update: func(request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				return &resource.UpdateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:          resource.OperationUpdate,
+						OperationStatus:    resource.OperationStatusSuccess,
+						NativeID:           request.NativeID,
+						ResourceProperties: json.RawMessage(`{"foo":"patched","rotation":"on"}`),
+					},
+				}, nil
+			},
+		}
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		target := pkgmodel.Target{Label: "test-target1", Namespace: "test-namespace1", Config: json.RawMessage(`{}`)}
+		forma := func(foo string) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks: []pkgmodel.Stack{{Label: "patch-stack"}},
+				Resources: []pkgmodel.Resource{{
+					Label: "resource-one", Type: "FakeAWS::Resource", Stack: "patch-stack",
+					Target: "test-target1", Schema: schema,
+					Properties: json.RawMessage(`{"foo":"` + foo + `"}`),
+				}},
+				Targets: []pkgmodel.Target{target},
+			}
+		}
+
+		_, err = m.ApplyForma(forma("bar"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+		var commands []*forma_command.FormaCommand
+		require.Eventually(t, func() bool {
+			commands, err = m.Datastore.LoadFormaCommands()
+			assert.NoError(t, err)
+			return countApplyCommands(commands) == 1 && allCommandsSuccessful(commands)
+		}, 10*time.Second, 100*time.Millisecond)
+
+		require.NoError(t, m.ForceSync())
+		require.Eventually(t, func() bool {
+			drift, derr := m.ListDrift("patch-stack")
+			assert.NoError(t, derr)
+			return drift != nil && len(drift.ModifiedResources) == 1
+		}, 10*time.Second, 100*time.Millisecond)
+
+		resp, err := m.ApplyForma(forma("patched"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch, Simulate: true},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+		assert.Empty(t, resp.Simulation.SuppressedDrift, "patch mode must not classify suppressed drift")
+	})
+}
+
+// A forced reconcile proceeds past unabsorbed drift as it always has, and its
+// command now records notes for the suppressed movement on absorbed
+// modifications.
+func TestApplyForma_SuppressedDriftNotes_ForcedReconcileCarriesNotes(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		schema := pkgmodel.Schema{
+			Fields: []string{"foo", "rotation"},
+			Hints:  map[string]pkgmodel.FieldHint{"rotation": {HasProviderDefault: true}},
+		}
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				// Echo the requested foo; the cloud sets rotation at create.
+				var req map[string]any
+				_ = json.Unmarshal(request.Properties, &req)
+				echoed, _ := json.Marshal(map[string]any{"foo": req["foo"], "rotation": "off"})
+				return &resource.CreateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:          resource.OperationCreate,
+						OperationStatus:    resource.OperationStatusSuccess,
+						NativeID:           request.Label,
+						ResourceProperties: json.RawMessage(echoed),
+					},
+				}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				// Both the declared field and the suppressed field moved OOB.
+				return &resource.ReadResult{ResourceType: request.ResourceType, Properties: `{"foo":"oob","rotation":"on"}`}, nil
+			},
+			Update: func(request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				return &resource.UpdateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:          resource.OperationUpdate,
+						OperationStatus:    resource.OperationStatusSuccess,
+						NativeID:           request.NativeID,
+						ResourceProperties: json.RawMessage(`{"foo":"bar","rotation":"on"}`),
+					},
+				}, nil
+			},
+		}
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		target := pkgmodel.Target{Label: "test-target1", Namespace: "test-namespace1", Config: json.RawMessage(`{}`)}
+		declared := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "force-stack"}},
+			Resources: []pkgmodel.Resource{
+				{
+					Label: "drifting", Type: "FakeAWS::Resource", Stack: "force-stack",
+					Target: "test-target1", Schema: schema,
+					Properties: json.RawMessage(`{"foo":"bar"}`),
+				},
+				{
+					// Declared at the value the cloud reports, so no update is
+					// ever generated for it: its modification is the suppressed
+					// rotation flip alone, which absorbs.
+					Label: "quiet", Type: "FakeAWS::Resource", Stack: "force-stack",
+					Target: "test-target1", Schema: schema,
+					Properties: json.RawMessage(`{"foo":"oob"}`),
+				},
+			},
+			Targets: []pkgmodel.Target{target},
+		}
+
+		_, err = m.ApplyForma(declared,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+		var commands []*forma_command.FormaCommand
+		require.Eventually(t, func() bool {
+			commands, err = m.Datastore.LoadFormaCommands()
+			assert.NoError(t, err)
+			return countApplyCommands(commands) == 1 && allCommandsSuccessful(commands)
+		}, 10*time.Second, 100*time.Millisecond)
+
+		require.NoError(t, m.ForceSync())
+		require.Eventually(t, func() bool {
+			drift, derr := m.ListDrift("force-stack")
+			assert.NoError(t, derr)
+			return drift != nil && len(drift.ModifiedResources) >= 1
+		}, 10*time.Second, 100*time.Millisecond)
+
+		// Non-forced: the declared-field drift on "drifting" rejects.
+		_, err = m.ApplyForma(declared,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
+			"test-client-id", "", "")
+		require.Error(t, err, "unabsorbed drift must still reject a non-forced reconcile")
+
+		// Forced: proceeds, and the command carries suppressed-drift notes
+		// for the absorbed modifications' suppressed movement.
+		resp, err := m.ApplyForma(declared,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false, Force: true},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+		var paths []string
+		for _, n := range resp.Simulation.SuppressedDrift {
+			paths = append(paths, n.Label+"."+n.Path)
+		}
+		assert.Contains(t, paths, "quiet.rotation", "the absorbed resource's suppressed movement is noted on the forced apply")
+	})
+}
+
+// Documents a pre-existing property of the drift-window anchor: the most
+// recent reconcile command with a persisted resource row anchors the window
+// regardless of the command's final state, so a partially failed reconcile
+// still takes prior drift out of the window. The suppressed-drift note
+// persisted with that failed command is then the surviving record of the
+// movement.
+func TestApplyForma_SuppressedDriftNotes_FailedReconcileStillAnchorsWindow(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		schema := pkgmodel.Schema{
+			Fields: []string{"foo", "rotation"},
+			Hints:  map[string]pkgmodel.FieldHint{"rotation": {HasProviderDefault: true}},
+		}
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				if request.Label == "failing" {
+					return &resource.CreateResult{
+						ProgressResult: &resource.ProgressResult{
+							Operation:       resource.OperationCreate,
+							OperationStatus: resource.OperationStatusFailure,
+							NativeID:        request.Label,
+						},
+					}, nil
+				}
+				var req map[string]any
+				_ = json.Unmarshal(request.Properties, &req)
+				echoed, _ := json.Marshal(map[string]any{"foo": req["foo"], "rotation": "off"})
+				return &resource.CreateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:          resource.OperationCreate,
+						OperationStatus:    resource.OperationStatusSuccess,
+						NativeID:           request.Label,
+						ResourceProperties: json.RawMessage(echoed),
+					},
+				}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{ResourceType: request.ResourceType, Properties: `{"foo":"bar","rotation":"on"}`}, nil
+			},
+		}
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		require.NoError(t, err)
+
+		target := pkgmodel.Target{Label: "test-target1", Namespace: "test-namespace1", Config: json.RawMessage(`{}`)}
+		res := func(label string) pkgmodel.Resource {
+			return pkgmodel.Resource{
+				Label: label, Type: "FakeAWS::Resource", Stack: "anchor-stack",
+				Target: "test-target1", Schema: schema,
+				Properties: json.RawMessage(`{"foo":"bar"}`),
+			}
+		}
+
+		initial := &pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: "anchor-stack"}},
+			Resources: []pkgmodel.Resource{res("steady")},
+			Targets:   []pkgmodel.Target{target},
+		}
+		_, err = m.ApplyForma(initial,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+		var commands []*forma_command.FormaCommand
+		require.Eventually(t, func() bool {
+			commands, err = m.Datastore.LoadFormaCommands()
+			assert.NoError(t, err)
+			return countApplyCommands(commands) == 1 && allCommandsSuccessful(commands)
+		}, 10*time.Second, 100*time.Millisecond)
+
+		require.NoError(t, m.ForceSync())
+		require.Eventually(t, func() bool {
+			drift, derr := m.ListDrift("anchor-stack")
+			assert.NoError(t, derr)
+			return drift != nil && len(drift.ModifiedResources) == 1
+		}, 10*time.Second, 100*time.Millisecond)
+
+		// A reconcile adding one succeeding and one failing resource: the
+		// command fails, but the succeeding create persists a resource row,
+		// which anchors the window.
+		expanded := &pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: "anchor-stack"}},
+			Resources: []pkgmodel.Resource{res("steady"), res("added"), res("failing")},
+			Targets:   []pkgmodel.Target{target},
+		}
+		resp, err := m.ApplyForma(expanded,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: false},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+		require.Len(t, resp.Simulation.SuppressedDrift, 1, "the failing reconcile still records the note")
+
+		require.Eventually(t, func() bool {
+			commands, err = m.Datastore.LoadFormaCommands()
+			assert.NoError(t, err)
+			for _, cmd := range commands {
+				if cmd.Command == pkgmodel.CommandApply && cmd.State == forma_command.CommandStateFailed {
+					return true
+				}
+			}
+			return false
+		}, 15*time.Second, 100*time.Millisecond, "the expanded reconcile should fail")
+
+		// Pre-existing behavior, pinned: the failed reconcile anchors the
+		// window and the prior drift record leaves it.
+		require.Eventually(t, func() bool {
+			drift, derr := m.ListDrift("anchor-stack")
+			assert.NoError(t, derr)
+			return drift != nil && len(drift.ModifiedResources) == 0
+		}, 10*time.Second, 100*time.Millisecond, "a failed reconcile with a persisted resource row advances the window (pre-existing behavior)")
+
+		// The durable record of the movement is the note on the failed
+		// command.
+		var noted *forma_command.FormaCommand
+		for _, cmd := range commands {
+			if len(cmd.SuppressedDriftNotes) > 0 {
+				noted = cmd
+			}
+		}
+		require.NotNil(t, noted)
+		assert.Equal(t, "rotation", noted.SuppressedDriftNotes[0].Path)
+	})
+}

--- a/pkg/api/model/types.go
+++ b/pkg/api/model/types.go
@@ -26,6 +26,10 @@ type Simulation struct {
 	ChangesRequired bool     `json:"ChangesRequired"`
 	Command         Command  `json:"Command"`
 	Warnings        []string `json:"Warnings,omitempty"`
+	// SuppressedDrift is present on every reconcile-mode response, including
+	// a no-changes one (where Command is empty), so callers see suppressed
+	// out-of-band movement regardless of whether anything was planned.
+	SuppressedDrift []SuppressedDriftNote `json:"SuppressedDrift,omitempty"`
 }
 
 type ListCommandStatusResponse struct {
@@ -65,6 +69,29 @@ type Command struct {
 	TargetUpdates   []TargetUpdate   `json:"TargetUpdates,omitempty"`
 	StackUpdates    []StackUpdate    `json:"StackUpdates,omitempty"`
 	PolicyUpdates   []PolicyUpdate   `json:"PolicyUpdates,omitempty"`
+	// SuppressedDrift records out-of-band movement on provider-default
+	// fields this command's plan could not see; completing the command
+	// absorbs it (see SuppressedDriftNote).
+	SuppressedDrift []SuppressedDriftNote `json:"SuppressedDrift,omitempty"`
+}
+
+// SuppressedDriftNote is out-of-band movement on a provider-default field a
+// reconcile's plan cannot see: the field is annotated hasProviderDefault and
+// the forma does not declare it, so the diff suppresses it. From and To
+// carry the moved content; both are absent for an opaque path, which records
+// path and movement only. Disposition says what the submission did about it:
+// "remaining" (nothing executed; the drift stays in the
+// changes-since-last-reconcile window) or "absorbed" (the command's
+// completion advances the window past it without addressing it).
+type SuppressedDriftNote struct {
+	Stack       string          `json:"Stack"`
+	Type        string          `json:"Type"`
+	Label       string          `json:"Label"`
+	Path        string          `json:"Path"`
+	From        json.RawMessage `json:"From,omitempty"`
+	To          json.RawMessage `json:"To,omitempty"`
+	Opaque      bool            `json:"Opaque,omitempty"`
+	Disposition string          `json:"Disposition"`
 }
 
 // wrapper for machine-readable output


### PR DESCRIPTION
## Summary

An out-of-band change on a `hasProviderDefault` field the forma does not declare is recorded by sync and visible in the drift API, but invisible to apply and simulate: the provider-default strip passes hide the field from the diff, no update is generated, and the absorbed-modification filter infers "absorbed" from "no update generated". A reconcile with co-located changes then advances the changes-since-last-reconcile window past the drift without ever showing it, and a drift-only apply returns "no changes" while the drift API says otherwise. That inference is also load-bearing: it is what keeps runtime-managed churn (ECS-registered target-group targets and the like) from rejecting every apply, so rejection behavior must not change.

This makes the movement visible without touching rejection:

- Every reconcile-mode submission takes one drift-window snapshot before the no-changes return and regardless of `--force`. The rejection gate consumes the same snapshot with its exact historical scope (the stacks with generated updates), including the convergence-only and alias rules; suppressed-only drift still never rejects, unabsorbed drift still does.
- Each absorbed update-operation modification is classified per suppressed provider-default field: a shared implementation of the strip predicates decides what is suppressed (omitted fields; undeclared-key elements of partially declared EntitySet fields; dotted leaves per the strip's regimes), and comparison is schema-aware so representation churn is not movement (EntitySet content compares keyed, unkeyed collections as unordered multisets, Array-hinted fields ordered, dotted leaves as leaf multisets). Fields that moved become typed suppressed-drift notes.
- Disposition `remaining` on a no-op apply: nothing executes, no command is persisted, the window does not advance, and the response says the drift stays pending. Disposition `absorbed` on an executing command: the notes persist with the command (one nullable `suppressed_drift_notes` column on `forma_commands` across sqlite, postgres, mssql, and aurora) as the durable record of what its completion absorbed without addressing.
- An opaque path (schema hint on the path, an ancestor or descendant, or an envelope visibility marker in the content) is sanitized at note construction: path and the fact of movement only, never values or digests, in the persisted command, responses, CLI output, and logs.
- The CLI renders the notes in the interactive simview (a warning panel above the plan), the plain renderer, and both no-changes paths; machine mode carries them in the typed `Simulation.SuppressedDrift` field, and command status projects them from the persisted command.
- Notes are additive only and fail closed: create/delete/replace modifications, missing property blobs, unmatched resources, and diff errors produce no note and keep today's behavior.

## Tests

- Classifier-level pins for every comparison rule: omitted scalars and collections, declared fields, null-as-omitted, EntitySet partial declarations and explicit-empty, reorder-only Set/EntitySet observations, Array-hint ordering, dotted-leaf regimes (array-nested compared regardless of declaration, pure-object conditional), opaque sanitization via schema hint and via nested envelope markers, and appearance/disappearance of a field.
- Note-assembly pins: absorbed vs unabsorbed candidacy, pending-update exclusion, alias resolution, convergence-only coexistence, extract-absorbed declarations, fail-closed cases, and no opaque material in a marshaled note.
- End-to-end workflow coverage: the pure-drift trace (simulate surfaces the note, a no-op apply persists nothing and leaves the window alone), co-located absorption (note on the response and the persisted command, window advances, next simulate clean), forced reconcile (unabsorbed drift still rejects non-forced; force proceeds and records notes), patch-mode exclusion, and a pin of the pre-existing anchor property that a partially failed reconcile with a persisted resource row still advances the window, with the note on the failed command as the surviving record.
- A cross-dialect datastore round-trip suite for the new column.

One reviewed residual, deliberately not handled: when actual state has an object where desired has an array at the same dotted segment, the classifier can over-collect a leaf the strip would leave alone; that shape divergence generates an update, which excludes the modification from note candidacy, so the residual is fenced by the candidate rule.