### PR TITLE
fix(metastructure,schema): extract keeps a reference's sub-key selector

### DIFF
--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -2400,7 +2400,7 @@ func replaceKSUIDs(jsonStr string, ksuidToTriplet map[string]pkgmodel.TripletKey
 				if ksuid := formaeUri.KSUID(); ksuid != "" {
 					if triplet, ok := ksuidToTriplet[ksuid]; ok {
 						dollarValue, _ := v["$value"].(string)
-						return map[string]any{
+						rewritten := map[string]any{
 							"$res":      true,
 							"$label":    triplet.Label,
 							"$type":     triplet.Type,
@@ -2408,6 +2408,18 @@ func replaceKSUIDs(jsonStr string, ksuidToTriplet map[string]pkgmodel.TripletKey
 							"$property": formaeUri.PropertyPath(),
 							"$value":    dollarValue,
 						}
+						// The selector is part of what the reference means: it
+						// names the sub-key of the referenced property. Dropping
+						// it would extract a reference to the whole document, so
+						// re-applying the extracted forma would write that
+						// document where one of its members belongs. Provenance
+						// keys are deliberately not carried over: they record
+						// formae's own writes and are stripped from any incoming
+						// forma.
+						if selector, ok := v["$json"].(string); ok && selector != "" {
+							rewritten["$json"] = selector
+						}
+						return rewritten
 					}
 				}
 			}

--- a/internal/schema/pkl/generator/examples/json/secret_json_selector_ref.json
+++ b/internal/schema/pkl/generator/examples/json/secret_json_selector_ref.json
@@ -1,0 +1,40 @@
+{
+  "Targets": [
+    { "Label": "testprovider-target", "Namespace": "TestProvider",
+      "Config": { "Type": "TestProvider", "Region": "us-east-1" } }
+  ],
+  "Stacks": [
+    { "Label": "app-stack", "Description": "Application stack with a secret-sourced credential" }
+  ],
+  "Resources": [
+    {
+      "Label": "db-credentials",
+      "Type": "TestProvider::SecretsManager::Secret",
+      "Stack": "app-stack",
+      "Target": "testprovider-target",
+      "Properties": {
+        "Name": "app/db-credentials",
+        "SecretString": {
+          "$value": "44c7c7231597046fc3ffd5c70b527f03aabb4a47694a4e51b39e3699b7be305a",
+          "$visibility": "Opaque", "$hashed": true, "$strategy": "Update"
+        }
+      }
+    },
+    {
+      "Label": "app-server",
+      "Type": "TestProvider::Compute::Server",
+      "Stack": "app-stack",
+      "Target": "testprovider-target",
+      "Properties": {
+        "ServerType": "t3.micro",
+        "ImageId": "ami-0123456789abcdef0",
+        "AdminPassword": {
+          "$res": true, "$label": "db-credentials", "$stack": "app-stack",
+          "$type": "TestProvider::SecretsManager::Secret",
+          "$property": "SecretString", "$json": "password",
+          "$value": "fa70c70d9532814c2b4d776fc7801f0fda22932182aab5bcc5a611ba9437f2c4"
+        }
+      }
+    }
+  ]
+}

--- a/internal/schema/pkl/generator/gen.pkl
+++ b/internal/schema/pkl/generator/gen.pkl
@@ -641,6 +641,9 @@ class FakeResolvable extends formae.Resolvable {
   FakeType: String?
   RealValue: Any?
   FakeProperty: String?
+  /// The sub-key selector, set when the reference addresses one member of the
+  /// referenced document rather than the whole of it.
+  FakeJSON: String?
 }
 
 /// Carrier for a pre-processed $embed field.
@@ -679,6 +682,21 @@ function applyPropertyWithMapping(valueAsMap: Map, prop: reflect.Property, rever
 /// Simple paths like "arn" render as "arn".
 /// Collection paths like "endpoints.lgtm\:3000" render as "endpoints.at("lgtm:3000")".
 /// Nested paths like "endpoints.0.uri" render as "endpoints.at(0).at("uri")".
+/// The accessor path for a reference that carries a sub-key selector. Only a
+/// secret-value resolvable can produce a selector, and both secret backends
+/// reach one through an accessor named `secretValue` declared in formae's own
+/// schema: a scalar backend's `secretValue` IS the value, and a map backend's
+/// is an accessor whose remaining path segments render as `at(...)` calls just
+/// as they do for any other collection path. So the base segment becomes
+/// `secretValue` and the rest is left for renderResolvableProperty.
+local function secretValuePath(property: String?): String? =
+    if (property == null)
+        null
+    else
+        let (segments = splitGjsonPath(property))
+        let (rest = segments.drop(1))
+        "secretValue" + rest.fold("", (acc, seg) -> acc + "." + seg)
+
 function renderResolvableProperty(property: String): String =
     if (!property.contains("."))
         // Simple scalar property — render as-is
@@ -803,6 +821,7 @@ local function applyDynamicOrMapping(type: reflect.Class, value: Dynamic|Mapping
         let (refType = valueAsMap.getOrNull("$type"))
         let (typeName = valueAsMap.getOrNull("$type"))
         let (property = valueAsMap.getOrNull("$property"))
+        let (selector = valueAsMap.getOrNull("$json") as String?)
         // Both carriers are handled as text — the type keys the resolvable
         // lookup, the property is split on dots and matched. Reject any other
         // shape here: further down they reach a lookup that takes a String and
@@ -835,7 +854,8 @@ local function applyDynamicOrMapping(type: reflect.Class, value: Dynamic|Mapping
                 RealValue = valueAsMap.getOrNull("$value")
                 type = refType
                 FakeType = typeName
-                FakeProperty = mappedProperty
+                FakeProperty = if (selector != null) secretValuePath(property) else mappedProperty
+                FakeJSON = selector
             })
 
             r
@@ -1230,7 +1250,9 @@ local function formatValueWithTypes(value: Any, indent: String): String =
               comment + "\n" +
               (if (stack != null) indent + "  stack = \"\(stack)\" //resolvable\n" else "") +
               (if (label != null) indent + "  label = \"\(label)\"\n" else "") +
-              indent + "}." + renderResolvableProperty(property)
+              indent + "}." + renderResolvableProperty(property) +
+              (let (selector = value.getOrNull("FakeJSON"))
+                if (selector is String) ".json(\"\(escapeString(selector))\")" else "")
         else if (typeName == "FakeValue")
           // Special handling for FakeValue - render using fluent API
           let (fakeValue = value.getOrNull("FakeValue"))

--- a/internal/schema/pkl/generator/tests/pklGenerator.pkl
+++ b/internal/schema/pkl/generator/tests/pklGenerator.pkl
@@ -19,6 +19,7 @@ local computeServerJson = new json.Parser {}.parse(read("../examples/json/comput
 local appRunnerServiceJson = new json.Parser {}.parse(read("../examples/json/apprunner_service.json"))
 local crossStackRefJson = new json.Parser {}.parse(read("../examples/json/cross_stack_ref.json"))
 local hashedValueJson = new json.Parser {}.parse(read("../examples/json/hashed_value.json"))
+local secretJsonSelectorJson = new json.Parser {}.parse(read("../examples/json/secret_json_selector_ref.json"))
 
 facts {
     ["SQS Queue - generates correct imports"] {
@@ -281,6 +282,14 @@ facts {
     ["Cross-stack ref - resolvable stack uses .res.label not .res"] {
         let (result = generator.generateFormaFile(crossStackRefJson))
         result.contains("infraStack.res.label")
+    }
+
+    ["Selector ref - renders the sub-key selector through the secret-value accessor"] {
+        let (result = generator.generateFormaFile(secretJsonSelectorJson))
+        // The selector names one member of the secret document. It must survive
+        // regeneration, and it must hang off secretValue: json() is defined on the
+        // secret-value resolvable, not on the accessor the property mapping picks.
+        result.contains(".secretValue.json(\"password\")")
     }
 
     ["Cross-stack ref - generates resolvable with VPCResolvable type"] {

--- a/internal/schema/pkl/generator/tests/schema/compute/server.pkl
+++ b/internal/schema/pkl/generator/tests/schema/compute/server.pkl
@@ -29,6 +29,12 @@ open class Server extends formae.Resource {
     @testprovider.FieldHint
     userData: (String|formae.Embedded)?
 
+    // Accepts a secret reference, so a regenerated forma can be checked for a
+    // reference that addresses one member of a secret document rather than the
+    // whole of it.
+    @testprovider.FieldHint
+    adminPassword: (String|formae.Resolvable|formae.SecretValue)?
+
     @testprovider.FieldHint
     networkConfig: networkconfig.NetworkConfig?
 

--- a/internal/workflow_tests/local/apply_forma/generated_secret_json_extract_reapply_test.go
+++ b/internal/workflow_tests/local/apply_forma/generated_secret_json_extract_reapply_test.go
@@ -1,0 +1,229 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// A provider-generated secret is never declared: the forma asks for a secret
+// and the provider mints the value, so the plaintext reaches formae only
+// through the plugin's Create/Read and lives at rest as a digest. A consumer
+// takes one key out of that JSON document via a $json sub-key extraction.
+//
+// Extracting the stack and re-applying the extracted forma in patch mode must
+// be a zero-operation apply: nothing about the world changed between the two
+// commands.
+func TestApplyForma_GeneratedSecretJSONConsumer_ExtractReapplyPlansNothing(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		// The provider mints this; it is never written in any forma.
+		const generatedDoc = `{"username":"owner","password":"gen-pass-abc123"}`
+		const generatedPassword = "gen-pass-abc123"
+
+		var secretStore sync.Map // nativeID -> provider-side properties JSON
+		var consumerCreateProps atomic.Value
+		var consumerUpdateProps atomic.Value
+		var consumerUpdateCalls atomic.Int32
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				switch req.ResourceType {
+				case "FakeAWS::SecretsManager::Secret":
+					// generateSecretString: the value is minted provider-side
+					// and echoed back on create; it is absent from the request.
+					require.False(t, gjson.GetBytes(req.Properties, "SecretString").Exists(),
+						"precondition: the secret's value must not be declared")
+					nativeID := "secret-native-1"
+					props := `{"Name":"gen-secret","SecretString":` + jsonQuote(generatedDoc) + `}`
+					secretStore.Store(nativeID, props)
+					return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+						Operation:          resource.OperationCreate,
+						OperationStatus:    resource.OperationStatusSuccess,
+						RequestID:          "secret-create-1",
+						NativeID:           nativeID,
+						ResourceProperties: json.RawMessage(props),
+					}}, nil
+				case "FakeAWS::S3::Bucket":
+					consumerCreateProps.Store(append(json.RawMessage(nil), req.Properties...))
+					return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationCreate,
+						OperationStatus: resource.OperationStatusSuccess,
+						RequestID:       "consumer-create-1",
+						NativeID:        "bucket-native-1",
+					}}, nil
+				}
+				return nil, nil
+			},
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				if props, ok := secretStore.Load(req.NativeID); ok {
+					return &resource.ReadResult{ResourceType: req.ResourceType, Properties: props.(string)}, nil
+				}
+				return &resource.ReadResult{ResourceType: req.ResourceType, Properties: "{}"}, nil
+			},
+			Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				if req.ResourceType != "FakeAWS::S3::Bucket" {
+					return nil, nil
+				}
+				consumerUpdateCalls.Add(1)
+				consumerUpdateProps.Store(append(json.RawMessage(nil), req.DesiredProperties...))
+				return &resource.UpdateResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationUpdate,
+					OperationStatus: resource.OperationStatusSuccess,
+					RequestID:       "consumer-update-1",
+					NativeID:        "bucket-native-1",
+				}}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		targets := []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}}
+
+		// The secret declares only its name: the value is provider-generated.
+		secret := pkgmodel.Resource{
+			Label:      "gen-secret",
+			Type:       "FakeAWS::SecretsManager::Secret",
+			Stack:      stack,
+			Target:     "test-target",
+			Schema:     secretSchema(),
+			Properties: json.RawMessage(`{"Name":"gen-secret"}`),
+		}
+		// The consumer takes one key out of the secret document.
+		consumer := pkgmodel.Resource{
+			Label:  "my-bucket",
+			Type:   "FakeAWS::S3::Bucket",
+			Stack:  stack,
+			Target: "test-target",
+			Schema: secretConsumerSchema(),
+			Properties: json.RawMessage(`{
+				"BucketName": "my-bucket",
+				"AccessControl": "Private",
+				"DbPassword": {
+					"$res":      true,
+					"$label":    "gen-secret",
+					"$type":     "FakeAWS::SecretsManager::Secret",
+					"$stack":    "` + stack + `",
+					"$property": "SecretString",
+					"$visibility": "Opaque",
+					"$json":    "password"
+				}
+			}`),
+		}
+
+		_, err = m.ApplyForma(&pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: stack}},
+			Resources: []pkgmodel.Resource{secret, consumer},
+			Targets:   targets,
+		}, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		createCmd := findCommandByType(cmds, pkgmodel.CommandApply)
+		require.NotNil(t, createCmd)
+		require.Equal(t, forma_command.CommandStateSuccess, createCmd.State,
+			"precondition: the create apply must succeed")
+
+		// The consumer really received the extracted leaf, not the document.
+		createProps, _ := consumerCreateProps.Load().(json.RawMessage)
+		require.Equal(t, generatedPassword, gjson.GetBytes(createProps, "DbPassword").String(),
+			"precondition: the consumer must receive the extracted leaf")
+
+		// --- Stored shapes after the first apply -------------------------
+		resources, err := m.Datastore.LoadResourcesByStack(stack)
+		require.NoError(t, err)
+		var storedSecret, storedConsumer *pkgmodel.Resource
+		for _, r := range resources {
+			if r.Type == "FakeAWS::SecretsManager::Secret" {
+				storedSecret = r
+			} else {
+				storedConsumer = r
+			}
+		}
+		require.NotNil(t, storedSecret)
+		require.NotNil(t, storedConsumer)
+		t.Logf("STORED source SecretString  = %s", gjson.GetBytes(storedSecret.Properties, "SecretString").Raw)
+		t.Logf("STORED source (whole row)   = %s", string(storedSecret.Properties))
+		t.Logf("STORED consumer DbPassword  = %s", gjson.GetBytes(storedConsumer.Properties, "DbPassword").Raw)
+		t.Logf("STORED source $hashed       = %v", gjson.GetBytes(storedSecret.Properties, "SecretString.$hashed").Bool())
+		t.Logf("STORED consumer $resolvedFrom = %q", gjson.GetBytes(storedConsumer.Properties, "DbPassword.$resolvedFrom").String())
+
+		// --- Control: re-applying the ORIGINAL forma plans nothing -------
+		ctrl, err := m.ApplyForma(&pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: stack}},
+			Resources: []pkgmodel.Resource{secret, consumer},
+			Targets:   targets,
+		}, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch, Simulate: true}, "test-client-id", "", "")
+		require.NoError(t, err)
+		t.Logf("CONTROL (original forma, patch+simulate) ChangesRequired=%v", ctrl.Simulation.ChangesRequired)
+		for _, ru := range ctrl.Simulation.Command.ResourceUpdates {
+			t.Logf("CONTROL planned: %s %s (%s) patch: %s",
+				ru.Operation, ru.ResourceLabel, ru.ResourceType, string(ru.PatchDocument))
+		}
+		require.False(t, ctrl.Simulation.ChangesRequired,
+			"control: re-applying the SAME forma must plan nothing, so any diff below "+
+				"belongs to the extract round trip and not to the generated secret")
+
+		// --- The regression: extract, then re-apply the extracted forma --
+		extracted, err := m.ExtractResources("stack:" + stack)
+		require.NoError(t, err)
+		require.NotNil(t, extracted)
+		for i := range extracted.Resources {
+			t.Logf("EXTRACTED %s properties = %s",
+				extracted.Resources[i].Label, string(extracted.Resources[i].Properties))
+		}
+		extracted.Targets = targets
+
+		// The reference's extraction selector is part of the occurrence's
+		// identity: an envelope that loses it reads as a repoint of the same
+		// reference at a different key, which always plans.
+		for i := range extracted.Resources {
+			if extracted.Resources[i].Label != "my-bucket" {
+				continue
+			}
+			assert.Equal(t, "password",
+				gjson.GetBytes(extracted.Resources[i].Properties, "DbPassword.$json").String(),
+				"the extracted reference must keep its $json selector")
+		}
+
+		resp, err := m.ApplyForma(extracted,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch, Simulate: true},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+		t.Logf("EXTRACT RE-APPLY ChangesRequired=%v", resp.Simulation.ChangesRequired)
+		for _, ru := range resp.Simulation.Command.ResourceUpdates {
+			t.Logf("EXTRACT RE-APPLY planned: %s %s (%s) patch: %s",
+				ru.Operation, ru.ResourceLabel, ru.ResourceType, string(ru.PatchDocument))
+		}
+
+		assert.False(t, resp.Simulation.ChangesRequired,
+			"re-applying the extracted forma must be a zero-operation apply")
+	})
+}
+


