### PR TITLE
fix(patch,resource-update): empty values survive hinted fields and unresolved reference adds plan

### DIFF
--- a/internal/metastructure/patch/empty_value_fidelity.go
+++ b/internal/metastructure/patch/empty_value_fidelity.go
@@ -1,0 +1,82 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package patch
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// firstPointerSegment returns the first segment of an RFC 6901 JSON Pointer,
+// unescaped (~1 -> /, then ~0 -> ~). ok is false for anything that is not a
+// pointer with at least one non-empty segment. Matching fidelity roots by
+// first segment (never by string prefix) is what keeps "/Specification" from
+// matching a root named "Spec".
+func firstPointerSegment(path string) (string, bool) {
+	rest, found := strings.CutPrefix(path, "/")
+	if !found || rest == "" {
+		return "", false
+	}
+	seg, _, _ := strings.Cut(rest, "/")
+	if seg == "" {
+		return "", false
+	}
+	seg = strings.ReplaceAll(seg, "~1", "/")
+	seg = strings.ReplaceAll(seg, "~0", "~")
+	return seg, true
+}
+
+// isKeepableReferenceEnvelope reports whether a desired-side value is a
+// reference envelope well-formed enough that its flattened placeholder must
+// survive the top-level empty-value drop: either a $ref that parses to a
+// formae URI with a KSUID, or a complete $res declaration. $ref wins when
+// both appear (the translated form is authoritative). Deliberately stricter
+// than occurrence collection: an envelope with no usable reference identity
+// is not kept, so a malformed object can never mint a placeholder op.
+func isKeepableReferenceEnvelope(value gjson.Result) bool {
+	if !value.IsObject() {
+		return false
+	}
+	if ref := value.Get("$ref"); ref.Exists() {
+		return ref.Type == gjson.String && pkgmodel.FormaeURI(ref.String()).KSUID() != ""
+	}
+	if res := value.Get("$res"); res.Exists() {
+		if !res.IsBool() || !res.Bool() {
+			return false
+		}
+		for _, key := range []string{"$label", "$type", "$stack", "$property"} {
+			member := value.Get(key)
+			if member.Type != gjson.String || member.String() == "" {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// referenceEnvelopeFields returns the schema fields whose desired pre-flatten
+// value is a keepable reference envelope. Absent, malformed, or non-object
+// input contributes nothing: the failure direction is always "field dropped
+// as today", never "non-envelope kept".
+func referenceEnvelopeFields(desiredEnvelopes []byte, schemaFields []string) map[string]bool {
+	fields := map[string]bool{}
+	if len(desiredEnvelopes) == 0 {
+		return fields
+	}
+	parsed := gjson.ParseBytes(desiredEnvelopes)
+	if !parsed.IsObject() {
+		return fields
+	}
+	for _, field := range schemaFields {
+		if isKeepableReferenceEnvelope(parsed.Get(field)) {
+			fields[field] = true
+		}
+	}
+	return fields
+}

--- a/internal/metastructure/patch/empty_value_fidelity.go
+++ b/internal/metastructure/patch/empty_value_fidelity.go
@@ -63,8 +63,12 @@ func isKeepableReferenceEnvelope(value gjson.Result) bool {
 // referenceEnvelopeFields returns the schema fields whose desired pre-flatten
 // value is a keepable reference envelope. Absent, malformed, or non-object
 // input contributes nothing: the failure direction is always "field dropped
-// as today", never "non-envelope kept".
-func referenceEnvelopeFields(desiredEnvelopes []byte, schemaFields []string) map[string]bool {
+// as today", never "non-envelope kept". CreateOnly destinations are excluded
+// outright: a kept placeholder there could only ever surface as a
+// replacement, and a replacement must never be planned from a value that has
+// not resolved - an import-shaped source whose property is never written
+// would otherwise destroy its consumer.
+func referenceEnvelopeFields(desiredEnvelopes []byte, schema pkgmodel.Schema) map[string]bool {
 	fields := map[string]bool{}
 	if len(desiredEnvelopes) == 0 {
 		return fields
@@ -73,7 +77,10 @@ func referenceEnvelopeFields(desiredEnvelopes []byte, schemaFields []string) map
 	if !parsed.IsObject() {
 		return fields
 	}
-	for _, field := range schemaFields {
+	for _, field := range schema.Fields {
+		if schema.Hints[field].CreateOnly {
+			continue
+		}
 		if isKeepableReferenceEnvelope(parsed.Get(field)) {
 			fields[field] = true
 		}

--- a/internal/metastructure/patch/empty_value_fidelity.go
+++ b/internal/metastructure/patch/empty_value_fidelity.go
@@ -88,12 +88,12 @@ func referenceEnvelopeFields(desiredEnvelopes []byte, schema pkgmodel.Schema) ma
 	return fields
 }
 
-// preserveEmptyRootFields returns the literal top-level rendered property
+// PreserveEmptyRootFields returns the literal top-level rendered property
 // names whose FieldHint sets PreserveEmptyValues, derived from schema.Hints
 // keys directly. Dotted hint keys (nested subresource hints) are skipped:
 // fidelity is top-level-scoped, and a nested hint keeps whatever other
 // meaning it carries with no fidelity behavior anywhere.
-func preserveEmptyRootFields(schema pkgmodel.Schema) map[string]bool {
+func PreserveEmptyRootFields(schema pkgmodel.Schema) map[string]bool {
 	fields := map[string]bool{}
 	for name, hint := range schema.Hints {
 		if hint.PreserveEmptyValues && !strings.Contains(name, ".") {

--- a/internal/metastructure/patch/empty_value_fidelity.go
+++ b/internal/metastructure/patch/empty_value_fidelity.go
@@ -80,3 +80,18 @@ func referenceEnvelopeFields(desiredEnvelopes []byte, schemaFields []string) map
 	}
 	return fields
 }
+
+// preserveEmptyRootFields returns the literal top-level rendered property
+// names whose FieldHint sets PreserveEmptyValues, derived from schema.Hints
+// keys directly. Dotted hint keys (nested subresource hints) are skipped:
+// fidelity is top-level-scoped, and a nested hint keeps whatever other
+// meaning it carries with no fidelity behavior anywhere.
+func preserveEmptyRootFields(schema pkgmodel.Schema) map[string]bool {
+	fields := map[string]bool{}
+	for name, hint := range schema.Hints {
+		if hint.PreserveEmptyValues && !strings.Contains(name, ".") {
+			fields[name] = true
+		}
+	}
+	return fields
+}

--- a/internal/metastructure/patch/empty_value_fidelity_test.go
+++ b/internal/metastructure/patch/empty_value_fidelity_test.go
@@ -247,3 +247,48 @@ func TestGeneratePatch_ReferenceOnCreateOnlyDestination_NoPlaceholder(t *testing
 	assert.Empty(t, createOnly, "no replacement may be planned from an unresolved placeholder")
 	assert.NotContains(t, string(patchDoc), "/Token")
 }
+
+// The accepted churn contract: an actual-side empty-shaped extra inside a
+// preserved field makes the whole value differ, producing exactly one
+// replace carrying the desired value verbatim.
+func TestGeneratePatch_PreserveEmpty_ActualExtraEmptyChurnsAsWholeReplace(t *testing.T) {
+	document := json.RawMessage(`{"Name":"x","Spec":{"selfSigned":{},"defaulted":{}}}`)
+	desired := json.RawMessage(`{"Name":"x","Spec":{"selfSigned":{}}}`)
+
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.JSONEq(t, `[{"op":"replace","path":"/Spec","value":{"selfSigned":{}}}]`, string(patchDoc))
+}
+
+// The no-change guarantee for existing plugins: Atomic WITHOUT
+// preserveEmptyValues keeps exactly today's behavior - nested empties are
+// stripped on both sides and equalize the diff.
+func TestGeneratePatch_AtomicWithoutPreserve_KeepsStripBehavior(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Doc"},
+		Hints:      map[string]pkgmodel.FieldHint{"Doc": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic}},
+	}
+	document := json.RawMessage(`{"Name":"x","Doc":{"stmt":{"cond":{}}}}`)
+	desired := json.RawMessage(`{"Name":"x","Doc":{"stmt":{}}}`)
+
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, patchDoc,
+		"symmetric stripping still equalizes empty-shaped differences for atomic-only fields")
+}
+
+// A dotted (nested subresource) hint key grants no fidelity anywhere.
+func TestGeneratePatch_DottedPreserveHint_NoFidelity(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Config"},
+		Hints:      map[string]pkgmodel.FieldHint{"Config.records": {PreserveEmptyValues: true}},
+	}
+	document := json.RawMessage(`{"Name":"x","Config":{"records":{"a":{}}}}`)
+	desired := json.RawMessage(`{"Name":"x","Config":{"records":{}}}`)
+
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, patchDoc, "nested hints are out of fidelity scope; today's stripping applies")
+}

--- a/internal/metastructure/patch/empty_value_fidelity_test.go
+++ b/internal/metastructure/patch/empty_value_fidelity_test.go
@@ -79,11 +79,15 @@ func TestReferenceEnvelopeFields(t *testing.T) {
 		"Plain": "",
 		"Extra": {"$ref": "formae://2ABcDeFgHiJkLmNoPqRsTuVwXyZ#/T"}
 	}`)
-	fields := referenceEnvelopeFields(desired, []string{"Token", "Bad", "Plain"})
+	fields := referenceEnvelopeFields(desired, pkgmodel.Schema{Fields: []string{"Token", "Bad", "Plain"}})
 	assert.Equal(t, map[string]bool{"Token": true}, fields,
 		"only well-formed envelopes on schema fields enter the keep-set")
-	assert.Empty(t, referenceEnvelopeFields(nil, []string{"Token"}))
-	assert.Empty(t, referenceEnvelopeFields([]byte(`not json`), []string{"Token"}))
+	assert.Empty(t, referenceEnvelopeFields(nil, pkgmodel.Schema{Fields: []string{"Token"}}))
+	assert.Empty(t, referenceEnvelopeFields([]byte(`not json`), pkgmodel.Schema{Fields: []string{"Token"}}))
+	assert.Empty(t, referenceEnvelopeFields(desired, pkgmodel.Schema{
+		Fields: []string{"Token"},
+		Hints:  map[string]pkgmodel.FieldHint{"Token": {CreateOnly: true}},
+	}), "createOnly destinations never enter the keep-set")
 }
 
 func TestPreserveEmptyRootFields(t *testing.T) {
@@ -226,9 +230,10 @@ func TestGeneratePatch_ReferenceAddSurvivesPatchMode(t *testing.T) {
 	assert.JSONEq(t, `[{"op":"add","path":"/Token","value":""}]`, string(patchDoc))
 }
 
-// A placeholder add on a createOnly-hinted destination routes to the
-// createOnly split like any createOnly change.
-func TestGeneratePatch_ReferenceAddOnCreateOnlyRoutesToCreateOnlyPatch(t *testing.T) {
+// A reference on a createOnly destination never mints a placeholder op: a
+// kept placeholder there could only surface as a replacement, and a
+// replacement is never planned from a value that has not resolved.
+func TestGeneratePatch_ReferenceOnCreateOnlyDestination_NoPlaceholder(t *testing.T) {
 	schema := pkgmodel.Schema{
 		Identifier: "Name",
 		Fields:     []string{"Name", "Token"},
@@ -239,6 +244,6 @@ func TestGeneratePatch_ReferenceAddOnCreateOnlyRoutesToCreateOnlyPatch(t *testin
 
 	patchDoc, createOnly, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, schema, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
-	assert.JSONEq(t, `[]`, string(patchDoc), "the createOnly change is not a mutable op")
-	assert.Contains(t, string(createOnly), "/Token")
+	assert.Empty(t, createOnly, "no replacement may be planned from an unresolved placeholder")
+	assert.NotContains(t, string(patchDoc), "/Token")
 }

--- a/internal/metastructure/patch/empty_value_fidelity_test.go
+++ b/internal/metastructure/patch/empty_value_fidelity_test.go
@@ -1,0 +1,81 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package patch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+func TestFirstPointerSegment(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+		ok   bool
+	}{
+		{"/Spec", "Spec", true},
+		{"/Spec/x", "Spec", true},
+		{"/Spec/0/y", "Spec", true},
+		{"/Specification", "Specification", true},
+		{"/a~1b/c", "a/b", true},
+		{"/a~0b", "a~b", true},
+		{"/a~01", "a~1", true},
+		{"", "", false},
+		{"Spec", "", false},
+		{"/", "", false},
+	}
+	for _, c := range cases {
+		got, ok := firstPointerSegment(c.path)
+		assert.Equal(t, c.ok, ok, "path %q ok", c.path)
+		if c.ok {
+			assert.Equal(t, c.want, got, "path %q", c.path)
+		}
+	}
+}
+
+func TestIsKeepableReferenceEnvelope(t *testing.T) {
+	keep := []string{
+		`{"$ref":"formae://2ABcDeFgHiJkLmNoPqRsTuVwXyZ#/SecretString"}`,
+		`{"$ref":"formae://2ABcDeFgHiJkLmNoPqRsTuVwXyZ#/S","$value":"x","$visibility":"Opaque"}`,
+		`{"$res":true,"$label":"a","$type":"T::B","$stack":"s","$property":"P"}`,
+		`{"$res":true,"$label":"a","$type":"T::B","$stack":"s","$property":"P","$json":"host"}`,
+	}
+	drop := []string{
+		`{"$res":false,"$label":"a","$type":"T::B","$stack":"s","$property":"P"}`,
+		`{"$res":true,"$label":"a","$type":"T::B","$stack":"s"}`,
+		`{"$res":true,"$label":"","$type":"T::B","$stack":"s","$property":"P"}`,
+		`{"$ref":42}`,
+		`{"$ref":"formae://#/S"}`,
+		`{"$ref":"not-a-uri"}`,
+		`{"$ref":"formae://#/S","$res":true,"$label":"a","$type":"T","$stack":"s","$property":"P"}`,
+		`"plain"`,
+		`{}`,
+		`[]`,
+	}
+	for _, s := range keep {
+		assert.True(t, isKeepableReferenceEnvelope(gjson.Parse(s)), "must keep %s", s)
+	}
+	for _, s := range drop {
+		assert.False(t, isKeepableReferenceEnvelope(gjson.Parse(s)), "must drop %s", s)
+	}
+}
+
+func TestReferenceEnvelopeFields(t *testing.T) {
+	desired := []byte(`{
+		"Token": {"$ref": "formae://2ABcDeFgHiJkLmNoPqRsTuVwXyZ#/S"},
+		"Bad": {"$res": true},
+		"Plain": "",
+		"Extra": {"$ref": "formae://2ABcDeFgHiJkLmNoPqRsTuVwXyZ#/T"}
+	}`)
+	fields := referenceEnvelopeFields(desired, []string{"Token", "Bad", "Plain"})
+	assert.Equal(t, map[string]bool{"Token": true}, fields,
+		"only well-formed envelopes on schema fields enter the keep-set")
+	assert.Empty(t, referenceEnvelopeFields(nil, []string{"Token"}))
+	assert.Empty(t, referenceEnvelopeFields([]byte(`not json`), []string{"Token"}))
+}

--- a/internal/metastructure/patch/empty_value_fidelity_test.go
+++ b/internal/metastructure/patch/empty_value_fidelity_test.go
@@ -100,9 +100,9 @@ func TestPreserveEmptyRootFields(t *testing.T) {
 			"Bare":       {PreserveEmptyValues: true},
 		},
 	}
-	assert.Equal(t, map[string]bool{"Spec": true, "Bare": true}, preserveEmptyRootFields(schema),
+	assert.Equal(t, map[string]bool{"Spec": true, "Bare": true}, PreserveEmptyRootFields(schema),
 		"only preserveEmptyValues hints on non-dotted keys enter the root set")
-	assert.Empty(t, preserveEmptyRootFields(pkgmodel.Schema{}))
+	assert.Empty(t, PreserveEmptyRootFields(pkgmodel.Schema{}))
 }
 
 func fidelitySchema() pkgmodel.Schema {

--- a/internal/metastructure/patch/empty_value_fidelity_test.go
+++ b/internal/metastructure/patch/empty_value_fidelity_test.go
@@ -292,3 +292,17 @@ func TestGeneratePatch_DottedPreserveHint_NoFidelity(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "nested hints are out of fidelity scope; today's stripping applies")
 }
+
+// The whole-resource change gate must see an empty-only difference inside a
+// preserveEmptyValues root: stored {} vs desired {selfSigned:{}} IS a change
+// there, while the same shape on an unhinted field keeps today's tolerance.
+// (The document-side tolerance exists for provider echoes; inside a preserved
+// root, empties are values.)
+func TestGeneratePatch_PreservedRoot_EmptyOnlyDifferenceMintsReplace(t *testing.T) {
+	document := json.RawMessage(`{"Name":"x","Spec":{}}`)
+	desired := json.RawMessage(`{"Name":"x","Spec":{"selfSigned":{}}}`)
+
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.JSONEq(t, `[{"op":"replace","path":"/Spec","value":{"selfSigned":{}}}]`, string(patchDoc))
+}

--- a/internal/metastructure/patch/empty_value_fidelity_test.go
+++ b/internal/metastructure/patch/empty_value_fidelity_test.go
@@ -7,12 +7,16 @@
 package patch
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 )
 
 func TestFirstPointerSegment(t *testing.T) {
@@ -95,4 +99,146 @@ func TestPreserveEmptyRootFields(t *testing.T) {
 	assert.Equal(t, map[string]bool{"Spec": true, "Bare": true}, preserveEmptyRootFields(schema),
 		"only preserveEmptyValues hints on non-dotted keys enter the root set")
 	assert.Empty(t, preserveEmptyRootFields(pkgmodel.Schema{}))
+}
+
+func fidelitySchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Spec", "Other"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Spec": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic, PreserveEmptyValues: true},
+		},
+	}
+}
+
+// The headline shape: a hinted field's empty-object member survives to the
+// single whole-value replace op. Requires both the diff-input exemption and
+// the op-value exemption; red until both land.
+func TestGeneratePatch_PreserveEmpty_ReplaceCarriesVerbatimValue(t *testing.T) {
+	document := json.RawMessage(`{"Name":"x","Spec":{"acme":{"server":"https://old"}}}`)
+	desired := json.RawMessage(`{"Name":"x","Spec":{"selfSigned":{}}}`)
+
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+
+	var ops []struct {
+		Op    string          `json:"op"`
+		Path  string          `json:"path"`
+		Value json.RawMessage `json:"value"`
+	}
+	require.NoError(t, json.Unmarshal(patchDoc, &ops))
+	require.Len(t, ops, 1)
+	assert.Equal(t, "replace", ops[0].Op)
+	assert.Equal(t, "/Spec", ops[0].Path)
+	assert.JSONEq(t, `{"selfSigned":{}}`, string(ops[0].Value),
+		"the empty-object member is the declaration and must survive")
+}
+
+// Symmetry: identical values incl. empties on both sides plan nothing.
+func TestGeneratePatch_PreserveEmpty_IdenticalSidesPlanNothing(t *testing.T) {
+	doc := json.RawMessage(`{"Name":"x","Spec":{"selfSigned":{}}}`)
+
+	patchDoc, _, _, err := GeneratePatch(doc, doc, doc, doc, resolver.ResolvableProperties{}, fidelitySchema(), pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, patchDoc)
+}
+
+// The default is pinned, not just the exemption: a field without the hint
+// keeps today's stripping even when another field carries it.
+func TestGeneratePatch_NonHintedFieldStillStripped(t *testing.T) {
+	document := json.RawMessage(`{"Name":"x","Other":{"acme":{"server":"https://old"}}}`)
+	desired := json.RawMessage(`{"Name":"x","Other":{"selfSigned":{}}}`)
+
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.NotContains(t, string(patchDoc), "selfSigned",
+		"unhinted fields keep the rendering-noise strip")
+}
+
+func refSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Token", "Other"},
+		Hints:      map[string]pkgmodel.FieldHint{"Name": {CreateOnly: true}},
+	}
+}
+
+// A first-declared unresolvable reference survives as a placeholder add op;
+// a plain empty string is still dropped as rendering noise.
+func TestGeneratePatch_ReferenceEnvelopeAddSurvives(t *testing.T) {
+	document := json.RawMessage(`{"Name":"x"}`)
+	desired := json.RawMessage(`{"Name":"x","Token":{"$ref":"formae://2ABcDeFgHiJkLmNoPqRsTuVwXyZ#/S"}}`)
+
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, refSchema(), pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.JSONEq(t, `[{"op":"add","path":"/Token","value":""}]`, string(patchDoc))
+
+	plain := json.RawMessage(`{"Name":"x","Token":""}`)
+	patchDoc, _, _, err = GeneratePatch(document, plain, document, plain, resolver.ResolvableProperties{}, refSchema(), pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, patchDoc, "a plain empty string is still rendering noise")
+}
+
+// A malformed envelope contributes nothing to the keep-set: current behavior
+// (silent drop) is preserved rather than minting a placeholder.
+func TestGeneratePatch_MalformedEnvelopeNotKept(t *testing.T) {
+	document := json.RawMessage(`{"Name":"x"}`)
+	desired := json.RawMessage(`{"Name":"x","Token":{"$res":true}}`)
+
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, refSchema(), pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.NotContains(t, string(patchDoc), `"value":""`,
+		"the keep-set must never mint an empty-string placeholder for a malformed envelope")
+	assert.JSONEq(t, `[{"op":"add","path":"/Token","value":{"$res":true}}]`, string(patchDoc),
+		"a malformed envelope keeps its pre-existing plain-map diff behavior, unchanged by the keep-set")
+}
+
+// Keeping a field only permits diffing: equal values still produce no op.
+func TestGeneratePatch_KeptFieldEqualValuesNoOp(t *testing.T) {
+	document := json.RawMessage(`{"Name":"x","Token":"v"}`)
+	desired := json.RawMessage(`{"Name":"x","Token":{"$ref":"formae://2ABcDeFgHiJkLmNoPqRsTuVwXyZ#/S","$value":"v"}}`)
+
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, refSchema(), pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.Empty(t, patchDoc)
+}
+
+// GREEN-FIRST GUARD: a preserveEmptyValues root omitted from desired while
+// the document holds a bare empty stays invisible (the absence-scoped
+// provider-echo tolerance). Fails exactly if an implementation wrongly
+// exempts preserved roots from that tolerance.
+func TestGeneratePatch_PreservedRootAbsentDesired_NoRemove(t *testing.T) {
+	document := json.RawMessage(`{"Name":"x","Spec":{}}`)
+	desired := json.RawMessage(`{"Name":"x"}`)
+
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.NotContains(t, string(patchDoc), "remove")
+}
+
+// The reference placeholder add survives under Patch mode too.
+func TestGeneratePatch_ReferenceAddSurvivesPatchMode(t *testing.T) {
+	document := json.RawMessage(`{"Name":"x"}`)
+	desired := json.RawMessage(`{"Name":"x","Token":{"$ref":"formae://2ABcDeFgHiJkLmNoPqRsTuVwXyZ#/S"}}`)
+
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, refSchema(), pkgmodel.FormaApplyModePatch)
+	require.NoError(t, err)
+	assert.JSONEq(t, `[{"op":"add","path":"/Token","value":""}]`, string(patchDoc))
+}
+
+// A placeholder add on a createOnly-hinted destination routes to the
+// createOnly split like any createOnly change.
+func TestGeneratePatch_ReferenceAddOnCreateOnlyRoutesToCreateOnlyPatch(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Token"},
+		Hints:      map[string]pkgmodel.FieldHint{"Token": {CreateOnly: true}},
+	}
+	document := json.RawMessage(`{"Name":"x"}`)
+	desired := json.RawMessage(`{"Name":"x","Token":{"$ref":"formae://2ABcDeFgHiJkLmNoPqRsTuVwXyZ#/S"}}`)
+
+	patchDoc, createOnly, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, schema, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	assert.JSONEq(t, `[]`, string(patchDoc), "the createOnly change is not a mutable op")
+	assert.Contains(t, string(createOnly), "/Token")
 }

--- a/internal/metastructure/patch/empty_value_fidelity_test.go
+++ b/internal/metastructure/patch/empty_value_fidelity_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
 func TestFirstPointerSegment(t *testing.T) {
@@ -78,4 +80,19 @@ func TestReferenceEnvelopeFields(t *testing.T) {
 		"only well-formed envelopes on schema fields enter the keep-set")
 	assert.Empty(t, referenceEnvelopeFields(nil, []string{"Token"}))
 	assert.Empty(t, referenceEnvelopeFields([]byte(`not json`), []string{"Token"}))
+}
+
+func TestPreserveEmptyRootFields(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Spec", "Other", "Nested"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Spec":       {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic, PreserveEmptyValues: true},
+			"Other":      {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic},
+			"Nested.sub": {PreserveEmptyValues: true},
+			"Bare":       {PreserveEmptyValues: true},
+		},
+	}
+	assert.Equal(t, map[string]bool{"Spec": true, "Bare": true}, preserveEmptyRootFields(schema),
+		"only preserveEmptyValues hints on non-dotted keys enter the root set")
+	assert.Empty(t, preserveEmptyRootFields(pkgmodel.Schema{}))
 }

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -113,14 +113,14 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 
 	requiredOnUpdateFields := schema.RequiredOnUpdate()
 	// Fields hinted preserveEmptyValues carry meaningful empty collections:
-	// every empty-value normalization below skips their subtrees, on both
-	// sides, in op values, and in the keep-set for the top-level drop.
+	// every empty-collection normalization below skips their subtrees, on
+	// both sides and in op values. The top-level empty-STRING drop is
+	// deliberately not exempted: the hint speaks about collections, which
+	// pass that filter anyway, and a preserved field rendered "" by an unset
+	// nullable declaration is still rendering noise.
 	preserveRoots := PreserveEmptyRootFields(schema)
 	keepFields := topLevelConvergeFields(schema.Fields, properties)
 	for field := range referenceEnvelopeFields(desiredEnvelopes, schema) {
-		keepFields[field] = true
-	}
-	for field := range preserveRoots {
 		keepFields[field] = true
 	}
 	patchOps, err := createPatchDocument(flattenedDocument, flattenedPatch, schema.Fields, requiredOnUpdateFields, schema.HasProviderDefault(), entitySetProviderDefaultsFromHints(schema.Hints), collectionSemanticsFromFieldHints(schema.Hints), defaultIgnoredFields, strategy, keepFields, preserveRoots)

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -115,7 +115,7 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 	// Fields hinted preserveEmptyValues carry meaningful empty collections:
 	// every empty-value normalization below skips their subtrees, on both
 	// sides, in op values, and in the keep-set for the top-level drop.
-	preserveRoots := preserveEmptyRootFields(schema)
+	preserveRoots := PreserveEmptyRootFields(schema)
 	keepFields := topLevelConvergeFields(schema.Fields, properties)
 	for field := range referenceEnvelopeFields(desiredEnvelopes, schema) {
 		keepFields[field] = true

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -117,7 +117,7 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 	// sides, in op values, and in the keep-set for the top-level drop.
 	preserveRoots := preserveEmptyRootFields(schema)
 	keepFields := topLevelConvergeFields(schema.Fields, properties)
-	for field := range referenceEnvelopeFields(desiredEnvelopes, schema.Fields) {
+	for field := range referenceEnvelopeFields(desiredEnvelopes, schema) {
 		keepFields[field] = true
 	}
 	for field := range preserveRoots {

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -112,7 +112,18 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 	}
 
 	requiredOnUpdateFields := schema.RequiredOnUpdate()
-	patchOps, err := createPatchDocument(flattenedDocument, flattenedPatch, schema.Fields, requiredOnUpdateFields, schema.HasProviderDefault(), entitySetProviderDefaultsFromHints(schema.Hints), collectionSemanticsFromFieldHints(schema.Hints), defaultIgnoredFields, strategy, topLevelConvergeFields(schema.Fields, properties))
+	// Fields hinted preserveEmptyValues carry meaningful empty collections:
+	// every empty-value normalization below skips their subtrees, on both
+	// sides, in op values, and in the keep-set for the top-level drop.
+	preserveRoots := preserveEmptyRootFields(schema)
+	keepFields := topLevelConvergeFields(schema.Fields, properties)
+	for field := range referenceEnvelopeFields(desiredEnvelopes, schema.Fields) {
+		keepFields[field] = true
+	}
+	for field := range preserveRoots {
+		keepFields[field] = true
+	}
+	patchOps, err := createPatchDocument(flattenedDocument, flattenedPatch, schema.Fields, requiredOnUpdateFields, schema.HasProviderDefault(), entitySetProviderDefaultsFromHints(schema.Hints), collectionSemanticsFromFieldHints(schema.Hints), defaultIgnoredFields, strategy, keepFields, preserveRoots)
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("failed to create patch document: %w", err)
 	}
@@ -122,14 +133,14 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 	// []/{}. An "add" of an empty collection to a field absent in the actual
 	// state is always PKL rendering noise — a user clearing a field would
 	// produce a "replace" (field exists in actual), not an "add".
-	patchOps = filterSpuriousEmptyAdds(patchOps)
+	patchOps = filterSpuriousEmptyAdds(patchOps, preserveRoots)
 
 	// Strip empty collections from inside all patch operation values. This
 	// cleans up phantom []/{}  values inside nested objects (e.g., empty
 	// ResponseParameters inside an IntegrationResponse). Without this,
 	// EntitySet array elements may not match their actual counterparts and
 	// produce "array items are not unique" errors.
-	patchOps = stripEmptyCollectionsFromOps(patchOps)
+	patchOps = stripEmptyCollectionsFromOps(patchOps, preserveRoots)
 
 	// Drop serialization-only ops on Format-hinted fields before the createOnly
 	// split, so a cosmetic diff on a (possibly createOnly) hinted field neither
@@ -194,7 +205,7 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 	return json.RawMessage(patchJson), createOnlyJson, onlyForceResent, nil
 }
 
-func createPatchDocument(document []byte, patch []byte, schemaFields []string, requiredOnUpdateFields []string, hasProviderDefaultFields []string, entitySetProviderDefaults map[string]string, collections jsonpatch.Collections, ignoredFields []jsonpatch.Path, strategy jsonpatch.PatchStrategy, convergeFields map[string]bool) ([]jsonpatch.JsonPatchOperation, error) {
+func createPatchDocument(document []byte, patch []byte, schemaFields []string, requiredOnUpdateFields []string, hasProviderDefaultFields []string, entitySetProviderDefaults map[string]string, collections jsonpatch.Collections, ignoredFields []jsonpatch.Path, strategy jsonpatch.PatchStrategy, convergeFields map[string]bool, preserveRoots map[string]bool) ([]jsonpatch.JsonPatchOperation, error) {
 	patchWithSchemaFieldsOnly, err := removeNonSchemaFields(patch, schemaFields, convergeFields)
 	if err != nil {
 		return nil, err
@@ -245,7 +256,7 @@ func createPatchDocument(document []byte, patch []byte, schemaFields []string, r
 	// nullable Listing/Mapping fields as []/{}. Without stripping, EntitySet
 	// element matching fails because elements have different shapes (one has
 	// phantom empty fields, the other doesn't), causing duplicate entries.
-	cleanedDesired, err := StripNestedEmptyCollections(patchWithSchemaFieldsOnly)
+	cleanedDesired, err := StripNestedEmptyCollectionsExcept(patchWithSchemaFieldsOnly, preserveRoots)
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +270,7 @@ func createPatchDocument(document []byte, patch []byte, schemaFields []string, r
 		return nil, err
 	}
 
-	cleanedDocument, err := StripNestedEmptyCollections(documentMinusTopEmpties)
+	cleanedDocument, err := StripNestedEmptyCollectionsExcept(documentMinusTopEmpties, preserveRoots)
 	if err != nil {
 		return nil, err
 	}
@@ -735,12 +746,23 @@ func removeNonSchemaFields(patch []byte, schemaFields []string, convergeFields m
 // resource updater (before sending Properties to plugins for Create/Update)
 // to clean PKL rendering artifacts (null → []/{}  from nullable Listing/Mapping fields).
 func StripNestedEmptyCollections(data []byte) ([]byte, error) {
+	return StripNestedEmptyCollectionsExcept(data, nil)
+}
+
+// StripNestedEmptyCollectionsExcept is StripNestedEmptyCollections with an
+// exemption set: subtrees rooted at a top-level key in preserveRoots are left
+// byte-for-byte intact — their empty collections are values, not rendering
+// noise (the preserveEmptyValues field hint).
+func StripNestedEmptyCollectionsExcept(data []byte, preserveRoots map[string]bool) ([]byte, error) {
 	var doc map[string]any
 	if err := json.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("StripNestedEmptyCollections: invalid JSON: %w", err)
 	}
 
 	for k, v := range doc {
+		if preserveRoots[k] {
+			continue
+		}
 		doc[k] = stripEmptyCollectionsFromValue(v)
 	}
 
@@ -752,9 +774,13 @@ func StripNestedEmptyCollections(data []byte) ([]byte, error) {
 // as []/{}. An "add" means the field is absent in the actual state, so adding
 // an empty collection is never user intent — it's PKL rendering noise. A user
 // clearing an existing field produces a "replace" (field exists), not "add".
-func filterSpuriousEmptyAdds(patchOps []jsonpatch.JsonPatchOperation) []jsonpatch.JsonPatchOperation {
+func filterSpuriousEmptyAdds(patchOps []jsonpatch.JsonPatchOperation, preserveRoots map[string]bool) []jsonpatch.JsonPatchOperation {
 	filtered := make([]jsonpatch.JsonPatchOperation, 0, len(patchOps))
 	for _, op := range patchOps {
+		if opUnderPreservedRoot(op.Path, preserveRoots) {
+			filtered = append(filtered, op)
+			continue
+		}
 		if op.Operation == "add" && isEmptyCollection(op.Value) {
 			continue
 		}
@@ -809,11 +835,25 @@ func dropCanonicallyEqualHintedOps(ops []jsonpatch.JsonPatchOperation, document,
 // stripEmptyCollectionsFromOps recursively removes empty arrays and maps from
 // inside all patch operation values. This ensures that EntitySet element
 // matching works correctly when elements contain phantom []/{}  values.
-func stripEmptyCollectionsFromOps(patchOps []jsonpatch.JsonPatchOperation) []jsonpatch.JsonPatchOperation {
+func stripEmptyCollectionsFromOps(patchOps []jsonpatch.JsonPatchOperation, preserveRoots map[string]bool) []jsonpatch.JsonPatchOperation {
 	for i := range patchOps {
+		if opUnderPreservedRoot(patchOps[i].Path, preserveRoots) {
+			continue
+		}
 		patchOps[i].Value = stripEmptyCollectionsFromValue(patchOps[i].Value)
 	}
 	return patchOps
+}
+
+// opUnderPreservedRoot reports whether an op's JSON Pointer path is at or
+// under a preserveEmptyValues root, matched by first segment (never by
+// string prefix).
+func opUnderPreservedRoot(path string, preserveRoots map[string]bool) bool {
+	if len(preserveRoots) == 0 {
+		return false
+	}
+	seg, ok := firstPointerSegment(path)
+	return ok && preserveRoots[seg]
 }
 
 func stripEmptyCollectionsFromValue(val any) any {

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -158,7 +158,7 @@ func TestCreatePatchDocument_PrimitiveArray(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			patches, err := createPatchDocument(tc.jsonA, tc.jsonB, []string{"label", "tags"}, nil, nil, nil, jsonpatch.Collections{}, nil, jsonpatch.PatchStrategyEnsureExists, nil)
+			patches, err := createPatchDocument(tc.jsonA, tc.jsonB, []string{"label", "tags"}, nil, nil, nil, jsonpatch.Collections{}, nil, jsonpatch.PatchStrategyEnsureExists, nil, nil)
 			if err != nil {
 				t.Fatalf("Error comparing JSONs: %v", err)
 			}
@@ -230,7 +230,7 @@ func TestCreatePatchDocument_ObjectArrayWithKeyValues(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			patches, err := createPatchDocument(tc.jsonA, tc.jsonB, []string{"label", "tags"}, nil, nil, nil, jsonpatch.Collections{EntitySets: jsonpatch.EntitySets{jsonpatch.Path("$.tags"): jsonpatch.Key("key")}}, nil, jsonpatch.PatchStrategyEnsureExists, nil)
+			patches, err := createPatchDocument(tc.jsonA, tc.jsonB, []string{"label", "tags"}, nil, nil, nil, jsonpatch.Collections{EntitySets: jsonpatch.EntitySets{jsonpatch.Path("$.tags"): jsonpatch.Key("key")}}, nil, jsonpatch.PatchStrategyEnsureExists, nil, nil)
 			if err != nil {
 				t.Fatalf("Error comparing JSONs: %v", err)
 			}
@@ -304,7 +304,7 @@ func TestCreatePatchDocument_ObjectArrayWithValues(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			patches, err := createPatchDocument(tc.jsonA, tc.jsonB, []string{"label", "tags"}, nil, nil, nil, jsonpatch.Collections{}, nil, jsonpatch.PatchStrategyEnsureExists, nil)
+			patches, err := createPatchDocument(tc.jsonA, tc.jsonB, []string{"label", "tags"}, nil, nil, nil, jsonpatch.Collections{}, nil, jsonpatch.PatchStrategyEnsureExists, nil, nil)
 			if err != nil {
 				t.Fatalf("Error comparing JSONs: %v", err)
 			}

--- a/internal/metastructure/resource_update/atomic_conversion_test.go
+++ b/internal/metastructure/resource_update/atomic_conversion_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
@@ -69,4 +71,44 @@ func TestMerge_PreserveEmptyRootSurvivesEmptyPluginEcho(t *testing.T) {
 	var m map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(merged, &m))
 	assert.NotContains(t, m, "Other", "unhinted empty-leaved objects keep today's drop")
+}
+
+// The whole-resource change gate must plan an update when the only difference
+// is an empty-shaped member inside a preserveEmptyValues root: the stored side
+// lost the member to the old normalization, and repairing it IS a change. An
+// unhinted field with the same shape keeps the gate's empty tolerance.
+func TestGenerateResourceUpdates_PreservedRootEmptyOnlyDifference_Plans(t *testing.T) {
+	ds, _ := GetDeps(t)
+	crSchema := pkgmodel.Schema{
+		Identifier: "FormaeId",
+		Fields:     []string{"ApiVersion", "Kind", "FormaeId", "Spec"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Spec": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic, PreserveEmptyValues: true},
+		},
+	}
+	existingStack := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{{
+			Label: "cr", Type: "Test::Custom", Stack: "test-stack", Target: "test-target",
+			Schema: crSchema, Ksuid: util.NewID(),
+			Properties: json.RawMessage(`{"ApiVersion":"v1","Kind":"W","FormaeId":"x","Spec":{}}`),
+		}},
+	}
+	_, err := ds.StoreStack(existingStack, "previous-command")
+	require.NoError(t, err)
+
+	forma := &pkgmodel.Forma{
+		Stacks:  []pkgmodel.Stack{{Label: "test-stack"}},
+		Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test", Config: json.RawMessage(`{}`)}},
+		Resources: []pkgmodel.Resource{{
+			Label: "cr", Type: "Test::Custom", Stack: "test-stack", Target: "test-target",
+			Schema:     crSchema,
+			Properties: json.RawMessage(`{"ApiVersion":"v1","Kind":"W","FormaeId":"x","Spec":{"selfSigned":{}}}`),
+		}},
+	}
+	existingTargets := []*pkgmodel.Target{{Label: "test-target", Namespace: "test", Config: json.RawMessage(`{}`)}}
+	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, existingTargets, ds, nil, nil, false)
+	require.NoError(t, err)
+	require.Len(t, updates, 1, "the empty-only difference under a preserved root must plan")
+	assert.Contains(t, string(updates[0].DesiredState.PatchDocument), "selfSigned")
 }

--- a/internal/metastructure/resource_update/atomic_conversion_test.go
+++ b/internal/metastructure/resource_update/atomic_conversion_test.go
@@ -51,3 +51,22 @@ func extractField(t *testing.T, props json.RawMessage, field string) string {
 	require.NoError(t, json.Unmarshal(props, &m))
 	return string(m[field])
 }
+
+// The persist merge keeps empty collections under a preserveEmptyValues root
+// even when the plugin echoes nothing; elsewhere the leaf-only walk drops
+// them as before.
+func TestMerge_PreserveEmptyRootSurvivesEmptyPluginEcho(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"ApiVersion", "Spec", "Other"},
+		Hints:  map[string]pkgmodel.FieldHint{"Spec": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic, PreserveEmptyValues: true}},
+	}
+	user := json.RawMessage(`{"ApiVersion":"v1","Spec":{"selfSigned":{"crl":[]}},"Other":{"e":{}}}`)
+
+	merged, err := mergeRefsPreservingUserRefs(user, json.RawMessage(`{}`), schema, true, nil)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"selfSigned":{"crl":[]}}`, extractField(t, merged, "Spec"),
+		"the hinted subtree persists verbatim, nested empty list included")
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(merged, &m))
+	assert.NotContains(t, m, "Other", "unhinted empty-leaved objects keep today's drop")
+}

--- a/internal/metastructure/resource_update/atomic_conversion_test.go
+++ b/internal/metastructure/resource_update/atomic_conversion_test.go
@@ -1,0 +1,53 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// Plugin-bound conversion preserves empty collections inside a
+// preserveEmptyValues-hinted field, in both the write converter and the
+// Read-context converter; unhinted fields keep the rendering-noise strip.
+func TestConvertResourceForPlugin_PreserveEmptyFieldSurvives(t *testing.T) {
+	res := pkgmodel.Resource{
+		Label: "cr", Type: "Test::Custom",
+		Schema: pkgmodel.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "Spec", "Other"},
+			Hints: map[string]pkgmodel.FieldHint{
+				"Spec": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic, PreserveEmptyValues: true},
+			},
+		},
+		Properties: json.RawMessage(`{"Name":"cr","Spec":{"selfSigned":{}},"Other":{"empty":{}}}`),
+	}
+
+	converted, err := convertResourceForPlugin(res)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"selfSigned":{}}`, extractField(t, converted.Properties, "Spec"),
+		"write payload keeps the hinted field verbatim")
+	assert.JSONEq(t, `{}`, extractField(t, converted.Properties, "Other"),
+		"unhinted fields keep the strip")
+
+	readConverted, err := convertResourceForPluginRead(res)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"selfSigned":{}}`, extractField(t, readConverted.Properties, "Spec"),
+		"Read/sync/delete context carries the true value too")
+}
+
+func extractField(t *testing.T, props json.RawMessage, field string) string {
+	t.Helper()
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(props, &m))
+	return string(m[field])
+}

