### PR TITLE
fix(discovery): make filters mean what they say

### DIFF
--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -702,17 +702,6 @@ func getMatchFiltersFromCache(data *DiscoveryData, namespace string) []pkgmodel.
 	return pluginInfo.MatchFilters
 }
 
-// findMatchFiltersForType finds all MatchFilters that apply to the given resource type
-func findMatchFiltersForType(filters []pkgmodel.MatchFilter, resourceType string) []pkgmodel.MatchFilter {
-	var result []pkgmodel.MatchFilter
-	for i := range filters {
-		if slices.Contains(filters[i].ResourceTypes, resourceType) {
-			result = append(result, filters[i])
-		}
-	}
-	return result
-}
-
 func synchronizeResources(op ListOperation, namespace string, target pkgmodel.Target, resources []plugin.ListedResource, data DiscoveryData, proc gen.Process) (string, error) {
 	// Get schema from cache instead of calling plugin directly
 	schema, err := getSchemaFromCache(&data, namespace, op.ResourceType)
@@ -757,7 +746,7 @@ func synchronizeResources(op ListOperation, namespace string, target pkgmodel.Ta
 	// Attach MatchFilters from cache to resource updates for declarative filtering
 	matchFilters := getMatchFiltersFromCache(&data, namespace)
 	for i := range resourceUpdates {
-		filters := findMatchFiltersForType(matchFilters, resourceUpdates[i].DesiredState.Type)
+		filters := pkgmodel.FiltersForType(matchFilters, resourceUpdates[i].DesiredState.Type)
 		if len(filters) > 0 {
 			resourceUpdates[i].MatchFilters = filters
 		}

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator.go
@@ -7,6 +7,7 @@ package plugin_coordinator
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -125,7 +126,10 @@ func (c *PluginCoordinator) mergePluginConfig(name, namespace string, announced 
 			merged.LabelConfig = *userCfg.LabelConfig
 		}
 		if userCfg.DiscoveryFilters != nil {
-			merged.MatchFilters = userCfg.DiscoveryFilters
+			// Additive. The plugin's own filters encode rules its author put
+			// there for a reason, so user config adds to them rather than
+			// replacing them.
+			merged.MatchFilters = slices.Concat(announced.MatchFilters, userCfg.DiscoveryFilters)
 		}
 		if len(userCfg.ResourceTypesToDiscover) > 0 {
 			merged.ResourceTypesToDiscover = userCfg.ResourceTypesToDiscover
@@ -522,7 +526,7 @@ func (c *PluginCoordinator) getPluginInfo(req messages.GetPluginInfo) messages.P
 			resp.LabelConfig = *userCfg.LabelConfig
 		}
 		if userCfg.DiscoveryFilters != nil {
-			resp.MatchFilters = userCfg.DiscoveryFilters
+			resp.MatchFilters = slices.Concat(resp.MatchFilters, userCfg.DiscoveryFilters)
 		}
 		if len(userCfg.ResourceTypesToDiscover) > 0 {
 			resp.ResourceTypesToDiscover = userCfg.ResourceTypesToDiscover

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator_test.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator_test.go
@@ -462,3 +462,31 @@ func TestPluginCoordinator_OidcBroker_OperatorEnvOmitsBothWhenUnpaired(t *testin
 	assert.False(t, hasNode)
 	assert.False(t, hasName)
 }
+
+// A plugin's own discovery filters carry safety rules the plugin author put
+// there (EKS Automode resources, GKE Autopilot resources). User config adds to
+// them; it does not get to silently drop them.
+func TestPluginCoordinator_UserDiscoveryFiltersAddToThePluginsOwn(t *testing.T) {
+	pluginFilter := model.MatchFilter{
+		ResourceTypes: []string{"AWS::EC2::Instance"},
+		Conditions:    []model.FilterCondition{{PropertyPath: "$.Tags.eks", PropertyValue: "owned"}},
+	}
+	userFilter := model.MatchFilter{
+		Conditions: []model.FilterCondition{{PropertyPath: "$.Tags.app", PropertyValue: "formae-agent"}},
+	}
+
+	c := &PluginCoordinator{
+		resourcePluginConfigs: map[string]model.ResourcePluginUserConfig{
+			"aws": {Type: "aws", Enabled: true, DiscoveryFilters: []model.MatchFilter{userFilter}},
+		},
+	}
+
+	merged, ok := c.mergePluginConfig("aws", "AWS", RegisteredPlugin{
+		MatchFilters: []model.MatchFilter{pluginFilter},
+	})
+
+	require.True(t, ok)
+	require.Len(t, merged.MatchFilters, 2)
+	assert.Equal(t, pluginFilter, merged.MatchFilters[0])
+	assert.Equal(t, userFilter, merged.MatchFilters[1])
+}

--- a/internal/metastructure/resource_persister/resource_persister.go
+++ b/internal/metastructure/resource_persister/resource_persister.go
@@ -580,13 +580,6 @@ func (rp *ResourcePersister) processResourceUpdate(commandID string, rc resource
 				}
 
 				for i := range rc.MatchFilters {
-					// A filter with no conditions never evicts here — skip it so that
-					// an unconfigured filter does not accidentally remove every row.
-					// This deliberately overrides the matcher's vacuous-true result
-					// for an empty condition set.
-					if len(rc.MatchFilters[i].Conditions) == 0 {
-						continue
-					}
 					if resource_update.ShouldFilterByMatchFilter(&rc.MatchFilters[i], completeProperties) {
 						slog.Info("Evicting unmanaged inventory row that matches a discovery filter",
 							"namespace", rc.ResourceTarget.Namespace,

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -1252,6 +1252,13 @@ func ShouldFilterByMatchFilter(filter *pkgmodel.MatchFilter, properties json.Raw
 		return false
 	}
 
+	// A filter naming no conditions excludes nothing. Reading it as a vacuous
+	// AND would make it exclude everything it is scoped to, so the emptiest
+	// filter anyone can write would be the most destructive one.
+	if len(filter.Conditions) == 0 {
+		return false
+	}
+
 	// All conditions must match (AND logic) to exclude
 	for _, cond := range filter.Conditions {
 		if !evaluateCondition(cond, properties) {

--- a/internal/metastructure/resource_update/resource_updater_test.go
+++ b/internal/metastructure/resource_update/resource_updater_test.go
@@ -334,8 +334,12 @@ func TestHandleProgressUpdate_FilteredDiscoveryEmitsTargetHealth(t *testing.T) {
 			Properties: json.RawMessage(`{"Name":"my-bucket"}`),
 		},
 		ResourceTarget: pkgmodel.Target{Label: targetLabel},
-		// A filter with no conditions always matches — the resource will be filtered.
-		MatchFilters: []pkgmodel.MatchFilter{{}},
+		// A filter this resource matches, so the discovery filter path is taken.
+		MatchFilters: []pkgmodel.MatchFilter{{
+			Conditions: []pkgmodel.FilterCondition{
+				{PropertyPath: "$.Name", PropertyValue: "my-bucket"},
+			},
+		}},
 	}
 
 	data := ResourceUpdateData{
@@ -457,4 +461,27 @@ func TestTimeoutHandlers_DoNotLogResolvedConfig(t *testing.T) {
 		}
 		assert.NotEmpty(t, clog2.all(), "a log message must have been emitted")
 	})
+}
+
+func TestShouldFilterByMatchFilterWithNoConditionsMatchesNothing(t *testing.T) {
+	filter := pkgmodel.MatchFilter{ResourceTypes: []string{"AWS::EC2::Instance"}}
+
+	got := ShouldFilterByMatchFilter(&filter, json.RawMessage(`{"Name":"anything"}`))
+
+	assert.False(t, got, "a filter naming no conditions must not exclude every resource")
+}
+
+func TestShouldFilterByMatchFilterRequiresEveryConditionToMatch(t *testing.T) {
+	filter := pkgmodel.MatchFilter{
+		Conditions: []pkgmodel.FilterCondition{
+			{PropertyPath: "$.tags.app", PropertyValue: "formae-agent"},
+			{PropertyPath: "$.tags.tier", PropertyValue: "control"},
+		},
+	}
+
+	both := json.RawMessage(`{"tags":{"app":"formae-agent","tier":"control"}}`)
+	one := json.RawMessage(`{"tags":{"app":"formae-agent","tier":"data"}}`)
+
+	assert.True(t, ShouldFilterByMatchFilter(&filter, both))
+	assert.False(t, ShouldFilterByMatchFilter(&filter, one))
 }

--- a/internal/metastructure/synchronizer.go
+++ b/internal/metastructure/synchronizer.go
@@ -6,7 +6,6 @@ package metastructure
 
 import (
 	"fmt"
-	"slices"
 	"time"
 
 	"ergo.services/actor/statemachine"
@@ -292,7 +291,7 @@ func synchronizeAllResources(state gen.Atom, data SynchronizerData, proc gen.Pro
 	for i := range allResourceUpdates {
 		namespace := allResourceUpdates[i].DesiredState.Namespace()
 		if cache, ok := pluginInfoByNamespace[namespace]; ok && cache.available {
-			filters := findMatchFiltersForType(cache.matchFilters, allResourceUpdates[i].DesiredState.Type)
+			filters := pkgmodel.FiltersForType(cache.matchFilters, allResourceUpdates[i].DesiredState.Type)
 			if len(filters) > 0 {
 				allResourceUpdates[i].MatchFilters = filters
 			}
@@ -394,18 +393,6 @@ func unregisterInProgressResource(from gen.PID, state gen.Atom, data Synchronize
 	delete(data.excludedResources, message.ResourceURI)
 	proc.Log().Debug("Resource unregistered from in-progress, can be synced resourceURI=%s", message.ResourceURI)
 	return state, data, nil, nil
-}
-
-// findMatchFiltersForType returns the subset of filters whose ResourceTypes list
-// includes the given resourceType. Mirrors the same helper in the discovery package.
-func findMatchFiltersForType(filters []pkgmodel.MatchFilter, resourceType string) []pkgmodel.MatchFilter {
-	var result []pkgmodel.MatchFilter
-	for i := range filters {
-		if slices.Contains(filters[i].ResourceTypes, resourceType) {
-			result = append(result, filters[i])
-		}
-	}
-	return result
 }
 
 // finalizeFailedCommand marks all resource updates in the command as failed and then

--- a/internal/schema/pkl/assets/formae/Config.pkl
+++ b/internal/schema/pkl/assets/formae/Config.pkl
@@ -217,8 +217,14 @@ class FilterCondition {
     propertyValue: String?
 }
 
+/// A rule that excludes matching resources from discovery.
 class MatchFilter {
+    /// Resource types this filter applies to. Leave it out to apply the
+    /// filter to every type the plugin discovers.
     resourceTypes: Listing<String>
+
+    /// Every condition must match for a resource to be excluded. A filter
+    /// naming no conditions excludes nothing.
     conditions: Listing<FilterCondition>
 }
 
@@ -227,6 +233,9 @@ open class BaseResourcePluginConfig {
     enabled: Boolean = true
     rateLimit: RateLimitConfig?
     labelConfig: LabelConfig?
+
+    /// Extra discovery filters for this plugin. These are added to the
+    /// filters the plugin declares for itself, never a replacement for them.
     discoveryFilters: Listing<MatchFilter>?
     resourceTypesToDiscover: Listing<String>?
     retry: RetryConfig?

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/url"
 	"regexp"
+	"slices"
 	"time"
 )
 
@@ -53,10 +54,35 @@ func (c LabelConfig) QueryForResourceType(resourceType string) string {
 }
 
 // MatchFilter is a declarative, serializable filter definition for discovery.
-// Resources matching ALL conditions in a filter are excluded from discovery.
+// A resource is excluded when it is of a type the filter applies to and every
+// one of the filter's conditions matches. A filter naming no conditions
+// excludes nothing.
 type MatchFilter struct {
-	ResourceTypes []string          // Resource types this filter applies to
+	ResourceTypes []string          // Resource types this filter applies to; empty means every type
 	Conditions    []FilterCondition // All conditions must match (AND logic) to exclude
+}
+
+// AppliesTo reports whether this filter is scoped to the given resource type.
+//
+// An empty ResourceTypes list applies to every type. That is what a filter
+// naming only conditions reads as, and writing one is the ordinary way to say
+// "exclude anything tagged like this, whatever it is".
+func (f MatchFilter) AppliesTo(resourceType string) bool {
+	if len(f.ResourceTypes) == 0 {
+		return true
+	}
+	return slices.Contains(f.ResourceTypes, resourceType)
+}
+
+// FiltersForType returns the filters that apply to the given resource type.
+func FiltersForType(filters []MatchFilter, resourceType string) []MatchFilter {
+	var result []MatchFilter
+	for i := range filters {
+		if filters[i].AppliesTo(resourceType) {
+			result = append(result, filters[i])
+		}
+	}
+	return result
 }
 
 // FilterCondition defines a single condition for filtering resources.

--- a/pkg/model/config_test.go
+++ b/pkg/model/config_test.go
@@ -56,3 +56,32 @@ func TestNetworkConfig_PluginConfigJSON_NilTailscaleMarshalsNull(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "null", string(got))
 }
+
+func TestMatchFilterAppliesToEveryTypeWhenNoTypesAreListed(t *testing.T) {
+	filter := MatchFilter{
+		Conditions: []FilterCondition{{PropertyPath: "$.tags.app", PropertyValue: "formae-agent"}},
+	}
+
+	assert.True(t, filter.AppliesTo("AZURE::Compute::VirtualMachine"))
+	assert.True(t, filter.AppliesTo("AWS::EC2::Instance"))
+}
+
+func TestMatchFilterAppliesOnlyToListedTypes(t *testing.T) {
+	filter := MatchFilter{
+		ResourceTypes: []string{"AWS::EC2::Instance"},
+		Conditions:    []FilterCondition{{PropertyPath: "$.SkipMe", PropertyValue: "yes"}},
+	}
+
+	assert.True(t, filter.AppliesTo("AWS::EC2::Instance"))
+	assert.False(t, filter.AppliesTo("AWS::S3::Bucket"))
+}
+
+func TestFiltersForTypeKeepsUntypedAndMatchingFilters(t *testing.T) {
+	untyped := MatchFilter{Conditions: []FilterCondition{{PropertyPath: "$.tags.app"}}}
+	matching := MatchFilter{ResourceTypes: []string{"AWS::EC2::Instance"}}
+	other := MatchFilter{ResourceTypes: []string{"AWS::S3::Bucket"}}
+
+	got := FiltersForType([]MatchFilter{untyped, matching, other}, "AWS::EC2::Instance")
+
+	assert.Equal(t, []MatchFilter{untyped, matching}, got)
+}

--- a/tests/e2e/go/plugin_config_test.go
+++ b/tests/e2e/go/plugin_config_test.go
@@ -102,7 +102,7 @@ func TestPluginConfig(t *testing.T) {
 				}
 			})
 
-			t.Run("discovery filters override", func(t *testing.T) {
+			t.Run("configured discovery filters reach the plugin", func(t *testing.T) {
 				if len(p.DiscoveryFilters) != 1 {
 					t.Fatalf("expected 1 discovery filter, got %d", len(p.DiscoveryFilters))
 				}


### PR DESCRIPTION
## Summary

A discovery filter had three behaviours that did not match how it reads. Together they meant the filters shipped in the bootstrap examples did nothing, and that configuring a filter silently dropped the ones a plugin ships for itself.

**A filter naming no resource types matched nothing.** `slices.Contains(f.ResourceTypes, resourceType)` is false for an empty list, so a filter written with only conditions, which is the natural way to say "exclude anything tagged like this", excluded nothing at all. Pkl defaults `Listing<String>` to empty, so this config evaluates cleanly and then does nothing, which is the worst way to be wrong. It now applies to every type.

**A filter naming no conditions matched everything it was scoped to.** The condition loop is an AND, so zero conditions returned true vacuously and the emptiest filter anyone can write was the most destructive one. It now excludes nothing. That was previously worked around locally in the resource persister, with a comment saying it "deliberately overrides the matcher"; the override is no longer needed and is removed.

**Configured filters replaced a plugin s own rather than adding to them.** `mergePluginConfig` assigned where it should append, at both call sites, so setting any `discoveryFilters` discarded the plugin author s rules (EKS Automode resources for aws, GKE Autopilot resources for gcp). They are additive now.

Also: the two copies of the type-scoping helper, one of which carried a comment noting it mirrored the other, become a single `MatchFilter.AppliesTo` method, and the config schema documents the semantics, which it previously did not at all.

## Operational note

The resource persister evicts unmanaged inventory rows that match a filter. Agents deployed from the bootstrap examples, and any agent with configured `discoveryFilters`, will therefore drop matching rows on the first sync after this lands. That is the intended effect of the filters finally working, but it moves visible inventory counts.

## Verification

- `go test -tags=unit ./internal/metastructure/... ./internal/schema/...` green, 25 packages.
- `pkg/model` module tests green.
- `make lint` reports 0 issues.
- Each new test was watched failing against the old behaviour first.

One existing test, `TestHandleProgressUpdate_FilteredDiscoveryEmitsTargetHealth`, used a conditionless filter purely as a lever to reach the filter path. Its subject is unchanged; it now uses a filter that genuinely matches.