### PR TITLE
fix(connect): keep the Google sign-in's own instructions when it fails

### DIFF
--- a/internal/cli/connect/gcpauth.go
+++ b/internal/cli/connect/gcpauth.go
@@ -5,6 +5,7 @@
 package connect
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -225,14 +226,35 @@ var runGcloudLogin = func(ctx context.Context, out io.Writer) error {
 	// what it is running.
 	_, _ = fmt.Fprintf(out, "running %s\n", gcloudLoginCommand)
 
+	// gcloud's output is captured as well as forwarded, because a sign-in that
+	// cannot finish has already printed the only thing that would let the
+	// operator finish it by hand.
+	//
+	// Where a browser can be opened, gcloud opens one and completes over a
+	// loopback redirect without ever reading stdin. Where it cannot - a
+	// container, an SSH session, a headless box - it falls back to printing a
+	// URL and waiting for a verification code typed back, and this process's
+	// stdin is not a terminal when an agent invoked it. The sign-in then fails
+	// having printed exactly what the operator needs, and forwarding that to a
+	// stream nobody reads is the same as discarding it: a machine caller reads
+	// this command's stdout, so the URL has to travel in the document.
+	var transcript bytes.Buffer
 	cmd := exec.CommandContext(ctx, path, "auth", "application-default", "login")
-	cmd.Stdout = out
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = io.MultiWriter(out, &transcript)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &transcript)
 	cmd.Stdin = os.Stdin
 	if err := cmd.Run(); err != nil {
+		details := map[string]any{"command": gcloudLoginCommand}
+		// Omitted when empty rather than sent as "": a present key invites the
+		// reader to look for meaning that is not there.
+		if said := strings.TrimSpace(transcript.String()); said != "" {
+			details["output"] = said
+		}
 		return printer.Fail(printer.CodeCredentialsRequired,
-			"the Google Cloud sign-in did not complete",
-			map[string]any{"command": gcloudLoginCommand})
+			"the Google Cloud sign-in did not complete; what gcloud reported is in the details. "+
+				"A machine with no browser cannot finish this sign-in unattended - run it in a "+
+				"terminal, then try again",
+			details)
 	}
 	return nil
 }

--- a/internal/cli/connect/gcpauth_test.go
+++ b/internal/cli/connect/gcpauth_test.go
@@ -1,0 +1,104 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package connect
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/internal/cli/printer"
+)
+
+// fakeGcloud writes a script standing in for gcloud and points the resolver at
+// it. body is the shell after the shebang, so a test decides what the sign-in
+// prints and whether it succeeds.
+func fakeGcloud(t *testing.T, body string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gcloud")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o700); err != nil {
+		t.Fatalf("write fake gcloud: %v", err)
+	}
+	restore := gcloudBinary
+	gcloudBinary = path
+	t.Cleanup(func() { gcloudBinary = restore })
+}
+
+// A sign-in that cannot finish must hand back what gcloud said, because that is
+// the only place the URL exists.
+//
+// On a machine that can open a browser gcloud completes over a loopback
+// redirect and never reads stdin. Where it cannot - a container, an SSH
+// session, a headless box - it falls back to printing a URL and waiting for a
+// verification code typed back, and the CLI's stdin is not a terminal there. So
+// the sign-in fails, and everything the operator needs in order to finish it by
+// hand has already been printed. Dropping that leaves them with "did not
+// complete" and no way to act on it.
+func TestFailedSignInReportsWhatGcloudPrinted(t *testing.T) {
+	fakeGcloud(t, `echo "Go to the following link in your browser:"
+echo "    https://accounts.google.com/o/oauth2/auth?code_challenge=abc"
+echo "gcloud crashed (EOFError): EOF when reading a line" >&2
+exit 1`)
+
+	err := runGcloudLogin(context.Background(), &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("a sign-in that exited non-zero must fail")
+	}
+
+	var failure *printer.Failure
+	if !errors.As(err, &failure) {
+		t.Fatalf("want a printer failure, got %T: %v", err, err)
+	}
+	if failure.Code != printer.CodeCredentialsRequired {
+		t.Errorf("code = %q, want %q", failure.Code, printer.CodeCredentialsRequired)
+	}
+	if failure.Details["command"] != gcloudLoginCommand {
+		t.Errorf("details lost the command: %#v", failure.Details)
+	}
+
+	output, _ := failure.Details["output"].(string)
+	if !strings.Contains(output, "https://accounts.google.com/o/oauth2/auth") {
+		t.Errorf("details must carry the sign-in URL, got %q", output)
+	}
+	// Both streams, because gcloud splits the instructions across them and
+	// either half alone is not enough to act on.
+	if !strings.Contains(output, "EOF when reading a line") {
+		t.Errorf("details must carry gcloud's own diagnosis, got %q", output)
+	}
+}
+
+// A sign-in that works carries no output detail. There is nothing to report and
+// an empty key invites a reader to look for meaning in it.
+func TestSuccessfulSignInReportsNothing(t *testing.T) {
+	fakeGcloud(t, `echo "Credentials saved."`)
+
+	if err := runGcloudLogin(context.Background(), &bytes.Buffer{}); err != nil {
+		t.Fatalf("a sign-in that exited zero must succeed: %v", err)
+	}
+}
+
+// What gcloud prints still reaches the operator's own stream as it happens.
+// Capturing it for the failure detail must not silence the live run, or a human
+// watching a terminal loses the URL they are supposed to open.
+func TestSignInStillReportsLive(t *testing.T) {
+	fakeGcloud(t, `echo "Go to https://accounts.google.com/o/oauth2/auth?x=1"
+exit 1`)
+
+	var out bytes.Buffer
+	_ = runGcloudLogin(context.Background(), &out)
+
+	if !strings.Contains(out.String(), "https://accounts.google.com/o/oauth2/auth") {
+		t.Errorf("the live stream lost the URL: %q", out.String())
+	}
+	if !strings.Contains(out.String(), gcloudLoginCommand) {
+		t.Errorf("the live stream must still name the command it ran: %q", out.String())
+	}
+}


### PR DESCRIPTION
## Summary

A Google sign-in that cannot finish has already printed the one thing that would let the operator finish it by hand, and formae was discarding it.

Where a browser can be opened, gcloud opens one and completes over a loopback redirect without ever reading stdin. Where it cannot — a container, an SSH session, a headless box — it falls back to printing a URL and waiting for a verification code typed back, and this process's stdin is not a terminal when an agent invoked it. The sign-in then fails having printed a URL and its own diagnosis, and both went somewhere a machine caller never reads: it takes this command's stdout, and under machine output the sign-in reports on stderr. The operator was left with `the Google Cloud sign-in did not complete` and no way to act on it.

- gcloud's stdout and stderr are now captured as well as forwarded, and a failed sign-in carries the transcript in the failure details under `output`. Omitted when empty, so a present key always means something.
- The message says plainly that a machine with no browser cannot finish this unattended, so the remedy is a terminal rather than another attempt.
- The live stream is untouched, so a human watching a terminal still sees the URL as gcloud prints it.

Found by running the connect flow through the MCP in a clean container with gcloud installed and no browser. formae resolved gcloud and ran it correctly — the failure was entirely in what came back.

Three tests, driving a fake gcloud rather than stubbing the runner, so they exercise the real capture path: a failed sign-in carries both streams in the details, a successful one carries nothing, and the live stream still receives the URL and the command being run.