--- a/internal/metastructure/resource_update/resource_comparison.go
+++ b/internal/metastructure/resource_update/resource_comparison.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tidwall/sjson"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/canonicalize"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/patch"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/transformations"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
@@ -59,7 +60,12 @@ func CompareFilteredResourceForUpdate(existing, new *pkgmodel.Resource, schema p
 	existingForCompare := canonicalizeHintedFields(existing.Properties, schema)
 	newForCompare := canonicalizeHintedFields(hashedForComparison.Properties, schema)
 
-	equal, err := util.JsonEqualIgnoreArrayOrder(existingForCompare, newForCompare)
+	// Fields hinted preserveEmptyValues carry meaningful empties, so the
+	// gate's empty-tolerant equality (absent == empty, there for provider
+	// echoes and legacy rendering noise) must not hide an empty-only
+	// difference inside them - repairing a member the old normalization
+	// stripped IS a change.
+	equal, err := util.JsonEqualIgnoreArrayOrderStrictRoots(existingForCompare, newForCompare, patch.PreserveEmptyRootFields(schema))
 	if err != nil {
 		return false, fmt.Errorf("failed to compare properties: %w", err)
 	}

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -746,6 +746,15 @@ func (m *propertyMerger) mergeObject(path string, userVal, pluginVal gjson.Resul
 		return
 	}
 
+	// An empty user object writes no leaves, so the recursion below would
+	// drop it from the merged document entirely. Under a preserveEmptyValues
+	// root the empty object IS the value and must persist.
+	if len(userVal.Map()) == 0 && m.underPreservedRoot(path) {
+		cleanPath := m.cleanPath(path)
+		*m.result, _ = sjson.SetRaw(*m.result, cleanPath, "{}")
+		return
+	}
+
 	// Not a $ref or $embed object - recursively merge each field
 	userVal.ForEach(func(key, val gjson.Result) bool {
 		childPath := m.buildChildPath(path, key.String())
@@ -753,6 +762,16 @@ func (m *propertyMerger) mergeObject(path string, userVal, pluginVal gjson.Resul
 		m.mergeValue(childPath, val, pluginChildVal)
 		return true
 	})
+}
+
+// underPreservedRoot reports whether a merge path's top-level field carries
+// the preserveEmptyValues hint.
+func (m *propertyMerger) underPreservedRoot(path string) bool {
+	if path == "" {
+		return false
+	}
+	root, _, _ := strings.Cut(path, ".")
+	return patch.PreserveEmptyRootFields(m.schema)[root]
 }
 
 // mergeRefObject handles merging of $ref objects (resolvable references)
@@ -976,6 +995,14 @@ func (m *propertyMerger) preferNonNullValue(userValue, pluginValue gjson.Result)
 func (m *propertyMerger) mergeArray(path string, userVal, pluginVal gjson.Result) {
 	userArray := userVal.Array()
 	pluginArray := pluginVal.Array()
+
+	// An empty user array writes no elements; under a preserveEmptyValues
+	// root it is the value and must persist (mirror of the empty-object case).
+	if len(userArray) == 0 && m.underPreservedRoot(path) {
+		cleanPath := m.cleanPath(path)
+		*m.result, _ = sjson.SetRaw(*m.result, cleanPath, "[]")
+		return
+	}
 
 	// Resolve this array's own hint by its index-less full path (e.g.
 	// "ContainerDefinitions.0.Environment" -> "ContainerDefinitions.Environment"),

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -74,8 +74,10 @@ func convertResourceForPluginWith(res pkgmodel.Resource, convert func(json.RawMe
 	}
 
 	// Strip nested empty collections from PKL null rendering artifacts.
-	// Top-level empty collections are preserved (may be intentional clears).
-	cleanedProps, err := patch.StripNestedEmptyCollections(convertedProps)
+	// Top-level empty collections are preserved (may be intentional clears),
+	// and preserveEmptyValues-hinted fields keep their subtrees verbatim in
+	// every plugin-bound context: their empties are values, not artifacts.
+	cleanedProps, err := patch.StripNestedEmptyCollectionsExcept(convertedProps, patch.PreserveEmptyRootFields(res.Schema))
 	if err != nil {
 		return res, err
 	}

--- a/internal/metastructure/util/json.go
+++ b/internal/metastructure/util/json.go
@@ -53,6 +53,15 @@ func JsonEqualRaw(a, b json.RawMessage) bool {
 // JsonEqualIgnoreArrayOrder compares two JSON objects treating all arrays as sets (order agnostic).
 // Null, empty arrays, empty maps, and absent keys are treated as semantically equivalent.
 func JsonEqualIgnoreArrayOrder(a, b json.RawMessage) (bool, error) {
+	return JsonEqualIgnoreArrayOrderStrictRoots(a, b, nil)
+}
+
+// JsonEqualIgnoreArrayOrderStrictRoots is JsonEqualIgnoreArrayOrder with an
+// exemption set: for top-level fields named in strictRoots, empties are
+// VALUES - an empty collection differs from an absent key and from a
+// non-empty value (the preserveEmptyValues field hint). Arrays stay
+// order-agnostic in both modes.
+func JsonEqualIgnoreArrayOrderStrictRoots(a, b json.RawMessage, strictRoots map[string]bool) (bool, error) {
 	aEmpty := len(a) == 0
 	bEmpty := len(b) == 0
 	if aEmpty && bEmpty {
@@ -71,7 +80,69 @@ func JsonEqualIgnoreArrayOrder(a, b json.RawMessage) (bool, error) {
 		}
 	}
 
+	if len(strictRoots) > 0 {
+		mapA, okA := objA.(map[string]any)
+		mapB, okB := objB.(map[string]any)
+		if okA && okB {
+			for root := range strictRoots {
+				va, aHas := mapA[root]
+				vb, bHas := mapB[root]
+				if aHas != bHas {
+					return false, nil
+				}
+				if aHas && !deepEqualArraysAsSets(va, vb) {
+					return false, nil
+				}
+				delete(mapA, root)
+				delete(mapB, root)
+			}
+		}
+	}
+
 	return deepEqualIgnoreArrayOrder(objA, objB), nil
+}
+
+// deepEqualArraysAsSets compares values with arrays as sets but with empties
+// significant: an empty collection equals only an empty collection of the
+// same kind, and a key present on one side only is a difference regardless
+// of its value.
+func deepEqualArraysAsSets(a, b any) bool {
+	switch valA := a.(type) {
+	case map[string]any:
+		valB, ok := b.(map[string]any)
+		if !ok || len(valA) != len(valB) {
+			return false
+		}
+		for k, va := range valA {
+			vb, has := valB[k]
+			if !has || !deepEqualArraysAsSets(va, vb) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		valB, ok := b.([]any)
+		if !ok || len(valA) != len(valB) {
+			return false
+		}
+		matched := make([]bool, len(valB))
+		for _, elemA := range valA {
+			found := false
+			for j, elemB := range valB {
+				if !matched[j] && deepEqualArraysAsSets(elemA, elemB) {
+					matched[j] = true
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+		return true
+	default:
+		return reflect.DeepEqual(a, b)
+	}
 }
 
 // isEmptyValue returns true for values that are semantically empty:

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -263,6 +263,9 @@ open class FieldHint extends Annotation {
     hidden edgeKind: EdgeKind = "default"        // NEW
     hidden indexField: String?
     hidden updateMethod: FieldUpdateMethod?
+    /// Opts this field's subtree out of empty-value normalization: empty
+    /// collections inside it are treated as values and preserved end to end.
+    hidden preserveEmptyValues: Boolean = false
     hidden format: String = ""                   // NEW: serialized-content format (e.g. "json"); PLA-196
 
     hidden outputField: String?
@@ -280,6 +283,7 @@ open class FieldHint extends Annotation {
     fixed AttachesTo: Boolean = attachesTo
     fixed EdgeKind: String = edgeKind
     fixed UpdateMethod: String = updateMethod ?? ""
+    fixed PreserveEmptyValues: Boolean = preserveEmptyValues
     fixed IndexField: String = indexField ?? ""
     fixed Format: String = format                // NEW
 }

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -266,7 +266,7 @@ open class FieldHint extends Annotation {
     /// Opts this field's subtree out of empty-value normalization: empty
     /// collections inside it are treated as values and preserved end to end.
     hidden preserveEmptyValues: Boolean = false
-    hidden format: String = ""                   // NEW: serialized-content format (e.g. "json"); PLA-196
+    hidden format: String = ""                   // serialized-content format (e.g. "json")
 
     hidden outputField: String?
     hidden outputTransformation: ((Any) -> Any)?

--- a/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
+++ b/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
@@ -123,6 +123,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        PreserveEmptyValues = false
         IndexField = ""
         Format = ""
       }
@@ -137,6 +138,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        PreserveEmptyValues = false
         IndexField = ""
         Format = ""
       }
@@ -151,6 +153,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        PreserveEmptyValues = false
         IndexField = ""
         Format = ""
       }
@@ -176,6 +179,7 @@ examples {
           AttachesTo = false
           EdgeKind = "default"
           UpdateMethod = ""
+          PreserveEmptyValues = false
           IndexField = ""
           Format = ""
         }
@@ -190,6 +194,7 @@ examples {
           AttachesTo = false
           EdgeKind = "default"
           UpdateMethod = ""
+          PreserveEmptyValues = false
           IndexField = ""
           Format = ""
         }
@@ -204,6 +209,7 @@ examples {
           AttachesTo = false
           EdgeKind = "default"
           UpdateMethod = ""
+          PreserveEmptyValues = false
           IndexField = ""
           Format = ""
         }
@@ -260,6 +266,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            PreserveEmptyValues = false
             IndexField = ""
             Format = ""
           }
@@ -274,6 +281,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            PreserveEmptyValues = false
             IndexField = ""
             Format = ""
           }
@@ -288,6 +296,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            PreserveEmptyValues = false
             IndexField = ""
             Format = ""
           }
@@ -352,6 +361,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            PreserveEmptyValues = false
             IndexField = ""
             Format = ""
           }
@@ -366,6 +376,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            PreserveEmptyValues = false
             IndexField = ""
             Format = ""
           }
@@ -380,6 +391,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            PreserveEmptyValues = false
             IndexField = ""
             Format = ""
           }
@@ -428,6 +440,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            PreserveEmptyValues = false
             IndexField = ""
             Format = ""
           }
