### PR TITLE
feat(conformance): record what providers do with hasProviderDefault fields

### DIFF
--- a/pkg/plugin-conformance-tests/README.md
+++ b/pkg/plugin-conformance-tests/README.md
@@ -128,10 +128,61 @@ exercised.
 | `FORMAE_BINARY` | Absolute path to a specific `formae` binary. Skips the channel-aware resolver. |
 | `FORMAE_VERSION` | Pin a specific formae version. The resolver searches stable then dev channels for an exact match. |
 | `FORMAE_TEST_RUN_ID` | Set by the harness for each run; available to Pkl fixtures for unique resource naming. |
+| `FORMAE_TEST_PROVIDER_DEFAULT_OBSERVATIONS` | Path to write the omit-and-observe sweep artifact to. Unset means no sweep. See below. |
+| `FORMAE_TEST_SETTLE_SECONDS` | Seconds to wait before the post-create sync, so asynchronously populated fields have settled before the second read. Default 0; capped at 300. |
 
 A timeout knob for the OOB-delete inventory-removal step is also exposed for
 slow backends; see the comment block above `RunCRUDTests` in
 [`runner.go`](./runner.go) for the current name and default.
+
+## The provider-default sweep
+
+Set `FORMAE_TEST_PROVIDER_DEFAULT_OBSERVATIONS` to a file path and the CRUD run
+also records what the provider does with every field the schema annotates
+`hasProviderDefault`:
+
+```bash
+FORMAE_TEST_PROVIDER_DEFAULT_OBSERVATIONS=/tmp/observations.json go test -v ./...
+```
+
+The suite is already running the experiment. A fixture declares a subset of the
+schema, so every annotated field it leaves out is created omitted, and the
+resource is read back twice: once from the create echo and once after a forced
+sync. The sweep captures those two reads per annotated field instead of
+discarding them.
+
+Each row records the two observations separately, and distinguishes absence
+from an explicit null and from an explicit empty collection, because the three
+carry different patch meanings:
+
+```json
+{
+  "testCase": "s3-bucket",
+  "resourceType": "AWS::S3::Bucket",
+  "path": "encryption",
+  "declared": false,
+  "createEcho": "value",
+  "afterSync": "value",
+  "moved": false
+}
+```
+
+`declared: false` marks the omitted-field experiment. `moved: true` means the
+value differs between the two reads — formae wrote nothing in between, so a
+writer other than formae did.
+
+What a row does and does not settle:
+
+- A field the provider **populates** when omitted has an empirically justified
+  annotation.
+- A field that **moves** between the two reads names a co-actor.
+- A field that **never appears** settles nothing on its own. The co-actor that
+  would populate it is absent from an isolated fixture by construction, so an
+  unexercised annotation needs a documentation pass, not a removal.
+
+The two reads are seconds apart, which catches asynchronous population but not
+a value a provider moves on a maintenance-window cadence. Widen the gap with
+`FORMAE_TEST_SETTLE_SECONDS`.
 
 ## Diagnostics on failure
 

