### PR TITLE
fix(cli): adjust output to terminal width

### DIFF
--- a/internal/cli/banner/banner.go
+++ b/internal/cli/banner/banner.go
@@ -12,6 +12,8 @@ import (
 	"os"
 
 	"github.com/charmbracelet/lipgloss"
+	"golang.org/x/term"
+
 	"github.com/platform-engineering-labs/formae"
 	"github.com/platform-engineering-labs/formae/internal/cli/tui"
 	"github.com/platform-engineering-labs/formae/internal/cli/tui/logo"
@@ -91,7 +93,15 @@ func PrintBanner() {
 	if wm := th.Palette.LogoWordmark; wm.Light != "" || wm.Dark != "" {
 		opts = append(opts, logo.WithWordmarkColor(wm))
 	}
-	art, rows := logo.Render(cap, logo.SizeFull, formae.Version, opts...)
+
+	size := logo.SizeFull
+	if width, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && width > 0 {
+		if width < 45 {
+			size = logo.SizeCompact
+		}
+	}
+
+	art, rows := logo.Render(cap, size, formae.Version, opts...)
 
 	// Blank line above the art so the logo doesn't render flush against the
 	// prior shell line. A plain newline is safe before both the braille/text art


### PR DESCRIPTION
Root cause: The logo banner was hardcoded to use `logo.SizeFull` which evaluates to a braille width of 44, causing it to visually break and wrap on terminal widths smaller than ~45 columns.
Fix: Updated `PrintBanner` in `internal/cli/banner/banner.go` to use `golang.org/x/term` to check the terminal width. If it's less than 45 characters, it falls back to `logo.SizeCompact` to prevent wrapping. The table writer has already been migrated to use `bubbles/table` and custom `lipgloss` responsive column-dropping logic which handles terminal resizing correctly natively.
Validation: Ran `go vet ./...` and `go build ./...` which both completed successfully. Verified the fix by locally running the agent command and verifying the banner.
Fixes https://github.com/platform-engineering-labs/formae/issues/39

---
*PR created automatically by Jules for task [11418156364839717197](https://jules.google.com/task/11418156364839717197) started by @awhite0030*

Fixes #39