@@ -442,6 +455,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            PreserveEmptyValues = false
             IndexField = ""
             Format = ""
           }
@@ -456,6 +470,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            PreserveEmptyValues = false
             IndexField = ""
             Format = ""
           }
@@ -470,6 +485,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            PreserveEmptyValues = false
             IndexField = ""
             Format = ""
           }
@@ -484,6 +500,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            PreserveEmptyValues = false
             IndexField = ""
             Format = ""
           }
@@ -498,6 +515,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            PreserveEmptyValues = false
             IndexField = ""
             Format = ""
           }
@@ -512,6 +530,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            PreserveEmptyValues = false
             IndexField = ""
             Format = ""
           }
@@ -555,6 +574,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        PreserveEmptyValues = false
         IndexField = ""
         Format = ""
       }
@@ -569,6 +589,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        PreserveEmptyValues = false
         IndexField = ""
         Format = ""
       }
@@ -583,6 +604,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        PreserveEmptyValues = false
         IndexField = ""
         Format = ""
       }
@@ -601,6 +623,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        PreserveEmptyValues = false
         IndexField = ""
         Format = ""
       }
@@ -615,6 +638,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        PreserveEmptyValues = false
         IndexField = ""
         Format = ""
       }
@@ -633,6 +657,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        PreserveEmptyValues = false
         IndexField = ""
         Format = ""
       }