--- a/pkg/plugin-conformance-tests/provider_default_sweep.go
+++ b/pkg/plugin-conformance-tests/provider_default_sweep.go
@@ -1,0 +1,309 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package conformance
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// The omit-and-observe sweep records what a provider actually does with every
+// field a schema annotates hasProviderDefault. The CRUD suite already performs
+// the experiment — its fixtures declare a subset of the schema, so every
+// annotated field a fixture leaves out is created omitted — and it already
+// reads the resource back twice, once from the create echo and once after a
+// forced cloud sync. The sweep captures those two reads per annotated field
+// instead of discarding them.
+//
+// What the record decides and what it does not: a field the provider populates
+// when omitted has an empirically justified annotation, and a value that moves
+// between the two reads without formae writing it names a co-actor. A field
+// that never appears decides nothing on its own — the co-actor that would
+// populate it is absent from an isolated fixture by construction — so an
+// unexercised annotation routes to the documentation pass rather than to
+// removal.
+//
+// Timescale is the honest limit. The two reads are seconds apart (widen with
+// FORMAE_TEST_SETTLE_SECONDS), which catches asynchronous population but not
+// values a provider moves on a maintenance-window cadence.
+
+const (
+	// envProviderDefaultObservations names the file the sweep artifact is
+	// written to. Unset means no sweep: the CRUD suite behaves exactly as it
+	// did before.
+	envProviderDefaultObservations = "FORMAE_TEST_PROVIDER_DEFAULT_OBSERVATIONS"
+
+	// envSettleWindowSeconds widens the gap between the create echo and the
+	// post-sync read, so a provider that populates a field asynchronously has
+	// had time to do it before the second observation is taken.
+	envSettleWindowSeconds = "FORMAE_TEST_SETTLE_SECONDS"
+
+	// settleWindowCap bounds the wait. The conformance matrix runs ~100 jobs
+	// against one shared account, so an oversized settle window stalls the
+	// whole run rather than only its own case.
+	settleWindowCap = 300 * time.Second
+)
+
+// getSettleWindow returns how long to wait before the post-create sync, from
+// FORMAE_TEST_SETTLE_SECONDS. Unset, non-numeric, or non-positive means no
+// wait, which is the default the CRUD suite has always run with.
+func getSettleWindow() time.Duration {
+	secs, err := strconv.Atoi(os.Getenv(envSettleWindowSeconds))
+	if err != nil || secs <= 0 {
+		return 0
+	}
+	window := time.Duration(secs) * time.Second
+	if window > settleWindowCap {
+		return settleWindowCap
+	}
+	return window
+}
+
+// Observation states. Absence, an explicit null, and an explicit empty carry
+// different patch meanings, so they stay distinguishable rather than
+// collapsing into one "unset".
+const (
+	obsAbsent          = "absent"
+	obsNull            = "null"
+	obsEmptyCollection = "empty-collection"
+	obsEmptyString     = "empty-string"
+	obsValue           = "value"
+)
+
+// obsRank orders observation states from weakest to strongest for aggregation
+// across list elements.
+var obsRank = map[string]int{
+	obsAbsent:          0,
+	obsNull:            1,
+	obsEmptyString:     2,
+	obsEmptyCollection: 3,
+	obsValue:           4,
+}
+
+// ProviderDefaultObservation is one annotated field's record from one fixture.
+type ProviderDefaultObservation struct {
+	TestCase     string `json:"testCase"`
+	ResourceType string `json:"resourceType"`
+	// Path is the schema hint path: dot-separated, with list indices collapsed.
+	Path string `json:"path"`
+	// Declared reports whether the fixture supplied a value at this path. A
+	// false here is what makes the row an omit-and-observe result.
+	Declared bool `json:"declared"`
+	// CreateEcho is the state read back straight after apply.
+	CreateEcho string `json:"createEcho"`
+	// AfterSync is the state read back after a forced sync with the cloud.
+	AfterSync string `json:"afterSync"`
+	// Moved reports that the value differs between the two reads. formae wrote
+	// nothing in between, so a true here names a co-actor or a late provider
+	// write.
+	Moved bool `json:"moved"`
+
+	// Sibling hints that put a field on one of the audit's separate branches:
+	// a writeOnly field is never read back, and a createOnly field is not
+	// reverted by a forced apply even though it still rejects a soft one.
+	CreateOnly bool `json:"createOnly,omitempty"`
+	WriteOnly  bool `json:"writeOnly,omitempty"`
+	Opaque     bool `json:"opaque,omitempty"`
+}
+
+type providerDefaultSweep struct {
+	mu   sync.Mutex
+	rows []ProviderDefaultObservation
+}
+
+func newSweep() *providerDefaultSweep {
+	return &providerDefaultSweep{}
+}
+
+// newSweepFromEnv returns a sweep when an artifact path is configured, and nil
+// otherwise. A nil sweep is inert, so callers need no guard.
+func newSweepFromEnv() *providerDefaultSweep {
+	if os.Getenv(envProviderDefaultObservations) == "" {
+		return nil
+	}
+	return newSweep()
+}
+
+// record captures one fixture's observations for every hasProviderDefault path
+// in hints. declared is the fixture's evaluated properties; afterCreate and
+// afterSync are the two inventory reads.
+func (s *providerDefaultSweep) record(testCase, resourceType string, hints, declared, afterCreate, afterSync map[string]any) {
+	if s == nil {
+		return
+	}
+	rows := make([]ProviderDefaultObservation, 0, len(hints))
+	for path, hint := range hints {
+		hintMap, ok := hint.(map[string]any)
+		if !ok {
+			continue
+		}
+		if hpd, ok := hintMap["HasProviderDefault"].(bool); !ok || !hpd {
+			continue
+		}
+		createValues := collectPath(afterCreate, path)
+		syncValues := collectPath(afterSync, path)
+		rows = append(rows, ProviderDefaultObservation{
+			TestCase:     testCase,
+			ResourceType: resourceType,
+			Path:         path,
+			Declared:     len(collectPath(declared, path)) > 0,
+			CreateEcho:   aggregateState(createValues),
+			AfterSync:    aggregateState(syncValues),
+			Moved:        !reflect.DeepEqual(createValues, syncValues),
+			CreateOnly:   boolHint(hintMap, "CreateOnly"),
+			WriteOnly:    boolHint(hintMap, "WriteOnly"),
+			Opaque:       boolHint(hintMap, "Opaque"),
+		})
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rows = append(s.rows, rows...)
+}
+
+func boolHint(hint map[string]any, key string) bool {
+	v, _ := hint[key].(bool)
+	return v
+}
+
+// observations returns every recorded row in a stable order.
+func (s *providerDefaultSweep) observations() []ProviderDefaultObservation {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]ProviderDefaultObservation, len(s.rows))
+	copy(out, s.rows)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ResourceType != out[j].ResourceType {
+			return out[i].ResourceType < out[j].ResourceType
+		}
+		if out[i].Path != out[j].Path {
+			return out[i].Path < out[j].Path
+		}
+		return out[i].TestCase < out[j].TestCase
+	})
+	return out
+}
+
+// writeTo writes the sweep artifact. Sorted, so a run diffs cleanly against
+// the previous one.
+func (s *providerDefaultSweep) writeTo(path string) error {
+	if s == nil {
+		return nil
+	}
+	artifact := struct {
+		Comment      string                       `json:"_comment"`
+		Observations []ProviderDefaultObservation `json:"observations"`
+	}{
+		Comment: "Omit-and-observe records for hasProviderDefault fields, from the conformance CRUD run. " +
+			"declared=false rows are the omitted-field experiment; moved=true names a writer other than formae.",
+		Observations: s.observations(),
+	}
+	raw, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(raw, '\n'), 0o644)
+}
+
+// observeState reports the observation state of a hint path in a property map.
+func observeState(props map[string]any, path string) string {
+	return aggregateState(collectPath(props, path))
+}
+
+// collectPath walks a dot-separated hint path and returns every value found at
+// it. A path crossing a list yields one entry per element that has the
+// remaining path, which is why hint paths with collapsed list indices resolve
+// to more than one value.
+func collectPath(props map[string]any, path string) []any {
+	if props == nil {
+		return nil
+	}
+	return collectFrom(any(props), strings.Split(path, "."))
+}
+
+func collectFrom(node any, segments []string) []any {
+	if len(segments) == 0 {
+		return []any{node}
+	}
+	switch typed := node.(type) {
+	case map[string]any:
+		child, ok := typed[segments[0]]
+		if !ok {
+			return nil
+		}
+		return collectFrom(child, segments[1:])
+	case []any:
+		var out []any
+		for _, element := range typed {
+			out = append(out, collectFrom(element, segments)...)
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// aggregateState reduces the values found at one path to a single observation.
+// The strongest state wins: the question a row answers is whether the provider
+// put anything there, so one populated list element makes the path populated.
+func aggregateState(values []any) string {
+	state := obsAbsent
+	for _, v := range values {
+		if s := stateOf(v); obsRank[s] > obsRank[state] {
+			state = s
+		}
+	}
+	return state
+}
+
+func stateOf(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return obsNull
+	case string:
+		if typed == "" {
+			return obsEmptyString
+		}
+		return obsValue
+	case map[string]any:
+		if len(typed) == 0 {
+			return obsEmptyCollection
+		}
+		return obsValue
+	case []any:
+		if len(typed) == 0 {
+			return obsEmptyCollection
+		}
+		return obsValue
+	default:
+		return obsValue
+	}
+}
+
+// schemaHints returns the Schema.Hints map of an evaluated or inventoried
+// resource, or nil when the resource carries no schema.
+func schemaHints(resource map[string]any) map[string]any {
+	schema, ok := resource["Schema"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	hints, _ := schema["Hints"].(map[string]any)
+	return hints
+}
+
+// propertiesOf returns a resource's Properties map, or nil when it has none.
+func propertiesOf(resource map[string]any) map[string]any {
+	props, _ := resource["Properties"].(map[string]any)
+	return props
+}

--- a/pkg/plugin-conformance-tests/provider_default_sweep_test.go
+++ b/pkg/plugin-conformance-tests/provider_default_sweep_test.go
@@ -1,0 +1,260 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package conformance
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestObserveState(t *testing.T) {
+	props := map[string]any{
+		"present":         "us-west-2",
+		"explicitNull":    nil,
+		"emptyMap":        map[string]any{},
+		"emptyList":       []any{},
+		"emptyString":     "",
+		"zero":            float64(0),
+		"false":           false,
+		"nested":          map[string]any{"leaf": "v", "blank": ""},
+		"list":            []any{map[string]any{"leaf": "a"}, map[string]any{"leaf": "b"}},
+		"listAllAbsent":   []any{map[string]any{"other": "a"}},
+		"listOneAbsent":   []any{map[string]any{"other": "a"}, map[string]any{"leaf": "b"}},
+		"listEmptyLeaves": []any{map[string]any{"leaf": ""}},
+	}
+
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"present", obsValue},
+		{"missing", obsAbsent},
+		{"explicitNull", obsNull},
+		{"emptyMap", obsEmptyCollection},
+		{"emptyList", obsEmptyCollection},
+		{"emptyString", obsEmptyString},
+		{"zero", obsValue},
+		{"false", obsValue},
+		{"nested.leaf", obsValue},
+		{"nested.blank", obsEmptyString},
+		{"nested.missing", obsAbsent},
+		{"missing.leaf", obsAbsent},
+		// A path crossing a list aggregates over the elements: the strongest
+		// observation wins, because the question is whether the provider put
+		// anything there at all.
+		{"list.leaf", obsValue},
+		{"listAllAbsent.leaf", obsAbsent},
+		{"listOneAbsent.leaf", obsValue},
+		{"listEmptyLeaves.leaf", obsEmptyString},
+	}
+
+	for _, tc := range cases {
+		if got := observeState(props, tc.path); got != tc.want {
+			t.Errorf("observeState(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestSweepRecordsOmittedFieldPopulatedByProvider(t *testing.T) {
+	sweep := newSweep()
+
+	declared := map[string]any{"bucketName": "b"}
+	afterCreate := map[string]any{"bucketName": "b", "encryption": "AES256"}
+	afterSync := map[string]any{"bucketName": "b", "encryption": "AES256"}
+	hints := map[string]any{
+		"encryption": map[string]any{"HasProviderDefault": true},
+		"bucketName": map[string]any{"HasProviderDefault": true, "CreateOnly": true},
+		"unhinted":   map[string]any{"HasProviderDefault": false},
+	}
+
+	sweep.record("s3-bucket", "AWS::S3::Bucket", hints, declared, afterCreate, afterSync)
+
+	got := sweep.observations()
+	want := []ProviderDefaultObservation{
+		{
+			TestCase:     "s3-bucket",
+			ResourceType: "AWS::S3::Bucket",
+			Path:         "bucketName",
+			Declared:     true,
+			CreateEcho:   obsValue,
+			AfterSync:    obsValue,
+			CreateOnly:   true,
+		},
+		{
+			TestCase:     "s3-bucket",
+			ResourceType: "AWS::S3::Bucket",
+			Path:         "encryption",
+			Declared:     false,
+			CreateEcho:   obsValue,
+			AfterSync:    obsValue,
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("observations mismatch:\ngot  %+v\nwant %+v", got, want)
+	}
+}
+
+func TestSweepFlagsAValueThatMovedBetweenCreateAndSync(t *testing.T) {
+	sweep := newSweep()
+	hints := map[string]any{"version": map[string]any{"HasProviderDefault": true}}
+
+	sweep.record("db", "AWS::RDS::DBInstance", hints,
+		map[string]any{},
+		map[string]any{"version": "14.1"},
+		map[string]any{"version": "14.2"},
+	)
+
+	got := sweep.observations()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 observation, got %d", len(got))
+	}
+	if !got[0].Moved {
+		t.Errorf("expected Moved=true for a value that changed between create and sync, got %+v", got[0])
+	}
+}
+
+func TestSweepDoesNotFlagMovementWhenTheValueIsStable(t *testing.T) {
+	sweep := newSweep()
+	hints := map[string]any{"tags": map[string]any{"HasProviderDefault": true}}
+
+	sweep.record("db", "AWS::RDS::DBInstance", hints,
+		map[string]any{},
+		map[string]any{"tags": map[string]any{"a": "1"}},
+		map[string]any{"tags": map[string]any{"a": "1"}},
+	)
+
+	if sweep.observations()[0].Moved {
+		t.Error("expected Moved=false for an unchanged value")
+	}
+}
+
+func TestSweepMergesRepeatedObservationsOfTheSameField(t *testing.T) {
+	sweep := newSweep()
+	hints := map[string]any{"kmsKeyId": map[string]any{"HasProviderDefault": true}}
+
+	// The same field observed by two fixtures: one declares it, one omits it.
+	sweep.record("bucket-plain", "AWS::S3::Bucket", hints,
+		map[string]any{},
+		map[string]any{},
+		map[string]any{},
+	)
+	sweep.record("bucket-encrypted", "AWS::S3::Bucket", hints,
+		map[string]any{"kmsKeyId": "arn:key"},
+		map[string]any{"kmsKeyId": "arn:key"},
+		map[string]any{"kmsKeyId": "arn:key"},
+	)
+
+	got := sweep.observations()
+	if len(got) != 2 {
+		t.Fatalf("expected one row per (resource type, path, test case), got %d: %+v", len(got), got)
+	}
+	if got[0].TestCase != "bucket-encrypted" || got[1].TestCase != "bucket-plain" {
+		t.Errorf("expected rows sorted by test case, got %q then %q", got[0].TestCase, got[1].TestCase)
+	}
+}
+
+func TestSweepWritesASortedJSONArtifact(t *testing.T) {
+	sweep := newSweep()
+	sweep.record("b", "AWS::S3::Bucket",
+		map[string]any{"zzz": map[string]any{"HasProviderDefault": true}},
+		map[string]any{}, map[string]any{}, map[string]any{})
+	sweep.record("a", "AWS::RDS::DBInstance",
+		map[string]any{"aaa": map[string]any{"HasProviderDefault": true}},
+		map[string]any{}, map[string]any{}, map[string]any{})
+
+	path := filepath.Join(t.TempDir(), "observations.json")
+	if err := sweep.writeTo(path); err != nil {
+		t.Fatalf("writeTo: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading artifact: %v", err)
+	}
+	var artifact struct {
+		Observations []ProviderDefaultObservation `json:"observations"`
+	}
+	if err := json.Unmarshal(raw, &artifact); err != nil {
+		t.Fatalf("parsing artifact: %v", err)
+	}
+	if len(artifact.Observations) != 2 {
+		t.Fatalf("expected 2 observations, got %d", len(artifact.Observations))
+	}
+	if artifact.Observations[0].ResourceType != "AWS::RDS::DBInstance" {
+		t.Errorf("expected rows sorted by resource type, got %q first", artifact.Observations[0].ResourceType)
+	}
+}
+
+func TestNewSweepFromEnvIsDisabledWithoutAnArtifactPath(t *testing.T) {
+	t.Setenv(envProviderDefaultObservations, "")
+	if newSweepFromEnv() != nil {
+		t.Error("expected no sweep when the artifact path is unset")
+	}
+
+	t.Setenv(envProviderDefaultObservations, "/tmp/obs.json")
+	if newSweepFromEnv() == nil {
+		t.Error("expected a sweep when the artifact path is set")
+	}
+}
+
+// A nil sweep is the disabled case and every entry point must tolerate it, so
+// the caller never has to guard.
+func TestNilSweepIsInert(t *testing.T) {
+	var sweep *providerDefaultSweep
+	sweep.record("c", "T", map[string]any{"f": map[string]any{"HasProviderDefault": true}},
+		map[string]any{}, map[string]any{}, map[string]any{})
+	if err := sweep.writeTo(filepath.Join(t.TempDir(), "unwritten.json")); err != nil {
+		t.Errorf("writeTo on a nil sweep: %v", err)
+	}
+}
+
+func TestGetSettleWindow(t *testing.T) {
+	cases := []struct {
+		env  string
+		want time.Duration
+	}{
+		{"", 0},
+		{"0", 0},
+		{"-5", 0},
+		{"junk", 0},
+		{"30", 30 * time.Second},
+		// Clamped: an oversized settle window would stall a ~100-job matrix.
+		{"999", settleWindowCap},
+	}
+	for _, tc := range cases {
+		t.Setenv(envSettleWindowSeconds, tc.env)
+		if got := getSettleWindow(); got != tc.want {
+			t.Errorf("getSettleWindow() with %s=%q = %v, want %v", envSettleWindowSeconds, tc.env, got, tc.want)
+		}
+	}
+}
+
+func TestSchemaHints(t *testing.T) {
+	hints := map[string]any{"f": map[string]any{"HasProviderDefault": true}}
+	resource := map[string]any{"Schema": map[string]any{"Hints": hints}}
+	if got := schemaHints(resource); !reflect.DeepEqual(got, hints) {
+		t.Errorf("schemaHints = %v, want %v", got, hints)
+	}
+	if got := schemaHints(map[string]any{}); got != nil {
+		t.Errorf("schemaHints on a resource with no Schema = %v, want nil", got)
+	}
+	if got := schemaHints(map[string]any{"Schema": map[string]any{}}); got != nil {
+		t.Errorf("schemaHints on a Schema with no Hints = %v, want nil", got)
+	}
+}
+
+func TestPropertiesOf(t *testing.T) {
+	props := map[string]any{"a": "1"}
+	if got := propertiesOf(map[string]any{"Properties": props}); !reflect.DeepEqual(got, props) {
+		t.Errorf("propertiesOf = %v, want %v", got, props)
+	}
+	if got := propertiesOf(map[string]any{}); got != nil {
+		t.Errorf("propertiesOf on a resource with no Properties = %v, want nil", got)
+	}
+}

--- a/pkg/plugin-conformance-tests/runner.go
+++ b/pkg/plugin-conformance-tests/runner.go
@@ -412,11 +412,26 @@ func RunCRUDTests(t *testing.T) {
 	rc := NewResultCollector()
 	t.Cleanup(func() { rc.PrintSummary() })
 
+	// The omit-and-observe sweep rides along on the CRUD run when an artifact
+	// path is configured; otherwise it is nil and inert.
+	sweep := newSweepFromEnv()
+	t.Cleanup(func() {
+		path := os.Getenv(envProviderDefaultObservations)
+		if sweep == nil || path == "" {
+			return
+		}
+		if err := sweep.writeTo(path); err != nil {
+			t.Errorf("writing provider-default observations to %s: %v", path, err)
+			return
+		}
+		t.Logf("Wrote %d provider-default observations to %s", len(sweep.observations()), path)
+	})
+
 	t.Logf("Discovered %d test case(s)", len(testCases))
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			runCRUDTest(t, tc, rc)
+			runCRUDTest(t, tc, rc, sweep)
 		})
 	}
 }
@@ -1445,7 +1460,7 @@ func describePlannedChanges(cmd *model.Command) string {
 //   - Non-comparison errors (eval, apply, poll, etc.) use rc.CRUDFatalf/CRUDErrorf directly.
 //   - Property comparison errors use rc.compareCRUDProperties, which wraps compareProperties
 //     with a collectingReporter to capture individual property mismatches for the result matrix.
-func runCRUDTest(t *testing.T, tc TestCase, rc *ResultCollector) {
+func runCRUDTest(t *testing.T, tc TestCase, rc *ResultCollector, sweep *providerDefaultSweep) {
 	if isParallelEnabled() {
 		t.Parallel()
 	}
@@ -1625,6 +1640,12 @@ func runCRUDTest(t *testing.T, tc TestCase, rc *ResultCollector) {
 	}
 
 	// === Step 7: Force synchronization to read actual state from cloud ===
+	// A configured settle window gives a provider that populates fields
+	// asynchronously time to do so before the post-sync read is taken.
+	if window := getSettleWindow(); window > 0 {
+		t.Logf("Waiting %s for provider state to settle before sync...", window)
+		time.Sleep(window)
+	}
 	t.Log("Step 7: Forcing synchronization...")
 	if err := harness.Sync(); err != nil {
 		rc.CRUDFatalf(t, idx, PhaseSync, "Sync command failed: %v", err)
@@ -1647,6 +1668,12 @@ func runCRUDTest(t *testing.T, tc TestCase, rc *ResultCollector) {
 	}
 
 	resourceAfterSync := inventoryAfterSync.Resources[0]
+
+	// Record the omit-and-observe result now that both reads exist: the create
+	// echo from step 5 and the post-sync read here. The fixture's own declared
+	// properties say which of the annotated fields were omitted.
+	sweep.record(tc.Name, actualResourceType, schemaHints(expectedResource),
+		expectedProperties, propertiesOf(actualResource), propertiesOf(resourceAfterSync))
 
 	// Compare properties using helper - verifies idempotency
 	syncFailed := !rc.compareCRUDProperties(t, idx, PhaseSync, expectedProperties, resourceAfterSync, "after sync", providerDefaults)


### PR DESCRIPTION
## Summary

`hasProviderDefault` is one boolean covering several distinct field semantics, and today the only way to tell which one an annotation actually means is a documentation pass per field: read the provider's API reference, work out the defaults, work out whether a co-actor writes there. That does not scale to the ~1000 annotations across the plugins, so most of them go unexamined.

The CRUD conformance suite has been running the experiment that answers most of the question and throwing the answer away. A fixture declares a subset of the schema, so every annotated field it leaves out is created omitted; the resource is then read back twice, from the create echo and again after a forced sync. Both readings were discarded.

This captures them. Set `FORMAE_TEST_PROVIDER_DEFAULT_OBSERVATIONS` to a path and the run writes a JSON artifact with one row per annotated field per fixture:

```json
{
  "testCase": "s3-bucket",
  "resourceType": "AWS::S3::Bucket",
  "path": "encryption",
  "declared": false,
  "createEcho": "value",
  "afterSync": "value",
  "moved": false
}
```

Two design points worth calling out:

- **Absence, explicit null, and explicit empty stay distinct.** They carry different patch meanings, and unset nullable collections deliberately render as absent, so collapsing them into one "unset" would lose exactly the distinction the reader needs.
- **A row is a lead, not a verdict.** A field the provider populates when omitted has an empirically justified annotation, and a value that differs between the two reads had a writer that was not formae. But a field that never appears settles nothing on its own: the co-actor that would populate it is absent from an isolated fixture by construction. The README says so explicitly, so the artifact is not read as more than it is.

`FORMAE_TEST_SETTLE_SECONDS` widens the gap before the sync for providers that populate asynchronously, capped so an oversized value cannot stall a large matrix. Both variables default off and a run without them behaves exactly as it did before.

Verified end to end against a kind cluster via the kubernetes plugin's conformance suite.