### PR DESCRIPTION
## Summary

A reference may address one member of the document it points at rather than the whole of it, written as `secret.res.secretValue.json("password")`. Extract dropped that selector in both halves of its pipeline, so a forma regenerated from live state addressed the **whole** document. Two consequences, the second worse than the first:

- **Every re-apply plans a replacement of the field, forever.** Occurrence identity includes the selector, so the round-tripped reference reads as a change of reference and is classified as movement, for a value nothing has touched. This is what turns the `rds-databaserole` conformance case red on every nightly run.
- **A re-apply from extracted code would write the whole secret document where one of its members belongs.** The regenerated forma is not equivalent to the one it was regenerated from.

## What changed

**Extract's JSON output** (`replaceKSUIDs`) rebuilt each reference from a fixed set of keys that omitted the selector. It now carries it through. Provenance keys stay out deliberately: they record formae's own writes and are stripped from any incoming forma.

**Rendering that output back to Pkl** dropped it again. The selector now renders as the `json()` call that produced it. The accessor it hangs off is deliberately *not* the one the property mapping picks: that mapping resolves a resolvable's own declared members, which for a secret is an accessor with no `json()` on it. Only a secret-value resolvable has one, and both secret backends reach one through a member named `secretValue` declared in formae's own schema. So the base segment renders as `secretValue` and any remaining segments keep rendering as `at()` calls, which covers both backends with one rule:

- scalar (`SecretString`) renders `secretValue.json("password")`
- map (`decodedData.password`) renders `secretValue.at("password").json("...")`

## Verification

A workflow test applies a forma, calls the real `ExtractResources`, and re-applies the extracted output; it fails on the parent commit and passes here. The control in the same test, re-applying the identical original forma, planned nothing throughout, so only the round trip was affected.

The example set gains a resource whose credential comes from a member of a secret document. Every example is generated and then **evaluated**, so an accessor that does not exist fails the suite instead of reaching a user as an un-evaluable forma. The full round trip is pinned end to end: the regenerated Pkl evaluates, and the resulting envelope carries the selector again.

Also green: the `apply_forma` workflow suite, `./internal/metastructure/...`, `./internal/schema/pkl/...`, and the generator's own pkl suites.

## Note on scope

The extracted reference also loses `$visibility`, so it no longer declares itself opaque. That is a separate defect, it does not cause this plan, and it is recorded rather than fixed here.