@@ -647,6 +672,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        PreserveEmptyValues = false
         IndexField = ""
         Format = ""
       }
@@ -672,6 +698,7 @@ examples {
           AttachesTo = false
           EdgeKind = "default"
           UpdateMethod = ""
+          PreserveEmptyValues = false
           IndexField = ""
           Format = ""
         }
@@ -686,6 +713,7 @@ examples {
           AttachesTo = false
           EdgeKind = "default"
           UpdateMethod = ""
+          PreserveEmptyValues = false
           IndexField = ""
           Format = ""
         }
@@ -700,6 +728,7 @@ examples {
           AttachesTo = false
           EdgeKind = "default"
           UpdateMethod = ""
+          PreserveEmptyValues = false
           IndexField = ""
           Format = ""
         }

--- a/internal/testplugin/fakeaws/fake_aws.go
+++ b/internal/testplugin/fakeaws/fake_aws.go
@@ -117,6 +117,13 @@ func (s *FakeAWS) SupportedResources() []plugin.ResourceDescriptor {
 			Type:         secretsManagerSecretType,
 			Discoverable: false,
 		},
+		// Custom::Resource models an opaque-bodied resource whose Spec is a
+		// user-owned document: hinted Atomic (whole-value diff) and
+		// preserveEmptyValues (empty collections inside it are values).
+		{
+			Type:         "FakeAWS::Custom::Resource",
+			Discoverable: false,
+		},
 	}
 }
 
@@ -170,6 +177,14 @@ func (s *FakeAWS) SchemaForResourceType(resourceType string) (model.Schema, erro
 			Fields:     []string{"Name", "Description", "SecretString", "Tags"},
 			Hints: map[string]model.FieldHint{
 				"SecretString": {Opaque: true},
+			},
+		}, nil
+	case "FakeAWS::Custom::Resource":
+		return model.Schema{
+			Identifier: "FormaeId",
+			Fields:     []string{"ApiVersion", "Kind", "FormaeId", "Spec"},
+			Hints: map[string]model.FieldHint{
+				"Spec": {UpdateMethod: model.FieldUpdateMethodAtomic, PreserveEmptyValues: true},
 			},
 		}, nil
 	default:

--- a/internal/workflow_tests/local/apply_forma/atomic_fidelity_test.go
+++ b/internal/workflow_tests/local/apply_forma/atomic_fidelity_test.go
@@ -1,0 +1,113 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+func customResource(stack, spec string) pkgmodel.Resource {
+	return pkgmodel.Resource{
+		Label:  "issuer",
+		Type:   "FakeAWS::Custom::Resource",
+		Stack:  stack,
+		Target: "test-target",
+		Schema: pkgmodel.Schema{
+			Identifier: "FormaeId",
+			Fields:     []string{"ApiVersion", "Kind", "FormaeId", "Spec"},
+			Hints: map[string]pkgmodel.FieldHint{
+				"Spec": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic, PreserveEmptyValues: true},
+			},
+		},
+		Properties: json.RawMessage(`{
+			"ApiVersion": "cert-manager.io/v1",
+			"Kind": "ClusterIssuer",
+			"FormaeId": "cert-manager.io/v1/ClusterIssuer//issuer",
+			"Spec": ` + spec + `
+		}`),
+	}
+}
+
+// A preserveEmptyValues-hinted field whose declaration IS an empty object
+// member reaches the plugin verbatim on create, re-applies clean, and a later
+// change arrives as one whole-field value still carrying the empty member.
+func TestApplyForma_PreserveEmptySpec_VerbatimCreateCleanReapplyWholeValueUpdate(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		var createSpec, updateSpec atomic.Value
+		var updateCalls atomic.Int32
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				createSpec.Store(gjson.GetBytes(req.Properties, "Spec").Raw)
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationCreate,
+					OperationStatus: resource.OperationStatusSuccess,
+					RequestID:       "cr-create-1",
+					NativeID:        "cr-native-1",
+				}}, nil
+			},
+			Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				updateCalls.Add(1)
+				updateSpec.Store(gjson.GetBytes(req.DesiredProperties, "Spec").Raw)
+				return &resource.UpdateResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationUpdate,
+					OperationStatus: resource.OperationStatusSuccess,
+					RequestID:       "cr-update-1",
+					NativeID:        "cr-native-1",
+				}}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		targets := []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}}
+		forma := func(spec string) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:    []pkgmodel.Stack{{Label: stack}},
+				Resources: []pkgmodel.Resource{customResource(stack, spec)},
+				Targets:   targets,
+			}
+		}
+
+		_, err = m.ApplyForma(forma(`{"selfSigned":{}}`), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+		created, _ := createSpec.Load().(string)
+		assert.JSONEq(t, `{"selfSigned":{}}`, created,
+			"the plugin must receive the empty-object member verbatim on create")
+
+		resp, err := m.ApplyForma(forma(`{"selfSigned":{}}`), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		assert.False(t, resp.Simulation.ChangesRequired, "identical re-apply must plan nothing")
+
+		_, err = m.ApplyForma(forma(`{"selfSigned":{},"other":"x"}`), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+		require.Greater(t, updateCalls.Load(), int32(0), "the change must reach the plugin")
+		updated, _ := updateSpec.Load().(string)
+		assert.JSONEq(t, `{"selfSigned":{},"other":"x"}`, updated,
+			"the update carries the whole field still holding the empty member")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/secret_consumer_convergence_test.go
+++ b/internal/workflow_tests/local/apply_forma/secret_consumer_convergence_test.go
@@ -8,6 +8,7 @@ package workflow_tests_local
 
 import (
 	"encoding/json"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -371,5 +372,89 @@ func TestApplyForma_SecretConsumer_RepointPlansAndDelivers(t *testing.T) {
 		props, _ := consumerUpdateProps.Load().(json.RawMessage)
 		require.Equal(t, secretB, gjson.GetBytes(props, "DbPassword").String(),
 			"the consumer must receive the new source's value")
+	})
+}
+
+// An existing resource gains a NEW reference field to a hashed secret in the
+// same apply as an ordinary field change: the update plans, dispatch waits
+// for resolution, and the plugin receives BOTH the resolved secret and the
+// ordinary change, with no placeholder left anywhere.
+func TestApplyForma_NewSecretReferenceOnExistingResource_PlansAndDelivers(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const secretV1 = "first-declared-secret"
+
+		var consumerUpdateCalls atomic.Int32
+		var consumerUpdateProps atomic.Value
+		overrides := secretConsumerOverrides(&consumerUpdateCalls, &consumerUpdateProps)
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		targets := []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}}
+
+		bareConsumer := pkgmodel.Resource{
+			Label: "my-bucket", Type: "FakeAWS::S3::Bucket", Stack: stack, Target: "test-target",
+			Schema:     secretConsumerSchema(),
+			Properties: json.RawMessage(`{"BucketName":"my-bucket","AccessControl":"Private"}`),
+		}
+		_, err = m.ApplyForma(&pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: stack}},
+			Resources: []pkgmodel.Resource{secretResource(stack, "my-secret", secretV1), bareConsumer},
+			Targets:   targets,
+		}, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		// The mixed change: the consumer gains DbPassword (a reference that
+		// cannot resolve at plan time) AND changes AccessControl.
+		withRef := secretConsumer(stack, "my-secret")
+		withRefProps := string(withRef.Properties)
+		withRef.Properties = json.RawMessage(strings.Replace(withRefProps, `"AccessControl": "Private"`, `"AccessControl": "PublicRead"`, 1))
+		resp, err := m.ApplyForma(&pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: stack}},
+			Resources: []pkgmodel.Resource{secretResource(stack, "my-secret", secretV1), withRef},
+			Targets:   targets,
+		}, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		require.True(t, resp.Simulation.ChangesRequired, "the new reference must plan")
+		waitForApplyComplete(t, m)
+
+		require.Greater(t, consumerUpdateCalls.Load(), int32(0), "the consumer plugin must be invoked")
+		props, _ := consumerUpdateProps.Load().(json.RawMessage)
+		assert.Equal(t, secretV1, gjson.GetBytes(props, "DbPassword").String(),
+			"the plugin receives the resolved secret, never a placeholder")
+		assert.Equal(t, "PublicRead", gjson.GetBytes(props, "AccessControl").String(),
+			"the ordinary change rides the same update")
+
+		// Steady state: the written occurrence is stamped; re-apply plans nothing.
+		resp, err = m.ApplyForma(&pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: stack}},
+			Resources: []pkgmodel.Resource{secretResource(stack, "my-secret", secretV1), withRef},
+			Targets:   targets,
+		}, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		assert.False(t, resp.Simulation.ChangesRequired, "re-apply after the first declaration plans nothing")
+
+		// The persisted executed patch keeps the placeholder, never the
+		// plaintext: the live value exists only in memory and the in-flight
+		// plugin request (the delivery assertions above), and at rest the
+		// occurrence op stays a resolution placeholder.
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		for _, c := range cmds {
+			updates, err := m.Datastore.LoadResourceUpdates(c.ID)
+			require.NoError(t, err)
+			for _, ru := range updates {
+				if ru.DesiredState.Label != "my-bucket" {
+					continue
+				}
+				assert.NotContains(t, string(ru.DesiredState.PatchDocument), secretV1,
+					"the persisted executed patch must never carry the plaintext")
+			}
+		}
 	})
 }

--- a/pkg/model/schema.go
+++ b/pkg/model/schema.go
@@ -55,8 +55,8 @@ type FieldHint struct {
 	// normalization: empty collections inside it are values, preserved on both
 	// diff sides, in op values, and in plugin-bound payloads. Orthogonal to
 	// UpdateMethod; typically paired with Atomic on opaque document fields.
-	PreserveEmptyValues bool `json:"PreserveEmptyValues" pkl:"PreserveEmptyValues"`
-	Format       string            `json:"Format" pkl:"Format"` // "" = opaque String; "json" = serialized JSON document
+	PreserveEmptyValues bool   `json:"PreserveEmptyValues" pkl:"PreserveEmptyValues"`
+	Format              string `json:"Format" pkl:"Format"` // "" = opaque String; "json" = serialized JSON document
 }
 
 // UnmarshalJSON normalizes the deprecated AttachesTo alias into EdgeKind so

--- a/pkg/model/schema.go
+++ b/pkg/model/schema.go
@@ -51,6 +51,11 @@ type FieldHint struct {
 
 	IndexField   string            `json:"IndexField" pkl:"IndexField"`
 	UpdateMethod FieldUpdateMethod `json:"UpdateMethod" pkl:"UpdateMethod"`
+	// PreserveEmptyValues opts a top-level field's subtree out of empty-value
+	// normalization: empty collections inside it are values, preserved on both
+	// diff sides, in op values, and in plugin-bound payloads. Orthogonal to
+	// UpdateMethod; typically paired with Atomic on opaque document fields.
+	PreserveEmptyValues bool `json:"PreserveEmptyValues" pkl:"PreserveEmptyValues"`
 	Format       string            `json:"Format" pkl:"Format"` // "" = opaque String; "json" = serialized JSON document
 }
 


### PR DESCRIPTION
## Summary

Two defects with one representational root cause: the property pipeline treats empty values as rendering noise and filters them, destroying values that are deliberate.

- An opaque document field (e.g. a Kubernetes custom resource `spec` where `selfSigned: {}` IS the declaration) reached providers with its empty members recursively stripped, from the create payload, the diff inputs, and patch op values - valid objects were rejected by admission and the recursive collapse defeated workarounds.
- Adding a NEW reference field to an existing resource planned nothing when the reference could not resolve at plan time: the unresolved envelope flattens to an empty string, the top-level empty-value filter drops it as noise, and the whole update is silently discarded before execution-time resolution can run.

## Mechanism

- A new opt-in schema hint, `preserveEmptyValues`, marks a top-level field's subtree as carrying meaningful empty collections. Every empty-collection normalization skips such subtrees: both diff inputs, post-diff op values, the spurious-add filter, and the plugin-bound property conversion (all contexts: write, Read, sync, delete). The persist merge keeps empty objects and arrays under such roots. Matching is by first RFC 6901 pointer segment against a root set derived from schema hints; dotted (nested subresource) hints grant nothing. The absence-scoped provider-echo tolerance is unchanged, empty strings gain no exemption, and `Atomic` keeps exactly its existing diff-granularity meaning - existing plugin schemas see no behavior change, pinned by tests.
- The top-level empty-value drop's keep-set widens to fields whose desired pre-flatten value is a well-formed reference envelope (strict predicate: a `$ref` with a parseable identity, or a complete `$res` declaration). A first-declared unresolvable reference now plans a placeholder op that execution resolves live; only the placeholder ever persists. CreateOnly destinations are excluded: a replacement is never planned from a value that has not resolved.

## Tests

Unit pins for every touched site (fidelity at each strip, defaults preserved for unhinted fields, path matcher prefix/escape cases, envelope predicate matrix, churn contract, no-change guarantees) and workflow acceptance: an opaque-bodied resource creates verbatim, re-applies clean, and updates as one whole value still carrying its empty member; an existing resource gaining a reference to a hashed secret plans, delivers the resolved value together with an ordinary sibling change, re-applies clean, and persists no plaintext.

A follow-up in the kubernetes plugin opts `K8S::Custom::Resource.spec` in with `updateMethod = "Atomic"` + `preserveEmptyValues = true` and a minFormaeVersion bump.