### PR TITLE
feat(metastructure,datastore,cli): draw a generator's value and deliver it to every sink

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -363,6 +363,13 @@ func (c *Client) parseSubmitCommandErrorResponse(body io.ReadCloser) (*apimodel.
 		}
 		return nil, &errResp
 
+	case apimodel.GeneratorDestinationsUnreachable:
+		var errResp apimodel.ErrorResponse[apimodel.FormaGeneratorDestinationsUnreachableError]
+		if err := json.Unmarshal(bodyBytes, &errResp); err != nil {
+			return nil, fmt.Errorf("failed to parse GeneratorDestinationsUnreachable error: %w", err)
+		}
+		return nil, &errResp
+
 	case apimodel.TargetAlreadyExists:
 		var errResp apimodel.ErrorResponse[apimodel.TargetAlreadyExistsError]
 		if err := json.Unmarshal(bodyBytes, &errResp); err != nil {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -73,6 +73,35 @@ func TestParseSubmitCommandErrorResponse_ReferencedGeneratorsNotFound(t *testing
 	assert.Equal(t, "value", got.Data.Missing[0].Output)
 }
 
+// TestParseSubmitCommandErrorResponse_GeneratorDestinationsUnreachable asserts
+// the client decodes a GeneratorDestinationsUnreachable body into its typed
+// error, so the CLI can name the destinations rather than printing "unknown
+// error type".
+func TestParseSubmitCommandErrorResponse_GeneratorDestinationsUnreachable(t *testing.T) {
+	body, err := json.Marshal(apimodel.ErrorResponse[apimodel.FormaGeneratorDestinationsUnreachableError]{
+		ErrorType: apimodel.GeneratorDestinationsUnreachable,
+		Data: apimodel.FormaGeneratorDestinationsUnreachableError{
+			Unreachable: []apimodel.UnreachableGeneratorDestination{
+				{GeneratorLabel: "db-password", GeneratorStack: "app", Stack: "web", Label: "api-secret", Type: "AWS::SecretsManager::Secret"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	c := &Client{}
+	_, perr := c.parseSubmitCommandErrorResponse(io.NopCloser(bytes.NewReader(body)))
+	require.Error(t, perr)
+
+	var got *apimodel.ErrorResponse[apimodel.FormaGeneratorDestinationsUnreachableError]
+	require.ErrorAs(t, perr, &got, "must decode into a typed FormaGeneratorDestinationsUnreachableError")
+	require.Len(t, got.Data.Unreachable, 1)
+	assert.Equal(t, "db-password", got.Data.Unreachable[0].GeneratorLabel)
+	assert.Equal(t, "app", got.Data.Unreachable[0].GeneratorStack)
+	assert.Equal(t, "api-secret", got.Data.Unreachable[0].Label)
+	assert.Equal(t, "web", got.Data.Unreachable[0].Stack)
+	assert.Equal(t, "AWS::SecretsManager::Secret", got.Data.Unreachable[0].Type)
+}
+
 // TestGetFormaCommandsStatusNotFoundReturnsConcreteEmptyResult verifies a 404
 // from the commands/status endpoint resolves to a well-formed empty result
 // (non-nil, zero Commands), not a bare nil that forces every caller to

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -818,6 +818,11 @@ func mapError(c echo.Context, err error) error {
 		return apiError(c, http.StatusBadRequest, apimodel.ReferencedGeneratorsNotFound, generatorNotFoundError)
 	}
 
+	var unreachableDestinationsError apimodel.FormaGeneratorDestinationsUnreachableError
+	if errors.As(err, &unreachableDestinationsError) {
+		return apiError(c, http.StatusUnprocessableEntity, apimodel.GeneratorDestinationsUnreachable, unreachableDestinationsError)
+	}
+
 	var targetExistsError apimodel.TargetAlreadyExistsError
 	if errors.As(err, &targetExistsError) {
 		return apiError(c, http.StatusConflict, apimodel.TargetAlreadyExists, targetExistsError)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -404,6 +404,61 @@ func TestServer_ApplyFormaGeneratorNotFoundError(t *testing.T) {
 	}
 }
 
+// A refusal to draw a generator for only part of its destination set must
+// reach the operator as its own typed 422, not as an opaque 500.
+func TestServer_ApplyFormaGeneratorDestinationsUnreachableError(t *testing.T) {
+	meta := &apitest.FakeMetastructure{}
+	unreachable := apimodel.FormaGeneratorDestinationsUnreachableError{
+		Unreachable: []apimodel.UnreachableGeneratorDestination{
+			{GeneratorLabel: "db-password", GeneratorStack: "app", Stack: "web", Label: "api-secret", Type: "AWS::SecretsManager::Secret"},
+		},
+	}
+	meta.ApplyResponses = []apitest.WrappedCommandResponse{{&apimodel.SubmitCommandResponse{}, unreachable}}
+
+	server := NewServer(t.Context(), meta, nil, nil, nil, nil)
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	_ = writer.WriteField("command", "apply")
+	_ = writer.WriteField("mode", "reconcile")
+	_ = writer.WriteField("simulate", "false")
+
+	part, err := writer.CreateFormFile("file", "forma.json")
+	if err != nil {
+		t.Fatalf("failed to create form file: %v", err)
+	}
+
+	jsonData, err := json.Marshal(&pkgmodel.Forma{})
+	if err != nil {
+		t.Fatalf("failed to marshal JSON: %v", err)
+	}
+	_, err = part.Write(jsonData)
+	if err != nil {
+		t.Fatalf("failed to write JSON data to form file: %v", err)
+	}
+	writer.Close()
+
+	req := httptest.NewRequest("POST", "/commands", body)
+	req.Header.Set("Client-ID", "test-client-id")
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	rec := httptest.NewRecorder()
+	c := server.echo.NewContext(req, rec)
+
+	if assert.NoError(t, server.SubmitFormaCommand(c)) {
+		assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+
+		var errorResponse apimodel.ErrorResponse[apimodel.FormaGeneratorDestinationsUnreachableError]
+		err = json.Unmarshal(rec.Body.Bytes(), &errorResponse)
+		assert.NoError(t, err)
+		assert.Equal(t, apimodel.GeneratorDestinationsUnreachable, errorResponse.ErrorType)
+		require.Len(t, errorResponse.Data.Unreachable, 1)
+		assert.Equal(t, "api-secret", errorResponse.Data.Unreachable[0].Label)
+		assert.Equal(t, "web", errorResponse.Data.Unreachable[0].Stack)
+	}
+}
+
 func TestServer_ApplyFormaStackReferenceNotFoundError(t *testing.T) {
 	meta := &apitest.FakeMetastructure{}
 	stackRefNotFound := apimodel.StackReferenceNotFoundError{

--- a/internal/cli/tui/components/operations.go
+++ b/internal/cli/tui/components/operations.go
@@ -53,13 +53,12 @@ func OperationColor(p theme.Palette, op string) lipgloss.AdaptiveColor {
 // question. Returns "" when there is nothing to do. th supplies the active
 // theme's colors for the rendered summary.
 func PromptForOperations(th *theme.Theme, cmd *apimodel.Command) string {
-	targetCreates, targetUpdates, stackCreates, stackUpdates, policyCreates, policyUpdates, generatorCreates, generatorUpdates, resourceCreates, resourceUpdates, resourceDeletes, resourceReplaces := analyzeCommands(cmd)
-
-	if targetCreates == 0 && targetUpdates == 0 && stackCreates == 0 && stackUpdates == 0 && policyCreates == 0 && policyUpdates == 0 && generatorCreates == 0 && generatorUpdates == 0 && resourceCreates == 0 && resourceUpdates == 0 && resourceDeletes == 0 && resourceReplaces == 0 {
+	tally := analyzeCommands(cmd)
+	if tally.empty() {
 		return ""
 	}
 
-	summary := operationSummary(th, targetCreates, targetUpdates, stackCreates, stackUpdates, policyCreates, policyUpdates, generatorCreates, generatorUpdates, resourceCreates, resourceUpdates, resourceDeletes, resourceReplaces)
+	summary := operationSummary(th, tally)
 	if summary == "" {
 		return ""
 	}
@@ -67,9 +66,35 @@ func PromptForOperations(th *theme.Theme, cmd *apimodel.Command) string {
 	return summary + "\n\nDo you want to continue?"
 }
 
+// opTally counts the operations a command performs, by entity and kind. It is
+// a struct rather than a return list because the counts are all ints and the
+// summary reads a dozen of them: a positional list is a transposition waiting
+// to happen.
+type opTally struct {
+	targetCreates    int
+	targetUpdates    int
+	stackCreates     int
+	stackUpdates     int
+	policyCreates    int
+	policyUpdates    int
+	generatorCreates int
+	generatorUpdates int
+	generatorDraws   int
+	resourceCreates  int
+	resourceUpdates  int
+	resourceDeletes  int
+	resourceReplaces int
+}
+
+// empty reports whether the command performs no operation at all.
+func (t opTally) empty() bool {
+	return t == opTally{}
+}
+
 // analyzeCommands counts each operation type in cmd, grouping grouped
 // (delete+create) pairs as replaces.
-func analyzeCommands(cmd *apimodel.Command) (targetCreates, targetUpdates, stackCreates, stackUpdates, policyCreates, policyUpdates, generatorCreates, generatorUpdates, resourceCreates, resourceUpdates, resourceDeletes, resourceReplaces int) {
+func analyzeCommands(cmd *apimodel.Command) opTally {
+	var tally opTally
 	// Group operations by GroupId
 	groupedOperations := make(map[string][]apimodel.ResourceUpdate)
 	ungroupedOperations := make([]apimodel.ResourceUpdate, 0)
@@ -108,13 +133,13 @@ func analyzeCommands(cmd *apimodel.Command) (targetCreates, targetUpdates, stack
 		}
 
 		if hasDelete && hasCreate {
-			resourceReplaces++
+			tally.resourceReplaces++
 		} else if hasDelete {
-			resourceDeletes++
+			tally.resourceDeletes++
 		} else if hasCreate {
-			resourceCreates++
+			tally.resourceCreates++
 		} else if hasUpdate {
-			resourceUpdates++
+			tally.resourceUpdates++
 		}
 	}
 
@@ -122,22 +147,22 @@ func analyzeCommands(cmd *apimodel.Command) (targetCreates, targetUpdates, stack
 	for _, rc := range ungroupedOperations {
 		switch rc.Operation {
 		case apimodel.OperationCreate:
-			resourceCreates++
+			tally.resourceCreates++
 		case apimodel.OperationUpdate:
-			resourceUpdates++
+			tally.resourceUpdates++
 		case apimodel.OperationDelete:
-			resourceDeletes++
+			tally.resourceDeletes++
 		case apimodel.OperationReplace:
-			resourceReplaces++
+			tally.resourceReplaces++
 		}
 	}
 
 	for _, tu := range cmd.TargetUpdates {
 		switch tu.Operation {
 		case "create":
-			targetCreates++
+			tally.targetCreates++
 		case "update":
-			targetUpdates++
+			tally.targetUpdates++
 		}
 	}
 
@@ -145,9 +170,9 @@ func analyzeCommands(cmd *apimodel.Command) (targetCreates, targetUpdates, stack
 	for _, su := range cmd.StackUpdates {
 		switch su.Operation {
 		case "create":
-			stackCreates++
+			tally.stackCreates++
 		case "update":
-			stackUpdates++
+			tally.stackUpdates++
 		}
 	}
 
@@ -155,79 +180,93 @@ func analyzeCommands(cmd *apimodel.Command) (targetCreates, targetUpdates, stack
 	for _, pu := range cmd.PolicyUpdates {
 		switch pu.Operation {
 		case "create":
-			policyCreates++
+			tally.policyCreates++
 		case "update":
-			policyUpdates++
+			tally.policyUpdates++
 		}
 	}
 
-	// Count generator updates
+	// Count generator updates. A draw counts separately from the three that
+	// change the generator's own row: it rotates the secret every resource
+	// bound to the generator holds, so an operator confirming the apply has to
+	// be told about it even when no row changes.
 	for _, gu := range cmd.GeneratorUpdates {
 		switch gu.Operation {
-		case "create":
-			generatorCreates++
-		case "update":
-			generatorUpdates++
+		case apimodel.OperationCreate:
+			tally.generatorCreates++
+		case apimodel.OperationUpdate:
+			tally.generatorUpdates++
+		case apimodel.OperationDraw:
+			tally.generatorDraws++
 		}
 	}
 
-	return
+	return tally
 }
 
 // operationSummary builds the colored "This operation will …" sentence.
-// Colors use theme roles: Error for destructive ops (delete/replace), Done for
-// creates, and TextPrimary for updates (no gold; routine updates aren't tinted).
-func operationSummary(th *theme.Theme, targetCreates, targetUpdates, stackCreates, stackUpdates, policyCreates, policyUpdates, generatorCreates, generatorUpdates, resourceCreates, resourceUpdates, resourceDeletes, resourceReplaces int) string {
-	if targetCreates == 0 && targetUpdates == 0 && stackCreates == 0 && stackUpdates == 0 && policyCreates == 0 && policyUpdates == 0 && generatorCreates == 0 && generatorUpdates == 0 && resourceCreates == 0 && resourceUpdates == 0 && resourceDeletes == 0 && resourceReplaces == 0 {
+// Colors use theme roles: Error for destructive ops (delete/replace), gold for
+// a credential rotation, Done for creates, and TextPrimary for updates
+// (routine updates aren't tinted).
+func operationSummary(th *theme.Theme, t opTally) string {
+	if t.empty() {
 		return ""
 	}
 
 	errSt := lipgloss.NewStyle().Foreground(th.Palette.Error)
+	rotateSt := lipgloss.NewStyle().Foreground(th.Palette.Warning)
 	doneSt := lipgloss.NewStyle().Foreground(th.Palette.Done)
 	updateSt := lipgloss.NewStyle().Foreground(th.Palette.TextPrimary)
 
 	var parts []string
 
 	// Destructive resource ops first
-	if resourceDeletes > 0 {
-		parts = append(parts, errSt.Render(fmt.Sprintf("delete %d resource(s)", resourceDeletes)))
+	if t.resourceDeletes > 0 {
+		parts = append(parts, errSt.Render(fmt.Sprintf("delete %d resource(s)", t.resourceDeletes)))
 	}
-	if resourceReplaces > 0 {
-		parts = append(parts, errSt.Render(fmt.Sprintf("replace %d resource(s)", resourceReplaces)))
+	if t.resourceReplaces > 0 {
+		parts = append(parts, errSt.Render(fmt.Sprintf("replace %d resource(s)", t.resourceReplaces)))
+	}
+
+	// A rotation destroys nothing but invalidates a live secret everywhere it
+	// is bound, so it leads the non-destructive ops and says what it costs.
+	if t.generatorDraws > 0 {
+		parts = append(parts, rotateSt.Render(fmt.Sprintf(
+			"rotate %d generator(s) (every bound resource takes a new secret)", t.generatorDraws)))
 	}
 
 	// Creates (stacks, policies, targets, resources)
-	if stackCreates > 0 {
-		parts = append(parts, doneSt.Render(fmt.Sprintf("create %d stack(s)", stackCreates)))
+	if t.stackCreates > 0 {
+		parts = append(parts, doneSt.Render(fmt.Sprintf("create %d stack(s)", t.stackCreates)))
 	}
-	if policyCreates > 0 {
-		parts = append(parts, doneSt.Render(fmt.Sprintf("create %d policy(ies)", policyCreates)))
+	if t.policyCreates > 0 {
+		parts = append(parts, doneSt.Render(fmt.Sprintf("create %d policy(ies)", t.policyCreates)))
 	}
-	if generatorCreates > 0 {
-		parts = append(parts, doneSt.Render(fmt.Sprintf("create %d generator(s)", generatorCreates)))
+	if t.generatorCreates > 0 {
+		parts = append(parts, doneSt.Render(fmt.Sprintf("create %d generator(s)", t.generatorCreates)))
 	}
-	if targetCreates > 0 {
-		parts = append(parts, doneSt.Render(fmt.Sprintf("create %d target(s)", targetCreates)))
+	if t.targetCreates > 0 {
+		parts = append(parts, doneSt.Render(fmt.Sprintf("create %d target(s)", t.targetCreates)))
 	}
-	if resourceCreates > 0 {
-		parts = append(parts, doneSt.Render(fmt.Sprintf("create %d resource(s)", resourceCreates)))
+	if t.resourceCreates > 0 {
+		parts = append(parts, doneSt.Render(fmt.Sprintf("create %d resource(s)", t.resourceCreates)))
 	}
 
 	// Updates (stacks, policies, targets, resources)
-	if stackUpdates > 0 {
-		parts = append(parts, updateSt.Render(fmt.Sprintf("update %d stack(s)", stackUpdates)))
+	if t.stackUpdates > 0 {
+		parts = append(parts, updateSt.Render(fmt.Sprintf("update %d stack(s)", t.stackUpdates)))
 	}
-	if policyUpdates > 0 {
-		parts = append(parts, updateSt.Render(fmt.Sprintf("update %d policy(ies)", policyUpdates)))
+	if t.policyUpdates > 0 {
+		parts = append(parts, updateSt.Render(fmt.Sprintf("update %d policy(ies)", t.policyUpdates)))
 	}
-	if generatorUpdates > 0 {
-		parts = append(parts, updateSt.Render(fmt.Sprintf("update %d generator(s)", generatorUpdates)))
+	if t.generatorUpdates > 0 {
+		parts = append(parts, updateSt.Render(fmt.Sprintf("update %d generator(s)", t.generatorUpdates)))
 	}
-	if targetUpdates > 0 {
-		parts = append(parts, updateSt.Render(fmt.Sprintf("update %d target(s)", targetUpdates)))
+	if t.targetUpdates > 0 {
+		parts = append(parts, updateSt.Render(fmt.Sprintf("update %d target(s)", t.targetUpdates)))
 	}
-	if resourceUpdates > 0 {
-		parts = append(parts, updateSt.Render(fmt.Sprintf("update %d resource(s)", resourceUpdates)))
+	if t.resourceUpdates > 0 {
+		parts = append(parts, updateSt.Render(fmt.Sprintf("update %d resource(s)", t.resourceUpdates)))
 	}
 
 	var joinedParts string

--- a/internal/cli/tui/components/operations_test.go
+++ b/internal/cli/tui/components/operations_test.go
@@ -133,3 +133,20 @@ func TestOperationGlyphAndColor(t *testing.T) {
 	assert.Equal(t, "", OperationGlyph(th.Glyphs, apimodel.OperationRead))
 	assert.Equal(t, th.Palette.TextPrimary, OperationColor(th.Palette, apimodel.OperationRead))
 }
+
+// TestPromptForOperations_GeneratorDraw verifies a draw is counted and worded
+// in the confirmation sentence, so an operator is told a credential rotates
+// before they answer.
+func TestPromptForOperations_GeneratorDraw(t *testing.T) {
+	cmd := &apimodel.Command{
+		GeneratorUpdates: []apimodel.GeneratorUpdate{
+			{GeneratorLabel: "db-password", Operation: "draw"},
+		},
+	}
+	out := PromptForOperations(theme.New("rich"), cmd)
+	plain := stripANSI(out)
+
+	assert.Contains(t, plain, "rotate 1 generator(s)")
+	assert.Contains(t, plain, "every bound resource takes a new secret")
+	assert.Contains(t, plain, "Do you want to continue?")
+}

--- a/internal/cli/tui/errfmt/errfmt.go
+++ b/internal/cli/tui/errfmt/errfmt.go
@@ -96,6 +96,14 @@ func (r *renderer) render(err error) (string, error) {
 		}
 	}
 
+	if errResp, ok := err.(*apimodel.ErrorResponse[apimodel.FormaGeneratorDestinationsUnreachableError]); ok {
+		var e error
+		msg, e = r.renderGeneratorDestinationsUnreachable(&errResp.Data)
+		if e != nil {
+			return "", e
+		}
+	}
+
 	if errResp, ok := err.(*apimodel.ErrorResponse[apimodel.FormaPatchRejectedError]); ok {
 		var e error
 		msg, e = r.renderPatchRejected(&errResp.Data)
@@ -266,6 +274,24 @@ func (r *renderer) renderReferencedGeneratorsNotFound(data *apimodel.FormaRefere
 		_, _ = fmt.Fprintf(&b, "    %s%s\n", r.subtle("from stack "), generator.Stack)
 		_, _ = fmt.Fprintf(&b, "    %s%s\n", r.subtle("output "), generator.Output)
 	}
+	return b.String(), nil
+}
+
+// renderGeneratorDestinationsUnreachable formats
+// FormaGeneratorDestinationsUnreachableError as an indented list of the
+// destinations the command does not reach, and says what to do about it.
+func (r *renderer) renderGeneratorDestinationsUnreachable(data *apimodel.FormaGeneratorDestinationsUnreachableError) (string, error) {
+	var b strings.Builder
+	_, _ = fmt.Fprintln(&b, r.error("forma rejected because a generator must draw a new value and the command does not reach every resource bound to it:"))
+	for _, destination := range data.Unreachable {
+		_, _ = fmt.Fprintf(&b, "  %s\n", destination.Label)
+		_, _ = fmt.Fprintf(&b, "    %s%s\n", r.subtle("of type "), destination.Type)
+		_, _ = fmt.Fprintf(&b, "    %s%s\n", r.subtle("from stack "), destination.Stack)
+		_, _ = fmt.Fprintf(&b, "    %s%s%s%s\n", r.subtle("bound to generator "), destination.GeneratorLabel,
+			r.subtle(" in stack "), destination.GeneratorStack)
+	}
+	b.WriteString("\n")
+	b.WriteString(r.warning("A generated value is never recoverable once the command that drew it ends, so apply every stack that binds the generator in one command.\n"))
 	return b.String(), nil
 }
 

--- a/internal/cli/tui/errfmt/errfmt_test.go
+++ b/internal/cli/tui/errfmt/errfmt_test.go
@@ -94,6 +94,23 @@ func TestRender_ReferencedGeneratorsNotFound_Golden(t *testing.T) {
 	tuitest.RequireGolden(t, []byte(out))
 }
 
+// ── 3c. FormaGeneratorDestinationsUnreachableError ────────────────────────────
+
+func TestRender_GeneratorDestinationsUnreachable_Golden(t *testing.T) {
+	err := &apimodel.ErrorResponse[apimodel.FormaGeneratorDestinationsUnreachableError]{
+		ErrorType: apimodel.GeneratorDestinationsUnreachable,
+		Data: apimodel.FormaGeneratorDestinationsUnreachableError{
+			Unreachable: []apimodel.UnreachableGeneratorDestination{
+				{GeneratorLabel: "db-password", GeneratorStack: "app", Stack: "web", Label: "api-secret", Type: "AWS::SecretsManager::Secret"},
+				{GeneratorLabel: "db-password", GeneratorStack: "app", Stack: "jobs", Label: "worker-secret", Type: "AWS::SecretsManager::Secret"},
+			},
+		},
+	}
+	out, rerr := Render(err)
+	require.NoError(t, rerr)
+	tuitest.RequireGolden(t, []byte(out))
+}
+
 // ── 4. FormaPatchRejectedError ────────────────────────────────────────────────
 
 func TestRender_PatchRejected_Golden(t *testing.T) {

--- a/internal/cli/tui/errfmt/testdata/TestRender_GeneratorDestinationsUnreachable_Golden.golden
+++ b/internal/cli/tui/errfmt/testdata/TestRender_GeneratorDestinationsUnreachable_Golden.golden
@@ -1,0 +1,12 @@
+[38;2;248;113;113mforma rejected because a generator must draw a new value and the command does not reach every resource bound to it:[0m
+  api-secret
+    [38;2;153;153;153mof type [0mAWS::SecretsManager::Secret
+    [38;2;153;153;153mfrom stack [0mweb
+    [38;2;153;153;153mbound to generator [0mdb-password[38;2;153;153;153m in stack [0mapp
+  worker-secret
+    [38;2;153;153;153mof type [0mAWS::SecretsManager::Secret
+    [38;2;153;153;153mfrom stack [0mjobs
+    [38;2;153;153;153mbound to generator [0mdb-password[38;2;153;153;153m in stack [0mapp
+
+[38;2;181;181;91mA generated value is never recoverable once the command that drew it ends, so apply every stack that binds the generator in one command.[0m
+[38;2;181;181;91m[0m                                                                                                                                        

--- a/internal/cli/tui/simview/cards.go
+++ b/internal/cli/tui/simview/cards.go
@@ -264,13 +264,16 @@ func buildPropertyChangeLines(_ *theme.Theme, r simRow, doneSt, errSt, subtleSt 
 }
 
 // cardEmptyNote returns a one-line summary for cards that have no property
-// detail to show (a delete has nothing to diff; a keep is a no-op).
+// detail to show (a delete has nothing to diff; a keep is a no-op; a draw
+// carries no declared config).
 func cardEmptyNote(r simRow) string {
 	switch r.op {
 	case opDelete:
 		return "This resource will be removed."
 	case opDetach:
 		return "This policy will be detached."
+	case opDraw:
+		return "A new value is drawn: every resource bound to this generator takes it."
 	case opKeep:
 		return "No changes."
 	default:

--- a/internal/cli/tui/simview/data.go
+++ b/internal/cli/tui/simview/data.go
@@ -27,10 +27,20 @@ type opKind int
 const (
 	opDelete  opKind = iota // "-"
 	opReplace               // "↻"
-	opUpdate                // "~"
-	opDetach                // "⊘"
-	opCreate                // "+"
-	opKeep                  // "="
+	// opDraw is a generator drawing a value. It sorts here, above a plain
+	// update, because it rotates a credential: every resource bound to the
+	// generator takes a new secret, including resources this plan otherwise
+	// leaves alone. It borrows opReplace's glyph and color rather than
+	// claiming a themeable role of its own — a generator row is never a
+	// replace (a generator's declared lifecycle is create/update/delete), so
+	// within the Generators group the rotation glyph is unambiguous, and a
+	// new required theme key would silently invalidate every user theme file
+	// that does not yet set it.
+	opDraw
+	opUpdate // "~"
+	opDetach // "⊘"
+	opCreate // "+"
+	opKeep   // "="
 )
 
 // opGlyph returns the themed glyph for an operation.
@@ -38,7 +48,7 @@ func opGlyph(g theme.Glyphs, o opKind) string {
 	switch o {
 	case opDelete:
 		return g.OpDelete
-	case opReplace:
+	case opReplace, opDraw:
 		return g.OpReplace
 	case opUpdate:
 		return g.OpUpdate
@@ -57,7 +67,7 @@ func opColor(p theme.Palette, o opKind) lipgloss.AdaptiveColor {
 	switch o {
 	case opDelete:
 		return p.OpDelete
-	case opReplace:
+	case opReplace, opDraw:
 		return p.OpReplace
 	case opUpdate:
 		return p.OpUpdate
@@ -78,6 +88,8 @@ func (o opKind) word() string {
 		return "delete"
 	case opReplace:
 		return "replace"
+	case opDraw:
+		return "draw"
 	case opUpdate:
 		return "update"
 	case opDetach:
@@ -323,15 +335,20 @@ func policyOpAndDetail(pu *apimodel.PolicyUpdate) (opKind, string) {
 
 // buildGeneratorRows converts GeneratorUpdates into simRows.
 // Operation vocabulary: a generator has no attach/detach and no standalone
-// form, so its lifecycle is Create/Update/Delete only (see
-// generator_update.GeneratorOperation), handled by genericOpKind like a
-// stack update.
+// form, so its row lifecycle is Create/Update/Delete, plus the Draw that
+// rotates its value (see generator_update.GeneratorOperation), all handled by
+// genericOpKind like a stack update.
+//
+// The key carries the operation as well as the identity, unlike the other row
+// builders: the projection emits a separate entry for a generator's declared
+// change and for its draw, so stack and label alone name two rows, and the
+// expand/collapse map is keyed on this string.
 func buildGeneratorRows(updates []apimodel.GeneratorUpdate) []simRow {
 	rows := make([]simRow, 0, len(updates))
 	for i := range updates {
 		gu := &updates[i]
 		row := simRow{
-			key:       fmt.Sprintf("generator/%s/%s", gu.StackLabel, gu.GeneratorLabel),
+			key:       fmt.Sprintf("generator/%s/%s/%s", gu.StackLabel, gu.GeneratorLabel, gu.Operation),
 			op:        genericOpKind(gu.Operation),
 			label:     gu.GeneratorLabel,
 			typ:       gu.GeneratorType,
@@ -440,13 +457,16 @@ func buildResourceRows(updates []apimodel.ResourceUpdate) []simRow {
 
 // genericOpKind converts a plain operation string to an opKind.
 // Mirrors coloredOperation (renderer.go:581-594) — only the four resource
-// operation strings are expected; anything else falls through to opCreate.
+// operation strings and the generator-only draw are expected; anything else
+// falls through to opCreate.
 func genericOpKind(op string) opKind {
 	switch op {
 	case apimodel.OperationDelete:
 		return opDelete
 	case apimodel.OperationReplace:
 		return opReplace
+	case apimodel.OperationDraw:
+		return opDraw
 	case apimodel.OperationUpdate:
 		return opUpdate
 	case apimodel.OperationCreate:

--- a/internal/cli/tui/simview/data_test.go
+++ b/internal/cli/tui/simview/data_test.go
@@ -645,6 +645,7 @@ func TestOpKindWord(t *testing.T) {
 		{opReplace, "replace"},
 		{opUpdate, "update"},
 		{opDetach, "detach"},
+		{opDraw, "draw"},
 		{opCreate, "create"},
 		{opKeep, "keep"},
 	}
@@ -685,4 +686,43 @@ func TestResourceRowCarriesPointer(t *testing.T) {
 	row := groups[0].rows[0]
 	require.NotNil(t, row.res)
 	assert.Equal(t, "r1", row.res.ResourceID)
+}
+
+// ---------------------------------------------------------------------------
+// Generator draw rows
+// ---------------------------------------------------------------------------
+
+// TestGeneratorDrawIsNotACreate verifies a draw maps to its own opKind, so the
+// row an operator confirms cannot be read as a new generator appearing.
+func TestGeneratorDrawIsNotACreate(t *testing.T) {
+	cmd := &apimodel.Command{
+		GeneratorUpdates: []apimodel.GeneratorUpdate{
+			{GeneratorLabel: "db-password", GeneratorType: "password", StackLabel: "prod", Operation: "draw"},
+		},
+	}
+
+	groups := buildSimGroups(cmd)
+	require.Len(t, groups, 1)
+	require.Len(t, groups[0].rows, 1)
+	row := groups[0].rows[0]
+	assert.Equal(t, opDraw, row.op)
+	assert.NotEqual(t, opCreate, row.op, "a draw rotates an existing secret and must not render as a create")
+}
+
+// TestGeneratorDrawKeyIsDistinctFromItsDeclaredChange verifies the two entries
+// a generator that both changes spec and draws produces get distinct row keys,
+// so expanding one does not expand the other.
+func TestGeneratorDrawKeyIsDistinctFromItsDeclaredChange(t *testing.T) {
+	cmd := &apimodel.Command{
+		GeneratorUpdates: []apimodel.GeneratorUpdate{
+			{GeneratorLabel: "db-password", GeneratorType: "password", StackLabel: "prod", Operation: "update"},
+			{GeneratorLabel: "db-password", GeneratorType: "password", StackLabel: "prod", Operation: "draw"},
+		},
+	}
+
+	groups := buildSimGroups(cmd)
+	require.Len(t, groups, 1)
+	require.Len(t, groups[0].rows, 2)
+	assert.NotEqual(t, groups[0].rows[0].key, groups[0].rows[1].key,
+		"a declared change and a draw on one generator are separate rows and need separate keys")
 }

--- a/internal/cli/tui/simview/print.go
+++ b/internal/cli/tui/simview/print.go
@@ -28,7 +28,7 @@ func RenderSimulationPlain(th *theme.Theme, sim *apimodel.Simulation, width int)
 	// The glyph is colored per-op from the theme palette; the count and word
 	// stay in the base text color.
 	wordSt := lipgloss.NewStyle().Foreground(p.TextPrimary)
-	ordered := []opKind{opCreate, opUpdate, opDelete, opReplace, opDetach, opKeep}
+	ordered := []opKind{opCreate, opUpdate, opDelete, opReplace, opDraw, opDetach, opKeep}
 	var parts []string
 	for _, op := range ordered {
 		n := counts[op]

--- a/internal/cli/tui/simview/render.go
+++ b/internal/cli/tui/simview/render.go
@@ -24,7 +24,7 @@ func (m Model) renderSummaryCounts() string {
 	// stay in the row's base text color.
 	wordSt := lipgloss.NewStyle().Foreground(p.TextPrimary)
 
-	ordered := []opKind{opCreate, opUpdate, opDelete, opReplace, opDetach, opKeep}
+	ordered := []opKind{opCreate, opUpdate, opDelete, opReplace, opDraw, opDetach, opKeep}
 	var parts []string
 	for _, op := range ordered {
 		n := counts[op]

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -2433,6 +2433,74 @@ func (d *DatastoreAuroraDataAPI) FindResourcesDependingOn(ksuid string) ([]*pkgm
 	return resources, nil
 }
 
+// FindResourcesReferencingGenerator finds the live resources that bind a property
+// to the given generator through a $gen envelope. A translated envelope's
+// $generator KSUID is an outbound reference KSUID, so it lands in the same
+// GIN-indexed refs column the $ref lookup uses and the array-overlap query
+// narrows the scan cheaply. That column records only that a KSUID is
+// referenced, not how, so the overlap is a prefilter and pkgmodel.BindsGenerator
+// decides which candidates are really destinations.
+func (d *DatastoreAuroraDataAPI) FindResourcesReferencingGenerator(generatorKsuid string) ([]*pkgmodel.Resource, error) {
+	ctx := context.Background()
+
+	// A single generator KSUID needs no comma, so the comma-delimited encoding
+	// refsToSQL expects is just the KSUID itself.
+	query := `
+	SELECT data, ksuid
+	FROM resources r1
+	WHERE refs && ` + refsToSQL(":refs") + `
+	AND NOT EXISTS (
+		SELECT 1
+		FROM resources r2
+		WHERE r1.uri = r2.uri
+		AND r2.version COLLATE "C" > r1.version COLLATE "C"
+	)
+	AND operation != :operation AND operation != 'reaped'
+	`
+	params := []types.SqlParameter{
+		{Name: aws.String("refs"), Value: &types.FieldMemberStringValue{Value: generatorKsuid}},
+		{Name: aws.String("operation"), Value: &types.FieldMemberStringValue{Value: string(resource_update.OperationDelete)}},
+	}
+
+	output, err := d.executeStatement(ctx, query, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var resources []*pkgmodel.Resource
+	for _, record := range output.Records {
+		if len(record) < 2 {
+			return nil, fmt.Errorf("unexpected record length: %d", len(record))
+		}
+
+		jsonData, err := getStringField(record[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse data: %w", err)
+		}
+
+		ksuidResult, err := getStringField(record[1])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse ksuid: %w", err)
+		}
+
+		// The SQL above is only a prefilter: it is deliberately broader than
+		// the truth so no destination is missed. pkgmodel.BindsGenerator is
+		// authoritative, and drops any candidate it matched for another reason.
+		if !pkgmodel.BindsGenerator([]byte(jsonData), generatorKsuid) {
+			continue
+		}
+
+		var resource pkgmodel.Resource
+		if err := json.Unmarshal([]byte(jsonData), &resource); err != nil {
+			return nil, err
+		}
+		resource.Ksuid = ksuidResult
+		resources = append(resources, &resource)
+	}
+
+	return resources, nil
+}
+
 func (d *DatastoreAuroraDataAPI) FindResourcesDependingOnMany(ksuids []string) (map[string][]*pkgmodel.Resource, error) {
 	ctx := context.Background()
 

--- a/internal/datastore/aurora/aurora_generators.go
+++ b/internal/datastore/aurora/aurora_generators.go
@@ -479,10 +479,10 @@ func (d *DatastoreAuroraDataAPI) GetGeneratorIdentityByID(generatorID string) (d
 // is not valid JSON, or if the generator's latest row is a tombstone: a
 // deleted id is not resurrected.
 //
-// No production caller in this slice: the executable generator node that
-// draws generations arrives in a later slice. It ships here because the
-// generation columns are inert without a writer, and a test-only backdoor
-// would misrepresent a mechanism we are shipping for real use.
+// The caller is the generator update actor
+// (generator_update.GeneratorUpdater): it calls this once it has drawn a
+// value, so the generation the value came from is durable before any
+// destination is stamped with it.
 func (d *DatastoreAuroraDataAPI) AdvanceGeneration(generatorID, generationID string, drawnUnder json.RawMessage) error {
 	ctx := context.Background()
 

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -344,11 +344,30 @@ type Datastore interface {
 	// ksuid's latest version is a delete or reaped tombstone, so callers receive
 	// not-found semantics for deleted resources regardless of their prior history.
 	LoadLatestResourceByKsuid(ksuid string) (*pkgmodel.Resource, error)
-	// FindResourcesDependingOn returns all resources that reference the given resource via $ref
+	// FindResourcesDependingOn returns all resources that reference the given
+	// resource via $ref. It takes a resource KSUID and only a resource KSUID:
+	// backends read $ref dependencies from different places (postgres and aurora
+	// from the refs column, sqlite and mssql by scanning the document), and the
+	// refs column records generator KSUIDs too, so the families agree on a
+	// resource KSUID and would disagree on a generator one. Generators are
+	// FindResourcesReferencingGenerator's question, not this one.
 	FindResourcesDependingOn(ksuid string) ([]*pkgmodel.Resource, error)
 	// FindResourcesDependingOnMany returns all resources that reference any of the given resources via $ref.
 	// Returns a map from referenced KSUID to the resources that depend on it.
+	// It carries FindResourcesDependingOn's resource-KSUID-only contract.
 	FindResourcesDependingOnMany(ksuids []string) (map[string][]*pkgmodel.Resource, error)
+	// FindResourcesReferencingGenerator returns all live resources that bind a
+	// property to the given generator through a translated $gen envelope.
+	// Superseded versions and deleted or reaped resources are excluded, so each
+	// returned resource appears once at its current version. An unknown
+	// generator KSUID yields an empty result, not an error, and a resource KSUID
+	// reached through $ref names no generator and yields nothing.
+	//
+	// Every backend returns the same set by construction. Each one's SQL is an
+	// index prefilter only, deliberately broader than the truth so that a
+	// destination is never missed, and pkgmodel.BindsGenerator is the
+	// authoritative test every candidate row must pass before it is returned.
+	FindResourcesReferencingGenerator(generatorKsuid string) ([]*pkgmodel.Resource, error)
 	// FindTargetsDependingOnMany returns all targets whose config references any of the given resources via $ref.
 	// Returns a map from source KSUID to the list of dependent targets.
 	FindTargetsDependingOnMany(ksuids []string) (map[string][]*pkgmodel.Target, error)

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -548,10 +548,10 @@ type Datastore interface {
 	// backend must agree on what counts as one), or if the generator has
 	// been deleted — a tombstoned id is not resurrected.
 	//
-	// No production caller in this slice: the executable generator node that
-	// draws generations arrives in a later slice. It ships here because the
-	// generation columns are inert without a writer, and a test-only
-	// backdoor would misrepresent a mechanism we are shipping for real use.
+	// Called by the GeneratorUpdater, which records the generation before it
+	// reports the drawn value: a value handed to a destination under a
+	// generation nobody stored is exactly the state the next apply cannot
+	// reason about.
 	AdvanceGeneration(generatorID, generationID string, drawnUnder json.RawMessage) error
 
 	// Close releases database connections

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -274,6 +274,19 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunFindResourcesDependingOnMany_DeepChain(t, newDS)
 	RunFindResourcesDependingOnMany_BroadFanOut(t, newDS)
 
+	RunFindResourcesReferencingGenerator(t, newDS)
+	RunFindResourcesReferencingGeneratorOtherGeneratorExcluded(t, newDS)
+	RunFindResourcesReferencingGeneratorUnboundResourceExcluded(t, newDS)
+	RunFindResourcesReferencingGeneratorAcrossStacks(t, newDS)
+	RunFindResourcesReferencingGeneratorDeletedExcluded(t, newDS)
+	RunFindResourcesReferencingGeneratorLatestVersionOnly(t, newDS)
+	RunFindResourcesReferencingGeneratorUnknownGenerator(t, newDS)
+	RunFindResourcesReferencingGeneratorNestedInArray(t, newDS)
+	RunFindResourcesReferencingGeneratorBareGeneratorKeyExcluded(t, newDS)
+	RunFindResourcesReferencingGeneratorGenFalseExcluded(t, newDS)
+	RunFindResourcesReferencingGeneratorCaseSensitive(t, newDS)
+	RunFindResourcesReferencingGeneratorResourceRefExcluded(t, newDS)
+
 	RunStackTransition(t, newDS)
 
 	RunGetResourcesAtLastReconcile_Empty(t, newDS)

--- a/internal/datastore/dstest/suite_generator_refs.go
+++ b/internal/datastore/dstest/suite_generator_refs.go
@@ -1,0 +1,411 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package dstest
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/demula/mksuid/v2"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// genBoundProperties returns a persisted resource's properties document with
+// one property bound to the given generator through a translated $gen
+// envelope — the shape a resource carries after translation and resolution,
+// with the opaque value stored as a digest rather than plaintext.
+func genBoundProperties(property, generatorKsuid string) json.RawMessage {
+	return json.RawMessage(fmt.Sprintf(
+		`{"%s":{"$gen":true,"$generator":"%s","$output":"value","$visibility":"Opaque","$value":"sha256:digest","$hashed":true,"$resolvedFrom":"sha256:digest"}}`,
+		property, generatorKsuid,
+	))
+}
+
+// createGeneratorRefsTarget creates the target every resource in this suite is
+// stored against.
+func createGeneratorRefsTarget(t *testing.T, td TestDatastore) {
+	t.Helper()
+	_, err := td.CreateTarget(&pkgmodel.Target{
+		Label:     "test-target",
+		Namespace: "AWS",
+		Config:    json.RawMessage(`{}`),
+	})
+	require.NoError(t, err)
+}
+
+// RunFindResourcesReferencingGenerator verifies the basic lookup: a resource
+// whose property is bound to the generator is returned.
+func RunFindResourcesReferencingGenerator(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("FindResourcesReferencingGenerator", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+		createGeneratorRefsTarget(t, td)
+
+		generatorKsuid := mksuid.New().String()
+		boundKsuid := mksuid.New().String()
+		_, err := ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: boundKsuid, NativeID: "bound-native", Stack: "app", Label: "database",
+			Type: "AWS::RDS::DBInstance", Target: "test-target",
+			Properties: genBoundProperties("MasterUserPassword", generatorKsuid),
+		}, "cmd-1")
+		require.NoError(t, err)
+
+		bound, err := ds.FindResourcesReferencingGenerator(generatorKsuid)
+		require.NoError(t, err)
+		require.Len(t, bound, 1)
+		assert.Equal(t, boundKsuid, bound[0].Ksuid)
+		assert.Equal(t, "database", bound[0].Label)
+	})
+}
+
+// RunFindResourcesReferencingGeneratorOtherGeneratorExcluded verifies that a
+// resource bound to a different generator is not returned.
+func RunFindResourcesReferencingGeneratorOtherGeneratorExcluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("FindResourcesReferencingGenerator_OtherGeneratorExcluded", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+		createGeneratorRefsTarget(t, td)
+
+		wantedGenerator := mksuid.New().String()
+		otherGenerator := mksuid.New().String()
+
+		boundKsuid := mksuid.New().String()
+		_, err := ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: boundKsuid, NativeID: "wanted-native", Stack: "app", Label: "wanted",
+			Type: "AWS::RDS::DBInstance", Target: "test-target",
+			Properties: genBoundProperties("MasterUserPassword", wantedGenerator),
+		}, "cmd-1")
+		require.NoError(t, err)
+
+		_, err = ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: mksuid.New().String(), NativeID: "other-native", Stack: "app", Label: "other",
+			Type: "AWS::RDS::DBInstance", Target: "test-target",
+			Properties: genBoundProperties("MasterUserPassword", otherGenerator),
+		}, "cmd-1")
+		require.NoError(t, err)
+
+		bound, err := ds.FindResourcesReferencingGenerator(wantedGenerator)
+		require.NoError(t, err)
+		require.Len(t, bound, 1, "only the resource bound to the queried generator may be returned")
+		assert.Equal(t, boundKsuid, bound[0].Ksuid)
+	})
+}
+
+// RunFindResourcesReferencingGeneratorUnboundResourceExcluded verifies that a
+// resource carrying no $gen envelope at all is not returned.
+func RunFindResourcesReferencingGeneratorUnboundResourceExcluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("FindResourcesReferencingGenerator_UnboundResourceExcluded", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+		createGeneratorRefsTarget(t, td)
+
+		generatorKsuid := mksuid.New().String()
+		_, err := ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: mksuid.New().String(), NativeID: "plain-native", Stack: "app", Label: "plain-bucket",
+			Type: "AWS::S3::Bucket", Target: "test-target",
+			Properties: json.RawMessage(`{"BucketName":"plain"}`),
+		}, "cmd-1")
+		require.NoError(t, err)
+
+		bound, err := ds.FindResourcesReferencingGenerator(generatorKsuid)
+		require.NoError(t, err)
+		assert.Empty(t, bound)
+	})
+}
+
+// RunFindResourcesReferencingGeneratorAcrossStacks verifies that every
+// destination of one generator is returned regardless of which stack it lives
+// on. A generator is bound by KSUID, so a consumer in another stack is as much
+// a destination as one in the generator's own stack, and the whole reverse
+// index exists to find it.
+func RunFindResourcesReferencingGeneratorAcrossStacks(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("FindResourcesReferencingGenerator_AcrossStacks", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+		createGeneratorRefsTarget(t, td)
+
+		generatorKsuid := mksuid.New().String()
+
+		firstKsuid := mksuid.New().String()
+		_, err := ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: firstKsuid, NativeID: "stack-a-native", Stack: "stack-a", Label: "database",
+			Type: "AWS::RDS::DBInstance", Target: "test-target",
+			Properties: genBoundProperties("MasterUserPassword", generatorKsuid),
+		}, "cmd-1")
+		require.NoError(t, err)
+
+		secondKsuid := mksuid.New().String()
+		_, err = ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: secondKsuid, NativeID: "stack-b-native", Stack: "stack-b", Label: "worker",
+			Type: "AWS::ECS::Service", Target: "test-target",
+			Properties: genBoundProperties("DatabasePassword", generatorKsuid),
+		}, "cmd-1")
+		require.NoError(t, err)
+
+		bound, err := ds.FindResourcesReferencingGenerator(generatorKsuid)
+		require.NoError(t, err)
+		require.Len(t, bound, 2, "a generator's destinations span stacks")
+
+		got := []string{bound[0].Ksuid, bound[1].Ksuid}
+		assert.ElementsMatch(t, []string{firstKsuid, secondKsuid}, got)
+	})
+}
+
+// RunFindResourcesReferencingGeneratorDeletedExcluded verifies that a deleted
+// destination is not returned: a torn-down resource no longer binds anything.
+func RunFindResourcesReferencingGeneratorDeletedExcluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("FindResourcesReferencingGenerator_DeletedExcluded", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+		createGeneratorRefsTarget(t, td)
+
+		generatorKsuid := mksuid.New().String()
+		destination := &pkgmodel.Resource{
+			Ksuid: mksuid.New().String(), NativeID: "deleted-native", Stack: "app", Label: "database",
+			Type: "AWS::RDS::DBInstance", Target: "test-target",
+			Properties: genBoundProperties("MasterUserPassword", generatorKsuid),
+		}
+		_, err := ds.StoreResource(destination, "cmd-1")
+		require.NoError(t, err)
+
+		_, err = ds.DeleteResource(destination, "cmd-2")
+		require.NoError(t, err)
+
+		bound, err := ds.FindResourcesReferencingGenerator(generatorKsuid)
+		require.NoError(t, err)
+		assert.Empty(t, bound, "a deleted destination is not a destination")
+	})
+}
+
+// RunFindResourcesReferencingGeneratorLatestVersionOnly verifies the
+// latest-version window: a resource written twice is returned exactly once, at
+// its current version, not once per stored version.
+func RunFindResourcesReferencingGeneratorLatestVersionOnly(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("FindResourcesReferencingGenerator_LatestVersionOnly", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+		createGeneratorRefsTarget(t, td)
+
+		generatorKsuid := mksuid.New().String()
+		destinationKsuid := mksuid.New().String()
+
+		firstProps := json.RawMessage(fmt.Sprintf(
+			`{"Engine":"postgres","MasterUserPassword":{"$gen":true,"$generator":"%s","$output":"value","$visibility":"Opaque","$value":"sha256:first","$hashed":true,"$resolvedFrom":"sha256:first"}}`,
+			generatorKsuid,
+		))
+		_, err := ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: destinationKsuid, NativeID: "versioned-native", Stack: "app", Label: "database",
+			Type: "AWS::RDS::DBInstance", Target: "test-target", Properties: firstProps,
+		}, "cmd-1")
+		require.NoError(t, err)
+
+		secondProps := json.RawMessage(fmt.Sprintf(
+			`{"Engine":"mysql","MasterUserPassword":{"$gen":true,"$generator":"%s","$output":"value","$visibility":"Opaque","$value":"sha256:second","$hashed":true,"$resolvedFrom":"sha256:second"}}`,
+			generatorKsuid,
+		))
+		_, err = ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: destinationKsuid, NativeID: "versioned-native", Stack: "app", Label: "database",
+			Type: "AWS::RDS::DBInstance", Target: "test-target", Properties: secondProps,
+		}, "cmd-2")
+		require.NoError(t, err)
+
+		bound, err := ds.FindResourcesReferencingGenerator(generatorKsuid)
+		require.NoError(t, err)
+		require.Len(t, bound, 1, "a superseded version must not be returned alongside the live one")
+		assert.Equal(t, destinationKsuid, bound[0].Ksuid)
+		assert.JSONEq(t, string(secondProps), string(bound[0].Properties),
+			"the returned version must be the live one, not the superseded one")
+	})
+}
+
+// RunFindResourcesReferencingGeneratorUnknownGenerator verifies that querying
+// a generator KSUID nothing is bound to returns an empty result rather than an
+// error.
+func RunFindResourcesReferencingGeneratorUnknownGenerator(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("FindResourcesReferencingGenerator_UnknownGenerator", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+		createGeneratorRefsTarget(t, td)
+
+		_, err := ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: mksuid.New().String(), NativeID: "unknown-gen-native", Stack: "app", Label: "database",
+			Type: "AWS::RDS::DBInstance", Target: "test-target",
+			Properties: genBoundProperties("MasterUserPassword", mksuid.New().String()),
+		}, "cmd-1")
+		require.NoError(t, err)
+
+		bound, err := ds.FindResourcesReferencingGenerator(mksuid.New().String())
+		require.NoError(t, err)
+		assert.Empty(t, bound)
+	})
+}
+
+// RunFindResourcesReferencingGeneratorNestedInArray verifies that a $gen
+// envelope inside an array element is found, not only one at the top level of
+// the properties document.
+func RunFindResourcesReferencingGeneratorNestedInArray(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("FindResourcesReferencingGenerator_NestedInArray", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+		createGeneratorRefsTarget(t, td)
+
+		generatorKsuid := mksuid.New().String()
+		destinationKsuid := mksuid.New().String()
+		props := json.RawMessage(fmt.Sprintf(
+			`{"Environment":[{"Name":"DB_HOST","Value":"db.internal"},{"Name":"DB_PASSWORD","Value":{"$gen":true,"$generator":"%s","$output":"value","$visibility":"Opaque","$value":"sha256:digest","$hashed":true,"$resolvedFrom":"sha256:digest"}}]}`,
+			generatorKsuid,
+		))
+		_, err := ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: destinationKsuid, NativeID: "nested-native", Stack: "app", Label: "task-definition",
+			Type: "AWS::ECS::TaskDefinition", Target: "test-target", Properties: props,
+		}, "cmd-1")
+		require.NoError(t, err)
+
+		bound, err := ds.FindResourcesReferencingGenerator(generatorKsuid)
+		require.NoError(t, err)
+		require.Len(t, bound, 1, "a $gen nested in an array element must be found")
+		assert.Equal(t, destinationKsuid, bound[0].Ksuid)
+	})
+}
+
+// swapKsuidCase returns the KSUID with the case of every ASCII letter flipped.
+// KSUIDs are base62, so the result is a different string that differs from the
+// original only in case.
+func swapKsuidCase(t *testing.T, ksuid string) string {
+	t.Helper()
+	swapped := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r - 'a' + 'A'
+		case r >= 'A' && r <= 'Z':
+			return r - 'A' + 'a'
+		default:
+			return r
+		}
+	}, ksuid)
+	require.NotEqual(t, ksuid, swapped, "the KSUID must contain at least one letter to case-swap")
+	return swapped
+}
+
+// RunFindResourcesReferencingGeneratorBareGeneratorKeyExcluded verifies that a
+// $generator key that is not part of a $gen envelope does not make its owner a
+// destination. Only a translated envelope binds a property to a generator; a
+// property that merely happens to carry a key of that name does not.
+func RunFindResourcesReferencingGeneratorBareGeneratorKeyExcluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("FindResourcesReferencingGenerator_BareGeneratorKeyExcluded", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+		createGeneratorRefsTarget(t, td)
+
+		generatorKsuid := mksuid.New().String()
+		_, err := ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: mksuid.New().String(), NativeID: "bare-native", Stack: "app", Label: "bare",
+			Type: "AWS::S3::Bucket", Target: "test-target",
+			Properties: json.RawMessage(fmt.Sprintf(`{"Config":{"$generator":"%s"}}`, generatorKsuid)),
+		}, "cmd-1")
+		require.NoError(t, err)
+
+		bound, err := ds.FindResourcesReferencingGenerator(generatorKsuid)
+		require.NoError(t, err)
+		assert.Empty(t, bound, "a $generator key outside a $gen envelope does not bind a property")
+	})
+}
+
+// RunFindResourcesReferencingGeneratorGenFalseExcluded verifies that an object
+// carrying $gen: false is not an envelope, so its $generator sibling binds
+// nothing.
+func RunFindResourcesReferencingGeneratorGenFalseExcluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("FindResourcesReferencingGenerator_GenFalseExcluded", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+		createGeneratorRefsTarget(t, td)
+
+		generatorKsuid := mksuid.New().String()
+		_, err := ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: mksuid.New().String(), NativeID: "gen-false-native", Stack: "app", Label: "gen-false",
+			Type: "AWS::RDS::DBInstance", Target: "test-target",
+			Properties: json.RawMessage(fmt.Sprintf(
+				`{"MasterUserPassword":{"$gen":false,"$generator":"%s","$output":"value"}}`, generatorKsuid)),
+		}, "cmd-1")
+		require.NoError(t, err)
+
+		bound, err := ds.FindResourcesReferencingGenerator(generatorKsuid)
+		require.NoError(t, err)
+		assert.Empty(t, bound, "$gen: false is not an envelope")
+	})
+}
+
+// RunFindResourcesReferencingGeneratorCaseSensitive verifies that the lookup
+// matches the generator KSUID exactly. KSUIDs are case-sensitive identifiers,
+// so a case-swapped KSUID names a different generator and has no destinations.
+func RunFindResourcesReferencingGeneratorCaseSensitive(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("FindResourcesReferencingGenerator_CaseSensitive", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+		createGeneratorRefsTarget(t, td)
+
+		generatorKsuid := mksuid.New().String()
+		_, err := ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: mksuid.New().String(), NativeID: "case-native", Stack: "app", Label: "database",
+			Type: "AWS::RDS::DBInstance", Target: "test-target",
+			Properties: genBoundProperties("MasterUserPassword", generatorKsuid),
+		}, "cmd-1")
+		require.NoError(t, err)
+
+		bound, err := ds.FindResourcesReferencingGenerator(swapKsuidCase(t, generatorKsuid))
+		require.NoError(t, err)
+		assert.Empty(t, bound, "a case-swapped KSUID names a different generator")
+	})
+}
+
+// RunFindResourcesReferencingGeneratorResourceRefExcluded verifies that this
+// lookup answers only for generators. A resource KSUID reached through a $ref
+// is a resource dependency, which FindResourcesDependingOn answers, and it must
+// not surface that resource's dependents here.
+func RunFindResourcesReferencingGeneratorResourceRefExcluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("FindResourcesReferencingGenerator_ResourceRefExcluded", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+		createGeneratorRefsTarget(t, td)
+
+		parentKsuid := mksuid.New().String()
+		_, err := ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: parentKsuid, NativeID: "parent-native", Stack: "app", Label: "parent",
+			Type: "AWS::S3::Bucket", Target: "test-target",
+			Properties: json.RawMessage(`{"BucketName":"parent"}`),
+		}, "cmd-1")
+		require.NoError(t, err)
+
+		_, err = ds.StoreResource(&pkgmodel.Resource{
+			Ksuid: mksuid.New().String(), NativeID: "child-native", Stack: "app", Label: "child",
+			Type: "AWS::IAM::Role", Target: "test-target",
+			Properties: json.RawMessage(fmt.Sprintf(
+				`{"RoleArn":{"$ref":"formae://%s#/Arn","$value":"arn:aws:s3:::parent"}}`, parentKsuid)),
+		}, "cmd-2")
+		require.NoError(t, err)
+
+		bound, err := ds.FindResourcesReferencingGenerator(parentKsuid)
+		require.NoError(t, err)
+		assert.Empty(t, bound, "a resource KSUID reached through $ref names no generator")
+	})
+}

--- a/internal/datastore/dstest/suite_generators.go
+++ b/internal/datastore/dstest/suite_generators.go
@@ -654,11 +654,12 @@ func RunAdvanceGenerationDoesNotAffectOtherGenerator(t *testing.T, newDS func(t 
 
 // RunAdvanceGenerationOnDeletedGeneratorFailsWithoutResurrecting verifies
 // AdvanceGeneration's tombstone guard: called against a deleted generator's
-// id, it must return an error AND must not write a new row. A half-fix that
-// errors but still inserts a version row would resurrect the generator with
-// an unparseable generator_data ('{}' copied from the tombstone), leaving
-// GetGenerator permanently failing with "unknown generator type:" — so this
-// checks both read paths stay at the zero value / nil, not just the error.
+// id, it must return an error AND must not write a new row. An implementation
+// that errors but still inserts a version row would resurrect the generator
+// with an unparseable generator_data ('{}' copied from the tombstone),
+// leaving GetGenerator permanently failing with "unknown generator type:" —
+// so this checks both read paths stay at the zero value / nil, not just the
+// error.
 func RunAdvanceGenerationOnDeletedGeneratorFailsWithoutResurrecting(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	t.Run("AdvanceGenerationOnDeletedGeneratorFailsWithoutResurrecting", func(t *testing.T) {
 		td := newDS(t)

--- a/internal/datastore/migration/resource_refs_backfill_test.go
+++ b/internal/datastore/migration/resource_refs_backfill_test.go
@@ -272,3 +272,54 @@ func TestBackfillResourceRefs_ParityPostgres(t *testing.T) {
 			"idempotency: refs for %s must be unchanged after second run", tc.label)
 	}
 }
+
+// TestBackfillResourceRefs_MakesAGeneratorBindingFindablePostgres proves the
+// backfill closes the loop for the generator reverse index: a row written
+// before generator KSUIDs were collected into refs carries an empty refs
+// column and is invisible to FindResourcesReferencingGenerator, and one
+// unconditional boot sweep makes it findable. No schema migration is involved;
+// the generator KSUID lands in the existing refs column.
+func TestBackfillResourceRefs_MakesAGeneratorBindingFindablePostgres(t *testing.T) {
+	d, cleanup := newPostgresTestDatastore(t)
+	defer cleanup()
+	storeTestTargetPG(t, d)
+
+	connStr := postgres.BuildConnStr("localhost", 5432, "postgres", "admin", d.Pool().Config().ConnConfig.Database)
+	conn, err := pgx.Connect(context.Background(), connStr)
+	require.NoError(t, err)
+	defer conn.Close(context.Background()) //nolint:errcheck
+
+	generatorKsuid := mksuid.New().String()
+	destinationKsuid := util.NewID()
+	storeResource(t, d, &pkgmodel.Resource{
+		Ksuid:    destinationKsuid,
+		NativeID: "gen-bound-native",
+		Stack:    "app",
+		Label:    "database",
+		Type:     "AWS::RDS::DBInstance",
+		Target:   "test-target",
+		Properties: json.RawMessage(fmt.Sprintf(
+			`{"MasterUserPassword":{"$gen":true,"$generator":"%s","$output":"value","$visibility":"Opaque","$value":"sha256:digest","$hashed":true,"$resolvedFrom":"sha256:digest"}}`,
+			generatorKsuid,
+		)),
+	})
+
+	// Put the row back into the state a write made before generator KSUIDs
+	// were collected would have left it in.
+	resetAllRefs(t, conn)
+	require.Empty(t, queryRefsRaw(t, conn, destinationKsuid))
+
+	beforeBackfill, err := d.FindResourcesReferencingGenerator(generatorKsuid)
+	require.NoError(t, err)
+	require.Empty(t, beforeBackfill, "a row with an empty refs column is not yet findable")
+
+	require.NoError(t, BackfillResourceRefs(d))
+
+	assert.Equal(t, []string{generatorKsuid}, queryRefsRaw(t, conn, destinationKsuid),
+		"the sweep must recompute the generator KSUID into the existing refs column")
+
+	afterBackfill, err := d.FindResourcesReferencingGenerator(generatorKsuid)
+	require.NoError(t, err)
+	require.Len(t, afterBackfill, 1, "the swept row must be findable by its generator")
+	assert.Equal(t, destinationKsuid, afterBackfill[0].Ksuid)
+}

--- a/internal/datastore/mock_datastore_test.go
+++ b/internal/datastore/mock_datastore_test.go
@@ -88,6 +88,9 @@ func (m *mockDatastore) LoadLatestResourceByKsuid(_ string) (*pkgmodel.Resource,
 func (m *mockDatastore) FindResourcesDependingOn(_ string) ([]*pkgmodel.Resource, error) {
 	return nil, nil
 }
+func (m *mockDatastore) FindResourcesReferencingGenerator(_ string) ([]*pkgmodel.Resource, error) {
+	return nil, nil
+}
 func (m *mockDatastore) FindResourcesDependingOnMany(_ []string) (map[string][]*pkgmodel.Resource, error) {
 	return nil, nil
 }

--- a/internal/datastore/mssql/mssql_generators.go
+++ b/internal/datastore/mssql/mssql_generators.go
@@ -365,10 +365,10 @@ func (d *DatastoreMSSQL) GetGeneratorIdentityByID(generatorID string) (datastore
 // is not valid JSON, or if the generator's latest row is a tombstone: a
 // deleted id is not resurrected.
 //
-// No production caller in this slice: the executable generator node that
-// draws generations arrives in a later slice. It ships here because the
-// generation columns are inert without a writer, and a test-only backdoor
-// would misrepresent a mechanism we are shipping for real use.
+// The caller is the generator update actor
+// (generator_update.GeneratorUpdater): it calls this once it has drawn a
+// value, so the generation the value came from is durable before any
+// destination is stamped with it.
 func (d *DatastoreMSSQL) AdvanceGeneration(generatorID, generationID string, drawnUnder json.RawMessage) error {
 	ctx, span := mssqlTracer.Start(context.Background(), "AdvanceGeneration")
 	defer span.End()

--- a/internal/datastore/mssql/mssql_resources.go
+++ b/internal/datastore/mssql/mssql_resources.go
@@ -603,6 +603,63 @@ func (d *DatastoreMSSQL) FindResourcesDependingOn(ksuid string) ([]*pkgmodel.Res
 	return resources, rows.Err()
 }
 
+// FindResourcesReferencingGenerator finds the live resources that bind a property
+// to the given generator through a $gen envelope. It matches
+// `"$generator":"<ksuid>"` over the nvarchar(max) data column with LIKE. Full
+// scan (same TODO as the $ref lookup). The LIKE is a prefilter kept
+// deliberately loose (it is blind to the database collation's case rules, and
+// to whether the key sits inside an envelope), and pkgmodel.BindsGenerator
+// decides which candidates are really destinations.
+func (d *DatastoreMSSQL) FindResourcesReferencingGenerator(generatorKsuid string) ([]*pkgmodel.Resource, error) {
+	ctx, span := mssqlTracer.Start(context.Background(), "FindResourcesReferencingGenerator")
+	defer span.End()
+
+	pattern := fmt.Sprintf("%%\"$generator\":\"%s\"%%", generatorKsuid)
+
+	query := fmt.Sprintf(`
+	SELECT data, ksuid
+	FROM resources r1
+	WHERE data LIKE @p1
+	AND NOT EXISTS (
+		SELECT 1
+		FROM resources r2
+		WHERE r1.uri = r2.uri
+		AND r2.version %[1]s > r1.version %[1]s
+	)
+	AND operation != @p2 AND operation != 'reaped'
+	`, binColl)
+
+	rows, err := d.conn.QueryContext(ctx, query, pattern, string(resource_update.OperationDelete))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var resources []*pkgmodel.Resource
+	for rows.Next() {
+		var jsonData, ksuidResult string
+		if err := rows.Scan(&jsonData, &ksuidResult); err != nil {
+			return nil, err
+		}
+
+		// The SQL above is only a prefilter: it is deliberately broader than
+		// the truth so no destination is missed. pkgmodel.BindsGenerator is
+		// authoritative, and drops any candidate it matched for another reason.
+		if !pkgmodel.BindsGenerator([]byte(jsonData), generatorKsuid) {
+			continue
+		}
+
+		var resource pkgmodel.Resource
+		if err := json.Unmarshal([]byte(jsonData), &resource); err != nil {
+			return nil, err
+		}
+		resource.Ksuid = ksuidResult
+		resources = append(resources, &resource)
+	}
+
+	return resources, rows.Err()
+}
+
 func (d *DatastoreMSSQL) FindResourcesDependingOnMany(ksuids []string) (map[string][]*pkgmodel.Resource, error) {
 	ctx, span := mssqlTracer.Start(context.Background(), "FindResourcesDependingOnMany")
 	defer span.End()

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -1597,6 +1597,61 @@ func (d DatastorePostgres) FindResourcesDependingOn(ksuid string) ([]*pkgmodel.R
 	return resources, rows.Err()
 }
 
+// FindResourcesReferencingGenerator finds the live resources that bind a property
+// to the given generator through a $gen envelope. A translated envelope's
+// $generator KSUID is an outbound reference KSUID, so it lands in the same
+// GIN-indexed refs column the $ref lookup uses and the array-overlap query
+// narrows the scan cheaply. That column records only that a KSUID is
+// referenced, not how, so the overlap is a prefilter and pkgmodel.BindsGenerator
+// decides which candidates are really destinations.
+func (d DatastorePostgres) FindResourcesReferencingGenerator(generatorKsuid string) ([]*pkgmodel.Resource, error) {
+	ctx, span := tracer.Start(context.Background(), "FindResourcesReferencingGenerator")
+	defer span.End()
+
+	query := `
+	SELECT data, ksuid
+	FROM resources r1
+	WHERE refs && $1
+	AND NOT EXISTS (
+		SELECT 1
+		FROM resources r2
+		WHERE r1.uri = r2.uri
+		AND r2.version COLLATE "C" > r1.version COLLATE "C"
+	)
+	AND operation != $2 AND operation != 'reaped'
+	`
+
+	rows, err := d.pool.Query(ctx, query, []string{generatorKsuid}, resource_update.OperationDelete)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var resources []*pkgmodel.Resource
+	for rows.Next() {
+		var jsonData, ksuidResult string
+		if err := rows.Scan(&jsonData, &ksuidResult); err != nil {
+			return nil, err
+		}
+
+		// The SQL above is only a prefilter: it is deliberately broader than
+		// the truth so no destination is missed. pkgmodel.BindsGenerator is
+		// authoritative, and drops any candidate it matched for another reason.
+		if !pkgmodel.BindsGenerator([]byte(jsonData), generatorKsuid) {
+			continue
+		}
+
+		var resource pkgmodel.Resource
+		if err := json.Unmarshal([]byte(jsonData), &resource); err != nil {
+			return nil, err
+		}
+		resource.Ksuid = ksuidResult
+		resources = append(resources, &resource)
+	}
+
+	return resources, rows.Err()
+}
+
 func (d DatastorePostgres) FindResourcesDependingOnMany(ksuids []string) (map[string][]*pkgmodel.Resource, error) {
 	ctx, span := tracer.Start(context.Background(), "FindResourcesDependingOnMany")
 	defer span.End()

--- a/internal/datastore/postgres/postgres_generators.go
+++ b/internal/datastore/postgres/postgres_generators.go
@@ -368,10 +368,10 @@ func (d DatastorePostgres) GetGeneratorIdentityByID(generatorID string) (datasto
 // is not valid JSON, or if the generator's latest row is a tombstone: a
 // deleted id is not resurrected.
 //
-// No production caller in this slice: the executable generator node that
-// draws generations arrives in a later slice. It ships here because the
-// generation columns are inert without a writer, and a test-only backdoor
-// would misrepresent a mechanism we are shipping for real use.
+// The caller is the generator update actor
+// (generator_update.GeneratorUpdater): it calls this once it has drawn a
+// value, so the generation the value came from is durable before any
+// destination is stamped with it.
 func (d DatastorePostgres) AdvanceGeneration(generatorID, generationID string, drawnUnder json.RawMessage) error {
 	ctx, span := tracer.Start(context.Background(), "AdvanceGeneration")
 	defer span.End()

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -3177,10 +3177,10 @@ func (d DatastoreSQLite) GetGeneratorIdentityByID(generatorID string) (datastore
 // is not valid JSON, or if the generator's latest row is a tombstone: a
 // deleted id is not resurrected.
 //
-// No production caller in this slice: the executable generator node that
-// draws generations arrives in a later slice. It ships here because the
-// generation columns are inert without a writer, and a test-only backdoor
-// would misrepresent a mechanism we are shipping for real use.
+// The caller is the generator update actor
+// (generator_update.GeneratorUpdater): it calls this once it has drawn a
+// value, so the generation the value came from is durable before any
+// destination is stamped with it.
 func (d DatastoreSQLite) AdvanceGeneration(generatorID, generationID string, drawnUnder json.RawMessage) error {
 	_, span := sqliteTracer.Start(context.Background(), "AdvanceGeneration")
 	defer span.End()
@@ -4931,6 +4931,69 @@ func (d DatastoreSQLite) FindResourcesDependingOn(ksuid string) ([]*pkgmodel.Res
 	}
 
 	return resources, nil
+}
+
+// FindResourcesReferencingGenerator finds the live resources that bind a property
+// to the given generator through a $gen envelope. SQLite has no refs column, so
+// like the $ref lookup this is a full table scan over the data column. The LIKE
+// is a prefilter kept deliberately loose (it is blind to case, and to whether
+// the key sits inside an envelope), and pkgmodel.BindsGenerator decides which
+// candidates are really destinations.
+func (d DatastoreSQLite) FindResourcesReferencingGenerator(generatorKsuid string) ([]*pkgmodel.Resource, error) {
+	slog.Debug("SQLite START", "method", "FindResourcesReferencingGenerator", "generator", generatorKsuid)
+	start := time.Now()
+	defer func() {
+		slog.Debug("SQLite END", "method", "FindResourcesReferencingGenerator", "generator", generatorKsuid, "duration", time.Since(start))
+	}()
+	_, span := sqliteTracer.Start(context.Background(), "FindResourcesReferencingGenerator")
+	defer span.End()
+
+	// A translated $gen envelope stores the generator KSUID under $generator
+	// (JSON without spaces after colons).
+	pattern := fmt.Sprintf("%%\"$generator\":\"%s\"%%", generatorKsuid)
+
+	query := `
+	SELECT data, ksuid
+	FROM resources r1
+	WHERE data LIKE ?
+	AND NOT EXISTS (
+		SELECT 1
+		FROM resources r2
+		WHERE r1.uri = r2.uri
+		AND r2.version > r1.version
+	)
+	AND operation != ? AND operation != 'reaped'
+	`
+
+	rows, err := d.conn.Query(query, pattern, resource_update.OperationDelete)
+	if err != nil {
+		return nil, err
+	}
+	defer closeRows(rows)
+
+	var resources []*pkgmodel.Resource
+	for rows.Next() {
+		var jsonData, ksuidResult string
+		if err := rows.Scan(&jsonData, &ksuidResult); err != nil {
+			return nil, err
+		}
+
+		// The SQL above is only a prefilter: it is deliberately broader than
+		// the truth so no destination is missed. pkgmodel.BindsGenerator is
+		// authoritative, and drops any candidate it matched for another reason.
+		if !pkgmodel.BindsGenerator([]byte(jsonData), generatorKsuid) {
+			continue
+		}
+
+		var resource pkgmodel.Resource
+		if err := json.Unmarshal([]byte(jsonData), &resource); err != nil {
+			return nil, err
+		}
+		resource.Ksuid = ksuidResult
+		resources = append(resources, &resource)
+	}
+
+	return resources, rows.Err()
 }
 
 func (d DatastoreSQLite) FindResourcesDependingOnMany(ksuids []string) (map[string][]*pkgmodel.Resource, error) {

--- a/internal/datastore/sqlite/sqlite_test.go
+++ b/internal/datastore/sqlite/sqlite_test.go
@@ -599,9 +599,9 @@ func TestBulkStoreResourceUpdates_StripsOpaqueRefValueFromExistingTarget(t *test
 // fail-closed strip at the storage boundary: a $gen envelope missing
 // $visibility entirely (a shape normal translation never produces — the
 // schema fixes $visibility to "Opaque" on every $gen) must still be stripped
-// before it reaches the database. Before the fix, gating the strip predicate
-// on a $visibility reading let this exact shape land in the SQLite file in
-// cleartext.
+// before it reaches the database. The strip predicate therefore keys off the
+// $gen envelope itself; a predicate gated on reading $visibility would let
+// this shape land in the SQLite file in cleartext.
 func TestCreateTarget_StripsOpaqueGenValueWithoutVisibility(t *testing.T) {
 	cfg := &pkgmodel.DatastoreConfig{
 		DatastoreType: pkgmodel.SqliteDatastore,

--- a/internal/metastructure/actornames/names.go
+++ b/internal/metastructure/actornames/names.go
@@ -44,3 +44,13 @@ func ResourceUpdater(resourceURI model.FormaeURI, operation string, commandID st
 func TargetUpdater(label, operation, commandID string) gen.Atom {
 	return gen.Atom(fmt.Sprintf("target://%s/target-updater/%s/%s", label, operation, commandID))
 }
+
+// GeneratorUpdater names the actor that draws one generator's value. Unlike
+// TargetUpdater it is keyed on the generator update's node URI rather than a
+// bare label, because a generator label is unique only within its stack: two
+// stacks in one command may each declare "db-password", and a label-only name
+// would put both on one actor. The node URI already carries the stack, the
+// label (each percent-encoded) and the operation.
+func GeneratorUpdater(nodeURI model.FormaeURI, commandID string) gen.Atom {
+	return gen.Atom(fmt.Sprintf("%s/generator-updater/%s", nodeURI, commandID))
+}

--- a/internal/metastructure/auto_reconciler.go
+++ b/internal/metastructure/auto_reconciler.go
@@ -384,7 +384,10 @@ func prepareReconcile(ds datastore.Datastore, stackLabel string, clientID string
 	if err != nil {
 		return nil, fmt.Errorf("failed to create changeset: %w", err)
 	}
-	cs, err := changeset.NewChangeset(resourceUpdates, synth, reconcileCommand.ID, pkgmodel.CommandApply, reconcileCommand.Config.Mode)
+	// No generator draws: an auto-reconcile re-asserts persisted desired
+	// state, whose $gen destinations already carry the value that was
+	// drawn for them. Rotating a credential is a user-initiated apply.
+	cs, err := changeset.NewChangeset(resourceUpdates, synth, nil, reconcileCommand.ID, pkgmodel.CommandApply, reconcileCommand.Config.Mode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create changeset: %w", err)
 	}

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -13,6 +13,7 @@ import (
 
 	"log/slog"
 
+	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
@@ -69,14 +70,21 @@ type DAGNode struct {
 	Dependencies []*DAGNode
 }
 
-// NewChangeset builds the execution DAG from the given resource and target
-// updates. It is a pure graph-builder: any synthetic Resolve target ops the
-// command needs (for unchanged targets carrying opaque $ref config) are generated
-// in the Update-construction phase by target_update.SynthesizeResolveTargetUpdates
-// and passed in via targetUpdates, so this constructor needs no datastore.
+// NewChangeset builds the execution DAG from the given resource, target and
+// generator updates. It is a pure graph-builder: the synthetic ops the command
+// needs are generated in the Update-construction phase and passed in — Resolve
+// target ops (for unchanged targets carrying opaque $ref config) by
+// target_update.SynthesizeResolveTargetUpdates, and generator draws by
+// generator_update.SynthesizeDrawGeneratorUpdates — so this constructor needs
+// no datastore.
+//
+// generatorUpdates carries draw ops only. A generator's own row is created,
+// updated or deleted before the changeset starts, so those operations never
+// appear here.
 func NewChangeset(
 	resourceUpdates []resource_update.ResourceUpdate,
 	targetUpdates []target_update.TargetUpdate,
+	generatorUpdates []generator_update.GeneratorUpdate,
 	commandID string,
 	command pkgmodel.Command,
 	mode pkgmodel.FormaApplyMode,
@@ -136,12 +144,33 @@ func NewChangeset(
 	// Build implicit edges between target and resource nodes
 	changeset.DAG.buildTargetResourceEdges(targetUpdates)
 
-	// Re-run cycle detection over the FULL graph. DAG.Init runs its cycle check
-	// before any target node or target-resolvable edge exists, so a cycle formed
-	// purely by target-resolvable edges — two in-command targets whose configs
-	// reference each other's secrets, or a target referencing a secret hosted on
-	// itself — would otherwise slip through and hang the executor. This second
-	// pass turns any such cycle into a clean build-time error.
+	// Copy the generator draws into a local slice for the same reason the
+	// target ops are copied: DAG nodes must not point into a caller's
+	// backing array.
+	allGeneratorOps := make([]generator_update.GeneratorUpdate, len(generatorUpdates))
+	copy(allGeneratorOps, generatorUpdates)
+
+	for i := range allGeneratorOps {
+		gu := &allGeneratorOps[i]
+		changeset.DAG.Nodes[gu.NodeURI()] = &DAGNode{
+			URI:          gu.NodeURI(),
+			Update:       gu,
+			Dependents:   []*DAGNode{},
+			Dependencies: []*DAGNode{},
+		}
+	}
+
+	if err := changeset.DAG.buildGeneratorResourceEdges(allGeneratorOps); err != nil {
+		return Changeset{}, err
+	}
+
+	// Re-run cycle detection over the FULL graph, generator edges included.
+	// DAG.Init runs its cycle check before any target node, target-resolvable
+	// edge or generator node exists, so a cycle formed purely by
+	// target-resolvable edges — two in-command targets whose configs reference
+	// each other's secrets, or a target referencing a secret hosted on itself —
+	// would otherwise slip through and hang the executor. This second pass
+	// turns any such cycle into a clean build-time error.
 	if changeset.DAG.HasCycles() {
 		return Changeset{}, fmt.Errorf("changeset has a dependency cycle involving target-resolvable references")
 	}
@@ -279,6 +308,66 @@ func (p *ExecutionDAG) buildTargetResourceEdges(targetUpdates []target_update.Ta
 			}
 		}
 	}
+}
+
+// buildGeneratorResourceEdges wires every resource op that still needs a value
+// from a generator to that generator's draw node, so the op cannot dispatch
+// before the value exists.
+//
+// A destination is wired only when its $gen occurrence did NOT classify
+// OccurrenceStable at planning. A stable occurrence already holds the value the
+// generator's current generation produced; wiring it would deliver a freshly
+// drawn value over a credential nothing asked to rotate. That reading of the
+// provenance records lives in exactly one place —
+// resource_update.IsGenDestinationStable — because the same question decides
+// whether a draw happens, which destinations it writes to, and which
+// destinations a resumed command still owes a value.
+//
+// A draw node is a sink: it has no dependencies of its own, so no edge added
+// here can close a cycle. The full-graph re-check still runs over these edges,
+// which is what keeps that property honest if a draw ever gains an upstream.
+func (p *ExecutionDAG) buildGeneratorResourceEdges(generatorUpdates []generator_update.GeneratorUpdate) error {
+	for i := range generatorUpdates {
+		gu := &generatorUpdates[i]
+		generatorNode := p.Nodes[gu.NodeURI()]
+		if generatorNode == nil {
+			continue
+		}
+
+		// The generator's KSUID is what a translated $gen envelope names it
+		// by. Without one the draw cannot be matched to any destination, so
+		// every destination bound to it would dispatch its envelope undrawn
+		// and be rejected at the provider boundary — on this apply and on
+		// every one after. Refuse to build such a changeset.
+		var generatorKsuid string
+		if gu.Generator != nil {
+			generatorKsuid = gu.Generator.GetID()
+		}
+		if generatorKsuid == "" {
+			return fmt.Errorf(
+				"generator update %s carries no generator identity, so the destinations bound to it cannot be found",
+				gu.NodeURI())
+		}
+
+		for _, node := range p.Nodes {
+			ru, ok := node.Update.(*resource_update.ResourceUpdate)
+			if !ok {
+				continue
+			}
+			for _, gen := range pkgmodel.FindGenObjectsFromProperties(ru.DesiredState.Properties) {
+				if gen.Generator != generatorKsuid {
+					continue
+				}
+				if resource_update.IsGenDestinationStable(ru.ProvenanceRecords, gen.Path) {
+					continue
+				}
+				node.LinkWith(generatorNode)
+				break
+			}
+		}
+	}
+
+	return nil
 }
 
 // buildDeleteDependencies creates dependencies for delete operations.

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -889,10 +889,16 @@ func (p *ExecutionDAG) propagateResolvedTargetConfig(targetLabel string, pluginC
 // file and this is the path that writes credentials, so it is restated here
 // where it applies.
 //
+// generationID is the generation the value was drawn under. It is what every
+// destination receiving the value is stamped with, so an unnamed generation
+// is refused for the same reason an unnamed generator is: the value would be
+// delivered with no provenance, every later apply would read the destination
+// as unknown movement, and the credential would silently rotate on each one.
+//
 // An error means some destination did not receive its value. The caller must
 // fail the draw closed rather than let a destination dispatch its undrawn
 // envelope.
-func (p *ExecutionDAG) propagateDrawnGeneratorValue(generatorKsuid string, value string, mode pkgmodel.FormaApplyMode) error {
+func (p *ExecutionDAG) propagateDrawnGeneratorValue(generatorKsuid string, value string, generationID string, mode pkgmodel.FormaApplyMode) error {
 	if generatorKsuid == "" {
 		return fmt.Errorf("cannot deliver a drawn value: the draw names no generator")
 	}
@@ -901,6 +907,9 @@ func (p *ExecutionDAG) propagateDrawnGeneratorValue(generatorKsuid string, value
 		// string into a destination would hand a provider a blank credential
 		// that nothing downstream would flag.
 		return fmt.Errorf("generator %s reported a successful draw with no value", generatorKsuid)
+	}
+	if generationID == "" {
+		return fmt.Errorf("generator %s reported a successful draw naming no generation", generatorKsuid)
 	}
 
 	for _, node := range p.Nodes {
@@ -911,7 +920,7 @@ func (p *ExecutionDAG) propagateDrawnGeneratorValue(generatorKsuid string, value
 		if ru.Operation == resource_update.OperationDelete || ru.Operation == resource_update.OperationReaped {
 			continue
 		}
-		if err := ru.ResolveGeneratorValue(generatorKsuid, value, mode); err != nil {
+		if err := ru.ResolveGeneratorValue(generatorKsuid, value, generationID, mode); err != nil {
 			// The error names paths and identities only, never the value.
 			return fmt.Errorf("failed to deliver the value drawn for generator %s to %s: %w",
 				generatorKsuid, ru.URI(), err)

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -880,10 +880,22 @@ func (p *ExecutionDAG) propagateResolvedTargetConfig(targetLabel string, pluginC
 // writes nothing, and delivering there would put a live credential into a row
 // on its way out.
 //
+// generatorKsuid is the caller's to guarantee non-empty. It is matched against
+// each occurrence's own $generator, and an AUTHORED (not yet translated)
+// envelope carries none — so an empty ksuid here would match every
+// untranslated envelope in the changeset and deliver the credential into all
+// of them. buildGeneratorResourceEdges already refuses to build a changeset
+// whose draw carries no identity, but that safety property lives in another
+// file and this is the path that writes credentials, so it is restated here
+// where it applies.
+//
 // An error means some destination did not receive its value. The caller must
 // fail the draw closed rather than let a destination dispatch its undrawn
 // envelope.
 func (p *ExecutionDAG) propagateDrawnGeneratorValue(generatorKsuid string, value string, mode pkgmodel.FormaApplyMode) error {
+	if generatorKsuid == "" {
+		return fmt.Errorf("cannot deliver a drawn value: the draw names no generator")
+	}
 	if value == "" {
 		// A success carrying no value cannot be delivered: writing an empty
 		// string into a destination would hand a provider a blank credential

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -314,14 +314,19 @@ func (p *ExecutionDAG) buildTargetResourceEdges(targetUpdates []target_update.Ta
 // from a generator to that generator's draw node, so the op cannot dispatch
 // before the value exists.
 //
-// A destination is wired only when its $gen occurrence did NOT classify
-// OccurrenceStable at planning. A stable occurrence already holds the value the
-// generator's current generation produced; wiring it would deliver a freshly
-// drawn value over a credential nothing asked to rotate. That reading of the
-// provenance records lives in exactly one place —
-// resource_update.IsGenDestinationStable — because the same question decides
-// whether a draw happens, which destinations it writes to, and which
-// destinations a resumed command still owes a value.
+// EVERY live destination is wired, whatever its $gen occurrence classified at
+// planning. Stability decides whether the generator draws at all
+// (resource_update.GeneratorsNeedingDraw); once a draw is in the graph, every
+// destination of it must receive the value, so every destination must also
+// wait for it. Wiring only the unstable ones would let a stable destination
+// dispatch before the draw and keep the old generation while its sibling took
+// the new one, which is how two consumers of one credential end up holding
+// different values.
+//
+// A destination being torn down is skipped, matching the rule that decides
+// whether to draw at all and the one that delivers: a delete's DesiredState is
+// the stored resource, so it carries the stored envelope, writes nothing, and
+// must not pull a fresh credential into a row on its way out.
 //
 // A draw node is a sink: it has no dependencies of its own, so no edge added
 // here can close a cycle. The full-graph re-check still runs over these edges,
@@ -354,11 +359,11 @@ func (p *ExecutionDAG) buildGeneratorResourceEdges(generatorUpdates []generator_
 			if !ok {
 				continue
 			}
+			if ru.Operation == resource_update.OperationDelete || ru.Operation == resource_update.OperationReaped {
+				continue
+			}
 			for _, gen := range pkgmodel.FindGenObjectsFromProperties(ru.DesiredState.Properties) {
 				if gen.Generator != generatorKsuid {
-					continue
-				}
-				if resource_update.IsGenDestinationStable(ru.ProvenanceRecords, gen.Path) {
 					continue
 				}
 				node.LinkWith(generatorNode)
@@ -879,6 +884,16 @@ func (p *ExecutionDAG) propagateResolvedTargetConfig(targetLabel string, pluginC
 // DesiredState is the stored resource, so it carries the stored envelope and
 // writes nothing, and delivering there would put a live credential into a row
 // on its way out.
+//
+// Every other destination receives it, whatever its occurrence classified.
+// The invariant is: once a generator draws, every live destination of it IN
+// THIS CHANGESET holds the same value and is stamped with the same
+// generation. The boundary is the changeset itself. A destination that is not
+// a node here — planned by another command, or suppressed by this one because
+// nothing about it moved — cannot be reached, and cannot be caught up later
+// either, because formae stores only a hash of a generated value and never
+// the value. Such a destination keeps an older generation and diverges from
+// its siblings; closing that needs co-planning, not a wider delivery.
 //
 // generatorKsuid is the caller's to guarantee non-empty. It is matched against
 // each occurrence's own $generator, and an AUTHORED (not yet translated)

--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -855,6 +855,60 @@ func (p *ExecutionDAG) propagateResolvedTargetConfig(targetLabel string, pluginC
 	}
 }
 
+// propagateDrawnGeneratorValue delivers a generator's freshly drawn value to
+// every resource-update node holding a destination bound to it. It is the
+// generator analogue of propagateResolvedTargetConfig, and it is safe for the
+// same reason: the ordering edges buildGeneratorResourceEdges added guarantee
+// no destination has dispatched yet, and startResourceUpdate takes a value
+// copy of the update at dispatch, so writing into the live node here is seen
+// by the dispatch that follows and by nothing that already happened.
+//
+// Delivery goes through ResourceUpdate.ResolveGeneratorValue rather than a
+// raw write for two reasons. The value must land inside the $gen envelope, so
+// the $visibility:"Opaque" marker that makes it hash at rest survives; and
+// mutating DesiredState.Properties invalidates the derived PatchDocument,
+// which must be re-derived under mode — the changeset's own apply mode, the
+// one planning used — or a reconcile-planned removal silently vanishes.
+//
+// mode is a parameter rather than DAG state because the ExecutionDAG does not
+// carry the command's configuration; the Changeset does, and the executor
+// passes changeset.Mode.
+//
+// A destination being torn down is skipped, matching the rule that decides
+// whether to draw at all (resource_update.GeneratorsNeedingDraw): a delete's
+// DesiredState is the stored resource, so it carries the stored envelope and
+// writes nothing, and delivering there would put a live credential into a row
+// on its way out.
+//
+// An error means some destination did not receive its value. The caller must
+// fail the draw closed rather than let a destination dispatch its undrawn
+// envelope.
+func (p *ExecutionDAG) propagateDrawnGeneratorValue(generatorKsuid string, value string, mode pkgmodel.FormaApplyMode) error {
+	if value == "" {
+		// A success carrying no value cannot be delivered: writing an empty
+		// string into a destination would hand a provider a blank credential
+		// that nothing downstream would flag.
+		return fmt.Errorf("generator %s reported a successful draw with no value", generatorKsuid)
+	}
+
+	for _, node := range p.Nodes {
+		ru, ok := node.Update.(*resource_update.ResourceUpdate)
+		if !ok {
+			continue
+		}
+		if ru.Operation == resource_update.OperationDelete || ru.Operation == resource_update.OperationReaped {
+			continue
+		}
+		if err := ru.ResolveGeneratorValue(generatorKsuid, value, mode); err != nil {
+			// The error names paths and identities only, never the value.
+			return fmt.Errorf("failed to deliver the value drawn for generator %s to %s: %w",
+				generatorKsuid, ru.URI(), err)
+		}
+	}
+
+	return nil
+}
+
 // clearTargetIncarnationOnResources drops the target-incarnation expectation
 // from every resource-update node bound to targetLabel. It runs after a reaped
 // target recovers: the recover target update mints a fresh incarnation and

--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -646,7 +646,13 @@ func startUpdates(updates []Update, commandID string, mode pkgmodel.FormaApplyMo
 				return err
 			}
 		default:
-			proc.Log().Error("Unknown update type in startUpdates uri=%v", update.NodeURI())
+			// GetExecutableUpdates has already marked this update in progress,
+			// so dropping it here would leave a node nothing ever finishes and
+			// every dependent blocked behind it — the changeset would never
+			// reach a terminal state. Fail the changeset instead: an update
+			// kind the executor cannot start is a wiring error, and a
+			// diagnosable failure beats a hang.
+			return fmt.Errorf("changeset contains an update this executor cannot start: %s", update.NodeURI())
 		}
 	}
 

--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/constants"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_persister"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
@@ -129,16 +130,19 @@ func (s *ChangesetExecutor) Init(args ...any) (statemachine.StateMachineSpec[Cha
 		statemachine.WithStateCallHandler(StateNotStarted, cancelBeforeStart),
 		statemachine.WithStateMessageHandler(StateProcessing, resourceUpdateFinished),
 		statemachine.WithStateMessageHandler(StateProcessing, targetUpdateFinished),
+		statemachine.WithStateMessageHandler(StateProcessing, generatorUpdateFinished),
 		statemachine.WithStateMessageHandler(StateProcessing, resume),
 		statemachine.WithStateCallHandler(StateProcessing, cancel),
 		statemachine.WithStateCallHandler(StateCanceling, cancelWhileCanceling),
 		statemachine.WithStateMessageHandler(StateCanceling, resourceUpdateFinished),
 		statemachine.WithStateMessageHandler(StateCanceling, targetUpdateFinished),
+		statemachine.WithStateMessageHandler(StateCanceling, generatorUpdateFinished),
 		statemachine.WithStateMessageHandler(StateCanceling, resumeWhileCanceling), // Ignore a late rate-limit Resume timer
 		statemachine.WithStateMessageHandler(StateFinishedWithError, shutdown),
 		statemachine.WithStateMessageHandler(StateFinishedSuccessfully, shutdown),
 		statemachine.WithStateMessageHandler(StateCanceled, resourceUpdateFinished),  // Ignore late messages from ResourceUpdaters
 		statemachine.WithStateMessageHandler(StateCanceled, targetUpdateFinished),    // Ignore late messages from TargetUpdaters
+		statemachine.WithStateMessageHandler(StateCanceled, generatorUpdateFinished), // Ignore late messages from GeneratorUpdaters
 		statemachine.WithStateMessageHandler(StateCanceled, ignoreStartWhenCanceled), // Ignore a Start that lost the race to a cancel-before-start
 		statemachine.WithStateMessageHandler(StateCanceled, shutdown),
 	), nil
@@ -383,8 +387,9 @@ func resumeWhileCanceling(from gen.PID, state gen.Atom, data ChangesetData, mess
 	return StateCanceling, data, nil, nil
 }
 
-// updateFinishedEvent normalizes the incoming completion message from either
-// a ResourceUpdater or TargetUpdater into a common shape for handleUpdateFinished.
+// updateFinishedEvent normalizes the incoming completion message from a
+// ResourceUpdater, TargetUpdater or GeneratorUpdater into a common shape for
+// handleUpdateFinished.
 type updateFinishedEvent struct {
 	nodeURI   pkgmodel.FormaeURI // URI to look up in the DAG
 	isSuccess bool
@@ -483,6 +488,49 @@ func targetUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, mess
 	}, proc)
 }
 
+// generatorUpdateFinished handles a completed draw. On success it delivers the
+// drawn value to every destination bound to the generator before the draw node
+// leaves the DAG and those destinations become schedulable.
+//
+// Nothing is persisted here, unlike the target path: a draw writes no row, and
+// the drawn value must not reach one. GeneratorUpdateFinished is its only
+// carrier, this handler its only reader, and the destinations' in-memory
+// DesiredState its only destination.
+//
+// Delivery failure is routed through handleUpdateFinished's failure branch
+// rather than reported as a success, exactly as the target path does on a
+// conversion error: a destination that never received its value would
+// otherwise dispatch its $gen envelope undrawn, and marking the node failed
+// here instead would make handleUpdateFinished treat it as already-completed
+// and skip the cascade. The error is structural and names identities only;
+// message.DrawnValue is never logged.
+func generatorUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, message generator_update.GeneratorUpdateFinished, proc gen.Process) (gen.Atom, ChangesetData, []statemachine.Action, error) {
+	if message.State == generator_update.GeneratorUpdateStateSuccess {
+		node, exists := data.changeset.DAG.Nodes[message.NodeURI]
+		if exists {
+			if gu, ok := node.Update.(*generator_update.GeneratorUpdate); ok {
+				generatorKsuid := ""
+				if gu.Generator != nil {
+					generatorKsuid = gu.Generator.GetID()
+				}
+				if err := data.changeset.DAG.propagateDrawnGeneratorValue(generatorKsuid, message.DrawnValue, data.changeset.Mode); err != nil {
+					proc.Log().Error("Failed to deliver a drawn generator value, failing its destinations node=%s: %v",
+						message.NodeURI, err)
+					return handleUpdateFinished(from, state, data, updateFinishedEvent{
+						nodeURI:   message.NodeURI,
+						isSuccess: false,
+					}, proc)
+				}
+			}
+		}
+	}
+
+	return handleUpdateFinished(from, state, data, updateFinishedEvent{
+		nodeURI:   message.NodeURI,
+		isSuccess: message.State == generator_update.GeneratorUpdateStateSuccess,
+	}, proc)
+}
+
 // findRunningUpdate searches the DAG for a running update matching messageURI and returns
 // it cast to T, or nil if not found.
 func findRunningUpdate[T Update](data ChangesetData, messageURI pkgmodel.FormaeURI) T {
@@ -555,6 +603,8 @@ func handleUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, even
 			u.State = resource_update.ResourceUpdateStateSuccess
 		case *target_update.TargetUpdate:
 			u.State = target_update.TargetUpdateStateSuccess
+		case *generator_update.GeneratorUpdate:
+			u.State = generator_update.GeneratorUpdateStateSuccess
 		}
 	} else {
 		node.Update.MarkFailed()
@@ -594,6 +644,18 @@ func handleUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, even
 					Label:     u.Target.Label,
 					Operation: u.Operation,
 				})
+			case *generator_update.GeneratorUpdate:
+				// A draw has no row and no entry in the command record, so
+				// there is nothing to persist and the log line is the whole
+				// record. No edge points AT a draw today — every generator
+				// edge runs destination -> draw (buildGeneratorResourceEdges),
+				// which makes a draw a source and puts it out of reach of the
+				// cascade — so this arm does not fire. It exists because the
+				// alternative is the default: silently dropped, with the
+				// nothing-was-recorded outcome indistinguishable from success
+				// the day a draw does gain an upstream.
+				proc.Log().Warning("Generator draw marked as failed due to cascade node=%s originalFailure=%v",
+					u.NodeURI(), event.nodeURI)
 			}
 		}
 		if len(failedResources) > 0 {
@@ -643,6 +705,10 @@ func startUpdates(updates []Update, commandID string, mode pkgmodel.FormaApplyMo
 			}
 		case *target_update.TargetUpdate:
 			if err := startTargetUpdate(u, commandID, proc); err != nil {
+				return err
+			}
+		case *generator_update.GeneratorUpdate:
+			if err := startGeneratorUpdate(u, commandID, proc); err != nil {
 				return err
 			}
 		default:
@@ -719,6 +785,43 @@ func startTargetUpdate(tu *target_update.TargetUpdate, commandID string, proc ge
 		})
 	if err != nil {
 		proc.Log().Error("Failed to send start message to target updater: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+// startGeneratorUpdate spawns a GeneratorUpdater and hands it the draw.
+//
+// The actor is named by the draw's node URI rather than the generator's label:
+// a label is unique only within its stack, and one command may draw for the
+// same label in two stacks (see actornames.GeneratorUpdater).
+//
+// No apply mode is passed, unlike startResourceUpdate: a draw calls no
+// provider and derives no patch, so nothing about it depends on the mode. The
+// mode matters where the drawn value LANDS, which is the destination's patch
+// regeneration in propagateDrawnGeneratorValue.
+func startGeneratorUpdate(gu *generator_update.GeneratorUpdate, commandID string, proc gen.Process) error {
+	proc.Log().Debug("Starting generator updater node=%s", gu.NodeURI())
+
+	// Spawn the GeneratorUpdater as a direct child of this ChangesetExecutor
+	// with LinkParent, for the same reason the other two updaters are: when
+	// the executor terminates the child receives an exit signal and terminates
+	// too, and the link is unidirectional so a crashing updater does not kill
+	// the executor.
+	name := actornames.GeneratorUpdater(gu.NodeURI(), commandID)
+	_, err := proc.SpawnRegister(name, generator_update.NewGeneratorUpdater, gen.ProcessOptions{LinkParent: true}, proc.PID())
+	if err != nil && err != gen.ErrTaken {
+		proc.Log().Error("Failed to spawn generator updater: %v", err)
+		return err
+	}
+
+	err = proc.Send(gen.ProcessID{Name: name, Node: proc.Node().Name()},
+		generator_update.StartGeneratorUpdate{
+			GeneratorUpdate: *gu,
+		})
+	if err != nil {
+		proc.Log().Error("Failed to send start message to generator updater: %v", err)
 		return err
 	}
 

--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -513,7 +513,7 @@ func generatorUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, m
 				if gu.Generator != nil {
 					generatorKsuid = gu.Generator.GetID()
 				}
-				if err := data.changeset.DAG.propagateDrawnGeneratorValue(generatorKsuid, message.DrawnValue, data.changeset.Mode); err != nil {
+				if err := data.changeset.DAG.propagateDrawnGeneratorValue(generatorKsuid, message.DrawnValue, message.GenerationID, data.changeset.Mode); err != nil {
 					proc.Log().Error("Failed to deliver a drawn generator value, failing its destinations node=%s: %v",
 						message.NodeURI, err)
 					return handleUpdateFinished(from, state, data, updateFinishedEvent{

--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -644,18 +644,6 @@ func handleUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, even
 					Label:     u.Target.Label,
 					Operation: u.Operation,
 				})
-			case *generator_update.GeneratorUpdate:
-				// A draw has no row and no entry in the command record, so
-				// there is nothing to persist and the log line is the whole
-				// record. No edge points AT a draw today — every generator
-				// edge runs destination -> draw (buildGeneratorResourceEdges),
-				// which makes a draw a source and puts it out of reach of the
-				// cascade — so this arm does not fire. It exists because the
-				// alternative is the default: silently dropped, with the
-				// nothing-was-recorded outcome indistinguishable from success
-				// the day a draw does gain an upstream.
-				proc.Log().Warning("Generator draw marked as failed due to cascade node=%s originalFailure=%v",
-					u.NodeURI(), event.nodeURI)
 			}
 		}
 		if len(failedResources) > 0 {

--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -393,6 +393,11 @@ func resumeWhileCanceling(from gen.PID, state gen.Atom, data ChangesetData, mess
 type updateFinishedEvent struct {
 	nodeURI   pkgmodel.FormaeURI // URI to look up in the DAG
 	isSuccess bool
+	// failureReason is the operator-facing explanation the finished update
+	// reported, carried so the cascade can stamp it on the resource updates it
+	// fails. Those never run, so they have no plugin progress of their own to
+	// explain them. Empty on success and on failures that carry no reason.
+	failureReason string
 }
 
 func resourceUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, message resource_update.ResourceUpdateFinished, proc gen.Process) (gen.Atom, ChangesetData, []statemachine.Action, error) {
@@ -504,6 +509,10 @@ func targetUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, mess
 // here instead would make handleUpdateFinished treat it as already-completed
 // and skip the cascade. The error is structural and names identities only;
 // message.DrawnValue is never logged.
+//
+// On failure the draw's reason travels with the event, so the destinations the
+// cascade fails carry it. They never ran and have no plugin progress of their
+// own, so without it the apply reports them failed and says nothing about why.
 func generatorUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, message generator_update.GeneratorUpdateFinished, proc gen.Process) (gen.Atom, ChangesetData, []statemachine.Action, error) {
 	if message.State == generator_update.GeneratorUpdateStateSuccess {
 		node, exists := data.changeset.DAG.Nodes[message.NodeURI]
@@ -526,8 +535,9 @@ func generatorUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, m
 	}
 
 	return handleUpdateFinished(from, state, data, updateFinishedEvent{
-		nodeURI:   message.NodeURI,
-		isSuccess: message.State == generator_update.GeneratorUpdateStateSuccess,
+		nodeURI:       message.NodeURI,
+		isSuccess:     message.State == generator_update.GeneratorUpdateStateSuccess,
+		failureReason: message.ErrorMessage,
 	}, proc)
 }
 
@@ -658,6 +668,7 @@ func handleUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, even
 				CommandID:          data.changeset.CommandID,
 				Resources:          failedResources,
 				ResourceModifiedTs: now,
+				FailureReason:      event.failureReason,
 			})
 			if err != nil {
 				proc.Log().Error("Failed to mark resources as failed in persister commandID=%s: %v", data.changeset.CommandID, err)

--- a/internal/metastructure/changeset/changeset_test.go
+++ b/internal/metastructure/changeset/changeset_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
@@ -23,6 +24,9 @@ var _ Update = (*resource_update.ResourceUpdate)(nil)
 
 // Compile-time verification that TargetUpdate satisfies the Update interface
 var _ Update = (*target_update.TargetUpdate)(nil)
+
+// Compile-time verification that GeneratorUpdate satisfies the Update interface
+var _ Update = (*generator_update.GeneratorUpdate)(nil)
 
 // asResourceUpdate is a test helper that type-asserts an Update to *resource_update.ResourceUpdate
 func asResourceUpdate(t *testing.T, u Update) *resource_update.ResourceUpdate {

--- a/internal/metastructure/changeset/generator_edges_test.go
+++ b/internal/metastructure/changeset/generator_edges_test.go
@@ -205,14 +205,11 @@ func TestCycleIsStillDetectedWithGeneratorNodesPresent(t *testing.T) {
 	require.Error(t, err, "mutually referencing in-command targets form a cycle and must be rejected, not hang")
 }
 
-// stubGeneratorSpecs answers GetGenerator from a (label, stack) keyed map.
-// Its generators carry no ID, exactly as a datastore load does.
-type stubGeneratorSpecs struct {
-	byKey map[pkgmodel.GeneratorKey]pkgmodel.Generator
-}
-
-func (s *stubGeneratorSpecs) GetGenerator(label, stackLabel string) (pkgmodel.Generator, error) {
-	return s.byKey[pkgmodel.GeneratorKey{Label: label, Stack: stackLabel}], nil
+// stubGeneratorLookup answers the draw synthesis's generator lookup from a
+// KSUID keyed map. Its generators carry no ID, exactly as a datastore load
+// does.
+func stubGeneratorLookup(byKsuid map[string]pkgmodel.Generator) func(string) (pkgmodel.Generator, error) {
+	return func(ksuid string) (pkgmodel.Generator, error) { return byKsuid[ksuid], nil }
 }
 
 // A resource newly bound to a generator whose own spec is untouched must
@@ -239,12 +236,11 @@ func TestSecondConsumerOnAnUnchangedGeneratorIsWiredToADraw(t *testing.T) {
 	draws, err := generator_update.SynthesizeDrawGeneratorUpdates(
 		resourceUpdates,
 		nil, // the generator's spec is unchanged: no GeneratorUpdate exists
-		map[pkgmodel.GeneratorKey]string{{Label: "db-password", Stack: "default"}: generatorKsuid},
-		&stubGeneratorSpecs{byKey: map[pkgmodel.GeneratorKey]pkgmodel.Generator{
-			{Label: "db-password", Stack: "default"}: &pkgmodel.PasswordGenerator{
+		stubGeneratorLookup(map[string]pkgmodel.Generator{
+			generatorKsuid: &pkgmodel.PasswordGenerator{
 				Label: "db-password", Stack: "default", Length: 24,
 			},
-		}},
+		}),
 	)
 	require.NoError(t, err)
 	require.Len(t, draws, 1)

--- a/internal/metastructure/changeset/generator_edges_test.go
+++ b/internal/metastructure/changeset/generator_edges_test.go
@@ -92,11 +92,17 @@ func TestGeneratorDrawGetsANodeAndTheConsumerDependsOnIt(t *testing.T) {
 	assert.Equal(t, consumer.URI, drawNode.Dependents[0].URI)
 }
 
-// A destination whose occurrence classified stable already holds the value
-// the generator's current generation produced. It must not be wired to the
-// draw: an edge would deliver a freshly drawn value over a credential that
-// nothing asked to rotate.
-func TestStableDestinationIsNotWiredToTheDraw(t *testing.T) {
+// Once a draw is in the graph, every live destination of that generator waits
+// for it, including one whose occurrence classified stable. Stability decides
+// whether the generator draws at all, not who the draw reaches: a stable
+// destination that dispatched before the draw would keep the old generation
+// while its sibling took the new one, and the two consumers of one credential
+// would hold different values.
+//
+// A destination being torn down is the exception. Its DesiredState is the
+// stored resource, it writes nothing, and an edge would only pull a fresh
+// credential into a row on its way out.
+func TestEveryLiveDestinationIsWiredToTheDraw(t *testing.T) {
 	generatorKsuid := util.NewID()
 
 	stable := genBoundSecret("stable-secret", generatorKsuid)
@@ -110,24 +116,30 @@ func TestStableDestinationIsNotWiredToTheDraw(t *testing.T) {
 	}}
 
 	fresh := genBoundSecret("fresh-secret", generatorKsuid)
+
+	torndown := genBoundSecret("torndown-secret", generatorKsuid)
+	torndown.Operation = resource_update.OperationDelete
+
 	draw := drawOp("db-password", generatorKsuid)
 
 	cs, err := NewChangeset(
-		[]resource_update.ResourceUpdate{stable, fresh},
+		[]resource_update.ResourceUpdate{stable, fresh, torndown},
 		nil,
 		[]generator_update.GeneratorUpdate{draw},
 		"cmd-stable", pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
 
-	assert.False(t, dependsOn(resourceNode(t, cs, stable), draw.NodeURI()),
-		"a stable destination must not be wired to the draw")
+	assert.True(t, dependsOn(resourceNode(t, cs, stable), draw.NodeURI()),
+		"a stable destination must still wait for the draw it is going to receive")
 	assert.True(t, dependsOn(resourceNode(t, cs, fresh), draw.NodeURI()),
 		"a destination that still needs a value must be wired to the draw")
+	assert.False(t, dependsOn(resourceNode(t, cs, torndown), draw.NodeURI()),
+		"a destination being torn down receives nothing and waits for nothing")
 
 	drawNode := cs.DAG.Nodes[draw.NodeURI()]
 	require.NotNil(t, drawNode)
-	assert.Len(t, drawNode.Dependents, 1, "only the destination that needs a value depends on the draw")
+	assert.Len(t, drawNode.Dependents, 2, "every live destination depends on the draw")
 }
 
 // Two generators are two independent producers: each consumer waits only for
@@ -217,6 +229,11 @@ func stubGeneratorLookup(byKsuid map[string]pkgmodel.Generator) func(string) (pk
 // the generator diff would put it in the graph; the destination is what puts
 // it there, and without the edge the new consumer would dispatch its $gen
 // envelope undrawn.
+//
+// The consumer that was already applied is wired too. It is what makes the
+// draw reach both of them, so the two end up holding the same credential
+// rather than the new one taking the new generation and the old one keeping
+// the previous.
 func TestSecondConsumerOnAnUnchangedGeneratorIsWiredToADraw(t *testing.T) {
 	generatorKsuid := util.NewID()
 
@@ -253,8 +270,8 @@ func TestSecondConsumerOnAnUnchangedGeneratorIsWiredToADraw(t *testing.T) {
 	require.NotNil(t, drawNode, "an unchanged generator with a new consumer must still get a node")
 	assert.True(t, dependsOn(resourceNode(t, cs, newConsumer), draws[0].NodeURI()),
 		"the newly bound consumer must wait for the draw")
-	assert.False(t, dependsOn(resourceNode(t, cs, appliedConsumer), draws[0].NodeURI()),
-		"the already-applied consumer must keep the value it holds")
+	assert.True(t, dependsOn(resourceNode(t, cs, appliedConsumer), draws[0].NodeURI()),
+		"the already-applied consumer must move to the same generation as the new one")
 }
 
 // A draw carrying no generator identity cannot be matched to the

--- a/internal/metastructure/changeset/generator_edges_test.go
+++ b/internal/metastructure/changeset/generator_edges_test.go
@@ -1,0 +1,281 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package changeset
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func genBoundProperties(generatorKsuid string) json.RawMessage {
+	return json.RawMessage(`{"password":{"$gen":true,"$generator":"` + generatorKsuid +
+		`","$output":"value","$visibility":"Opaque"}}`)
+}
+
+// genBoundSecret builds a create op for a resource whose "password" property
+// is bound to generatorKsuid.
+func genBoundSecret(label, generatorKsuid string) resource_update.ResourceUpdate {
+	return resource_update.ResourceUpdate{
+		DesiredState: pkgmodel.Resource{
+			Label:      label,
+			Type:       "AWS::SecretsManager::Secret",
+			Stack:      "default",
+			Ksuid:      util.NewID(),
+			Target:     "aws",
+			Properties: genBoundProperties(generatorKsuid),
+		},
+		Operation:  resource_update.OperationCreate,
+		State:      resource_update.ResourceUpdateStateNotStarted,
+		StackLabel: "default",
+	}
+}
+
+func drawOp(label, generatorKsuid string) generator_update.GeneratorUpdate {
+	return generator_update.NewDrawGeneratorUpdate(
+		&pkgmodel.PasswordGenerator{Label: label, Stack: "default", Length: 24, ID: generatorKsuid},
+		"default",
+	)
+}
+
+func resourceNode(t *testing.T, cs Changeset, ru resource_update.ResourceUpdate) *DAGNode {
+	t.Helper()
+	node := cs.DAG.Nodes[createOperationURI(ru.URI(), ru.Operation)]
+	require.NotNil(t, node, "no DAG node for resource %s", ru.DesiredState.Label)
+	return node
+}
+
+func dependsOn(node *DAGNode, uri pkgmodel.FormaeURI) bool {
+	for _, dep := range node.Dependencies {
+		if dep.URI == uri {
+			return true
+		}
+	}
+	return false
+}
+
+// A generator whose value a destination still needs gets its own node, and
+// the resource op holding that destination waits for it.
+func TestGeneratorDrawGetsANodeAndTheConsumerDependsOnIt(t *testing.T) {
+	generatorKsuid := util.NewID()
+	secret := genBoundSecret("app-secret", generatorKsuid)
+	draw := drawOp("db-password", generatorKsuid)
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{secret},
+		nil,
+		[]generator_update.GeneratorUpdate{draw},
+		"cmd-draw", pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+
+	drawNode := cs.DAG.Nodes[draw.NodeURI()]
+	require.NotNil(t, drawNode, "the generator draw must be a DAG node")
+
+	consumer := resourceNode(t, cs, secret)
+	assert.True(t, dependsOn(consumer, draw.NodeURI()),
+		"the consumer must wait for the draw that produces its value")
+	assert.Len(t, drawNode.Dependencies, 0, "a draw waits for nothing")
+	require.Len(t, drawNode.Dependents, 1)
+	assert.Equal(t, consumer.URI, drawNode.Dependents[0].URI)
+}
+
+// A destination whose occurrence classified stable already holds the value
+// the generator's current generation produced. It must not be wired to the
+// draw: an edge would deliver a freshly drawn value over a credential that
+// nothing asked to rotate.
+func TestStableDestinationIsNotWiredToTheDraw(t *testing.T) {
+	generatorKsuid := util.NewID()
+
+	stable := genBoundSecret("stable-secret", generatorKsuid)
+	stable.Operation = resource_update.OperationUpdate
+	stable.ProvenanceRecords = []resource_update.OccurrenceRecord{{
+		DestinationPath: "password",
+		DesiredIdentity: resource_update.OccurrenceIdentity{
+			Kind: resource_update.OccurrenceKindGenerator, Ksuid: generatorKsuid, PropertyPath: "value",
+		},
+		Class: resource_update.OccurrenceStable,
+	}}
+
+	fresh := genBoundSecret("fresh-secret", generatorKsuid)
+	draw := drawOp("db-password", generatorKsuid)
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{stable, fresh},
+		nil,
+		[]generator_update.GeneratorUpdate{draw},
+		"cmd-stable", pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+
+	assert.False(t, dependsOn(resourceNode(t, cs, stable), draw.NodeURI()),
+		"a stable destination must not be wired to the draw")
+	assert.True(t, dependsOn(resourceNode(t, cs, fresh), draw.NodeURI()),
+		"a destination that still needs a value must be wired to the draw")
+
+	drawNode := cs.DAG.Nodes[draw.NodeURI()]
+	require.NotNil(t, drawNode)
+	assert.Len(t, drawNode.Dependents, 1, "only the destination that needs a value depends on the draw")
+}
+
+// Two generators are two independent producers: each consumer waits only for
+// the generator its own destination names.
+func TestTwoGeneratorsProduceIndependentSubgraphs(t *testing.T) {
+	firstKsuid := util.NewID()
+	secondKsuid := util.NewID()
+
+	firstConsumer := genBoundSecret("db-secret", firstKsuid)
+	secondConsumer := genBoundSecret("api-secret", secondKsuid)
+	firstDraw := drawOp("db-password", firstKsuid)
+	secondDraw := drawOp("api-key", secondKsuid)
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{firstConsumer, secondConsumer},
+		nil,
+		[]generator_update.GeneratorUpdate{firstDraw, secondDraw},
+		"cmd-two", pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, cs.DAG.Nodes[firstDraw.NodeURI()])
+	require.NotNil(t, cs.DAG.Nodes[secondDraw.NodeURI()])
+
+	first := resourceNode(t, cs, firstConsumer)
+	second := resourceNode(t, cs, secondConsumer)
+
+	assert.True(t, dependsOn(first, firstDraw.NodeURI()))
+	assert.False(t, dependsOn(first, secondDraw.NodeURI()))
+	assert.True(t, dependsOn(second, secondDraw.NodeURI()))
+	assert.False(t, dependsOn(second, firstDraw.NodeURI()))
+}
+
+// The full-graph cycle re-check runs after the generator edges are in place,
+// so a cycle formed by target-resolvable edges is still rejected rather than
+// hanging the executor.
+func TestCycleIsStillDetectedWithGeneratorNodesPresent(t *testing.T) {
+	const (
+		targetA = "target-a"
+		targetB = "target-b"
+	)
+	resOnA := pkgmodel.NewFormaeURI(util.NewID(), "SecretString")
+	resOnB := pkgmodel.NewFormaeURI(util.NewID(), "SecretString")
+
+	generatorKsuid := util.NewID()
+	secretOnA := genBoundSecret("secret-on-a", generatorKsuid)
+	secretOnA.DesiredState.Ksuid = resOnA.KSUID()
+	secretOnA.DesiredState.Target = targetA
+
+	secretOnB := genBoundSecret("secret-on-b", generatorKsuid)
+	secretOnB.DesiredState.Ksuid = resOnB.KSUID()
+	secretOnB.DesiredState.Target = targetB
+
+	targetUpdates := []target_update.TargetUpdate{
+		{
+			Target:               pkgmodel.Target{Label: targetA, Namespace: "AWS", Config: opaqueRefConfig(string(resOnB))},
+			Operation:            target_update.TargetOperationCreate,
+			State:                target_update.TargetUpdateStateNotStarted,
+			RemainingResolvables: []pkgmodel.FormaeURI{resOnB},
+		},
+		{
+			Target:               pkgmodel.Target{Label: targetB, Namespace: "AWS", Config: opaqueRefConfig(string(resOnA))},
+			Operation:            target_update.TargetOperationCreate,
+			State:                target_update.TargetUpdateStateNotStarted,
+			RemainingResolvables: []pkgmodel.FormaeURI{resOnA},
+		},
+	}
+
+	_, err := NewChangeset(
+		[]resource_update.ResourceUpdate{secretOnA, secretOnB},
+		targetUpdates,
+		[]generator_update.GeneratorUpdate{drawOp("db-password", generatorKsuid)},
+		"cmd-cycle", pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+	)
+	require.Error(t, err, "mutually referencing in-command targets form a cycle and must be rejected, not hang")
+}
+
+// stubGeneratorSpecs answers GetGenerator from a (label, stack) keyed map.
+// Its generators carry no ID, exactly as a datastore load does.
+type stubGeneratorSpecs struct {
+	byKey map[pkgmodel.GeneratorKey]pkgmodel.Generator
+}
+
+func (s *stubGeneratorSpecs) GetGenerator(label, stackLabel string) (pkgmodel.Generator, error) {
+	return s.byKey[pkgmodel.GeneratorKey{Label: label, Stack: stackLabel}], nil
+}
+
+// A resource newly bound to a generator whose own spec is untouched must
+// still reach a draw. The generator produces no row update, so nothing about
+// the generator diff would put it in the graph; the destination is what puts
+// it there, and without the edge the new consumer would dispatch its $gen
+// envelope undrawn.
+func TestSecondConsumerOnAnUnchangedGeneratorIsWiredToADraw(t *testing.T) {
+	generatorKsuid := util.NewID()
+
+	appliedConsumer := genBoundSecret("app-secret", generatorKsuid)
+	appliedConsumer.Operation = resource_update.OperationUpdate
+	appliedConsumer.ProvenanceRecords = []resource_update.OccurrenceRecord{{
+		DestinationPath: "password",
+		DesiredIdentity: resource_update.OccurrenceIdentity{
+			Kind: resource_update.OccurrenceKindGenerator, Ksuid: generatorKsuid, PropertyPath: "value",
+		},
+		Class: resource_update.OccurrenceStable,
+	}}
+
+	newConsumer := genBoundSecret("worker-secret", generatorKsuid)
+	resourceUpdates := []resource_update.ResourceUpdate{appliedConsumer, newConsumer}
+
+	draws, err := generator_update.SynthesizeDrawGeneratorUpdates(
+		resourceUpdates,
+		nil, // the generator's spec is unchanged: no GeneratorUpdate exists
+		map[pkgmodel.GeneratorKey]string{{Label: "db-password", Stack: "default"}: generatorKsuid},
+		&stubGeneratorSpecs{byKey: map[pkgmodel.GeneratorKey]pkgmodel.Generator{
+			{Label: "db-password", Stack: "default"}: &pkgmodel.PasswordGenerator{
+				Label: "db-password", Stack: "default", Length: 24,
+			},
+		}},
+	)
+	require.NoError(t, err)
+	require.Len(t, draws, 1)
+
+	cs, err := NewChangeset(resourceUpdates, nil, draws, "cmd-second-consumer",
+		pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+
+	drawNode := cs.DAG.Nodes[draws[0].NodeURI()]
+	require.NotNil(t, drawNode, "an unchanged generator with a new consumer must still get a node")
+	assert.True(t, dependsOn(resourceNode(t, cs, newConsumer), draws[0].NodeURI()),
+		"the newly bound consumer must wait for the draw")
+	assert.False(t, dependsOn(resourceNode(t, cs, appliedConsumer), draws[0].NodeURI()),
+		"the already-applied consumer must keep the value it holds")
+}
+
+// A draw carrying no generator identity cannot be matched to the
+// destinations that need its value, which would leave them dispatching an
+// undrawn envelope. It is rejected at build time instead.
+func TestDrawWithoutGeneratorIdentityIsRejected(t *testing.T) {
+	generatorKsuid := util.NewID()
+	anonymous := generator_update.NewDrawGeneratorUpdate(
+		&pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24},
+		"default",
+	)
+
+	_, err := NewChangeset(
+		[]resource_update.ResourceUpdate{genBoundSecret("app-secret", generatorKsuid)},
+		nil,
+		[]generator_update.GeneratorUpdate{anonymous},
+		"cmd-anonymous", pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+	)
+	require.Error(t, err)
+}

--- a/internal/metastructure/changeset/generator_propagation_test.go
+++ b/internal/metastructure/changeset/generator_propagation_test.go
@@ -1,0 +1,404 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package changeset
+
+import (
+	"encoding/json"
+	"testing"
+
+	"ergo.services/ergo/gen"
+	"ergo.services/ergo/testing/unit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_persister"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// changesetWithOneDraw builds a changeset holding a single draw and a single
+// create bound to it, with the draw already dispatched (in progress) so the
+// executor's finished handler treats the completion as valid.
+func changesetWithOneDraw(t *testing.T, commandID string, mode pkgmodel.FormaApplyMode) (Changeset, generator_update.GeneratorUpdate, resource_update.ResourceUpdate) {
+	t.Helper()
+
+	generatorKsuid := util.NewID()
+	secret := genBoundSecret("app-secret", generatorKsuid)
+	draw := drawOp("db-password", generatorKsuid)
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{secret}, nil,
+		[]generator_update.GeneratorUpdate{draw},
+		commandID, pkgmodel.CommandApply, mode,
+	)
+	require.NoError(t, err)
+
+	drawNode := cs.DAG.Nodes[draw.NodeURI()]
+	require.NotNil(t, drawNode)
+	drawNode.Update.MarkInProgress()
+
+	return cs, draw, secret
+}
+
+// testExecutorProcess returns a ChangesetExecutor TestActor and its process,
+// for calling the executor's handlers as plain functions.
+func testExecutorProcess(t *testing.T) (*unit.TestActor, gen.Process) {
+	t.Helper()
+	actor, err := unit.Spawn(t, NewChangesetExecutor, unit.WithArgs(gen.PID{}), unit.WithLogLevel(gen.LogLevelError))
+	require.NoError(t, err)
+	return actor, actor.Process()
+}
+
+// The drawn value reaches its destination inside the $gen envelope. The
+// envelope is what carries $visibility:"Opaque", and that marker is the only
+// reason the persist path hashes the value at rest, so a bare scalar in the
+// envelope's place would put a live credential in cleartext into the stored
+// properties.
+func TestGeneratorDrawFinished_DeliversTheValueInsideTheEnvelope(t *testing.T) {
+	cs, draw, secret := changesetWithOneDraw(t, "cmd-draw-delivers", pkgmodel.FormaApplyModeReconcile)
+	actor, proc := testExecutorProcess(t)
+	_ = actor
+
+	// Pre-track the destination so the resume() that follows does not reach
+	// for the RateLimiter actor, which does not exist in a unit test.
+	opURI := createOperationURI(secret.URI(), secret.Operation)
+	cs.trackedUpdates[string(opURI)] = true
+
+	data := ChangesetData{changeset: cs}
+	_, updated, _, _ := generatorUpdateFinished(gen.PID{}, StateProcessing, data,
+		generator_update.GeneratorUpdateFinished{
+			NodeURI:    draw.NodeURI(),
+			State:      generator_update.GeneratorUpdateStateSuccess,
+			DrawnValue: "drawn-credential",
+		}, proc)
+
+	node := updated.changeset.DAG.Nodes[opURI]
+	require.NotNil(t, node, "the destination must still be schedulable after a successful draw")
+	ru := node.Update.(*resource_update.ResourceUpdate)
+
+	envelope := gjson.GetBytes(ru.DesiredState.Properties, "password")
+	require.True(t, envelope.IsObject(), "the value must land inside the envelope, not replace it")
+	assert.Equal(t, "drawn-credential", envelope.Get("$value").String())
+	assert.Equal(t, "Opaque", envelope.Get("$visibility").String())
+}
+
+// A successful draw must be recorded as a success on the update itself, or
+// UpdateDAG reads it as an unexpected state, treats it as a failure, and
+// cascades every destination waiting on it.
+func TestGeneratorDrawFinished_MarksTheDrawSucceededAndReleasesItsDestination(t *testing.T) {
+	cs, draw, secret := changesetWithOneDraw(t, "cmd-draw-success", pkgmodel.FormaApplyModeReconcile)
+	actor, proc := testExecutorProcess(t)
+	_ = actor
+
+	opURI := createOperationURI(secret.URI(), secret.Operation)
+	cs.trackedUpdates[string(opURI)] = true
+
+	drawUpdate := cs.DAG.Nodes[draw.NodeURI()].Update
+
+	data := ChangesetData{changeset: cs}
+	_, updated, _, _ := generatorUpdateFinished(gen.PID{}, StateProcessing, data,
+		generator_update.GeneratorUpdateFinished{
+			NodeURI:    draw.NodeURI(),
+			State:      generator_update.GeneratorUpdateStateSuccess,
+			DrawnValue: "drawn-credential",
+		}, proc)
+
+	assert.True(t, drawUpdate.IsSuccess(), "a completed draw must be recorded as a success")
+	assert.Nil(t, updated.changeset.DAG.Nodes[draw.NodeURI()], "a succeeded draw leaves the DAG")
+
+	node := updated.changeset.DAG.Nodes[opURI]
+	require.NotNil(t, node, "the destination must survive a successful draw")
+	assert.False(t, node.Update.IsFailed(), "a successful draw must not fail its destination")
+	assert.Empty(t, node.Dependencies, "the destination is released once the draw completes")
+}
+
+// A draw that fails must not leave its destinations hanging: they cascade to
+// failed and that cascade is persisted, so the command reports what happened
+// rather than sitting in progress forever.
+func TestGeneratorDrawFailed_CascadesToItsDestinationAndPersistsTheFailure(t *testing.T) {
+	cs, draw, secret := changesetWithOneDraw(t, "cmd-draw-failure", pkgmodel.FormaApplyModeReconcile)
+	actor, proc := testExecutorProcess(t)
+
+	opURI := createOperationURI(secret.URI(), secret.Operation)
+	node := cs.DAG.Nodes[opURI]
+	require.NotNil(t, node)
+	ru := node.Update.(*resource_update.ResourceUpdate)
+
+	data := ChangesetData{changeset: cs}
+	_, updated, _, _ := generatorUpdateFinished(gen.PID{}, StateProcessing, data,
+		generator_update.GeneratorUpdateFinished{
+			NodeURI:      draw.NodeURI(),
+			State:        generator_update.GeneratorUpdateStateFailed,
+			ErrorMessage: "cannot draw a value for this generator",
+		}, proc)
+
+	assert.True(t, ru.IsFailed(), "a destination whose draw failed must fail rather than dispatch undrawn")
+	assert.Nil(t, updated.changeset.DAG.Nodes[opURI], "the failed destination leaves the DAG")
+	assert.False(t, gjson.GetBytes(ru.DesiredState.Properties, "password.$value").Exists(),
+		"a failed draw writes no value anywhere")
+
+	var marked []forma_persister.ResourceUpdateRef
+	for _, event := range actor.Events() {
+		callEvent, ok := event.(unit.CallEvent)
+		if !ok {
+			continue
+		}
+		if failed, ok := callEvent.Request.(forma_persister.MarkResourcesAsFailed); ok {
+			marked = append(marked, failed.Resources...)
+		}
+	}
+	require.Len(t, marked, 1, "the cascaded destination must be recorded as failed")
+	assert.Equal(t, secret.URI(), marked[0].URI)
+}
+
+// If the drawn value cannot be delivered, the draw is treated as a failure so
+// the cascade runs: a destination that never received its value must not go
+// on to dispatch its undrawn envelope.
+func TestGeneratorDrawFinished_UndeliverableValueFailsClosed(t *testing.T) {
+	cs, draw, secret := changesetWithOneDraw(t, "cmd-draw-undeliverable", pkgmodel.FormaApplyModeReconcile)
+	actor, proc := testExecutorProcess(t)
+	_ = actor
+
+	// Break the destination's envelope after planning, so delivery cannot
+	// find a generator reference to write into.
+	opURI := createOperationURI(secret.URI(), secret.Operation)
+	node := cs.DAG.Nodes[opURI]
+	require.NotNil(t, node)
+	ru := node.Update.(*resource_update.ResourceUpdate)
+
+	data := ChangesetData{changeset: cs}
+	_, updated, _, _ := generatorUpdateFinished(gen.PID{}, StateProcessing, data,
+		generator_update.GeneratorUpdateFinished{
+			NodeURI:    draw.NodeURI(),
+			State:      generator_update.GeneratorUpdateStateSuccess,
+			DrawnValue: "", // a success carrying no value is undeliverable
+		}, proc)
+
+	assert.True(t, ru.IsFailed(), "an undeliverable draw must fail its destinations closed")
+	assert.Nil(t, updated.changeset.DAG.Nodes[opURI])
+	assert.False(t, gjson.GetBytes(ru.DesiredState.Properties, "password.$value").Exists(),
+		"nothing is written when delivery is refused")
+}
+
+// A destination being torn down never receives a drawn value: a delete
+// carries the stored envelope and writes nothing, so delivering there would
+// put a live credential into a row about to be removed.
+func TestPropagateDrawnGeneratorValue_SkipsATeardownDestination(t *testing.T) {
+	generatorKsuid := util.NewID()
+
+	teardown := genBoundSecret("dying-secret", generatorKsuid)
+	teardown.Operation = resource_update.OperationDelete
+	teardown.PriorState = teardown.DesiredState
+
+	survivor := genBoundSecret("live-secret", generatorKsuid)
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{teardown, survivor}, nil,
+		[]generator_update.GeneratorUpdate{drawOp("db-password", generatorKsuid)},
+		"cmd-teardown", pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(generatorKsuid, "drawn-credential", pkgmodel.FormaApplyModeReconcile))
+
+	dying := cs.DAG.Nodes[createOperationURI(teardown.URI(), resource_update.OperationDelete)].Update.(*resource_update.ResourceUpdate)
+	assert.False(t, gjson.GetBytes(dying.DesiredState.Properties, "password.$value").Exists(),
+		"a destination being torn down must never receive a drawn value")
+
+	live := cs.DAG.Nodes[createOperationURI(survivor.URI(), resource_update.OperationCreate)].Update.(*resource_update.ResourceUpdate)
+	assert.Equal(t, "drawn-credential", gjson.GetBytes(live.DesiredState.Properties, "password.$value").String())
+}
+
+// The value is delivered only to destinations naming the generator that drew.
+func TestPropagateDrawnGeneratorValue_LeavesAnotherGeneratorsDestinationAlone(t *testing.T) {
+	firstKsuid := util.NewID()
+	secondKsuid := util.NewID()
+
+	first := genBoundSecret("db-secret", firstKsuid)
+	second := genBoundSecret("api-secret", secondKsuid)
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{first, second}, nil,
+		[]generator_update.GeneratorUpdate{drawOp("db-password", firstKsuid), drawOp("api-key", secondKsuid)},
+		"cmd-two-draws", pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(firstKsuid, "first-credential", pkgmodel.FormaApplyModeReconcile))
+
+	firstRU := cs.DAG.Nodes[createOperationURI(first.URI(), resource_update.OperationCreate)].Update.(*resource_update.ResourceUpdate)
+	secondRU := cs.DAG.Nodes[createOperationURI(second.URI(), resource_update.OperationCreate)].Update.(*resource_update.ResourceUpdate)
+
+	assert.Equal(t, "first-credential", gjson.GetBytes(firstRU.DesiredState.Properties, "password.$value").String())
+	assert.False(t, gjson.GetBytes(secondRU.DesiredState.Properties, "password.$value").Exists(),
+		"a destination bound to a different generator must not receive this draw")
+}
+
+// Delivery re-derives the destination's patch under the changeset's own apply
+// mode. Under reconcile an EntitySet member dropped from the desired state
+// keeps its remove op; regenerating under patch semantics would drop it.
+func TestPropagateDrawnGeneratorValue_RegeneratesUnderTheChangesetsMode(t *testing.T) {
+	generatorKsuid := util.NewID()
+
+	schema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "password", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Tags": {UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Key"},
+		},
+	}
+	newUpdate := func() resource_update.ResourceUpdate {
+		ksuid := util.NewID()
+		return resource_update.ResourceUpdate{
+			Operation:  resource_update.OperationUpdate,
+			State:      resource_update.ResourceUpdateStateNotStarted,
+			StackLabel: "default",
+			PriorState: pkgmodel.Resource{
+				Label: "app-secret", Type: "AWS::SecretsManager::Secret", Stack: "default",
+				Ksuid: ksuid, Target: "aws", Schema: schema,
+				Properties: json.RawMessage(`{"Name":"app-secret","password":"old","Tags":[{"Key":"env","Value":"prod"},{"Key":"legacy","Value":"true"}]}`),
+			},
+			DesiredState: pkgmodel.Resource{
+				Label: "app-secret", Type: "AWS::SecretsManager::Secret", Stack: "default",
+				Ksuid: ksuid, Target: "aws", Schema: schema,
+				Properties: json.RawMessage(`{"Name":"app-secret","password":{"$gen":true,"$generator":"` + generatorKsuid + `","$output":"value","$visibility":"Opaque"},"Tags":[{"Key":"env","Value":"prod"}]}`),
+			},
+		}
+	}
+
+	build := func(mode pkgmodel.FormaApplyMode) *resource_update.ResourceUpdate {
+		ru := newUpdate()
+		cs, err := NewChangeset(
+			[]resource_update.ResourceUpdate{ru}, nil,
+			[]generator_update.GeneratorUpdate{drawOp("db-password", generatorKsuid)},
+			"cmd-mode-"+string(mode), pkgmodel.CommandApply, mode,
+		)
+		require.NoError(t, err)
+		require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(generatorKsuid, "drawn", cs.Mode))
+		return cs.DAG.Nodes[createOperationURI(ru.URI(), resource_update.OperationUpdate)].Update.(*resource_update.ResourceUpdate)
+	}
+
+	reconciled := build(pkgmodel.FormaApplyModeReconcile)
+	assert.Contains(t, string(reconciled.DesiredState.PatchDocument), "remove",
+		"reconcile delivery must keep the remove op planning derived")
+
+	patched := build(pkgmodel.FormaApplyModePatch)
+	assert.NotContains(t, string(patched.DesiredState.PatchDocument), "remove",
+		"patch-mode delivery must leave the undeclared member unchanged")
+}
+
+// A draw that becomes executable is dispatched to a GeneratorUpdater spawned
+// under the canonical name, carrying the draw itself.
+func TestStartUpdates_DispatchesADrawToAGeneratorUpdater(t *testing.T) {
+	const commandID = "cmd-dispatch"
+	generatorKsuid := util.NewID()
+	draw := drawOp("db-password", generatorKsuid)
+
+	actor, proc := testExecutorProcess(t)
+
+	require.NoError(t, startUpdates([]Update{&draw}, commandID, pkgmodel.FormaApplyModeReconcile, proc))
+
+	expectedName := actornames.GeneratorUpdater(draw.NodeURI(), commandID)
+
+	var dispatched *generator_update.StartGeneratorUpdate
+	var dispatchedTo gen.ProcessID
+	for _, event := range actor.Events() {
+		sendEvent, ok := event.(unit.SendEvent)
+		if !ok {
+			continue
+		}
+		if start, ok := sendEvent.Message.(generator_update.StartGeneratorUpdate); ok {
+			dispatched = &start
+			dispatchedTo, _ = sendEvent.To.(gen.ProcessID)
+		}
+	}
+	require.NotNil(t, dispatched, "a draw must be dispatched to a GeneratorUpdater")
+	assert.Equal(t, expectedName, dispatchedTo.Name,
+		"the draw must go to the actor registered under the canonical generator-updater name")
+	assert.Equal(t, draw.NodeURI(), dispatched.GeneratorUpdate.NodeURI())
+}
+
+// Every draw the synthesis produces has at least one destination waiting on
+// it, whatever shape that destination takes. Both sides read the same
+// classification over the same updates, and the edge builder considers a
+// superset of the ops the synthesis does — it does not skip a teardown.
+//
+// This is the invariant a failed draw's reporting rests on. A draw writes no
+// row and has no entry in the command record, so a draw failure is observable
+// only through the destinations it cascades to; a draw with no destination
+// would fail invisibly and leave the command reporting success.
+func TestEverySynthesizedDrawHasADestinationWaitingOnIt(t *testing.T) {
+	generatorKsuid := util.NewID()
+	generatorKey := pkgmodel.GeneratorKey{Label: "db-password", Stack: "default"}
+	specs := &stubGeneratorSpecs{byKey: map[pkgmodel.GeneratorKey]pkgmodel.Generator{
+		generatorKey: &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24},
+	}}
+
+	stable := genBoundSecret("stable-secret", generatorKsuid)
+	stable.Operation = resource_update.OperationUpdate
+	stable.ProvenanceRecords = []resource_update.OccurrenceRecord{{
+		DestinationPath: "password",
+		DesiredIdentity: resource_update.OccurrenceIdentity{
+			Kind: resource_update.OccurrenceKindGenerator, Ksuid: generatorKsuid, PropertyPath: "value",
+		},
+		Class: resource_update.OccurrenceStable,
+	}}
+
+	teardown := genBoundSecret("dying-secret", generatorKsuid)
+	teardown.Operation = resource_update.OperationDelete
+	teardown.PriorState = teardown.DesiredState
+
+	fresh := genBoundSecret("fresh-secret", generatorKsuid)
+
+	replaced := genBoundSecret("replaced-secret", generatorKsuid)
+	replaced.Operation = resource_update.OperationReplace
+
+	cases := []struct {
+		name    string
+		updates []resource_update.ResourceUpdate
+	}{
+		{"a create", []resource_update.ResourceUpdate{fresh}},
+		{"a replace, split into a delete and a create", []resource_update.ResourceUpdate{replaced}},
+		{"a stable destination beside a fresh one", []resource_update.ResourceUpdate{stable, fresh}},
+		{"a teardown beside a fresh one", []resource_update.ResourceUpdate{teardown, fresh}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			draws, err := generator_update.SynthesizeDrawGeneratorUpdates(
+				tc.updates, nil,
+				map[pkgmodel.GeneratorKey]string{generatorKey: generatorKsuid},
+				specs,
+			)
+			require.NoError(t, err)
+			require.Len(t, draws, 1, "a destination that still needs a value produces a draw")
+
+			cs, err := NewChangeset(tc.updates, nil, draws, "cmd-invariant",
+				pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile)
+			require.NoError(t, err)
+
+			drawNode := cs.DAG.Nodes[draws[0].NodeURI()]
+			require.NotNil(t, drawNode)
+			assert.NotEmpty(t, drawNode.Dependents,
+				"a draw with no destination would fail invisibly: nothing else records its state")
+		})
+	}
+
+	// The other half of the rule: nothing to deliver to means no draw at all,
+	// so there is no node whose failure could go unreported.
+	draws, err := generator_update.SynthesizeDrawGeneratorUpdates(
+		[]resource_update.ResourceUpdate{stable, teardown}, nil,
+		map[pkgmodel.GeneratorKey]string{generatorKey: generatorKsuid},
+		specs,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, draws, "a generator no destination needs a value from draws nothing")
+}

--- a/internal/metastructure/changeset/generator_propagation_test.go
+++ b/internal/metastructure/changeset/generator_propagation_test.go
@@ -162,30 +162,81 @@ func TestGeneratorDrawFailed_CascadesToItsDestinationAndPersistsTheFailure(t *te
 // If the drawn value cannot be delivered, the draw is treated as a failure so
 // the cascade runs: a destination that never received its value must not go
 // on to dispatch its undrawn envelope.
+//
+// Delivery is driven to refuse through a door that production can open: a
+// destination whose $gen sits under a map key containing a dot. The walk that
+// selects destinations addresses them by a dot-joined path, so such a
+// destination is not addressable and SetGenValues refuses rather than writing
+// the credential wherever that path happens to land.
 func TestGeneratorDrawFinished_UndeliverableValueFailsClosed(t *testing.T) {
-	cs, draw, secret := changesetWithOneDraw(t, "cmd-draw-undeliverable", pkgmodel.FormaApplyModeReconcile)
-	actor, proc := testExecutorProcess(t)
-	_ = actor
+	generatorKsuid := util.NewID()
 
-	// Break the destination's envelope after planning, so delivery cannot
-	// find a generator reference to write into.
-	opURI := createOperationURI(secret.URI(), secret.Operation)
+	unaddressable := genBoundSecret("dotted-key-secret", generatorKsuid)
+	unaddressable.DesiredState.Properties = json.RawMessage(`{"labels":{"app.kubernetes.io/secret":{"$gen":true,"$generator":"` +
+		generatorKsuid + `","$output":"value","$visibility":"Opaque"}}}`)
+	draw := drawOp("db-password", generatorKsuid)
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{unaddressable}, nil,
+		[]generator_update.GeneratorUpdate{draw},
+		"cmd-draw-undeliverable", pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+
+	opURI := createOperationURI(unaddressable.URI(), unaddressable.Operation)
 	node := cs.DAG.Nodes[opURI]
 	require.NotNil(t, node)
+	require.True(t, dependsOn(node, draw.NodeURI()),
+		"precondition: the destination is wired to the draw, so a refusal is what stops it")
 	ru := node.Update.(*resource_update.ResourceUpdate)
+
+	drawNode := cs.DAG.Nodes[draw.NodeURI()]
+	require.NotNil(t, drawNode)
+	drawNode.Update.MarkInProgress()
+
+	actor, proc := testExecutorProcess(t)
+	_ = actor
 
 	data := ChangesetData{changeset: cs}
 	_, updated, _, _ := generatorUpdateFinished(gen.PID{}, StateProcessing, data,
 		generator_update.GeneratorUpdateFinished{
 			NodeURI:    draw.NodeURI(),
 			State:      generator_update.GeneratorUpdateStateSuccess,
-			DrawnValue: "", // a success carrying no value is undeliverable
+			DrawnValue: "drawn-credential",
 		}, proc)
 
 	assert.True(t, ru.IsFailed(), "an undeliverable draw must fail its destinations closed")
 	assert.Nil(t, updated.changeset.DAG.Nodes[opURI])
-	assert.False(t, gjson.GetBytes(ru.DesiredState.Properties, "password.$value").Exists(),
+	assert.NotContains(t, string(ru.DesiredState.Properties), "drawn-credential",
 		"nothing is written when delivery is refused")
+}
+
+// A draw naming no generator delivers nothing. An authored, not yet
+// translated envelope carries no $generator either, so an empty ksuid would
+// otherwise match every one of them and deliver the credential into all of
+// them. The changeset builder already refuses to build such a draw; this is
+// the same refusal restated where the write happens.
+func TestPropagateDrawnGeneratorValue_WithoutAGeneratorIdentityDeliversNothing(t *testing.T) {
+	generatorKsuid := util.NewID()
+
+	authored := genBoundSecret("authored-secret", generatorKsuid)
+	authored.DesiredState.Properties = json.RawMessage(
+		`{"password":{"$gen":true,"$label":"db-password","$stack":"default","$output":"value","$visibility":"Opaque"}}`)
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{authored}, nil,
+		[]generator_update.GeneratorUpdate{drawOp("db-password", generatorKsuid)},
+		"cmd-no-identity", pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+
+	err = cs.DAG.propagateDrawnGeneratorValue("", "drawn-credential", pkgmodel.FormaApplyModeReconcile)
+	require.Error(t, err, "a draw naming no generator must refuse delivery outright")
+	assert.NotContains(t, err.Error(), "drawn-credential")
+
+	ru := cs.DAG.Nodes[createOperationURI(authored.URI(), resource_update.OperationCreate)].Update.(*resource_update.ResourceUpdate)
+	assert.NotContains(t, string(ru.DesiredState.Properties), "drawn-credential",
+		"an untranslated envelope must never receive a credential")
 }
 
 // A destination being torn down never receives a drawn value: a delete

--- a/internal/metastructure/changeset/generator_propagation_test.go
+++ b/internal/metastructure/changeset/generator_propagation_test.go
@@ -414,10 +414,9 @@ func TestStartUpdates_DispatchesADrawToAGeneratorUpdater(t *testing.T) {
 // would fail invisibly and leave the command reporting success.
 func TestEverySynthesizedDrawHasADestinationWaitingOnIt(t *testing.T) {
 	generatorKsuid := util.NewID()
-	generatorKey := pkgmodel.GeneratorKey{Label: "db-password", Stack: "default"}
-	specs := &stubGeneratorSpecs{byKey: map[pkgmodel.GeneratorKey]pkgmodel.Generator{
-		generatorKey: &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24},
-	}}
+	lookup := stubGeneratorLookup(map[string]pkgmodel.Generator{
+		generatorKsuid: &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24},
+	})
 
 	stable := genBoundSecret("stable-secret", generatorKsuid)
 	stable.Operation = resource_update.OperationUpdate
@@ -450,11 +449,7 @@ func TestEverySynthesizedDrawHasADestinationWaitingOnIt(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			draws, err := generator_update.SynthesizeDrawGeneratorUpdates(
-				tc.updates, nil,
-				map[pkgmodel.GeneratorKey]string{generatorKey: generatorKsuid},
-				specs,
-			)
+			draws, err := generator_update.SynthesizeDrawGeneratorUpdates(tc.updates, nil, lookup)
 			require.NoError(t, err)
 			require.Len(t, draws, 1, "a destination that still needs a value produces a draw")
 
@@ -472,10 +467,7 @@ func TestEverySynthesizedDrawHasADestinationWaitingOnIt(t *testing.T) {
 	// The other half of the rule: nothing to deliver to means no draw at all,
 	// so there is no node whose failure could go unreported.
 	draws, err := generator_update.SynthesizeDrawGeneratorUpdates(
-		[]resource_update.ResourceUpdate{stable, teardown}, nil,
-		map[pkgmodel.GeneratorKey]string{generatorKey: generatorKsuid},
-		specs,
-	)
+		[]resource_update.ResourceUpdate{stable, teardown}, nil, lookup)
 	require.NoError(t, err)
 	assert.Empty(t, draws, "a generator no destination needs a value from draws nothing")
 }

--- a/internal/metastructure/changeset/generator_propagation_test.go
+++ b/internal/metastructure/changeset/generator_propagation_test.go
@@ -75,9 +75,10 @@ func TestGeneratorDrawFinished_DeliversTheValueInsideTheEnvelope(t *testing.T) {
 	data := ChangesetData{changeset: cs}
 	_, updated, _, _ := generatorUpdateFinished(gen.PID{}, StateProcessing, data,
 		generator_update.GeneratorUpdateFinished{
-			NodeURI:    draw.NodeURI(),
-			State:      generator_update.GeneratorUpdateStateSuccess,
-			DrawnValue: "drawn-credential",
+			NodeURI:      draw.NodeURI(),
+			State:        generator_update.GeneratorUpdateStateSuccess,
+			DrawnValue:   "drawn-credential",
+			GenerationID: "generation-1",
 		}, proc)
 
 	node := updated.changeset.DAG.Nodes[opURI]
@@ -106,9 +107,10 @@ func TestGeneratorDrawFinished_MarksTheDrawSucceededAndReleasesItsDestination(t 
 	data := ChangesetData{changeset: cs}
 	_, updated, _, _ := generatorUpdateFinished(gen.PID{}, StateProcessing, data,
 		generator_update.GeneratorUpdateFinished{
-			NodeURI:    draw.NodeURI(),
-			State:      generator_update.GeneratorUpdateStateSuccess,
-			DrawnValue: "drawn-credential",
+			NodeURI:      draw.NodeURI(),
+			State:        generator_update.GeneratorUpdateStateSuccess,
+			DrawnValue:   "drawn-credential",
+			GenerationID: "generation-1",
 		}, proc)
 
 	assert.True(t, drawUpdate.IsSuccess(), "a completed draw must be recorded as a success")
@@ -200,9 +202,10 @@ func TestGeneratorDrawFinished_UndeliverableValueFailsClosed(t *testing.T) {
 	data := ChangesetData{changeset: cs}
 	_, updated, _, _ := generatorUpdateFinished(gen.PID{}, StateProcessing, data,
 		generator_update.GeneratorUpdateFinished{
-			NodeURI:    draw.NodeURI(),
-			State:      generator_update.GeneratorUpdateStateSuccess,
-			DrawnValue: "drawn-credential",
+			NodeURI:      draw.NodeURI(),
+			State:        generator_update.GeneratorUpdateStateSuccess,
+			DrawnValue:   "drawn-credential",
+			GenerationID: "generation-1",
 		}, proc)
 
 	assert.True(t, ru.IsFailed(), "an undeliverable draw must fail its destinations closed")
@@ -230,13 +233,36 @@ func TestPropagateDrawnGeneratorValue_WithoutAGeneratorIdentityDeliversNothing(t
 	)
 	require.NoError(t, err)
 
-	err = cs.DAG.propagateDrawnGeneratorValue("", "drawn-credential", pkgmodel.FormaApplyModeReconcile)
+	err = cs.DAG.propagateDrawnGeneratorValue("", "drawn-credential", "generation-1", pkgmodel.FormaApplyModeReconcile)
 	require.Error(t, err, "a draw naming no generator must refuse delivery outright")
 	assert.NotContains(t, err.Error(), "drawn-credential")
 
 	ru := cs.DAG.Nodes[createOperationURI(authored.URI(), resource_update.OperationCreate)].Update.(*resource_update.ResourceUpdate)
 	assert.NotContains(t, string(ru.DesiredState.Properties), "drawn-credential",
 		"an untranslated envelope must never receive a credential")
+}
+
+// A draw naming no generation delivers nothing. The destination would be
+// written with a credential and no provenance, so every later apply would
+// read its movement as unknown, plan it, and rotate the credential again.
+func TestPropagateDrawnGeneratorValue_WithoutAGenerationDeliversNothing(t *testing.T) {
+	generatorKsuid := util.NewID()
+	destination := genBoundSecret("db-secret", generatorKsuid)
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{destination}, nil,
+		[]generator_update.GeneratorUpdate{drawOp("db-password", generatorKsuid)},
+		"cmd-no-generation", pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+
+	err = cs.DAG.propagateDrawnGeneratorValue(generatorKsuid, "drawn-credential", "", pkgmodel.FormaApplyModeReconcile)
+	require.Error(t, err, "a draw naming no generation must refuse delivery outright")
+	assert.NotContains(t, err.Error(), "drawn-credential")
+
+	ru := cs.DAG.Nodes[createOperationURI(destination.URI(), resource_update.OperationCreate)].Update.(*resource_update.ResourceUpdate)
+	assert.NotContains(t, string(ru.DesiredState.Properties), "drawn-credential",
+		"nothing is written when the generation cannot be attested")
 }
 
 // A destination being torn down never receives a drawn value: a delete
@@ -258,7 +284,7 @@ func TestPropagateDrawnGeneratorValue_SkipsATeardownDestination(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(generatorKsuid, "drawn-credential", pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(generatorKsuid, "drawn-credential", "generation-1", pkgmodel.FormaApplyModeReconcile))
 
 	dying := cs.DAG.Nodes[createOperationURI(teardown.URI(), resource_update.OperationDelete)].Update.(*resource_update.ResourceUpdate)
 	assert.False(t, gjson.GetBytes(dying.DesiredState.Properties, "password.$value").Exists(),
@@ -283,7 +309,7 @@ func TestPropagateDrawnGeneratorValue_LeavesAnotherGeneratorsDestinationAlone(t 
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(firstKsuid, "first-credential", pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(firstKsuid, "first-credential", "generation-1", pkgmodel.FormaApplyModeReconcile))
 
 	firstRU := cs.DAG.Nodes[createOperationURI(first.URI(), resource_update.OperationCreate)].Update.(*resource_update.ResourceUpdate)
 	secondRU := cs.DAG.Nodes[createOperationURI(second.URI(), resource_update.OperationCreate)].Update.(*resource_update.ResourceUpdate)
@@ -333,7 +359,7 @@ func TestPropagateDrawnGeneratorValue_RegeneratesUnderTheChangesetsMode(t *testi
 			"cmd-mode-"+string(mode), pkgmodel.CommandApply, mode,
 		)
 		require.NoError(t, err)
-		require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(generatorKsuid, "drawn", cs.Mode))
+		require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(generatorKsuid, "drawn", "generation-1", cs.Mode))
 		return cs.DAG.Nodes[createOperationURI(ru.URI(), resource_update.OperationUpdate)].Update.(*resource_update.ResourceUpdate)
 	}
 

--- a/internal/metastructure/changeset/generator_update_node_uri_test.go
+++ b/internal/metastructure/changeset/generator_update_node_uri_test.go
@@ -1,0 +1,79 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package changeset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/types"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// A GeneratorUpdate's NodeURI must never collide with a resource operation
+// URI (createOperationURI's "<ksuid>/<propertyPath>/<operation>", no scheme)
+// or a target operation URI (target_update's "target://<label>/<operation>"),
+// since all three share the single ExecutionDAG.Nodes keyspace. This test
+// builds all three through their real, in-package construction paths — not
+// hand-rolled string copies — so it fails if any of the three formats ever
+// changes in a way that could reopen a collision.
+func TestGeneratorUpdateNodeURIDoesNotCollideWithResourceOrTargetOperationURI(t *testing.T) {
+	resourceKsuid := util.NewID()
+
+	resourceOps := []types.OperationType{
+		types.OperationCreate, types.OperationUpdate, types.OperationDelete,
+		types.OperationRead, types.OperationReplace,
+	}
+	var resourceOpURIs []pkgmodel.FormaeURI
+	for _, op := range resourceOps {
+		ru := resource_update.ResourceUpdate{
+			DesiredState: pkgmodel.Resource{Ksuid: resourceKsuid},
+			Operation:    op,
+		}
+		resourceOpURIs = append(resourceOpURIs, createOperationURI(ru.URI(), ru.Operation))
+	}
+
+	targetOps := []types.OperationType{
+		target_update.TargetOperationCreate, target_update.TargetOperationUpdate,
+		target_update.TargetOperationDelete, target_update.TargetOperationResolve,
+	}
+	var targetOpURIs []pkgmodel.FormaeURI
+	for _, op := range targetOps {
+		tu := target_update.TargetUpdate{
+			Target:    pkgmodel.Target{Label: "db-password"},
+			Operation: op,
+		}
+		targetOpURIs = append(targetOpURIs, tu.NodeURI())
+	}
+
+	generatorOps := []types.OperationType{
+		types.OperationCreate, types.OperationUpdate, types.OperationDelete,
+	}
+	var generatorOpURIs []pkgmodel.FormaeURI
+	for _, op := range generatorOps {
+		gu := generator_update.GeneratorUpdate{
+			Generator:  &pkgmodel.PasswordGenerator{Label: "db-password"},
+			StackLabel: "default",
+			Operation:  op,
+		}
+		generatorOpURIs = append(generatorOpURIs, gu.NodeURI())
+	}
+
+	for _, gURI := range generatorOpURIs {
+		for _, rURI := range resourceOpURIs {
+			assert.NotEqual(t, rURI, gURI, "generator node URI collided with a resource operation URI")
+		}
+		for _, tURI := range targetOpURIs {
+			assert.NotEqual(t, tURI, gURI, "generator node URI collided with a target operation URI")
+		}
+	}
+}

--- a/internal/metastructure/changeset/resolve_test_helper_test.go
+++ b/internal/metastructure/changeset/resolve_test_helper_test.go
@@ -36,5 +36,5 @@ func buildChangesetForTest(
 	if err != nil {
 		return Changeset{}, err
 	}
-	return NewChangeset(resourceUpdates, append(targetUpdates, synth...), commandID, command, pkgmodel.FormaApplyModeReconcile)
+	return NewChangeset(resourceUpdates, append(targetUpdates, synth...), nil, commandID, command, pkgmodel.FormaApplyModeReconcile)
 }

--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -801,7 +801,9 @@ func synchronizeResources(op ListOperation, namespace string, target pkgmodel.Ta
 		finalizeFailedSyncCommand(syncCommand, proc)
 		return "", fmt.Errorf("failed to build changeset: %w", err)
 	}
-	cs, err := changeset.NewChangeset(syncCommand.ResourceUpdates, synth, syncCommand.ID, pkgmodel.CommandSync, syncCommand.Config.Mode)
+	// No generator draws: a sync command only reads the inventory, so no
+	// destination in it is waiting for a generated value.
+	cs, err := changeset.NewChangeset(syncCommand.ResourceUpdates, synth, nil, syncCommand.ID, pkgmodel.CommandSync, syncCommand.Config.Mode)
 	if err != nil {
 		slog.Error("failed to build changeset for discovery sync command", "commandID", syncCommand.ID, "error", err)
 		finalizeFailedSyncCommand(syncCommand, proc)

--- a/internal/metastructure/extract_resources_test.go
+++ b/internal/metastructure/extract_resources_test.go
@@ -173,6 +173,9 @@ func (m *mockExtractDatastore) LoadLatestResourceByKsuid(_ string) (*pkgmodel.Re
 func (m *mockExtractDatastore) FindResourcesDependingOn(_ string) ([]*pkgmodel.Resource, error) {
 	panic("not implemented")
 }
+func (m *mockExtractDatastore) FindResourcesReferencingGenerator(_ string) ([]*pkgmodel.Resource, error) {
+	panic("not implemented")
+}
 func (m *mockExtractDatastore) FindResourcesDependingOnMany(_ []string) (map[string][]*pkgmodel.Resource, error) {
 	panic("not implemented")
 }

--- a/internal/metastructure/forma_command/forma_command.go
+++ b/internal/metastructure/forma_command/forma_command.go
@@ -53,12 +53,23 @@ type FormaCommand struct {
 	StackUpdates     []stack_update.StackUpdate         `json:"StackUpdates,omitempty"`
 	PolicyUpdates    []policy_update.PolicyUpdate       `json:"PolicyUpdates,omitempty"`
 	GeneratorUpdates []generator_update.GeneratorUpdate `json:"GeneratorUpdates,omitempty"`
-	Config           config.FormaCommandConfig          `json:"Config"`
-	Command          pkgmodel.Command                   `json:"Command"`
-	ClientID         string                             `json:"ClientId,omitempty"`
-	Subject          string                             `json:"Subject,omitempty"`
-	SubjectName      string                             `json:"SubjectName,omitempty"`
-	Source           Source                             `json:"Source,omitempty"`
+	// DrawGeneratorUpdates are the synthetic draws the changeset schedules,
+	// one per generator whose value some destination in this command still
+	// needs. They are not part of the generator diff above: a draw writes no
+	// generator row, and a generator whose spec never changed still gets one
+	// when a resource is newly bound to it.
+	//
+	// Deliberately not serialized. A draw produces a value in memory for the
+	// destinations in the same changeset and is meaningless outside it, so a
+	// command recovered from storage re-derives its draws from the surviving
+	// destinations rather than replaying a stale set.
+	DrawGeneratorUpdates []generator_update.GeneratorUpdate `json:"-"`
+	Config               config.FormaCommandConfig          `json:"Config"`
+	Command              pkgmodel.Command                   `json:"Command"`
+	ClientID             string                             `json:"ClientId,omitempty"`
+	Subject              string                             `json:"Subject,omitempty"`
+	SubjectName          string                             `json:"SubjectName,omitempty"`
+	Source               Source                             `json:"Source,omitempty"`
 }
 
 type FormaCommandResult struct {

--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -301,10 +301,18 @@ type MarkTargetsAsFailed struct {
 	TargetModifiedTs time.Time
 }
 
-// FinalizeIncompleteCommand is sent during crash recovery when all resource
-// updates in a command have already reached a terminal state but the command
-// itself was never marked complete (the agent crashed between the last
-// resource completion and the command state transition).
+// FinalizeIncompleteCommand is sent when every resource update in a command
+// has reached a terminal state but the command itself was never marked
+// complete. Two callers:
+//
+//   - crash recovery, where the agent went down between the last resource
+//     completion and the command state transition;
+//   - a submitted command with no changeset work at all, whose updates were
+//     applied synchronously during submission (generator work) and which
+//     therefore has nothing left to report its completion.
+//
+// A command with no resource updates satisfies the terminality guard
+// trivially, which is what makes the second caller work.
 type FinalizeIncompleteCommand struct {
 	CommandID string
 }
@@ -1098,8 +1106,10 @@ func (f *FormaCommandPersister) markResourceUpdateAsComplete(msg *messages.MarkR
 
 // finalizeIncompleteCommand handles crash recovery for commands where all
 // resource updates reached a terminal state but the command itself never
-// transitioned. It computes the final command state and persists it through
-// the normal finalization path (hashing, cache eviction, etc.).
+// transitioned, whether because the agent crashed or because the command
+// carried no changeset work to report it. It computes the final command state
+// and persists it through the normal finalization path (hashing, cache
+// eviction, etc.).
 func (f *FormaCommandPersister) finalizeIncompleteCommand(msg *FinalizeIncompleteCommand) (bool, error) {
 	cached, err := f.getOrLoadCommand(msg.CommandID)
 	if err != nil {

--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -246,10 +246,19 @@ type MarkResourcesAsRejected struct {
 	ResourceModifiedTs time.Time
 }
 
+// MarkResourcesAsFailed is sent by the changeset executor when resource
+// updates are cascade-failed by a dependency's failure.
+//
+// FailureReason is the operator-facing explanation from the node that failed,
+// stamped on every resource in the batch. These resources never ran, so they
+// have no plugin progress of their own to explain them, and without it the
+// apply reports them failed with nothing said about why. It is empty when the
+// failing node offered no reason.
 type MarkResourcesAsFailed struct {
 	CommandID          string
 	Resources          []ResourceUpdateRef
 	ResourceModifiedTs time.Time
+	FailureReason      string
 }
 
 type MarkResourcesAsCanceled struct {
@@ -699,11 +708,11 @@ func (f *FormaCommandPersister) updatePolicyStates(msg *messages.UpdatePolicySta
 }
 
 func (f *FormaCommandPersister) markResourcesAsRejected(msg *MarkResourcesAsRejected) (bool, error) {
-	return f.bulkUpdateResourceState(msg.CommandID, msg.Resources, types.ResourceUpdateStateRejected, msg.ResourceModifiedTs)
+	return f.bulkUpdateResourceState(msg.CommandID, msg.Resources, types.ResourceUpdateStateRejected, msg.ResourceModifiedTs, "")
 }
 
 func (f *FormaCommandPersister) markResourcesAsFailed(msg *MarkResourcesAsFailed) (bool, error) {
-	return f.bulkUpdateResourceState(msg.CommandID, msg.Resources, types.ResourceUpdateStateFailed, msg.ResourceModifiedTs)
+	return f.bulkUpdateResourceState(msg.CommandID, msg.Resources, types.ResourceUpdateStateFailed, msg.ResourceModifiedTs, msg.FailureReason)
 }
 
 func (f *FormaCommandPersister) markTargetsAsFailed(msg *MarkTargetsAsFailed) (bool, error) {
@@ -749,7 +758,7 @@ func (f *FormaCommandPersister) markTargetsAsFailed(msg *MarkTargetsAsFailed) (b
 }
 
 func (f *FormaCommandPersister) markResourcesAsCanceled(msg *MarkResourcesAsCanceled) (bool, error) {
-	return f.bulkUpdateResourceState(msg.CommandID, msg.Resources, types.ResourceUpdateStateCanceled, util.TimeNow())
+	return f.bulkUpdateResourceState(msg.CommandID, msg.Resources, types.ResourceUpdateStateCanceled, util.TimeNow(), "")
 }
 
 func (f *FormaCommandPersister) markCommandResourcesAsCanceled(msg *MarkCommandResourcesAsCanceled) (bool, error) {
@@ -770,7 +779,7 @@ func (f *FormaCommandPersister) markCommandResourcesAsCanceled(msg *MarkCommandR
 	if len(refs) == 0 {
 		return true, nil
 	}
-	return f.bulkUpdateResourceState(msg.CommandID, refs, types.ResourceUpdateStateCanceled, util.TimeNow())
+	return f.bulkUpdateResourceState(msg.CommandID, refs, types.ResourceUpdateStateCanceled, util.TimeNow(), "")
 }
 
 // plannedForceCancel describes one in-memory resource-update mutation to apply ONLY
@@ -1135,11 +1144,21 @@ func (f *FormaCommandPersister) finalizeIncompleteCommand(msg *FinalizeIncomplet
 	return true, nil
 }
 
+// bulkUpdateResourceState terminalizes a batch of resource updates in one
+// persister turn.
+//
+// failureReason explains a failure that the resource update itself could not
+// record, because it never ran: a cascade from another node. It is stamped on
+// every row in the batch and is empty for the transitions that have no such
+// explanation. It reaches the database with the rest of the command at
+// finalization (BatchUpdateResourceUpdateState below writes state only), which
+// is where every terminalized command lands.
 func (f *FormaCommandPersister) bulkUpdateResourceState(
 	commandID string,
 	resources []ResourceUpdateRef,
 	state types.ResourceUpdateState,
 	modifiedTs time.Time,
+	failureReason string,
 ) (bool, error) {
 	cached, err := f.getOrLoadCommand(commandID)
 	if err != nil {
@@ -1181,6 +1200,9 @@ func (f *FormaCommandPersister) bulkUpdateResourceState(
 
 			res.State = state
 			res.ModifiedTs = modifiedTs
+			if failureReason != "" {
+				res.FailureReason = failureReason
+			}
 		}
 	}
 

--- a/internal/metastructure/generator_destination_refusal_test.go
+++ b/internal/metastructure/generator_destination_refusal_test.go
@@ -1,0 +1,64 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package metastructure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// The refusal names destinations an operator has to go and find, so the order
+// it names them in has to be the same every time the same apply is refused.
+// None of the datastore backends order the rows they answer with, so the order
+// is imposed here.
+func TestRefuseUnreachableGeneratorDestinations_NamesDestinationsInAStableOrder(t *testing.T) {
+	generator := &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "gen-stack"}
+	generator.SetID("gen1")
+	draws := []generator_update.GeneratorUpdate{{Generator: generator, StackLabel: "gen-stack"}}
+
+	destination := func(ksuid, stack, label string) *pkgmodel.Resource {
+		return &pkgmodel.Resource{
+			Ksuid: ksuid, Stack: stack, Label: label,
+			Type: "FakeAWS::SecretsManager::Secret",
+		}
+	}
+	rows := []*pkgmodel.Resource{
+		destination("res3", "beta-stack", "gamma"),
+		destination("res1", "alpha-stack", "beta"),
+		destination("res4", "beta-stack", "alpha"),
+		destination("res2", "alpha-stack", "alpha"),
+	}
+
+	refuse := func(rows []*pkgmodel.Resource) []apimodel.UnreachableGeneratorDestination {
+		err := refuseUnreachableGeneratorDestinations(
+			draws, map[string][]*pkgmodel.Resource{"gen1": rows}, nil)
+		var unreachable apimodel.FormaGeneratorDestinationsUnreachableError
+		require.ErrorAs(t, err, &unreachable)
+		return unreachable.Unreachable
+	}
+
+	want := []apimodel.UnreachableGeneratorDestination{
+		{GeneratorLabel: "db-password", GeneratorStack: "gen-stack", Stack: "alpha-stack", Label: "alpha", Type: "FakeAWS::SecretsManager::Secret"},
+		{GeneratorLabel: "db-password", GeneratorStack: "gen-stack", Stack: "alpha-stack", Label: "beta", Type: "FakeAWS::SecretsManager::Secret"},
+		{GeneratorLabel: "db-password", GeneratorStack: "gen-stack", Stack: "beta-stack", Label: "alpha", Type: "FakeAWS::SecretsManager::Secret"},
+		{GeneratorLabel: "db-password", GeneratorStack: "gen-stack", Stack: "beta-stack", Label: "gamma", Type: "FakeAWS::SecretsManager::Secret"},
+	}
+	assert.Equal(t, want, refuse(rows), "the destinations must be named by stack and then by label")
+
+	reversed := make([]*pkgmodel.Resource, 0, len(rows))
+	for i := len(rows) - 1; i >= 0; i-- {
+		reversed = append(reversed, rows[i])
+	}
+	assert.Equal(t, want, refuse(reversed),
+		"the order the datastore answers in must not reach the operator")
+}

--- a/internal/metastructure/generator_lookup_test.go
+++ b/internal/metastructure/generator_lookup_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/platform-engineering-labs/formae/internal/datastore"
 	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
-	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
@@ -51,20 +50,11 @@ func createGeneratorOn(t *testing.T, ds datastore.Datastore, stackLabel, generat
 	return identity.ID
 }
 
-// destinationOn is a pending resource update that sits on stackLabel, which
-// is all the resume path knows about where to look for generators.
-func destinationOn(stackLabel string) resource_update.ResourceUpdate {
-	return resource_update.ResourceUpdate{
-		DesiredState: pkgmodel.Resource{Label: "consumer", Stack: stackLabel},
-		Operation:    resource_update.OperationCreate,
-	}
-}
-
 // A generator that has drawn is reachable from its KSUID alone, whatever
 // stack it lives on. GeneratorIdentity carries no label and no stack, but its
 // GenerationSpec is the serialized generator, which carries both — so a
-// destination on one stack bound to a generator on another still resolves,
-// and the resume path never has to guess which stacks to enumerate.
+// destination on one stack bound to a generator on another still resolves
+// without enumerating anything.
 func TestGeneratorLookupForResume_ResolvesADrawnGeneratorOnAnotherStack(t *testing.T) {
 	ds := lookupTestDatastore(t)
 	ksuid := createGeneratorOn(t, ds, "secrets", "db-password", 24)
@@ -72,7 +62,7 @@ func TestGeneratorLookupForResume_ResolvesADrawnGeneratorOnAnotherStack(t *testi
 	require.NoError(t, ds.AdvanceGeneration(ksuid, "generation-1",
 		json.RawMessage(`{"Type":"password","Label":"db-password","Stack":"secrets","Length":24}`)))
 
-	lookup := generatorLookupForResume([]resource_update.ResourceUpdate{destinationOn("app")}, ds)
+	lookup := generatorLookupForResume(ds)
 	require.NotNil(t, lookup)
 
 	generator, err := lookup(ksuid)
@@ -100,7 +90,7 @@ func TestGeneratorLookupForResume_ReturnsTheCurrentSpecNotTheGenerationsSpec(t *
 	}, "cmd-edit")
 	require.NoError(t, err)
 
-	lookup := generatorLookupForResume([]resource_update.ResourceUpdate{destinationOn("app")}, ds)
+	lookup := generatorLookupForResume(ds)
 	generator, err := lookup(ksuid)
 	require.NoError(t, err)
 	require.NotNil(t, generator)
@@ -111,10 +101,9 @@ func TestGeneratorLookupForResume_ReturnsTheCurrentSpecNotTheGenerationsSpec(t *
 }
 
 // A generator that has never drawn carries no generation spec, so the KSUID
-// route cannot reach it. It is still found when it lives on a stack one of
-// the surviving destinations sits on, which is the case a resume actually
-// hits: an interrupted first apply.
-func TestGeneratorLookupForResume_FallsBackToTheDestinationsStacksForANeverDrawnGenerator(t *testing.T) {
+// route cannot reach it. The fallback finds it by walking the inventory,
+// which is the case a resume actually hits: an interrupted first apply.
+func TestGeneratorLookupForResume_FindsANeverDrawnGeneratorOnItsOwnStack(t *testing.T) {
 	ds := lookupTestDatastore(t)
 	ksuid := createGeneratorOn(t, ds, "app", "db-password", 24)
 
@@ -122,26 +111,41 @@ func TestGeneratorLookupForResume_FallsBackToTheDestinationsStacksForANeverDrawn
 	require.NoError(t, err)
 	require.Empty(t, identity.GenerationID, "precondition: nothing has been drawn")
 
-	lookup := generatorLookupForResume([]resource_update.ResourceUpdate{destinationOn("app")}, ds)
+	lookup := generatorLookupForResume(ds)
 	generator, err := lookup(ksuid)
 	require.NoError(t, err)
-	require.NotNil(t, generator, "a never-drawn generator on the destination's own stack must still be found")
+	require.NotNil(t, generator, "a never-drawn generator must still be found")
 	assert.Equal(t, "db-password", generator.GetLabel())
 	assert.Equal(t, "app", generator.GetStack())
 }
 
-// The one shape neither route reaches: a generator that has never drawn AND
-// lives on a stack no surviving destination sits on. Nothing is returned and
-// nothing errors — the synthesis logs it and the destination is refused at
-// the provider boundary, naming the property.
-func TestGeneratorLookupForResume_NeverDrawnOnAnotherStackResolvesToNothing(t *testing.T) {
+// A generator belongs to one stack and is meant to be referenced from others,
+// so a never-drawn generator is reached whatever stack it sits on relative to
+// the destination that names it, and it comes back carrying the stack the
+// draw op is filed under.
+func TestGeneratorLookupForResume_FindsANeverDrawnGeneratorOnAnotherStack(t *testing.T) {
 	ds := lookupTestDatastore(t)
 	ksuid := createGeneratorOn(t, ds, "secrets", "db-password", 24)
 	_, err := ds.CreateStack(&pkgmodel.Stack{Label: "app"}, "cmd-stack")
 	require.NoError(t, err)
 
-	lookup := generatorLookupForResume([]resource_update.ResourceUpdate{destinationOn("app")}, ds)
+	lookup := generatorLookupForResume(ds)
 	generator, err := lookup(ksuid)
+	require.NoError(t, err)
+	require.NotNil(t, generator, "a never-drawn generator on another stack must be found by KSUID")
+	assert.Equal(t, "db-password", generator.GetLabel())
+	assert.Equal(t, "secrets", generator.GetStack())
+}
+
+// A KSUID no generator holds resolves to nothing and does not error: the
+// synthesis logs it and the destination is refused at the provider boundary,
+// naming the property.
+func TestGeneratorLookupForResume_UnknownKsuidResolvesToNothing(t *testing.T) {
+	ds := lookupTestDatastore(t)
+	createGeneratorOn(t, ds, "secrets", "db-password", 24)
+
+	lookup := generatorLookupForResume(ds)
+	generator, err := lookup("2ZqXo0nEXAMPLEksuidNOTREAL0")
 	require.NoError(t, err)
 	assert.Nil(t, generator)
 }

--- a/internal/metastructure/generator_lookup_test.go
+++ b/internal/metastructure/generator_lookup_test.go
@@ -1,0 +1,147 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package metastructure
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func lookupTestDatastore(t *testing.T) datastore.Datastore {
+	t.Helper()
+	ds, err := dssqlite.NewDatastoreSQLite(context.Background(), &pkgmodel.DatastoreConfig{
+		DatastoreType: pkgmodel.SqliteDatastore,
+		Sqlite:        pkgmodel.SqliteConfig{FilePath: ":memory:"},
+	}, "test")
+	require.NoError(t, err)
+	return ds
+}
+
+// createGeneratorOn persists a generator on a freshly created stack and
+// returns its KSUID.
+func createGeneratorOn(t *testing.T, ds datastore.Datastore, stackLabel, generatorLabel string, length int) string {
+	t.Helper()
+	stack := &pkgmodel.Stack{Label: stackLabel}
+	_, err := ds.CreateStack(stack, "cmd-stack")
+	require.NoError(t, err)
+	require.NotEmpty(t, stack.ID)
+
+	_, err = ds.CreateGenerator(&pkgmodel.PasswordGenerator{
+		Label: generatorLabel, Stack: stackLabel, StackID: stack.ID,
+		Length: length, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+	}, "cmd-generator")
+	require.NoError(t, err)
+
+	identity, err := ds.GetGeneratorIdentity(generatorLabel, stackLabel)
+	require.NoError(t, err)
+	require.NotEmpty(t, identity.ID)
+	return identity.ID
+}
+
+// destinationOn is a pending resource update that sits on stackLabel, which
+// is all the resume path knows about where to look for generators.
+func destinationOn(stackLabel string) resource_update.ResourceUpdate {
+	return resource_update.ResourceUpdate{
+		DesiredState: pkgmodel.Resource{Label: "consumer", Stack: stackLabel},
+		Operation:    resource_update.OperationCreate,
+	}
+}
+
+// A generator that has drawn is reachable from its KSUID alone, whatever
+// stack it lives on. GeneratorIdentity carries no label and no stack, but its
+// GenerationSpec is the serialized generator, which carries both — so a
+// destination on one stack bound to a generator on another still resolves,
+// and the resume path never has to guess which stacks to enumerate.
+func TestGeneratorLookupForResume_ResolvesADrawnGeneratorOnAnotherStack(t *testing.T) {
+	ds := lookupTestDatastore(t)
+	ksuid := createGeneratorOn(t, ds, "secrets", "db-password", 24)
+
+	require.NoError(t, ds.AdvanceGeneration(ksuid, "generation-1",
+		json.RawMessage(`{"Type":"password","Label":"db-password","Stack":"secrets","Length":24}`)))
+
+	lookup := generatorLookupForResume([]resource_update.ResourceUpdate{destinationOn("app")}, ds)
+	require.NotNil(t, lookup)
+
+	generator, err := lookup(ksuid)
+	require.NoError(t, err)
+	require.NotNil(t, generator, "a drawn generator must be reachable by KSUID from any stack")
+	assert.Equal(t, "db-password", generator.GetLabel())
+	assert.Equal(t, "secrets", generator.GetStack())
+}
+
+// The spec a draw runs under is the generator as it stands now, not the spec
+// the last generation happened to be drawn under: an edited generator must
+// produce a value at its edited length.
+func TestGeneratorLookupForResume_ReturnsTheCurrentSpecNotTheGenerationsSpec(t *testing.T) {
+	ds := lookupTestDatastore(t)
+	ksuid := createGeneratorOn(t, ds, "secrets", "db-password", 24)
+
+	require.NoError(t, ds.AdvanceGeneration(ksuid, "generation-1",
+		json.RawMessage(`{"Type":"password","Label":"db-password","Stack":"secrets","Length":24}`)))
+	secrets, err := ds.GetStackByLabel("secrets")
+	require.NoError(t, err)
+	require.NotNil(t, secrets)
+	_, err = ds.UpdateGenerator(&pkgmodel.PasswordGenerator{
+		Label: "db-password", Stack: "secrets", StackID: secrets.ID, Length: 40,
+		Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+	}, "cmd-edit")
+	require.NoError(t, err)
+
+	lookup := generatorLookupForResume([]resource_update.ResourceUpdate{destinationOn("app")}, ds)
+	generator, err := lookup(ksuid)
+	require.NoError(t, err)
+	require.NotNil(t, generator)
+
+	spec, ok := generator.(*pkgmodel.PasswordGenerator)
+	require.True(t, ok)
+	assert.Equal(t, 40, spec.Length, "the draw must run under the spec the row holds now")
+}
+
+// A generator that has never drawn carries no generation spec, so the KSUID
+// route cannot reach it. It is still found when it lives on a stack one of
+// the surviving destinations sits on, which is the case a resume actually
+// hits: an interrupted first apply.
+func TestGeneratorLookupForResume_FallsBackToTheDestinationsStacksForANeverDrawnGenerator(t *testing.T) {
+	ds := lookupTestDatastore(t)
+	ksuid := createGeneratorOn(t, ds, "app", "db-password", 24)
+
+	identity, err := ds.GetGeneratorIdentityByID(ksuid)
+	require.NoError(t, err)
+	require.Empty(t, identity.GenerationID, "precondition: nothing has been drawn")
+
+	lookup := generatorLookupForResume([]resource_update.ResourceUpdate{destinationOn("app")}, ds)
+	generator, err := lookup(ksuid)
+	require.NoError(t, err)
+	require.NotNil(t, generator, "a never-drawn generator on the destination's own stack must still be found")
+	assert.Equal(t, "db-password", generator.GetLabel())
+	assert.Equal(t, "app", generator.GetStack())
+}
+
+// The one shape neither route reaches: a generator that has never drawn AND
+// lives on a stack no surviving destination sits on. Nothing is returned and
+// nothing errors — the synthesis logs it and the destination is refused at
+// the provider boundary, naming the property.
+func TestGeneratorLookupForResume_NeverDrawnOnAnotherStackResolvesToNothing(t *testing.T) {
+	ds := lookupTestDatastore(t)
+	ksuid := createGeneratorOn(t, ds, "secrets", "db-password", 24)
+	_, err := ds.CreateStack(&pkgmodel.Stack{Label: "app"}, "cmd-stack")
+	require.NoError(t, err)
+
+	lookup := generatorLookupForResume([]resource_update.ResourceUpdate{destinationOn("app")}, ds)
+	generator, err := lookup(ksuid)
+	require.NoError(t, err)
+	assert.Nil(t, generator)
+}

--- a/internal/metastructure/generator_update/changeset_node_test.go
+++ b/internal/metastructure/generator_update/changeset_node_test.go
@@ -53,6 +53,20 @@ func TestGeneratorUpdateNodeURIVariesByOperationAndIdentity(t *testing.T) {
 	}
 }
 
+// A StackLabel and a generator label are both free-form strings that may
+// themselves contain "/" (nothing validates against it). Naively joining
+// "<stack>/<label>/<operation>" with "/" would let two distinct (stack,
+// label) pairs collapse onto the same NodeURI — StackLabel="s", label="a/b"
+// and StackLabel="s/a", label="b" both naively join to the same
+// "s/a/b/create". NodeURI must percent-encode each segment so these two
+// genuinely different generators never collide in ExecutionDAG.Nodes.
+func TestGeneratorUpdateNodeURIDoesNotCollideAcrossStackAndLabelBoundary(t *testing.T) {
+	slashInLabel := newTestGeneratorUpdate("s", "a/b", GeneratorOperationCreate, GeneratorUpdateStateNotStarted)
+	slashInStack := newTestGeneratorUpdate("s/a", "b", GeneratorOperationCreate, GeneratorUpdateStateNotStarted)
+
+	assert.NotEqual(t, slashInLabel.NodeURI(), slashInStack.NodeURI())
+}
+
 // resourceOperationURI replicates changeset.createOperationURI's (unexported)
 // format exactly: "<ksuid>/<propertyPath>/<operation>", with no scheme. It
 // exists here only to construct a resource-shaped URI for the collision test
@@ -154,6 +168,16 @@ func TestGeneratorUpdateIsRateLimitedFalse(t *testing.T) {
 	gu := newTestGeneratorUpdate("prod", "db-password", GeneratorOperationCreate, GeneratorUpdateStateNotStarted)
 
 	assert.False(t, gu.IsRateLimited())
+}
+
+// Namespace's value never gates concurrency while IsRateLimited is false
+// (see the doc comment on Namespace), but the contract is still a non-empty,
+// stable pseudo-namespace distinct from any provider's — pin it so a stub
+// returning "" cannot pass silently.
+func TestGeneratorUpdateNamespace(t *testing.T) {
+	gu := newTestGeneratorUpdate("prod", "db-password", GeneratorOperationCreate, GeneratorUpdateStateNotStarted)
+
+	assert.Equal(t, "generator", gu.Namespace())
 }
 
 // The state predicates must partition GeneratorUpdateState exactly: every

--- a/internal/metastructure/generator_update/changeset_node_test.go
+++ b/internal/metastructure/generator_update/changeset_node_test.go
@@ -1,0 +1,207 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package generator_update
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/types"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// The compile-time assertion that *GeneratorUpdate satisfies changeset.Update
+// lives in internal/metastructure/changeset, not here: the changeset package
+// imports generator_update transitively (via forma_persister/forma_command),
+// so this package importing changeset back would be an import cycle. See
+// changeset/changeset_test.go (the assertion) and
+// changeset/generator_update_node_uri_test.go (a matching collision test
+// built from the real, in-package URI constructors on both sides).
+
+func newTestGeneratorUpdate(stack, label string, op GeneratorOperation, state GeneratorUpdateState) *GeneratorUpdate {
+	return &GeneratorUpdate{
+		Generator:  &pkgmodel.PasswordGenerator{Label: label},
+		Operation:  op,
+		State:      state,
+		StackLabel: stack,
+	}
+}
+
+func TestGeneratorUpdateNodeURI(t *testing.T) {
+	gu := newTestGeneratorUpdate("prod", "db-password", GeneratorOperationCreate, GeneratorUpdateStateNotStarted)
+
+	assert.Equal(t, pkgmodel.FormaeURI("generator://prod/db-password/create"), gu.NodeURI())
+}
+
+func TestGeneratorUpdateNodeURIVariesByOperationAndIdentity(t *testing.T) {
+	create := newTestGeneratorUpdate("prod", "db-password", GeneratorOperationCreate, GeneratorUpdateStateNotStarted)
+	update := newTestGeneratorUpdate("prod", "db-password", GeneratorOperationUpdate, GeneratorUpdateStateNotStarted)
+	otherStack := newTestGeneratorUpdate("staging", "db-password", GeneratorOperationCreate, GeneratorUpdateStateNotStarted)
+	otherLabel := newTestGeneratorUpdate("prod", "api-key", GeneratorOperationCreate, GeneratorUpdateStateNotStarted)
+
+	uris := []pkgmodel.FormaeURI{create.NodeURI(), update.NodeURI(), otherStack.NodeURI(), otherLabel.NodeURI()}
+	seen := make(map[pkgmodel.FormaeURI]bool)
+	for _, u := range uris {
+		assert.False(t, seen[u], "duplicate NodeURI %q", u)
+		seen[u] = true
+	}
+}
+
+// resourceOperationURI replicates changeset.createOperationURI's (unexported)
+// format exactly: "<ksuid>/<propertyPath>/<operation>", with no scheme. It
+// exists here only to construct a resource-shaped URI for the collision test
+// below, without reaching into the changeset package's internals.
+func resourceOperationURI(ksuid, propertyPath string, operation types.OperationType) pkgmodel.FormaeURI {
+	base := pkgmodel.NewFormaeURI(ksuid, propertyPath)
+	return pkgmodel.FormaeURI(fmt.Sprintf("%s/%s/%s", base.KSUID(), base.PropertyPath(), operation))
+}
+
+// targetOperationURI replicates target_update.TargetUpdate.NodeURI's format:
+// "target://<label>/<operation>".
+func targetOperationURI(label string, operation types.OperationType) pkgmodel.FormaeURI {
+	return pkgmodel.FormaeURI("target://" + label + "/" + string(operation))
+}
+
+// A generator node URI must never collide with a resource or target node
+// URI, since all three share the same ExecutionDAG.Nodes keyspace.
+//
+// A resource operation URI never contains "://" at all: a KSUID is 27
+// base62 characters, a property path is dot/slash-joined JSON field names,
+// and an OperationType is one of a fixed set of lowercase words (create,
+// update, delete, read, replace, resolve, reaped) — none of those character
+// sets can produce the substring "://". A generator URI and a target URI
+// both start with a literal "<scheme>://" prefix, so by that presence/
+// absence alone a generator URI can never equal a resource URI. A generator
+// URI and a target URI carry different literal scheme prefixes
+// ("generator://" vs "target://"), so they can never be equal to each other
+// either. This test verifies both properties by construction, across a
+// spread of realistic and adversarial inputs (empty property paths, a
+// generator label that happens to spell "target" or the scheme itself).
+func TestGeneratorNodeURICannotCollideWithResourceOrTargetURI(t *testing.T) {
+	ksuids := []string{
+		"0ujsswThIGTUYm2K8FjOOfXtY1K", // a realistic 27-char KSUID
+		"generator",                   // adversarial: spells the other scheme's word
+		"target",
+	}
+	propertyPaths := []string{"", "spec/length", "a/b/c"}
+	resourceOps := []types.OperationType{
+		types.OperationCreate, types.OperationUpdate, types.OperationDelete,
+		types.OperationRead, types.OperationReplace, types.OperationReaped,
+	}
+
+	labels := []string{"db-password", "target", "generator", ""}
+	stacks := []string{"prod", "staging", "target", "generator"}
+	generatorOps := []GeneratorOperation{GeneratorOperationCreate, GeneratorOperationUpdate, GeneratorOperationDelete}
+
+	var generatorURIs []pkgmodel.FormaeURI
+	for _, stack := range stacks {
+		for _, label := range labels {
+			for _, op := range generatorOps {
+				gu := newTestGeneratorUpdate(stack, label, op, GeneratorUpdateStateNotStarted)
+				generatorURIs = append(generatorURIs, gu.NodeURI())
+			}
+		}
+	}
+
+	var resourceURIs []pkgmodel.FormaeURI
+	for _, ksuid := range ksuids {
+		for _, path := range propertyPaths {
+			for _, op := range resourceOps {
+				resourceURIs = append(resourceURIs, resourceOperationURI(ksuid, path, op))
+			}
+		}
+	}
+
+	var targetURIs []pkgmodel.FormaeURI
+	for _, label := range labels {
+		for _, op := range resourceOps {
+			targetURIs = append(targetURIs, targetOperationURI(label, op))
+		}
+	}
+
+	for _, gURI := range generatorURIs {
+		assert.True(t, len(gURI) >= 12 && string(gURI)[:12] == "generator://",
+			"generator NodeURI %q must start with the generator:// scheme", gURI)
+
+		for _, rURI := range resourceURIs {
+			assert.NotEqual(t, rURI, gURI, "generator URI collided with resource URI")
+		}
+		for _, tURI := range targetURIs {
+			assert.NotEqual(t, tURI, gURI, "generator URI collided with target URI")
+		}
+	}
+
+	// And the reverse invariant that the argument above rests on: no
+	// resource-shaped URI ever contains "://" at all.
+	for _, rURI := range resourceURIs {
+		assert.NotContains(t, string(rURI), "://")
+	}
+}
+
+func TestGeneratorUpdateResolvablesIsNil(t *testing.T) {
+	gu := newTestGeneratorUpdate("prod", "db-password", GeneratorOperationCreate, GeneratorUpdateStateNotStarted)
+
+	assert.Nil(t, gu.Resolvables())
+}
+
+func TestGeneratorUpdateIsRateLimitedFalse(t *testing.T) {
+	gu := newTestGeneratorUpdate("prod", "db-password", GeneratorOperationCreate, GeneratorUpdateStateNotStarted)
+
+	assert.False(t, gu.IsRateLimited())
+}
+
+// The state predicates must partition GeneratorUpdateState exactly: every
+// defined state satisfies exactly one of IsReady/IsRunning/IsSuccess/
+// IsFailed, with no state satisfying zero or more than one.
+func TestGeneratorUpdateStatePredicatesPartitionState(t *testing.T) {
+	allStates := []GeneratorUpdateState{
+		GeneratorUpdateStateNotStarted,
+		GeneratorUpdateStateInProgress,
+		GeneratorUpdateStateSuccess,
+		GeneratorUpdateStateFailed,
+	}
+
+	for _, state := range allStates {
+		t.Run(string(state), func(t *testing.T) {
+			gu := newTestGeneratorUpdate("prod", "db-password", GeneratorOperationCreate, state)
+
+			predicates := map[string]bool{
+				"IsReady":   gu.IsReady(),
+				"IsRunning": gu.IsRunning(),
+				"IsSuccess": gu.IsSuccess(),
+				"IsFailed":  gu.IsFailed(),
+			}
+
+			trueCount := 0
+			for _, v := range predicates {
+				if v {
+					trueCount++
+				}
+			}
+			assert.Equal(t, 1, trueCount, "state %s satisfied %d predicates, want exactly 1: %+v", state, trueCount, predicates)
+		})
+	}
+
+	assert.True(t, newTestGeneratorUpdate("prod", "l", GeneratorOperationCreate, GeneratorUpdateStateNotStarted).IsReady())
+	assert.True(t, newTestGeneratorUpdate("prod", "l", GeneratorOperationCreate, GeneratorUpdateStateInProgress).IsRunning())
+	assert.True(t, newTestGeneratorUpdate("prod", "l", GeneratorOperationCreate, GeneratorUpdateStateSuccess).IsSuccess())
+	assert.True(t, newTestGeneratorUpdate("prod", "l", GeneratorOperationCreate, GeneratorUpdateStateFailed).IsFailed())
+}
+
+func TestGeneratorUpdateMarkInProgressAndMarkFailed(t *testing.T) {
+	gu := newTestGeneratorUpdate("prod", "db-password", GeneratorOperationCreate, GeneratorUpdateStateNotStarted)
+
+	gu.MarkInProgress()
+	assert.Equal(t, GeneratorUpdateStateInProgress, gu.State)
+	assert.True(t, gu.IsRunning())
+
+	gu.MarkFailed()
+	assert.Equal(t, GeneratorUpdateStateFailed, gu.State)
+	assert.True(t, gu.IsFailed())
+}

--- a/internal/metastructure/generator_update/draw_synthesis.go
+++ b/internal/metastructure/generator_update/draw_synthesis.go
@@ -65,7 +65,7 @@ func NewDrawGeneratorUpdate(generator pkgmodel.Generator, stackLabel string) Gen
 // rather than a datastore method because its two callers reach a generator by
 // different routes and neither route is the other's: planning has the
 // (label, stack) -> KSUID map translation just built, and resume has only the
-// stacks its surviving destinations sit on. The generator it returns must
+// KSUID an already-persisted envelope carries. The generator it returns must
 // carry its stack (GetStack), which is what the draw op is filed under; the
 // KSUID is stamped here, since a loaded generator never carries one.
 //

--- a/internal/metastructure/generator_update/draw_synthesis.go
+++ b/internal/metastructure/generator_update/draw_synthesis.go
@@ -1,0 +1,145 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package generator_update
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// GeneratorSpecLookup is the minimal datastore surface the draw synthesis
+// needs: the live spec of a generator this command references but does not
+// itself declare. Declared locally, like GeneratorDatastore, because
+// internal/datastore imports this package.
+type GeneratorSpecLookup interface {
+	// GetGenerator returns the live generator with this label on this stack,
+	// or nil when there is none.
+	GetGenerator(label, stackLabel string) (pkgmodel.Generator, error)
+}
+
+// NewDrawGeneratorUpdate creates a synthetic GeneratorUpdate whose only
+// purpose is to draw one generator's value into memory for the destinations
+// bound to it. It is the generator analogue of
+// target_update.NewResolveTargetUpdate: never persisted, no row written, no
+// provider called. ExistingGenerator is nil because there is nothing to
+// compare or persist.
+//
+// generator MUST carry its KSUID (Generator.GetID()): the draw records its
+// generation against that identity, and it is what matches the draw to the
+// $gen envelopes naming it. A generator loaded from the datastore does NOT
+// carry one — PasswordGenerator.ID is json:"-", so the KSUID lives only in
+// the generators table and never round-trips through generator_data — so a
+// caller building one from a load must stamp it first.
+func NewDrawGeneratorUpdate(generator pkgmodel.Generator, stackLabel string) GeneratorUpdate {
+	now := util.TimeNow()
+	return GeneratorUpdate{
+		Generator:  generator,
+		Operation:  GeneratorOperationDraw,
+		State:      GeneratorUpdateStateNotStarted,
+		StackLabel: stackLabel,
+		StartTs:    now,
+		ModifiedTs: now,
+	}
+}
+
+// SynthesizeDrawGeneratorUpdates builds one synthetic draw op per generator
+// that at least one $gen destination in resourceUpdates needs a value from.
+//
+// The node set is derived from the DESTINATIONS, not from a diff of the
+// generator's own row. A generator whose spec is unchanged produces no
+// Create/Update/Delete GeneratorUpdate, yet a resource newly bound to it —
+// or one whose stored provenance no longer matches the generation the
+// generator holds — still needs a value drawn. Keying the draw off the row
+// diff would leave such a destination dispatching its $gen envelope undrawn,
+// which the provider boundary rejects on this apply and on every one after
+// it, with nothing about the forma to change to get past it.
+//
+// The other half of the rule is the suppression that
+// resource_update.GeneratorsNeedingDraw applies: a generator every one of
+// whose destinations classified OccurrenceStable is absent from the result
+// and draws nothing. That is what stops an unrelated edit elsewhere in the
+// forma rotating a live credential.
+//
+// A generator's spec comes from this command's own generatorUpdates when it
+// declares one (the desired spec, which is what the row will hold and what
+// the value must be drawn under), and from the datastore otherwise.
+// genKeyToKsuid is the (label, stack) -> KSUID map translation resolved for
+// every $gen this command saw, which is the only route from an envelope's
+// KSUID back to the label and stack a datastore load needs.
+//
+// A KSUID this command can map to no generator at all draws nothing and is
+// logged. It is not an error: the destination bound to it still dispatches,
+// and the provider boundary refuses it with a message naming the property,
+// which is more use to an operator than rejecting the whole command with a
+// bare KSUID. That is a different case from the one this synthesis exists to
+// close, which is a generator we CAN resolve being left out of the graph.
+func SynthesizeDrawGeneratorUpdates(
+	resourceUpdates []resource_update.ResourceUpdate,
+	generatorUpdates []GeneratorUpdate,
+	genKeyToKsuid map[pkgmodel.GeneratorKey]string,
+	ds GeneratorSpecLookup,
+) ([]GeneratorUpdate, error) {
+	needed := resource_update.GeneratorsNeedingDraw(resourceUpdates)
+	if len(needed) == 0 {
+		return nil, nil
+	}
+
+	// This command's declared generators, by the KSUID GenerateGeneratorUpdates
+	// stamped on them. A Delete is excluded deliberately: its row is removed
+	// before the changeset starts, so its spec is not what a draw would be
+	// recorded under.
+	declared := make(map[string]*GeneratorUpdate, len(generatorUpdates))
+	for i := range generatorUpdates {
+		gu := &generatorUpdates[i]
+		if gu.Operation != GeneratorOperationCreate && gu.Operation != GeneratorOperationUpdate {
+			continue
+		}
+		if gu.Generator == nil || gu.Generator.GetID() == "" {
+			continue
+		}
+		declared[gu.Generator.GetID()] = gu
+	}
+
+	keyByKsuid := make(map[string]pkgmodel.GeneratorKey, len(genKeyToKsuid))
+	for key, ksuid := range genKeyToKsuid {
+		keyByKsuid[ksuid] = key
+	}
+
+	draws := make([]GeneratorUpdate, 0, len(needed))
+	for _, ksuid := range needed {
+		if gu, ok := declared[ksuid]; ok {
+			draws = append(draws, NewDrawGeneratorUpdate(gu.Generator, gu.StackLabel))
+			continue
+		}
+
+		key, ok := keyByKsuid[ksuid]
+		if !ok || ds == nil {
+			slog.Warn("No generator to draw from for a bound destination; the destination will be refused at the provider boundary",
+				"generator", ksuid)
+			continue
+		}
+
+		stored, err := ds.GetGenerator(key.Label, key.Stack)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load generator %q in stack %q: %w", key.Label, key.Stack, err)
+		}
+		if stored == nil {
+			slog.Warn("Generator named by a bound destination no longer exists; the destination will be refused at the provider boundary",
+				"generator", key.Label, "stack", key.Stack)
+			continue
+		}
+
+		// A loaded generator carries no ID; stamp the KSUID the $gen
+		// envelopes were translated to, which is the same one its row holds.
+		stored.SetID(ksuid)
+		draws = append(draws, NewDrawGeneratorUpdate(stored, key.Stack))
+	}
+
+	return draws, nil
+}

--- a/internal/metastructure/generator_update/draw_synthesis.go
+++ b/internal/metastructure/generator_update/draw_synthesis.go
@@ -13,16 +13,6 @@ import (
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
-// GeneratorSpecLookup is the minimal datastore surface the draw synthesis
-// needs: the live spec of a generator this command references but does not
-// itself declare. Declared locally, like GeneratorDatastore, because
-// internal/datastore imports this package.
-type GeneratorSpecLookup interface {
-	// GetGenerator returns the live generator with this label on this stack,
-	// or nil when there is none.
-	GetGenerator(label, stackLabel string) (pkgmodel.Generator, error)
-}
-
 // NewDrawGeneratorUpdate creates a synthetic GeneratorUpdate whose only
 // purpose is to draw one generator's value into memory for the destinations
 // bound to it. It is the generator analogue of
@@ -68,12 +58,18 @@ func NewDrawGeneratorUpdate(generator pkgmodel.Generator, stackLabel string) Gen
 //
 // A generator's spec comes from this command's own generatorUpdates when it
 // declares one (the desired spec, which is what the row will hold and what
-// the value must be drawn under), and from the datastore otherwise.
-// genKeyToKsuid is the (label, stack) -> KSUID map translation resolved for
-// every $gen this command saw, which is the only route from an envelope's
-// KSUID back to the label and stack a datastore load needs.
+// the value must be drawn under), and from lookup otherwise.
 //
-// A KSUID this command can map to no generator at all draws nothing and is
+// lookup resolves a generator KSUID to the live generator holding that
+// KSUID's spec, returning a nil generator when there is none. It is a closure
+// rather than a datastore method because its two callers reach a generator by
+// different routes and neither route is the other's: planning has the
+// (label, stack) -> KSUID map translation just built, and resume has only the
+// stacks its surviving destinations sit on. The generator it returns must
+// carry its stack (GetStack), which is what the draw op is filed under; the
+// KSUID is stamped here, since a loaded generator never carries one.
+//
+// A KSUID lookup resolves to no generator at all draws nothing and is
 // logged. It is not an error: the destination bound to it still dispatches,
 // and the provider boundary refuses it with a message naming the property,
 // which is more use to an operator than rejecting the whole command with a
@@ -82,8 +78,7 @@ func NewDrawGeneratorUpdate(generator pkgmodel.Generator, stackLabel string) Gen
 func SynthesizeDrawGeneratorUpdates(
 	resourceUpdates []resource_update.ResourceUpdate,
 	generatorUpdates []GeneratorUpdate,
-	genKeyToKsuid map[pkgmodel.GeneratorKey]string,
-	ds GeneratorSpecLookup,
+	lookup func(ksuid string) (pkgmodel.Generator, error),
 ) ([]GeneratorUpdate, error) {
 	needed := resource_update.GeneratorsNeedingDraw(resourceUpdates)
 	if len(needed) == 0 {
@@ -106,11 +101,6 @@ func SynthesizeDrawGeneratorUpdates(
 		declared[gu.Generator.GetID()] = gu
 	}
 
-	keyByKsuid := make(map[string]pkgmodel.GeneratorKey, len(genKeyToKsuid))
-	for key, ksuid := range genKeyToKsuid {
-		keyByKsuid[ksuid] = key
-	}
-
 	draws := make([]GeneratorUpdate, 0, len(needed))
 	for _, ksuid := range needed {
 		if gu, ok := declared[ksuid]; ok {
@@ -118,27 +108,26 @@ func SynthesizeDrawGeneratorUpdates(
 			continue
 		}
 
-		key, ok := keyByKsuid[ksuid]
-		if !ok || ds == nil {
+		if lookup == nil {
 			slog.Warn("No generator to draw from for a bound destination; the destination will be refused at the provider boundary",
 				"generator", ksuid)
 			continue
 		}
 
-		stored, err := ds.GetGenerator(key.Label, key.Stack)
+		stored, err := lookup(ksuid)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load generator %q in stack %q: %w", key.Label, key.Stack, err)
+			return nil, fmt.Errorf("failed to resolve generator %s: %w", ksuid, err)
 		}
 		if stored == nil {
-			slog.Warn("Generator named by a bound destination no longer exists; the destination will be refused at the provider boundary",
-				"generator", key.Label, "stack", key.Stack)
+			slog.Warn("Generator named by a bound destination cannot be resolved; the destination will be refused at the provider boundary",
+				"generator", ksuid)
 			continue
 		}
 
 		// A loaded generator carries no ID; stamp the KSUID the $gen
 		// envelopes were translated to, which is the same one its row holds.
 		stored.SetID(ksuid)
-		draws = append(draws, NewDrawGeneratorUpdate(stored, key.Stack))
+		draws = append(draws, NewDrawGeneratorUpdate(stored, stored.GetStack()))
 	}
 
 	return draws, nil

--- a/internal/metastructure/generator_update/draw_synthesis_test.go
+++ b/internal/metastructure/generator_update/draw_synthesis_test.go
@@ -1,0 +1,212 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package generator_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/provenance"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// stubSpecLookup answers GetGenerator from a (label, stack) keyed map. The
+// generators it hands back carry no ID, exactly as a datastore load does:
+// PasswordGenerator.ID is json:"-", so the KSUID never round-trips through
+// generator_data.
+type stubSpecLookup struct {
+	byKey map[pkgmodel.GeneratorKey]pkgmodel.Generator
+}
+
+func (s *stubSpecLookup) GetGenerator(label, stackLabel string) (pkgmodel.Generator, error) {
+	return s.byKey[pkgmodel.GeneratorKey{Label: label, Stack: stackLabel}], nil
+}
+
+func genEnvelopeProperties(path, generatorKsuid string) json.RawMessage {
+	return json.RawMessage(`{"` + path + `":{"$gen":true,"$generator":"` + generatorKsuid + `","$output":"value","$visibility":"Opaque"}}`)
+}
+
+func TestSynthesizeDrawGeneratorUpdates_SecondConsumerOnUnchangedGeneratorDraws(t *testing.T) {
+	// A stack already holds `db-password` with one applied consumer. The
+	// author adds a second resource bound to the same generator; the
+	// generator's own spec is untouched, so the row diff produces no
+	// GeneratorUpdate at all. The new consumer still needs a value.
+	const ksuid = "2abcDEFghiJKLmnoPQRstuVWxyz"
+
+	stored := &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24}
+	ds := &stubSpecLookup{byKey: map[pkgmodel.GeneratorKey]pkgmodel.Generator{
+		{Label: "db-password", Stack: "default"}: stored,
+	}}
+
+	resourceUpdates := []resource_update.ResourceUpdate{
+		// The pre-existing consumer: unchanged, provably stable.
+		{
+			DesiredState: pkgmodel.Resource{Label: "app-secret", Properties: genEnvelopeProperties("password", ksuid)},
+			Operation:    resource_update.OperationUpdate,
+			ProvenanceRecords: []resource_update.OccurrenceRecord{{
+				DestinationPath: "password",
+				DesiredIdentity: resource_update.OccurrenceIdentity{
+					Kind: resource_update.OccurrenceKindGenerator, Ksuid: ksuid, PropertyPath: "value",
+				},
+				Class: resource_update.OccurrenceStable,
+			}},
+		},
+		// The newly added consumer: no stored provenance at all.
+		{
+			DesiredState: pkgmodel.Resource{Label: "worker-secret", Properties: genEnvelopeProperties("password", ksuid)},
+			Operation:    resource_update.OperationCreate,
+		},
+	}
+
+	draws, err := SynthesizeDrawGeneratorUpdates(
+		resourceUpdates,
+		nil, // the generator's row did not change: no GeneratorUpdate exists
+		map[pkgmodel.GeneratorKey]string{{Label: "db-password", Stack: "default"}: ksuid},
+		ds,
+	)
+	require.NoError(t, err)
+	require.Len(t, draws, 1)
+
+	assert.Equal(t, GeneratorOperationDraw, draws[0].Operation)
+	assert.Equal(t, GeneratorUpdateStateNotStarted, draws[0].State)
+	assert.Equal(t, "default", draws[0].StackLabel)
+	require.NotNil(t, draws[0].Generator)
+	assert.Equal(t, "db-password", draws[0].Generator.GetLabel())
+	// The KSUID a datastore load drops must be stamped back on, or the draw
+	// has no identity to record its generation against.
+	assert.Equal(t, ksuid, draws[0].Generator.GetID())
+	assert.Nil(t, draws[0].ExistingGenerator)
+}
+
+func TestSynthesizeDrawGeneratorUpdates_StaleProvenanceOnUnchangedGeneratorRedraws(t *testing.T) {
+	// The generator's spec is untouched and the destination has a written
+	// value, but the generation the generator now holds is not the one that
+	// value was stamped with — the shape left behind when a generation was
+	// recorded and the destinations were never committed.
+	const ksuid = "2abcDEFghiJKLmnoPQRstuVWxyz"
+
+	rec := resource_update.OccurrenceRecord{
+		DestinationPath: "password",
+		DesiredIdentity: resource_update.OccurrenceIdentity{
+			Kind: resource_update.OccurrenceKindGenerator, Ksuid: ksuid, PropertyPath: "value",
+		},
+		StoredIdentity: resource_update.OccurrenceIdentity{
+			Kind: resource_update.OccurrenceKindGenerator, Ksuid: ksuid, PropertyPath: "value",
+		},
+		HasStoredWritten:  true,
+		WrittenProvenance: provenance.DigestOfString("the generation the value was stamped with"),
+		SourceRootDigest:  provenance.DigestOfString("the generation the generator holds now"),
+		WrittenDigest:     provenance.DigestOfString("the value on the destination"),
+	}
+	resource_update.ClassifyOccurrence(&rec, true, false, false, func() (string, bool) { return "", false })
+	require.NotEqual(t, resource_update.OccurrenceStable, rec.Class,
+		"a destination stamped with a generation the generator no longer holds must not classify stable")
+
+	stored := &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24}
+	ds := &stubSpecLookup{byKey: map[pkgmodel.GeneratorKey]pkgmodel.Generator{
+		{Label: "db-password", Stack: "default"}: stored,
+	}}
+
+	draws, err := SynthesizeDrawGeneratorUpdates(
+		[]resource_update.ResourceUpdate{{
+			DesiredState:      pkgmodel.Resource{Label: "app-secret", Properties: genEnvelopeProperties("password", ksuid)},
+			Operation:         resource_update.OperationUpdate,
+			ProvenanceRecords: []resource_update.OccurrenceRecord{rec},
+		}},
+		nil,
+		map[pkgmodel.GeneratorKey]string{{Label: "db-password", Stack: "default"}: ksuid},
+		ds,
+	)
+	require.NoError(t, err)
+	require.Len(t, draws, 1)
+	assert.Equal(t, ksuid, draws[0].Generator.GetID())
+}
+
+func TestSynthesizeDrawGeneratorUpdates_AllStableDestinationsDrawNothing(t *testing.T) {
+	const ksuid = "2abcDEFghiJKLmnoPQRstuVWxyz"
+
+	stored := &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24}
+	ds := &stubSpecLookup{byKey: map[pkgmodel.GeneratorKey]pkgmodel.Generator{
+		{Label: "db-password", Stack: "default"}: stored,
+	}}
+
+	draws, err := SynthesizeDrawGeneratorUpdates(
+		[]resource_update.ResourceUpdate{{
+			DesiredState: pkgmodel.Resource{Label: "app-secret", Properties: genEnvelopeProperties("password", ksuid)},
+			Operation:    resource_update.OperationUpdate,
+			ProvenanceRecords: []resource_update.OccurrenceRecord{{
+				DestinationPath: "password",
+				DesiredIdentity: resource_update.OccurrenceIdentity{
+					Kind: resource_update.OccurrenceKindGenerator, Ksuid: ksuid, PropertyPath: "value",
+				},
+				Class: resource_update.OccurrenceStable,
+			}},
+		}},
+		nil,
+		map[pkgmodel.GeneratorKey]string{{Label: "db-password", Stack: "default"}: ksuid},
+		ds,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, draws)
+}
+
+func TestSynthesizeDrawGeneratorUpdates_PrefersThisCommandsDeclaredSpec(t *testing.T) {
+	// A generator created or edited by this same command is not yet (or no
+	// longer) what the datastore holds, so its draw must be built from the
+	// declaration this command carries.
+	const ksuid = "2abcDEFghiJKLmnoPQRstuVWxyz"
+
+	declared := &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 40, ID: ksuid}
+	ds := &stubSpecLookup{byKey: map[pkgmodel.GeneratorKey]pkgmodel.Generator{
+		{Label: "db-password", Stack: "default"}: &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24},
+	}}
+
+	draws, err := SynthesizeDrawGeneratorUpdates(
+		[]resource_update.ResourceUpdate{{
+			DesiredState: pkgmodel.Resource{Label: "app-secret", Properties: genEnvelopeProperties("password", ksuid)},
+			Operation:    resource_update.OperationCreate,
+		}},
+		[]GeneratorUpdate{{
+			Generator:  declared,
+			Operation:  GeneratorOperationUpdate,
+			StackLabel: "default",
+		}},
+		map[pkgmodel.GeneratorKey]string{{Label: "db-password", Stack: "default"}: ksuid},
+		ds,
+	)
+	require.NoError(t, err)
+	require.Len(t, draws, 1)
+
+	spec, ok := draws[0].Generator.(*pkgmodel.PasswordGenerator)
+	require.True(t, ok)
+	assert.Equal(t, 40, spec.Length)
+	assert.Equal(t, ksuid, spec.ID)
+}
+
+func TestSynthesizeDrawGeneratorUpdates_UnresolvableGeneratorDrawsNothing(t *testing.T) {
+	// A $gen envelope naming a KSUID this command can map to no generator
+	// has nothing to draw from. The command is not rejected over it: the
+	// destination goes on to be refused at the provider boundary, which
+	// names the property rather than a bare KSUID.
+	const ksuid = "2abcDEFghiJKLmnoPQRstuVWxyz"
+
+	draws, err := SynthesizeDrawGeneratorUpdates(
+		[]resource_update.ResourceUpdate{{
+			DesiredState: pkgmodel.Resource{Label: "app-secret", Properties: genEnvelopeProperties("password", ksuid)},
+			Operation:    resource_update.OperationCreate,
+		}},
+		nil,
+		nil,
+		&stubSpecLookup{},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, draws)
+}

--- a/internal/metastructure/generator_update/draw_synthesis_test.go
+++ b/internal/metastructure/generator_update/draw_synthesis_test.go
@@ -18,16 +18,13 @@ import (
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
-// stubSpecLookup answers GetGenerator from a (label, stack) keyed map. The
-// generators it hands back carry no ID, exactly as a datastore load does:
+// stubLookup answers the synthesis's generator lookup from a KSUID keyed map.
+// The generators it hands back carry no ID, exactly as a datastore load does:
 // PasswordGenerator.ID is json:"-", so the KSUID never round-trips through
-// generator_data.
-type stubSpecLookup struct {
-	byKey map[pkgmodel.GeneratorKey]pkgmodel.Generator
-}
-
-func (s *stubSpecLookup) GetGenerator(label, stackLabel string) (pkgmodel.Generator, error) {
-	return s.byKey[pkgmodel.GeneratorKey{Label: label, Stack: stackLabel}], nil
+// generator_data. They do carry their stack, which the lookup's contract
+// requires and which both real call sites stamp from the row they read.
+func stubLookup(byKsuid map[string]pkgmodel.Generator) func(string) (pkgmodel.Generator, error) {
+	return func(ksuid string) (pkgmodel.Generator, error) { return byKsuid[ksuid], nil }
 }
 
 func genEnvelopeProperties(path, generatorKsuid string) json.RawMessage {
@@ -41,10 +38,9 @@ func TestSynthesizeDrawGeneratorUpdates_SecondConsumerOnUnchangedGeneratorDraws(
 	// GeneratorUpdate at all. The new consumer still needs a value.
 	const ksuid = "2abcDEFghiJKLmnoPQRstuVWxyz"
 
-	stored := &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24}
-	ds := &stubSpecLookup{byKey: map[pkgmodel.GeneratorKey]pkgmodel.Generator{
-		{Label: "db-password", Stack: "default"}: stored,
-	}}
+	lookup := stubLookup(map[string]pkgmodel.Generator{
+		ksuid: &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24},
+	})
 
 	resourceUpdates := []resource_update.ResourceUpdate{
 		// The pre-existing consumer: unchanged, provably stable.
@@ -69,8 +65,7 @@ func TestSynthesizeDrawGeneratorUpdates_SecondConsumerOnUnchangedGeneratorDraws(
 	draws, err := SynthesizeDrawGeneratorUpdates(
 		resourceUpdates,
 		nil, // the generator's row did not change: no GeneratorUpdate exists
-		map[pkgmodel.GeneratorKey]string{{Label: "db-password", Stack: "default"}: ksuid},
-		ds,
+		lookup,
 	)
 	require.NoError(t, err)
 	require.Len(t, draws, 1)
@@ -110,10 +105,9 @@ func TestSynthesizeDrawGeneratorUpdates_StaleProvenanceOnUnchangedGeneratorRedra
 	require.NotEqual(t, resource_update.OccurrenceStable, rec.Class,
 		"a destination stamped with a generation the generator no longer holds must not classify stable")
 
-	stored := &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24}
-	ds := &stubSpecLookup{byKey: map[pkgmodel.GeneratorKey]pkgmodel.Generator{
-		{Label: "db-password", Stack: "default"}: stored,
-	}}
+	lookup := stubLookup(map[string]pkgmodel.Generator{
+		ksuid: &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24},
+	})
 
 	draws, err := SynthesizeDrawGeneratorUpdates(
 		[]resource_update.ResourceUpdate{{
@@ -122,8 +116,7 @@ func TestSynthesizeDrawGeneratorUpdates_StaleProvenanceOnUnchangedGeneratorRedra
 			ProvenanceRecords: []resource_update.OccurrenceRecord{rec},
 		}},
 		nil,
-		map[pkgmodel.GeneratorKey]string{{Label: "db-password", Stack: "default"}: ksuid},
-		ds,
+		lookup,
 	)
 	require.NoError(t, err)
 	require.Len(t, draws, 1)
@@ -133,10 +126,9 @@ func TestSynthesizeDrawGeneratorUpdates_StaleProvenanceOnUnchangedGeneratorRedra
 func TestSynthesizeDrawGeneratorUpdates_AllStableDestinationsDrawNothing(t *testing.T) {
 	const ksuid = "2abcDEFghiJKLmnoPQRstuVWxyz"
 
-	stored := &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24}
-	ds := &stubSpecLookup{byKey: map[pkgmodel.GeneratorKey]pkgmodel.Generator{
-		{Label: "db-password", Stack: "default"}: stored,
-	}}
+	lookup := stubLookup(map[string]pkgmodel.Generator{
+		ksuid: &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24},
+	})
 
 	draws, err := SynthesizeDrawGeneratorUpdates(
 		[]resource_update.ResourceUpdate{{
@@ -151,8 +143,7 @@ func TestSynthesizeDrawGeneratorUpdates_AllStableDestinationsDrawNothing(t *test
 			}},
 		}},
 		nil,
-		map[pkgmodel.GeneratorKey]string{{Label: "db-password", Stack: "default"}: ksuid},
-		ds,
+		lookup,
 	)
 	require.NoError(t, err)
 	assert.Empty(t, draws)
@@ -165,9 +156,9 @@ func TestSynthesizeDrawGeneratorUpdates_PrefersThisCommandsDeclaredSpec(t *testi
 	const ksuid = "2abcDEFghiJKLmnoPQRstuVWxyz"
 
 	declared := &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 40, ID: ksuid}
-	ds := &stubSpecLookup{byKey: map[pkgmodel.GeneratorKey]pkgmodel.Generator{
-		{Label: "db-password", Stack: "default"}: &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24},
-	}}
+	lookup := stubLookup(map[string]pkgmodel.Generator{
+		ksuid: &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "default", Length: 24},
+	})
 
 	draws, err := SynthesizeDrawGeneratorUpdates(
 		[]resource_update.ResourceUpdate{{
@@ -179,8 +170,7 @@ func TestSynthesizeDrawGeneratorUpdates_PrefersThisCommandsDeclaredSpec(t *testi
 			Operation:  GeneratorOperationUpdate,
 			StackLabel: "default",
 		}},
-		map[pkgmodel.GeneratorKey]string{{Label: "db-password", Stack: "default"}: ksuid},
-		ds,
+		lookup,
 	)
 	require.NoError(t, err)
 	require.Len(t, draws, 1)
@@ -204,8 +194,7 @@ func TestSynthesizeDrawGeneratorUpdates_UnresolvableGeneratorDrawsNothing(t *tes
 			Operation:    resource_update.OperationCreate,
 		}},
 		nil,
-		nil,
-		&stubSpecLookup{},
+		stubLookup(nil),
 	)
 	require.NoError(t, err)
 	assert.Empty(t, draws)

--- a/internal/metastructure/generator_update/generator_update.go
+++ b/internal/metastructure/generator_update/generator_update.go
@@ -6,6 +6,7 @@ package generator_update
 
 import (
 	"encoding/json"
+	"net/url"
 	"time"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/types"
@@ -136,9 +137,10 @@ func (gu *GeneratorUpdate) UnmarshalJSON(data []byte) error {
 // changeset/generator_update_node_uri_test.go for the compile-time
 // assertion and the cross-format collision test.
 
-// NodeURI renders generator://<stack>/<label>/<operation>. This scheme
-// distinguishes it, by construction, from the other two Update kinds that
-// share the same ExecutionDAG.Nodes keyspace:
+// NodeURI renders generator://<stack>/<label>/<operation>, with StackLabel
+// and the generator's label each percent-encoded (url.PathEscape) before
+// joining. This scheme distinguishes it, by construction, from the other two
+// Update kinds that share the same ExecutionDAG.Nodes keyspace:
 //   - a resource operation URI (changeset.createOperationURI) is the bare
 //     "<ksuid>/<propertyPath>/<operation>" with no scheme at all: a KSUID,
 //     a property path, and an OperationType are each drawn from character
@@ -147,12 +149,36 @@ func (gu *GeneratorUpdate) UnmarshalJSON(data []byte) error {
 //   - a target operation URI (target_update.TargetUpdate.NodeURI) is
 //     "target://<label>/<operation>" — a different literal scheme, so it
 //     can never equal a "generator://" URI either.
+//
+// StackLabel and a generator's label are both free-form user-authored
+// strings that may themselves contain "/" — nothing in this codebase
+// validates against it. Joining two such fields with "/" as a plain
+// delimiter would let two distinct (stack, label) pairs collapse onto the
+// same string: StackLabel="s", label="a/b" and StackLabel="s/a", label="b"
+// both naively join to "s/a/b". url.PathEscape rules this out: it escapes
+// every literal "/" (and "%") within a segment to a %XX triplet, so the
+// only unescaped "/" characters ExecutionDAG ever sees in a generator URI
+// are the delimiters this function inserts itself, and PathEscape/
+// PathUnescape are exact inverses, so two different raw segments can never
+// produce the same escaped output.
+//
+// This is deliberately per-segment escaping rather than keying on the
+// generator's own KSUID (which is how ResourceUpdate avoids the same class
+// of collision, and would make it structurally impossible rather than
+// merely escaped): GetID() is not reliably populated on every path a
+// GeneratorUpdate is constructed on today. GenerateGeneratorUpdates's create
+// and update branches call Generator.SetID from genKeyToKsuid before
+// building the update, but its reconcile-driven delete branch builds the
+// update directly from a generator LoadGeneratorsByStack returned — and
+// PasswordGenerator.ID is `json:"-"`, so nothing in the persisted
+// generator_data JSON round-trips it back on load. Every reconcile-driven
+// GeneratorOperationDelete update therefore carries GetID() == "" today.
 func (gu *GeneratorUpdate) NodeURI() pkgmodel.FormaeURI {
 	label := ""
 	if gu.Generator != nil {
 		label = gu.Generator.GetLabel()
 	}
-	return pkgmodel.FormaeURI("generator://" + gu.StackLabel + "/" + label + "/" + string(gu.Operation))
+	return pkgmodel.FormaeURI("generator://" + url.PathEscape(gu.StackLabel) + "/" + url.PathEscape(label) + "/" + string(gu.Operation))
 }
 
 // Resolvables returns nil: a generator draws a value locally, it never

--- a/internal/metastructure/generator_update/generator_update.go
+++ b/internal/metastructure/generator_update/generator_update.go
@@ -39,8 +39,9 @@ const (
 	GeneratorUpdateStateFailed     = types.GeneratorUpdateStateFailed
 )
 
-// GeneratorUpdate represents a single generator change: a create, an update
-// (spec change and/or rename), or a delete.
+// GeneratorUpdate represents a single piece of generator work: a create, an
+// update (spec change and/or rename), a delete, or the draw that produces a
+// new value.
 type GeneratorUpdate struct {
 	Generator         pkgmodel.Generator   `json:"-"`
 	ExistingGenerator pkgmodel.Generator   `json:"-"`

--- a/internal/metastructure/generator_update/generator_update.go
+++ b/internal/metastructure/generator_update/generator_update.go
@@ -15,8 +15,9 @@ import (
 
 // GeneratorOperation and GeneratorUpdateState reuse the generic operation and
 // state vocabularies from types, the same way stack_update does — a
-// generator's lifecycle is Create/Update/Delete only, with no attach/detach
-// and no standalone form, so there is nothing generator-specific to add.
+// generator's row lifecycle is Create/Update/Delete only, with no
+// attach/detach and no standalone form, so there is nothing
+// generator-specific to add.
 type (
 	GeneratorOperation   = types.OperationType
 	GeneratorUpdateState = types.GeneratorUpdateState
@@ -26,6 +27,11 @@ const (
 	GeneratorOperationCreate GeneratorOperation = types.OperationCreate
 	GeneratorOperationUpdate GeneratorOperation = types.OperationUpdate
 	GeneratorOperationDelete GeneratorOperation = types.OperationDelete
+	// GeneratorOperationDraw is the synthetic op that draws a value. It is
+	// the only generator operation the ExecutionDAG schedules: the three
+	// above write the generator's row and are persisted before the changeset
+	// starts.
+	GeneratorOperationDraw GeneratorOperation = types.OperationDraw
 
 	GeneratorUpdateStateNotStarted = types.GeneratorUpdateStateNotStarted
 	GeneratorUpdateStateInProgress = types.GeneratorUpdateStateInProgress

--- a/internal/metastructure/generator_update/generator_update.go
+++ b/internal/metastructure/generator_update/generator_update.go
@@ -27,6 +27,7 @@ const (
 	GeneratorOperationDelete GeneratorOperation = types.OperationDelete
 
 	GeneratorUpdateStateNotStarted = types.GeneratorUpdateStateNotStarted
+	GeneratorUpdateStateInProgress = types.GeneratorUpdateStateInProgress
 	GeneratorUpdateStateSuccess    = types.GeneratorUpdateStateSuccess
 	GeneratorUpdateStateFailed     = types.GeneratorUpdateStateFailed
 )
@@ -126,6 +127,58 @@ func (gu *GeneratorUpdate) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+// changeset.Update interface implementation for ExecutionDAG integration.
+// The interface type itself is not referenced here (importing the changeset
+// package from generator_update would be an import cycle: changeset imports
+// forma_persister, which imports forma_command, which imports
+// generator_update) — see changeset/changeset_test.go and
+// changeset/generator_update_node_uri_test.go for the compile-time
+// assertion and the cross-format collision test.
+
+// NodeURI renders generator://<stack>/<label>/<operation>. This scheme
+// distinguishes it, by construction, from the other two Update kinds that
+// share the same ExecutionDAG.Nodes keyspace:
+//   - a resource operation URI (changeset.createOperationURI) is the bare
+//     "<ksuid>/<propertyPath>/<operation>" with no scheme at all: a KSUID,
+//     a property path, and an OperationType are each drawn from character
+//     sets that never contain "://", so a resource URI can never begin with
+//     "generator://".
+//   - a target operation URI (target_update.TargetUpdate.NodeURI) is
+//     "target://<label>/<operation>" — a different literal scheme, so it
+//     can never equal a "generator://" URI either.
+func (gu *GeneratorUpdate) NodeURI() pkgmodel.FormaeURI {
+	label := ""
+	if gu.Generator != nil {
+		label = gu.Generator.GetLabel()
+	}
+	return pkgmodel.FormaeURI("generator://" + gu.StackLabel + "/" + label + "/" + string(gu.Operation))
+}
+
+// Resolvables returns nil: a generator draws a value locally, it never
+// resolves a $ref against a resource or target property.
+func (gu *GeneratorUpdate) Resolvables() []pkgmodel.FormaeURI { return nil }
+
+// Namespace returns a fixed pseudo-namespace. A generator draw calls no
+// provider plugin, so it has no provider namespace to report. Because
+// IsRateLimited is false, this value never gates concurrency in
+// ExecutionDAG.GetExecutableUpdates — it only keeps generator nodes in
+// their own bucket, distinct from any provider's.
+func (gu *GeneratorUpdate) Namespace() string { return "generator" }
+
+// IsRateLimited returns false: drawing a password is local CPU work with no
+// provider call, so it needs no rate-limit token. A future generator arm
+// that calls out to a provider (e.g. fetching a secret from a vault) would
+// need to revisit this.
+func (gu *GeneratorUpdate) IsRateLimited() bool { return false }
+
+func (gu *GeneratorUpdate) IsReady() bool   { return gu.State == GeneratorUpdateStateNotStarted }
+func (gu *GeneratorUpdate) IsRunning() bool { return gu.State == GeneratorUpdateStateInProgress }
+func (gu *GeneratorUpdate) IsSuccess() bool { return gu.State == GeneratorUpdateStateSuccess }
+func (gu *GeneratorUpdate) IsFailed() bool  { return gu.State == GeneratorUpdateStateFailed }
+
+func (gu *GeneratorUpdate) MarkInProgress() { gu.State = GeneratorUpdateStateInProgress }
+func (gu *GeneratorUpdate) MarkFailed()     { gu.State = GeneratorUpdateStateFailed }
 
 // PersistGeneratorUpdates is a message to persist generator updates.
 type PersistGeneratorUpdates struct {

--- a/internal/metastructure/generator_update/generator_updater.go
+++ b/internal/metastructure/generator_update/generator_updater.go
@@ -26,9 +26,14 @@ const (
 // Operator-facing failure reasons. Like resource_update's
 // updateRequestFailureReason/createRequestFailureReason, a draw failure is
 // mapped to one of these fixed strings rather than surfacing the underlying
-// error: this text is projected to the API as GeneratorUpdate.ErrorMessage,
-// and the errors behind it name spec internals, database hosts and, in the
+// error: the errors behind it name spec internals, database hosts and, in the
 // worst case, could be made to echo input.
+//
+// The text reaches an operator on GeneratorUpdateFinished.ErrorMessage, which
+// the changeset executor stamps onto every resource update the failed draw
+// cascades to. Those are projected to the API as ResourceUpdate.ErrorMessage,
+// which is where an apply explains itself. The draw's own projected
+// GeneratorUpdate is frozen at planning time and never carries it.
 const (
 	failureReasonDrawFailed = "cannot draw a value for this generator: its specification admits no value. Check its length and its character-class settings."
 

--- a/internal/metastructure/generator_update/generator_updater.go
+++ b/internal/metastructure/generator_update/generator_updater.go
@@ -203,13 +203,15 @@ func handleDrawValue(from gen.PID, state gen.Atom, data GeneratorUpdaterData, me
 
 	spec := data.generatorUpdate.Generator
 
-	// The KSUID comes off the declared generator, where GenerateGeneratorUpdates
-	// stamped it from the translation phase's genKeyToKsuid map — the same
-	// value CreateGenerator/UpdateGenerator persisted, and the same value any
-	// $gen reference in this command was translated to. A generator LOADED
-	// from the datastore carries no ID (PasswordGenerator.ID is `json:"-"`),
-	// but the only updates built from a loaded generator are the reconcile
-	// deletes returned above.
+	// The KSUID comes off the generator on the update, and is the same value
+	// CreateGenerator/UpdateGenerator persisted and the same value any $gen
+	// reference in this command was translated to. For a generator this
+	// command declares, GenerateGeneratorUpdates stamped it from the
+	// translation phase's genKeyToKsuid map; for one it only references,
+	// SynthesizeDrawGeneratorUpdates stamps it after loading the generator —
+	// a LOADED generator carries no ID of its own, since
+	// PasswordGenerator.ID is `json:"-"` and the KSUID lives only in the
+	// generators table.
 	generatorID := ""
 	if spec != nil {
 		generatorID = spec.GetID()

--- a/internal/metastructure/generator_update/generator_updater.go
+++ b/internal/metastructure/generator_update/generator_updater.go
@@ -88,10 +88,18 @@ type DrawValue struct{}
 // TargetUpdateFinished.ResolvedConfig. DrawnValue is populated on success and
 // only on success; ErrorMessage is populated on failure and only on failure,
 // always from the fixed set of reasons above.
+//
+// GenerationID travels with the value because the two belong together: every
+// destination the value reaches is stamped with the generation it was drawn
+// under, and that stamp is what lets the next apply prove the value did not
+// move. Re-reading the generator's identity at the destination instead would
+// read whatever generation the row holds by then, which a concurrent draw
+// may already have advanced past this value.
 type GeneratorUpdateFinished struct {
 	NodeURI      pkgmodel.FormaeURI
 	State        GeneratorUpdateState
 	DrawnValue   string
+	GenerationID string
 	ErrorMessage string
 }
 
@@ -115,6 +123,9 @@ type GeneratorUpdaterData struct {
 	// GeneratorUpdate: the update is marshalled into the command record, this
 	// struct is not.
 	drawnValue string
+	// generationID is the identity of the generation drawnValue was drawn
+	// under, held alongside it for the same lifetime and reported with it.
+	generationID string
 	// errorMessage is one of the fixed operator-facing reasons above, set
 	// only on the failure path.
 	errorMessage string
@@ -251,6 +262,7 @@ func handleDrawValue(from gen.PID, state gen.Atom, data GeneratorUpdaterData, me
 	}
 
 	data.drawnValue = value
+	data.generationID = generationID
 	return StateFinishedSuccessfully, data, nil, nil
 }
 
@@ -271,6 +283,7 @@ func onGeneratorUpdaterStateChange(oldState gen.Atom, newState gen.Atom, data Ge
 	if newState == StateFinishedSuccessfully {
 		finished.State = GeneratorUpdateStateSuccess
 		finished.DrawnValue = data.drawnValue
+		finished.GenerationID = data.generationID
 	} else {
 		finished.ErrorMessage = data.errorMessage
 	}

--- a/internal/metastructure/generator_update/generator_updater.go
+++ b/internal/metastructure/generator_update/generator_updater.go
@@ -1,0 +1,282 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package generator_update
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+
+	"ergo.services/actor/statemachine"
+	"ergo.services/ergo/gen"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+const (
+	StateNotStarted           = gen.Atom("not_started")
+	StateDrawing              = gen.Atom("drawing")
+	StateFinishedSuccessfully = gen.Atom("finished_successfully")
+	StateFinishedWithError    = gen.Atom("finished_with_error")
+)
+
+// Operator-facing failure reasons. Like resource_update's
+// updateRequestFailureReason/createRequestFailureReason, a draw failure is
+// mapped to one of these fixed strings rather than surfacing the underlying
+// error: this text is projected to the API as GeneratorUpdate.ErrorMessage,
+// and the errors behind it name spec internals, database hosts and, in the
+// worst case, could be made to echo input.
+const (
+	failureReasonDrawFailed = "cannot draw a value for this generator: its specification admits no value. Check its length and its character-class settings."
+
+	failureReasonUnknownIdentity = "cannot draw a value for this generator: formae holds no identity for it, so it has nothing to record the new generation against."
+
+	failureReasonSpecNotRecordable = "cannot draw a value for this generator: formae could not record the specification the value would be drawn under."
+
+	failureReasonGenerationNotRecorded = "cannot draw a value for this generator: the value was drawn but its generation could not be recorded, so the value was discarded. Retry the apply."
+)
+
+// generationAdvancer is the minimal datastore surface this actor needs: it
+// records that a new generation was drawn for a generator. Declared locally
+// rather than taking datastore.Datastore because internal/datastore imports
+// this package (through forma_command), so importing it back would cycle.
+type generationAdvancer interface {
+	AdvanceGeneration(generatorID, generationID string, drawnUnder json.RawMessage) error
+}
+
+// GeneratorUpdater is an FSM actor that draws one generator's value, records
+// the generation it was drawn under, and reports the value to its requester.
+//
+// The drawn value exists in exactly two places, both of them in memory and
+// both of them for the lifetime of a single draw: GeneratorUpdaterData's
+// drawnValue field, and the GeneratorUpdateFinished message this actor sends
+// its requester before terminating. It is never written to the datastore,
+// never placed on the GeneratorUpdate (which IS persisted, and is projected
+// to the API), and never logged.
+type GeneratorUpdater struct {
+	statemachine.StateMachine[GeneratorUpdaterData]
+}
+
+// StartGeneratorUpdate is sent to the GeneratorUpdater to begin a draw.
+type StartGeneratorUpdate struct {
+	GeneratorUpdate GeneratorUpdate
+	CommandID       string
+}
+
+// DrawValue is sent by the actor to itself to leave StateNotStarted before
+// doing the draw, so the actor is observably in StateDrawing while it runs
+// rather than still reporting StateNotStarted. Exported for the same reason
+// Shutdown is: ergo dispatches handlers on the concrete message type.
+type DrawValue struct{}
+
+// GeneratorUpdateFinished is sent back to the requester when the draw
+// completes. It is the ONLY carrier of the drawn value — the analogue of
+// TargetUpdateFinished.ResolvedConfig. DrawnValue is populated on success and
+// only on success; ErrorMessage is populated on failure and only on failure,
+// always from the fixed set of reasons above.
+type GeneratorUpdateFinished struct {
+	NodeURI      pkgmodel.FormaeURI
+	State        GeneratorUpdateState
+	DrawnValue   string
+	ErrorMessage string
+}
+
+// Shutdown is sent to terminate the GeneratorUpdater process.
+type Shutdown struct{}
+
+// GeneratorUpdaterData holds the FSM's internal state. It is process-local
+// and is never persisted.
+type GeneratorUpdaterData struct {
+	generatorUpdate GeneratorUpdate
+	commandID       string
+	requestedBy     gen.PID
+	// entropy is the source Draw reads random bytes from: crypto/rand.Read in
+	// production, a deterministic source in tests so a specific drawn value is
+	// reproducible without relying on chance.
+	entropy pkgmodel.ByteSource
+	// datastore records the generation advance. Nothing else about a
+	// generator is written from here.
+	datastore generationAdvancer
+	// drawnValue holds the live credential between the draw and the finished
+	// signal. It is deliberately unexported and deliberately absent from
+	// GeneratorUpdate: the update is marshalled into the command record, this
+	// struct is not.
+	drawnValue string
+	// errorMessage is one of the fixed operator-facing reasons above, set
+	// only on the failure path.
+	errorMessage string
+}
+
+func NewGeneratorUpdater() gen.ProcessBehavior {
+	return &GeneratorUpdater{}
+}
+
+func (g *GeneratorUpdater) Init(args ...any) (statemachine.StateMachineSpec[GeneratorUpdaterData], error) {
+	data := GeneratorUpdaterData{
+		requestedBy: args[0].(gen.PID),
+		entropy:     rand.Read,
+	}
+
+	// The datastore is mandatory, unlike TargetUpdater's optional re-read
+	// handle: without it a drawn generation cannot be recorded, and a value
+	// handed out under a generation nobody stored is exactly the state the
+	// next apply cannot reason about.
+	ds, ok := g.Env("Datastore")
+	if !ok {
+		g.Log().Error("GeneratorUpdater: missing 'Datastore' environment variable")
+		return statemachine.StateMachineSpec[GeneratorUpdaterData]{}, fmt.Errorf("generatorUpdater: missing 'Datastore' environment variable")
+	}
+	advancer, ok := ds.(generationAdvancer)
+	if !ok {
+		g.Log().Error("GeneratorUpdater: 'Datastore' does not record generations")
+		return statemachine.StateMachineSpec[GeneratorUpdaterData]{}, fmt.Errorf("generatorUpdater: 'Datastore' does not implement AdvanceGeneration")
+	}
+	data.datastore = advancer
+
+	g.Log().Debug("GeneratorUpdater %s initialized", g.Name())
+
+	return statemachine.NewStateMachineSpec(StateNotStarted,
+		statemachine.WithData(data),
+		statemachine.WithStateEnterCallback(onGeneratorUpdaterStateChange),
+		// Not started — waiting for StartGeneratorUpdate.
+		statemachine.WithStateMessageHandler(StateNotStarted, handleStartGeneratorUpdate),
+		statemachine.WithStateMessageHandler(StateNotStarted, shutdownGeneratorUpdater),
+		// Drawing.
+		statemachine.WithStateMessageHandler(StateDrawing, handleDrawValue),
+		statemachine.WithStateMessageHandler(StateDrawing, shutdownGeneratorUpdater),
+		// Terminal states.
+		statemachine.WithStateMessageHandler(StateFinishedSuccessfully, shutdownGeneratorUpdater),
+		statemachine.WithStateMessageHandler(StateFinishedWithError, shutdownGeneratorUpdater),
+	), nil
+}
+
+// handleStartGeneratorUpdate records the request and enters StateDrawing. The
+// draw itself happens in handleDrawValue, off a message this actor sends
+// itself, so the FSM reports the state it is actually in while drawing.
+func handleStartGeneratorUpdate(from gen.PID, state gen.Atom, data GeneratorUpdaterData, message StartGeneratorUpdate, proc gen.Process) (gen.Atom, GeneratorUpdaterData, []statemachine.Action, error) {
+	data.generatorUpdate = message.GeneratorUpdate
+	data.commandID = message.CommandID
+
+	if err := proc.Send(proc.PID(), DrawValue{}); err != nil {
+		proc.Log().Error("GeneratorUpdater: failed to send draw message node=%s: %v", data.generatorUpdate.NodeURI(), err)
+		data.errorMessage = failureReasonDrawFailed
+		return StateFinishedWithError, data, nil, nil
+	}
+
+	return StateDrawing, data, nil, nil
+}
+
+// handleDrawValue draws the value, records the generation it was drawn under,
+// and moves to a terminal state.
+//
+// The order is deliberate. Everything that can fail without a live credential
+// in hand is done first: identity, then the marshalled spec. The draw itself
+// comes next, and the generation is recorded BEFORE success is reported, so a
+// value can never reach a destination under a generation the datastore does
+// not know about. If the recording fails the drawn value is dropped on the
+// floor here rather than reported.
+//
+// No log line in this function formats the generator's spec or its value —
+// identity only.
+func handleDrawValue(from gen.PID, state gen.Atom, data GeneratorUpdaterData, message DrawValue, proc gen.Process) (gen.Atom, GeneratorUpdaterData, []statemachine.Action, error) {
+	nodeURI := data.generatorUpdate.NodeURI()
+
+	// A delete has nothing to draw: the generator's row was already removed
+	// by PersistGeneratorUpdates before the changeset started, so the node's
+	// work is done. Drawing here would mint a credential for a generator that
+	// no longer exists and then try to advance a tombstoned row's generation.
+	if data.generatorUpdate.Operation == GeneratorOperationDelete {
+		return StateFinishedSuccessfully, data, nil, nil
+	}
+
+	spec := data.generatorUpdate.Generator
+
+	// The KSUID comes off the declared generator, where GenerateGeneratorUpdates
+	// stamped it from the translation phase's genKeyToKsuid map — the same
+	// value CreateGenerator/UpdateGenerator persisted, and the same value any
+	// $gen reference in this command was translated to. A generator LOADED
+	// from the datastore carries no ID (PasswordGenerator.ID is `json:"-"`),
+	// but the only updates built from a loaded generator are the reconcile
+	// deletes returned above.
+	generatorID := ""
+	if spec != nil {
+		generatorID = spec.GetID()
+	}
+	if generatorID == "" {
+		proc.Log().Error("GeneratorUpdater: no generator identity to record a generation against node=%s", nodeURI)
+		data.errorMessage = failureReasonUnknownIdentity
+		return StateFinishedWithError, data, nil, nil
+	}
+
+	// drawnUnder is the generator SPEC, never the value: it lands in a JSONB
+	// column that nothing in the stack redacts.
+	drawnUnder, err := json.Marshal(spec)
+	if err != nil {
+		proc.Log().Error("GeneratorUpdater: failed to marshal the generator spec node=%s", nodeURI)
+		data.errorMessage = failureReasonSpecNotRecordable
+		return StateFinishedWithError, data, nil, nil
+	}
+
+	// A fresh KSUID: this is the generation's identity, which a later apply
+	// digests and compares against what each destination was stamped with. It
+	// is not a digest of anything itself.
+	generationID := util.NewID()
+
+	value, err := pkgmodel.Draw(spec, data.entropy)
+	if err != nil {
+		// The error names spec internals; only the fixed reason is reported.
+		proc.Log().Error("GeneratorUpdater: failed to draw a value node=%s", nodeURI)
+		data.errorMessage = failureReasonDrawFailed
+		return StateFinishedWithError, data, nil, nil
+	}
+
+	if err := data.datastore.AdvanceGeneration(generatorID, generationID, drawnUnder); err != nil {
+		proc.Log().Error("GeneratorUpdater: failed to record the generation node=%s generation=%s", nodeURI, generationID)
+		data.errorMessage = failureReasonGenerationNotRecorded
+		return StateFinishedWithError, data, nil, nil
+	}
+
+	data.drawnValue = value
+	return StateFinishedSuccessfully, data, nil, nil
+}
+
+// onGeneratorUpdaterStateChange reports the outcome to the requester on
+// reaching a terminal state, then shuts the actor down. The drawn value is
+// attached to the finished message on the success branch and nowhere else, so
+// a failure — including one that happened after a value was already drawn —
+// can never propagate one.
+func onGeneratorUpdaterStateChange(oldState gen.Atom, newState gen.Atom, data GeneratorUpdaterData, proc gen.Process) (gen.Atom, GeneratorUpdaterData, error) {
+	if newState != StateFinishedSuccessfully && newState != StateFinishedWithError {
+		return newState, data, nil
+	}
+
+	finished := GeneratorUpdateFinished{
+		NodeURI: data.generatorUpdate.NodeURI(),
+		State:   GeneratorUpdateStateFailed,
+	}
+	if newState == StateFinishedSuccessfully {
+		finished.State = GeneratorUpdateStateSuccess
+		finished.DrawnValue = data.drawnValue
+	} else {
+		finished.ErrorMessage = data.errorMessage
+	}
+
+	proc.Log().Debug("GeneratorUpdater: sending GeneratorUpdateFinished to requester state=%s node=%s", newState, finished.NodeURI)
+	if err := proc.Send(data.requestedBy, finished); err != nil {
+		proc.Log().Error("GeneratorUpdater: failed to send GeneratorUpdateFinished to requester: %v", err)
+	}
+
+	// Send ourselves a shutdown message to terminate the process.
+	if err := proc.Send(proc.PID(), Shutdown{}); err != nil {
+		proc.Log().Error("GeneratorUpdater: failed to send shutdown message: %v", err)
+	}
+
+	return newState, data, nil
+}
+
+func shutdownGeneratorUpdater(from gen.PID, state gen.Atom, data GeneratorUpdaterData, shutdown Shutdown, proc gen.Process) (gen.Atom, GeneratorUpdaterData, []statemachine.Action, error) {
+	return state, data, nil, gen.TerminateReasonNormal
+}

--- a/internal/metastructure/generator_update/generator_updater.go
+++ b/internal/metastructure/generator_update/generator_updater.go
@@ -37,6 +37,12 @@ const (
 	failureReasonSpecNotRecordable = "cannot draw a value for this generator: formae could not record the specification the value would be drawn under."
 
 	failureReasonGenerationNotRecorded = "cannot draw a value for this generator: the value was drawn but its generation could not be recorded, so the value was discarded. Retry the apply."
+
+	// Distinct from failureReasonDrawFailed on purpose: the generator's spec
+	// is fine here, the actor could not hand the draw to itself. Telling the
+	// operator to check the length and character classes would send them
+	// looking for a fault that is not there.
+	failureReasonDrawNotStarted = "cannot draw a value for this generator: formae could not start the draw. Retry the apply."
 )
 
 // generationAdvancer is the minimal datastore surface this actor needs: it
@@ -61,9 +67,14 @@ type GeneratorUpdater struct {
 }
 
 // StartGeneratorUpdate is sent to the GeneratorUpdater to begin a draw.
+//
+// It carries no CommandID, unlike StartTargetUpdate: a TargetUpdater needs one
+// to address the per-command ResolveCache actor and to stamp the persist
+// message it sends the ResourcePersister, and this actor sends neither. The
+// command is already in the actor's registered name (see
+// actornames.GeneratorUpdater), which is the caller's to build.
 type StartGeneratorUpdate struct {
 	GeneratorUpdate GeneratorUpdate
-	CommandID       string
 }
 
 // DrawValue is sent by the actor to itself to leave StateNotStarted before
@@ -91,7 +102,6 @@ type Shutdown struct{}
 // and is never persisted.
 type GeneratorUpdaterData struct {
 	generatorUpdate GeneratorUpdate
-	commandID       string
 	requestedBy     gen.PID
 	// entropy is the source Draw reads random bytes from: crypto/rand.Read in
 	// production, a deterministic source in tests so a specific drawn value is
@@ -158,11 +168,10 @@ func (g *GeneratorUpdater) Init(args ...any) (statemachine.StateMachineSpec[Gene
 // itself, so the FSM reports the state it is actually in while drawing.
 func handleStartGeneratorUpdate(from gen.PID, state gen.Atom, data GeneratorUpdaterData, message StartGeneratorUpdate, proc gen.Process) (gen.Atom, GeneratorUpdaterData, []statemachine.Action, error) {
 	data.generatorUpdate = message.GeneratorUpdate
-	data.commandID = message.CommandID
 
 	if err := proc.Send(proc.PID(), DrawValue{}); err != nil {
 		proc.Log().Error("GeneratorUpdater: failed to send draw message node=%s: %v", data.generatorUpdate.NodeURI(), err)
-		data.errorMessage = failureReasonDrawFailed
+		data.errorMessage = failureReasonDrawNotStarted
 		return StateFinishedWithError, data, nil, nil
 	}
 

--- a/internal/metastructure/generator_update/generator_updater_test.go
+++ b/internal/metastructure/generator_update/generator_updater_test.go
@@ -35,8 +35,9 @@ func (stubGeneratorUpdaterLog) Panic(string, ...any)   {}
 type stubGeneratorUpdaterProcess struct {
 	gen.Process
 
-	mu    sync.Mutex
-	sends []any
+	mu      sync.Mutex
+	sends   []any
+	sendErr error
 }
 
 func (p *stubGeneratorUpdaterProcess) Log() gen.Log { return stubGeneratorUpdaterLog{} }
@@ -44,6 +45,9 @@ func (p *stubGeneratorUpdaterProcess) PID() gen.PID { return gen.PID{Node: "test
 func (p *stubGeneratorUpdaterProcess) Send(_ any, msg any) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.sendErr != nil {
+		return p.sendErr
+	}
 	p.sends = append(p.sends, msg)
 	return nil
 }
@@ -125,7 +129,6 @@ func drawingData(t *testing.T, op GeneratorOperation, advancer *recordingAdvance
 			State:      GeneratorUpdateStateNotStarted,
 			StackLabel: "app",
 		},
-		commandID:   "cmd-1",
 		requestedBy: gen.PID{Node: "test-node", ID: 99},
 		entropy:     countingSource(),
 		datastore:   advancer,
@@ -285,6 +288,85 @@ func TestGeneratorUpdaterActorName_DistinguishesStacks(t *testing.T) {
 	assert.NotEqual(t,
 		actornames.GeneratorUpdater(a.NodeURI(), "cmd-1"),
 		actornames.GeneratorUpdater(b.NodeURI(), "cmd-1"))
+}
+
+// TestGeneratorUpdater_UndeliverableDrawTriggerIsNotASpecFailure asserts that
+// failing to hand the draw to ourselves is reported as its own reason. The
+// generator's spec is not at fault, so the operator must not be sent to check
+// its length and character classes.
+func TestGeneratorUpdater_UndeliverableDrawTriggerIsNotASpecFailure(t *testing.T) {
+	data := drawingData(t, GeneratorOperationCreate, &recordingAdvancer{})
+	proc := &stubGeneratorUpdaterProcess{sendErr: datastoreError("mailbox full")}
+
+	state, out, _, err := handleStartGeneratorUpdate(gen.PID{}, StateNotStarted, data,
+		StartGeneratorUpdate{GeneratorUpdate: data.generatorUpdate}, proc)
+	require.NoError(t, err)
+
+	assert.Equal(t, StateFinishedWithError, state)
+	assert.Equal(t, failureReasonDrawNotStarted, out.errorMessage)
+	assert.NotEqual(t, failureReasonDrawFailed, out.errorMessage)
+	assert.Empty(t, out.drawnValue)
+}
+
+// TestGeneratorUpdater_EachDrawGetsAFreshGeneration asserts two successive
+// draws record two different generation identities. The generation ID is the
+// rotation's identity, and a later apply compares a digest of it against what
+// each destination was stamped with, so a repeated value would make a fresh
+// draw indistinguishable from the previous one.
+func TestGeneratorUpdater_EachDrawGetsAFreshGeneration(t *testing.T) {
+	advancer := &recordingAdvancer{}
+	proc := &stubGeneratorUpdaterProcess{}
+
+	for range 2 {
+		state, _, _, err := handleDrawValue(gen.PID{}, StateDrawing, drawingData(t, GeneratorOperationCreate, advancer), DrawValue{}, proc)
+		require.NoError(t, err)
+		require.Equal(t, StateFinishedSuccessfully, state)
+	}
+
+	require.Len(t, advancer.calls, 2)
+	assert.NotEqual(t, advancer.calls[0].generationID, advancer.calls[1].generationID,
+		"every draw must record a fresh generation identity")
+}
+
+// TestGeneratorUpdater_FaultyEntropyFailsWithoutAValue asserts a byte source
+// that cannot deliver — either by erroring or by returning fewer bytes than
+// asked for without an error — fails the draw with the fixed reason, attaches
+// no value, and never advances the generation.
+func TestGeneratorUpdater_FaultyEntropyFailsWithoutAValue(t *testing.T) {
+	tests := []struct {
+		name   string
+		source pkgmodel.ByteSource
+	}{
+		{
+			name: "source returns an error",
+			source: func([]byte) (int, error) {
+				return 0, datastoreError("entropy pool exhausted at /dev/urandom")
+			},
+		},
+		{
+			name:   "source short-reads without an error",
+			source: func([]byte) (int, error) { return 0, nil },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			advancer := &recordingAdvancer{}
+			data := drawingData(t, GeneratorOperationCreate, advancer)
+			data.entropy = tt.source
+
+			proc := &stubGeneratorUpdaterProcess{}
+			state, out, _, err := handleDrawValue(gen.PID{}, StateDrawing, data, DrawValue{}, proc)
+			require.NoError(t, err)
+
+			assert.Equal(t, StateFinishedWithError, state)
+			assert.Equal(t, failureReasonDrawFailed, out.errorMessage)
+			assert.NotContains(t, out.errorMessage, "urandom",
+				"the operator-facing message must not carry raw error text")
+			assert.Empty(t, out.drawnValue)
+			assert.Empty(t, advancer.calls, "a failed draw must not advance the generation")
+		})
+	}
 }
 
 // datastoreError builds an error carrying text that must not reach an operator.

--- a/internal/metastructure/generator_update/generator_updater_test.go
+++ b/internal/metastructure/generator_update/generator_updater_test.go
@@ -140,6 +140,7 @@ func drawingData(t *testing.T, op GeneratorOperation, advancer *recordingAdvance
 func TestGeneratorUpdater_SuccessCarriesDrawnValue(t *testing.T) {
 	data := drawingData(t, GeneratorOperationCreate, &recordingAdvancer{})
 	data.drawnValue = "s3cret-value"
+	data.generationID = "2mnoPQRstuVWxyzabcDEFghiJKL"
 
 	proc := &stubGeneratorUpdaterProcess{}
 	_, _, err := onGeneratorUpdaterStateChange(StateDrawing, StateFinishedSuccessfully, data, proc)
@@ -150,6 +151,8 @@ func TestGeneratorUpdater_SuccessCarriesDrawnValue(t *testing.T) {
 	assert.Equal(t, GeneratorUpdateStateSuccess, finished[0].State)
 	assert.Equal(t, "s3cret-value", finished[0].DrawnValue,
 		"the drawn value must reach the requester through the finished signal")
+	assert.Equal(t, "2mnoPQRstuVWxyzabcDEFghiJKL", finished[0].GenerationID,
+		"the generation the value was drawn under travels with it, so destinations can be stamped with it")
 	assert.Empty(t, finished[0].ErrorMessage)
 	assert.Equal(t, 1, proc.sentShutdowns(), "the actor must terminate itself once it has reported")
 }
@@ -159,6 +162,7 @@ func TestGeneratorUpdater_SuccessCarriesDrawnValue(t *testing.T) {
 func TestGeneratorUpdater_FailureOmitsDrawnValue(t *testing.T) {
 	data := drawingData(t, GeneratorOperationCreate, &recordingAdvancer{})
 	data.drawnValue = "s3cret-value"
+	data.generationID = "2mnoPQRstuVWxyzabcDEFghiJKL"
 	data.errorMessage = failureReasonDrawFailed
 
 	proc := &stubGeneratorUpdaterProcess{}
@@ -170,6 +174,8 @@ func TestGeneratorUpdater_FailureOmitsDrawnValue(t *testing.T) {
 	assert.Equal(t, GeneratorUpdateStateFailed, finished[0].State)
 	assert.Empty(t, finished[0].DrawnValue,
 		"a failed draw must never propagate a value")
+	assert.Empty(t, finished[0].GenerationID,
+		"a failed draw attests no generation")
 	assert.Equal(t, failureReasonDrawFailed, finished[0].ErrorMessage)
 }
 
@@ -194,6 +200,8 @@ func TestGeneratorUpdater_DrawRecordsGenerationUnderTheSpec(t *testing.T) {
 	call := advancer.calls[0]
 	assert.Equal(t, testPasswordGenerator().ID, call.generatorID)
 	assert.Len(t, call.generationID, 27, "the generation identity must be a fresh KSUID")
+	assert.Equal(t, call.generationID, out.generationID,
+		"the generation reported with the value is the one recorded for it, never one re-read afterwards")
 
 	var spec pkgmodel.PasswordGenerator
 	require.NoError(t, json.Unmarshal(call.drawnUnder, &spec),

--- a/internal/metastructure/generator_update/generator_updater_test.go
+++ b/internal/metastructure/generator_update/generator_updater_test.go
@@ -1,0 +1,293 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package generator_update
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// stubGeneratorUpdaterLog swallows all log output.
+type stubGeneratorUpdaterLog struct{ gen.Log }
+
+func (stubGeneratorUpdaterLog) Trace(string, ...any)   {}
+func (stubGeneratorUpdaterLog) Debug(string, ...any)   {}
+func (stubGeneratorUpdaterLog) Info(string, ...any)    {}
+func (stubGeneratorUpdaterLog) Warning(string, ...any) {}
+func (stubGeneratorUpdaterLog) Error(string, ...any)   {}
+func (stubGeneratorUpdaterLog) Panic(string, ...any)   {}
+
+// stubGeneratorUpdaterProcess is a gen.Process double that records every Send
+// so tests can inspect what the actor reported to its requester.
+type stubGeneratorUpdaterProcess struct {
+	gen.Process
+
+	mu    sync.Mutex
+	sends []any
+}
+
+func (p *stubGeneratorUpdaterProcess) Log() gen.Log { return stubGeneratorUpdaterLog{} }
+func (p *stubGeneratorUpdaterProcess) PID() gen.PID { return gen.PID{Node: "test-node", ID: 1} }
+func (p *stubGeneratorUpdaterProcess) Send(_ any, msg any) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.sends = append(p.sends, msg)
+	return nil
+}
+
+func (p *stubGeneratorUpdaterProcess) sentFinishedMessages() []GeneratorUpdateFinished {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var out []GeneratorUpdateFinished
+	for _, s := range p.sends {
+		if m, ok := s.(GeneratorUpdateFinished); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func (p *stubGeneratorUpdaterProcess) sentShutdowns() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	n := 0
+	for _, s := range p.sends {
+		if _, ok := s.(Shutdown); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// advanceCall records one AdvanceGeneration invocation.
+type advanceCall struct {
+	generatorID  string
+	generationID string
+	drawnUnder   json.RawMessage
+}
+
+// recordingAdvancer is a generationAdvancer double.
+type recordingAdvancer struct {
+	calls []advanceCall
+	err   error
+}
+
+func (r *recordingAdvancer) AdvanceGeneration(generatorID, generationID string, drawnUnder json.RawMessage) error {
+	r.calls = append(r.calls, advanceCall{generatorID, generationID, drawnUnder})
+	return r.err
+}
+
+// countingSource is a deterministic ByteSource: it hands out 0, 1, 2, ...
+// wrapping at 256, so two independently constructed sources produce the same
+// sequence and therefore the same drawn value.
+func countingSource() pkgmodel.ByteSource {
+	var n int
+	return func(b []byte) (int, error) {
+		for i := range b {
+			b[i] = byte(n % 256)
+			n++
+		}
+		return len(b), nil
+	}
+}
+
+func testPasswordGenerator() *pkgmodel.PasswordGenerator {
+	return &pkgmodel.PasswordGenerator{
+		Label:     "db-password",
+		Stack:     "app",
+		ID:        "2abcDEFghiJKLmnoPQRstuVWxyz",
+		Length:    24,
+		Uppercase: true,
+		Lowercase: true,
+		Digits:    true,
+	}
+}
+
+func drawingData(t *testing.T, op GeneratorOperation, advancer *recordingAdvancer) GeneratorUpdaterData {
+	t.Helper()
+	return GeneratorUpdaterData{
+		generatorUpdate: GeneratorUpdate{
+			Generator:  testPasswordGenerator(),
+			Operation:  op,
+			State:      GeneratorUpdateStateNotStarted,
+			StackLabel: "app",
+		},
+		commandID:   "cmd-1",
+		requestedBy: gen.PID{Node: "test-node", ID: 99},
+		entropy:     countingSource(),
+		datastore:   advancer,
+	}
+}
+
+// TestGeneratorUpdater_SuccessCarriesDrawnValue asserts the finished signal
+// carries the drawn value on success, and that the actor then shuts itself down.
+func TestGeneratorUpdater_SuccessCarriesDrawnValue(t *testing.T) {
+	data := drawingData(t, GeneratorOperationCreate, &recordingAdvancer{})
+	data.drawnValue = "s3cret-value"
+
+	proc := &stubGeneratorUpdaterProcess{}
+	_, _, err := onGeneratorUpdaterStateChange(StateDrawing, StateFinishedSuccessfully, data, proc)
+	require.NoError(t, err)
+
+	finished := proc.sentFinishedMessages()
+	require.Len(t, finished, 1, "exactly one GeneratorUpdateFinished must be sent on success")
+	assert.Equal(t, GeneratorUpdateStateSuccess, finished[0].State)
+	assert.Equal(t, "s3cret-value", finished[0].DrawnValue,
+		"the drawn value must reach the requester through the finished signal")
+	assert.Empty(t, finished[0].ErrorMessage)
+	assert.Equal(t, 1, proc.sentShutdowns(), "the actor must terminate itself once it has reported")
+}
+
+// TestGeneratorUpdater_FailureOmitsDrawnValue asserts a failed draw reports no
+// value at all, even if one is somehow present in the actor's data.
+func TestGeneratorUpdater_FailureOmitsDrawnValue(t *testing.T) {
+	data := drawingData(t, GeneratorOperationCreate, &recordingAdvancer{})
+	data.drawnValue = "s3cret-value"
+	data.errorMessage = failureReasonDrawFailed
+
+	proc := &stubGeneratorUpdaterProcess{}
+	_, _, err := onGeneratorUpdaterStateChange(StateDrawing, StateFinishedWithError, data, proc)
+	require.NoError(t, err)
+
+	finished := proc.sentFinishedMessages()
+	require.Len(t, finished, 1, "exactly one GeneratorUpdateFinished must be sent on failure")
+	assert.Equal(t, GeneratorUpdateStateFailed, finished[0].State)
+	assert.Empty(t, finished[0].DrawnValue,
+		"a failed draw must never propagate a value")
+	assert.Equal(t, failureReasonDrawFailed, finished[0].ErrorMessage)
+}
+
+// TestGeneratorUpdater_DrawRecordsGenerationUnderTheSpec asserts a successful
+// draw records a fresh generation against the generator's KSUID, under the
+// marshalled spec, and that the recorded spec is not the drawn value.
+func TestGeneratorUpdater_DrawRecordsGenerationUnderTheSpec(t *testing.T) {
+	advancer := &recordingAdvancer{}
+	data := drawingData(t, GeneratorOperationCreate, advancer)
+
+	proc := &stubGeneratorUpdaterProcess{}
+	state, out, _, err := handleDrawValue(gen.PID{}, StateDrawing, data, DrawValue{}, proc)
+	require.NoError(t, err)
+	require.Equal(t, StateFinishedSuccessfully, state)
+
+	expected, err := pkgmodel.Draw(testPasswordGenerator(), countingSource())
+	require.NoError(t, err)
+	assert.Equal(t, expected, out.drawnValue, "the draw must consume the injected entropy source")
+	assert.Len(t, out.drawnValue, 24)
+
+	require.Len(t, advancer.calls, 1, "a successful draw records exactly one generation")
+	call := advancer.calls[0]
+	assert.Equal(t, testPasswordGenerator().ID, call.generatorID)
+	assert.Len(t, call.generationID, 27, "the generation identity must be a fresh KSUID")
+
+	var spec pkgmodel.PasswordGenerator
+	require.NoError(t, json.Unmarshal(call.drawnUnder, &spec),
+		"drawnUnder must be the marshalled generator spec")
+	assert.Equal(t, 24, spec.Length)
+	assert.NotContains(t, string(call.drawnUnder), out.drawnValue,
+		"the drawn value must never be written to the datastore")
+}
+
+// TestGeneratorUpdater_RecordingFailureDiscardsTheValue asserts that when the
+// generation cannot be recorded the drawn value is discarded rather than
+// reported, and the failure carries a fixed operator-facing reason.
+func TestGeneratorUpdater_RecordingFailureDiscardsTheValue(t *testing.T) {
+	advancer := &recordingAdvancer{err: datastoreError("connection refused to db-host:5432")}
+	data := drawingData(t, GeneratorOperationCreate, advancer)
+
+	proc := &stubGeneratorUpdaterProcess{}
+	state, out, _, err := handleDrawValue(gen.PID{}, StateDrawing, data, DrawValue{}, proc)
+	require.NoError(t, err)
+
+	assert.Equal(t, StateFinishedWithError, state)
+	assert.Empty(t, out.drawnValue, "a value that could not be recorded must not be kept")
+	assert.Equal(t, failureReasonGenerationNotRecorded, out.errorMessage)
+	assert.NotContains(t, out.errorMessage, "db-host",
+		"the operator-facing message must not carry raw error text")
+}
+
+// TestGeneratorUpdater_UndrawableSpecMapsToAFixedReason asserts a spec that
+// admits no value fails with a fixed reason and never reaches the datastore.
+func TestGeneratorUpdater_UndrawableSpecMapsToAFixedReason(t *testing.T) {
+	advancer := &recordingAdvancer{}
+	data := drawingData(t, GeneratorOperationCreate, advancer)
+	data.generatorUpdate.Generator = &pkgmodel.PasswordGenerator{
+		Label:  "db-password",
+		Stack:  "app",
+		ID:     "2abcDEFghiJKLmnoPQRstuVWxyz",
+		Length: 0,
+	}
+
+	proc := &stubGeneratorUpdaterProcess{}
+	state, out, _, err := handleDrawValue(gen.PID{}, StateDrawing, data, DrawValue{}, proc)
+	require.NoError(t, err)
+
+	assert.Equal(t, StateFinishedWithError, state)
+	assert.Equal(t, failureReasonDrawFailed, out.errorMessage)
+	assert.False(t, strings.Contains(out.errorMessage, "non-positive"),
+		"the operator-facing message must not carry raw error text")
+	assert.Empty(t, advancer.calls, "a failed draw must not advance the generation")
+}
+
+// TestGeneratorUpdater_DeleteDrawsNothing asserts a delete node finishes
+// successfully without drawing a value or touching the datastore: the
+// generator row was already removed before the changeset started.
+func TestGeneratorUpdater_DeleteDrawsNothing(t *testing.T) {
+	advancer := &recordingAdvancer{}
+	data := drawingData(t, GeneratorOperationDelete, advancer)
+
+	proc := &stubGeneratorUpdaterProcess{}
+	state, out, _, err := handleDrawValue(gen.PID{}, StateDrawing, data, DrawValue{}, proc)
+	require.NoError(t, err)
+
+	assert.Equal(t, StateFinishedSuccessfully, state)
+	assert.Empty(t, out.drawnValue)
+	assert.Empty(t, advancer.calls)
+}
+
+// TestGeneratorUpdater_UnknownIdentityFailsBeforeDrawing asserts a generator
+// with no KSUID fails before any value is drawn, since the generation it would
+// be drawn under could not be recorded against anything.
+func TestGeneratorUpdater_UnknownIdentityFailsBeforeDrawing(t *testing.T) {
+	advancer := &recordingAdvancer{}
+	data := drawingData(t, GeneratorOperationCreate, advancer)
+	data.generatorUpdate.Generator.SetID("")
+
+	proc := &stubGeneratorUpdaterProcess{}
+	state, out, _, err := handleDrawValue(gen.PID{}, StateDrawing, data, DrawValue{}, proc)
+	require.NoError(t, err)
+
+	assert.Equal(t, StateFinishedWithError, state)
+	assert.Equal(t, failureReasonUnknownIdentity, out.errorMessage)
+	assert.Empty(t, out.drawnValue)
+	assert.Empty(t, advancer.calls)
+}
+
+// TestGeneratorUpdaterActorName_DistinguishesStacks asserts two generators
+// sharing a label in different stacks get distinct actor names, so one command
+// touching both spawns two actors rather than colliding on one.
+func TestGeneratorUpdaterActorName_DistinguishesStacks(t *testing.T) {
+	a := GeneratorUpdate{Generator: &pkgmodel.PasswordGenerator{Label: "db-password"}, Operation: GeneratorOperationCreate, StackLabel: "app"}
+	b := GeneratorUpdate{Generator: &pkgmodel.PasswordGenerator{Label: "db-password"}, Operation: GeneratorOperationCreate, StackLabel: "batch"}
+
+	assert.NotEqual(t,
+		actornames.GeneratorUpdater(a.NodeURI(), "cmd-1"),
+		actornames.GeneratorUpdater(b.NodeURI(), "cmd-1"))
+}
+
+// datastoreError builds an error carrying text that must not reach an operator.
+type datastoreError string
+
+func (e datastoreError) Error() string { return string(e) }

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -671,6 +671,31 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 		// Forma.Generators to the datastore. The generator writes themselves
 		// (CreateGenerator/UpdateGenerator/DeleteGenerator, just above) are
 		// fully durable regardless.
+
+		// A command whose only work is generator work has now done all of it,
+		// and nothing downstream will ever move it off NotStarted: the
+		// changeset executor below starts only for resource or target
+		// updates, and a generator update has no state message of its own to
+		// recompute the command state the way UpdateStackStates and
+		// UpdatePolicyStates do for theirs. Left alone the command sits
+		// incomplete forever, which is worse than failing: it never
+		// self-heals, and dropping an unreferenced generator from a forma is
+		// an ordinary edit. Finalize it here instead, which recomputes the
+		// command state over its (empty) resource updates and reads Success.
+		//
+		// A failure to finalize is logged rather than returned: the generator
+		// writes are already durable, so reporting the apply as failed would
+		// misdescribe it, and the recovery sweep finalizes the command on the
+		// agent's next start.
+		if len(fa.ResourceUpdates) == 0 && len(fa.TargetUpdates) == 0 {
+			if _, ferr := m.callActor(
+				gen.ProcessID{Name: actornames.FormaCommandPersister, Node: m.Node.Name()},
+				forma_persister.FinalizeIncompleteCommand{CommandID: fa.ID},
+			); ferr != nil {
+				slog.Error("Failed to finalize a generator-only command",
+					"commandID", fa.ID, "error", ferr)
+			}
+		}
 	}
 
 	if len(fa.ResourceUpdates) > 0 || len(fa.TargetUpdates) > 0 {

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -422,7 +422,7 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 		if synthErr != nil {
 			return nil, synthErr
 		}
-		cs, err = changeset.NewChangeset(fa.ResourceUpdates, append(fa.TargetUpdates, synth...), fa.ID, fa.Command, config.Mode)
+		cs, err = changeset.NewChangeset(fa.ResourceUpdates, append(fa.TargetUpdates, synth...), fa.DrawGeneratorUpdates, fa.ID, fa.Command, config.Mode)
 		if err != nil {
 			return nil, err
 		}
@@ -1026,7 +1026,8 @@ func (m *Metastructure) DestroyForma(forma *pkgmodel.Forma, config *config.Forma
 		if synthErr != nil {
 			return nil, synthErr
 		}
-		cs, err := changeset.NewChangeset(fa.ResourceUpdates, append(fa.TargetUpdates, synth...), fa.ID, pkgmodel.CommandDestroy, config.Mode)
+		// No generator draws: a destroy writes no property.
+		cs, err := changeset.NewChangeset(fa.ResourceUpdates, append(fa.TargetUpdates, synth...), nil, fa.ID, pkgmodel.CommandDestroy, config.Mode)
 		if err != nil {
 			return nil, err
 		}
@@ -1626,7 +1627,11 @@ func (m *Metastructure) ReRunIncompleteCommands() error {
 			slog.Error("Failed to build changeset for incomplete forma command, skipping", "commandID", fa.ID, "error", synthErr)
 			continue
 		}
-		cs, err := changeset.NewChangeset(pendingUpdates, append(pendingTargetUpdates, synth...), fa.ID, pkgmodel.CommandApply, fa.Config.Mode)
+		// No generator draws yet. A draw is meaningless outside the changeset
+		// it produced a value for, so it is not stored with the command and
+		// cannot be replayed; the surviving destinations have to be re-read to
+		// derive it, which this recovery path does not do.
+		cs, err := changeset.NewChangeset(pendingUpdates, append(pendingTargetUpdates, synth...), nil, fa.ID, pkgmodel.CommandApply, fa.Config.Mode)
 		if err != nil {
 			slog.Error("Failed to build changeset for incomplete forma command, skipping", "commandID", fa.ID, "error", err)
 			continue
@@ -2298,7 +2303,18 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 		return nil, err
 	}
 
-	return forma_command.NewFormaCommand(
+	// The draws are derived from the DESTINATIONS that still need a value,
+	// not from the generator diff above: a generator whose spec is unchanged
+	// produces no GeneratorUpdate, yet a resource newly bound to it still
+	// needs a value drawn. genKeyToKsuid is what maps a translated $gen
+	// envelope's KSUID back to the generator it names.
+	drawGeneratorUpdates, err := generator_update.SynthesizeDrawGeneratorUpdates(
+		resourceUpdates, generatorUpdates, genKeyToKsuid, ds)
+	if err != nil {
+		return nil, err
+	}
+
+	fc := forma_command.NewFormaCommand(
 		forma,
 		formaCommandConfig,
 		command,
@@ -2311,7 +2327,10 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 		subject,
 		subjectName,
 		forma_command.SourceUser,
-	), nil
+	)
+	fc.DrawGeneratorUpdates = drawGeneratorUpdates
+
+	return fc, nil
 }
 
 // RegisteredPlugins returns plugins currently registered with the

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1660,7 +1660,7 @@ func (m *Metastructure) ReRunIncompleteCommands() error {
 		// here unchanged and a credential the interrupted command never meant
 		// to touch is not rotated by the resume.
 		draws, drawErr := generator_update.SynthesizeDrawGeneratorUpdates(
-			pendingUpdates, nil, generatorLookupByStack(pendingUpdates, m.Datastore))
+			pendingUpdates, nil, generatorLookupForResume(pendingUpdates, m.Datastore))
 		if drawErr != nil {
 			slog.Error("Failed to build changeset for incomplete forma command, skipping", "commandID", fa.ID, "error", drawErr)
 			continue
@@ -1729,66 +1729,123 @@ func generatorLookupByTranslation(
 	}
 }
 
-// generatorLookupByStack is the resume path's route to the same thing. The
+// generatorLookupForResume is the resume path's route to the same thing. The
 // translation map lived in the planning call's stack frame and is long gone,
-// and a $gen envelope that survived to the datastore carries only a KSUID —
-// pkgmodel.GeneratorIdentity has no label and no stack, so an identity lookup
-// by ID cannot reach a spec either. What the surviving updates do still say
-// is which stacks they sit on, and a stack's generators are enumerable: each
-// one's label plus its stack yields its KSUID, which is the pairing the
-// envelopes are matched against.
+// and a $gen envelope that survived to the datastore carries only a KSUID.
 //
-// A generator on some other stack than any surviving destination's resolves
-// to nothing here, and the synthesis logs it and draws nothing for it; the
-// destination is then refused at the provider boundary, naming the property.
-// Reaching it would take a by-KSUID spec load, which is a new datastore
-// method and four backend implementations for a case one read per resumed
-// stack already covers.
-func generatorLookupByStack(
+// The KSUID is enough. GeneratorIdentity has no Label or Stack field, but its
+// GenerationSpec IS the serialized generator the current generation was drawn
+// under, and that carries both. So GetGeneratorIdentityByID gives the spec,
+// parsing it gives (label, stack), and GetGenerator on that pair gives the
+// generator as it stands NOW — which is what a draw must run under, not the
+// spec the last generation happened to use. Two existing interface methods,
+// no new datastore surface, one lookup per KSUID.
+//
+// GenerationSpec is nil until something has been drawn, so a generator that
+// has never drawn cannot be reached that way. For that case only, the stacks
+// the surviving destinations sit on are enumerated and each generator's label
+// resolved to its KSUID. The index is built once, on the first miss, so the
+// ordinary case pays nothing for it.
+func generatorLookupForResume(
 	pendingUpdates []resource_update.ResourceUpdate,
 	ds datastore.Datastore,
 ) func(string) (pkgmodel.Generator, error) {
 	if ds == nil {
 		return nil
 	}
-	// Built on the first lookup rather than up front, so a resumed command
-	// with no $gen destinations at all does no datastore work: the synthesis
-	// returns before it ever calls this.
-	var byKsuid map[string]pkgmodel.Generator
+	var neverDrawnByKsuid map[string]pkgmodel.Generator
 	return func(ksuid string) (pkgmodel.Generator, error) {
-		if byKsuid == nil {
-			built := make(map[string]pkgmodel.Generator)
-			seen := make(map[string]bool)
-			for i := range pendingUpdates {
-				stack := pendingUpdates[i].DesiredState.Stack
-				if stack == "" || seen[stack] {
-					continue
-				}
-				seen[stack] = true
-
-				generators, err := ds.LoadGeneratorsByStack(stack)
-				if err != nil {
-					return nil, fmt.Errorf("failed to load the generators of stack %q: %w", stack, err)
-				}
-				for _, generator := range generators {
-					identity, err := ds.GetGeneratorIdentity(generator.GetLabel(), stack)
-					if err != nil {
-						return nil, fmt.Errorf("failed to resolve the identity of generator %q in stack %q: %w",
-							generator.GetLabel(), stack, err)
-					}
-					if identity.ID == "" {
-						continue
-					}
-					// The stack the row was found under is authoritative for
-					// the draw op, whatever the serialized spec carries.
-					generator.SetStack(stack)
-					built[identity.ID] = generator
-				}
-			}
-			byKsuid = built
+		generator, err := generatorByKsuid(ksuid, ds)
+		if err != nil || generator != nil {
+			return generator, err
 		}
-		return byKsuid[ksuid], nil
+		if neverDrawnByKsuid == nil {
+			neverDrawnByKsuid, err = generatorsOnStacksOf(pendingUpdates, ds)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return neverDrawnByKsuid[ksuid], nil
 	}
+}
+
+// generatorByKsuid resolves a generator KSUID to the generator that holds it,
+// through the generation spec its identity carries. A nil generator and a nil
+// error mean the KSUID reaches no generator this way — either none exists, or
+// none has drawn yet and there is therefore no spec to read a label and stack
+// out of.
+func generatorByKsuid(ksuid string, ds datastore.Datastore) (pkgmodel.Generator, error) {
+	identity, err := ds.GetGeneratorIdentityByID(ksuid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve the identity of generator %s: %w", ksuid, err)
+	}
+	if len(identity.GenerationSpec) == 0 {
+		return nil, nil
+	}
+	drawnUnder, err := pkgmodel.ParseGenerator(identity.GenerationSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the generation spec of generator %s: %w", ksuid, err)
+	}
+	label, stack := drawnUnder.GetLabel(), drawnUnder.GetStack()
+	if label == "" || stack == "" {
+		return nil, nil
+	}
+	// The CURRENT generator, not the spec the last generation was drawn
+	// under: an edited spec must be what the next value is drawn from.
+	stored, err := ds.GetGenerator(label, stack)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load generator %q in stack %q: %w", label, stack, err)
+	}
+	if stored == nil {
+		return nil, nil
+	}
+	stored.SetStack(stack)
+	return stored, nil
+}
+
+// generatorsOnStacksOf indexes, by KSUID, every generator owned by a stack
+// that at least one of these updates sits on. It is the fallback for a
+// generator that has never drawn, whose identity therefore carries no spec to
+// read a label and stack out of.
+//
+// A never-drawn generator on some other stack than any surviving
+// destination's is not found. The synthesis logs that and draws nothing for
+// it, and the destination is refused at the provider boundary naming the
+// property. Reaching it would take loading the generator itself by KSUID,
+// which is a new Datastore method and four backend implementations, for a
+// case that needs a cross-stack binding AND a generator that has never once
+// drawn.
+func generatorsOnStacksOf(
+	pendingUpdates []resource_update.ResourceUpdate,
+	ds datastore.Datastore,
+) (map[string]pkgmodel.Generator, error) {
+	byKsuid := make(map[string]pkgmodel.Generator)
+	seen := make(map[string]bool)
+	for i := range pendingUpdates {
+		stack := pendingUpdates[i].DesiredState.Stack
+		if stack == "" || seen[stack] {
+			continue
+		}
+		seen[stack] = true
+
+		generators, err := ds.LoadGeneratorsByStack(stack)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load the generators of stack %q: %w", stack, err)
+		}
+		for _, generator := range generators {
+			identity, err := ds.GetGeneratorIdentity(generator.GetLabel(), stack)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve the identity of generator %q in stack %q: %w",
+					generator.GetLabel(), stack, err)
+			}
+			if identity.ID == "" {
+				continue
+			}
+			generator.SetStack(stack)
+			byKsuid[identity.ID] = generator
+		}
+	}
+	return byKsuid, nil
 }
 
 func (m *Metastructure) checkForConflictingCommands(commandStackLabels []string) error {

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1652,11 +1652,20 @@ func (m *Metastructure) ReRunIncompleteCommands() error {
 			slog.Error("Failed to build changeset for incomplete forma command, skipping", "commandID", fa.ID, "error", synthErr)
 			continue
 		}
-		// No generator draws yet. A draw is meaningless outside the changeset
-		// it produced a value for, so it is not stored with the command and
-		// cannot be replayed; the surviving destinations have to be re-read to
-		// derive it, which this recovery path does not do.
-		cs, err := changeset.NewChangeset(pendingUpdates, append(pendingTargetUpdates, synth...), nil, fa.ID, pkgmodel.CommandApply, fa.Config.Mode)
+		// A draw is meaningless outside the changeset it produced a value for:
+		// the value was never persisted, so an interrupted command cannot
+		// replay it and has to draw again for whatever it still owes. That is
+		// the same synthesis the planning path runs, over the surviving
+		// destinations, so the rule that suppresses a stable binding applies
+		// here unchanged and a credential the interrupted command never meant
+		// to touch is not rotated by the resume.
+		draws, drawErr := generator_update.SynthesizeDrawGeneratorUpdates(
+			pendingUpdates, nil, generatorLookupByStack(pendingUpdates, m.Datastore))
+		if drawErr != nil {
+			slog.Error("Failed to build changeset for incomplete forma command, skipping", "commandID", fa.ID, "error", drawErr)
+			continue
+		}
+		cs, err := changeset.NewChangeset(pendingUpdates, append(pendingTargetUpdates, synth...), draws, fa.ID, pkgmodel.CommandApply, fa.Config.Mode)
 		if err != nil {
 			slog.Error("Failed to build changeset for incomplete forma command, skipping", "commandID", fa.ID, "error", err)
 			continue
@@ -1684,6 +1693,102 @@ func (m *Metastructure) ReRunIncompleteCommands() error {
 	}
 
 	return nil
+}
+
+// generatorLookupByTranslation is the planning path's route from a $gen
+// envelope's KSUID to the generator holding its spec. Translation has just
+// resolved every $gen this command saw into genKeyToKsuid, so the label and
+// stack a datastore load needs are already in hand.
+func generatorLookupByTranslation(
+	genKeyToKsuid map[pkgmodel.GeneratorKey]string,
+	ds datastore.Datastore,
+) func(string) (pkgmodel.Generator, error) {
+	if ds == nil {
+		return nil
+	}
+	keyByKsuid := make(map[string]pkgmodel.GeneratorKey, len(genKeyToKsuid))
+	for key, ksuid := range genKeyToKsuid {
+		keyByKsuid[ksuid] = key
+	}
+	return func(ksuid string) (pkgmodel.Generator, error) {
+		key, ok := keyByKsuid[ksuid]
+		if !ok {
+			return nil, nil
+		}
+		stored, err := ds.GetGenerator(key.Label, key.Stack)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load generator %q in stack %q: %w", key.Label, key.Stack, err)
+		}
+		if stored == nil {
+			return nil, nil
+		}
+		// The stack the row was found under is authoritative for the draw op,
+		// whatever the serialized spec happens to carry.
+		stored.SetStack(key.Stack)
+		return stored, nil
+	}
+}
+
+// generatorLookupByStack is the resume path's route to the same thing. The
+// translation map lived in the planning call's stack frame and is long gone,
+// and a $gen envelope that survived to the datastore carries only a KSUID —
+// pkgmodel.GeneratorIdentity has no label and no stack, so an identity lookup
+// by ID cannot reach a spec either. What the surviving updates do still say
+// is which stacks they sit on, and a stack's generators are enumerable: each
+// one's label plus its stack yields its KSUID, which is the pairing the
+// envelopes are matched against.
+//
+// A generator on some other stack than any surviving destination's resolves
+// to nothing here, and the synthesis logs it and draws nothing for it; the
+// destination is then refused at the provider boundary, naming the property.
+// Reaching it would take a by-KSUID spec load, which is a new datastore
+// method and four backend implementations for a case one read per resumed
+// stack already covers.
+func generatorLookupByStack(
+	pendingUpdates []resource_update.ResourceUpdate,
+	ds datastore.Datastore,
+) func(string) (pkgmodel.Generator, error) {
+	if ds == nil {
+		return nil
+	}
+	// Built on the first lookup rather than up front, so a resumed command
+	// with no $gen destinations at all does no datastore work: the synthesis
+	// returns before it ever calls this.
+	var byKsuid map[string]pkgmodel.Generator
+	return func(ksuid string) (pkgmodel.Generator, error) {
+		if byKsuid == nil {
+			built := make(map[string]pkgmodel.Generator)
+			seen := make(map[string]bool)
+			for i := range pendingUpdates {
+				stack := pendingUpdates[i].DesiredState.Stack
+				if stack == "" || seen[stack] {
+					continue
+				}
+				seen[stack] = true
+
+				generators, err := ds.LoadGeneratorsByStack(stack)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load the generators of stack %q: %w", stack, err)
+				}
+				for _, generator := range generators {
+					identity, err := ds.GetGeneratorIdentity(generator.GetLabel(), stack)
+					if err != nil {
+						return nil, fmt.Errorf("failed to resolve the identity of generator %q in stack %q: %w",
+							generator.GetLabel(), stack, err)
+					}
+					if identity.ID == "" {
+						continue
+					}
+					// The stack the row was found under is authoritative for
+					// the draw op, whatever the serialized spec carries.
+					generator.SetStack(stack)
+					built[identity.ID] = generator
+				}
+			}
+			byKsuid = built
+		}
+		return byKsuid[ksuid], nil
+	}
 }
 
 func (m *Metastructure) checkForConflictingCommands(commandStackLabels []string) error {
@@ -2342,7 +2447,7 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 	var drawGeneratorUpdates []generator_update.GeneratorUpdate
 	if command != pkgmodel.CommandDestroy {
 		drawGeneratorUpdates, err = generator_update.SynthesizeDrawGeneratorUpdates(
-			resourceUpdates, generatorUpdates, genKeyToKsuid, ds)
+			resourceUpdates, generatorUpdates, generatorLookupByTranslation(genKeyToKsuid, ds))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1704,7 +1704,7 @@ func (m *Metastructure) ReRunIncompleteCommands() error {
 		// here unchanged and a credential the interrupted command never meant
 		// to touch is not rotated by the resume.
 		draws, drawErr := generator_update.SynthesizeDrawGeneratorUpdates(
-			pendingUpdates, nil, generatorLookupForResume(pendingUpdates, m.Datastore))
+			pendingUpdates, nil, generatorLookupForResume(m.Datastore))
 		if drawErr != nil {
 			slog.Error("Failed to build changeset for incomplete forma command, skipping", "commandID", fa.ID, "error", drawErr)
 			continue
@@ -1786,14 +1786,15 @@ func generatorLookupByTranslation(
 // no new datastore surface, one lookup per KSUID.
 //
 // GenerationSpec is nil until something has been drawn, so a generator that
-// has never drawn cannot be reached that way. For that case only, the stacks
-// the surviving destinations sit on are enumerated and each generator's label
-// resolved to its KSUID. The index is built once, on the first miss, so the
-// ordinary case pays nothing for it.
-func generatorLookupForResume(
-	pendingUpdates []resource_update.ResourceUpdate,
-	ds datastore.Datastore,
-) func(string) (pkgmodel.Generator, error) {
+// has never drawn cannot be reached that way. For that case only, every stack
+// is enumerated and each generator's label resolved to its KSUID. A generator
+// belongs to one stack and is meant to be referenced from others, so the
+// search cannot be narrowed to the stacks the surviving destinations sit on:
+// that is precisely the cross-stack binding the design is built around, and
+// narrowing it leaves the destination refused at the provider boundary. The
+// index is built once, on the first miss, so the ordinary case pays nothing
+// for it.
+func generatorLookupForResume(ds datastore.Datastore) func(string) (pkgmodel.Generator, error) {
 	if ds == nil {
 		return nil
 	}
@@ -1804,7 +1805,7 @@ func generatorLookupForResume(
 			return generator, err
 		}
 		if neverDrawnByKsuid == nil {
-			neverDrawnByKsuid, err = generatorsOnStacksOf(pendingUpdates, ds)
+			neverDrawnByKsuid, err = neverDrawnGeneratorsByKsuid(ds)
 			if err != nil {
 				return nil, err
 			}
@@ -1847,45 +1848,44 @@ func generatorByKsuid(ksuid string, ds datastore.Datastore) (pkgmodel.Generator,
 	return stored, nil
 }
 
-// generatorsOnStacksOf indexes, by KSUID, every generator owned by a stack
-// that at least one of these updates sits on. It is the fallback for a
-// generator that has never drawn, whose identity therefore carries no spec to
-// read a label and stack out of.
+// neverDrawnGeneratorsByKsuid indexes every live generator by its KSUID. It
+// is the fallback for a generator that has never drawn, whose identity
+// therefore carries no spec to read a label and stack out of, and which no
+// (label, stack) pair in hand can name.
 //
-// A never-drawn generator on some other stack than any surviving
-// destination's is not found. The synthesis logs that and draws nothing for
-// it, and the destination is refused at the provider boundary naming the
-// property. Reaching it would take loading the generator itself by KSUID,
-// which is a new Datastore method and four backend implementations, for a
-// case that needs a cross-stack binding AND a generator that has never once
-// drawn.
-func generatorsOnStacksOf(
-	pendingUpdates []resource_update.ResourceUpdate,
-	ds datastore.Datastore,
-) (map[string]pkgmodel.Generator, error) {
+// The whole inventory is walked because the KSUID is all there is to go on: a
+// generator's stack is not derivable from its destinations', and the
+// cross-stack binding is the case this exists to serve. It costs one stack
+// listing plus a load and an identity read per generator, once per resume
+// that has such a generator, which is a rare path over a small table.
+//
+// The stack the row was found under is stamped on each generator, since that
+// is what the draw op is filed under and a serialized spec need not carry it.
+func neverDrawnGeneratorsByKsuid(ds datastore.Datastore) (map[string]pkgmodel.Generator, error) {
+	stacks, err := ds.ListAllStacks()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list the stacks to search for generators: %w", err)
+	}
+
 	byKsuid := make(map[string]pkgmodel.Generator)
-	seen := make(map[string]bool)
-	for i := range pendingUpdates {
-		stack := pendingUpdates[i].DesiredState.Stack
-		if stack == "" || seen[stack] {
+	for _, stack := range stacks {
+		if stack == nil || stack.Label == "" {
 			continue
 		}
-		seen[stack] = true
-
-		generators, err := ds.LoadGeneratorsByStack(stack)
+		generators, err := ds.LoadGeneratorsByStack(stack.Label)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load the generators of stack %q: %w", stack, err)
+			return nil, fmt.Errorf("failed to load the generators of stack %q: %w", stack.Label, err)
 		}
 		for _, generator := range generators {
-			identity, err := ds.GetGeneratorIdentity(generator.GetLabel(), stack)
+			identity, err := ds.GetGeneratorIdentity(generator.GetLabel(), stack.Label)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve the identity of generator %q in stack %q: %w",
-					generator.GetLabel(), stack, err)
+					generator.GetLabel(), stack.Label, err)
 			}
 			if identity.ID == "" {
 				continue
 			}
-			generator.SetStack(stack)
+			generator.SetStack(stack.Label)
 			byKsuid[identity.ID] = generator
 		}
 	}

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -2308,10 +2308,19 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 	// produces no GeneratorUpdate, yet a resource newly bound to it still
 	// needs a value drawn. genKeyToKsuid is what maps a translated $gen
 	// envelope's KSUID back to the generator it names.
-	drawGeneratorUpdates, err := generator_update.SynthesizeDrawGeneratorUpdates(
-		resourceUpdates, generatorUpdates, genKeyToKsuid, ds)
-	if err != nil {
-		return nil, err
+	//
+	// A destroy never draws: it writes no property, and its generators go
+	// with the stack. DestroyForma passes no draws to its changeset either,
+	// so computing them here would only cost a datastore read per referenced
+	// generator and leave a populated field on a command that must never use
+	// it.
+	var drawGeneratorUpdates []generator_update.GeneratorUpdate
+	if command != pkgmodel.CommandDestroy {
+		drawGeneratorUpdates, err = generator_update.SynthesizeDrawGeneratorUpdates(
+			resourceUpdates, generatorUpdates, genKeyToKsuid, ds)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	fc := forma_command.NewFormaCommand(

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -5,10 +5,12 @@
 package metastructure
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -953,6 +955,63 @@ func translateToAPICommand(fa *forma_command.FormaCommand) apimodel.Command {
 		})
 	}
 
+	// The draws are projected from their own field, in their own loop, after
+	// the declared diff above. fa.GeneratorUpdates is what changes a
+	// generator's row; fa.DrawGeneratorUpdates is what draws a value, and a
+	// draw exists for generators the diff above says nothing about at all —
+	// a generator whose spec nobody edited still draws when a destination is
+	// added to it. Projecting only the diff leaves an apply that is about to
+	// rotate a credential reading as no generator activity whatsoever.
+	//
+	// A generator with both a declared change and a draw appears twice, once
+	// per operation, rather than as one merged entry. They are separate work
+	// with separate consequences: one rewrites the generator's row before the
+	// changeset starts, the other rotates the credential every bound
+	// destination holds. Merging them would force a single Operation string
+	// that either hides the rotation or hides the spec diff.
+	//
+	// On a declared entry the State, Duration and ErrorMessage carried here
+	// track the update as it runs. On a draw they are plan-time values and
+	// stay that way: DrawGeneratorUpdates is json:"-" and the changeset takes
+	// its own copy, so nothing writes back to the slice this reads. A draw's
+	// outcome reaches an operator through the destinations it cascades to,
+	// whose FailureReason carries the reason the draw could not produce a
+	// value.
+	//
+	// A draw carries no config, neither current nor old. It changes nothing
+	// about the declared spec: NewDrawGeneratorUpdate leaves ExistingGenerator
+	// nil, and its Generator is the spec the value will be drawn under, which
+	// is either this command's desired spec (already projected above, with its
+	// diff) or the unchanged stored one. Marshaling it here would present a
+	// non-diff as one. Nothing on this path marshals a generator at all, so it
+	// cannot leak a KSUID (json:"-" on the concrete type regardless), the
+	// drawing spec (pkgmodel.GeneratorIdentity, never on Generator) or a drawn
+	// value (none exists until the changeset runs).
+	for _, dgu := range fa.DrawGeneratorUpdates {
+		var dur time.Duration = 0
+		if !dgu.StartTs.IsZero() {
+			dur = dgu.ModifiedTs.Sub(dgu.StartTs)
+		}
+
+		var generatorLabel, generatorType string
+		if dgu.Generator != nil {
+			generatorLabel = dgu.Generator.GetLabel()
+			generatorType = dgu.Generator.GetType()
+		}
+
+		apiCommand.GeneratorUpdates = append(apiCommand.GeneratorUpdates, apimodel.GeneratorUpdate{
+			GeneratorLabel: generatorLabel,
+			GeneratorType:  generatorType,
+			StackLabel:     dgu.StackLabel,
+			Operation:      string(dgu.Operation),
+			State:          string(dgu.State),
+			Duration:       dur.Milliseconds(),
+			ErrorMessage:   dgu.ErrorMessage,
+			StartTs:        dgu.StartTs,
+			ModifiedTs:     dgu.ModifiedTs,
+		})
+	}
+
 	return apiCommand
 }
 
@@ -1602,21 +1661,6 @@ func (m *Metastructure) ReRunIncompleteCommands() error {
 			if ru.State == resource_update.ResourceUpdateStateNotStarted {
 				pendingUpdates = append(pendingUpdates, *ru)
 			}
-		}
-
-		// If all resource updates already reached a terminal state, the command
-		// just needs its own state updated — no changeset execution needed.
-		// This happens when the agent crashed after all CRUD ops completed but
-		// before the command transitioned to a final state.
-		if len(pendingUpdates) == 0 {
-			_, err := m.callActor(
-				gen.ProcessID{Name: actornames.FormaCommandPersister, Node: m.Node.Name()},
-				forma_persister.FinalizeIncompleteCommand{CommandID: fa.ID},
-			)
-			if err != nil {
-				slog.Error("Failed to finalize incomplete command", "commandID", fa.ID, "error", err)
-			}
-			continue
 		}
 
 		// If all resource updates already reached a terminal state, the command
@@ -2508,6 +2552,38 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 		if err != nil {
 			return nil, err
 		}
+
+		// A draw reaches the destinations that are nodes in the changeset and
+		// no others, so every live destination of a drawing generator that
+		// this forma declares must be planned — including the ones the
+		// ordinary pass suppressed because nothing about them moved. Without
+		// this the new destination takes the new generation and the applied
+		// one keeps the old, and no later apply can level them.
+		//
+		// The order here is what keeps the feedback loop open. The drawing set
+		// is derived from the planned updates, and co-planning ADDS updates,
+		// so re-deriving it over the widened plan could make a co-planned
+		// resource's other, stable bindings look like they need a draw and
+		// rotate a credential nobody touched. drawGeneratorUpdates is computed
+		// once, above, from the ordinary pass, and is never recomputed.
+		liveDestinations, err := liveGeneratorDestinations(drawGeneratorUpdates, ds)
+		if err != nil {
+			return nil, err
+		}
+		coPlanKsuids := generatorDestinationsToCoPlan(liveDestinations, resourceUpdates, forma)
+		coPlanned, err := resource_update.CoPlanGeneratorDestinations(
+			forma, coPlanKsuids, formaCommandConfig.Mode, source, existingTargets, ds, formaCommandConfig.Force)
+		if err != nil {
+			return nil, err
+		}
+		resourceUpdates = append(resourceUpdates, coPlanned...)
+
+		// What is left unreachable after co-planning is what the forma does
+		// not declare at all, which is what the refusal exists for.
+		if err := refuseUnreachableGeneratorDestinations(
+			drawGeneratorUpdates, liveDestinations, resourceUpdates); err != nil {
+			return nil, err
+		}
 	}
 
 	fc := forma_command.NewFormaCommand(
@@ -2527,6 +2603,198 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 	fc.DrawGeneratorUpdates = drawGeneratorUpdates
 
 	return fc, nil
+}
+
+// liveGeneratorDestinations indexes, per drawing generator, the live resources
+// the datastore records as bound to it.
+//
+// The read is done once and handed to both passes that need it. Co-planning
+// and the refusal ask the same question of the same rows a moment apart —
+// which of a drawing generator's live destinations the command reaches — and
+// separating the read from the two decisions keeps each of them a decision
+// over data rather than a datastore round trip of its own.
+//
+// One draw exists per generator KSUID (SynthesizeDrawGeneratorUpdates derives
+// them from a deduplicated set), so the KSUID is a key. A generator with no
+// live destination at all is absent rather than present-and-empty: neither
+// caller has anything to say about it.
+func liveGeneratorDestinations(
+	draws []generator_update.GeneratorUpdate,
+	ds datastore.Datastore,
+) (map[string][]*pkgmodel.Resource, error) {
+	if len(draws) == 0 {
+		return nil, nil
+	}
+
+	destinations := make(map[string][]*pkgmodel.Resource, len(draws))
+	for i := range draws {
+		generator := draws[i].Generator
+		if generator == nil || generator.GetID() == "" {
+			continue
+		}
+		indexed, err := ds.FindResourcesReferencingGenerator(generator.GetID())
+		if err != nil {
+			return nil, fmt.Errorf("failed to find the resources bound to generator %q in stack %q: %w",
+				generator.GetLabel(), draws[i].StackLabel, err)
+		}
+		if len(indexed) == 0 {
+			continue
+		}
+		destinations[generator.GetID()] = indexed
+	}
+
+	return destinations, nil
+}
+
+// generatorDestinationsToCoPlan returns the KSUIDs of the resources this
+// command must plan on a draw's account: a live destination of a generator
+// that is going to draw, declared by the forma being applied, that the
+// ordinary planning pass produced no update for.
+//
+// The declaration test is by KSUID, which translation has already resolved on
+// both sides — a forma resource carries the KSUID of the row it matches, and
+// the index answers with the row. A destination the forma does not declare is
+// deliberately left out: it cannot be planned from a declaration that is not
+// there, and it is precisely what refuseUnreachableGeneratorDestinations
+// refuses the command for.
+//
+// A resource the ordinary pass already planned is never co-planned either.
+// The two passes emit whole ResourceUpdates and the changeset keeps one node
+// per operation URI, so a second update for one resource would be dropped on
+// the floor with nothing terminalizing it. That is the same reach question the
+// refusal asks, so both read it from resource_update.ResourceKsuidsInCommand.
+//
+// liveDestinations is indexed from the drawing set derived by the ORIGINAL
+// planning pass. Nothing here may recompute that set over the updates
+// co-planning adds; see the call site.
+func generatorDestinationsToCoPlan(
+	liveDestinations map[string][]*pkgmodel.Resource,
+	resourceUpdates []resource_update.ResourceUpdate,
+	forma *pkgmodel.Forma,
+) map[string]bool {
+	if len(liveDestinations) == 0 {
+		return nil
+	}
+
+	declared := make(map[string]bool, len(forma.Resources))
+	for i := range forma.Resources {
+		if ksuid := forma.Resources[i].Ksuid; ksuid != "" {
+			declared[ksuid] = true
+		}
+	}
+	if len(declared) == 0 {
+		return nil
+	}
+
+	inCommand := resource_update.ResourceKsuidsInCommand(resourceUpdates)
+
+	var coPlan map[string]bool
+	for _, indexed := range liveDestinations {
+		for _, destination := range indexed {
+			if destination == nil || inCommand[destination.Ksuid] || !declared[destination.Ksuid] {
+				continue
+			}
+			if coPlan == nil {
+				coPlan = make(map[string]bool)
+			}
+			coPlan[destination.Ksuid] = true
+		}
+	}
+
+	return coPlan
+}
+
+// refuseUnreachableGeneratorDestinations rejects a command that would draw a
+// generator's value while reaching only some of the resources bound to it.
+//
+// formae keeps a hash of a drawn value, never the value, so a destination
+// that was not in the command when the draw happened can never be brought
+// level afterwards: the only way to give it a value is to draw again, which
+// puts its siblings behind. That oscillation has no fixed point, so the
+// command is refused instead, naming the destinations it cannot reach.
+//
+// Reach is a property of the graph: a destination with a planned update is
+// reached by the command whatever its desired document now says about the
+// binding, which is why this reads resource_update.ResourceKsuidsInCommand
+// rather than the bindings. An apply that unbinds one destination while
+// drawing for another writes both of them, and refusing it would be a refusal
+// of something perfectly deliverable.
+//
+// Which STACKS the destinations sit on is irrelevant. A command carries all
+// of a forma's resource updates, so an apply spanning several stacks reaches
+// every destination in them; what is refused is an apply reaching only part
+// of a drawing generator's destination set.
+//
+// It runs AFTER co-planning, and that is what leaves it a narrow job. A
+// destination the applied forma declares is pulled into the command by
+// generatorDestinationsToCoPlan whether or not anything about it moved, so
+// what reaches this check is the destination the forma does not declare at
+// all — a consumer in another stack the operator did not apply. Running it
+// before co-planning would refuse an apply that merely adds a second
+// destination to a generator, since the applied destination beside it has
+// nothing to plan on its own account.
+//
+// The list is sorted before it goes into the error. It is read by an operator
+// who has to go and find each destination, and none of the datastore backends
+// order the rows they answer with, so two runs of the same refused apply would
+// otherwise name the same destinations in a different order.
+//
+// Two boundaries this deliberately does not cross:
+//
+//   - It is an admission check for a NEW command only. ReRunIncompleteCommands
+//     rebuilds a changeset from what a crashed command still owes, which is
+//     deliberately a SUBSET of the original destinations, so checking there
+//     would refuse every resumed command whose fan-out was partly done.
+//   - A destroy never draws, so its caller never computes draws to check.
+//
+// It DOES fire under simulation. The cascade aborts nearby skip simulation so
+// the CLI can render the cascade and the operator elevate on confirmation;
+// there is no confirmation that makes a split draw correct, and rendering a
+// plan that can never be applied is worse than a refusal naming what is
+// missing.
+func refuseUnreachableGeneratorDestinations(
+	draws []generator_update.GeneratorUpdate,
+	liveDestinations map[string][]*pkgmodel.Resource,
+	resourceUpdates []resource_update.ResourceUpdate,
+) error {
+	if len(liveDestinations) == 0 {
+		return nil
+	}
+
+	inCommand := resource_update.ResourceKsuidsInCommand(resourceUpdates)
+
+	var unreachable []apimodel.UnreachableGeneratorDestination
+	for i := range draws {
+		generator := draws[i].Generator
+		if generator == nil {
+			continue
+		}
+		for _, destination := range liveDestinations[generator.GetID()] {
+			if destination == nil || inCommand[destination.Ksuid] {
+				continue
+			}
+			unreachable = append(unreachable, apimodel.UnreachableGeneratorDestination{
+				GeneratorLabel: generator.GetLabel(),
+				GeneratorStack: draws[i].StackLabel,
+				Stack:          destination.Stack,
+				Label:          destination.Label,
+				Type:           destination.Type,
+			})
+		}
+	}
+	if len(unreachable) == 0 {
+		return nil
+	}
+	slices.SortFunc(unreachable, func(a, b apimodel.UnreachableGeneratorDestination) int {
+		return cmp.Or(
+			strings.Compare(a.GeneratorStack, b.GeneratorStack),
+			strings.Compare(a.GeneratorLabel, b.GeneratorLabel),
+			strings.Compare(a.Stack, b.Stack),
+			strings.Compare(a.Label, b.Label),
+			strings.Compare(a.Type, b.Type),
+		)
+	})
+	return apimodel.FormaGeneratorDestinationsUnreachableError{Unreachable: unreachable}
 }
 
 // RegisteredPlugins returns plugins currently registered with the
@@ -2660,9 +2928,9 @@ func extractKSUIDs(jsonStr string, ksuidSet map[string]struct{}) {
 //
 // This handles $ref only. A $gen envelope's bare $generator KSUID is not
 // reverse-translated here, and extractKSUIDs above does not even collect it
-// (it only looks at strings that parse as formae:// URIs): no resource row
-// can persist a $gen today, so there is nothing for this function to see.
-// The reverse arm for $gen is owed by whichever slice lands value drawing.
+// (it only looks at strings that parse as formae:// URIs). Resource rows do
+// persist $gen envelopes, so extraction carries the raw $generator KSUID
+// through into what it emits instead of an authorable generator declaration.
 func replaceKSUIDs(jsonStr string, ksuidToTriplet map[string]pkgmodel.TripletKey) string {
 	var replace func(value any) any
 	replace = func(value any) any {
@@ -2775,12 +3043,14 @@ func rewriteEmbedSpans(tmpl string, fn func(map[string]any) map[string]any) stri
 }
 
 // validateNoOpaqueEmbed rejects any forma whose resource properties or target
-// configs contain a $embed field whose $template carries a framed span for a
-// $res envelope with $visibility == "Opaque".
+// configs contain a $embed field whose $template carries a framed span for an
+// envelope with $visibility == "Opaque". Both a $res naming an opaque property
+// and a $gen bound to a generator carry that visibility, so the check covers
+// each of them without naming either: it reads $visibility and nothing else.
 //
-// v1 limitation: once an opaque resolvable is assembled into a string the
-// structured span needed for redaction is lost, so we hard-reject it at plan
-// time rather than silently leaking secrets.
+// v1 limitation: once an opaque value is assembled into a string the structured
+// span needed for redaction is lost, so we hard-reject it at plan time rather
+// than silently leaking secrets.
 //
 // This MUST run before translation (doTranslate) because translation replaces
 // $res envelopes with {"$ref":…} and drops $visibility.
@@ -2843,7 +3113,7 @@ func walkForOpaqueEmbed(val gjson.Result, label, path string) error {
 			for _, span := range spans {
 				visibility := gjson.Get(span.EnvelopeJSON, "$visibility")
 				if visibility.String() == pkgmodel.VisibilityOpaque {
-					return fmt.Errorf("opaque resolvables cannot be embedded in string fields (field %q on %q); v1 limitation", path, label)
+					return fmt.Errorf("opaque values cannot be embedded in string fields (field %q on %q): a secret assembled into a larger string can no longer be redacted, so bind it to its own field instead", path, label)
 				}
 			}
 		}

--- a/internal/metastructure/resolver/gen_value.go
+++ b/internal/metastructure/resolver/gen_value.go
@@ -1,0 +1,69 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package resolver
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// SetGenValues writes value into the $value field of the $gen envelope at
+// each of paths, and changes nothing else. It is the generator sibling of
+// setRefValue/resolveReference: those resolve a $ref, this delivers a drawn
+// value, and neither ever replaces the envelope it writes into.
+//
+// Writing INSIDE the envelope is the whole point, not an implementation
+// detail. A translated $gen always carries $visibility:"Opaque", and that
+// marker is the only reason the persist path hashes the value at rest.
+// Replacing the envelope with the bare drawn string would strip the marker
+// along with it and persist a live credential in cleartext in the resource's
+// properties. The plugin-format conversion that runs at the provider boundary
+// is what unwraps the envelope to the scalar a plugin receives, and it is the
+// only thing that should.
+//
+// A path that is absent, or that holds something other than a generator
+// envelope, is an error rather than an overwrite: paths come from a walk of
+// this same document, so either condition means the caller and the document
+// have diverged, and writing a credential over an arbitrary node would put
+// plaintext somewhere nothing marked opaque. Errors name the path only —
+// never the value.
+func SetGenValues(properties json.RawMessage, paths []string, value string) (json.RawMessage, error) {
+	result := string(properties)
+
+	for _, path := range paths {
+		node := gjson.Get(result, path)
+		if !node.Exists() {
+			return nil, fmt.Errorf("cannot deliver a generated value: no property at %q", path)
+		}
+		if !pkgmodel.IsGenObject(node) {
+			return nil, fmt.Errorf("cannot deliver a generated value: the property at %q is not a generator reference", path)
+		}
+
+		envelope := make(map[string]any)
+		node.ForEach(func(key, val gjson.Result) bool {
+			envelope[key.String()] = val.Value()
+			return true
+		})
+		envelope["$value"] = value
+
+		encoded, err := json.Marshal(envelope)
+		if err != nil {
+			return nil, fmt.Errorf("cannot deliver a generated value: failed to encode the envelope at %q", path)
+		}
+
+		updated, err := sjson.SetRaw(result, path, string(encoded))
+		if err != nil {
+			return nil, fmt.Errorf("cannot deliver a generated value: failed to write the envelope at %q", path)
+		}
+		result = updated
+	}
+
+	return json.RawMessage(result), nil
+}

--- a/internal/metastructure/resolver/gen_value.go
+++ b/internal/metastructure/resolver/gen_value.go
@@ -19,6 +19,16 @@ import (
 // setRefValue/resolveReference: those resolve a $ref, this delivers a drawn
 // value, and neither ever replaces the envelope it writes into.
 //
+// generatorKsuid is the generator the value was drawn for, and every envelope
+// written must name it. The caller selects paths by walking the same document
+// and matching that ksuid, so this looks redundant — it is not. The walk
+// addresses nodes by a dot-joined path, and a map key that itself contains a
+// dot produces a path that resolves somewhere else entirely (or nowhere).
+// Where it resolves onto a different generator's envelope, matching on the
+// $gen marker alone would deliver one generator's credential into another
+// generator's destination. Re-checking the identity at the write is what
+// makes that a refusal instead.
+//
 // Writing INSIDE the envelope is the whole point, not an implementation
 // detail. A translated $gen always carries $visibility:"Opaque", and that
 // marker is the only reason the persist path hashes the value at rest.
@@ -34,7 +44,7 @@ import (
 // have diverged, and writing a credential over an arbitrary node would put
 // plaintext somewhere nothing marked opaque. Errors name the path only —
 // never the value.
-func SetGenValues(properties json.RawMessage, paths []string, value string) (json.RawMessage, error) {
+func SetGenValues(properties json.RawMessage, generatorKsuid string, paths []string, value string) (json.RawMessage, error) {
 	result := string(properties)
 
 	for _, path := range paths {
@@ -44,6 +54,9 @@ func SetGenValues(properties json.RawMessage, paths []string, value string) (jso
 		}
 		if !pkgmodel.IsGenObject(node) {
 			return nil, fmt.Errorf("cannot deliver a generated value: the property at %q is not a generator reference", path)
+		}
+		if got := pkgmodel.GenGeneratorKSUID(node); got != generatorKsuid {
+			return nil, fmt.Errorf("cannot deliver a generated value: the generator reference at %q names %q, not %q", path, got, generatorKsuid)
 		}
 
 		envelope := make(map[string]any)

--- a/internal/metastructure/resolver/gen_value.go
+++ b/internal/metastructure/resolver/gen_value.go
@@ -38,6 +38,14 @@ import (
 // is what unwraps the envelope to the scalar a plugin receives, and it is the
 // only thing that should.
 //
+// A stale $hashed marker is dropped as the value is written. An envelope can
+// arrive here carrying the stored digest of the value the destination already
+// holds, marked $hashed; the value being written is live plaintext, and the
+// persist transformer skips re-hashing anything already marked hashed, so
+// leaving the marker would persist a live credential in cleartext while
+// claiming it is hashed. This mirrors what mergeResObject does when it adopts
+// a fresh value over a stored digest.
+//
 // A path that is absent, or that holds something other than a generator
 // envelope, is an error rather than an overwrite: paths come from a walk of
 // this same document, so either condition means the caller and the document
@@ -65,6 +73,7 @@ func SetGenValues(properties json.RawMessage, generatorKsuid string, paths []str
 			return true
 		})
 		envelope["$value"] = value
+		delete(envelope, "$hashed")
 
 		encoded, err := json.Marshal(envelope)
 		if err != nil {

--- a/internal/metastructure/resolver/gen_value_test.go
+++ b/internal/metastructure/resolver/gen_value_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
 // A drawn value lands INSIDE the $gen envelope, as its $value. The envelope
@@ -25,7 +27,7 @@ func TestSetGenValues_WritesTheValueInsideTheEnvelope(t *testing.T) {
 		"SecretString": {"$gen": true, "$generator": "gen-ksuid", "$output": "value", "$visibility": "Opaque"}
 	}`)
 
-	updated, err := SetGenValues(properties, []string{"SecretString"}, "drawn-credential")
+	updated, err := SetGenValues(properties, "gen-ksuid", []string{"SecretString"}, "drawn-credential")
 	require.NoError(t, err)
 
 	envelope := gjson.GetBytes(updated, "SecretString")
@@ -47,7 +49,7 @@ func TestSetGenValues_WritesOnlyTheNamedPaths(t *testing.T) {
 		"Nested": {"Second": {"$gen": true, "$generator": "b", "$output": "value", "$visibility": "Opaque"}}
 	}`)
 
-	updated, err := SetGenValues(properties, []string{"Nested.Second"}, "drawn")
+	updated, err := SetGenValues(properties, "b", []string{"Nested.Second"}, "drawn")
 	require.NoError(t, err)
 
 	assert.Equal(t, "drawn", gjson.GetBytes(updated, "Nested.Second.$value").String())
@@ -61,10 +63,10 @@ func TestSetGenValues_WritesOnlyTheNamedPaths(t *testing.T) {
 func TestSetGenValues_RefusesAPathThatIsNotAGeneratorEnvelope(t *testing.T) {
 	properties := json.RawMessage(`{"Name": "db", "Ref": {"$ref": "formae://k#/Token"}}`)
 
-	_, err := SetGenValues(properties, []string{"Name"}, "drawn")
+	_, err := SetGenValues(properties, "gen-a", []string{"Name"}, "drawn")
 	require.Error(t, err)
 
-	_, err = SetGenValues(properties, []string{"Ref"}, "drawn")
+	_, err = SetGenValues(properties, "gen-a", []string{"Ref"}, "drawn")
 	require.Error(t, err, "a $ref envelope is not a generator envelope")
 }
 
@@ -73,7 +75,7 @@ func TestSetGenValues_RefusesAPathThatIsNotAGeneratorEnvelope(t *testing.T) {
 func TestSetGenValues_RefusesAnAbsentPath(t *testing.T) {
 	properties := json.RawMessage(`{"Name": "db"}`)
 
-	_, err := SetGenValues(properties, []string{"SecretString"}, "drawn")
+	_, err := SetGenValues(properties, "gen-a", []string{"SecretString"}, "drawn")
 	require.Error(t, err)
 }
 
@@ -81,7 +83,7 @@ func TestSetGenValues_RefusesAnAbsentPath(t *testing.T) {
 func TestSetGenValues_ErrorNeverCarriesTheValue(t *testing.T) {
 	properties := json.RawMessage(`{"Name": "db"}`)
 
-	_, err := SetGenValues(properties, []string{"SecretString"}, "drawn-credential")
+	_, err := SetGenValues(properties, "gen-ksuid", []string{"SecretString"}, "drawn-credential")
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "drawn-credential")
 	assert.Contains(t, err.Error(), "SecretString")
@@ -93,8 +95,45 @@ func TestSetGenValues_WritesIntoAnArrayElement(t *testing.T) {
 		"Entries": [{"$gen": true, "$generator": "a", "$output": "value", "$visibility": "Opaque"}]
 	}`)
 
-	updated, err := SetGenValues(properties, []string{"Entries.0"}, "drawn")
+	updated, err := SetGenValues(properties, "a", []string{"Entries.0"}, "drawn")
 	require.NoError(t, err)
 	assert.Equal(t, "drawn", gjson.GetBytes(updated, "Entries.0.$value").String())
 	assert.Equal(t, "Opaque", gjson.GetBytes(updated, "Entries.0.$visibility").String())
+}
+
+// A path that resolves onto an envelope naming a DIFFERENT generator is
+// refused, not written. Paths are dot-joined by the caller's walk, and a map
+// key containing a dot produces a path that resolves somewhere else: without
+// this check the value drawn for one generator would land in another
+// generator's destination.
+func TestSetGenValues_RefusesAnEnvelopeNamingAnotherGenerator(t *testing.T) {
+	properties := json.RawMessage(`{
+		"SecretString": {"$gen": true, "$generator": "gen-b", "$output": "value", "$visibility": "Opaque"}
+	}`)
+
+	_, err := SetGenValues(properties, "gen-a", []string{"SecretString"}, "drawn-credential")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "drawn-credential")
+	assert.False(t, gjson.GetBytes(properties, "SecretString.$value").Exists(),
+		"a refused delivery writes nothing")
+}
+
+// A $gen nested under a map key that itself contains a dot cannot be
+// addressed by the dot-joined path the caller's walk produces. Delivery
+// refuses rather than writing the credential wherever that path happens to
+// land. This is the same addressing convention $res/$ref use, so the
+// limitation is shared, not generator-specific.
+func TestSetGenValues_RefusesAPathThroughADottedKey(t *testing.T) {
+	properties := json.RawMessage(`{
+		"labels": {"app.kubernetes.io/secret": {"$gen": true, "$generator": "gen-a", "$output": "value", "$visibility": "Opaque"}}
+	}`)
+
+	occurrences := pkgmodel.FindGenObjectsFromProperties(properties)
+	require.Len(t, occurrences, 1)
+	require.Equal(t, "labels.app.kubernetes.io/secret", occurrences[0].Path,
+		"precondition: the walk dot-joins the key, producing an unresolvable path")
+
+	_, err := SetGenValues(properties, "gen-a", []string{occurrences[0].Path}, "drawn-credential")
+	require.Error(t, err, "an unaddressable destination must refuse delivery, not write elsewhere")
+	assert.NotContains(t, err.Error(), "drawn-credential")
 }

--- a/internal/metastructure/resolver/gen_value_test.go
+++ b/internal/metastructure/resolver/gen_value_test.go
@@ -1,0 +1,100 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resolver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// A drawn value lands INSIDE the $gen envelope, as its $value. The envelope
+// itself survives untouched, $visibility:"Opaque" included: that marker is
+// the only reason the persist path hashes the value at rest, so replacing the
+// envelope with a bare scalar would persist the credential in cleartext.
+func TestSetGenValues_WritesTheValueInsideTheEnvelope(t *testing.T) {
+	properties := json.RawMessage(`{
+		"Name": "db",
+		"SecretString": {"$gen": true, "$generator": "gen-ksuid", "$output": "value", "$visibility": "Opaque"}
+	}`)
+
+	updated, err := SetGenValues(properties, []string{"SecretString"}, "drawn-credential")
+	require.NoError(t, err)
+
+	envelope := gjson.GetBytes(updated, "SecretString")
+	require.True(t, envelope.IsObject(), "the envelope must still be an object, not a bare scalar")
+	assert.Equal(t, "drawn-credential", envelope.Get("$value").String())
+	assert.True(t, envelope.Get("$gen").Bool(), "the $gen marker must survive")
+	assert.Equal(t, "gen-ksuid", envelope.Get("$generator").String())
+	assert.Equal(t, "value", envelope.Get("$output").String())
+	assert.Equal(t, "Opaque", envelope.Get("$visibility").String(),
+		"the opaque marker is what makes the value hash at rest and must survive")
+	assert.Equal(t, "db", gjson.GetBytes(updated, "Name").String(), "unrelated fields are untouched")
+}
+
+// Only the paths named are written. Another generator's destination in the
+// same document keeps its undrawn envelope.
+func TestSetGenValues_WritesOnlyTheNamedPaths(t *testing.T) {
+	properties := json.RawMessage(`{
+		"First": {"$gen": true, "$generator": "a", "$output": "value", "$visibility": "Opaque"},
+		"Nested": {"Second": {"$gen": true, "$generator": "b", "$output": "value", "$visibility": "Opaque"}}
+	}`)
+
+	updated, err := SetGenValues(properties, []string{"Nested.Second"}, "drawn")
+	require.NoError(t, err)
+
+	assert.Equal(t, "drawn", gjson.GetBytes(updated, "Nested.Second.$value").String())
+	assert.False(t, gjson.GetBytes(updated, "First.$value").Exists(),
+		"a destination that was not named must keep its undrawn envelope")
+}
+
+// A path that does not hold a generator envelope is refused rather than
+// overwritten: writing a drawn credential over an arbitrary node would put a
+// live secret somewhere nothing marked opaque.
+func TestSetGenValues_RefusesAPathThatIsNotAGeneratorEnvelope(t *testing.T) {
+	properties := json.RawMessage(`{"Name": "db", "Ref": {"$ref": "formae://k#/Token"}}`)
+
+	_, err := SetGenValues(properties, []string{"Name"}, "drawn")
+	require.Error(t, err)
+
+	_, err = SetGenValues(properties, []string{"Ref"}, "drawn")
+	require.Error(t, err, "a $ref envelope is not a generator envelope")
+}
+
+// A path that is not present at all is refused: the caller derived it from
+// this same document, so an absent path means the two have diverged.
+func TestSetGenValues_RefusesAnAbsentPath(t *testing.T) {
+	properties := json.RawMessage(`{"Name": "db"}`)
+
+	_, err := SetGenValues(properties, []string{"SecretString"}, "drawn")
+	require.Error(t, err)
+}
+
+// The error names the path and never the value.
+func TestSetGenValues_ErrorNeverCarriesTheValue(t *testing.T) {
+	properties := json.RawMessage(`{"Name": "db"}`)
+
+	_, err := SetGenValues(properties, []string{"SecretString"}, "drawn-credential")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "drawn-credential")
+	assert.Contains(t, err.Error(), "SecretString")
+}
+
+// An array element addressed by index is written the same way.
+func TestSetGenValues_WritesIntoAnArrayElement(t *testing.T) {
+	properties := json.RawMessage(`{
+		"Entries": [{"$gen": true, "$generator": "a", "$output": "value", "$visibility": "Opaque"}]
+	}`)
+
+	updated, err := SetGenValues(properties, []string{"Entries.0"}, "drawn")
+	require.NoError(t, err)
+	assert.Equal(t, "drawn", gjson.GetBytes(updated, "Entries.0.$value").String())
+	assert.Equal(t, "Opaque", gjson.GetBytes(updated, "Entries.0.$visibility").String())
+}

--- a/internal/metastructure/resource_persister/opaque_log_redaction_test.go
+++ b/internal/metastructure/resource_persister/opaque_log_redaction_test.go
@@ -1,0 +1,129 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_persister
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/transformations"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	pkgresource "github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// storeFailingDatastore rejects every resource write, which is what drives the
+// persist-failure reporting under test.
+type storeFailingDatastore struct {
+	datastore.Datastore
+}
+
+func (storeFailingDatastore) StoreResource(*pkgmodel.Resource, string, ...string) (string, error) {
+	return "", errors.New("datastore unavailable")
+}
+
+// goByteSlice matches the way Go renders a []byte through fmt's %v/%+v verbs:
+// a bracketed run of decimal byte values, e.g. "[123 34 80 97 ...]".
+var goByteSlice = regexp.MustCompile(`\[\d+(?: \d+)*\]`)
+
+// decodeGoByteSlices returns the text spelled out by every Go-rendered byte
+// slice in s. A property document rendered this way carries all of its bytes
+// while matching no substring search for the characters they spell, so a
+// diagnostic is only clean if the decoded text is clean too.
+func decodeGoByteSlices(s string) []string {
+	var decoded []string
+	for _, match := range goByteSlice.FindAllString(s, -1) {
+		fields := strings.Fields(strings.Trim(match, "[]"))
+		buf := make([]byte, 0, len(fields))
+		ok := true
+		for _, f := range fields {
+			n, err := strconv.Atoi(f)
+			if err != nil || n < 0 || n > 255 {
+				ok = false
+				break
+			}
+			buf = append(buf, byte(n))
+		}
+		if ok && len(buf) > 0 {
+			decoded = append(decoded, string(buf))
+		}
+	}
+	return decoded
+}
+
+// TestStoreResourceUpdate_PersistFailureWithholdsOpaqueValues asserts that when
+// a resource cannot be persisted, neither the log line nor the returned error
+// carries the plaintext of an opaque value the resource holds, in any rendering
+// — including the byte-slice rendering a raw JSON document takes through fmt.
+// Both must still identify the resource and the property that holds the value.
+func TestStoreResourceUpdate_PersistFailureWithholdsOpaqueValues(t *testing.T) {
+	const plaintext = "drawn-plaintext-value-7e1d"
+
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	rp := &ResourcePersister{
+		datastore:               storeFailingDatastore{},
+		persistValueTransformer: transformations.NewPersistValueTransformer(),
+	}
+
+	ru := &resource_update.ResourceUpdate{
+		DesiredState: pkgmodel.Resource{
+			Label: "app-database",
+			Type:  "FakeAWS::RDS::DBInstance",
+			Stack: "test-stack",
+			Properties: json.RawMessage(`{"MasterUserPassword":{"$gen":true,` +
+				`"$generator":"2ABcDeFgHiJkLmNoPqRsTuVwXyZ","$output":"value",` +
+				`"$visibility":"Opaque","$value":"` + plaintext + `"}}`),
+		},
+		StackLabel: "test-stack",
+		State:      resource_update.ResourceUpdateStateSuccess,
+		ProgressResult: []plugin.TrackedProgress{{
+			ProgressResult: pkgresource.ProgressResult{
+				Operation:       pkgresource.OperationCreate,
+				OperationStatus: pkgresource.OperationStatusSuccess,
+				NativeID:        "db-1",
+			},
+		}},
+	}
+
+	_, err := rp.storeResourceUpdate("cmd-persist", resource_update.OperationCreate, pkgresource.OperationCreate, ru)
+	require.Error(t, err, "a failing datastore must surface as an error")
+
+	logged := buf.String()
+	require.Contains(t, logged, "Failed to persist resource updates",
+		"the persist failure must be reported in a log line")
+	assert.Contains(t, logged, "app-database", "the log line must still identify the resource")
+
+	for _, subject := range []struct {
+		name string
+		text string
+	}{
+		{"log", logged},
+		{"error", err.Error()},
+	} {
+		assert.NotContains(t, subject.text, plaintext,
+			"the %s must not render the opaque plaintext", subject.name)
+		for _, decoded := range decodeGoByteSlices(subject.text) {
+			assert.NotContains(t, decoded, plaintext,
+				"the %s must not carry the opaque plaintext as a byte slice", subject.name)
+		}
+	}
+}

--- a/internal/metastructure/resource_persister/resource_persister.go
+++ b/internal/metastructure/resource_persister/resource_persister.go
@@ -218,9 +218,13 @@ func (rp *ResourcePersister) storeResourceUpdate(commandID string, resourceOpera
 	if err != nil {
 		slog.Error("Failed to persist resource updates",
 			"error", err,
-			"resource", resourceUpdate.DesiredState,
+			"resourceLabel", resourceUpdate.DesiredState.Label,
+			"stackLabel", resourceUpdate.DesiredState.Stack,
+			"resourceType", resourceUpdate.DesiredState.Type,
+			"resourceProperties", pkgmodel.RedactOpaqueJSONForLog(resourceUpdate.DesiredState.Properties),
 			"operation", pluginOperation)
-		return "", fmt.Errorf("failed to store stacks for resource update %v: %w", resourceUpdate.DesiredState, err)
+		return "", fmt.Errorf("failed to store stacks for resource update %s in stack %s: %w",
+			resourceUpdate.DesiredState.Label, resourceUpdate.DesiredState.Stack, err)
 	}
 	hash := forma.ResourceUpdates[0].Version
 

--- a/internal/metastructure/resource_summaries_test.go
+++ b/internal/metastructure/resource_summaries_test.go
@@ -162,6 +162,9 @@ func (m *mockSummaryDatastore) LatestLabelForResource(_ string) (string, error) 
 func (m *mockSummaryDatastore) FindResourcesDependingOn(_ string) ([]*pkgmodel.Resource, error) {
 	panic("not implemented")
 }
+func (m *mockSummaryDatastore) FindResourcesReferencingGenerator(_ string) ([]*pkgmodel.Resource, error) {
+	panic("not implemented")
+}
 func (m *mockSummaryDatastore) FindResourcesDependingOnMany(_ []string) (map[string][]*pkgmodel.Resource, error) {
 	panic("not implemented")
 }

--- a/internal/metastructure/resource_update/gen_co_planning.go
+++ b/internal/metastructure/resource_update/gen_co_planning.go
@@ -1,0 +1,139 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package resource_update
+
+import (
+	"fmt"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// CoPlanGeneratorDestinations plans the resources named by ksuids even though
+// the ordinary planning pass found nothing about them to do.
+//
+// It is the second half of the draw obligation. Once a generator is going to
+// draw, every one of its live destinations that this forma declares has to be
+// a node in the changeset, because delivery reaches nodes and nothing else and
+// formae keeps only a hash of a drawn value. A destination the command skipped
+// would keep the generation it already holds while its siblings moved to the
+// new one, and no later apply could level them: the only way to give the
+// laggard a value is to draw again, which puts the others behind.
+//
+// The caller decides who is owed a plan; this decides nothing. It is handed
+// resource KSUIDs and plans exactly those, through the same
+// NewResourceUpdateForExisting the ordinary pass uses, so provenance
+// classification, the stable-binding carry-forward and the freeze at the
+// provider boundary all still apply to them. The only difference is the
+// CoPlannedForDraw marker, which stops the "nothing moved" suppressions
+// dropping the update on the floor.
+//
+// THE FEEDBACK LOOP THIS MUST NOT CLOSE. The set of drawing generators is
+// derived from the planned updates (GeneratorsNeedingDraw), and this adds
+// updates. If the caller re-derived that set over the widened plan, a
+// co-planned resource's OTHER bindings — to generators that were stable and
+// had no reason to draw — could be read as needing a draw, and every apply
+// would rotate one more credential than the last. The caller computes the
+// drawing set ONCE, from the ordinary pass, and never recomputes it over what
+// this returns. Nothing here reads the drawing set, so this file cannot close
+// that loop on its own; metastructure.FormaCommandFromForma is where the
+// ordering is kept.
+//
+// A KSUID with no live row, or none the forma declares, is skipped: this plans
+// against a declaration and an existing row, and without both there is nothing
+// to pair. Reaching such a destination is not this pass's problem — it is
+// exactly what the unreachable-destination refusal is for.
+//
+// mode is passed through rather than assumed: reconcile and patch build the
+// same three views of the forma and hand NewResourceUpdateForExisting the same
+// arguments, so co-planning is the same work under either. Its one caller is
+// the apply path, which is the only command that draws — a destroy writes no
+// property, and sync and discovery carry no authored forma to plan from.
+func CoPlanGeneratorDestinations(
+	forma *pkgmodel.Forma,
+	ksuids map[string]bool,
+	mode pkgmodel.FormaApplyMode,
+	source FormaCommandSource,
+	existingTargets []*pkgmodel.Target,
+	ds ResourceDataLookup,
+	force bool,
+) ([]ResourceUpdate, error) {
+	if len(ksuids) == 0 {
+		return nil, nil
+	}
+
+	allResourcesByStack, err := ds.LoadAllResourcesByStack()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load existing stacks: %w", err)
+	}
+	existingByKsuid := make(map[string]*pkgmodel.Resource)
+	for _, resources := range allResourcesByStack {
+		for _, existing := range resources {
+			if ksuids[existing.Ksuid] {
+				existingByKsuid[existing.Ksuid] = existing
+			}
+		}
+	}
+	if len(existingByKsuid) == 0 {
+		return nil, nil
+	}
+
+	// The same three views of the forma the reconcile pass builds, so a
+	// co-planned resource's desired document is derived exactly as it would
+	// have been had something about it moved.
+	resolvableLookup := resourcesForResolvables(forma, allResourcesByStack)
+	effectiveDesired, err := ComputeEffectiveDesired(forma, allResourcesByStack)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute effective desired state: %w", err)
+	}
+	generatorGenerationLookup, err := generatorGenerations(forma, ds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve generator generations: %w", err)
+	}
+	existingTargetMap, desiredTargetMap := buildTargetMaps(forma, existingTargets)
+
+	var coPlanned []ResourceUpdate
+	for _, newResource := range forma.Resources {
+		existing, ok := existingByKsuid[newResource.Ksuid]
+		if !ok {
+			continue
+		}
+		existingTarget, ok := existingTargetMap[existing.Target]
+		if !ok {
+			return nil, fmt.Errorf("failed to co-plan resource %s: its target %s is unknown",
+				existing.Label, existing.Target)
+		}
+		desiredTarget, ok := desiredTargetMap[newResource.Target]
+		if !ok {
+			return nil, fmt.Errorf("failed to co-plan resource %s: its target %s is unknown",
+				newResource.Label, newResource.Target)
+		}
+
+		readOnlyProperties, err := resolver.LoadResolvablePropertiesFromStacks(
+			newResource, resolvableLookup, effectiveDesired, generatorGenerationLookup)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load resolvable properties for %s: %w", newResource.Label, err)
+		}
+
+		updates, err := NewResourceUpdateForExisting(
+			readOnlyProperties,
+			effectiveDesired[existing.Ksuid],
+			*existing,
+			newResource,
+			*existingTarget,
+			*desiredTarget,
+			mode,
+			source,
+			force,
+			true,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to co-plan resource %s: %w", newResource.Label, err)
+		}
+		coPlanned = append(coPlanned, updates...)
+	}
+
+	return coPlanned, nil
+}

--- a/internal/metastructure/resource_update/gen_destinations.go
+++ b/internal/metastructure/resource_update/gen_destinations.go
@@ -12,13 +12,19 @@ import (
 // destinationPath was classified OccurrenceStable when this update was
 // planned.
 //
-// This is the ONE reading of ProvenanceRecords for $gen destinations.
-// Whether a generator draws at all, which destinations an executing draw
-// writes to, and which destinations a resumed command still owes a value are
-// three phrasings of the same question, and two independent readings of the
-// same records would eventually disagree without anything observing it: a
-// destination that got an edge but is frozen at delivery discards the value
-// drawn for it, and one frozen but edge-less never gets a value at all.
+// This is the ONE reading of ProvenanceRecords for $gen destinations, and it
+// answers ONE question: does anything still need a value from this generator?
+// Whether a generator draws at all, and which destinations a resumed command
+// still owes a value, are two phrasings of that question; two independent
+// readings of the same records would eventually disagree without anything
+// observing it.
+//
+// It does NOT decide who a draw reaches. Once a generator draws, every live
+// non-delete destination of it in the changeset receives the value and is
+// stamped with the new generation — see
+// ResourceUpdate.ResolveGeneratorValue. Using stability to narrow delivery is
+// what leaves two consumers of one credential holding different values, with
+// each apply repairing one and breaking the other.
 //
 // An absent record is NOT stable, and neither is a record whose desired
 // identity resolves against the resources table rather than the generators

--- a/internal/metastructure/resource_update/gen_destinations.go
+++ b/internal/metastructure/resource_update/gen_destinations.go
@@ -18,12 +18,20 @@ import (
 // destinationPath was classified OccurrenceStable when this update was
 // planned.
 //
-// This is the ONE reading of ProvenanceRecords for $gen destinations, and it
-// answers ONE question: does anything still need a value from this generator?
-// Whether a generator draws at all, and which destinations a resumed command
-// still owes a value, are two phrasings of that question; two independent
-// readings of the same records would eventually disagree without anything
-// observing it.
+// This is the ONE reading of $gen destination stability, and it answers ONE
+// question: does anything still need a value from this generator? Whether a
+// generator draws at all, and which destinations a resumed command still owes
+// a value, are two phrasings of that question; two independent readings of
+// the same records would eventually disagree without anything observing it.
+//
+// Other code reads the same records for different questions:
+// writtenProvenanceAt for the digest a destination was last written under,
+// and ResourceUpdate.regeneratePatchDocument for every occurrence of any kind
+// that stays suppressed through a regeneration. That last one tests Class
+// alone, without the generator-kind check below, and still cannot disagree
+// with this reading at a $gen destination: a $gen envelope normalizes to
+// OccurrenceKindGenerator, and an occurrence whose desired envelope does not
+// normalize is classified OccurrenceDeferredUpdate outright.
 //
 // It does NOT decide who a draw reaches. Once a generator draws, every live
 // non-delete destination of it in the changeset receives the value and is
@@ -113,6 +121,60 @@ func GeneratorsNeedingDraw(updates []ResourceUpdate) []string {
 	}
 	return ksuids
 }
+
+// ResourceKsuidsInCommand returns the KSUIDs of the resources this command
+// holds a planned operation for.
+//
+// It answers ONE question — can this command reach this resource — and it is
+// asked in two places: subtracted from the live destinations the datastore
+// indexes for a drawing generator, what is left is what no delivery could get
+// to; and a resource already in the set is never co-planned, because the
+// changeset keeps one node per operation URI and a second update for one
+// resource would be dropped on the floor with nothing terminalizing it.
+//
+// Reach is a property of the graph, not of the document. Delivery runs over
+// the changeset's nodes, so ANY planned update reaches its resource, whatever
+// its desired document now says about the generator. A destination the same
+// command unbinds is written by that command like any other node; narrowing
+// the set to the updates that still bind the generator would refuse an apply
+// that both unbinds one destination and draws for another, which is perfectly
+// deliverable.
+//
+// Both ends of an update are counted, so a destination the command is tearing
+// down is reached rather than named unreachable. It is owed no value — a
+// delete writes no property — but the command does reach it, and omitting it
+// would make removing a consumer of a generator whose spec also moved
+// impossible.
+func ResourceKsuidsInCommand(updates []ResourceUpdate) map[string]bool {
+	inCommand := make(map[string]bool, len(updates))
+	for i := range updates {
+		if ksuid := updates[i].DesiredState.Ksuid; ksuid != "" {
+			inCommand[ksuid] = true
+		}
+		if ksuid := updates[i].PriorState.Ksuid; ksuid != "" {
+			inCommand[ksuid] = true
+		}
+	}
+	return inCommand
+}
+
+// CoPlannedForDraw marks a resource that this command must plan because a
+// generator it binds to draws here, not because anything about the resource
+// itself moved.
+//
+// A drawn value reaches only the destinations that are nodes in the changeset,
+// and formae keeps a hash of the value rather than the value, so a destination
+// left out of the command cannot be brought level on any later apply. Adding a
+// second destination to a generator therefore has to carry the destinations
+// already applied beside it into the same command: they take the new
+// generation together or they diverge for good.
+//
+// It is a distinct type rather than one more bool so it cannot be transposed
+// with the `force` argument beside it. The two are unrelated: force is the
+// operator re-asserting declared state, and it deliberately does not touch a
+// generator binding (ClassifyOccurrence R2), while this is the planner
+// discharging an obligation a draw created.
+type CoPlannedForDraw bool
 
 // CarryStableGeneratorBindingForward restores, on the desired document of an
 // update, what a $gen destination whose occurrence classified stable already
@@ -208,4 +270,81 @@ func writtenProvenanceAt(records []OccurrenceRecord, destinationPath string) str
 		}
 	}
 	return ""
+}
+
+// SuppressCarriedStableGeneratorBindings drops, from both sides of a patch
+// regeneration, every $gen destination that classified stable and whose
+// desired envelope holds a carried digest rather than a value.
+//
+// It is the $gen counterpart of what SuppressUnchangedOpaqueValues does for a
+// literal opaque field, and it exists because that function cannot decide this
+// case. It calls a leaf unchanged by comparing the digest of the desired value
+// against the digest STORED on the prior side, and a provider whose Read
+// returns the secret (a secret store's GetSecretValue) has by then replaced
+// that stored digest with the live plaintext. Digest against plaintext never
+// matches, so the field survives into the "after" side of the diff carrying
+// the digest CarryStableGeneratorBindingForward put there, and the guarded
+// conversion rightly refuses to hand a provider a digest where a secret
+// belongs — taking the unrelated edit beside it down with it.
+//
+// Stability is the answer that comparison was reaching for, and a better one:
+// it was decided at planning from the destination's provenance and persisted
+// immutably on this row, so it holds whatever a Read has since merged into
+// prior state. A stable destination provably still holds the generation it was
+// drawn from, so it contributes nothing to the diff and belongs on neither
+// side of it. Dropping it from BOTH is what leaves no op behind — dropping it
+// from the desired side alone would read as a removal under reconcile
+// semantics.
+//
+// Only a $hashed envelope is dropped. A destination a draw was delivered into
+// moments ago carries a LIVE value and no marker, and stability never narrows
+// delivery: that value has to reach the patch or the destination stays on the
+// old generation while its siblings move. A bare envelope carries nothing to
+// refuse and is left for the stable-occurrence substitution in patch
+// generation, which already neutralises it.
+//
+// This drops from the diff inputs only. The update's own desired document is
+// untouched, so the freeze at the provider boundary still substitutes its
+// preserved sentinel, and the row still persists the digest and the generation
+// it was drawn from.
+//
+// Inputs are not mutated; rewritten copies are returned.
+func SuppressCarriedStableGeneratorBindings(
+	existing, desired json.RawMessage,
+	records []OccurrenceRecord,
+) (json.RawMessage, json.RawMessage, error) {
+	if len(existing) == 0 || len(desired) == 0 || len(records) == 0 {
+		return existing, desired, nil
+	}
+
+	strippedExisting := string(existing)
+	strippedDesired := string(desired)
+	for _, occurrence := range pkgmodel.FindGenObjectsFromProperties(desired) {
+		if !IsGenDestinationStable(records, occurrence.Path) {
+			continue
+		}
+		// A destination is addressed by a dot-joined path, so a map key
+		// containing a dot resolves elsewhere. Act only where the path still
+		// addresses this envelope, exactly as the freeze does.
+		node := gjson.Get(strippedDesired, occurrence.Path)
+		if !pkgmodel.IsGenObject(node) || !node.Get("$hashed").Bool() {
+			continue
+		}
+
+		var err error
+		strippedDesired, err = sjson.Delete(strippedDesired, occurrence.Path)
+		if err != nil {
+			// The path can contain user-authored map keys, so it stays out of
+			// the error: this text reaches an operator-visible failure reason.
+			return nil, nil, fmt.Errorf("failed to drop a stable generator binding from the desired diff input: %w", err)
+		}
+		if gjson.Get(strippedExisting, occurrence.Path).Exists() {
+			strippedExisting, err = sjson.Delete(strippedExisting, occurrence.Path)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to drop a stable generator binding from the existing diff input: %w", err)
+			}
+		}
+	}
+
+	return json.RawMessage(strippedExisting), json.RawMessage(strippedDesired), nil
 }

--- a/internal/metastructure/resource_update/gen_destinations.go
+++ b/internal/metastructure/resource_update/gen_destinations.go
@@ -1,0 +1,80 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package resource_update
+
+import (
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// IsGenDestinationStable reports whether the $gen occurrence at
+// destinationPath was classified OccurrenceStable when this update was
+// planned.
+//
+// This is the ONE reading of ProvenanceRecords for $gen destinations.
+// Whether a generator draws at all, which destinations an executing draw
+// writes to, and which destinations a resumed command still owes a value are
+// three phrasings of the same question, and two independent readings of the
+// same records would eventually disagree without anything observing it: a
+// destination that got an edge but is frozen at delivery discards the value
+// drawn for it, and one frozen but edge-less never gets a value at all.
+//
+// An absent record is NOT stable, and neither is a record whose desired
+// identity resolves against the resources table rather than the generators
+// one. ProvenanceRecords is computed on the update path only (a create has
+// none), and OccurrenceDeferredUpdate is deliberately the zero value of
+// OccurrenceClass for the same reason: a missing classification must never
+// suppress a write.
+func IsGenDestinationStable(records []OccurrenceRecord, destinationPath string) bool {
+	for i := range records {
+		if records[i].DestinationPath != destinationPath {
+			continue
+		}
+		if records[i].DesiredIdentity.Kind != OccurrenceKindGenerator {
+			return false
+		}
+		return records[i].Class == OccurrenceStable
+	}
+	return false
+}
+
+// GeneratorsNeedingDraw returns the distinct generator KSUIDs that at least
+// one $gen destination among these updates needs a freshly drawn value from,
+// in first-seen order.
+//
+// The set is derived from the DESTINATIONS, never from a diff of the
+// generator's own row. A generator whose spec is unchanged produces no
+// GeneratorUpdate, but a resource newly bound to it — or one whose stored
+// provenance no longer matches the generation the generator holds — still
+// needs a value: without a draw its $gen envelope reaches the provider
+// boundary undrawn and is rejected there, on this apply and on every one
+// after it.
+//
+// A generator every one of whose destinations classified OccurrenceStable is
+// absent from the result and must NOT draw: its held generation is provably
+// the one those destinations already carry, so drawing would rotate a live
+// credential because something unrelated in the same forma changed.
+//
+// An untranslated $gen envelope carries no generator KSUID and is skipped.
+// Translation rejects a $gen that resolves to no generator before planning,
+// so an untranslated one here belongs to a path that never translated and
+// has no identity to draw against.
+func GeneratorsNeedingDraw(updates []ResourceUpdate) []string {
+	var ksuids []string
+	seen := make(map[string]bool)
+	for i := range updates {
+		records := updates[i].ProvenanceRecords
+		for _, gen := range pkgmodel.FindGenObjectsFromProperties(updates[i].DesiredState.Properties) {
+			if gen.Generator == "" || seen[gen.Generator] {
+				continue
+			}
+			if IsGenDestinationStable(records, gen.Path) {
+				continue
+			}
+			seen[gen.Generator] = true
+			ksuids = append(ksuids, gen.Generator)
+		}
+	}
+	return ksuids
+}

--- a/internal/metastructure/resource_update/gen_destinations.go
+++ b/internal/metastructure/resource_update/gen_destinations.go
@@ -56,6 +56,26 @@ func IsGenDestinationStable(records []OccurrenceRecord, destinationPath string) 
 // the one those destinations already carry, so drawing would rotate a live
 // credential because something unrelated in the same forma changed.
 //
+// An update that is tearing its destination down is skipped whatever its
+// occurrence says. A destroy sets DesiredState to the stored resource, so a
+// delete carries the stored $gen envelope and no ProvenanceRecords at all;
+// counting it would draw a value nothing writes, advance the generation, and
+// rotate the credential out from under every consumer that survives. Replace
+// is unaffected: the changeset splits it into a delete and a create, and the
+// create half still draws.
+//
+// Only DesiredState.Properties is scanned, unlike the resolver's
+// answerGeneratorOutputs, which also scans ReadOnlyProperties. The divergence
+// is deliberate and the two are answering different questions. The resolver
+// answers every occurrence that might be CLASSIFIED, wherever it sits; this
+// decides what must be DRAWN, and a draw is owed only to a property formae
+// writes. Read-only properties are never dispatched to a provider — only
+// DesiredState.Properties goes through convertResourceForPlugin, and
+// ReadOnlyProperties is carried alongside for persistence and comparison —
+// so a $gen there names a destination nothing writes. Drawing for it would
+// advance the generation and rotate the credential for every consumer that
+// does get written, which is the same harm the delete skip above avoids.
+//
 // An untranslated $gen envelope carries no generator KSUID and is skipped.
 // Translation rejects a $gen that resolves to no generator before planning,
 // so an untranslated one here belongs to a path that never translated and
@@ -64,6 +84,9 @@ func GeneratorsNeedingDraw(updates []ResourceUpdate) []string {
 	var ksuids []string
 	seen := make(map[string]bool)
 	for i := range updates {
+		if updates[i].Operation == OperationDelete || updates[i].Operation == OperationReaped {
+			continue
+		}
 		records := updates[i].ProvenanceRecords
 		for _, gen := range pkgmodel.FindGenObjectsFromProperties(updates[i].DesiredState.Properties) {
 			if gen.Generator == "" || seen[gen.Generator] {

--- a/internal/metastructure/resource_update/gen_destinations.go
+++ b/internal/metastructure/resource_update/gen_destinations.go
@@ -5,6 +5,12 @@
 package resource_update
 
 import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
@@ -106,4 +112,100 @@ func GeneratorsNeedingDraw(updates []ResourceUpdate) []string {
 		}
 	}
 	return ksuids
+}
+
+// CarryStableGeneratorBindingForward restores, on the desired document of an
+// update, what a $gen destination whose occurrence classified stable already
+// holds: the stored digest of its value, its $hashed marker, and — through
+// the returned digest seeds — the provenance of the generation it was drawn
+// from. It returns the rewritten desired document and the seeds to put on
+// ResourceUpdate.ResolvedRootDigests.
+//
+// A stable destination draws nothing, so its desired envelope is bare: the
+// forma declares a reference, never a value. That is fine for the write (the
+// freeze substitutes a preserved-value sentinel on the copy the provider
+// sees) but not for what lands at rest. The row is written from the desired
+// document, so a bare envelope persists a destination with no value and no
+// provenance, and the next apply reads that as a destination that moved:
+// it plans, draws, and rotates a credential nothing asked to rotate. Carrying
+// the two forward is what makes an unrelated edit on a generator-bound
+// resource a no-op for the binding beside it.
+//
+// This is the $gen counterpart of what already happens for a literal opaque
+// field, whose desired document carries the stored digest by construction
+// because the author declared a value there.
+//
+// Stability is read through IsGenDestinationStable, and the gate is absolute:
+// re-stamping an occurrence that is NOT stable would assert that a
+// destination still holds a generation it may not hold, and would suppress
+// the very rotation that classification exists to require. An occurrence with
+// no stored value, or one stored unhashed, is left alone — there is nothing
+// to carry and nothing to prove.
+//
+// Inputs are not mutated; a rewritten copy of desired is returned.
+func CarryStableGeneratorBindingForward(
+	desired, stored json.RawMessage,
+	records []OccurrenceRecord,
+) (json.RawMessage, map[string]string, error) {
+	if len(desired) == 0 || len(stored) == 0 || len(records) == 0 {
+		return desired, nil, nil
+	}
+
+	out := string(desired)
+	var seeds map[string]string
+	for _, occurrence := range pkgmodel.FindGenObjectsFromProperties(desired) {
+		if !IsGenDestinationStable(records, occurrence.Path) {
+			continue
+		}
+		// A destination is addressed by a dot-joined path, so a map key
+		// containing a dot resolves elsewhere. Write only where the path
+		// still addresses this envelope, exactly as the freeze does.
+		if !pkgmodel.IsGenObject(gjson.Get(out, occurrence.Path)) {
+			continue
+		}
+		storedEnvelope := gjson.GetBytes(stored, occurrence.Path)
+		storedValue := storedEnvelope.Get("$value")
+		if !storedValue.Exists() || !storedEnvelope.Get("$hashed").Bool() {
+			continue
+		}
+
+		updated, err := sjson.Set(out, occurrence.Path+".$value", storedValue.Value())
+		if err != nil {
+			// The path can contain user-authored map keys, so it stays out of
+			// the error: this text reaches an operator-visible failure reason.
+			return nil, nil, fmt.Errorf("failed to carry a stable generator binding forward: %w", err)
+		}
+		// The digest is carried as a digest: without the marker the persist
+		// transformer would hash it again and store a hash of a hash.
+		updated, err = sjson.Set(updated, occurrence.Path+".$hashed", true)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to carry a stable generator binding forward: %w", err)
+		}
+		out = updated
+
+		key := generatorSourceKey(occurrence.Generator, occurrence.Output)
+		provenanceDigest := writtenProvenanceAt(records, occurrence.Path)
+		if key == "" || provenanceDigest == "" {
+			continue
+		}
+		if seeds == nil {
+			seeds = make(map[string]string)
+		}
+		seeds[key] = provenanceDigest
+	}
+
+	return json.RawMessage(out), seeds, nil
+}
+
+// writtenProvenanceAt returns the generation digest the destination at this
+// path was last written under, as the classifier recorded it. That value is
+// exactly the $resolvedFrom the stored envelope carries, which is what the
+// write-origin merge has to put back.
+func writtenProvenanceAt(records []OccurrenceRecord, destinationPath string) string {
+	for i := range records {
+		if records[i].DestinationPath == destinationPath {
+			return records[i].WrittenProvenance
+		}
+	}
+	return ""
 }

--- a/internal/metastructure/resource_update/gen_destinations_test.go
+++ b/internal/metastructure/resource_update/gen_destinations_test.go
@@ -263,3 +263,84 @@ func TestCarryStableGeneratorBindingForward(t *testing.T) {
 		assert.Empty(t, seeds)
 	})
 }
+
+func TestSuppressCarriedStableGeneratorBindings(t *testing.T) {
+	const ksuid = "2abcDEFghiJKLmnoPQRstuVWxyz"
+	const digest = "9f2c1a0b"
+	const writtenProvenance = "v1:aaaabbbbcccc"
+
+	stableRecords := []OccurrenceRecord{{
+		DestinationPath: "password",
+		DesiredIdentity: OccurrenceIdentity{
+			Kind: OccurrenceKindGenerator, Ksuid: ksuid, PropertyPath: "value",
+		},
+		WrittenProvenance: writtenProvenance,
+		HasStoredWritten:  true,
+		Class:             OccurrenceStable,
+	}}
+
+	carried := json.RawMessage(`{"password":{"$gen":true,"$generator":"` + ksuid +
+		`","$output":"value","$visibility":"Opaque","$hashed":true,"$value":"` + digest + `"},"name":"new"}`)
+
+	// A Read that returns the secret leaves the live plaintext on the prior
+	// side, so the digest the desired document carries has nothing to compare
+	// equal against. Stability is the answer instead, and it has to leave both
+	// sides of the diff with nothing to say about the destination.
+	t.Run("a carried digest is dropped from both sides", func(t *testing.T) {
+		existing := json.RawMessage(`{"password":{"$gen":true,"$generator":"` + ksuid +
+			`","$output":"value","$visibility":"Opaque","$value":"live-plaintext"},"name":"old"}`)
+
+		strippedExisting, strippedDesired, err := SuppressCarriedStableGeneratorBindings(
+			existing, carried, stableRecords)
+		require.NoError(t, err)
+
+		assert.False(t, gjson.GetBytes(strippedDesired, "password").Exists(),
+			"the digest must not reach the guarded conversion")
+		assert.False(t, gjson.GetBytes(strippedExisting, "password").Exists(),
+			"leaving it on one side alone reads as a removal")
+		assert.Equal(t, "new", gjson.GetBytes(strippedDesired, "name").String(),
+			"the property beside the binding must still be diffed")
+	})
+
+	// Stability decides whether a generator draws, never who a draw reaches. A
+	// destination a draw was delivered into holds the value it must write.
+	t.Run("a delivered value is kept", func(t *testing.T) {
+		delivered := json.RawMessage(`{"password":{"$gen":true,"$generator":"` + ksuid +
+			`","$output":"value","$visibility":"Opaque","$value":"freshly-drawn"}}`)
+
+		_, strippedDesired, err := SuppressCarriedStableGeneratorBindings(
+			json.RawMessage(`{"password":{"$gen":true,"$value":"old"}}`), delivered, stableRecords)
+		require.NoError(t, err)
+
+		assert.Equal(t, "freshly-drawn", gjson.GetBytes(strippedDesired, "password.$value").String(),
+			"a delivered value must reach the patch or its destination stays on the old generation")
+	})
+
+	t.Run("an unstable destination is kept", func(t *testing.T) {
+		unstable := []OccurrenceRecord{{
+			DestinationPath: "password",
+			DesiredIdentity: OccurrenceIdentity{
+				Kind: OccurrenceKindGenerator, Ksuid: ksuid, PropertyPath: "value",
+			},
+			Class: OccurrenceDeferredUpdate,
+		}}
+
+		_, strippedDesired, err := SuppressCarriedStableGeneratorBindings(
+			json.RawMessage(`{"password":{"$gen":true,"$value":"live-plaintext"}}`), carried, unstable)
+		require.NoError(t, err)
+
+		assert.True(t, gjson.GetBytes(strippedDesired, "password").Exists(),
+			"only a proven-stable destination may be taken out of the diff")
+	})
+
+	t.Run("a bare envelope is left to patch generation", func(t *testing.T) {
+		bare := genProperties("password", ksuid)
+
+		_, strippedDesired, err := SuppressCarriedStableGeneratorBindings(
+			json.RawMessage(`{"password":{"$gen":true,"$value":"live-plaintext"}}`), bare, stableRecords)
+		require.NoError(t, err)
+
+		assert.True(t, gjson.GetBytes(strippedDesired, "password").Exists(),
+			"a bare envelope carries no digest to refuse")
+	})
+}

--- a/internal/metastructure/resource_update/gen_destinations_test.go
+++ b/internal/metastructure/resource_update/gen_destinations_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
@@ -175,5 +177,89 @@ func TestGeneratorsNeedingDraw(t *testing.T) {
 		}
 
 		assert.Equal(t, []string{"gen1", "gen2"}, GeneratorsNeedingDraw(updates))
+	})
+}
+
+// storedGenDestination is the same destination at rest: the drawn value
+// hashed, and the generation it was drawn from recorded on the envelope.
+func storedGenDestination(path, generatorKsuid, digest, resolvedFrom string) json.RawMessage {
+	return json.RawMessage(`{"` + path + `":{"$gen":true,"$generator":"` + generatorKsuid +
+		`","$output":"value","$visibility":"Opaque","$hashed":true,"$value":"` + digest +
+		`","$resolvedFrom":"` + resolvedFrom + `"}}`)
+}
+
+func TestCarryStableGeneratorBindingForward(t *testing.T) {
+	const ksuid = "2abcDEFghiJKLmnoPQRstuVWxyz"
+	const digest = "9f2c1a0b"
+	const writtenProvenance = "v1:aaaabbbbcccc"
+
+	stableRecords := []OccurrenceRecord{{
+		DestinationPath: "password",
+		DesiredIdentity: OccurrenceIdentity{
+			Kind: OccurrenceKindGenerator, Ksuid: ksuid, PropertyPath: "value",
+		},
+		WrittenProvenance: writtenProvenance,
+		HasStoredWritten:  true,
+		Class:             OccurrenceStable,
+	}}
+
+	t.Run("a stable destination keeps the digest it holds and the generation it holds it under", func(t *testing.T) {
+		desired, seeds, err := CarryStableGeneratorBindingForward(
+			genProperties("password", ksuid),
+			storedGenDestination("password", ksuid, digest, writtenProvenance),
+			stableRecords)
+		require.NoError(t, err)
+
+		envelope := gjson.GetBytes(desired, "password")
+		assert.Equal(t, digest, envelope.Get("$value").String(),
+			"the desired document must carry what the row already holds, or the row loses it")
+		assert.True(t, envelope.Get("$hashed").Bool(),
+			"without the marker the digest is hashed again as if it were a secret")
+		assert.False(t, envelope.Get("$resolvedFrom").Exists(),
+			"provenance is stamped by the write-origin merge, never written into the desired document")
+
+		assert.Equal(t, map[string]string{
+			generatorSourceKey(ksuid, "value"): writtenProvenance,
+		}, seeds, "the merge needs the generation digest to stamp back")
+	})
+
+	// The gate. An occurrence that is NOT stable is one whose destination may
+	// no longer hold the generation the row records, and a draw is planned for
+	// it. Carrying the old digest and the old provenance forward would assert
+	// that it did not move, and the next apply would read it as settled and
+	// never rotate it.
+	t.Run("an unstable destination is left exactly as it was", func(t *testing.T) {
+		unstable := []OccurrenceRecord{{
+			DestinationPath: "password",
+			DesiredIdentity: OccurrenceIdentity{
+				Kind: OccurrenceKindGenerator, Ksuid: ksuid, PropertyPath: "value",
+			},
+			WrittenProvenance: writtenProvenance,
+			HasStoredWritten:  true,
+			Class:             OccurrenceDeferredUpdate,
+		}}
+
+		input := genProperties("password", ksuid)
+		desired, seeds, err := CarryStableGeneratorBindingForward(
+			input,
+			storedGenDestination("password", ksuid, digest, writtenProvenance),
+			unstable)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, string(input), string(desired),
+			"nothing may be carried onto a destination that is about to be redrawn")
+		assert.Empty(t, seeds,
+			"stamping an unstable occurrence would suppress the rotation it exists to require")
+	})
+
+	t.Run("a destination with nothing stored is left alone", func(t *testing.T) {
+		desired, seeds, err := CarryStableGeneratorBindingForward(
+			genProperties("password", ksuid),
+			json.RawMessage(`{}`),
+			stableRecords)
+		require.NoError(t, err)
+
+		assert.False(t, gjson.GetBytes(desired, "password.$value").Exists())
+		assert.Empty(t, seeds)
 	})
 }

--- a/internal/metastructure/resource_update/gen_destinations_test.go
+++ b/internal/metastructure/resource_update/gen_destinations_test.go
@@ -127,6 +127,37 @@ func TestGeneratorsNeedingDraw(t *testing.T) {
 		assert.Empty(t, GeneratorsNeedingDraw(updates))
 	})
 
+	t.Run("a destination being torn down is never drawn for", func(t *testing.T) {
+		// A destroy sets DesiredState to the stored resource, so a delete
+		// carries the stored $gen envelope and no provenance records. Drawing
+		// for it would advance the generation and rotate the credential out
+		// from under every consumer that survives.
+		for _, op := range []OperationType{OperationDelete, OperationReaped} {
+			updates := []ResourceUpdate{{
+				DesiredState: pkgmodel.Resource{Properties: genProperties("password", "gen1")},
+				PriorState:   pkgmodel.Resource{Properties: genProperties("password", "gen1")},
+				Operation:    op,
+			}}
+
+			assert.Empty(t, GeneratorsNeedingDraw(updates), "operation %s", op)
+		}
+	})
+
+	t.Run("a surviving consumer still draws when a sibling is deleted", func(t *testing.T) {
+		updates := []ResourceUpdate{
+			{
+				DesiredState: pkgmodel.Resource{Properties: genProperties("password", "gen1")},
+				Operation:    OperationDelete,
+			},
+			{
+				DesiredState: pkgmodel.Resource{Properties: genProperties("password", "gen1")},
+				Operation:    OperationCreate,
+			},
+		}
+
+		assert.Equal(t, []string{"gen1"}, GeneratorsNeedingDraw(updates))
+	})
+
 	t.Run("distinct generators are reported once each in first-seen order", func(t *testing.T) {
 		updates := []ResourceUpdate{
 			{

--- a/internal/metastructure/resource_update/gen_destinations_test.go
+++ b/internal/metastructure/resource_update/gen_destinations_test.go
@@ -1,0 +1,148 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func genProperties(path, generatorKsuid string) json.RawMessage {
+	return json.RawMessage(`{"` + path + `":{"$gen":true,"$generator":"` + generatorKsuid + `","$output":"value","$visibility":"Opaque"}}`)
+}
+
+func TestIsGenDestinationStable(t *testing.T) {
+	t.Run("a record classified stable at the destination path is stable", func(t *testing.T) {
+		records := []OccurrenceRecord{{
+			DestinationPath: "password",
+			DesiredIdentity: OccurrenceIdentity{Kind: OccurrenceKindGenerator, Ksuid: "gen1", PropertyPath: "value"},
+			Class:           OccurrenceStable,
+		}}
+
+		assert.True(t, IsGenDestinationStable(records, "password"))
+	})
+
+	t.Run("a record that must plan is not stable", func(t *testing.T) {
+		records := []OccurrenceRecord{{
+			DestinationPath: "password",
+			DesiredIdentity: OccurrenceIdentity{Kind: OccurrenceKindGenerator, Ksuid: "gen1", PropertyPath: "value"},
+			Class:           OccurrenceDeferredUpdate,
+		}}
+
+		assert.False(t, IsGenDestinationStable(records, "password"))
+	})
+
+	t.Run("a destination with no record at all is not stable", func(t *testing.T) {
+		assert.False(t, IsGenDestinationStable(nil, "password"))
+		assert.False(t, IsGenDestinationStable([]OccurrenceRecord{{
+			DestinationPath: "other",
+			Class:           OccurrenceStable,
+		}}, "password"))
+	})
+
+	t.Run("a stable resource reference at the path is not a stable gen destination", func(t *testing.T) {
+		records := []OccurrenceRecord{{
+			DestinationPath: "password",
+			DesiredIdentity: OccurrenceIdentity{Kind: OccurrenceKindResource, Ksuid: "res1"},
+			Class:           OccurrenceStable,
+		}}
+
+		assert.False(t, IsGenDestinationStable(records, "password"))
+	})
+}
+
+func TestGeneratorsNeedingDraw(t *testing.T) {
+	t.Run("a non-stable destination needs its generator drawn", func(t *testing.T) {
+		updates := []ResourceUpdate{{
+			DesiredState: pkgmodel.Resource{Properties: genProperties("password", "gen1")},
+			Operation:    OperationUpdate,
+			ProvenanceRecords: []OccurrenceRecord{{
+				DestinationPath: "password",
+				DesiredIdentity: OccurrenceIdentity{Kind: OccurrenceKindGenerator, Ksuid: "gen1", PropertyPath: "value"},
+				Class:           OccurrenceDeferredUpdate,
+			}},
+		}}
+
+		assert.Equal(t, []string{"gen1"}, GeneratorsNeedingDraw(updates))
+	})
+
+	t.Run("a generator whose every destination is stable is not drawn", func(t *testing.T) {
+		updates := []ResourceUpdate{{
+			DesiredState: pkgmodel.Resource{Properties: genProperties("password", "gen1")},
+			Operation:    OperationUpdate,
+			ProvenanceRecords: []OccurrenceRecord{{
+				DestinationPath: "password",
+				DesiredIdentity: OccurrenceIdentity{Kind: OccurrenceKindGenerator, Ksuid: "gen1", PropertyPath: "value"},
+				Class:           OccurrenceStable,
+			}},
+		}}
+
+		assert.Empty(t, GeneratorsNeedingDraw(updates))
+	})
+
+	t.Run("one non-stable destination is enough when a sibling is stable", func(t *testing.T) {
+		updates := []ResourceUpdate{
+			{
+				DesiredState: pkgmodel.Resource{Properties: genProperties("password", "gen1")},
+				Operation:    OperationUpdate,
+				ProvenanceRecords: []OccurrenceRecord{{
+					DestinationPath: "password",
+					DesiredIdentity: OccurrenceIdentity{Kind: OccurrenceKindGenerator, Ksuid: "gen1", PropertyPath: "value"},
+					Class:           OccurrenceStable,
+				}},
+			},
+			{
+				DesiredState: pkgmodel.Resource{Properties: genProperties("password", "gen1")},
+				Operation:    OperationCreate,
+			},
+		}
+
+		assert.Equal(t, []string{"gen1"}, GeneratorsNeedingDraw(updates))
+	})
+
+	t.Run("a create carries no provenance records and always needs a draw", func(t *testing.T) {
+		updates := []ResourceUpdate{{
+			DesiredState: pkgmodel.Resource{Properties: genProperties("password", "gen1")},
+			Operation:    OperationCreate,
+		}}
+
+		assert.Equal(t, []string{"gen1"}, GeneratorsNeedingDraw(updates))
+	})
+
+	t.Run("an untranslated gen envelope names no generator and is skipped", func(t *testing.T) {
+		updates := []ResourceUpdate{{
+			DesiredState: pkgmodel.Resource{Properties: json.RawMessage(
+				`{"password":{"$gen":true,"$label":"db-password","$stack":"default","$output":"value"}}`)},
+			Operation: OperationCreate,
+		}}
+
+		assert.Empty(t, GeneratorsNeedingDraw(updates))
+	})
+
+	t.Run("distinct generators are reported once each in first-seen order", func(t *testing.T) {
+		updates := []ResourceUpdate{
+			{
+				DesiredState: pkgmodel.Resource{Properties: genProperties("password", "gen1")},
+				Operation:    OperationCreate,
+			},
+			{
+				DesiredState: pkgmodel.Resource{Properties: genProperties("password", "gen2")},
+				Operation:    OperationCreate,
+			},
+			{
+				DesiredState: pkgmodel.Resource{Properties: genProperties("password", "gen1")},
+				Operation:    OperationCreate,
+			},
+		}
+
+		assert.Equal(t, []string{"gen1", "gen2"}, GeneratorsNeedingDraw(updates))
+	})
+}

--- a/internal/metastructure/resource_update/gen_freeze.go
+++ b/internal/metastructure/resource_update/gen_freeze.go
@@ -37,14 +37,19 @@ import (
 // ProvenanceRecords for $gen destinations. An absent or non-generator record
 // is not stable and is left to the guard.
 //
-// An envelope that already carries a $value is left alone whatever its
-// classification says. A $value is only ever there because a draw was
-// delivered into it moments ago, and a draw reaches every destination of its
-// generator in the changeset, stable ones included: stability decides whether
-// the generator draws, not who a draw reaches. Freezing a delivered value
-// would throw away the credential the draw was made for and send the provider
-// a preserved-sentinel instead, leaving that destination on the old
-// generation while its siblings moved to the new one.
+// An envelope carrying a LIVE value — a $value with no $hashed marker — is
+// left alone whatever its classification says. Such a value is only ever
+// there because a draw was delivered into it moments ago, and a draw reaches
+// every destination of its generator in the changeset, stable ones included:
+// stability decides whether the generator draws, not who a draw reaches.
+// Freezing a delivered value would throw away the credential the draw was
+// made for and send the provider a preserved sentinel instead, leaving that
+// destination on the old generation while its siblings moved to the new one.
+//
+// A $value marked $hashed is the opposite case and is still frozen. It is the
+// digest CarryStableGeneratorBindingForward put back so the row keeps what it
+// already held; it is not a credential, and the guard at the provider
+// boundary refuses a digest sent where a secret belongs.
 //
 // A path that does not address a $gen envelope is skipped rather than written
 // over: destinations are addressed by a dot-joined path, so a map key
@@ -68,7 +73,7 @@ func FreezeStableGeneratorBindings(desired json.RawMessage, records []Occurrence
 		if !pkgmodel.IsGenObject(node) {
 			continue
 		}
-		if node.Get("$value").Exists() {
+		if node.Get("$value").Exists() && !node.Get("$hashed").Bool() {
 			continue
 		}
 		updated, err := sjson.SetRaw(out, occurrence.Path, opaquePreservedSentinel)

--- a/internal/metastructure/resource_update/gen_freeze.go
+++ b/internal/metastructure/resource_update/gen_freeze.go
@@ -1,0 +1,72 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package resource_update
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// FreezeStableGeneratorBindings replaces, in a desired document about to be
+// converted for a plugin Update, every $gen destination whose occurrence
+// classified stable with opaquePreservedSentinel.
+//
+// A stable binding is one whose generation is provably the one the destination
+// already carries. Nothing draws for it and nothing is delivered into it, so
+// its envelope is still bare when the update is dispatched — and the envelope
+// is not the value: GuardNoUnresolvedGenerators refuses to hand a provider a
+// reference where a secret belongs. Without this substitution that refusal
+// takes the whole document with it, so an edit to any unrelated property on a
+// generator-bound resource can never be applied. This is the $gen counterpart
+// of FreezeUnrecoverableOpaqueValues, and its rationale is the same: the guard
+// protecting one value must not block every other property beside it.
+//
+// Substituting rather than deleting is deliberate, for the reason
+// opaquePreservedSentinel documents: absence on DesiredProperties means "no
+// value", and a plugin rebuilding a whole-document write from it could clear
+// the secret it was meant to leave alone.
+//
+// Stability is read through IsGenDestinationStable, the one reading of
+// ProvenanceRecords for $gen destinations, so what is frozen here is exactly
+// what got no edge in the changeset and no value at delivery. An absent or
+// non-generator record is not stable and is left to the guard.
+//
+// A path that does not address a $gen envelope is skipped rather than written
+// over: destinations are addressed by a dot-joined path, so a map key
+// containing a dot resolves elsewhere — onto nothing, or onto a neighbour.
+// Skipping leaves the envelope for the guard to refuse, which fails the update
+// closed instead of writing a sentinel over an unrelated property.
+//
+// Inputs are not mutated; a rewritten copy of desired is returned, so the
+// caller keeps its durable record of the binding.
+func FreezeStableGeneratorBindings(desired json.RawMessage, records []OccurrenceRecord) (json.RawMessage, error) {
+	if len(desired) == 0 || len(records) == 0 {
+		return desired, nil
+	}
+
+	out := string(desired)
+	for _, occurrence := range pkgmodel.FindGenObjectsFromProperties(desired) {
+		if !IsGenDestinationStable(records, occurrence.Path) {
+			continue
+		}
+		if !pkgmodel.IsGenObject(gjson.Get(out, occurrence.Path)) {
+			continue
+		}
+		updated, err := sjson.SetRaw(out, occurrence.Path, opaquePreservedSentinel)
+		if err != nil {
+			// The path can contain user-authored map keys, so it stays out of
+			// the error: this text reaches an operator-visible failure reason.
+			return nil, fmt.Errorf("failed to substitute a stable generator binding: %w", err)
+		}
+		out = updated
+	}
+
+	return json.RawMessage(out), nil
+}

--- a/internal/metastructure/resource_update/gen_freeze.go
+++ b/internal/metastructure/resource_update/gen_freeze.go
@@ -34,9 +34,17 @@ import (
 // the secret it was meant to leave alone.
 //
 // Stability is read through IsGenDestinationStable, the one reading of
-// ProvenanceRecords for $gen destinations, so what is frozen here is exactly
-// what got no edge in the changeset and no value at delivery. An absent or
-// non-generator record is not stable and is left to the guard.
+// ProvenanceRecords for $gen destinations. An absent or non-generator record
+// is not stable and is left to the guard.
+//
+// An envelope that already carries a $value is left alone whatever its
+// classification says. A $value is only ever there because a draw was
+// delivered into it moments ago, and a draw reaches every destination of its
+// generator in the changeset, stable ones included: stability decides whether
+// the generator draws, not who a draw reaches. Freezing a delivered value
+// would throw away the credential the draw was made for and send the provider
+// a preserved-sentinel instead, leaving that destination on the old
+// generation while its siblings moved to the new one.
 //
 // A path that does not address a $gen envelope is skipped rather than written
 // over: destinations are addressed by a dot-joined path, so a map key
@@ -56,7 +64,11 @@ func FreezeStableGeneratorBindings(desired json.RawMessage, records []Occurrence
 		if !IsGenDestinationStable(records, occurrence.Path) {
 			continue
 		}
-		if !pkgmodel.IsGenObject(gjson.Get(out, occurrence.Path)) {
+		node := gjson.Get(out, occurrence.Path)
+		if !pkgmodel.IsGenObject(node) {
+			continue
+		}
+		if node.Get("$value").Exists() {
 			continue
 		}
 		updated, err := sjson.SetRaw(out, occurrence.Path, opaquePreservedSentinel)

--- a/internal/metastructure/resource_update/gen_freeze_test.go
+++ b/internal/metastructure/resource_update/gen_freeze_test.go
@@ -208,3 +208,19 @@ func TestFreezeStableGeneratorBindings_FreezesABareEnvelope(t *testing.T) {
 
 	assert.JSONEq(t, `{"$opaque":"preserved"}`, gjson.GetBytes(out, "Password").Raw)
 }
+
+// A carried-forward digest is not a credential. It sits on the envelope so
+// the row keeps the value it already holds, and the provider must still be
+// sent the sentinel: the guard at the boundary refuses a digest where a
+// secret belongs, and would take the whole document with it.
+func TestFreezeStableGeneratorBindings_FreezesACarriedDigest(t *testing.T) {
+	carried := `{"$gen":true,"$generator":"` + boundGeneratorKsuid +
+		`","$output":"value","$visibility":"Opaque","$hashed":true,"$value":"` +
+		pkgmodel.ComputeValueHash("the-drawn-password") + `"}`
+
+	out, err := FreezeStableGeneratorBindings(
+		genBoundProperties("one", carried), stableGenRecord())
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"$opaque":"preserved"}`, gjson.GetBytes(out, "Password").Raw)
+}

--- a/internal/metastructure/resource_update/gen_freeze_test.go
+++ b/internal/metastructure/resource_update/gen_freeze_test.go
@@ -1,0 +1,179 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/provenance"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// genBoundSchema declares one generator-bound secret alongside plain metadata,
+// the shape of a provider secret whose value formae mints.
+func genBoundSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Description", "Password"},
+		Hints:      map[string]pkgmodel.FieldHint{"Password": {Opaque: true}},
+	}
+}
+
+// boundGenLeaf is the destination as the forma declares it once command
+// translation has resolved the generator: a reference to an output, carrying
+// no value of its own.
+const boundGenLeaf = `{"$gen":true,"$generator":"` + boundGeneratorKsuid +
+	`","$output":"value","$visibility":"Opaque"}`
+
+// storedGenLeaf is that same destination at rest: the drawn value hashed, and
+// the generation it was drawn from recorded on the occurrence.
+func storedGenLeaf(digest, resolvedFrom string) string {
+	return `{"$gen":true,"$generator":"` + boundGeneratorKsuid +
+		`","$output":"value","$visibility":"Opaque","$hashed":true,"$value":"` + digest +
+		`","$resolvedFrom":"` + resolvedFrom + `"}`
+}
+
+func genBoundProperties(description, passwordLeaf string) json.RawMessage {
+	return json.RawMessage(`{"Name":"n","Description":"` + description + `","Password":` + passwordLeaf + `}`)
+}
+
+// genBoundUpdate builds the ResourceUpdateData for an update to a resource
+// whose Password is bound to a generator, with the given planning-time
+// occurrence records.
+func genBoundUpdate(records []OccurrenceRecord, digest, priorDescription, desiredDescription, patch string) ResourceUpdateData {
+	schema := genBoundSchema()
+	ru := &ResourceUpdate{
+		Operation: OperationUpdate,
+		PriorState: pkgmodel.Resource{
+			Label: "consumer", Type: "Test::Generated::Consumer", Stack: "default",
+			Schema:     schema,
+			Properties: genBoundProperties(priorDescription, storedGenLeaf(digest, provenance.DigestOfString("generation-1"))),
+		},
+		DesiredState: pkgmodel.Resource{
+			Label: "consumer", Type: "Test::Generated::Consumer", Stack: "default",
+			Schema:        schema,
+			Properties:    genBoundProperties(desiredDescription, boundGenLeaf),
+			PatchDocument: json.RawMessage(patch),
+		},
+		ProvenanceRecords: records,
+		ResourceTarget:    pkgmodel.Target{Label: "us-east-1", Namespace: "test", Config: json.RawMessage(`{}`)},
+	}
+	return ResourceUpdateData{resourceUpdate: ru, commandID: "cmd-1", originalResourceKsuidURI: ru.DesiredState.URI()}
+}
+
+// stableGenRecord is the planning-time record for a binding whose generation
+// is provably the one the destination already carries.
+func stableGenRecord() []OccurrenceRecord {
+	return []OccurrenceRecord{{
+		DestinationPath:  "Password",
+		DesiredIdentity:  OccurrenceIdentity{Kind: OccurrenceKindGenerator, Ksuid: boundGeneratorKsuid, PropertyPath: "value"},
+		StoredIdentity:   OccurrenceIdentity{Kind: OccurrenceKindGenerator, Ksuid: boundGeneratorKsuid, PropertyPath: "value"},
+		HasStoredWritten: true,
+		Class:            OccurrenceStable,
+	}}
+}
+
+// A binding whose occurrence classified stable draws no value, so its
+// destination still holds the bare envelope when the update is dispatched. The
+// envelope is never sent to a provider, and it must not block the rest of the
+// document either: an edit to an unrelated property on the same resource has to
+// reach the plugin, with the bound destination present but unusable.
+func TestUpdate_StableGeneratorBinding_SiblingEditReachesPlugin(t *testing.T) {
+	digest := pkgmodel.ComputeValueHash("the-drawn-password")
+	data := genBoundUpdate(stableGenRecord(), digest, "one", "two",
+		`[{"op":"replace","path":"/Description","value":"two"}]`)
+	proc := newOperationCapturingProcess()
+
+	_, _, _, err := update(StateUpdating, data, proc)
+	require.NoError(t, err)
+
+	op := proc.capturedUpdate(t)
+	assert.JSONEq(t, `[{"op":"replace","path":"/Description","value":"two"}]`, op.PatchDocument,
+		"the patch must carry the unrelated change and nothing else")
+
+	desired := map[string]any{}
+	require.NoError(t, json.Unmarshal(op.DesiredProperties, &desired))
+	assert.Equal(t, "two", desired["Description"], "the unrelated change must reach the plugin")
+	assert.Equal(t, map[string]any{"$opaque": "preserved"}, desired["Password"],
+		"a stable generator binding must reach the plugin as a present-but-unusable sentinel")
+	assert.Contains(t, desired, "Password",
+		"the bound field must stay present: absence means no value, which can clear the secret")
+	assert.NotContains(t, string(op.DesiredProperties), "$gen",
+		"the generator reference itself must never leave the agent")
+	assert.NotContains(t, string(op.DesiredProperties), digest,
+		"the stored digest must never leave the agent")
+	assert.NotContains(t, string(op.PriorProperties), digest,
+		"the stored digest must never leave the agent")
+
+	assert.Contains(t, string(data.resourceUpdate.DesiredState.Properties), "$gen",
+		"the durable desired state must keep the binding")
+}
+
+// A forced apply over an unchanged generator-bound secret classifies the
+// binding stable — force is not a rotation — so it dispatches like any other
+// update: the plugin call is made, the destination is present but unusable,
+// and no value is drawn or written.
+func TestUpdate_ForcedApplyOverUnchangedGeneratorBinding_DoesNotRotate(t *testing.T) {
+	digest := pkgmodel.ComputeValueHash("the-drawn-password")
+	desired := genBoundProperties("one", boundGenLeaf)
+	stored := genBoundProperties("one", storedGenLeaf(digest, provenance.DigestOfString("generation-1")))
+
+	spec := genSpec(func(*pkgmodel.PasswordGenerator) {})
+	consumer := pkgmodel.Resource{
+		Label: "consumer", Type: "Test::Generated::Consumer", Stack: "default",
+		Schema: genBoundSchema(), Properties: desired,
+	}
+	answers, err := resolver.LoadResolvablePropertiesFromStacks(consumer, nil, nil,
+		func(string) (pkgmodel.GeneratorIdentity, pkgmodel.Generator) {
+			return heldGeneration(t, "generation-1", spec), spec
+		})
+	require.NoError(t, err)
+
+	records := buildProvenanceRecords(desired, stored, answers, genBoundSchema(), true)
+	require.Len(t, records, 1)
+	require.Equal(t, OccurrenceStable, records[0].Class,
+		"a forced apply must not reclassify a generator binding as one to re-assert")
+
+	data := genBoundUpdate(records, digest, "one", "one", `[]`)
+	proc := newOperationCapturingProcess()
+
+	_, _, _, err = update(StateUpdating, data, proc)
+	require.NoError(t, err)
+
+	op := proc.capturedUpdate(t)
+	desiredProps := map[string]any{}
+	require.NoError(t, json.Unmarshal(op.DesiredProperties, &desiredProps))
+	assert.Equal(t, map[string]any{"$opaque": "preserved"}, desiredProps["Password"],
+		"a forced apply must leave the provider's value in place, not clear it and not replace it")
+	assert.NotContains(t, string(op.DesiredProperties), digest)
+
+	assert.Contains(t, string(data.resourceUpdate.DesiredState.Properties), "$gen",
+		"a forced apply must not rotate the binding")
+}
+
+// The freeze is keyed on the planning-time classification, never on the mere
+// presence of an envelope. A destination that has no stable record still owes a
+// drawn value, and dispatching it unresolved stays a refusal.
+func TestUpdate_GeneratorBindingWithoutStableRecord_IsStillRefused(t *testing.T) {
+	digest := pkgmodel.ComputeValueHash("the-drawn-password")
+	data := genBoundUpdate(nil, digest, "one", "two",
+		`[{"op":"replace","path":"/Description","value":"two"}]`)
+	proc := newOperationCapturingProcess()
+
+	state, _, _, err := update(StateUpdating, data, proc)
+	require.NoError(t, err)
+	require.Equal(t, StateFinishedWithError, state, "an undrawn binding must not be dispatched")
+	assert.Nil(t, proc.operation, "the plugin must never be called with an undrawn binding")
+	assert.Contains(t, strings.Join(proc.log.all(), "\n"), "failed to convert resource properties for plugin")
+	assert.Equal(t, failureReasonUndrawnGeneratorValueOnUpdate, data.resourceUpdate.MostRecentFailureMessage())
+}

--- a/internal/metastructure/resource_update/gen_freeze_test.go
+++ b/internal/metastructure/resource_update/gen_freeze_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/provenance"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
@@ -176,4 +177,34 @@ func TestUpdate_GeneratorBindingWithoutStableRecord_IsStillRefused(t *testing.T)
 	assert.Nil(t, proc.operation, "the plugin must never be called with an undrawn binding")
 	assert.Contains(t, strings.Join(proc.log.all(), "\n"), "failed to convert resource properties for plugin")
 	assert.Equal(t, failureReasonUndrawnGeneratorValueOnUpdate, data.resourceUpdate.MostRecentFailureMessage())
+}
+
+// A stable binding that a draw was delivered into carries the drawn value in
+// its envelope, and the freeze must leave it alone. Stability decides whether
+// the generator draws, not who a draw reaches, so a stable destination does
+// receive a draw that is happening — and substituting the sentinel over it
+// would send the provider a preserved marker instead of the credential,
+// leaving that destination on the old generation while its siblings moved.
+func TestFreezeStableGeneratorBindings_LeavesADeliveredValueAlone(t *testing.T) {
+	delivered := `{"$gen":true,"$generator":"` + boundGeneratorKsuid +
+		`","$output":"value","$visibility":"Opaque","$value":"the-freshly-drawn-password"}`
+
+	out, err := FreezeStableGeneratorBindings(
+		genBoundProperties("one", delivered), stableGenRecord())
+	require.NoError(t, err)
+
+	assert.JSONEq(t, delivered, gjson.GetBytes(out, "Password").Raw,
+		"a delivered value must survive the freeze untouched")
+}
+
+// The same binding with no value delivered into it is still frozen: nothing
+// drew for it, so its envelope is bare, and the guard that refuses to hand a
+// provider a reference in a secret's place would otherwise take the whole
+// document with it.
+func TestFreezeStableGeneratorBindings_FreezesABareEnvelope(t *testing.T) {
+	out, err := FreezeStableGeneratorBindings(
+		genBoundProperties("one", boundGenLeaf), stableGenRecord())
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"$opaque":"preserved"}`, gjson.GetBytes(out, "Password").Raw)
 }

--- a/internal/metastructure/resource_update/gen_provenance_stamp_test.go
+++ b/internal/metastructure/resource_update/gen_provenance_stamp_test.go
@@ -40,13 +40,28 @@ func TestResolveGeneratorValue_StampsTheDigestThePlannerComputes(t *testing.T) {
 		"the delivered destination must carry a current-domain digest, got %q", stamped)
 
 	// The planner's side, from the resolver's own answer for the same $gen
-	// occurrence against a generator holding this generation.
+	// occurrence against a generator holding this generation. The lookup
+	// answers a DECLARED generator with the spec its generation was drawn
+	// under, which is the shape a real second apply presents: the planner
+	// then checks the held generation against the declared spec before
+	// digesting it.
+	declared := &pkgmodel.PasswordGenerator{
+		Label: "db-password", Stack: "s", ID: stampGeneratorKsuid,
+		Length: 24, Uppercase: true, Lowercase: true, Digits: true,
+	}
+	drawnUnder, err := json.Marshal(declared)
+	require.NoError(t, err)
+
 	planned, err := resolver.LoadResolvablePropertiesFromStacks(
 		genBoundCreate(stampGeneratorKsuid).DesiredState,
 		map[string][]*pkgmodel.Resource{},
 		map[string]json.RawMessage{},
 		func(ksuid string) (pkgmodel.GeneratorIdentity, pkgmodel.Generator) {
-			return pkgmodel.GeneratorIdentity{ID: ksuid, GenerationID: stampGenerationID}, nil
+			return pkgmodel.GeneratorIdentity{
+				ID:             ksuid,
+				GenerationID:   stampGenerationID,
+				GenerationSpec: drawnUnder,
+			}, declared
 		},
 	)
 	require.NoError(t, err)
@@ -85,17 +100,6 @@ func TestResolveGeneratorValue_ReadOriginMergeStampsNothing(t *testing.T) {
 
 	assert.False(t, gjson.GetBytes(ru.DesiredState.Properties, "SecretString.$resolvedFrom").Exists(),
 		"only the echo of formae's own write may attest where a value came from")
-}
-
-// A draw that names no generation leaves the destination unstamped rather
-// than stamping a digest of nothing, which would be a well-formed digest
-// attesting a generation that does not exist.
-func TestResolveGeneratorValue_UnnamedGenerationStampsNothing(t *testing.T) {
-	ru := genBoundCreate(stampGeneratorKsuid)
-
-	require.NoError(t, ru.ResolveGeneratorValue(stampGeneratorKsuid, "drawn-credential", "", pkgmodel.FormaApplyModeReconcile))
-
-	assert.Empty(t, ru.ResolvedRootDigests)
 }
 
 // The key a generator occurrence is stamped under is the key the merge reads

--- a/internal/metastructure/resource_update/gen_provenance_stamp_test.go
+++ b/internal/metastructure/resource_update/gen_provenance_stamp_test.go
@@ -1,0 +1,112 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/provenance"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+const (
+	stampGeneratorKsuid = "2abc123def456ghi7jk8lmno9p0"
+	stampGenerationID   = "2zyx987wvu654tsr321qponmlkj"
+)
+
+// The digest a delivered generator value is stamped with is compared, on the
+// next apply, against the digest the planner computes for the generation the
+// generator holds. The two are computed by different packages on different
+// sides of a persist, so they are asserted equal here directly rather than
+// inferred from a quiet re-apply: a mismatch of any kind — a wrapper, a
+// prefix, a different domain — makes the root-versus-root rule unable to
+// fire, and every re-apply then redraws with nothing reporting a fault.
+func TestResolveGeneratorValue_StampsTheDigestThePlannerComputes(t *testing.T) {
+	ru := genBoundCreate(stampGeneratorKsuid)
+	require.NoError(t, ru.ResolveGeneratorValue(stampGeneratorKsuid, "drawn-credential", stampGenerationID, pkgmodel.FormaApplyModeReconcile))
+
+	stamped := ru.ResolvedRootDigests[generatorSourceKey(stampGeneratorKsuid, "value")]
+	require.True(t, provenance.Valid(stamped),
+		"the delivered destination must carry a current-domain digest, got %q", stamped)
+
+	// The planner's side, from the resolver's own answer for the same $gen
+	// occurrence against a generator holding this generation.
+	planned, err := resolver.LoadResolvablePropertiesFromStacks(
+		genBoundCreate(stampGeneratorKsuid).DesiredState,
+		map[string][]*pkgmodel.Resource{},
+		map[string]json.RawMessage{},
+		func(ksuid string) (pkgmodel.GeneratorIdentity, pkgmodel.Generator) {
+			return pkgmodel.GeneratorIdentity{ID: ksuid, GenerationID: stampGenerationID}, nil
+		},
+	)
+	require.NoError(t, err)
+	answer, ok := planned.Answer(stampGeneratorKsuid, "value")
+	require.True(t, ok, "the planner must answer the generator occurrence")
+
+	assert.Equal(t, answer.SourceRootDigest, stamped,
+		"the stamped digest and the planner's generation digest must be byte-identical")
+}
+
+// The stamp is only useful if it reaches the envelope that lands at rest: the
+// write-origin merge of the provider's echo is what carries it from the
+// update's digest map into the destination's $resolvedFrom.
+func TestResolveGeneratorValue_StampReachesTheStoredEnvelope(t *testing.T) {
+	ru := genBoundCreate(stampGeneratorKsuid)
+	ru.DesiredState.Schema = pkgmodel.Schema{Identifier: "Name", Fields: []string{"Name", "SecretString"}}
+
+	require.NoError(t, ru.ResolveGeneratorValue(stampGeneratorKsuid, "drawn-credential", stampGenerationID, pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, ru.updateResourceProperties(`{"Name":"db","SecretString":"drawn-credential"}`, true))
+
+	envelope := gjson.GetBytes(ru.DesiredState.Properties, "SecretString")
+	require.True(t, envelope.IsObject(), "the envelope must survive the merge")
+	assert.Equal(t, provenance.DigestOfString(stampGenerationID), envelope.Get("$resolvedFrom").String(),
+		"the merged envelope must carry the generation the value was drawn from")
+}
+
+// A read-origin merge — a sync or discovery read, not the echo of formae's
+// own write — attests nothing, so it must never stamp provenance a
+// destination did not earn.
+func TestResolveGeneratorValue_ReadOriginMergeStampsNothing(t *testing.T) {
+	ru := genBoundCreate(stampGeneratorKsuid)
+	ru.DesiredState.Schema = pkgmodel.Schema{Identifier: "Name", Fields: []string{"Name", "SecretString"}}
+
+	require.NoError(t, ru.ResolveGeneratorValue(stampGeneratorKsuid, "drawn-credential", stampGenerationID, pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, ru.updateResourceProperties(`{"Name":"db","SecretString":"drawn-credential"}`, false))
+
+	assert.False(t, gjson.GetBytes(ru.DesiredState.Properties, "SecretString.$resolvedFrom").Exists(),
+		"only the echo of formae's own write may attest where a value came from")
+}
+
+// A draw that names no generation leaves the destination unstamped rather
+// than stamping a digest of nothing, which would be a well-formed digest
+// attesting a generation that does not exist.
+func TestResolveGeneratorValue_UnnamedGenerationStampsNothing(t *testing.T) {
+	ru := genBoundCreate(stampGeneratorKsuid)
+
+	require.NoError(t, ru.ResolveGeneratorValue(stampGeneratorKsuid, "drawn-credential", "", pkgmodel.FormaApplyModeReconcile))
+
+	assert.Empty(t, ru.ResolvedRootDigests)
+}
+
+// The key a generator occurrence is stamped under is the key the merge reads
+// back off the envelope. They are derived in different functions, so they are
+// asserted to agree.
+func TestReferenceURIOf_KeysATranslatedGeneratorEnvelope(t *testing.T) {
+	envelope := gjson.Parse(`{"$gen":true,"$generator":"` + stampGeneratorKsuid + `","$output":"value","$visibility":"Opaque"}`)
+
+	assert.Equal(t, generatorSourceKey(stampGeneratorKsuid, "value"), referenceURIOf(envelope))
+
+	authored := gjson.Parse(`{"$gen":true,"$label":"db-password","$stack":"s","$output":"value"}`)
+	assert.Empty(t, referenceURIOf(authored),
+		"an untranslated envelope names no generator, so there is nothing to key on")
+}

--- a/internal/metastructure/resource_update/occurrence_classification.go
+++ b/internal/metastructure/resource_update/occurrence_classification.go
@@ -163,7 +163,14 @@ func ClassifyOccurrence(rec *OccurrenceRecord, opaque, destCreateOnly, force boo
 	case !opaque:
 		rec.Class = OccurrenceDeferredUpdate
 	// R2: force is the sanctioned re-assert path and bypasses suppression.
-	case force:
+	// It does NOT apply to a generator binding: formae holds no copy of a
+	// drawn value, so there is nothing to re-assert, and the only thing a
+	// forced apply could write is a NEW credential. Rotation is a movement
+	// of the generation (R3/R4/R5), never a property of how the apply was
+	// submitted. Forcing also buys nothing here — if the secret drifted in
+	// the cloud, formae cannot restore what it had, so it would cost a
+	// rotation and repair nothing.
+	case force && rec.DesiredIdentity.Kind != OccurrenceKindGenerator:
 		rec.Class = OccurrenceDeferredUpdate
 	// R3: a repoint or selector change always plans, digests notwithstanding.
 	case rec.DesiredIdentity != rec.StoredIdentity:

--- a/internal/metastructure/resource_update/occurrence_classification_test.go
+++ b/internal/metastructure/resource_update/occurrence_classification_test.go
@@ -140,6 +140,7 @@ func TestClassifyOccurrence(t *testing.T) {
 	writtenLeaf := provenance.DigestOfString("leaf-value")
 	id := occIdentity(t, `{"$ref":"formae://2abcdefghijklmnopqrstuvwxyz#/S"}`)
 	otherID := occIdentity(t, `{"$ref":"formae://2zzzzzzzzzzzzzzzzzzzzzzzzzz#/S"}`)
+	genID := occIdentity(t, `{"$gen":true,"$generator":"2abcdefghijklmnopqrstuvwxyz","$output":"value"}`)
 
 	base := func() *OccurrenceRecord {
 		return &OccurrenceRecord{
@@ -178,6 +179,35 @@ func TestClassifyOccurrence(t *testing.T) {
 		rec := base()
 		ClassifyOccurrence(rec, true, false, true, noLeaf)
 		assert.Equal(t, OccurrenceDeferredUpdate, rec.Class)
+	})
+
+	t.Run("force does not unsuppress a generator binding", func(t *testing.T) {
+		// Force means re-assert the value we hold. formae holds no copy of a
+		// drawn value, so on a generator binding the only thing a forced
+		// apply could write is a NEW credential. A provably-unmoved
+		// generation stays suppressed; the same record pointed at a resource
+		// property does not.
+		gen := base()
+		gen.DesiredIdentity = genID
+		gen.StoredIdentity = genID
+		ClassifyOccurrence(gen, true, false, true, noLeaf)
+		assert.Equal(t, OccurrenceStable, gen.Class,
+			"a forced apply must not rotate a credential whose generation has not moved")
+
+		ref := base()
+		ClassifyOccurrence(ref, true, false, true, noLeaf)
+		assert.Equal(t, OccurrenceDeferredUpdate, ref.Class,
+			"force still re-asserts a resource reference in the same position")
+	})
+
+	t.Run("a generator binding still defers when its generation moved", func(t *testing.T) {
+		rec := base()
+		rec.DesiredIdentity = genID
+		rec.StoredIdentity = genID
+		rec.SourceRootDigest = rootB
+		ClassifyOccurrence(rec, true, false, true, noLeaf)
+		assert.Equal(t, OccurrenceDeferredUpdate, rec.Class,
+			"rotation is a movement of the generation, which force neither creates nor hides")
 	})
 
 	t.Run("repoint defers despite equal digests", func(t *testing.T) {

--- a/internal/metastructure/resource_update/opaque_freeze.go
+++ b/internal/metastructure/resource_update/opaque_freeze.go
@@ -200,3 +200,18 @@ func escapeGjsonKey(key string) string {
 	}
 	return escaped.String()
 }
+
+// isOpaquePreservedSentinel reports whether v is the present-but-unusable
+// marker the freezes substitute for a value the agent must not send. It is
+// matched structurally rather than by raw bytes so re-encoding on the way
+// through a plugin cannot change the answer.
+func isOpaquePreservedSentinel(v gjson.Result) bool {
+	if !v.IsObject() {
+		return false
+	}
+	fields := v.Map()
+	if len(fields) != 1 {
+		return false
+	}
+	return fields["$opaque"].String() == "preserved"
+}

--- a/internal/metastructure/resource_update/opaque_log_redaction_test.go
+++ b/internal/metastructure/resource_update/opaque_log_redaction_test.go
@@ -1,0 +1,141 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"ergo.services/ergo/gen"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// debugCapturingLog records Debug-level messages so a test can inspect what a
+// handler rendered into them.
+type debugCapturingLog struct {
+	gen.Log
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (l *debugCapturingLog) Debug(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.msgs = append(l.msgs, fmt.Sprintf(format, args...))
+}
+func (l *debugCapturingLog) Trace(string, ...any)   {}
+func (l *debugCapturingLog) Info(string, ...any)    {}
+func (l *debugCapturingLog) Warning(string, ...any) {}
+func (l *debugCapturingLog) Error(string, ...any)   {}
+func (l *debugCapturingLog) Panic(string, ...any)   {}
+
+func (l *debugCapturingLog) all() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.msgs...)
+}
+
+// persistingProcess answers proc.Call with a resource version so the state
+// machine proceeds past the persist step, and captures Debug output.
+type persistingProcess struct {
+	*stubUpdaterProcess
+	log *debugCapturingLog
+}
+
+func (p *persistingProcess) Log() gen.Log { return p.log }
+func (p *persistingProcess) Call(_ any, _ any) (any, error) {
+	return "resource-version-1", nil
+}
+
+// opaqueGenEnvelope builds a property document whose single property holds a
+// drawn generator value: an opaque envelope carrying live plaintext.
+func opaqueGenEnvelope(plaintext string) json.RawMessage {
+	return json.RawMessage(`{"MasterUserPassword":{"$gen":true,"$generator":"2ABcDeFgHiJkLmNoPqRsTuVwXyZ","$output":"value","$visibility":"Opaque","$value":"` + plaintext + `"}}`)
+}
+
+// TestHandleProgressUpdate_RejectionLogWithholdsOpaqueValues asserts that the
+// log line explaining why a synchronizing update was rejected names the
+// properties that differ without rendering the plaintext of any opaque value
+// either of them carries.
+func TestHandleProgressUpdate_RejectionLogWithholdsOpaqueValues(t *testing.T) {
+	const desiredPlaintext = "desired-plaintext-value-9f3a"
+	const previousPlaintext = "previous-plaintext-value-4c7b"
+
+	ru := &ResourceUpdate{
+		Operation: OperationUpdate,
+		DesiredState: pkgmodel.Resource{
+			Label:      "app-database",
+			Type:       "FakeAWS::RDS::DBInstance",
+			Stack:      "test-stack",
+			Properties: opaqueGenEnvelope(desiredPlaintext),
+		},
+		PreviousProperties: opaqueGenEnvelope(previousPlaintext),
+		ResourceTarget:     pkgmodel.Target{Label: "us-east-1"},
+		StackLabel:         "test-stack",
+	}
+
+	data := ResourceUpdateData{
+		resourceUpdate: ru,
+		commandID:      "cmd-reject",
+	}
+
+	readProgress := plugin.TrackedProgress{
+		ProgressResult: resource.ProgressResult{
+			Operation:       resource.OperationRead,
+			OperationStatus: resource.OperationStatusSuccess,
+			NativeID:        "db-1",
+		},
+	}
+
+	clog := &debugCapturingLog{}
+	proc := &persistingProcess{stubUpdaterProcess: &stubUpdaterProcess{}, log: clog}
+
+	state, _, _, err := handleProgressUpdate(gen.PID{}, StateSynchronizing, data, readProgress, proc)
+	require.NoError(t, err)
+	require.Equal(t, StateRejected, state, "a change detected during synchronize must reject the update")
+
+	msgs := clog.all()
+	var rejection string
+	for _, m := range msgs {
+		if strings.Contains(m, "rejected") {
+			rejection = m
+		}
+	}
+	require.NotEmpty(t, rejection, "the rejection must be explained in a log line, got: %v", msgs)
+
+	assert.Contains(t, rejection, "MasterUserPassword",
+		"the line must still name the property that differs")
+	assert.NotContains(t, rejection, desiredPlaintext,
+		"the drawn value in the desired properties must not be rendered")
+	assert.NotContains(t, rejection, previousPlaintext,
+		"the drawn value in the previous properties must not be rendered")
+}
+
+// TestGetPreservedValueString_WithholdsOpaqueValues asserts that the value
+// reported when a SetOnce property or tag keeps its existing setting is
+// withheld for an opaque property and reported verbatim for any other.
+func TestGetPreservedValueString_WithholdsOpaqueValues(t *testing.T) {
+	opaque := gjson.Parse(`{"$strategy":"SetOnce","$visibility":"Opaque","$value":"kept-plaintext-value-2b8f"}`)
+	assert.Equal(t, pkgmodel.RedactedForLog, getPreservedValueString(opaque),
+		"an opaque preserved value must not be reported")
+
+	clear := gjson.Parse(`{"$strategy":"SetOnce","$visibility":"Clear","$value":"us-east-1a"}`)
+	assert.Equal(t, "us-east-1a", getPreservedValueString(clear),
+		"a clear preserved value must still be reported")
+
+	plain := gjson.Parse(`"us-east-1a"`)
+	assert.Equal(t, "us-east-1a", getPreservedValueString(plain),
+		"a bare preserved value must still be reported")
+}

--- a/internal/metastructure/resource_update/opaque_suppression_test.go
+++ b/internal/metastructure/resource_update/opaque_suppression_test.go
@@ -58,7 +58,7 @@ func planUpdates(t *testing.T, existing, desired pkgmodel.Resource) []ResourceUp
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
 	updates, err := NewResourceUpdateForExisting(
 		resolver.ResolvableProperties{}, nil, existing, desired,
-		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false)
+		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
 	require.NoError(t, err)
 	return updates
 }

--- a/internal/metastructure/resource_update/resolve_generator_value_test.go
+++ b/internal/metastructure/resource_update/resolve_generator_value_test.go
@@ -1,0 +1,147 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func genBoundCreate(generatorKsuid string) ResourceUpdate {
+	return ResourceUpdate{
+		Operation: OperationCreate,
+		DesiredState: pkgmodel.Resource{
+			Label: "db", Type: "Test::Secret::Entry", Stack: "s",
+			Properties: json.RawMessage(`{
+				"Name": "db",
+				"SecretString": {"$gen": true, "$generator": "` + generatorKsuid + `", "$output": "value", "$visibility": "Opaque"}
+			}`),
+		},
+	}
+}
+
+// The drawn value reaches the destination inside its envelope, with the
+// opaque marker intact — the envelope is what the persist path reads to
+// decide the value is hashed at rest.
+func TestResolveGeneratorValue_WritesInsideTheEnvelope(t *testing.T) {
+	ru := genBoundCreate("gen-a")
+
+	require.NoError(t, ru.ResolveGeneratorValue("gen-a", "drawn-credential", pkgmodel.FormaApplyModeReconcile))
+
+	envelope := gjson.GetBytes(ru.DesiredState.Properties, "SecretString")
+	require.True(t, envelope.IsObject(), "the envelope must not be replaced by a bare scalar")
+	assert.Equal(t, "drawn-credential", envelope.Get("$value").String())
+	assert.Equal(t, "Opaque", envelope.Get("$visibility").String())
+	assert.True(t, envelope.Get("$gen").Bool())
+}
+
+// A destination bound to a different generator is left alone.
+func TestResolveGeneratorValue_LeavesAnotherGeneratorsDestinationAlone(t *testing.T) {
+	ru := genBoundCreate("gen-a")
+
+	require.NoError(t, ru.ResolveGeneratorValue("gen-b", "drawn-credential", pkgmodel.FormaApplyModeReconcile))
+
+	assert.False(t, gjson.GetBytes(ru.DesiredState.Properties, "SecretString.$value").Exists(),
+		"only destinations naming the generator that drew may receive the value")
+}
+
+// A destination whose occurrence classified stable already holds the value
+// this generator's current generation produced. Delivering a fresh draw over
+// it would rotate a credential nothing asked to rotate, so it is skipped —
+// the same reading the changeset uses to decide whether to wire the edge at
+// all, applied again here because one resource may hold both a stable and an
+// unstable destination for the same generator.
+func TestResolveGeneratorValue_LeavesAStableDestinationAlone(t *testing.T) {
+	ru := ResourceUpdate{
+		Operation: OperationUpdate,
+		DesiredState: pkgmodel.Resource{
+			Label: "db", Type: "Test::Secret::Entry", Stack: "s",
+			Properties: json.RawMessage(`{
+				"Stable": {"$gen": true, "$generator": "gen-a", "$output": "value", "$visibility": "Opaque"},
+				"Fresh":  {"$gen": true, "$generator": "gen-a", "$output": "value", "$visibility": "Opaque"}
+			}`),
+		},
+		ProvenanceRecords: []OccurrenceRecord{{
+			DestinationPath: "Stable",
+			DesiredIdentity: OccurrenceIdentity{
+				Kind: OccurrenceKindGenerator, Ksuid: "gen-a", PropertyPath: "value",
+			},
+			Class: OccurrenceStable,
+		}},
+	}
+
+	require.NoError(t, ru.ResolveGeneratorValue("gen-a", "drawn-credential", pkgmodel.FormaApplyModeReconcile))
+
+	assert.False(t, gjson.GetBytes(ru.DesiredState.Properties, "Stable.$value").Exists(),
+		"a stable destination keeps the credential it already holds")
+	assert.Equal(t, "drawn-credential", gjson.GetBytes(ru.DesiredState.Properties, "Fresh.$value").String(),
+		"a destination that still needs a value receives the draw")
+}
+
+// Delivering a drawn value mutates DesiredState.Properties, so the derived
+// patch must be re-derived under the SAME apply-mode semantics the command
+// was planned with. Under reconcile an EntitySet member dropped from the
+// desired state produces a remove op; under patch mode absence means "leave
+// unchanged" and no remove may appear.
+func TestResolveGeneratorValue_RegeneratesUnderCommandMode(t *testing.T) {
+	newUpdate := func() ResourceUpdate {
+		schema := pkgmodel.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "SecretString", "Tags"},
+			Hints: map[string]pkgmodel.FieldHint{
+				"Tags": {UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Key"},
+			},
+		}
+		return ResourceUpdate{
+			Operation: OperationUpdate,
+			PriorState: pkgmodel.Resource{
+				Label: "db", Type: "Test::Secret::Entry", Schema: schema,
+				Properties: json.RawMessage(`{"Name": "db", "SecretString": "old", "Tags": [{"Key": "env", "Value": "prod"}, {"Key": "legacy", "Value": "true"}]}`),
+			},
+			DesiredState: pkgmodel.Resource{
+				Label: "db", Type: "Test::Secret::Entry", Schema: schema,
+				Properties: json.RawMessage(`{"Name": "db", "SecretString": {"$gen": true, "$generator": "gen-a", "$output": "value"}, "Tags": [{"Key": "env", "Value": "prod"}]}`),
+			},
+		}
+	}
+
+	reconcile := newUpdate()
+	require.NoError(t, reconcile.ResolveGeneratorValue("gen-a", "drawn", pkgmodel.FormaApplyModeReconcile))
+	assert.Contains(t, string(reconcile.DesiredState.PatchDocument), "remove",
+		"reconcile regeneration must keep the remove op for the dropped Tags member")
+	assert.Contains(t, string(reconcile.DesiredState.PatchDocument), "Tags")
+
+	patchMode := newUpdate()
+	require.NoError(t, patchMode.ResolveGeneratorValue("gen-a", "drawn", pkgmodel.FormaApplyModePatch))
+	assert.NotContains(t, string(patchMode.DesiredState.PatchDocument), "remove",
+		"patch-mode regeneration must leave the undeclared Tags member unchanged")
+}
+
+// A resource holding no destination for this generator is a no-op: nothing is
+// written and no patch is re-derived.
+func TestResolveGeneratorValue_WithNoDestinationChangesNothing(t *testing.T) {
+	ru := ResourceUpdate{
+		Operation: OperationUpdate,
+		DesiredState: pkgmodel.Resource{
+			Label: "plain", Type: "Test::Secret::Entry", Stack: "s",
+			Properties:    json.RawMessage(`{"Name": "plain"}`),
+			PatchDocument: json.RawMessage(`[{"op":"replace","path":"/Name","value":"plain"}]`),
+		},
+	}
+
+	require.NoError(t, ru.ResolveGeneratorValue("gen-a", "drawn", pkgmodel.FormaApplyModeReconcile))
+
+	assert.JSONEq(t, `{"Name": "plain"}`, string(ru.DesiredState.Properties))
+	assert.JSONEq(t, `[{"op":"replace","path":"/Name","value":"plain"}]`, string(ru.DesiredState.PatchDocument),
+		"a resource with nothing to deliver keeps its planned patch")
+}

--- a/internal/metastructure/resource_update/resolve_generator_value_test.go
+++ b/internal/metastructure/resource_update/resolve_generator_value_test.go
@@ -55,13 +55,12 @@ func TestResolveGeneratorValue_LeavesAnotherGeneratorsDestinationAlone(t *testin
 		"only destinations naming the generator that drew may receive the value")
 }
 
-// A destination whose occurrence classified stable already holds the value
-// this generator's current generation produced. Delivering a fresh draw over
-// it would rotate a credential nothing asked to rotate, so it is skipped —
-// the same reading the changeset uses to decide whether to wire the edge at
-// all, applied again here because one resource may hold both a stable and an
-// unstable destination for the same generator.
-func TestResolveGeneratorValue_LeavesAStableDestinationAlone(t *testing.T) {
+// A draw that is happening reaches every destination naming its generator,
+// including one whose occurrence classified stable. Stability decides whether
+// the generator draws at all; narrowing delivery by it is what leaves two
+// consumers of one credential holding different values, each apply repairing
+// one and breaking the other.
+func TestResolveGeneratorValue_ReachesEveryDestinationIncludingAStableOne(t *testing.T) {
 	ru := ResourceUpdate{
 		Operation: OperationUpdate,
 		DesiredState: pkgmodel.Resource{
@@ -82,8 +81,8 @@ func TestResolveGeneratorValue_LeavesAStableDestinationAlone(t *testing.T) {
 
 	require.NoError(t, ru.ResolveGeneratorValue("gen-a", "drawn-credential", "generation-1", pkgmodel.FormaApplyModeReconcile))
 
-	assert.False(t, gjson.GetBytes(ru.DesiredState.Properties, "Stable.$value").Exists(),
-		"a stable destination keeps the credential it already holds")
+	assert.Equal(t, "drawn-credential", gjson.GetBytes(ru.DesiredState.Properties, "Stable.$value").String(),
+		"a stable destination receives the draw its siblings receive")
 	assert.Equal(t, "drawn-credential", gjson.GetBytes(ru.DesiredState.Properties, "Fresh.$value").String(),
 		"a destination that still needs a value receives the draw")
 }

--- a/internal/metastructure/resource_update/resolve_generator_value_test.go
+++ b/internal/metastructure/resource_update/resolve_generator_value_test.go
@@ -36,7 +36,7 @@ func genBoundCreate(generatorKsuid string) ResourceUpdate {
 func TestResolveGeneratorValue_WritesInsideTheEnvelope(t *testing.T) {
 	ru := genBoundCreate("gen-a")
 
-	require.NoError(t, ru.ResolveGeneratorValue("gen-a", "drawn-credential", pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, ru.ResolveGeneratorValue("gen-a", "drawn-credential", "generation-1", pkgmodel.FormaApplyModeReconcile))
 
 	envelope := gjson.GetBytes(ru.DesiredState.Properties, "SecretString")
 	require.True(t, envelope.IsObject(), "the envelope must not be replaced by a bare scalar")
@@ -49,7 +49,7 @@ func TestResolveGeneratorValue_WritesInsideTheEnvelope(t *testing.T) {
 func TestResolveGeneratorValue_LeavesAnotherGeneratorsDestinationAlone(t *testing.T) {
 	ru := genBoundCreate("gen-a")
 
-	require.NoError(t, ru.ResolveGeneratorValue("gen-b", "drawn-credential", pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, ru.ResolveGeneratorValue("gen-b", "drawn-credential", "generation-1", pkgmodel.FormaApplyModeReconcile))
 
 	assert.False(t, gjson.GetBytes(ru.DesiredState.Properties, "SecretString.$value").Exists(),
 		"only destinations naming the generator that drew may receive the value")
@@ -80,7 +80,7 @@ func TestResolveGeneratorValue_LeavesAStableDestinationAlone(t *testing.T) {
 		}},
 	}
 
-	require.NoError(t, ru.ResolveGeneratorValue("gen-a", "drawn-credential", pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, ru.ResolveGeneratorValue("gen-a", "drawn-credential", "generation-1", pkgmodel.FormaApplyModeReconcile))
 
 	assert.False(t, gjson.GetBytes(ru.DesiredState.Properties, "Stable.$value").Exists(),
 		"a stable destination keeps the credential it already holds")
@@ -116,13 +116,13 @@ func TestResolveGeneratorValue_RegeneratesUnderCommandMode(t *testing.T) {
 	}
 
 	reconcile := newUpdate()
-	require.NoError(t, reconcile.ResolveGeneratorValue("gen-a", "drawn", pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, reconcile.ResolveGeneratorValue("gen-a", "drawn", "generation-1", pkgmodel.FormaApplyModeReconcile))
 	assert.Contains(t, string(reconcile.DesiredState.PatchDocument), "remove",
 		"reconcile regeneration must keep the remove op for the dropped Tags member")
 	assert.Contains(t, string(reconcile.DesiredState.PatchDocument), "Tags")
 
 	patchMode := newUpdate()
-	require.NoError(t, patchMode.ResolveGeneratorValue("gen-a", "drawn", pkgmodel.FormaApplyModePatch))
+	require.NoError(t, patchMode.ResolveGeneratorValue("gen-a", "drawn", "generation-1", pkgmodel.FormaApplyModePatch))
 	assert.NotContains(t, string(patchMode.DesiredState.PatchDocument), "remove",
 		"patch-mode regeneration must leave the undeclared Tags member unchanged")
 }
@@ -139,7 +139,7 @@ func TestResolveGeneratorValue_WithNoDestinationChangesNothing(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, ru.ResolveGeneratorValue("gen-a", "drawn", pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, ru.ResolveGeneratorValue("gen-a", "drawn", "generation-1", pkgmodel.FormaApplyModeReconcile))
 
 	assert.JSONEq(t, `{"Name": "plain"}`, string(ru.DesiredState.Properties))
 	assert.JSONEq(t, `[{"op":"replace","path":"/Name","value":"plain"}]`, string(ru.DesiredState.PatchDocument),

--- a/internal/metastructure/resource_update/resource_comparison.go
+++ b/internal/metastructure/resource_update/resource_comparison.go
@@ -394,9 +394,15 @@ func shouldPreserveSetOnce(newProp, existingProp gjson.Result) bool {
 	return existingProp.Value() != nil
 }
 
-// getPreservedValueString extracts the display value from a gjson.Result for logging
+// getPreservedValueString extracts the display value from a gjson.Result for
+// logging. An opaque envelope's value is withheld: what a SetOnce property or
+// tag preserves is as much a secret as what set it, and the line is still
+// useful without it because the property and the resource are named alongside.
 func getPreservedValueString(val gjson.Result) string {
 	if val.IsObject() {
+		if val.Get("$visibility").String() == pkgmodel.VisibilityOpaque {
+			return pkgmodel.RedactedForLog
+		}
 		return val.Get("$value").String()
 	}
 	return val.String()

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -306,6 +306,18 @@ func (ru *ResourceUpdate) regeneratePatchDocument(mode pkgmodel.FormaApplyMode) 
 		return nil, nil, fmt.Errorf("failed to suppress unchanged opaque values: %w", err)
 	}
 
+	// A $gen destination that classified stable is unchanged by proof rather
+	// than by comparison, and only the proof survives a Read that enriches
+	// prior state with the live secret. Drop it from both sides here, or the
+	// digest it carries reaches the guarded conversion below and fails an
+	// update whose only real change is the property beside it. See
+	// SuppressCarriedStableGeneratorBindings.
+	existingForPatch, desiredForPatch, err = SuppressCarriedStableGeneratorBindings(
+		existingForPatch, desiredForPatch, ru.ProvenanceRecords)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	// Read-safe/comparison conversion: existingPluginProps is only used as the
 	// "before" side of this local diff, never transmitted to a plugin. A
 	// genuinely-rotated opaque field's existing side is a stored hash that can

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -139,17 +139,15 @@ func (ru *ResourceUpdate) ListResolvables() []pkgmodel.FormaeURI {
 // PatchDocument in sync. PatchDocument is a derived view of (PriorState,
 // DesiredState, Schema) — whenever the executor mutates the state the
 // patch is derived from, the patch must be re-derived so the eventual
-// plugin call sees a diff that matches reality. ResolveValue is the only
-// apply-time mutator of DesiredState.Properties, so it owns the regen.
+// plugin call sees a diff that matches reality. ResolveValue and its $gen
+// sibling ResolveGeneratorValue are the only apply-time mutators of
+// DesiredState.Properties, and both route the regen through
+// reDerivePatchAfterSubstitution.
 //
 // mode is the command's configured apply mode (reconcile vs patch), the
 // same mode planning used to derive the original patch — regeneration must
 // use identical semantics or a reconcile-planned removal can silently
 // vanish when a resolvable resolves at execution time.
-//
-// Only Updates need a fresh patch — Create/Delete/Replace carry full
-// desired/prior state to the provider rather than a diff. Patch regen is
-// also a no-op when no Schema is available (sync/discovery paths).
 func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value string, mode pkgmodel.FormaApplyMode) error {
 	properties, err := resolver.ResolvePropertyReferences(formaeUri, ru.DesiredState.Properties, value)
 	if err != nil {
@@ -158,20 +156,80 @@ func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value strin
 	}
 	ru.DesiredState.Properties = properties
 
-	if ru.Operation == OperationUpdate && len(ru.DesiredState.Schema.Fields) > 0 {
-		patchDoc, createOnlyPatch, derr := ru.regeneratePatchDocument(mode)
-		if derr != nil {
-			return fmt.Errorf("failed to re-derive patch document after resolving %s: %w", formaeUri, derr)
+	return ru.reDerivePatchAfterSubstitution(mode, string(formaeUri))
+}
+
+// ResolveGeneratorValue delivers a generator's freshly drawn value to every
+// destination in this update that still needs it, and keeps the derived
+// PatchDocument in sync. It is the $gen sibling of ResolveValue, and together
+// with it they are the only apply-time mutators of DesiredState.Properties,
+// so between them they own the patch regeneration.
+//
+// The value is written INSIDE each $gen envelope, as its $value, never in
+// place of the envelope: see resolver.SetGenValues for why that distinction
+// is what keeps the credential hashed at rest.
+//
+// A destination whose occurrence classified stable is skipped. The changeset
+// already declines to wire such a destination to the draw, but the two
+// decisions are not the same one: a single resource may hold both a stable
+// and an unstable destination for the same generator, and one edge covers the
+// whole resource. Re-reading the classification here is what stops the fresh
+// draw landing on the stable destination too and rotating a credential
+// nothing asked to rotate.
+//
+// mode is the command's configured apply mode, threaded through for exactly
+// the reason ResolveValue documents: regeneration must use the semantics
+// planning used or a reconcile-planned removal silently vanishes.
+func (ru *ResourceUpdate) ResolveGeneratorValue(generatorKsuid string, value string, mode pkgmodel.FormaApplyMode) error {
+	var paths []string
+	for _, occurrence := range pkgmodel.FindGenObjectsFromProperties(ru.DesiredState.Properties) {
+		if occurrence.Generator != generatorKsuid {
+			continue
 		}
-		if len(createOnlyPatch) > 0 {
-			fields, ferr := createOnlyPatchFields(createOnlyPatch)
-			if ferr != nil {
-				return fmt.Errorf("failed to inspect createOnly patch after resolving %s: %w", formaeUri, ferr)
-			}
-			return LateCreateOnlyChangeError{ResourceLabel: ru.DesiredState.Label, Fields: fields}
+		if IsGenDestinationStable(ru.ProvenanceRecords, occurrence.Path) {
+			continue
 		}
-		ru.DesiredState.PatchDocument = patchDoc
+		paths = append(paths, occurrence.Path)
 	}
+	if len(paths) == 0 {
+		return nil
+	}
+
+	properties, err := resolver.SetGenValues(ru.DesiredState.Properties, paths, value)
+	if err != nil {
+		// The error names paths only; the drawn value is never in it.
+		slog.Error("Failed to deliver a generated value", "error", err)
+		return fmt.Errorf("failed to deliver a generated value: %w", err)
+	}
+	ru.DesiredState.Properties = properties
+
+	return ru.reDerivePatchAfterSubstitution(mode, "generator "+generatorKsuid)
+}
+
+// reDerivePatchAfterSubstitution re-derives PatchDocument after an apply-time
+// mutation of DesiredState.Properties. subject names what was substituted and
+// appears in error messages only — it must never carry a resolved value.
+//
+// Only Updates need a fresh patch — Create/Delete/Replace carry full
+// desired/prior state to the provider rather than a diff. Patch regen is also
+// a no-op when no Schema is available (sync/discovery paths).
+func (ru *ResourceUpdate) reDerivePatchAfterSubstitution(mode pkgmodel.FormaApplyMode, subject string) error {
+	if ru.Operation != OperationUpdate || len(ru.DesiredState.Schema.Fields) == 0 {
+		return nil
+	}
+
+	patchDoc, createOnlyPatch, derr := ru.regeneratePatchDocument(mode)
+	if derr != nil {
+		return fmt.Errorf("failed to re-derive patch document after resolving %s: %w", subject, derr)
+	}
+	if len(createOnlyPatch) > 0 {
+		fields, ferr := createOnlyPatchFields(createOnlyPatch)
+		if ferr != nil {
+			return fmt.Errorf("failed to inspect createOnly patch after resolving %s: %w", subject, ferr)
+		}
+		return LateCreateOnlyChangeError{ResourceLabel: ru.DesiredState.Label, Fields: fields}
+	}
+	ru.DesiredState.PatchDocument = patchDoc
 
 	return nil
 }

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -195,7 +195,7 @@ func (ru *ResourceUpdate) ResolveGeneratorValue(generatorKsuid string, value str
 		return nil
 	}
 
-	properties, err := resolver.SetGenValues(ru.DesiredState.Properties, paths, value)
+	properties, err := resolver.SetGenValues(ru.DesiredState.Properties, generatorKsuid, paths, value)
 	if err != nil {
 		// The error names paths only; the drawn value is never in it.
 		slog.Error("Failed to deliver a generated value", "error", err)

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -177,11 +177,19 @@ func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value strin
 // draw landing on the stable destination too and rotating a credential
 // nothing asked to rotate.
 //
+// generationID is the generation the value was drawn under, and every
+// destination that receives the value is stamped with its digest: the same
+// digest the planner computes for that generation, so the next apply can
+// prove the destination did not move and suppress its op. Without the stamp
+// the occurrence classifies as unknown movement on every subsequent apply,
+// which plans, redraws, and silently rotates the credential.
+//
 // mode is the command's configured apply mode, threaded through for exactly
 // the reason ResolveValue documents: regeneration must use the semantics
 // planning used or a reconcile-planned removal silently vanishes.
-func (ru *ResourceUpdate) ResolveGeneratorValue(generatorKsuid string, value string, mode pkgmodel.FormaApplyMode) error {
+func (ru *ResourceUpdate) ResolveGeneratorValue(generatorKsuid string, value string, generationID string, mode pkgmodel.FormaApplyMode) error {
 	var paths []string
+	var outputs []string
 	for _, occurrence := range pkgmodel.FindGenObjectsFromProperties(ru.DesiredState.Properties) {
 		if occurrence.Generator != generatorKsuid {
 			continue
@@ -190,6 +198,7 @@ func (ru *ResourceUpdate) ResolveGeneratorValue(generatorKsuid string, value str
 			continue
 		}
 		paths = append(paths, occurrence.Path)
+		outputs = append(outputs, occurrence.Output)
 	}
 	if len(paths) == 0 {
 		return nil
@@ -202,8 +211,40 @@ func (ru *ResourceUpdate) ResolveGeneratorValue(generatorKsuid string, value str
 		return fmt.Errorf("failed to deliver a generated value: %w", err)
 	}
 	ru.DesiredState.Properties = properties
+	ru.stampDrawnGeneration(generatorKsuid, outputs, generationID)
 
 	return ru.reDerivePatchAfterSubstitution(mode, "generator "+generatorKsuid)
+}
+
+// stampDrawnGeneration records, for every generator output this update just
+// received a value for, the digest of the generation it was drawn under.
+//
+// The digest is provenance.DigestOfString over the generation's identity, and
+// it must stay byte-identical to what the planner computes for the same
+// generation (resolver's generationRootDigest): the occurrence classifier
+// compares the two directly, and a digest that differs by so much as a
+// wrapper would never match, so every re-apply would re-plan and redraw with
+// nothing anywhere reporting a fault.
+//
+// The carrier holds digests only and is persisted verbatim, so the generation
+// identity itself never goes in. The map is written before the plugin call,
+// so the write-origin merge of the echo finds it and stamps $resolvedFrom
+// into the envelope that lands at rest.
+func (ru *ResourceUpdate) stampDrawnGeneration(generatorKsuid string, outputs []string, generationID string) {
+	if generationID == "" {
+		return
+	}
+	digest := provenance.DigestOfString(generationID)
+	for _, output := range outputs {
+		key := generatorSourceKey(generatorKsuid, output)
+		if key == "" {
+			continue
+		}
+		if ru.ResolvedRootDigests == nil {
+			ru.ResolvedRootDigests = make(map[string]string)
+		}
+		ru.ResolvedRootDigests[key] = digest
+	}
 }
 
 // reDerivePatchAfterSubstitution re-derives PatchDocument after an apply-time
@@ -956,10 +997,42 @@ func (m *propertyMerger) applyResolutionProvenance(updatedRef string, userVal, u
 	return updatedRef
 }
 
-// referenceURIOf returns the envelope's source URI in the carrier's key form
-// (the $ref string), or "" for a shape without one.
+// referenceURIOf returns the envelope's source URI in the carrier's key form,
+// or "" for a shape without one.
+//
+// Two shapes have one: a translated $ref, whose key IS its $ref string, and a
+// translated $gen, whose key is built from the generator it names and the
+// output it draws (generatorSourceKey). Everything else (an untranslated
+// $res, an untranslated $gen) names no source this update resolved against
+// and is never stamped.
 func referenceURIOf(envelope gjson.Result) string {
-	return envelope.Get("$ref").String()
+	if ref := envelope.Get("$ref"); ref.Exists() {
+		return ref.String()
+	}
+	if envelope.Get("$gen").Bool() {
+		return generatorSourceKey(pkgmodel.GenGeneratorKSUID(envelope), envelope.Get("$output").String())
+	}
+	return ""
+}
+
+// generatorSourceKey renders the ResolvedRootDigests key for one generator
+// output: "generator://<generator ksuid>#/<output>".
+//
+// A generator KSUID and a resource KSUID come from the same minter but name
+// rows in different tables, so keying a generator on the "formae://" scheme
+// resource references use could let a $gen and a $ref collide on one entry.
+// The distinct scheme rules that out by construction, exactly as
+// GeneratorUpdate.NodeURI does for the ExecutionDAG keyspace. Neither
+// segment needs escaping: a KSUID is base62, and $output is checked against
+// pkgmodel.KnownGeneratorOutputs at translation.
+//
+// Either half missing means the envelope names no generator output, and ""
+// is never a key: the caller stamps nothing.
+func generatorSourceKey(generatorKsuid, output string) string {
+	if generatorKsuid == "" || output == "" {
+		return ""
+	}
+	return "generator://" + generatorKsuid + "#/" + output
 }
 
 // mergeResObject handles merging of $res and $gen objects (structured resolvable

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -230,10 +230,12 @@ func (ru *ResourceUpdate) ResolveGeneratorValue(generatorKsuid string, value str
 // identity itself never goes in. The map is written before the plugin call,
 // so the write-origin merge of the echo finds it and stamps $resolvedFrom
 // into the envelope that lands at rest.
+//
+// generationID is the delivery boundary's to guarantee non-empty
+// (ExecutionDAG.propagateDrawnGeneratorValue refuses a draw naming none).
+// Re-checking it here would stamp nothing and carry on, which is the silent
+// outcome that guard exists to make loud.
 func (ru *ResourceUpdate) stampDrawnGeneration(generatorKsuid string, outputs []string, generationID string) {
-	if generationID == "" {
-		return
-	}
 	digest := provenance.DigestOfString(generationID)
 	for _, output := range outputs {
 		key := generatorSourceKey(generatorKsuid, output)

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -1075,6 +1075,18 @@ func (m *propertyMerger) mergeResObject(path string, userVal, pluginVal gjson.Re
 		effectivePluginVal = pluginVal.Get("$value")
 	}
 
+	// A preserved-value sentinel is not a value. It is what the freeze put in
+	// this field's place on the copy sent to the provider, meaning "leave this
+	// alone"; a plugin that echoes its request back returns it verbatim.
+	// Treated as an ordinary echo it is a non-empty object, so it beats the
+	// stored value in preferNonNullValue and lands in $value — and the persist
+	// transformer then hashes the sentinel itself, replacing the digest of the
+	// credential with the digest of a marker. Discard it here so the two
+	// decisions below see it for what it is: nothing adopted.
+	if isOpaquePreservedSentinel(effectivePluginVal) {
+		effectivePluginVal = gjson.Result{}
+	}
+
 	valueToSet := m.preferNonNullValue(userValue, effectivePluginVal)
 	// Determine "did we keep the stored value?" against the SAME unwrapped value
 	// used for valueToSet. keptUserValue only unwraps $ref, so passing the raw

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -169,13 +169,21 @@ func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value strin
 // place of the envelope: see resolver.SetGenValues for why that distinction
 // is what keeps the credential hashed at rest.
 //
-// A destination whose occurrence classified stable is skipped. The changeset
-// already declines to wire such a destination to the draw, but the two
-// decisions are not the same one: a single resource may hold both a stable
-// and an unstable destination for the same generator, and one edge covers the
-// whole resource. Re-reading the classification here is what stops the fresh
-// draw landing on the stable destination too and rotating a credential
-// nothing asked to rotate.
+// EVERY destination of this generator receives the value, including one whose
+// occurrence classified stable. Stability decides WHETHER the generator draws
+// (resource_update.GeneratorsNeedingDraw), never WHO a draw that is already
+// happening reaches. Delivering to only the unstable destinations is what
+// leaves two consumers of one credential holding different values: the new
+// consumer gets the new generation, the applied one keeps the old, and each
+// subsequent apply repairs one and breaks the other without ever settling.
+//
+// The invariant, and its boundary: every destination of this generator IN
+// THIS CHANGESET receives this draw and is stamped with its generation. A
+// destination outside the changeset cannot be reached at all, and cannot be
+// caught up afterwards either — formae keeps only a hash of a generated
+// value, never the value — so a generator whose destinations are split across
+// commands still diverges. That is a co-planning question, not something this
+// seam can close.
 //
 // generationID is the generation the value was drawn under, and every
 // destination that receives the value is stamped with its digest: the same
@@ -192,9 +200,6 @@ func (ru *ResourceUpdate) ResolveGeneratorValue(generatorKsuid string, value str
 	var outputs []string
 	for _, occurrence := range pkgmodel.FindGenObjectsFromProperties(ru.DesiredState.Properties) {
 		if occurrence.Generator != generatorKsuid {
-			continue
-		}
-		if IsGenDestinationStable(ru.ProvenanceRecords, occurrence.Path) {
 			continue
 		}
 		paths = append(paths, occurrence.Path)
@@ -330,7 +335,11 @@ func (ru *ResourceUpdate) regeneratePatchDocument(mode pkgmodel.FormaApplyMode) 
 	// Provably-stable occurrences stay suppressed through every regeneration:
 	// the classification was decided at planning and persisted immutably on
 	// this row, so recovery reproduces the same suppression without
-	// recomputing anything from inputs that no longer exist.
+	// recomputing anything from inputs that no longer exist. A destination a
+	// draw was just delivered into is unaffected: the substitution that
+	// suppression performs stops at a $ref/$res/$gen marker, and the
+	// plugin-format conversion has already replaced a delivered envelope with
+	// its bare value, so the write still reaches the patch.
 	regenProperties := resolver.NewResolvableProperties()
 	for _, rec := range ru.ProvenanceRecords {
 		if rec.Class == OccurrenceStable {

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -27,9 +27,16 @@ func NewResourceUpdateForExisting(
 	mode pkgmodel.FormaApplyMode,
 	source FormaCommandSource,
 	force bool,
+	coPlanned CoPlannedForDraw,
 ) ([]ResourceUpdate, error) {
 
-	if reflect.DeepEqual(existingResource, newResource) {
+	// The three suppressions below all say the same thing: nothing about this
+	// resource moved, so the command has nothing to do for it. coPlanned is
+	// the one case where that is true and the update is still owed — a
+	// generator this resource binds to draws in this command, and only a
+	// resource that is a node in the changeset receives the drawn value. See
+	// CoPlannedForDraw.
+	if reflect.DeepEqual(existingResource, newResource) && !bool(coPlanned) {
 		slog.Debug("No changes detected between existing and new resource, skipping update")
 		return nil, nil
 	}
@@ -61,7 +68,7 @@ func NewResourceUpdateForExisting(
 	if err != nil {
 		return nil, fmt.Errorf("failed to compare resources: %w", err)
 	}
-	if !hasChanges && !stackChanged && !labelChanged {
+	if !hasChanges && !stackChanged && !labelChanged && !bool(coPlanned) {
 		return []ResourceUpdate{}, nil
 	}
 
@@ -122,7 +129,7 @@ func NewResourceUpdateForExisting(
 		// one place that decision is allowed to drop the update outright —
 		// regeneratePatchDocument at execution time must never do the same, or
 		// an in-flight update would lose the force-resent field from its payload.
-		if (patchDocument == nil || onlyForceResent) && len(createOnlyPatch) == 0 && !stackChanged && !labelChanged {
+		if (patchDocument == nil || onlyForceResent) && len(createOnlyPatch) == 0 && !stackChanged && !labelChanged && !bool(coPlanned) {
 			return []ResourceUpdate{}, nil
 		}
 	} else {

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -142,6 +142,16 @@ func NewResourceUpdateForExisting(
 	// Extract resolvables for the new resource
 	newRemainingResolvables := resolver.ExtractResolvableURIs(newResource)
 
+	// Runs after the patch is derived, so what the provider is asked to do is
+	// unaffected: a stable occurrence is already suppressed from the diff.
+	// This is only about what the row keeps, which is written from the desired
+	// document below.
+	filteredProps, generatorDigests, err := CarryStableGeneratorBindingForward(
+		filteredProps, existingResource.Properties, provenanceRecords)
+	if err != nil {
+		return nil, fmt.Errorf("failed to carry stable generator bindings forward for resource %s: %w", existingResource.Label, err)
+	}
+
 	updateResource := ResourceUpdate{
 		PriorState:     existingResource,
 		ExistingTarget: existingTarget,
@@ -173,6 +183,7 @@ func NewResourceUpdateForExisting(
 		RemainingResolvables: newRemainingResolvables,
 		PreviousProperties:   existingResource.Properties,
 		ProvenanceRecords:    provenanceRecords,
+		ResolvedRootDigests:  generatorDigests,
 	}
 
 	return []ResourceUpdate{updateResource}, nil

--- a/internal/metastructure/resource_update/resource_update_factory_list_resolvable_test.go
+++ b/internal/metastructure/resource_update/resource_update_factory_list_resolvable_test.go
@@ -69,7 +69,7 @@ func TestNewResourceUpdateForExisting_ListResolvableMatchingLiveValue_NoUpdate(t
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
 
 	updates, err := NewResourceUpdateForExisting(resolvableProps, nil, existing, newResource, target, target,
-		pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false)
+		pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
 	require.NoError(t, err)
 	assert.Empty(t, updates, "an unchanged list-valued resolvable must reconcile to a no-op")
 }

--- a/internal/metastructure/resource_update/resource_update_factory_stack_transition_test.go
+++ b/internal/metastructure/resource_update/resource_update_factory_stack_transition_test.go
@@ -103,7 +103,7 @@ func requireSingleUpdate(t *testing.T, existing, new pkgmodel.Resource) Resource
 	resolvableProps := resolver.ResolvableProperties{}
 
 	updates, err := NewResourceUpdateForExisting(resolvableProps, nil, existing, new, target, target,
-		pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false)
+		pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
 	require.NoError(t, err)
 
 	if len(updates) == 0 {

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -64,37 +64,7 @@ func GenerateResourceUpdates(
 
 	var resourceUpdates []ResourceUpdate
 
-	// existingTargetMap contains targets as they currently exist in the DB.
-	// Used for delete operations and as the "prior state" of a resource's target.
-	var existingTargetMap = make(map[string]*pkgmodel.Target)
-	for _, target := range existingTargets {
-		existingTargetMap[target.Label] = target
-	}
-
-	// desiredTargetMap starts as a copy of existingTargetMap with configs converted
-	// to plugin format (stripping $ref/$value metadata from target resolvables).
-	// Then overridden with forma targets for new targets only. For existing targets,
-	// the DB config is preferred because it contains resolved values; but we must
-	// convert it because Ergo Framework cannot serialize json.RawMessage with nested
-	// $ref/$value objects (ETF encoding silently drops the message).
-	var desiredTargetMap = make(map[string]*pkgmodel.Target)
-	for _, target := range existingTargets {
-		t := *target
-		if converted, err := resolver.ConvertToPluginFormat(t.Config); err == nil {
-			t.Config = converted
-		}
-		tCopy := t
-		desiredTargetMap[target.Label] = &tCopy
-	}
-	for _, target := range forma.Targets {
-		t := target
-		if _, exists := existingTargetMap[target.Label]; !exists {
-			desiredTargetMap[target.Label] = &t
-			slog.Debug("Target does not exist in existing targets - adding it", "target", target.Label)
-			existingTargetMap[target.Label] = &t
-		}
-		// Existing targets: keep the DB config (already converted above)
-	}
+	existingTargetMap, desiredTargetMap := buildTargetMaps(forma, existingTargets)
 
 	// Validate stack references for commands that modify resources, sync commands are triggered from the agent
 	// and are guaranteed to reference existing stacks only
@@ -143,6 +113,51 @@ func GenerateResourceUpdates(
 	}
 
 	return resourceUpdates, nil
+}
+
+// buildTargetMaps derives the prior and desired views of this command's
+// targets. It is shared by the ordinary planning pass and by the co-planning
+// pass that follows a generator draw, so both hand NewResourceUpdateForExisting
+// the same target on either side.
+//
+// existingTargetMap contains targets as they currently exist in the DB. It is
+// used for delete operations and as the "prior state" of a resource's target.
+//
+// desiredTargetMap starts as a copy of existingTargetMap with configs converted
+// to plugin format (stripping $ref/$value metadata from target resolvables).
+// Then overridden with forma targets for new targets only. For existing targets,
+// the DB config is preferred because it contains resolved values; but we must
+// convert it because Ergo Framework cannot serialize json.RawMessage with nested
+// $ref/$value objects (ETF encoding silently drops the message).
+func buildTargetMaps(
+	forma *pkgmodel.Forma,
+	existingTargets []*pkgmodel.Target,
+) (map[string]*pkgmodel.Target, map[string]*pkgmodel.Target) {
+	existingTargetMap := make(map[string]*pkgmodel.Target)
+	for _, target := range existingTargets {
+		existingTargetMap[target.Label] = target
+	}
+
+	desiredTargetMap := make(map[string]*pkgmodel.Target)
+	for _, target := range existingTargets {
+		t := *target
+		if converted, err := resolver.ConvertToPluginFormat(t.Config); err == nil {
+			t.Config = converted
+		}
+		tCopy := t
+		desiredTargetMap[target.Label] = &tCopy
+	}
+	for _, target := range forma.Targets {
+		t := target
+		if _, exists := existingTargetMap[target.Label]; !exists {
+			desiredTargetMap[target.Label] = &t
+			slog.Debug("Target does not exist in existing targets - adding it", "target", target.Label)
+			existingTargetMap[target.Label] = &t
+		}
+		// Existing targets: keep the DB config (already converted above)
+	}
+
+	return existingTargetMap, desiredTargetMap
 }
 
 // matchExistingForDesired finds the existing managed resource that corresponds
@@ -853,6 +868,7 @@ func generateResourceUpdatesForReconcile(
 						mode,
 						source,
 						force,
+						false,
 					)
 					if err != nil {
 						return nil, fmt.Errorf("failed to generate resource update for existing unmanaged resource: %w", err)
@@ -908,6 +924,7 @@ func generateResourceUpdatesForReconcile(
 						mode,
 						source,
 						force,
+						false,
 					)
 
 					if err != nil {
@@ -988,6 +1005,7 @@ func generateResourceUpdatesForReconcile(
 						mode,
 						source,
 						force,
+						false,
 					)
 					if err != nil {
 						return nil, fmt.Errorf("failed to generate resource update for unmanaged resource: %w", err)
@@ -1356,6 +1374,7 @@ func generateResourceUpdatesForPatch(
 					mode,
 					source,
 					force,
+					false,
 				)
 
 				if err != nil {

--- a/internal/metastructure/resource_update/resource_update_rename_test.go
+++ b/internal/metastructure/resource_update/resource_update_rename_test.go
@@ -46,7 +46,7 @@ func TestRename_PreservesExistingKsuidNotNewResourceKsuid(t *testing.T) {
 
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
 	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newResource,
-		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false)
+		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
 	require.NoError(t, err)
 	require.Len(t, updates, 1)
 
@@ -81,7 +81,7 @@ func TestRename_PureLabelChange_AliasDriven(t *testing.T) {
 
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
 	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newResource,
-		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false)
+		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
 	require.NoError(t, err)
 	require.Len(t, updates, 1, "pure label rename must emit one update, got %d", len(updates))
 
@@ -115,7 +115,7 @@ func TestRename_LabelAndProperties_AliasDriven(t *testing.T) {
 
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
 	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newResource,
-		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false)
+		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
 	require.NoError(t, err)
 	require.Len(t, updates, 1)
 
@@ -142,7 +142,7 @@ func TestRename_LabelMismatchWithoutAlias_Rejected(t *testing.T) {
 
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
 	_, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newResource,
-		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false)
+		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
 	require.Error(t, err, "label mismatch without alias must be a generator bug")
 }
 
@@ -162,7 +162,7 @@ func TestRename_AliasDoesNotMatchExisting_Rejected(t *testing.T) {
 
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
 	_, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newResource,
-		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false)
+		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
 	require.Error(t, err, "alias mismatch is a generator bug")
 }
 
@@ -198,7 +198,7 @@ func TestRename_BringingUnderManagementAndRename(t *testing.T) {
 
 	target := pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
 	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newResource,
-		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false)
+		target, target, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
 	require.NoError(t, err)
 	require.Len(t, updates, 1, "combined import+rename must emit one update")
 

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -1102,7 +1102,8 @@ func handleProgressUpdate(from gen.PID, state gen.Atom, data ResourceUpdateData,
 		// and exit the state machine.
 		if state == StateSynchronizing && data.resourceUpdate.Operation != OperationRead && operation == resource.OperationRead && hash != "" && !data.resourceUpdate.IsDelete() {
 			proc.Log().Debug("Resource update rejected as a change to the resource was detected previousProperties=%s currentProperties=%s",
-				string(data.resourceUpdate.PreviousProperties), string(data.resourceUpdate.DesiredState.Properties))
+				pkgmodel.RedactOpaqueJSONForLog(data.resourceUpdate.PreviousProperties),
+				pkgmodel.RedactOpaqueJSONForLog(data.resourceUpdate.DesiredState.Properties))
 			data.resourceUpdate.Reject()
 
 			return StateRejected, data, nil, nil

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -872,6 +872,24 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 	}
 	desiredForPlugin.Properties = frozenProperties
 
+	// A generator binding the planner classified stable draws no value, so its
+	// destination still holds the bare envelope here. Swap it for the same
+	// present-but-unusable sentinel, so the guard that refuses to send a
+	// reference in a secret's place stops blocking every other property on the
+	// resource. Only this copy changes; DesiredState.Properties stays the
+	// durable record of the binding.
+	frozenProperties, err = FreezeStableGeneratorBindings(
+		desiredForPlugin.Properties,
+		data.resourceUpdate.ProvenanceRecords,
+	)
+	if err != nil {
+		proc.Log().Error("failed to prepare desired resource properties for plugin: %v", err)
+		data.resourceUpdate.FailureReason = updateRequestFailureReason(err)
+		data.resourceUpdate.MarkAsFailed()
+		return StateFinishedWithError, data, nil, nil
+	}
+	desiredForPlugin.Properties = frozenProperties
+
 	// Convert properties to plugin format (extracts $value from opaque structures).
 	// DesiredState is the NEW value being written to the cloud as DesiredProperties,
 	// so this stays guarded: a stored hash must never be sent to a plugin in place

--- a/internal/metastructure/stack_expirer.go
+++ b/internal/metastructure/stack_expirer.go
@@ -276,7 +276,9 @@ func prepareDestroyExpiredStack(ds datastore.Datastore, stackInfo datastore.Expi
 	if err != nil {
 		return nil, fmt.Errorf("failed to create changeset: %w", err)
 	}
-	cs, err := changeset.NewChangeset(resourceUpdates, synth, destroyCommand.ID, pkgmodel.CommandDestroy, destroyCommand.Config.Mode)
+	// No generator draws: a destroy writes no property, and the stack's
+	// generators go with it.
+	cs, err := changeset.NewChangeset(resourceUpdates, synth, nil, destroyCommand.ID, pkgmodel.CommandDestroy, destroyCommand.Config.Mode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create changeset: %w", err)
 	}

--- a/internal/metastructure/synchronizer.go
+++ b/internal/metastructure/synchronizer.go
@@ -344,7 +344,9 @@ func synchronizeAllResources(state gen.Atom, data SynchronizerData, proc gen.Pro
 		finalizeFailedCommand(syncCommand, proc)
 		return StateIdle, data, rescheduleAction(data), nil
 	}
-	cs, err := changeset.NewChangeset(allResourceUpdates, synth, syncCommand.ID, pkgmodel.CommandSync, syncCommand.Config.Mode)
+	// No generator draws: a sync command only reads the inventory, so no
+	// destination in it is waiting for a generated value.
+	cs, err := changeset.NewChangeset(allResourceUpdates, synth, nil, syncCommand.ID, pkgmodel.CommandSync, syncCommand.Config.Mode)
 	if err != nil {
 		proc.Log().Error("Synchronizer: failed to build changeset, skipping sync cycle commandID=%s: %v", syncCommand.ID, err)
 		finalizeFailedCommand(syncCommand, proc)

--- a/internal/metastructure/types/types.go
+++ b/internal/metastructure/types/types.go
@@ -96,11 +96,28 @@ const (
 	PolicyUpdateStateFailed     PolicyUpdateState = "Failed"
 )
 
-// GeneratorUpdateState represents the state of a generator update
+// GeneratorUpdateState represents the state of a generator update.
+//
+// InProgress is required to make a generator update schedulable as an
+// ExecutionDAG node: without a state distinct from NotStarted/Success/Failed,
+// MarkInProgress and IsRunning cannot be told apart, and GetExecutableUpdates,
+// findRunningUpdate, and handleUpdateFinished all misbehave.
+//
+// Canceled is deliberately NOT included, unlike TargetUpdateState (whose
+// terminal set is Success | Failed | Canceled per isTargetInFinalState). A
+// target update reaches Canceled because the changeset executor's cancel
+// paths (changeset_executor.go's cancel/forceCancel) range over
+// data.changeset.DAG.Nodes and type-switch on *target_update.TargetUpdate
+// (and *resource_update.ResourceUpdate). Nothing in this codebase adds a
+// *generator_update.GeneratorUpdate to that DAG yet, and neither cancel
+// switch has a case for it, so a generator node cannot reach Canceled today.
+// Add it if and when a later change wires GeneratorUpdate into DAG
+// construction and the executor's cancel switch.
 type GeneratorUpdateState string
 
 const (
 	GeneratorUpdateStateNotStarted GeneratorUpdateState = "NotStarted"
+	GeneratorUpdateStateInProgress GeneratorUpdateState = "InProgress"
 	GeneratorUpdateStateSuccess    GeneratorUpdateState = "Success"
 	GeneratorUpdateStateFailed     GeneratorUpdateState = "Failed"
 )

--- a/internal/metastructure/types/types.go
+++ b/internal/metastructure/types/types.go
@@ -115,12 +115,11 @@ const (
 // terminal set is Success | Failed | Canceled per isTargetInFinalState). A
 // target update reaches Canceled because the changeset executor's cancel
 // paths (changeset_executor.go's cancel/forceCancel) range over
-// data.changeset.DAG.Nodes and type-switch on *target_update.TargetUpdate
-// (and *resource_update.ResourceUpdate). Nothing in this codebase adds a
-// *generator_update.GeneratorUpdate to that DAG yet, and neither cancel
-// switch has a case for it, so a generator node cannot reach Canceled today.
-// Add it if and when a later change wires GeneratorUpdate into DAG
-// construction and the executor's cancel switch.
+// data.changeset.DAG.Nodes and act only on *resource_update.ResourceUpdate
+// and *target_update.TargetUpdate. Changeset construction does put a
+// *generator_update.GeneratorUpdate in that DAG, but neither cancel path has
+// a case for it, so a generator node never reaches Canceled. Add the state if
+// and when a cancel path terminalizes generator nodes.
 type GeneratorUpdateState string
 
 const (

--- a/internal/metastructure/types/types.go
+++ b/internal/metastructure/types/types.go
@@ -41,6 +41,14 @@ const (
 	// in-memory for an otherwise-unchanged target. It is never persisted and does
 	// not trigger discovery or cloud-side mutations.
 	OperationResolve OperationType = "resolve"
+
+	// OperationDraw is a synthetic op that draws a generator's value in
+	// memory for the destinations bound to it. Like OperationResolve it is
+	// never persisted and never reaches a provider: it exists only to
+	// produce a value the destinations in the same changeset consume. The
+	// generator's own row is created, updated or deleted by the ordinary
+	// Create/Update/Delete ops, which a draw never stands in for.
+	OperationDraw OperationType = "draw"
 )
 
 // ResourceUpdateState represents the current state of a resource update operation

--- a/internal/workflow_tests/local/apply_forma/command_desired_state_boundary_test.go
+++ b/internal/workflow_tests/local/apply_forma/command_desired_state_boundary_test.go
@@ -1,0 +1,131 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// A command's desired state is the input the command executes from, and while
+// the command is live the row holds it as the author wrote it, opaque values in
+// the clear. Only once the command is final does the same row hold a digest.
+//
+// The window is what makes a command resumable. An agent returning to an
+// unfinished command re-reads its desired state from the row and dispatches
+// what it still owes; a row hashed at write time would leave it holding a
+// digest where a credential belongs, with no way to recover the value, so
+// every unfinished write would have to be failed instead. The window closes
+// with the command, and every other sink on the path (read-back properties,
+// progress snapshots, the resource row) is hashed at its own write, so this
+// column is where a live command's plaintext is at rest.
+//
+// A generator-bound property is not part of this window. A drawn value is
+// delivered into the in-memory update and never written back to the row, which
+// is why a resumed command draws again for the destinations it still owes
+// rather than replaying a value it could read back.
+func TestApplyForma_InFlightCommand_HoldsDesiredSecretUntilItIsFinal(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const secret = "in-flight-desired-secret"
+		var released atomic.Bool
+
+		// The secret's create reports in progress and is polled until the test
+		// releases it, which parks the command in a live, unfinished state for
+		// as long as the observation needs.
+		parking := &plugin.ResourcePluginOverrides{
+			Create: func(_ *resource.CreateRequest) (*resource.CreateResult, error) {
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationCreate,
+					OperationStatus: resource.OperationStatusInProgress,
+				}}, nil
+			},
+			Status: func(_ *resource.StatusRequest) (*resource.StatusResult, error) {
+				if !released.Load() {
+					return &resource.StatusResult{ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationCreate,
+						OperationStatus: resource.OperationStatusInProgress,
+					}}, nil
+				}
+				// The completion reports no properties of its own, so nothing
+				// merges over the desired document: what the row ends up
+				// holding is what the command's own finalization leaves there.
+				return &resource.StatusResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationCreate,
+					OperationStatus: resource.OperationStatusSuccess,
+					NativeID:        "native-parked",
+				}}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, parking, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := &pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: stack}},
+			Targets:   []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Resources: []pkgmodel.Resource{secretResource(stack, "parked", secret)},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+
+		var commandID string
+		require.Eventually(t, func() bool {
+			incomplete, loadErr := m.Datastore.LoadIncompleteFormaCommands()
+			if loadErr != nil || len(incomplete) != 1 {
+				return false
+			}
+			commandID = incomplete[0].ID
+			updates, loadErr := m.Datastore.LoadResourceUpdates(commandID)
+			return loadErr == nil && len(updates) == 1
+		}, 10*time.Second, 25*time.Millisecond,
+			"the command should be live with its resource update stored")
+
+		inFlight, err := m.Datastore.LoadResourceUpdates(commandID)
+		require.NoError(t, err)
+		require.Len(t, inFlight, 1)
+		assert.Equal(t, secret,
+			gjson.GetBytes(inFlight[0].DesiredState.Properties, "SecretString").String(),
+			"a live command must keep its desired secret executable, not a digest of it")
+
+		released.Store(true)
+		waitForApplyComplete(t, m)
+
+		final, err := m.Datastore.GetFormaCommandByCommandID(commandID)
+		require.NoError(t, err)
+		require.NotNil(t, final)
+		require.Equal(t, forma_command.CommandStateSuccess, final.State)
+
+		settled, err := m.Datastore.LoadResourceUpdates(commandID)
+		require.NoError(t, err)
+		require.Len(t, settled, 1)
+		stored := gjson.GetBytes(settled[0].DesiredState.Properties, "SecretString")
+		assert.True(t, stored.Get("$hashed").Bool(),
+			"a final command must hold the desired secret as a digest, got %s", stored.Raw)
+		assert.Equal(t, pkgmodel.ComputeValueHash(secret), stored.Get("$value").String(),
+			"the digest must be the digest of the value the command executed with")
+		assertNoPlaintextInResourceUpdates(t, m, commandID, secret)
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/embed_resolvable_test.go
+++ b/internal/workflow_tests/local/apply_forma/embed_resolvable_test.go
@@ -627,3 +627,139 @@ func TestEmbed_SyncPreservesEnvelope(t *testing.T) {
 			"stored functionCode must NOT be the assembled plain string after sync")
 	})
 }
+
+// A generator reference framed into a string field is refused for the same
+// reason a resolvable is: once a value is assembled into a larger string, the
+// structured span a redactor needs is gone, so the composite would persist the
+// credential in the clear.
+//
+// The check keys on the span's $visibility and on nothing else, so it covers a
+// $gen without naming one. That is deliberate rather than incidental: an output
+// whose visibility is not Opaque carries nothing to redact and belongs in a
+// composed string. It also means a generator kind that declares a non-Opaque
+// output makes this shape legal for that output, which is why the test asserts
+// the visibility that produces the refusal rather than the envelope kind.
+//
+// This path reaches a field no generator binding otherwise can. Interpolation
+// renders the envelope through the output's own string form, so the result is a
+// String and any String-typed field accepts it, whatever its declared union.
+func TestMetastructure_RejectsOpaqueGeneratorEmbed(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, def, err := test_helpers.NewTestMetastructure(t, &plugin.ResourcePluginOverrides{})
+		defer def()
+		require.NoError(t, err)
+
+		// The authored shape a generator output renders when interpolated into
+		// a string: named by label and stack, with the visibility every
+		// currently shipping generator kind gives its output.
+		genEnvelope := `{"$gen":true,"$label":"db-password","$stack":"test-stack","$output":"value","$visibility":"Opaque"}`
+		framedSpan := pkgmodel.FrameEnvelope(genEnvelope)
+
+		embedFieldJSON, err := json.Marshal(map[string]any{
+			"$embed":    true,
+			"$template": "postgres://app:" + framedSpan + "@db.internal/appdb",
+		})
+		require.NoError(t, err)
+
+		propsJSON, err := json.Marshal(map[string]any{
+			"Name":         "consumer-resource",
+			"functionCode": json.RawMessage(embedFieldJSON),
+		})
+		require.NoError(t, err)
+
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+			Generators: []json.RawMessage{
+				passwordGeneratorFor(t, "db-password", "test-stack"),
+			},
+			Resources: []pkgmodel.Resource{{
+				Label:      "consumer",
+				Type:       "FakeAWS::S3::Bucket",
+				Stack:      "test-stack",
+				Target:     "test-target",
+				Properties: json.RawMessage(propsJSON),
+			}},
+			Targets: []pkgmodel.Target{{
+				Label:     "test-target",
+				Namespace: "test-namespace",
+			}},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test-client-id", "", "")
+
+		require.Error(t, err, "a generator reference embedded in a string field must be refused")
+		assert.Contains(t, err.Error(), "opaque")
+		assert.Contains(t, err.Error(), "embed")
+
+		fas, dsErr := m.Datastore.LoadFormaCommands()
+		require.NoError(t, dsErr)
+		assert.Empty(t, fas, "no command should be persisted when the embed is refused")
+
+		resources, dsErr := m.Datastore.LoadAllResources()
+		require.NoError(t, dsErr)
+		assert.Empty(t, resources, "no resource row should be persisted when the embed is refused")
+
+		// The generator must not have drawn: the refusal precedes translation,
+		// so nothing reached a draw.
+		identity, dsErr := m.Datastore.GetGeneratorIdentity("db-password", "test-stack")
+		require.NoError(t, dsErr)
+		assert.Empty(t, identity.GenerationID, "no value may be drawn for a refused command")
+	})
+}
+
+// A generator reference framed inside an array element is refused, mirroring
+// the resolvable case: the walk descends into arrays, so nesting is not an
+// escape.
+func TestMetastructure_RejectsOpaqueGeneratorEmbed_InArray(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, def, err := test_helpers.NewTestMetastructure(t, &plugin.ResourcePluginOverrides{})
+		defer def()
+		require.NoError(t, err)
+
+		genEnvelope := `{"$gen":true,"$label":"db-password","$stack":"test-stack","$output":"value","$visibility":"Opaque"}`
+		framedSpan := pkgmodel.FrameEnvelope(genEnvelope)
+
+		propsJSON, err := json.Marshal(map[string]any{
+			"Name": "consumer-resource",
+			"environment": []any{
+				map[string]any{"Name": "PLAIN", "Value": "no-secret-here"},
+				map[string]any{
+					"Name": "DATABASE_URL",
+					"Value": map[string]any{
+						"$embed":    true,
+						"$template": "postgres://app:" + framedSpan + "@db.internal/appdb",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		forma := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+			Generators: []json.RawMessage{
+				passwordGeneratorFor(t, "db-password", "test-stack"),
+			},
+			Resources: []pkgmodel.Resource{{
+				Label:      "consumer",
+				Type:       "FakeAWS::S3::Bucket",
+				Stack:      "test-stack",
+				Target:     "test-target",
+				Properties: json.RawMessage(propsJSON),
+			}},
+			Targets: []pkgmodel.Target{{
+				Label:     "test-target",
+				Namespace: "test-namespace",
+			}},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		}, "test-client-id", "", "")
+
+		require.Error(t, err, "a generator reference embedded inside an array element must be refused")
+		assert.Contains(t, err.Error(), "opaque")
+		assert.Contains(t, err.Error(), "embed")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/generator_co_planning_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_co_planning_test.go
@@ -1,0 +1,453 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/provenance"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// These tests pin what a generator's draw obliges the command to plan. A draw
+// reaches every destination that is a node in the changeset and nothing else,
+// and formae keeps only a hash of a drawn value, so a destination left out
+// cannot be caught up afterwards. Adding a second destination to a generator
+// therefore has to plan the destination already applied beside it, even though
+// nothing about that destination moved: the draw the new one needs is the only
+// way either of them can get a value, so they move together or they diverge.
+//
+// The obligation is bounded by the same fact in the other direction. A
+// generator that is not drawing owes nothing, so nothing may be dragged into
+// the command on its account, or every apply would rewrite every
+// generator-bound resource and rotate credentials that nobody asked to rotate.
+
+// describedGenBoundSecret is genBoundSecret with a Description field, so a test
+// can move something that has nothing to do with the binding.
+func describedGenBoundSecret(stack, label, generatorLabel, description string) pkgmodel.Resource {
+	secret := genBoundSecret(stack, label, generatorLabel, "value")
+	secret.Properties = json.RawMessage(`{
+		"Name": "` + label + `",
+		"Description": "` + description + `",
+		"SecretString": {
+			"$gen":        true,
+			"$label":      "` + generatorLabel + `",
+			"$stack":      "` + stack + `",
+			"$output":     "value",
+			"$visibility": "Opaque"
+		}
+	}`)
+	return secret
+}
+
+// Adding a second destination to a generator that already has one draws a new
+// value, and both destinations must end up holding it. The forma text of the
+// applied destination is untouched, so nothing about it moved and the ordinary
+// planning pass suppresses it; it has to be co-planned onto the strength of
+// the draw alone, or the new destination takes the new generation and the
+// applied one keeps the old.
+//
+// "No error" is not the assertion. A build that plans nothing would also
+// return no error and leave the two destinations holding different values, so
+// what is asserted is the values themselves: the same one on both, different
+// from what the applied destination held before, under a generation that
+// advanced.
+func TestApplyForma_GeneratorBoundSecret_AddingASecondDestinationRotatesBoth(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := func(resources ...pkgmodel.Resource) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:     []pkgmodel.Stack{{Label: stack}},
+				Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+				Resources:  resources,
+			}
+		}
+		alpha := genBoundSecret(stack, "alpha", "db-password", "value")
+		beta := genBoundSecret(stack, "beta", "db-password", "value")
+
+		_, err = m.ApplyForma(forma(alpha),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		firstGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, firstGeneration.GenerationID, "the first apply must draw")
+		alphaCreates := delivered.createdWith("alpha")
+		require.Len(t, alphaCreates, 1, "alpha must have been created with the first draw")
+
+		// The second apply adds beta and changes nothing else. alpha's forma
+		// text is byte-identical to what was applied a moment ago.
+		_, err = m.ApplyForma(forma(alpha, beta),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err, "adding a destination to an existing generator must be appliable")
+		waitForApplyComplete(t, m)
+
+		betaCreates := delivered.createdWith("beta")
+		require.Len(t, betaCreates, 1, "beta must have been created")
+		alphaUpdates := delivered.updatedWith("alpha")
+		require.Len(t, alphaUpdates, 1,
+			"the applied destination must be planned and written, though nothing about it moved")
+		assert.Equal(t, betaCreates[0], alphaUpdates[0],
+			"two destinations of one generator must hold the same value")
+		assert.NotEqual(t, alphaCreates[0], alphaUpdates[0],
+			"the applied destination must move to the new value, not keep the old one")
+
+		alphaPatches := delivered.patchesFor("alpha")
+		require.Len(t, alphaPatches, 1)
+		assert.Contains(t, alphaPatches[0], "/SecretString",
+			"a delivered value must appear in the patch, or a patch-driven plugin never writes it")
+
+		secondGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEqual(t, firstGeneration.GenerationID, secondGeneration.GenerationID,
+			"adding a destination draws a new generation")
+
+		// Both rows must be stamped with the generation the value came from,
+		// or the next apply reads one of them as moved and rotates again.
+		expected := provenance.DigestOfString(secondGeneration.GenerationID)
+		assert.Equal(t, expected, storedResolvedFrom(t, m, stack, "alpha"))
+		assert.Equal(t, expected, storedResolvedFrom(t, m, stack, "beta"))
+	})
+}
+
+// The same, with the two destinations on separate stacks that the applied
+// forma declares together. One command carries every resource update the forma
+// produced, so the destination in the other stack is reachable and must be
+// co-planned exactly as a sibling in one stack would be.
+func TestApplyForma_GeneratorBoundSecret_AddingADestinationInAnotherDeclaredStackRotatesBoth(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		f := newTwoStackGeneratorFixture()
+		generatorOnly := &pkgmodel.Forma{
+			Stacks:  []pkgmodel.Stack{{Label: f.generatorStack}},
+			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+				Label: "db-password", Stack: f.generatorStack,
+				Length: 24, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+			})},
+			Resources: []pkgmodel.Resource{
+				crossStackGenBoundSecret(f.generatorStack, "alpha", f.generatorStack, "db-password", "before"),
+			},
+		}
+
+		_, err = m.ApplyForma(generatorOnly,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		firstGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", f.generatorStack)
+		require.NoError(t, err)
+		require.NotEmpty(t, firstGeneration.GenerationID)
+		alphaCreates := delivered.createdWith("alpha")
+		require.Len(t, alphaCreates, 1)
+
+		// The second apply declares both stacks and adds beta to the other
+		// one. alpha's forma text is unchanged.
+		_, err = m.ApplyForma(f.bothStacks(t, 24, "before"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err, "a destination added in another declared stack must be appliable")
+		waitForApplyComplete(t, m)
+
+		betaCreates := delivered.createdWith("beta")
+		require.Len(t, betaCreates, 1, "the destination in the other stack must be created")
+		alphaUpdates := delivered.updatedWith("alpha")
+		require.Len(t, alphaUpdates, 1,
+			"the applied destination must be planned and written, though nothing about it moved")
+		assert.Equal(t, betaCreates[0], alphaUpdates[0],
+			"one draw serves every destination bound to it, whatever stack it sits on")
+		assert.NotEqual(t, alphaCreates[0], alphaUpdates[0],
+			"the applied destination must move to the new value")
+
+		secondGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", f.generatorStack)
+		require.NoError(t, err)
+		require.NotEqual(t, firstGeneration.GenerationID, secondGeneration.GenerationID,
+			"adding a destination draws a new generation")
+
+		expected := provenance.DigestOfString(secondGeneration.GenerationID)
+		assert.Equal(t, expected, storedResolvedFrom(t, m, f.generatorStack, "alpha"))
+		assert.Equal(t, expected, storedResolvedFrom(t, m, f.otherStack, "beta"))
+	})
+}
+
+// Co-planning reaches what the applied forma declares. A destination the forma
+// does not declare at all is outside the command whatever planning does, and
+// the draw the new destination needs would leave it behind for good, so the
+// apply is refused and the refusal names it.
+func TestApplyForma_GeneratorBoundSecret_AddingADestinationIsRefusedWhenAnotherIsUndeclared(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		f := newTwoStackGeneratorFixture()
+		_, err = m.ApplyForma(f.bothStacks(t, 24, "before"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		firstGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", f.generatorStack)
+		require.NoError(t, err)
+		require.NotEmpty(t, firstGeneration.GenerationID)
+
+		// A third destination is added beside the generator while beta's stack
+		// is left out of the forma. The new destination makes the generator
+		// draw; beta cannot be reached by any amount of co-planning.
+		withGamma := &pkgmodel.Forma{
+			Stacks:  []pkgmodel.Stack{{Label: f.generatorStack}},
+			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+				Label: "db-password", Stack: f.generatorStack,
+				Length: 24, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+			})},
+			Resources: []pkgmodel.Resource{
+				crossStackGenBoundSecret(f.generatorStack, "alpha", f.generatorStack, "db-password", "before"),
+				crossStackGenBoundSecret(f.generatorStack, "gamma", f.generatorStack, "db-password", "gamma"),
+			},
+		}
+
+		_, err = m.ApplyForma(withGamma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.Error(t, err, "a draw that cannot reach an undeclared destination must be refused")
+
+		var unreachable apimodel.FormaGeneratorDestinationsUnreachableError
+		require.ErrorAs(t, err, &unreachable)
+		require.Len(t, unreachable.Unreachable, 1,
+			"only the destination the forma does not declare may be named")
+		assert.Equal(t, "beta", unreachable.Unreachable[0].Label)
+		assert.Equal(t, f.otherStack, unreachable.Unreachable[0].Stack)
+		assert.Equal(t, "FakeAWS::SecretsManager::Secret", unreachable.Unreachable[0].Type)
+
+		refusedGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", f.generatorStack)
+		require.NoError(t, err)
+		assert.Equal(t, firstGeneration.GenerationID, refusedGeneration.GenerationID,
+			"the refusal must land before anything is drawn")
+		assert.Empty(t, delivered.createdWith("gamma"), "nothing may be written by a refused apply")
+	})
+}
+
+// Co-planning is owed to a draw and to nothing else. Re-applying the forma
+// that added the second destination, unchanged, must plan nothing at all: no
+// generator draws, so no destination is dragged in on a draw's account.
+//
+// A build that co-planned unconditionally would rotate the credential on this
+// apply and on every one after it, so what is asserted is that the generation
+// stood still and that no second command was created — not merely that the
+// simulation reported no changes.
+func TestApplyForma_GeneratorBoundSecret_ReapplyAfterAddingADestinationPlansNothing(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := func(resources ...pkgmodel.Resource) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:     []pkgmodel.Stack{{Label: stack}},
+				Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+				Resources:  resources,
+			}
+		}
+		alpha := genBoundSecret(stack, "alpha", "db-password", "value")
+		beta := genBoundSecret(stack, "beta", "db-password", "value")
+
+		_, err = m.ApplyForma(forma(alpha),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		_, err = m.ApplyForma(forma(alpha, beta),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		settledGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, settledGeneration.GenerationID)
+		require.Len(t, delivered.updatedWith("alpha"), 1)
+
+		_, err = m.ApplyForma(forma(alpha, beta),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		assert.Len(t, cmds, 2, "an apply with nothing to do must not create a command")
+
+		reappliedGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		assert.Equal(t, settledGeneration.GenerationID, reappliedGeneration.GenerationID,
+			"an apply that plans nothing must not draw")
+		assert.Len(t, delivered.updatedWith("alpha"), 1, "no further write may reach the provider")
+		assert.Len(t, delivered.updatedWith("beta"), 0, "no further write may reach the provider")
+	})
+}
+
+// A generator that is not drawing pulls nothing into the command. Editing a
+// field beside one destination's binding plans that destination and no other:
+// the binding is stable, nothing draws, and the sibling destination's stored
+// credential is left exactly as it was.
+func TestApplyForma_GeneratorBoundSecret_AnUnrelatedEditPlansOnlyTheEditedDestination(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := func(alphaDescription string) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:     []pkgmodel.Stack{{Label: stack}},
+				Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+				Resources: []pkgmodel.Resource{
+					describedGenBoundSecret(stack, "alpha", "db-password", alphaDescription),
+					describedGenBoundSecret(stack, "beta", "db-password", "beta"),
+				},
+			}
+		}
+
+		_, err = m.ApplyForma(forma("before"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		firstGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, firstGeneration.GenerationID)
+		betaBefore := storedBinding(t, m, stack, "beta")
+		require.True(t, betaBefore.Get("$hashed").Bool())
+		require.NotEmpty(t, betaBefore.Get("$value").String())
+
+		_, err = m.ApplyForma(forma("after"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		assert.Len(t, delivered.updatedWith("alpha"), 1, "the edited destination must be written")
+		assert.Empty(t, delivered.updatedWith("beta"),
+			"a generator that is not drawing must not pull its other destinations into the command")
+
+		secondGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		assert.Equal(t, firstGeneration.GenerationID, secondGeneration.GenerationID,
+			"an edit beside a stable binding must not draw")
+
+		betaAfter := storedBinding(t, m, stack, "beta")
+		assert.Equal(t, betaBefore.Get("$value").String(), betaAfter.Get("$value").String(),
+			"the untouched destination must keep the credential it held")
+		assert.Equal(t, betaBefore.Get("$resolvedFrom").String(), betaAfter.Get("$resolvedFrom").String(),
+			"the untouched destination must keep the generation it was drawn from")
+	})
+}
+
+// The obligation is the same under either apply mode. Reconcile and patch
+// build the same three views of the forma and hand
+// NewResourceUpdateForExisting the same arguments, so a patch that adds a
+// destination to an existing generator carries the destination already applied
+// beside it exactly as a reconcile does, and both end on the value the draw
+// produced.
+//
+// What patch does NOT do is the point of running it here: it plans no delete
+// for what the forma leaves out, so the co-planned destination is in the
+// command because a draw obliged it, not because a reconcile was sweeping the
+// stack anyway.
+func TestApplyForma_GeneratorBoundSecret_PatchAddingADestinationRotatesBoth(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := func(resources ...pkgmodel.Resource) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:     []pkgmodel.Stack{{Label: stack}},
+				Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+				Resources:  resources,
+			}
+		}
+		alpha := genBoundSecret(stack, "alpha", "db-password", "value")
+		beta := genBoundSecret(stack, "beta", "db-password", "value")
+
+		_, err = m.ApplyForma(forma(alpha),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		firstGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, firstGeneration.GenerationID, "the first apply must draw")
+		alphaCreates := delivered.createdWith("alpha")
+		require.Len(t, alphaCreates, 1)
+
+		_, err = m.ApplyForma(forma(alpha, beta),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch}, "test-client-id", "", "")
+		require.NoError(t, err, "a patch that adds a destination to an existing generator must be appliable")
+		waitForApplyComplete(t, m)
+
+		betaCreates := delivered.createdWith("beta")
+		require.Len(t, betaCreates, 1, "the added destination must be created")
+		alphaUpdates := delivered.updatedWith("alpha")
+		require.Len(t, alphaUpdates, 1,
+			"the applied destination must be co-planned under patch, though nothing about it moved")
+		assert.Equal(t, betaCreates[0], alphaUpdates[0],
+			"two destinations of one generator must hold the same value")
+		assert.NotEqual(t, alphaCreates[0], alphaUpdates[0],
+			"the applied destination must move to the new value, not keep the old one")
+
+		secondGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEqual(t, firstGeneration.GenerationID, secondGeneration.GenerationID,
+			"adding a destination draws a new generation")
+
+		expected := provenance.DigestOfString(secondGeneration.GenerationID)
+		assert.Equal(t, expected, storedResolvedFrom(t, m, stack, "alpha"))
+		assert.Equal(t, expected, storedResolvedFrom(t, m, stack, "beta"))
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/generator_delivery_scope_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_delivery_scope_test.go
@@ -48,11 +48,15 @@ import (
 // different values, and the next apply repairs the one and breaks the other,
 // forever.
 //
-// "In the changeset" is load-bearing in shape 2. A consumer that this command
-// plans no operation for — because nothing about it moved — is not a node in
-// the graph, so no delivery can reach it, and it cannot be caught up later
-// either: formae keeps only a hash of a generated value, never the value.
-// Such a consumer is left on its older generation.
+// "In the changeset" is load-bearing in shape 2, and it is the boundary of
+// this seam rather than of formae. Delivery reaches the nodes of the graph and
+// nothing else, and formae keeps only a hash of a generated value, never the
+// value, so a consumer that is not a node when a draw happens could never be
+// brought level afterwards. Two passes outside this file are what close that
+// boundary: a live destination the applied forma declares is co-planned into
+// the command so that it IS a node (generator_co_planning_test.go), and one
+// the forma does not declare cannot be, so the apply is refused rather than
+// run (generator_destination_reach_test.go).
 
 // deliveredValues is a per-label fake secret store that records every value
 // each label was written with, per operation, so a test can see which
@@ -180,13 +184,14 @@ func storedResolvedFrom(t *testing.T, m *metastructure.Metastructure, stack, lab
 // Shape 2. A draw that happens must reach every destination of its generator
 // in the changeset, including one whose own occurrence classified stable.
 //
-// The second apply adds a consumer AND edits an unrelated field on the
-// consumer that was already applied, so the applied one is planned and is a
-// node in the changeset. Its $gen occurrence is stable — nothing about the
-// binding moved — but the generator is drawing for the new consumer, and
-// delivering that draw to only the new consumer would leave the two holding
-// different credentials. Every apply after that would repair one and break
-// the other, forever.
+// The second apply adds a consumer and edits an unrelated field on the
+// consumer that was already applied. The edit is kept so that consumer reaches
+// the changeset as an ordinary planned node, which is what makes this the
+// delivery seam's own case rather than co-planning's. Its $gen occurrence is
+// stable (nothing about the binding moved), but the generator is drawing for
+// the new consumer, and delivering that draw to only the new consumer would
+// leave the two holding different credentials. Every apply after that would
+// repair one and break the other, forever.
 //
 // The convergence is asserted the only way that cannot be faked: a third,
 // identical apply must plan nothing at all.

--- a/internal/workflow_tests/local/apply_forma/generator_delivery_scope_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_delivery_scope_test.go
@@ -1,0 +1,411 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/provenance"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// These tests pin the scope of a generator delivery: WHETHER a generator
+// draws is decided by the destinations' stability, but once a draw happens
+// every live non-delete destination of that generator in the changeset
+// receives it. The four shapes that rule has to get right are:
+//
+//  1. an ordinary re-apply, nothing moved — no draw at all. Pinned by
+//     TestApplyForma_GeneratorBoundSecret_IdenticalReapplyDoesNotRedraw.
+//  2. a second consumer added — one destination is new, so a draw happens,
+//     and every destination of that generator in the changeset must end up on
+//     the new generation, the already-applied one included.
+//  3. the generator's spec edited — every destination is unstable, draws,
+//     and every one gets the new value.
+//  4. an unrelated field edited on a bound resource — nothing about the
+//     binding moved, so no draw, and the stable binding is frozen rather
+//     than refused at the provider boundary.
+//
+// Shape 2 is the one that decides convergence. Giving the new generation only
+// to the new destination leaves the two consumers of one credential holding
+// different values, and the next apply repairs the one and breaks the other,
+// forever.
+//
+// "In the changeset" is load-bearing in shape 2. A consumer that this command
+// plans no operation for — because nothing about it moved — is not a node in
+// the graph, so no delivery can reach it, and it cannot be caught up later
+// either: formae keeps only a hash of a generated value, never the value.
+// Such a consumer is left on its older generation.
+
+// deliveredValues is a per-label fake secret store that records every value
+// each label was written with, per operation, so a test can see which
+// destinations a draw actually reached.
+//
+// It has to stand in for FakeAWS's own SecretsManager handling rather than
+// fall through to it, because FakeAWS mints a single constant NativeID
+// ("5678") for every resource it creates. Two secrets in one stack would then
+// share a cloud identity and the second would be read as a rename of the
+// first. Everything else mirrors FakeAWS: what a write sends is what a later
+// Read returns, secret values bare rather than enveloped.
+type deliveredValues struct {
+	mu      sync.Mutex
+	creates map[string][]string
+	updates map[string][]string
+	patches map[string][]string
+	stored  map[string]json.RawMessage
+}
+
+func newDeliveredValues() *deliveredValues {
+	return &deliveredValues{
+		creates: map[string][]string{},
+		updates: map[string][]string{},
+		patches: map[string][]string{},
+		stored:  map[string]json.RawMessage{},
+	}
+}
+
+func nativeIDFor(label string) string { return "native-" + label }
+
+func (d *deliveredValues) overrides() *plugin.ResourcePluginOverrides {
+	return &plugin.ResourcePluginOverrides{
+		Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+			props := gjson.ParseBytes(req.Properties)
+			label := props.Get("Name").String()
+			nativeID := nativeIDFor(label)
+			d.mu.Lock()
+			d.creates[label] = append(d.creates[label], props.Get("SecretString").String())
+			d.stored[nativeID] = req.Properties
+			d.mu.Unlock()
+			return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+				Operation:          resource.OperationCreate,
+				OperationStatus:    resource.OperationStatusSuccess,
+				NativeID:           nativeID,
+				ResourceProperties: req.Properties,
+			}}, nil
+		},
+		Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+			props := gjson.ParseBytes(req.DesiredProperties)
+			label := props.Get("Name").String()
+			patch := ""
+			if req.PatchDocument != nil {
+				patch = string(*req.PatchDocument)
+			}
+			d.mu.Lock()
+			d.updates[label] = append(d.updates[label], props.Get("SecretString").String())
+			d.patches[label] = append(d.patches[label], patch)
+			d.stored[req.NativeID] = req.DesiredProperties
+			d.mu.Unlock()
+			return &resource.UpdateResult{ProgressResult: &resource.ProgressResult{
+				Operation:          resource.OperationUpdate,
+				OperationStatus:    resource.OperationStatusSuccess,
+				NativeID:           req.NativeID,
+				ResourceProperties: req.DesiredProperties,
+			}}, nil
+		},
+		Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+			d.mu.Lock()
+			stored := d.stored[req.NativeID]
+			d.mu.Unlock()
+			if len(stored) == 0 {
+				stored = json.RawMessage("{}")
+			}
+			return &resource.ReadResult{ResourceType: req.ResourceType, Properties: string(stored)}, nil
+		},
+	}
+}
+
+func (d *deliveredValues) createdWith(label string) []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.creates[label]...)
+}
+
+func (d *deliveredValues) updatedWith(label string) []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.updates[label]...)
+}
+
+// patchesFor returns the PatchDocument each update carried. A plugin is
+// entitled to drive its write from the patch rather than from the whole
+// desired document, so a delivered value that is missing from the patch is a
+// value that plugin never writes.
+func (d *deliveredValues) patchesFor(label string) []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.patches[label]...)
+}
+
+// storedResolvedFrom returns the provenance digest a stored destination
+// carries for its generator-bound property, which is what the next apply
+// classifies against.
+func storedResolvedFrom(t *testing.T, m *metastructure.Metastructure, stack, label string) string {
+	t.Helper()
+	resources, err := m.Datastore.LoadResourcesByStack(stack)
+	require.NoError(t, err)
+	for i := range resources {
+		if resources[i].Label == label {
+			return gjson.GetBytes(resources[i].Properties, "SecretString.$resolvedFrom").String()
+		}
+	}
+	t.Fatalf("no stored resource %q in stack %q", label, stack)
+	return ""
+}
+
+// Shape 2. A draw that happens must reach every destination of its generator
+// in the changeset, including one whose own occurrence classified stable.
+//
+// The second apply adds a consumer AND edits an unrelated field on the
+// consumer that was already applied, so the applied one is planned and is a
+// node in the changeset. Its $gen occurrence is stable — nothing about the
+// binding moved — but the generator is drawing for the new consumer, and
+// delivering that draw to only the new consumer would leave the two holding
+// different credentials. Every apply after that would repair one and break
+// the other, forever.
+//
+// The convergence is asserted the only way that cannot be faked: a third,
+// identical apply must plan nothing at all.
+func TestApplyForma_GeneratorBoundSecret_ADrawReachesEveryDestinationInTheChangeset(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		describedSecret := func(label, description string) pkgmodel.Resource {
+			secret := genBoundSecret(stack, label, "db-password", "value")
+			secret.Properties = json.RawMessage(`{
+				"Name": "` + label + `",
+				"Description": "` + description + `",
+				"SecretString": {
+					"$gen":        true,
+					"$label":      "db-password",
+					"$stack":      "` + stack + `",
+					"$output":     "value",
+					"$visibility": "Opaque"
+				}
+			}`)
+			return secret
+		}
+		forma := func(resources ...pkgmodel.Resource) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:     []pkgmodel.Stack{{Label: stack}},
+				Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+				Resources:  resources,
+			}
+		}
+
+		_, err = m.ApplyForma(forma(describedSecret("alpha", "before")),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		firstGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, firstGeneration.GenerationID, "the first apply must draw")
+		require.Len(t, delivered.createdWith("alpha"), 1, "alpha must have been created with the first draw")
+
+		_, err = m.ApplyForma(forma(describedSecret("alpha", "after"), describedSecret("beta", "beta")),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		require.Len(t, cmds, 2, "the second apply must produce a command")
+		for _, cmd := range cmds {
+			require.Equal(t, forma_command.CommandStateSuccess, cmd.State)
+		}
+
+		secondGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEqual(t, firstGeneration.GenerationID, secondGeneration.GenerationID,
+			"adding a consumer draws a new generation")
+
+		betaCreates := delivered.createdWith("beta")
+		require.Len(t, betaCreates, 1, "beta must have been created")
+		alphaUpdates := delivered.updatedWith("alpha")
+		require.Len(t, alphaUpdates, 1, "the applied consumer is planned, so it must be written")
+		assert.Equal(t, betaCreates[0], alphaUpdates[0],
+			"two consumers of one generator must hold the same value")
+		assert.NotEqual(t, delivered.createdWith("alpha")[0], alphaUpdates[0],
+			"the applied consumer must move to the new generation, not keep the old value")
+
+		alphaPatches := delivered.patchesFor("alpha")
+		require.Len(t, alphaPatches, 1)
+		assert.Contains(t, alphaPatches[0], "/SecretString",
+			"a delivered value must appear in the patch, or a patch-driven plugin never writes it")
+
+		// Both rows must be stamped with the generation that value came from,
+		// or the next apply reads one of them as moved and rotates again.
+		expected := provenance.DigestOfString(secondGeneration.GenerationID)
+		assert.Equal(t, expected, storedResolvedFrom(t, m, stack, "alpha"))
+		assert.Equal(t, expected, storedResolvedFrom(t, m, stack, "beta"))
+
+		// The convergence proof: a third identical apply plans nothing.
+		resp, err := m.ApplyForma(forma(describedSecret("alpha", "after"), describedSecret("beta", "beta")),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		assert.False(t, resp.Simulation.ChangesRequired,
+			"once both consumers hold the same generation, an identical apply must plan nothing")
+
+		cmds, err = m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		assert.Len(t, cmds, 2, "no third command may be created")
+
+		thirdGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		assert.Equal(t, secondGeneration.GenerationID, thirdGeneration.GenerationID,
+			"the generation must stop advancing once the destinations agree")
+	})
+}
+
+// Shape 3. Editing the generator's own spec makes every destination unstable,
+// so a draw happens and every destination receives the new value — at the
+// length the edited spec declares.
+func TestApplyForma_GeneratorBoundSecret_SpecEditRedrawsForEveryConsumer(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		formaWithLength := func(length int) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:  []pkgmodel.Stack{{Label: stack}},
+				Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+					Label: "db-password", Stack: stack,
+					Length: length, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+				})},
+				Resources: []pkgmodel.Resource{
+					genBoundSecret(stack, "alpha", "db-password", "value"),
+					genBoundSecret(stack, "beta", "db-password", "value"),
+				},
+			}
+		}
+
+		_, err = m.ApplyForma(formaWithLength(24), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		require.Len(t, delivered.createdWith("alpha"), 1)
+		require.Len(t, delivered.createdWith("beta"), 1)
+		require.Equal(t, delivered.createdWith("alpha")[0], delivered.createdWith("beta")[0],
+			"one draw serves every destination bound to it")
+		require.Len(t, delivered.createdWith("alpha")[0], 24)
+
+		_, err = m.ApplyForma(formaWithLength(40), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		alphaUpdates := delivered.updatedWith("alpha")
+		betaUpdates := delivered.updatedWith("beta")
+		require.Len(t, alphaUpdates, 1, "a spec edit must rewrite every destination")
+		require.Len(t, betaUpdates, 1, "a spec edit must rewrite every destination")
+		assert.Len(t, alphaUpdates[0], 40, "the new value must be drawn under the edited spec")
+		assert.Equal(t, alphaUpdates[0], betaUpdates[0],
+			"one redraw serves every destination bound to it")
+
+		generation, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		expected := provenance.DigestOfString(generation.GenerationID)
+		assert.Equal(t, expected, storedResolvedFrom(t, m, stack, "alpha"))
+		assert.Equal(t, expected, storedResolvedFrom(t, m, stack, "beta"))
+	})
+}
+
+// Shape 4. Editing a field that has nothing to do with the binding leaves
+// every $gen occurrence stable, so no draw happens and the generation does
+// not advance. The update still has to apply: the bare envelope is frozen to
+// the preserved-value sentinel rather than refused at the provider boundary,
+// so the guard protecting the credential does not block the edit beside it.
+func TestApplyForma_GeneratorBoundSecret_UnrelatedFieldEditDoesNotRedraw(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		formaWithDescription := func(description string) *pkgmodel.Forma {
+			secret := genBoundSecret(stack, "alpha", "db-password", "value")
+			secret.Properties = json.RawMessage(`{
+				"Name": "alpha",
+				"Description": "` + description + `",
+				"SecretString": {
+					"$gen":        true,
+					"$label":      "db-password",
+					"$stack":      "` + stack + `",
+					"$output":     "value",
+					"$visibility": "Opaque"
+				}
+			}`)
+			return &pkgmodel.Forma{
+				Stacks:     []pkgmodel.Stack{{Label: stack}},
+				Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+				Resources:  []pkgmodel.Resource{secret},
+			}
+		}
+
+		_, err = m.ApplyForma(formaWithDescription("before"), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		firstGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, firstGeneration.GenerationID)
+
+		_, err = m.ApplyForma(formaWithDescription("after"), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		require.Len(t, cmds, 2)
+		for _, cmd := range cmds {
+			assert.Equal(t, forma_command.CommandStateSuccess, cmd.State,
+				"a stable binding must not block the edit beside it")
+		}
+
+		secondGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		assert.Equal(t, firstGeneration.GenerationID, secondGeneration.GenerationID,
+			"an edit that leaves every binding stable must not draw")
+
+		updates := delivered.updatedWith("alpha")
+		require.Len(t, updates, 1, "the unrelated edit must reach the provider")
+		assert.NotContains(t, updates[0], "$gen",
+			"a stable binding is frozen to the preserved sentinel, never dispatched as a bare envelope")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/generator_delivery_scope_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_delivery_scope_test.go
@@ -153,20 +153,28 @@ func (d *deliveredValues) patchesFor(label string) []string {
 	return append([]string(nil), d.patches[label]...)
 }
 
-// storedResolvedFrom returns the provenance digest a stored destination
-// carries for its generator-bound property, which is what the next apply
-// classifies against.
-func storedResolvedFrom(t *testing.T, m *metastructure.Metastructure, stack, label string) string {
+// storedBinding returns the generator-bound envelope a destination carries at
+// rest. It is what the next apply classifies against: the digest of the value
+// the destination holds, the marker saying that value is a digest, and the
+// generation it was drawn from.
+func storedBinding(t *testing.T, m *metastructure.Metastructure, stack, label string) gjson.Result {
 	t.Helper()
 	resources, err := m.Datastore.LoadResourcesByStack(stack)
 	require.NoError(t, err)
 	for i := range resources {
 		if resources[i].Label == label {
-			return gjson.GetBytes(resources[i].Properties, "SecretString.$resolvedFrom").String()
+			return gjson.GetBytes(resources[i].Properties, "SecretString")
 		}
 	}
 	t.Fatalf("no stored resource %q in stack %q", label, stack)
-	return ""
+	return gjson.Result{}
+}
+
+// storedResolvedFrom returns the provenance digest a stored destination
+// carries for its generator-bound property.
+func storedResolvedFrom(t *testing.T, m *metastructure.Metastructure, stack, label string) string {
+	t.Helper()
+	return storedBinding(t, m, stack, label).Get("$resolvedFrom").String()
 }
 
 // Shape 2. A draw that happens must reach every destination of its generator
@@ -386,6 +394,14 @@ func TestApplyForma_GeneratorBoundSecret_UnrelatedFieldEditDoesNotRedraw(t *test
 		require.NoError(t, err)
 		require.NotEmpty(t, firstGeneration.GenerationID)
 
+		appliedBinding := storedBinding(t, m, stack, "alpha")
+		require.True(t, appliedBinding.Get("$hashed").Bool(), "precondition: the drawn value is stored as a digest")
+		appliedValue := appliedBinding.Get("$value").String()
+		require.NotEmpty(t, appliedValue)
+		appliedResolvedFrom := appliedBinding.Get("$resolvedFrom").String()
+		require.Equal(t, provenance.DigestOfString(firstGeneration.GenerationID), appliedResolvedFrom,
+			"precondition: the destination is stamped with the generation it was drawn from")
+
 		_, err = m.ApplyForma(formaWithDescription("after"), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
@@ -407,5 +423,35 @@ func TestApplyForma_GeneratorBoundSecret_UnrelatedFieldEditDoesNotRedraw(t *test
 		require.Len(t, updates, 1, "the unrelated edit must reach the provider")
 		assert.NotContains(t, updates[0], "$gen",
 			"a stable binding is frozen to the preserved sentinel, never dispatched as a bare envelope")
+
+		// What the row keeps is what the next apply classifies against. A
+		// binding nothing wrote must come out of the edit exactly as it went
+		// in: the same digest, still marked a digest, still stamped with its
+		// generation.
+		edited := storedBinding(t, m, stack, "alpha")
+		assert.Equal(t, appliedValue, edited.Get("$value").String(),
+			"the stored digest of the credential must survive an edit that did not touch it")
+		assert.True(t, edited.Get("$hashed").Bool(),
+			"the stored value must still be marked a digest, or it is hashed again as if it were a secret")
+		assert.Equal(t, appliedResolvedFrom, edited.Get("$resolvedFrom").String(),
+			"the destination must keep the generation it was drawn from")
+
+		// The proof that the row is intact: a third identical apply has
+		// nothing to do, and the generator does not advance.
+		resp, err := m.ApplyForma(formaWithDescription("after"), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		assert.False(t, resp.Simulation.ChangesRequired,
+			"an unrelated edit must not leave the binding looking moved on the next apply")
+
+		cmds, err = m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		assert.Len(t, cmds, 2, "no third command may be created")
+
+		thirdGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		assert.Equal(t, firstGeneration.GenerationID, thirdGeneration.GenerationID,
+			"an unrelated edit must not rotate the credential on the apply after it")
+		assert.Len(t, delivered.updatedWith("alpha"), 1,
+			"no third write may reach the provider")
 	})
 }

--- a/internal/workflow_tests/local/apply_forma/generator_destination_reach_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_destination_reach_test.go
@@ -1,0 +1,427 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// These tests pin the reach a draw must have. formae keeps only a hash of a
+// drawn value, never the value, so a destination that was not in the command
+// when a draw happened can never be brought level afterwards: the only way to
+// give it a value is to draw again, which puts its siblings behind. An apply
+// that would draw for some of a generator's destinations but not all of them
+// is refused, naming the ones it cannot reach.
+//
+// The refusal turns on which destinations the CHANGESET reaches, never on
+// which stack they sit on. One command carries every resource update the
+// forma produced, across all of its stacks, so a generator whose destinations
+// span stacks is served fine as long as the apply covers them together.
+
+// crossStackGenBoundSecret is a secret in resourceStack whose opaque
+// SecretString binds to a generator declared in generatorStack.
+func crossStackGenBoundSecret(resourceStack, label, generatorStack, generatorLabel, description string) pkgmodel.Resource {
+	return pkgmodel.Resource{
+		Label:  label,
+		Type:   "FakeAWS::SecretsManager::Secret",
+		Stack:  resourceStack,
+		Target: "test-target",
+		Schema: secretSchema(),
+		Properties: json.RawMessage(`{
+			"Name": "` + label + `",
+			"Description": "` + description + `",
+			"SecretString": {
+				"$gen":        true,
+				"$label":      "` + generatorLabel + `",
+				"$stack":      "` + generatorStack + `",
+				"$output":     "value",
+				"$visibility": "Opaque"
+			}
+		}`)}
+}
+
+// twoStackGeneratorFixture is the shape every test in this file starts from:
+// one generator in generatorStack, one destination beside it, and a second
+// destination in another stack entirely.
+type twoStackGeneratorFixture struct {
+	generatorStack string
+	otherStack     string
+}
+
+func newTwoStackGeneratorFixture() twoStackGeneratorFixture {
+	id := util.NewID()
+	return twoStackGeneratorFixture{
+		generatorStack: "gen-stack-" + id,
+		otherStack:     "other-stack-" + id,
+	}
+}
+
+// bothStacks is the forma that declares the generator and both of its
+// destinations, with the generator at the given length so a test can move the
+// spec and make every destination unstable.
+func (f twoStackGeneratorFixture) bothStacks(t *testing.T, length int, alphaDescription string) *pkgmodel.Forma {
+	t.Helper()
+	return &pkgmodel.Forma{
+		Stacks:  []pkgmodel.Stack{{Label: f.generatorStack}, {Label: f.otherStack}},
+		Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+		Generators: []json.RawMessage{rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+			Label: "db-password", Stack: f.generatorStack,
+			Length: length, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+		})},
+		Resources: []pkgmodel.Resource{
+			crossStackGenBoundSecret(f.generatorStack, "alpha", f.generatorStack, "db-password", alphaDescription),
+			crossStackGenBoundSecret(f.otherStack, "beta", f.generatorStack, "db-password", "beta"),
+		},
+	}
+}
+
+// generatorStackOnly is the same forma with the other stack's destination left
+// out entirely — the partial apply the refusal exists to stop.
+func (f twoStackGeneratorFixture) generatorStackOnly(t *testing.T, length int, alphaDescription string) *pkgmodel.Forma {
+	t.Helper()
+	return &pkgmodel.Forma{
+		Stacks:  []pkgmodel.Stack{{Label: f.generatorStack}},
+		Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+		Generators: []json.RawMessage{rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+			Label: "db-password", Stack: f.generatorStack,
+			Length: length, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+		})},
+		Resources: []pkgmodel.Resource{
+			crossStackGenBoundSecret(f.generatorStack, "alpha", f.generatorStack, "db-password", alphaDescription),
+		},
+	}
+}
+
+// A generator's destinations may live on separate stacks. One command carries
+// every resource update the forma produced, so an apply covering both stacks
+// reaches both destinations and must succeed, with both holding the one value
+// the single draw produced.
+//
+// The second apply is what pins the rule. By then both destinations are live
+// and indexed against the generator, and moving the spec makes both draw, so
+// a refusal that read reach per stack rather than per command would reject an
+// apply that in fact reaches everything.
+func TestApplyForma_GeneratorBoundSecret_DestinationsInTwoStacksApplyTogether(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		f := newTwoStackGeneratorFixture()
+		_, err = m.ApplyForma(f.bothStacks(t, 24, "before"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err, "a generator whose destinations span stacks must apply when the command covers them all")
+		waitForApplyComplete(t, m)
+
+		alphaCreates := delivered.createdWith("alpha")
+		betaCreates := delivered.createdWith("beta")
+		require.Len(t, alphaCreates, 1, "the destination beside the generator must be written")
+		require.Len(t, betaCreates, 1, "the destination in the other stack must be written")
+		assert.Equal(t, alphaCreates[0], betaCreates[0],
+			"one draw serves every destination bound to it, whatever stack it sits on")
+
+		firstGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", f.generatorStack)
+		require.NoError(t, err)
+		require.NotEmpty(t, firstGeneration.GenerationID, "the apply must draw")
+
+		// Both destinations are stored and indexed now. Moving the spec makes
+		// both of them draw, and the command reaches both.
+		_, err = m.ApplyForma(f.bothStacks(t, 40, "after"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err, "a redraw that reaches every destination must not be refused because they span stacks")
+		waitForApplyComplete(t, m)
+
+		alphaUpdates := delivered.updatedWith("alpha")
+		betaUpdates := delivered.updatedWith("beta")
+		require.Len(t, alphaUpdates, 1, "the destination beside the generator must receive the redraw")
+		require.Len(t, betaUpdates, 1, "the destination in the other stack must receive the redraw")
+		assert.Len(t, alphaUpdates[0], 40, "the new value must be drawn under the edited spec")
+		assert.Equal(t, alphaUpdates[0], betaUpdates[0],
+			"one redraw serves every destination bound to it, whatever stack it sits on")
+
+		secondGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", f.generatorStack)
+		require.NoError(t, err)
+		assert.NotEqual(t, firstGeneration.GenerationID, secondGeneration.GenerationID,
+			"the spec edit must draw a new generation")
+	})
+}
+
+// An apply that would draw but reaches only some of the generator's
+// destinations is refused, and the refusal names the destination it cannot
+// reach: its stack, its label and its type.
+//
+// Nothing may be drawn before the refusal. Observing that no destination was
+// written would not tell a value that was never drawn from one that was drawn
+// and thrown away, so the generation identity itself is asserted unchanged.
+func TestApplyForma_GeneratorBoundSecret_PartialApplyThatWouldDrawIsRefused(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		f := newTwoStackGeneratorFixture()
+		_, err = m.ApplyForma(f.bothStacks(t, 24, "before"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		firstGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", f.generatorStack)
+		require.NoError(t, err)
+		require.NotEmpty(t, firstGeneration.GenerationID)
+
+		// Moving the generator's spec makes every destination unstable, so
+		// this apply would draw — for alpha only, since beta's stack is not
+		// declared.
+		_, err = m.ApplyForma(f.generatorStackOnly(t, 40, "before"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.Error(t, err, "an apply that draws for only some of a generator's destinations must be refused")
+
+		var unreachable apimodel.FormaGeneratorDestinationsUnreachableError
+		require.ErrorAs(t, err, &unreachable)
+		require.Len(t, unreachable.Unreachable, 1)
+		assert.Equal(t, "beta", unreachable.Unreachable[0].Label,
+			"the refusal must name the destination it cannot reach")
+		assert.Equal(t, f.otherStack, unreachable.Unreachable[0].Stack)
+		assert.Equal(t, "FakeAWS::SecretsManager::Secret", unreachable.Unreachable[0].Type)
+		assert.Equal(t, "db-password", unreachable.Unreachable[0].GeneratorLabel)
+		assert.Equal(t, f.generatorStack, unreachable.Unreachable[0].GeneratorStack)
+
+		refusedGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", f.generatorStack)
+		require.NoError(t, err)
+		assert.Equal(t, firstGeneration.GenerationID, refusedGeneration.GenerationID,
+			"the refusal must land before anything is drawn")
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		assert.Len(t, cmds, 1, "a refused apply must persist no command")
+	})
+}
+
+// Simulation is refused on the same terms. The neighbouring cascade aborts let
+// a simulation through so the CLI can render the cascade and the operator can
+// elevate on confirmation; no confirmation makes a split draw correct, so
+// rendering a plan that can never be applied would be worse than the refusal.
+func TestApplyForma_GeneratorBoundSecret_PartialApplySimulationIsRefused(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		f := newTwoStackGeneratorFixture()
+		_, err = m.ApplyForma(f.bothStacks(t, 24, "before"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		_, err = m.ApplyForma(f.generatorStackOnly(t, 40, "before"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: true}, "test-client-id", "", "")
+		require.Error(t, err, "a simulation of a split draw must be refused, not rendered")
+
+		var unreachable apimodel.FormaGeneratorDestinationsUnreachableError
+		require.ErrorAs(t, err, &unreachable)
+		require.Len(t, unreachable.Unreachable, 1)
+		assert.Equal(t, "beta", unreachable.Unreachable[0].Label)
+	})
+}
+
+// A generator whose in-command destinations are all stable draws nothing, so
+// there is nothing a destination outside the command can fall behind on and
+// the partial apply proceeds. Without this the refusal would fail every
+// partial apply of a generator-bound stack.
+func TestApplyForma_GeneratorBoundSecret_PartialApplyThatDrawsNothingIsAllowed(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		f := newTwoStackGeneratorFixture()
+		_, err = m.ApplyForma(f.bothStacks(t, 24, "before"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		firstGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", f.generatorStack)
+		require.NoError(t, err)
+		require.NotEmpty(t, firstGeneration.GenerationID)
+
+		// The generator's spec is untouched and only a field beside the
+		// binding moves, so alpha is planned with a stable occurrence and no
+		// draw happens.
+		_, err = m.ApplyForma(f.generatorStackOnly(t, 24, "after"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err, "a partial apply that draws nothing must not be refused")
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		require.Len(t, cmds, 2, "the edit must produce a command of its own")
+
+		secondGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", f.generatorStack)
+		require.NoError(t, err)
+		assert.Equal(t, firstGeneration.GenerationID, secondGeneration.GenerationID,
+			"an apply that plans only stable bindings must not draw")
+		assert.Len(t, delivered.updatedWith("alpha"), 1, "the unrelated edit must still reach the provider")
+		assert.Empty(t, delivered.updatedWith("beta"), "the untouched stack must be left alone")
+	})
+}
+
+// A destination the command is tearing down is reached by the command; it is
+// simply owed nothing. It must not count as unreachable, or removing a
+// consumer of a generator whose spec also moved would be impossible.
+func TestApplyForma_GeneratorBoundSecret_DestinationBeingDeletedDoesNotBlockADraw(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		formaWith := func(length int, resources ...pkgmodel.Resource) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:  []pkgmodel.Stack{{Label: stack}},
+				Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+					Label: "db-password", Stack: stack,
+					Length: length, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+				})},
+				Resources: resources,
+			}
+		}
+		alpha := crossStackGenBoundSecret(stack, "alpha", stack, "db-password", "alpha")
+		beta := crossStackGenBoundSecret(stack, "beta", stack, "db-password", "beta")
+
+		_, err = m.ApplyForma(formaWith(24, alpha, beta),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+		require.Len(t, delivered.createdWith("beta"), 1)
+
+		// The spec moves (so alpha draws) and beta is dropped from the forma,
+		// which a reconcile turns into a delete.
+		_, err = m.ApplyForma(formaWith(40, alpha),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err, "a destination present in the command as a delete is reached, not unreachable")
+		waitForApplyComplete(t, m)
+
+		alphaUpdates := delivered.updatedWith("alpha")
+		require.Len(t, alphaUpdates, 1, "the surviving destination must receive the redraw")
+		assert.Len(t, alphaUpdates[0], 40, "the value must be drawn under the edited spec")
+
+		remaining, err := m.Datastore.LoadResourcesByStack(stack)
+		require.NoError(t, err)
+		for i := range remaining {
+			assert.NotEqual(t, "beta", remaining[i].Label, "the dropped destination must be gone")
+		}
+	})
+}
+
+// literalSecret is the same secret with a plain authored value in place of the
+// $gen envelope: the shape a forma takes once an operator unbinds a
+// destination from its generator.
+func literalSecret(stack, label, value string) pkgmodel.Resource {
+	return pkgmodel.Resource{
+		Label:  label,
+		Type:   "FakeAWS::SecretsManager::Secret",
+		Stack:  stack,
+		Target: "test-target",
+		Schema: secretSchema(),
+		Properties: json.RawMessage(`{
+			"Name": "` + label + `",
+			"Description": "` + label + `",
+			"SecretString": "` + value + `"
+		}`)}
+}
+
+// A destination the command unbinds from the generator is reached by that
+// command: its update is a node in the changeset, whatever its desired
+// document now says about the binding. Reach is a property of the graph, not
+// of the document, so an apply that both unbinds one destination and makes the
+// generator draw for another must go through.
+func TestApplyForma_GeneratorBoundSecret_UnbindingADestinationWhileDrawingIsAllowed(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		formaWith := func(length int, resources ...pkgmodel.Resource) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:  []pkgmodel.Stack{{Label: stack}},
+				Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+					Label: "db-password", Stack: stack,
+					Length: length, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+				})},
+				Resources: resources,
+			}
+		}
+		boundAlpha := crossStackGenBoundSecret(stack, "alpha", stack, "db-password", "alpha")
+		beta := crossStackGenBoundSecret(stack, "beta", stack, "db-password", "beta")
+
+		_, err = m.ApplyForma(formaWith(24, boundAlpha, beta),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+		require.Len(t, delivered.createdWith("alpha"), 1)
+		require.Len(t, delivered.createdWith("beta"), 1)
+
+		// alpha's binding is replaced by a literal while the generator's spec
+		// moves, so the generator draws for beta and alpha is planned without
+		// binding it any more.
+		_, err = m.ApplyForma(formaWith(40, literalSecret(stack, "alpha", "unbound-literal"), beta),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err, "unbinding a destination must not make it unreachable")
+		waitForApplyComplete(t, m)
+
+		betaUpdates := delivered.updatedWith("beta")
+		require.Len(t, betaUpdates, 1, "the destination that kept its binding must receive the draw")
+		assert.Len(t, betaUpdates[0], 40, "the new value must be drawn under the edited spec")
+
+		alphaUpdates := delivered.updatedWith("alpha")
+		require.Len(t, alphaUpdates, 1, "the unbound destination must be written")
+		assert.NotEqual(t, betaUpdates[0], alphaUpdates[0],
+			"an unbound destination must not receive the generator's value")
+
+		unbound := storedBinding(t, m, stack, "alpha")
+		assert.False(t, unbound.Get("$gen").Exists(),
+			"the unbound row must no longer carry the binding")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/generator_draw_delivery_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_draw_delivery_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/provenance"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
@@ -144,4 +145,88 @@ func assertDrawnValueIsNotStored(t *testing.T, m *metastructure.Metastructure, c
 	require.NoError(t, err)
 	assert.False(t, strings.Contains(string(encodedGenerator), drawnValue),
 		"the generator row must never hold the value drawn from it")
+}
+
+// An identical re-apply of a generator-bound secret must not redraw. The
+// destination carries the generation the value it holds was drawn from, so
+// the occurrence classifies stable, nothing is planned, and the credential
+// in the cloud object is left alone.
+//
+// Planning nothing is asserted twice over: the simulation reports no change
+// AND no second command reaches the datastore. Only the first would still
+// pass against a build that plans a harmless no-op update, which would still
+// redraw.
+func TestApplyForma_GeneratorBoundSecret_IdenticalReapplyDoesNotRedraw(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		captured := newCapturedCreates("SecretString", "Name")
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, captured.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		buildForma := func() *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:     []pkgmodel.Stack{{Label: stack}},
+				Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+				Resources:  []pkgmodel.Resource{genBoundSecret(stack, "db", "db-password", "value")},
+			}
+		}
+
+		_, err = m.ApplyForma(buildForma(), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		firstCmd := findCommandByType(cmds, pkgmodel.CommandApply)
+		require.NotNil(t, firstCmd)
+		require.Equal(t, forma_command.CommandStateSuccess, firstCmd.State,
+			"precondition: the first apply must draw and write")
+
+		drawn, ok := captured.valueFor("db")
+		require.True(t, ok, "precondition: the provider must have been called with the drawn value")
+
+		firstGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, firstGeneration.GenerationID, "precondition: the draw must be recorded")
+
+		// The stored destination carries resolution provenance: a well-formed
+		// digest, never the value.
+		resources, err := m.Datastore.LoadResourcesByStack(stack)
+		require.NoError(t, err)
+		var secretRow *pkgmodel.Resource
+		for i := range resources {
+			if resources[i].Label == "db" {
+				secretRow = resources[i]
+			}
+		}
+		require.NotNil(t, secretRow)
+		resolvedFrom := gjson.GetBytes(secretRow.Properties, "SecretString.$resolvedFrom").String()
+		assert.True(t, provenance.Valid(resolvedFrom),
+			"the drawn destination must carry a current-domain provenance digest, got %q", resolvedFrom)
+		assert.Equal(t, provenance.DigestOfString(firstGeneration.GenerationID), resolvedFrom,
+			"the destination must be stamped with the generation its value was drawn from")
+
+		resp, err := m.ApplyForma(buildForma(), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		assert.False(t, resp.Simulation.ChangesRequired,
+			"an identical re-apply of a generator-bound secret must plan nothing")
+
+		cmds, err = m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		assert.Len(t, cmds, 1, "no second command may be created")
+
+		secondGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		assert.Equal(t, firstGeneration.GenerationID, secondGeneration.GenerationID,
+			"the re-apply must not advance the generation")
+
+		later, ok := captured.valueFor("db")
+		require.True(t, ok)
+		assert.Equal(t, drawn, later, "the credential in the cloud object must be untouched")
+	})
 }

--- a/internal/workflow_tests/local/apply_forma/generator_draw_delivery_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_draw_delivery_test.go
@@ -8,6 +8,8 @@ package workflow_tests_local
 
 import (
 	"encoding/json"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -16,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
+	"github.com/platform-engineering-labs/formae/internal/logging"
 	"github.com/platform-engineering-labs/formae/internal/metastructure"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
@@ -145,6 +148,79 @@ func assertDrawnValueIsNotStored(t *testing.T, m *metastructure.Metastructure, c
 	require.NoError(t, err)
 	assert.False(t, strings.Contains(string(encodedGenerator), drawnValue),
 		"the generator row must never hold the value drawn from it")
+}
+
+// goByteSlice matches the way Go renders a []byte through fmt's %v/%+v verbs:
+// a bracketed run of decimal byte values, e.g. "[123 34 80 97 ...]".
+var goByteSlice = regexp.MustCompile(`\[\d+(?: \d+)*\]`)
+
+// decodeGoByteSlices returns the text spelled out by every Go-rendered byte
+// slice in s. A property document rendered this way carries all of its bytes
+// while matching no substring search for the characters they spell, so a log
+// line is only clean if its decoded text is clean too.
+func decodeGoByteSlices(s string) []string {
+	var decoded []string
+	for _, match := range goByteSlice.FindAllString(s, -1) {
+		fields := strings.Fields(strings.Trim(match, "[]"))
+		buf := make([]byte, 0, len(fields))
+		ok := true
+		for _, f := range fields {
+			n, err := strconv.Atoi(f)
+			if err != nil || n < 0 || n > 255 {
+				ok = false
+				break
+			}
+			buf = append(buf, byte(n))
+		}
+		if ok && len(buf) > 0 {
+			decoded = append(decoded, string(buf))
+		}
+	}
+	return decoded
+}
+
+// assertNoPlaintextInLogs sweeps every captured slog entry for a secret, in
+// both the renderings a raw JSON document can take: the characters themselves,
+// and the decimal byte array fmt produces for a json.RawMessage under a text
+// handler. Only the first is visible to a substring search, so a plaintext
+// carried through the second would pass an unaided assert.NotContains.
+func assertNoPlaintextInLogs(t *testing.T, capture *logging.TestLogCapture, plaintext string) {
+	t.Helper()
+	require.NotEmpty(t, plaintext)
+	entries := capture.GetEntries()
+	require.NotEmpty(t, entries, "the log capture must have seen the run it is being swept for")
+	for _, entry := range entries {
+		assert.NotContains(t, entry, plaintext, "a log entry leaked the secret")
+		for _, decoded := range decodeGoByteSlices(entry) {
+			assert.NotContains(t, decoded, plaintext,
+				"a log entry carried the secret as a byte slice")
+		}
+	}
+}
+
+// assertProvenanceCarriersAreWellFormed checks every digest a command's
+// resource updates carry: a provenance carrier holds an identity of a value,
+// so anything in one that is not a current-domain digest is either a leak or a
+// comparison that will silently never match.
+func assertProvenanceCarriersAreWellFormed(t *testing.T, m *metastructure.Metastructure, commandID string) {
+	t.Helper()
+	updates, err := m.Datastore.LoadResourceUpdates(commandID)
+	require.NoError(t, err)
+	require.NotEmpty(t, updates)
+	for _, ru := range updates {
+		for _, rec := range ru.ProvenanceRecords {
+			for _, d := range []string{rec.SourceRootDigest, rec.WrittenProvenance, rec.WrittenDigest} {
+				if d != "" {
+					assert.True(t, provenance.Valid(d),
+						"provenance record digest must be well-formed, got %q", d)
+				}
+			}
+		}
+		for uri, d := range ru.ResolvedRootDigests {
+			assert.True(t, provenance.Valid(d),
+				"resolved root digest for %s must be well-formed, got %q", uri, d)
+		}
+	}
 }
 
 // An identical re-apply of a generator-bound secret must not redraw. The

--- a/internal/workflow_tests/local/apply_forma/generator_draw_delivery_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_draw_delivery_test.go
@@ -1,0 +1,147 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// capturedCreates records the properties each Create reached the provider
+// with, so a test can assert on the value a destination was actually written
+// with. Returning nil falls through to FakeAWS's own handling.
+type capturedCreates struct {
+	mu         sync.Mutex
+	byLabel    map[string]string
+	fieldPath  string
+	labelField string
+}
+
+func newCapturedCreates(fieldPath, labelField string) *capturedCreates {
+	return &capturedCreates{byLabel: map[string]string{}, fieldPath: fieldPath, labelField: labelField}
+}
+
+func (c *capturedCreates) overrides() *plugin.ResourcePluginOverrides {
+	return &plugin.ResourcePluginOverrides{
+		Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			props := gjson.ParseBytes(req.Properties)
+			c.byLabel[props.Get(c.labelField).String()] = props.Get(c.fieldPath).String()
+			return nil, nil
+		},
+	}
+}
+
+func (c *capturedCreates) valueFor(label string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	v, ok := c.byLabel[label]
+	return v, ok
+}
+
+// A secret bound to a generator is created with the value that generator
+// drew: the draw runs before its destination dispatches, the value is
+// delivered into the destination's $gen envelope, and the plugin receives the
+// plain credential rather than the envelope.
+//
+// The drawn value must then exist nowhere durable in plaintext — not in the
+// command record, not on the generator's own row. The generator holds the
+// spec a value was drawn under and the generation's identity; it never holds
+// the value.
+func TestApplyForma_GeneratorBoundSecret_DrawnValueReachesTheProviderAndNothingElse(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		captured := newCapturedCreates("SecretString", "Name")
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, captured.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := &pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: stack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+			Resources:  []pkgmodel.Resource{genBoundSecret(stack, "db", "db-password", "value")},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		cmd := findCommandByType(cmds, pkgmodel.CommandApply)
+		require.NotNil(t, cmd)
+		require.Equal(t, forma_command.CommandStateSuccess, cmd.State,
+			"a generator that draws lets its destination be written")
+
+		secretUpdate := findResourceUpdate(cmd.ResourceUpdates, "db")
+		require.NotNil(t, secretUpdate)
+		assert.Equal(t, resource_update.ResourceUpdateStateSuccess, secretUpdate.State)
+
+		drawnValue, ok := captured.valueFor("db")
+		require.True(t, ok, "the provider must have been called for the bound secret")
+		assert.Len(t, drawnValue, 24, "the provider receives the drawn value, at its declared length")
+		assert.NotContains(t, drawnValue, "$gen",
+			"the provider must receive the drawn value, never the envelope naming it")
+
+		// The value exists in the cloud object and in nothing formae stored.
+		assertDrawnValueIsNotStored(t, m, cmd.ID, drawnValue, "db-password", stack)
+	})
+}
+
+// assertDrawnValueIsNotStored re-reads the durable records a drawn value
+// could leak into and asserts none of them holds it in plaintext.
+func assertDrawnValueIsNotStored(t *testing.T, m *metastructure.Metastructure, commandID, drawnValue, generatorLabel, stack string) {
+	t.Helper()
+	require.NotEmpty(t, drawnValue)
+
+	assertNoPlaintextInResourceUpdates(t, m, commandID, drawnValue)
+
+	stored, err := m.Datastore.GetFormaCommandByCommandID(commandID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	encodedCommand, err := json.Marshal(stored)
+	require.NoError(t, err)
+	assert.False(t, strings.Contains(string(encodedCommand), drawnValue),
+		"the command record must never hold the drawn value")
+
+	identity, err := m.Datastore.GetGeneratorIdentity(generatorLabel, stack)
+	require.NoError(t, err)
+	require.NotEmpty(t, identity.GenerationID,
+		"a delivered draw must leave its generation recorded")
+	assert.False(t, strings.Contains(string(identity.GenerationSpec), drawnValue),
+		"the recorded generation spec must never hold the drawn value")
+
+	generator, err := m.Datastore.GetGenerator(generatorLabel, stack)
+	require.NoError(t, err)
+	require.NotNil(t, generator)
+	encodedGenerator, err := json.Marshal(generator)
+	require.NoError(t, err)
+	assert.False(t, strings.Contains(string(encodedGenerator), drawnValue),
+		"the generator row must never hold the value drawn from it")
+}

--- a/internal/workflow_tests/local/apply_forma/generator_draw_failure_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_draw_failure_test.go
@@ -1,0 +1,166 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/querier"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// A draw that cannot produce a value fails, and every destination waiting on
+// it fails with it rather than dispatching the envelope that names the value.
+// The failure is recorded: the command reaches a terminal failed state, both
+// destinations are stored failed, and nothing was written on either side of
+// the boundary — no provider call, no resource row, and no generation recorded
+// for a generator that never produced one.
+//
+// The spec asks for three character classes in a value of two characters,
+// which nothing can satisfy. It is admitted, because what a spec can produce
+// is decided where the value is drawn and not at the door.
+func TestApplyForma_GeneratorDrawFailure_FailsItsDestinationsAndIsRecorded(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := &pkgmodel.Forma{
+			Stacks:  []pkgmodel.Stack{{Label: stack}},
+			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+				Label: "db-password", Stack: stack,
+				Length: 2, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+			})},
+			Resources: []pkgmodel.Resource{
+				genBoundSecret(stack, "alpha", "db-password", "value"),
+				genBoundSecret(stack, "beta", "db-password", "value"),
+			},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err, "an undrawable spec is admitted and fails where the value is drawn")
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		cmd := findCommandByType(cmds, pkgmodel.CommandApply)
+		require.NotNil(t, cmd)
+		assert.Equal(t, forma_command.CommandStateFailed, cmd.State,
+			"a command whose draw failed must not be reported as applied")
+
+		// Reloaded from the datastore rather than read off the in-memory
+		// command: a failure the command reports but never stores is a failure
+		// nothing can be asked about afterwards.
+		stored, err := m.Datastore.GetFormaCommandByCommandID(cmd.ID)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		assert.Equal(t, forma_command.CommandStateFailed, stored.State)
+		for _, label := range []string{"alpha", "beta"} {
+			ru := findResourceUpdate(stored.ResourceUpdates, label)
+			require.NotNil(t, ru, "%s must be in the stored command", label)
+			assert.Equal(t, resource_update.ResourceUpdateStateFailed, ru.State,
+				"%s waits on the failed draw and must fail with it", label)
+		}
+
+		assert.Empty(t, delivered.createdWith("alpha"),
+			"a destination whose value was never drawn must not reach the provider")
+		assert.Empty(t, delivered.createdWith("beta"),
+			"a destination whose value was never drawn must not reach the provider")
+
+		resources, err := m.Datastore.LoadResourcesByStack(stack)
+		require.NoError(t, err)
+		assert.Empty(t, resources, "a refused write must leave no resource behind")
+
+		identity, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		assert.Empty(t, identity.GenerationID,
+			"a generator that produced no value must record no generation")
+	})
+}
+
+// A destination that failed because the draw failed carries the draw's reason,
+// so the apply explains itself. The reason is read back off the stored command
+// through MostRecentFailureMessage, which is what the API projection puts on
+// ResourceUpdate.ErrorMessage and what every status surface renders.
+func TestApplyForma_GeneratorDrawFailure_ExplainsWhyItsDestinationsFailed(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := &pkgmodel.Forma{
+			Stacks:  []pkgmodel.Stack{{Label: stack}},
+			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+				Label: "db-password", Stack: stack,
+				Length: 2, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+			})},
+			Resources: []pkgmodel.Resource{
+				genBoundSecret(stack, "alpha", "db-password", "value"),
+				genBoundSecret(stack, "beta", "db-password", "value"),
+			},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		cmd := findCommandByType(cmds, pkgmodel.CommandApply)
+		require.NotNil(t, cmd)
+
+		stored, err := m.Datastore.GetFormaCommandByCommandID(cmd.ID)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		for _, label := range []string{"alpha", "beta"} {
+			ru := findResourceUpdate(stored.ResourceUpdates, label)
+			require.NotNil(t, ru, "%s must be in the stored command", label)
+			assert.Contains(t, ru.MostRecentFailureMessage(),
+				"its specification admits no value",
+				"%s failed because the draw failed and must say so", label)
+		}
+
+		// The same reason read back through the status API, which is the
+		// projection every operator-facing surface renders.
+		status, err := m.ListFormaCommandStatus("", querier.Caller{ClientID: "test-client-id"}, 1, apimodel.CommandScopeClient)
+		require.NoError(t, err)
+		require.Len(t, status.Commands, 1)
+		reported := 0
+		for _, ru := range status.Commands[0].ResourceUpdates {
+			if ru.ResourceLabel != "alpha" && ru.ResourceLabel != "beta" {
+				continue
+			}
+			reported++
+			assert.Contains(t, ru.ErrorMessage, "its specification admits no value",
+				"%s must report why it failed", ru.ResourceLabel)
+		}
+		assert.Equal(t, 2, reported, "both destinations must appear in the status projection")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/generator_draw_plan_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_draw_plan_test.go
@@ -1,0 +1,278 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// A draw is a credential rotation: every destination bound to the generator
+// takes the new value, including the ones whose forma text nobody touched.
+// These tests pin what a simulate says about that before it happens. The plan
+// is the only thing an operator sees between deciding to apply and the
+// credential changing, so a draw that the plan does not name is a rotation
+// nobody agreed to.
+//
+// The other half is the same statement in reverse: a plan that names a draw on
+// every apply tells an operator nothing, so an ordinary apply beside a
+// generator whose binding is stable must show no draw at all.
+
+// generatorUpdatesWithOperation returns the projected generator updates
+// carrying one operation, so an assertion can name the operation it is about
+// rather than counting a mixed list.
+func generatorUpdatesWithOperation(updates []apimodel.GeneratorUpdate, operation string) []apimodel.GeneratorUpdate {
+	var matching []apimodel.GeneratorUpdate
+	for _, gu := range updates {
+		if gu.Operation == operation {
+			matching = append(matching, gu)
+		}
+	}
+	return matching
+}
+
+// A generator whose spec nobody edited still draws when a destination is added
+// to it, and the simulate has to say so. Nothing about the generator's own row
+// is changing here, so the declared generator diff is empty and the draw is the
+// only generator work in the command.
+func TestApplyForma_Simulate_ShowsAnImpendingDraw(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := func(resources ...pkgmodel.Resource) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:     []pkgmodel.Stack{{Label: stack}},
+				Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+				Resources:  resources,
+			}
+		}
+		alpha := genBoundSecret(stack, "alpha", "db-password", "value")
+		beta := genBoundSecret(stack, "beta", "db-password", "value")
+
+		_, err = m.ApplyForma(forma(alpha),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		res, err := m.ApplyForma(forma(alpha, beta),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: true},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+		require.True(t, res.Simulation.ChangesRequired)
+
+		draws := generatorUpdatesWithOperation(res.Simulation.Command.GeneratorUpdates, "draw")
+		require.Len(t, draws, 1, "the draw the apply will make must appear in the plan")
+		assert.Equal(t, "db-password", draws[0].GeneratorLabel)
+		assert.Equal(t, "password", draws[0].GeneratorType)
+		assert.Equal(t, stack, draws[0].StackLabel)
+		assert.Empty(t, generatorUpdatesWithOperation(res.Simulation.Command.GeneratorUpdates, "update"),
+			"nothing about the generator's declared spec is changing")
+	})
+}
+
+// A generator can be edited and draw in the same command: its spec moves and a
+// destination is added beside it. The two are separate pieces of work with
+// separate consequences — one rewrites the generator's row, the other rotates
+// the credential every destination holds — so the plan carries them as two
+// entries, each naming its own operation.
+func TestApplyForma_Simulate_ShowsADeclaredGeneratorChangeAndItsDrawSeparately(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := func(length int, resources ...pkgmodel.Resource) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:  []pkgmodel.Stack{{Label: stack}},
+				Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+					Label: "db-password", Stack: stack,
+					Length: length, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+				})},
+				Resources: resources,
+			}
+		}
+		alpha := genBoundSecret(stack, "alpha", "db-password", "value")
+		beta := genBoundSecret(stack, "beta", "db-password", "value")
+
+		_, err = m.ApplyForma(forma(24, alpha),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		res, err := m.ApplyForma(forma(32, alpha, beta),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: true},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+		require.True(t, res.Simulation.ChangesRequired)
+
+		updates := generatorUpdatesWithOperation(res.Simulation.Command.GeneratorUpdates, "update")
+		require.Len(t, updates, 1, "the edited generator's own row change must appear in the plan")
+		assert.Equal(t, "db-password", updates[0].GeneratorLabel)
+		assert.Equal(t, stack, updates[0].StackLabel)
+		assert.NotEmpty(t, updates[0].GeneratorConfig, "an edited generator's plan entry carries its diff")
+		assert.NotEmpty(t, updates[0].OldGeneratorConfig, "an edited generator's plan entry carries its diff")
+
+		draws := generatorUpdatesWithOperation(res.Simulation.Command.GeneratorUpdates, "draw")
+		require.Len(t, draws, 1, "the draw is work of its own and must not be folded into the row change")
+		assert.Equal(t, "db-password", draws[0].GeneratorLabel)
+		assert.Equal(t, "password", draws[0].GeneratorType)
+		assert.Equal(t, stack, draws[0].StackLabel)
+
+		// The desired spec projected beside the draw belongs to a generator
+		// carrying its KSUID, so this is where a marshalled config could put
+		// identity into the plan. It must not: a generator is named to a
+		// reader by label, type and stack.
+		identity, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, identity.ID)
+		require.NotEmpty(t, identity.GenerationID)
+
+		projectedGenerators, err := json.Marshal(res.Simulation.Command.GeneratorUpdates)
+		require.NoError(t, err)
+		assert.NotContains(t, string(projectedGenerators), identity.ID,
+			"a generator's KSUID must not reach the plan through a marshalled config")
+		assert.NotContains(t, string(projectedGenerators), identity.GenerationID,
+			"the generation a generator holds must not reach the plan through a marshalled config")
+	})
+}
+
+// An apply that touches a field beside a generator binding draws nothing: the
+// binding is stable and the credential stands still. The plan must say that by
+// showing no draw, or an operator reading it can never tell a rotation from an
+// ordinary edit.
+func TestApplyForma_Simulate_ShowsNoDrawWhenTheBindingIsStable(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := func(alphaDescription string) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:     []pkgmodel.Stack{{Label: stack}},
+				Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+				Resources: []pkgmodel.Resource{
+					describedGenBoundSecret(stack, "alpha", "db-password", alphaDescription),
+					describedGenBoundSecret(stack, "beta", "db-password", "beta"),
+				},
+			}
+		}
+
+		_, err = m.ApplyForma(forma("before"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		res, err := m.ApplyForma(forma("after"),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: true},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+
+		require.True(t, res.Simulation.ChangesRequired, "the edited destination is real work")
+		require.NotEmpty(t, res.Simulation.Command.ResourceUpdates, "the edited destination is real work")
+		assert.Empty(t, generatorUpdatesWithOperation(res.Simulation.Command.GeneratorUpdates, "draw"),
+			"an edit beside a stable binding rotates nothing, and the plan must not say it does")
+	})
+}
+
+// The plan carries what a person needs to decide and no generator material:
+// no credential in the response at all, and no generator identity in the
+// generator entries, which describe the work by the generator's label, type
+// and stack — the names a forma author writes — and never by its KSUID.
+//
+// No value has been drawn when a simulate is built, so the value assertion
+// holds structurally rather than by filtering; the credential its destinations
+// already hold is real and in the datastore while this simulate is built, and
+// that is what it is checked against. The identity assertion is scoped to the
+// generator entries because a translated $gen envelope carries the generator
+// KSUID in the bound resource's own properties, which is the resource
+// projection's shape and not this one's.
+func TestApplyForma_Simulate_DrawProjectionCarriesNoGeneratorMaterial(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := func(resources ...pkgmodel.Resource) *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:     []pkgmodel.Stack{{Label: stack}},
+				Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+				Resources:  resources,
+			}
+		}
+		alpha := genBoundSecret(stack, "alpha", "db-password", "value")
+		beta := genBoundSecret(stack, "beta", "db-password", "value")
+
+		_, err = m.ApplyForma(forma(alpha),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		alphaCreates := delivered.createdWith("alpha")
+		require.Len(t, alphaCreates, 1)
+		liveValue := alphaCreates[0]
+		require.NotEmpty(t, liveValue)
+
+		identity, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, identity.ID)
+		require.NotEmpty(t, identity.GenerationID)
+
+		res, err := m.ApplyForma(forma(alpha, beta),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: true},
+			"test-client-id", "", "")
+		require.NoError(t, err)
+		require.Len(t, generatorUpdatesWithOperation(res.Simulation.Command.GeneratorUpdates, "draw"), 1)
+
+		projected, err := json.Marshal(res)
+		require.NoError(t, err)
+		assert.NotContains(t, string(projected), liveValue,
+			"a plan must never carry the credential its destinations hold")
+
+		projectedGenerators, err := json.Marshal(res.Simulation.Command.GeneratorUpdates)
+		require.NoError(t, err)
+		assert.NotContains(t, string(projectedGenerators), identity.ID,
+			"a generator's KSUID is controller state and never names it in the plan")
+		assert.NotContains(t, string(projectedGenerators), identity.GenerationID,
+			"the generation a generator holds is controller state and never reaches the plan")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/generator_moved_generation_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_moved_generation_test.go
@@ -1,0 +1,209 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/provenance"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// What a destination is planned against is the generation its generator holds
+// now, compared with the generation the destination was last written under. A
+// generator whose generation has moved on owes its destinations a value; one
+// whose generation still matches owes nothing, and pulling its destinations in
+// would rotate a live credential nobody asked to rotate.
+//
+// Two generators are what makes this a gate rather than an observation. With a
+// single generator the same run passes against a build that plans every $gen
+// destination it can see, and against one that plans on the generation
+// comparison; the two are only told apart by a second generator in the same
+// forma, bound to a second destination, whose generation did not move. The two
+// halves are equally load-bearing: the planned destination alone would also be
+// satisfied by planning everything, and the suppressed one alone would also be
+// satisfied by planning nothing.
+//
+// The generation is advanced directly on the generator's row rather than by
+// editing its spec. A spec edit moves two things at once (the declared spec
+// and, through it, the acceptability of the held generation), so a build that
+// planned off the spec diff and never read the generation would pass. Moving
+// only the generation leaves the declared spec byte-identical, so the
+// comparison against what the destination holds is the only thing left that
+// can decide it.
+func TestApplyForma_MovedGeneration_PlansOnlyItsOwnDestinations(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		logCapture := test_helpers.SetupTestLogger()
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		generator := func(label string) json.RawMessage {
+			return rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+				Label: label, Stack: stack,
+				Length: 24, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+			})
+		}
+		buildForma := func() *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:     []pkgmodel.Stack{{Label: stack}},
+				Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{generator("moved-password"), generator("steady-password")},
+				Resources: []pkgmodel.Resource{
+					genBoundSecret(stack, "alpha", "moved-password", "value"),
+					genBoundSecret(stack, "beta", "steady-password", "value"),
+				},
+			}
+		}
+
+		_, err = m.ApplyForma(buildForma(),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		movedBefore, err := m.Datastore.GetGeneratorIdentity("moved-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, movedBefore.GenerationID, "precondition: each generator must have drawn")
+		steadyBefore, err := m.Datastore.GetGeneratorIdentity("steady-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, steadyBefore.GenerationID)
+
+		alphaFirst := delivered.createdWith("alpha")
+		betaFirst := delivered.createdWith("beta")
+		require.Len(t, alphaFirst, 1, "precondition: alpha must be created with its generator's draw")
+		require.Len(t, betaFirst, 1, "precondition: beta must be created with its generator's draw")
+		require.NotEqual(t, alphaFirst[0], betaFirst[0],
+			"precondition: two generators draw two values")
+		betaBinding := storedBinding(t, m, stack, "beta")
+		require.True(t, betaBinding.Get("$hashed").Bool())
+		betaDigestBefore := betaBinding.Get("$value").String()
+		betaResolvedBefore := betaBinding.Get("$resolvedFrom").String()
+		require.Equal(t, provenance.DigestOfString(steadyBefore.GenerationID), betaResolvedBefore)
+
+		// One generator's generation moves on. Its declared spec is untouched,
+		// and the other generator is not touched at all.
+		movedGenerationID := util.NewID()
+		require.NoError(t, m.Datastore.AdvanceGeneration(
+			movedBefore.ID, movedGenerationID, movedBefore.GenerationSpec))
+		steadyUnmoved, err := m.Datastore.GetGeneratorIdentity("steady-password", stack)
+		require.NoError(t, err)
+		require.Equal(t, steadyBefore.GenerationID, steadyUnmoved.GenerationID,
+			"precondition: advancing one generator must not move the other")
+
+		sim, err := m.ApplyForma(buildForma(), &config.FormaCommandConfig{
+			Mode:     pkgmodel.FormaApplyModeReconcile,
+			Simulate: true,
+		}, "test-client-id", "", "")
+		require.NoError(t, err)
+		require.True(t, sim.Simulation.ChangesRequired,
+			"a destination holding a superseded generation must be planned")
+		plannedLabels := map[string]bool{}
+		for _, ru := range sim.Simulation.Command.ResourceUpdates {
+			plannedLabels[ru.ResourceLabel] = true
+		}
+		assert.True(t, plannedLabels["alpha"],
+			"the destination of the generator whose generation moved must be planned, got %v", plannedLabels)
+		assert.False(t, plannedLabels["beta"],
+			"the destination of the generator whose generation stood still must not be planned, got %v", plannedLabels)
+
+		// The response is presentation data: neither destination's value nor
+		// its at-rest digest may appear in it.
+		simJSON, err := json.Marshal(sim)
+		require.NoError(t, err)
+		for _, value := range []string{alphaFirst[0], betaFirst[0]} {
+			assert.NotContains(t, string(simJSON), value,
+				"the simulate response must never carry a drawn value")
+			assert.NotContains(t, string(simJSON), pkgmodel.ComputeValueHash(value),
+				"digests live at rest, never in a response")
+		}
+
+		// Applying it carries the plan through: alpha is rewritten under a
+		// freshly drawn value, beta is left exactly as it was.
+		_, err = m.ApplyForma(buildForma(),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		require.Len(t, cmds, 2, "the second apply must produce exactly one further command")
+		var second *forma_command.FormaCommand
+		for _, c := range cmds {
+			require.Equal(t, forma_command.CommandStateSuccess, c.State)
+			if second == nil || c.StartTs.After(second.StartTs) {
+				second = c
+			}
+		}
+		require.NotNil(t, second)
+
+		alphaUpdates := delivered.updatedWith("alpha")
+		require.Len(t, alphaUpdates, 1, "the planned destination must be written")
+		assert.Len(t, alphaUpdates[0], 24)
+		assert.NotEqual(t, alphaFirst[0], alphaUpdates[0],
+			"the planned destination must move to a freshly drawn value")
+		assert.Empty(t, delivered.updatedWith("beta"),
+			"a generator whose generation stood still must not have its destination written")
+
+		movedAfter, err := m.Datastore.GetGeneratorIdentity("moved-password", stack)
+		require.NoError(t, err)
+		assert.NotEqual(t, movedGenerationID, movedAfter.GenerationID,
+			"writing the destination draws its own generation")
+		steadyAfter, err := m.Datastore.GetGeneratorIdentity("steady-password", stack)
+		require.NoError(t, err)
+		assert.Equal(t, steadyBefore.GenerationID, steadyAfter.GenerationID,
+			"the untouched generator must not draw")
+
+		alphaBinding := storedBinding(t, m, stack, "alpha")
+		assert.True(t, alphaBinding.Get("$hashed").Bool(),
+			"the rewritten destination must store a digest")
+		assert.Equal(t, pkgmodel.ComputeValueHash(alphaUpdates[0]), alphaBinding.Get("$value").String(),
+			"the stored digest must be the digest of the value the provider received")
+		assert.Equal(t, provenance.DigestOfString(movedAfter.GenerationID),
+			alphaBinding.Get("$resolvedFrom").String(),
+			"the rewritten destination must be stamped with the generation it was drawn from")
+
+		betaAfter := storedBinding(t, m, stack, "beta")
+		assert.Equal(t, betaDigestBefore, betaAfter.Get("$value").String(),
+			"the untouched destination must keep the credential it held")
+		assert.Equal(t, betaResolvedBefore, betaAfter.Get("$resolvedFrom").String(),
+			"the untouched destination must keep the generation it was drawn from")
+
+		resources, err := m.Datastore.LoadResourcesByStack(stack)
+		require.NoError(t, err)
+		require.Len(t, resources, 2)
+		for i := range resources {
+			for _, value := range []string{alphaFirst[0], alphaUpdates[0], betaFirst[0]} {
+				assert.NotContains(t, string(resources[i].Properties), value,
+					"resources.properties leaked a drawn value for %s", resources[i].Label)
+			}
+		}
+
+		for _, cmd := range cmds {
+			for _, value := range []string{alphaFirst[0], alphaUpdates[0], betaFirst[0]} {
+				assertNoPlaintextInResourceUpdates(t, m, cmd.ID, value)
+			}
+			assertProvenanceCarriersAreWellFormed(t, m, cmd.ID)
+		}
+		for _, value := range []string{alphaFirst[0], alphaUpdates[0], betaFirst[0]} {
+			assertNoPlaintextInLogs(t, logCapture, value)
+		}
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/generator_reference_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_reference_test.go
@@ -141,9 +141,13 @@ func TestApplyForma_GeneratorBoundSecret_UndrawnValueIsNeverWritten(t *testing.T
 
 // A generator declared by one command and referenced by a later one resolves
 // to the KSUID the generator's own row already carries: the binding names one
-// identity, not a freshly minted one per command. This pins identity
-// stability only; nothing here says anything about whether a moved generation
-// is suppressed, which needs a drawn value to be observable at all.
+// identity, not a freshly minted one per command.
+//
+// The second command's translation is observed through what it plans. A
+// binding translated to a freshly minted KSUID would name a different source
+// than the stored envelope does, which is a repoint and always plans; that
+// the identical second command plans nothing for the bound secret is
+// therefore the identity holding across commands.
 func TestApplyForma_GeneratorBoundSecret_BindingNamesTheGeneratorsOwnIdentity(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		cfg := test_helpers.NewTestMetastructureConfig()
@@ -162,9 +166,8 @@ func TestApplyForma_GeneratorBoundSecret_BindingNamesTheGeneratorsOwnIdentity(t 
 			}
 		}
 
-		// The first command establishes the generator's row. Its resource
-		// write is refused (no value has been drawn), which is beside the
-		// point here: the generator is persisted either way.
+		// The first command establishes the generator's row and writes the
+		// bound secret with the value drawn for it.
 		_, err = m.ApplyForma(buildForma(), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
@@ -173,22 +176,29 @@ func TestApplyForma_GeneratorBoundSecret_BindingNamesTheGeneratorsOwnIdentity(t 
 		require.NoError(t, err)
 		require.NotEmpty(t, identity.ID, "precondition: the declared generator must have a row")
 
+		resources, err := m.Datastore.LoadResourcesByStack(stack)
+		require.NoError(t, err)
+		var secretRow *pkgmodel.Resource
+		for i := range resources {
+			if resources[i].Label == "db" {
+				secretRow = resources[i]
+			}
+		}
+		require.NotNil(t, secretRow, "precondition: the bound secret must be written")
+		assert.Equal(t, identity.ID,
+			gjson.GetBytes(secretRow.Properties, "SecretString.$generator").String(),
+			"the binding must name the generator's own KSUID, not one minted for this command")
+
 		resp, err := m.ApplyForma(buildForma(), &config.FormaCommandConfig{
 			Mode:     pkgmodel.FormaApplyModeReconcile,
 			Simulate: true,
 		}, "test-client-id", "", "")
 		require.NoError(t, err)
 
-		var secretUpdate *apimodel.ResourceUpdate
-		for i, ru := range resp.Simulation.Command.ResourceUpdates {
-			if ru.ResourceLabel == "db" {
-				secretUpdate = &resp.Simulation.Command.ResourceUpdates[i]
-			}
+		for _, ru := range resp.Simulation.Command.ResourceUpdates {
+			assert.NotEqual(t, "db", ru.ResourceLabel,
+				"a second command that named a fresh KSUID would repoint the binding and plan it")
 		}
-		require.NotNil(t, secretUpdate, "the bound secret must be in the plan")
-		assert.Equal(t, identity.ID,
-			gjson.GetBytes(secretUpdate.Properties, "SecretString.$generator").String(),
-			"the binding must name the generator's own KSUID, not one minted for this command")
 
 		identityAfter, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
 		require.NoError(t, err)

--- a/internal/workflow_tests/local/apply_forma/generator_reference_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_reference_test.go
@@ -9,6 +9,7 @@ package workflow_tests_local
 import (
 	"encoding/json"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -18,6 +19,7 @@ import (
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/provenance"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
@@ -85,23 +87,20 @@ func findResourceUpdate(updates []resource_update.ResourceUpdate, label string) 
 	return nil
 }
 
-// A property bound to a generator holds a reference to a value, never the
-// value itself. Until that value has been drawn there is nothing to write, so
-// the apply fails at the plugin boundary and the provider is never called:
-// formae refuses to put the reference into the cloud object in the value's
-// place. This is a property of the write path, not of the current state of
-// generator support — a draw that fails must leave the destination unwritten
-// for the same reason.
-func TestApplyForma_GeneratorBoundSecret_UndrawnValueIsNeverWritten(t *testing.T) {
+// A property bound to a generator holds a reference to a value, and the apply
+// that writes it is what turns the reference into one. The generator draws
+// before its destination dispatches, the provider is handed the drawn
+// credential itself, and what lands at rest is a digest of that credential
+// under the generation it came from — never the credential and never the
+// envelope naming it.
+func TestApplyForma_GeneratorBoundSecret_DrawnValueIsWrittenAndStoredHashed(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
-		var secretCreates atomic.Int32
-		overrides := countingCreates(map[string]*atomic.Int32{
-			"FakeAWS::SecretsManager::Secret": &secretCreates,
-		})
+		logCapture := test_helpers.SetupTestLogger()
+		captured := newCapturedCreates("SecretString", "Name")
 
 		cfg := test_helpers.NewTestMetastructureConfig()
 		cfg.Agent.Synchronization.Enabled = false
-		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, captured.overrides(), cfg)
 		defer def()
 		require.NoError(t, err)
 
@@ -114,28 +113,57 @@ func TestApplyForma_GeneratorBoundSecret_UndrawnValueIsNeverWritten(t *testing.T
 		}
 
 		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
-		require.NoError(t, err, "the forma is well-formed, so it is admitted and fails at execution")
+		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
 		cmds, err := m.Datastore.LoadFormaCommands()
 		require.NoError(t, err)
 		cmd := findCommandByType(cmds, pkgmodel.CommandApply)
 		require.NotNil(t, cmd)
-		assert.Equal(t, forma_command.CommandStateFailed, cmd.State,
-			"an undrawn generator binding must not be reported as applied")
+		assert.Equal(t, forma_command.CommandStateSuccess, cmd.State,
+			"a generator that draws lets its destination be written")
 
 		secretUpdate := findResourceUpdate(cmd.ResourceUpdates, "db")
-		require.NotNil(t, secretUpdate, "the bound secret must be planned and then refused")
-		assert.Equal(t, resource_update.ResourceUpdateStateFailed, secretUpdate.State)
-		assert.Contains(t, secretUpdate.FailureReason, "bound to a generator whose value has not been drawn",
-			"the refusal must say what is wrong with the resource, not just that a request could not be built")
+		require.NotNil(t, secretUpdate, "the bound secret must be planned and written")
+		assert.Equal(t, resource_update.ResourceUpdateStateSuccess, secretUpdate.State)
+		assert.Empty(t, secretUpdate.FailureReason)
 
-		assert.Zero(t, secretCreates.Load(),
-			"the provider must never be called with a value formae does not have")
+		// Delivery: the provider is handed the credential, at the length the
+		// spec declares, rather than the envelope that names it.
+		drawn, ok := captured.valueFor("db")
+		require.True(t, ok, "the provider must have been called for the bound secret")
+		assert.Len(t, drawn, 24, "the provider receives the drawn value, at its declared length")
+		assert.NotContains(t, drawn, "$gen",
+			"the provider must receive the drawn value, never the envelope naming it")
+
+		// At rest: a digest of the credential, marked a digest, stamped with
+		// the generation it was drawn from.
+		identity, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, identity.GenerationID, "a delivered draw must leave its generation recorded")
 
 		resources, err := m.Datastore.LoadResourcesByStack(stack)
 		require.NoError(t, err)
-		assert.Empty(t, resources, "a refused write must leave no resource behind")
+		require.Len(t, resources, 1, "the destination must be written")
+		for i := range resources {
+			assert.NotContains(t, string(resources[i].Properties), drawn,
+				"resources.properties leaked the drawn value for %s", resources[i].Label)
+		}
+		binding := storedBinding(t, m, stack, "db")
+		assert.True(t, binding.Get("$hashed").Bool(),
+			"the drawn value must be stored as a digest")
+		assert.Equal(t, pkgmodel.ComputeValueHash(drawn), binding.Get("$value").String(),
+			"the stored digest must be the digest of the value the provider received")
+		resolvedFrom := binding.Get("$resolvedFrom").String()
+		assert.True(t, provenance.Valid(resolvedFrom),
+			"the drawn destination must carry a current-domain provenance digest, got %q", resolvedFrom)
+		assert.Equal(t, provenance.DigestOfString(identity.GenerationID), resolvedFrom,
+			"the destination must be stamped with the generation its value was drawn from")
+
+		// The value exists in the cloud object and in nothing formae stored.
+		assertDrawnValueIsNotStored(t, m, cmd.ID, drawn, "db-password", stack)
+		assertProvenanceCarriersAreWellFormed(t, m, cmd.ID)
+		assertNoPlaintextInLogs(t, logCapture, drawn)
 	})
 }
 
@@ -292,40 +320,96 @@ func TestApplyForma_GeneratorReference_DanglingIsRejected(t *testing.T) {
 	})
 }
 
+// capturedChainCreates records what each of the two resource types in a
+// generator-fed reference chain was created with: the secret's own bound
+// property and the consumer's referencing one. The consumer answers its own
+// create so it carries a NativeID of its own; the secret falls through to
+// FakeAWS, whose SecretsManager handling reads the value back bare.
+type capturedChainCreates struct {
+	mu       sync.Mutex
+	secret   string
+	consumer string
+	seen     map[string]int
+}
+
+func newCapturedChainCreates() *capturedChainCreates {
+	return &capturedChainCreates{seen: map[string]int{}}
+}
+
+func (c *capturedChainCreates) overrides() *plugin.ResourcePluginOverrides {
+	return &plugin.ResourcePluginOverrides{
+		Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+			props := gjson.ParseBytes(req.Properties)
+			c.mu.Lock()
+			c.seen[req.ResourceType]++
+			if req.ResourceType == "FakeAWS::S3::Bucket" {
+				c.consumer = props.Get("DbPassword").String()
+			} else {
+				c.secret = props.Get("SecretString").String()
+			}
+			c.mu.Unlock()
+			if req.ResourceType != "FakeAWS::S3::Bucket" {
+				return nil, nil
+			}
+			return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+				Operation:       resource.OperationCreate,
+				OperationStatus: resource.OperationStatusSuccess,
+				NativeID:        "bucket-native-1",
+			}}, nil
+		},
+	}
+}
+
+func (c *capturedChainCreates) values() (string, string, map[string]int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	seen := map[string]int{}
+	for k, v := range c.seen {
+		seen[k] = v
+	}
+	return c.secret, c.consumer, seen
+}
+
 // A $ref consumer reading a generator-fed secret is planned as a chain: the
 // consumer's reference resolves to the secret's property, and the secret's own
-// property is the generator binding. Nothing in that chain is writable until
-// the value has been drawn, so the whole command is refused at the plugin
-// boundary — the consumer is not written from a source that was itself never
-// written, and neither provider is called.
-func TestApplyForma_ConsumerDownstreamOfGeneratorFedSecret_IsRejectedBeforeAnyWrite(t *testing.T) {
+// property is the generator binding. The draw at the root of that chain is
+// what makes the whole of it writable — the secret is written with the drawn
+// credential and the consumer is written with the same one, resolved from the
+// source that has just received it.
+//
+// The chain is a second place the credential could escape, so every sink is
+// swept for it: the two rows, the command's resource updates, the simulate
+// response, and the captured log output.
+func TestApplyForma_ConsumerDownstreamOfGeneratorFedSecret_ReceivesTheDrawnValue(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
-		var secretCreates, consumerCreates atomic.Int32
-		overrides := countingCreates(map[string]*atomic.Int32{
-			"FakeAWS::SecretsManager::Secret": &secretCreates,
-			"FakeAWS::S3::Bucket":             &consumerCreates,
-		})
+		logCapture := test_helpers.SetupTestLogger()
+		captured := newCapturedChainCreates()
 
 		cfg := test_helpers.NewTestMetastructureConfig()
 		cfg.Agent.Synchronization.Enabled = false
-		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, captured.overrides(), cfg)
 		defer def()
 		require.NoError(t, err)
 
 		stack := "test-stack-" + util.NewID()
-		forma := &pkgmodel.Forma{
-			Stacks:     []pkgmodel.Stack{{Label: stack}},
-			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
-			Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
-			Resources: []pkgmodel.Resource{
-				genBoundSecret(stack, "my-secret", "db-password", "value"),
-				secretConsumer(stack, "my-secret"),
-			},
+		// A forma is translated in place, so each submission gets its own:
+		// re-submitting the document a previous command rewrote would name
+		// identities that command minted rather than the ones this one does.
+		buildForma := func() *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:     []pkgmodel.Stack{{Label: stack}},
+				Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+				Resources: []pkgmodel.Resource{
+					genBoundSecret(stack, "my-secret", "db-password", "value"),
+					secretConsumer(stack, "my-secret"),
+				},
+			}
 		}
 
 		// The plan carries the whole chain: the secret's generator binding and
 		// the consumer's reference to that secret's property.
-		sim, err := m.ApplyForma(forma, &config.FormaCommandConfig{
+		sim, err := m.ApplyForma(buildForma(), &config.FormaCommandConfig{
 			Mode:     pkgmodel.FormaApplyModeReconcile,
 			Simulate: true,
 		}, "test-client-id", "", "")
@@ -345,7 +429,7 @@ func TestApplyForma_ConsumerDownstreamOfGeneratorFedSecret_IsRejectedBeforeAnyWr
 			strings.HasSuffix(consumerRef, "#/SecretString"),
 			"the consumer must reference the generator-fed secret's property, got %q", consumerRef)
 
-		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		_, err = m.ApplyForma(buildForma(), &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
 		require.NoError(t, err)
 		waitForApplyComplete(t, m)
 
@@ -353,16 +437,67 @@ func TestApplyForma_ConsumerDownstreamOfGeneratorFedSecret_IsRejectedBeforeAnyWr
 		require.NoError(t, err)
 		cmd := findCommandByType(cmds, pkgmodel.CommandApply)
 		require.NotNil(t, cmd)
-		assert.Equal(t, forma_command.CommandStateFailed, cmd.State,
-			"a chain rooted in an undrawn generator must not be reported as applied")
+		assert.Equal(t, forma_command.CommandStateSuccess, cmd.State,
+			"a chain rooted in a generator that draws must apply")
+		for _, label := range []string{"my-secret", "my-bucket"} {
+			ru := findResourceUpdate(cmd.ResourceUpdates, label)
+			require.NotNil(t, ru, "%s must be in the command", label)
+			assert.Equal(t, resource_update.ResourceUpdateStateSuccess, ru.State, "%s must be written", label)
+		}
 
-		assert.Zero(t, secretCreates.Load(), "the source secret must never be written")
-		assert.Zero(t, consumerCreates.Load(),
-			"the consumer must never be written from a source that was itself refused")
+		secretValue, consumerValue, seen := captured.values()
+		assert.Equal(t, map[string]int{
+			"FakeAWS::SecretsManager::Secret": 1,
+			"FakeAWS::S3::Bucket":             1,
+		}, seen, "both ends of the chain must be created exactly once")
+		require.Len(t, secretValue, 24, "the source must be written with the drawn value")
+		assert.Equal(t, secretValue, consumerValue,
+			"the consumer must receive the value its source was just given")
+		assert.NotContains(t, consumerValue, "$ref",
+			"the consumer must receive a value, never the reference naming it")
+
+		// Both rows hold digests and provenance, never the credential.
+		identity, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, identity.GenerationID)
 
 		resources, err := m.Datastore.LoadResourcesByStack(stack)
 		require.NoError(t, err)
-		assert.Empty(t, resources, "a refused chain must leave nothing behind")
+		require.Len(t, resources, 2, "both ends of the chain must be written")
+		var consumerRow *pkgmodel.Resource
+		for i := range resources {
+			assert.NotContains(t, string(resources[i].Properties), secretValue,
+				"resources.properties leaked the drawn value for %s", resources[i].Label)
+			if resources[i].Label == "my-bucket" {
+				consumerRow = resources[i]
+			}
+		}
+		require.NotNil(t, consumerRow)
+
+		sourceBinding := storedBinding(t, m, stack, "my-secret")
+		assert.True(t, sourceBinding.Get("$hashed").Bool(), "the source must store a digest")
+		assert.Equal(t, pkgmodel.ComputeValueHash(secretValue), sourceBinding.Get("$value").String(),
+			"the source's stored digest must be the digest of the drawn value")
+		assert.Equal(t, provenance.DigestOfString(identity.GenerationID),
+			sourceBinding.Get("$resolvedFrom").String(),
+			"the source must be stamped with the generation its value was drawn from")
+
+		consumerResolvedFrom := gjson.GetBytes(consumerRow.Properties, "DbPassword.$resolvedFrom").String()
+		assert.True(t, provenance.Valid(consumerResolvedFrom),
+			"the consumer must carry a current-domain provenance digest, got %q", consumerResolvedFrom)
+
+		// The simulate response is presentation data: neither the credential
+		// nor its at-rest digest may appear in it.
+		simJSON, err := json.Marshal(sim)
+		require.NoError(t, err)
+		assert.NotContains(t, string(simJSON), secretValue,
+			"the simulate response must never carry the drawn value")
+		assert.NotContains(t, string(simJSON), pkgmodel.ComputeValueHash(secretValue),
+			"digests live at rest, never in a response")
+
+		assertDrawnValueIsNotStored(t, m, cmd.ID, secretValue, "db-password", stack)
+		assertProvenanceCarriersAreWellFormed(t, m, cmd.ID)
+		assertNoPlaintextInLogs(t, logCapture, secretValue)
 	})
 }
 

--- a/internal/workflow_tests/local/apply_forma/generator_resume_redraw_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_resume_redraw_test.go
@@ -1,0 +1,263 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// recordedCreates keeps EVERY value a destination was dispatched with, in
+// order, rather than only the last, so a test can tell one draw from another
+// across a restart.
+type recordedCreates struct {
+	mu      sync.Mutex
+	byLabel map[string][]string
+}
+
+func newRecordedCreates() *recordedCreates {
+	return &recordedCreates{byLabel: map[string][]string{}}
+}
+
+func (r *recordedCreates) record(properties json.RawMessage) {
+	props := gjson.ParseBytes(properties)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	label := props.Get("Name").String()
+	r.byLabel[label] = append(r.byLabel[label], props.Get("SecretString").String())
+}
+
+func (r *recordedCreates) valuesFor(label string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.byLabel[label]...)
+}
+
+// gatedGenBoundSecret is a generator-bound secret that also carries a plain
+// $res reference to another resource, which puts it downstream of that
+// resource in the changeset. Holding the upstream open is how this test parks
+// a destination before it is ever dispatched.
+func gatedGenBoundSecret(stack, label, generatorLabel, gateLabel string) pkgmodel.Resource {
+	res := genBoundSecret(stack, label, generatorLabel, "value")
+	res.Properties = json.RawMessage(`{
+		"Name": "` + label + `",
+		"Description": {
+			"$res":      true,
+			"$label":    "` + gateLabel + `",
+			"$type":     "FakeAWS::SecretsManager::Secret",
+			"$stack":    "` + stack + `",
+			"$property": "Name"
+		},
+		"SecretString": {
+			"$gen":        true,
+			"$label":      "` + generatorLabel + `",
+			"$stack":      "` + stack + `",
+			"$output":     "value",
+			"$visibility": "Opaque"
+		}
+	}`)
+	return res
+}
+
+// A command that is interrupted while it still owes destinations a value
+// redraws its generator on resume. The value the interrupted run drew was
+// never persisted and cannot be replayed, so the only correct resume is a
+// fresh draw for exactly what the command still owes: the destinations that
+// never dispatched are written with a value that is NOT the one the
+// interrupted run produced, they all receive the same one, a destination that
+// already finished is left alone, and neither generation survives in
+// plaintext.
+func TestApplyForma_GeneratorBoundSecret_ResumedCommandRedrawsForWhatItStillOwes(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		recorded := newRecordedCreates()
+		const gateNativeID = "native-gate"
+		gateProperties := json.RawMessage(`{"Name":"gate","SecretString":"gate-literal"}`)
+
+		// Before the interruption "settled" completes outright while "gate"
+		// reports in progress and is polled forever, which parks the two
+		// destinations downstream of it before they are ever dispatched. Each
+		// resource answers its own create rather than falling through to
+		// FakeAWS, because the stalling Status below cannot tell one resource
+		// from another.
+		stalling := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				recorded.record(req.Properties)
+				if gjson.ParseBytes(req.Properties).Get("Name").String() == "settled" {
+					return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationCreate,
+						OperationStatus: resource.OperationStatusSuccess,
+						NativeID:        "native-settled",
+					}}, nil
+				}
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationCreate,
+					OperationStatus: resource.OperationStatusInProgress,
+				}}, nil
+			},
+			Status: func(_ *resource.StatusRequest) (*resource.StatusResult, error) {
+				return &resource.StatusResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationCreate,
+					OperationStatus: resource.OperationStatusInProgress,
+				}}, nil
+			},
+		}
+		// After the restart the gate's in-flight create reports done — a
+		// create already dispatched is resumed by polling, never re-issued —
+		// and the destinations behind it are dispatched for the first time.
+		completing := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				recorded.record(req.Properties)
+				return nil, nil
+			},
+			Status: func(_ *resource.StatusRequest) (*resource.StatusResult, error) {
+				return &resource.StatusResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					NativeID:           gateNativeID,
+					ResourceProperties: gateProperties,
+				}}, nil
+			},
+			// The gate was never created through FakeAWS, so FakeAWS cannot
+			// read it back. The only read this node makes is the one that
+			// resolves the gate's Name for the destinations behind it.
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				return &resource.ReadResult{
+					ResourceType: req.ResourceType,
+					Properties:   string(gateProperties),
+				}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		cfg.Agent.Datastore.DatastoreType = pkgmodel.SqliteDatastore
+		// "no-reset" keeps the file alive across the node restart.
+		cfg.Agent.Datastore.Sqlite = pkgmodel.SqliteConfig{FilePath: t.TempDir() + "/no-reset-generator-resume.db"}
+
+		db, err := dssqlite.NewDatastoreSQLite(context.Background(), &cfg.Agent.Datastore, "test")
+		require.NoError(t, err)
+
+		m, stop, err := test_helpers.NewTestMetastructureWithEverything(t, stalling, db, cfg)
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		// The gate borrows the bound secret's type, schema and target but
+		// declares a literal: it is the thing the owed destinations wait on,
+		// not a destination itself.
+		gate := genBoundSecret(stack, "gate", "db-password", "value")
+		gate.Properties = gateProperties
+		forma := &pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: stack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+			Resources: []pkgmodel.Resource{
+				gate,
+				genBoundSecret(stack, "settled", "db-password", "value"),
+				gatedGenBoundSecret(stack, "owed-one", "db-password", "gate"),
+				gatedGenBoundSecret(stack, "owed-two", "db-password", "gate"),
+			},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+
+		// The interruption point has to be pinned down, not merely likely:
+		// "settled" recorded terminal, and the two destinations behind the
+		// gate not yet started. A resume that owed nothing, or that owed
+		// everything, would prove nothing about a redraw.
+		require.Eventually(t, func() bool {
+			cmds, loadErr := db.LoadFormaCommands()
+			if loadErr != nil || len(cmds) != 1 {
+				return false
+			}
+			settled := findResourceUpdate(cmds[0].ResourceUpdates, "settled")
+			owedOne := findResourceUpdate(cmds[0].ResourceUpdates, "owed-one")
+			owedTwo := findResourceUpdate(cmds[0].ResourceUpdates, "owed-two")
+			return settled != nil && settled.State == resource_update.ResourceUpdateStateSuccess &&
+				owedOne != nil && owedOne.State == resource_update.ResourceUpdateStateNotStarted &&
+				owedTwo != nil && owedTwo.State == resource_update.ResourceUpdateStateNotStarted
+		}, 15*time.Second, 50*time.Millisecond,
+			"the command should be parked with one destination written and two still owed")
+
+		settledValues := recorded.valuesFor("settled")
+		require.Len(t, settledValues, 1)
+		firstDraw := settledValues[0]
+		require.Len(t, firstDraw, 24, "the interrupted run must have drawn a value")
+		require.Empty(t, recorded.valuesFor("owed-one"), "the owed destinations must not have been dispatched yet")
+		require.Empty(t, recorded.valuesFor("owed-two"), "the owed destinations must not have been dispatched yet")
+
+		firstGeneration, err := db.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, firstGeneration.GenerationID, "the interrupted run's draw must have been recorded")
+
+		// Crash the node with the command still in flight.
+		stop()
+
+		db, err = dssqlite.NewDatastoreSQLite(context.Background(), &cfg.Agent.Datastore, "test")
+		require.NoError(t, err)
+		incomplete, err := db.LoadIncompleteFormaCommands()
+		require.NoError(t, err)
+		require.Len(t, incomplete, 1, "the command must still be incomplete after the crash")
+
+		m, def, err := test_helpers.NewTestMetastructureWithEverything(t, completing, db, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		waitForApplyComplete(t, m)
+
+		cmds, err := db.LoadFormaCommands()
+		require.NoError(t, err)
+		require.Len(t, cmds, 1)
+		cmd := cmds[0]
+		require.Equal(t, forma_command.CommandStateSuccess, cmd.State,
+			"the resumed command must be able to write the destinations it still owed")
+
+		owedOne := recorded.valuesFor("owed-one")
+		owedTwo := recorded.valuesFor("owed-two")
+		require.Len(t, owedOne, 1, "the resumed command must dispatch the destination it still owed")
+		require.Len(t, owedTwo, 1, "the resumed command must dispatch the destination it still owed")
+
+		secondDraw := owedOne[0]
+		assert.Len(t, secondDraw, 24, "the resumed command must draw a value at the generator's declared length")
+		assert.NotContains(t, secondDraw, "$gen",
+			"the provider must receive the drawn value, never the envelope naming it")
+		assert.NotEqual(t, firstDraw, secondDraw,
+			"the resumed command must redraw: the interrupted run's value was never persisted and cannot be replayed")
+		assert.Equal(t, secondDraw, owedTwo[0],
+			"every destination the command still owed must receive the same post-restart value")
+
+		assert.Len(t, recorded.valuesFor("settled"), 1,
+			"a destination that already reached a terminal state must not be written again")
+
+		secondGeneration, err := db.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		assert.NotEqual(t, firstGeneration.GenerationID, secondGeneration.GenerationID,
+			"the redraw must record its own generation")
+
+		// Neither generation may survive anywhere durable.
+		assertNoPlaintextInResourceUpdates(t, m, cmd.ID, firstDraw)
+		assertNoPlaintextInResourceUpdates(t, m, cmd.ID, secondDraw)
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/generator_resume_redraw_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_resume_redraw_test.go
@@ -9,6 +9,7 @@ package workflow_tests_local
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
+	"github.com/platform-engineering-labs/formae/internal/datastore"
 	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
@@ -259,5 +261,125 @@ func TestApplyForma_GeneratorBoundSecret_ResumedCommandRedrawsForWhatItStillOwes
 		// Neither generation may survive anywhere durable.
 		assertNoPlaintextInResourceUpdates(t, m, cmd.ID, firstDraw)
 		assertNoPlaintextInResourceUpdates(t, m, cmd.ID, secondDraw)
+	})
+}
+
+// stalledGenerationDatastore holds a draw open at the exact point the
+// generation would become durable. A command interrupted there has its
+// generator's row created and no generation recorded at all, which is the
+// state a generator that has never once drawn is left in.
+type stalledGenerationDatastore struct {
+	datastore.Datastore
+	reached chan struct{}
+	once    sync.Once
+}
+
+func (d *stalledGenerationDatastore) AdvanceGeneration(_, _ string, _ json.RawMessage) error {
+	d.once.Do(func() { close(d.reached) })
+	// The node is force-stopped while this call is outstanding, after its
+	// datastore has been closed, so nothing this returns can reach a row. The
+	// wait is bounded only so the goroutine cannot outlive the test.
+	<-time.After(5 * time.Second)
+	return fmt.Errorf("the draw was interrupted before its generation was recorded")
+}
+
+// A generator belongs to one stack and is meant to be referenced from others.
+// When a command that binds a destination in one stack to a generator in
+// another is interrupted before the generator has ever drawn, the resume must
+// still reach that generator: the destination it still owes gets a freshly
+// drawn value and the command completes, rather than dispatching the envelope
+// naming the generator and being refused at the provider boundary.
+func TestApplyForma_GeneratorBoundSecret_ResumedCommandRedrawsForACrossStackGenerator(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		recorded := newRecordedCreates()
+		recording := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				recorded.record(req.Properties)
+				return nil, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		cfg.Agent.Datastore.DatastoreType = pkgmodel.SqliteDatastore
+		// "no-reset" keeps the file alive across the node restart.
+		cfg.Agent.Datastore.Sqlite = pkgmodel.SqliteConfig{FilePath: t.TempDir() + "/no-reset-cross-stack-resume.db"}
+
+		db, err := dssqlite.NewDatastoreSQLite(context.Background(), &cfg.Agent.Datastore, "test")
+		require.NoError(t, err)
+		stalled := &stalledGenerationDatastore{Datastore: db, reached: make(chan struct{})}
+
+		m, stop, err := test_helpers.NewTestMetastructureWithEverything(t, recording, stalled, cfg)
+		require.NoError(t, err)
+
+		id := util.NewID()
+		generatorStack := "gen-stack-" + id
+		destinationStack := "other-stack-" + id
+		forma := &pkgmodel.Forma{
+			Stacks:  []pkgmodel.Stack{{Label: generatorStack}, {Label: destinationStack}},
+			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{
+				passwordGeneratorFor(t, "db-password", generatorStack),
+			},
+			Resources: []pkgmodel.Resource{
+				crossStackGenBoundSecret(destinationStack, "beta", generatorStack, "db-password", "beta"),
+			},
+		}
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+
+		select {
+		case <-stalled.reached:
+		case <-time.After(15 * time.Second):
+			t.Fatal("the interrupted command should have reached the point of recording its generation")
+		}
+		require.Empty(t, recorded.valuesFor("beta"),
+			"the destination must not have been dispatched before the value it waits on exists")
+
+		// Crash the node with the draw still outstanding.
+		stop()
+
+		db, err = dssqlite.NewDatastoreSQLite(context.Background(), &cfg.Agent.Datastore, "test")
+		require.NoError(t, err)
+
+		generator, err := db.GetGeneratorIdentity("db-password", generatorStack)
+		require.NoError(t, err)
+		require.NotEmpty(t, generator.ID, "the interrupted command must have persisted the generator's row")
+		require.Empty(t, generator.GenerationID,
+			"the interrupted command must have left the generator having never drawn")
+
+		incomplete, err := db.LoadIncompleteFormaCommands()
+		require.NoError(t, err)
+		require.Len(t, incomplete, 1, "the command must still be incomplete after the crash")
+		beta := findResourceUpdate(incomplete[0].ResourceUpdates, "beta")
+		require.NotNil(t, beta)
+		require.Equal(t, resource_update.ResourceUpdateStateNotStarted, beta.State,
+			"the destination in the other stack must still be owed a value")
+
+		m, def, err := test_helpers.NewTestMetastructureWithEverything(t, recording, db, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		waitForApplyComplete(t, m)
+
+		cmds, err := db.LoadFormaCommands()
+		require.NoError(t, err)
+		require.Len(t, cmds, 1)
+		require.Equal(t, forma_command.CommandStateSuccess, cmds[0].State,
+			"the resumed command must be able to write the destination it still owed")
+
+		betaValues := recorded.valuesFor("beta")
+		require.Len(t, betaValues, 1, "the resumed command must dispatch the destination it still owed")
+		drawn := betaValues[0]
+		assert.Len(t, drawn, 24, "the resumed command must draw a value at the generator's declared length")
+		assert.NotContains(t, drawn, "$gen",
+			"the provider must receive the drawn value, never the envelope naming it")
+
+		redrawn, err := db.GetGeneratorIdentity("db-password", generatorStack)
+		require.NoError(t, err)
+		assert.NotEmpty(t, redrawn.GenerationID, "the redraw must record its own generation")
+
+		assertNoPlaintextInResourceUpdates(t, m, cmds[0].ID, drawn)
 	})
 }

--- a/internal/workflow_tests/local/apply_forma/generator_stable_binding_reference_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_stable_binding_reference_test.go
@@ -1,0 +1,285 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+const refParentType = "FakeAWS::Noted::Parent"
+
+// referencingSecretStore is a fake secret store for a resource that carries a
+// generator-bound opaque field AND a reference to a sibling resolved at
+// execution time. Like deliveredValues it stands in for FakeAWS's own
+// SecretsManager handling because FakeAWS mints one constant NativeID for
+// every resource it creates.
+//
+// enrich decides what a Read reports for the opaque field: an enriching store
+// returns the live secret on every Read (Secrets Manager's GetSecretValue), a
+// non-enriching one never returns it at all (a write-only credential).
+type referencingSecretStore struct {
+	mu      sync.Mutex
+	enrich  bool
+	updates map[string][]string
+	desired map[string][]string
+	patches map[string][]string
+	stored  map[string]json.RawMessage
+}
+
+func newReferencingSecretStore(enrich bool) *referencingSecretStore {
+	return &referencingSecretStore{
+		enrich:  enrich,
+		updates: map[string][]string{},
+		desired: map[string][]string{},
+		patches: map[string][]string{},
+		stored:  map[string]json.RawMessage{},
+	}
+}
+
+func (s *referencingSecretStore) overrides() *plugin.ResourcePluginOverrides {
+	return &plugin.ResourcePluginOverrides{
+		Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+			label := gjson.GetBytes(req.Properties, "Name").String()
+			nativeID := "native-" + label
+			s.mu.Lock()
+			s.stored[nativeID] = req.Properties
+			s.mu.Unlock()
+			return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+				Operation:          resource.OperationCreate,
+				OperationStatus:    resource.OperationStatusSuccess,
+				NativeID:           nativeID,
+				ResourceProperties: req.Properties,
+			}}, nil
+		},
+		Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+			props := gjson.ParseBytes(req.DesiredProperties)
+			label := props.Get("Name").String()
+			s.mu.Lock()
+			if req.ResourceType != refParentType {
+				patch := ""
+				if req.PatchDocument != nil {
+					patch = string(*req.PatchDocument)
+				}
+				s.updates[label] = append(s.updates[label], props.Get("SecretString").String())
+				s.desired[label] = append(s.desired[label], string(req.DesiredProperties))
+				s.patches[label] = append(s.patches[label], patch)
+			}
+			s.stored[req.NativeID] = req.DesiredProperties
+			s.mu.Unlock()
+			return &resource.UpdateResult{ProgressResult: &resource.ProgressResult{
+				Operation:          resource.OperationUpdate,
+				OperationStatus:    resource.OperationStatusSuccess,
+				NativeID:           req.NativeID,
+				ResourceProperties: req.DesiredProperties,
+			}}, nil
+		},
+		Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+			s.mu.Lock()
+			stored := s.stored[req.NativeID]
+			enrich := s.enrich
+			s.mu.Unlock()
+			if len(stored) == 0 {
+				stored = json.RawMessage("{}")
+			}
+			if req.ResourceType != refParentType && !enrich {
+				reported, err := sjson.DeleteBytes(append(json.RawMessage(nil), stored...), "SecretString")
+				if err != nil {
+					return nil, err
+				}
+				stored = reported
+			}
+			return &resource.ReadResult{ResourceType: req.ResourceType, Properties: string(stored)}, nil
+		},
+	}
+}
+
+func (s *referencingSecretStore) updatedWith(label string) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.updates[label]...)
+}
+
+func (s *referencingSecretStore) desiredFor(label string) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.desired[label]...)
+}
+
+func (s *referencingSecretStore) patchesFor(label string) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.patches[label]...)
+}
+
+// referencingSecretSchema is secretSchema plus a non-opaque field that holds a
+// reference to a sibling resource.
+func referencingSecretSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Identifier: "Id",
+		Fields:     []string{"Name", "Description", "ParentRef", "SecretString"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"SecretString": {Opaque: true},
+		},
+	}
+}
+
+// A resource may hold a generator-bound opaque field and a reference to a
+// sibling at the same time. Editing an unrelated field on such a resource
+// leaves the binding stable, so nothing is drawn; the reference is still
+// re-resolved at execution time, which re-derives the patch from the resolved
+// document. That regeneration must carry the stable binding the same way the
+// provider write does, so the edit beside the credential applies.
+func TestApplyForma_GeneratorBoundSecret_UnrelatedEditBesideAnExecutionTimeReference(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		enrich bool
+	}{
+		{name: "enriching_read", enrich: true},
+		{name: "non_enriching_read", enrich: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+				store := newReferencingSecretStore(tc.enrich)
+
+				cfg := test_helpers.NewTestMetastructureConfig()
+				cfg.Agent.Synchronization.Enabled = false
+				m, def, err := test_helpers.NewTestMetastructureWithConfig(t, store.overrides(), cfg)
+				defer def()
+				require.NoError(t, err)
+
+				stack := "test-stack-" + util.NewID()
+				formaWithDescription := func(description string) *pkgmodel.Forma {
+					return &pkgmodel.Forma{
+						Stacks:     []pkgmodel.Stack{{Label: stack}},
+						Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+						Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+						Resources: []pkgmodel.Resource{
+							{
+								Label:      "parent",
+								Type:       refParentType,
+								Stack:      stack,
+								Target:     "test-target",
+								Schema:     pkgmodel.Schema{Identifier: "Name", Fields: []string{"Name", "Value"}},
+								Properties: json.RawMessage(`{"Name":"parent","Value":"hello"}`),
+							},
+							{
+								Label:  "alpha",
+								Type:   "FakeAWS::SecretsManager::Secret",
+								Stack:  stack,
+								Target: "test-target",
+								Schema: referencingSecretSchema(),
+								Properties: json.RawMessage(`{
+									"Name": "alpha",
+									"Description": "` + description + `",
+									"ParentRef": {
+										"$res":      true,
+										"$label":    "parent",
+										"$type":     "` + refParentType + `",
+										"$stack":    "` + stack + `",
+										"$property": "Name"
+									},
+									"SecretString": {
+										"$gen":        true,
+										"$label":      "db-password",
+										"$stack":      "` + stack + `",
+										"$output":     "value",
+										"$visibility": "Opaque"
+									}
+								}`),
+							},
+						},
+					}
+				}
+
+				_, err = m.ApplyForma(formaWithDescription("before"),
+					&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+				require.NoError(t, err)
+				waitForApplyComplete(t, m)
+
+				firstGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+				require.NoError(t, err)
+				require.NotEmpty(t, firstGeneration.GenerationID, "precondition: the first apply draws")
+
+				appliedBinding := storedBinding(t, m, stack, "alpha")
+				require.True(t, appliedBinding.Get("$hashed").Bool(),
+					"precondition: the drawn value is stored as a digest")
+				appliedValue := appliedBinding.Get("$value").String()
+				require.NotEmpty(t, appliedValue)
+				appliedResolvedFrom := appliedBinding.Get("$resolvedFrom").String()
+				require.NotEmpty(t, appliedResolvedFrom,
+					"precondition: the destination is stamped with the generation it was drawn from")
+
+				_, err = m.ApplyForma(formaWithDescription("after"),
+					&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+				require.NoError(t, err)
+				waitForApplyComplete(t, m)
+
+				cmds, err := m.Datastore.LoadFormaCommands()
+				require.NoError(t, err)
+				require.Len(t, cmds, 2)
+				for _, cmd := range cmds {
+					require.Equal(t, forma_command.CommandStateSuccess, cmd.State,
+						"a stable binding beside a re-resolved reference must not block the edit")
+				}
+
+				updates := store.updatedWith("alpha")
+				require.Len(t, updates, 1, "the unrelated edit must reach the provider")
+				assert.NotContains(t, updates[0], "$gen",
+					"a stable binding is frozen to the preserved sentinel, never dispatched as a bare envelope")
+
+				desired := store.desiredFor("alpha")
+				require.Len(t, desired, 1)
+				assert.Contains(t, desired[0], `"SecretString":{"$opaque":"preserved"}`,
+					"the credential must be handed to the provider as a preserved sentinel")
+				assert.NotContains(t, desired[0], "$hashed",
+					"a stored digest must never reach the provider in a secret's place")
+
+				patches := store.patchesFor("alpha")
+				require.Len(t, patches, 1)
+				assert.Contains(t, patches[0], "/Description", "the edited field must be in the patch")
+				assert.NotContains(t, patches[0], "/SecretString",
+					"a binding nothing wrote must produce no patch op")
+
+				secondGeneration, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+				require.NoError(t, err)
+				assert.Equal(t, firstGeneration.GenerationID, secondGeneration.GenerationID,
+					"an edit that leaves every binding stable must not draw")
+
+				// What the row keeps is what the next apply classifies
+				// against: the same digest, still marked a digest, still
+				// stamped with the generation it was drawn from.
+				edited := storedBinding(t, m, stack, "alpha")
+				assert.Equal(t, appliedValue, edited.Get("$value").String())
+				assert.True(t, edited.Get("$hashed").Bool())
+				assert.Equal(t, appliedResolvedFrom, edited.Get("$resolvedFrom").String())
+
+				resp, err := m.ApplyForma(formaWithDescription("after"),
+					&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+				require.NoError(t, err)
+				assert.False(t, resp.Simulation.ChangesRequired,
+					"an unrelated edit must not leave the binding looking moved on the next apply")
+				assert.Len(t, store.updatedWith("alpha"), 1, "no third write may reach the provider")
+			})
+		})
+	}
+}

--- a/internal/workflow_tests/local/apply_forma/generator_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_test.go
@@ -227,3 +227,167 @@ func TestMetastructure_SameCommandGeneratorAndConsumer_ShareOneKSUID(t *testing.
 			"the resource's $generator must equal the generator update's own KSUID, not an independently minted one")
 	})
 }
+
+// generatorOnlyFixture stands up a metastructure with a stack that already
+// exists and holds one resource that never changes, so a later apply's only
+// work is the generator work. Without the anchor the stack itself would be
+// created or emptied by the same command, and a stack update carries its own
+// command-state recompute, which is exactly what a generator-only command
+// does not have.
+type generatorOnlyFixture struct {
+	m           *metastructure.Metastructure
+	stack       string
+	anchorValue string
+}
+
+func newGeneratorOnlyFixture(t *testing.T) (*generatorOnlyFixture, func()) {
+	t.Helper()
+	cfg := test_helpers.NewTestMetastructureConfig()
+	cfg.Agent.Synchronization.Enabled = false
+	m, def, err := test_helpers.NewTestMetastructureWithConfig(t, nil, cfg)
+	require.NoError(t, err)
+
+	f := &generatorOnlyFixture{
+		m:           m,
+		stack:       "generator-only-stack",
+		anchorValue: "anchor-v1",
+	}
+	return f, def
+}
+
+// forma builds a forma holding the unchanged anchor plus whatever generators
+// are given.
+func (f *generatorOnlyFixture) forma(generators ...json.RawMessage) *pkgmodel.Forma {
+	return &pkgmodel.Forma{
+		Stacks:     []pkgmodel.Stack{{Label: f.stack}},
+		Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+		Resources:  []pkgmodel.Resource{secretResource(f.stack, "anchor", f.anchorValue)},
+		Generators: generators,
+	}
+}
+
+func (f *generatorOnlyFixture) apply(t *testing.T, forma *pkgmodel.Forma) {
+	t.Helper()
+	_, err := f.m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+	require.NoError(t, err)
+	waitForApplyComplete(t, f.m)
+}
+
+// requireLatestCommandSucceeded asserts the command count and that the newest
+// command reached Success. Success, not merely terminal: a command that hangs
+// and a command that fails are both bugs, and only one of them is what this
+// pins.
+func requireLatestCommandSucceeded(t *testing.T, m *metastructure.Metastructure, want int) {
+	t.Helper()
+	cmds, err := m.Datastore.LoadFormaCommands()
+	require.NoError(t, err)
+	require.Len(t, cmds, want)
+	latest := cmds[0]
+	for _, c := range cmds {
+		if c.StartTs.After(latest.StartTs) {
+			latest = c
+		}
+	}
+	assert.Equal(t, forma_command.CommandStateSuccess, latest.State,
+		"a command whose only work is generator work must reach a terminal state")
+}
+
+func generatorOfLength(t *testing.T, stack string, length int) json.RawMessage {
+	t.Helper()
+	return rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+		Label: "db-password", Stack: stack,
+		Length: length, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+	})
+}
+
+// Adding a generator to a stack that already exists is a command whose only
+// work is generator work. It must reach a terminal state: the generator write
+// is durable before the command is even schedulable, so a command left
+// NotStarted would never self-heal and would sit incomplete forever.
+func TestApplyForma_GeneratorOnlyCreate_ReachesATerminalState(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		f, def := newGeneratorOnlyFixture(t)
+		defer def()
+
+		f.apply(t, f.forma())
+		f.apply(t, f.forma(generatorOfLength(t, f.stack, 24)))
+
+		requireLatestCommandSucceeded(t, f.m, 2)
+
+		stored, err := f.m.Datastore.GetGenerator("db-password", f.stack)
+		require.NoError(t, err)
+		require.NotNil(t, stored, "the generator-only command must still have written the generator")
+	})
+}
+
+// Editing a generator's spec on a stack that already exists is likewise
+// generator-only work.
+func TestApplyForma_GeneratorOnlyUpdate_ReachesATerminalState(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		f, def := newGeneratorOnlyFixture(t)
+		defer def()
+
+		f.apply(t, f.forma(generatorOfLength(t, f.stack, 24)))
+		f.apply(t, f.forma(generatorOfLength(t, f.stack, 32)))
+
+		requireLatestCommandSucceeded(t, f.m, 2)
+
+		stored, err := f.m.Datastore.GetGenerator("db-password", f.stack)
+		require.NoError(t, err)
+		pw, ok := stored.(*pkgmodel.PasswordGenerator)
+		require.True(t, ok)
+		assert.Equal(t, 32, pw.Length, "the generator-only command must still have applied the edit")
+	})
+}
+
+// Removing a generator nobody references is an ordinary edit, and the
+// resulting command's only work is the delete.
+func TestApplyForma_GeneratorOnlyDelete_ReachesATerminalState(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		f, def := newGeneratorOnlyFixture(t)
+		defer def()
+
+		f.apply(t, f.forma(generatorOfLength(t, f.stack, 24)))
+		f.apply(t, f.forma())
+
+		requireLatestCommandSucceeded(t, f.m, 2)
+
+		stored, err := f.m.Datastore.GetGenerator("db-password", f.stack)
+		require.NoError(t, err)
+		assert.Nil(t, stored, "the generator-only command must still have removed the generator")
+	})
+}
+
+// A command carrying generator work AND resource work keeps going through the
+// changeset executor, which owns its terminal state. Finalizing generator work
+// early must not pre-empt that.
+func TestApplyForma_GeneratorPlusResourceWork_StillRunsTheChangeset(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		f, def := newGeneratorOnlyFixture(t)
+		defer def()
+
+		f.apply(t, f.forma())
+
+		f.anchorValue = "anchor-v2"
+		f.apply(t, f.forma(generatorOfLength(t, f.stack, 24)))
+
+		requireLatestCommandSucceeded(t, f.m, 2)
+
+		cmds, err := f.m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		mixed := cmds[0]
+		for _, c := range cmds {
+			if c.StartTs.After(mixed.StartTs) {
+				mixed = c
+			}
+		}
+		anchorUpdate := findResourceUpdate(mixed.ResourceUpdates, "anchor")
+		require.NotNil(t, anchorUpdate, "the mixed command must carry the anchor's update")
+		assert.Equal(t, resource_update.ResourceUpdateStateSuccess, anchorUpdate.State,
+			"the resource half of a mixed command must still be executed")
+
+		stored, err := f.m.Datastore.GetGenerator("db-password", f.stack)
+		require.NoError(t, err)
+		require.NotNil(t, stored, "the generator half of a mixed command must still be written")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/generator_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_test.go
@@ -33,9 +33,9 @@ func rawPasswordGenerator(t *testing.T, gen *pkgmodel.PasswordGenerator) json.Ra
 
 // TestMetastructure_ApplyFormaPersistsGeneratorThenReapplyIsANoop is the
 // generator lifecycle's end-to-end case: applying a forma that declares a
-// generator actually persists it, and re-applying the identical forma
-// persists nothing new — connecting Forma.Generators to the datastore is
-// exactly what this slice adds; nothing read it before.
+// generator persists it, because the apply path reads Forma.Generators
+// through to the datastore, and re-applying the identical forma persists
+// nothing new.
 func TestMetastructure_ApplyFormaPersistsGeneratorThenReapplyIsANoop(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		m, def, err := test_helpers.NewTestMetastructure(t, nil)
@@ -93,9 +93,9 @@ func TestMetastructure_ApplyFormaPersistsGeneratorThenReapplyIsANoop(t *testing.
 }
 
 // TestMetastructure_ApplyFormaSimulate_GeneratorOnlyChangeReportsANonEmptyPlan
-// pins the defect this task fixes: a forma whose only change is a generator
-// must report ChangesRequired together with a plan that actually shows the
-// change, never ChangesRequired with an empty Command. The stack is
+// requires that a forma whose only change is a generator reports
+// ChangesRequired together with a plan that actually shows the change, never
+// ChangesRequired with an empty Command. The stack is
 // established first with no generator, so the second (simulated) apply's
 // only change is the generator, and asserts against the in-memory simulate
 // response only — a reloaded command has no GeneratorUpdates column yet.
@@ -169,14 +169,14 @@ func TestMetastructure_ApplyFormaSimulate_GeneratorOnlyChangeReportsANonEmptyPla
 	})
 }
 
-// TestMetastructure_SameCommandGeneratorAndConsumer_ShareOneKSUID pins the
-// KSUID-threading fix: a generator declared in the SAME command as a
-// resource's $gen reference to it must translate to the exact KSUID that
-// generator's own GeneratorUpdate carries — not two independently minted
-// KSUIDs. Calls FormaCommandFromForma directly (build only, no execution),
-// which isolates the wiring bug from plugin execution and from
-// generation-drawing (a later slice: no value is drawn here, only the
-// generator's identity and the $gen envelope's reference to it).
+// TestMetastructure_SameCommandGeneratorAndConsumer_ShareOneKSUID covers
+// KSUID threading: a generator declared in the SAME command as a resource's
+// $gen reference to it must translate to the exact KSUID that generator's own
+// GeneratorUpdate carries, not two independently minted KSUIDs. Calls
+// FormaCommandFromForma directly (build only, no execution), which keeps the
+// assertion on identity threading alone, with no plugin execution and no
+// drawing: no value is drawn here, only the generator's identity and the $gen
+// envelope's reference to it.
 func TestMetastructure_SameCommandGeneratorAndConsumer_ShareOneKSUID(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		m, def, err := test_helpers.NewTestMetastructure(t, nil)

--- a/internal/workflow_tests/local/apply_forma/secret_hashing_test.go
+++ b/internal/workflow_tests/local/apply_forma/secret_hashing_test.go
@@ -53,6 +53,13 @@ func waitForApplyComplete(t *testing.T, m *metastructure.Metastructure) {
 // assertNoPlaintextInResourceUpdates loads every ResourceUpdate for commandID and asserts
 // none of the resource_updates sinks (resource/DesiredState, existing_resource/PriorState,
 // previous_properties, progress_result, most_recent_progress) contain the plaintext secret.
+//
+// DesiredState.PatchDocument is swept alongside DesiredState.Properties. It is
+// a derived view of the same document rather than a copy of it: a diff of
+// prior against desired, re-derived whenever an apply-time substitution
+// rewrites the desired side. A value kept out of the properties can therefore
+// still be carried into the patch by that derivation, and the patch travels to
+// the provider and into the same row.
 func assertNoPlaintextInResourceUpdates(t *testing.T, m *metastructure.Metastructure, commandID, plaintext string) {
 	t.Helper()
 	updates, err := m.Datastore.LoadResourceUpdates(commandID)
@@ -68,6 +75,8 @@ func assertNoPlaintextInResourceUpdates(t *testing.T, m *metastructure.Metastruc
 			"resource_updates.existing_resource (PriorState.Properties) leaked plaintext")
 		assert.NotContains(t, string(ru.PriorState.ReadOnlyProperties), plaintext,
 			"resource_updates.existing_resource (PriorState.ReadOnlyProperties) leaked plaintext")
+		assert.NotContains(t, string(ru.DesiredState.PatchDocument), plaintext,
+			"resource_updates.resource (DesiredState.PatchDocument) leaked plaintext")
 		assert.NotContains(t, string(ru.PreviousProperties), plaintext,
 			"resource_updates.previous_properties leaked plaintext")
 		assert.NotContains(t, string(ru.MostRecentProgressResult.ResourceProperties), plaintext,

--- a/internal/workflow_tests/local/changeset_resolve_helper_test.go
+++ b/internal/workflow_tests/local/changeset_resolve_helper_test.go
@@ -36,5 +36,5 @@ func buildChangesetWithResolves(
 	if err != nil {
 		return changeset.Changeset{}, err
 	}
-	return changeset.NewChangeset(resourceUpdates, append(targetUpdates, synth...), commandID, command, pkgmodel.FormaApplyModeReconcile)
+	return changeset.NewChangeset(resourceUpdates, append(targetUpdates, synth...), nil, commandID, command, pkgmodel.FormaApplyModeReconcile)
 }

--- a/internal/workflow_tests/local/generator_updater_draw_test.go
+++ b/internal/workflow_tests/local/generator_updater_draw_test.go
@@ -1,0 +1,279 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// persistedGenerator creates a stack and a password generator on it, and
+// returns the generator carrying the KSUID its row holds — the shape the
+// executor hands a GeneratorUpdater, where a $gen envelope has already been
+// translated to that same KSUID.
+func persistedGenerator(t *testing.T, ds datastore.Datastore, stackLabel, label string, length int) *pkgmodel.PasswordGenerator {
+	t.Helper()
+
+	stack := &pkgmodel.Stack{Label: stackLabel}
+	_, err := ds.CreateStack(stack, "cmd-generator-stack")
+	require.NoError(t, err)
+	require.NotEmpty(t, stack.ID)
+
+	generator := &pkgmodel.PasswordGenerator{
+		Label:                   label,
+		Stack:                   stackLabel,
+		StackID:                 stack.ID,
+		Length:                  length,
+		Uppercase:               true,
+		Lowercase:               true,
+		Digits:                  true,
+		RequireEachIncludedType: true,
+	}
+	_, err = ds.CreateGenerator(generator, "cmd-generator-create")
+	require.NoError(t, err)
+
+	identity, err := ds.GetGeneratorIdentity(label, stackLabel)
+	require.NoError(t, err)
+	require.NotEmpty(t, identity.ID)
+	generator.SetID(identity.ID)
+
+	return generator
+}
+
+// spawnGeneratorUpdater spawns a GeneratorUpdater on the node under the
+// canonical name for a draw, exactly as the ChangesetExecutor does. from is
+// the PID that will receive GeneratorUpdateFinished.
+func spawnGeneratorUpdater(t *testing.T, node gen.Node, from gen.PID, nodeURI pkgmodel.FormaeURI, commandID string) (gen.PID, error) {
+	t.Helper()
+	name := actornames.GeneratorUpdater(nodeURI, commandID)
+	return node.SpawnRegister(name, generator_update.NewGeneratorUpdater, gen.ProcessOptions{}, from)
+}
+
+// A GeneratorUpdater spawned the way the executor spawns it draws a value end
+// to end: the spawn itself proves Init reads the node's Datastore env and
+// that the argument the executor passes is the shape Init expects, and the
+// finished signal proves the handler registration table routes both the start
+// message and the draw the actor sends itself.
+//
+// It also asserts the generation is recorded against the real row, and that
+// the actor's process is gone afterwards.
+func TestGeneratorUpdater_DrawsAValueAndRecordsItsGeneration(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, def, err := test_helpers.NewTestMetastructure(t, nil)
+		defer def()
+		require.NoError(t, err)
+
+		received := make(chan any, 1)
+		helperPID, err := testutil.StartTestHelperActor(m.Node, received)
+		require.NoError(t, err)
+
+		const (
+			commandID   = "cmd-draw-on-node"
+			declaredLen = 24
+		)
+		stackLabel := "draw-stack-" + util.NewID()
+		generator := persistedGenerator(t, m.Datastore, stackLabel, "db-password", declaredLen)
+
+		draw := generator_update.NewDrawGeneratorUpdate(generator, stackLabel)
+		updaterPID, err := spawnGeneratorUpdater(t, m.Node, helperPID, draw.NodeURI(), commandID)
+		require.NoError(t, err)
+
+		name := actornames.GeneratorUpdater(draw.NodeURI(), commandID)
+		require.NoError(t, testutil.Send(m.Node, name,
+			generator_update.StartGeneratorUpdate{GeneratorUpdate: draw}))
+
+		var drawnValue string
+		testutil.ExpectMessageWithPredicate(t, received, 10*time.Second,
+			func(msg generator_update.GeneratorUpdateFinished) bool {
+				assert.Equal(t, generator_update.GeneratorUpdateStateSuccess, msg.State,
+					"a well-formed generator must draw: %s", msg.ErrorMessage)
+				assert.Len(t, msg.DrawnValue, declaredLen,
+					"the drawn value must have the declared length")
+				drawnValue = msg.DrawnValue
+				return true
+			},
+		)
+		require.NotEmpty(t, drawnValue)
+
+		// The generation is recorded against the generator's real row, under
+		// the spec the value was drawn from.
+		identity, err := m.Datastore.GetGeneratorIdentityByID(generator.GetID())
+		require.NoError(t, err)
+		assert.NotEmpty(t, identity.GenerationID,
+			"a drawn value must leave a generation recorded against the generator")
+		require.NotEmpty(t, identity.GenerationSpec,
+			"the generation must record the spec it was drawn under")
+		recorded, err := pkgmodel.ParseGenerator(identity.GenerationSpec)
+		require.NoError(t, err, "the recorded spec must parse back as a generator")
+		recordedPassword, ok := recorded.(*pkgmodel.PasswordGenerator)
+		require.True(t, ok)
+		assert.Equal(t, declaredLen, recordedPassword.Length)
+		assert.Equal(t, "db-password", recordedPassword.Label)
+
+		// The actor shuts itself down once it has reported, so its process
+		// must be gone rather than left holding the registered name.
+		assert.Eventually(t, func() bool {
+			state, stateErr := m.Node.ProcessState(updaterPID)
+			return stateErr != nil || state == gen.ProcessStateTerminated || state == gen.ProcessStateZombee
+		}, 5*time.Second, 50*time.Millisecond,
+			"the GeneratorUpdater must terminate itself after reporting")
+	})
+}
+
+// The same generator label in two different stacks is two different
+// generators. Both must draw, under their own canonical names and against
+// their own rows: a name keyed on the label alone would put them on one
+// actor and lose a draw.
+func TestGeneratorUpdater_SameLabelInTwoStacksBothDraw(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, def, err := test_helpers.NewTestMetastructure(t, nil)
+		defer def()
+		require.NoError(t, err)
+
+		received := make(chan any, 2)
+		helperPID, err := testutil.StartTestHelperActor(m.Node, received)
+		require.NoError(t, err)
+
+		const commandID = "cmd-two-stacks"
+		firstStack := "first-stack-" + util.NewID()
+		secondStack := "second-stack-" + util.NewID()
+
+		first := persistedGenerator(t, m.Datastore, firstStack, "db-password", 20)
+		second := persistedGenerator(t, m.Datastore, secondStack, "db-password", 32)
+		require.NotEqual(t, first.GetID(), second.GetID(),
+			"precondition: the same label in two stacks is two generators")
+
+		for _, draw := range []generator_update.GeneratorUpdate{
+			generator_update.NewDrawGeneratorUpdate(first, firstStack),
+			generator_update.NewDrawGeneratorUpdate(second, secondStack),
+		} {
+			_, spawnErr := spawnGeneratorUpdater(t, m.Node, helperPID, draw.NodeURI(), commandID)
+			require.NoError(t, spawnErr)
+			require.NoError(t, testutil.Send(m.Node, actornames.GeneratorUpdater(draw.NodeURI(), commandID),
+				generator_update.StartGeneratorUpdate{GeneratorUpdate: draw}))
+		}
+
+		lengths := map[int]bool{}
+		for range 2 {
+			testutil.ExpectMessageWithPredicate(t, received, 10*time.Second,
+				func(msg generator_update.GeneratorUpdateFinished) bool {
+					assert.Equal(t, generator_update.GeneratorUpdateStateSuccess, msg.State, msg.ErrorMessage)
+					lengths[len(msg.DrawnValue)] = true
+					return true
+				},
+			)
+		}
+		assert.Equal(t, map[int]bool{20: true, 32: true}, lengths,
+			"both generators must draw, each under its own spec")
+
+		for _, generator := range []*pkgmodel.PasswordGenerator{first, second} {
+			identity, err := m.Datastore.GetGeneratorIdentityByID(generator.GetID())
+			require.NoError(t, err)
+			assert.NotEmpty(t, identity.GenerationID,
+				"each generator must carry its own recorded generation")
+		}
+	})
+}
+
+// A draw against a generator formae holds no identity for is refused before
+// anything is drawn, and reports an operator-facing reason rather than a raw
+// error.
+func TestGeneratorUpdater_WithoutAnIdentityRefusesToDraw(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, def, err := test_helpers.NewTestMetastructure(t, nil)
+		defer def()
+		require.NoError(t, err)
+
+		received := make(chan any, 1)
+		helperPID, err := testutil.StartTestHelperActor(m.Node, received)
+		require.NoError(t, err)
+
+		const commandID = "cmd-no-identity"
+		anonymous := generator_update.NewDrawGeneratorUpdate(
+			&pkgmodel.PasswordGenerator{
+				Label: "db-password", Stack: "nowhere", Length: 24,
+				Uppercase: true, Lowercase: true, Digits: true,
+			},
+			"nowhere",
+		)
+
+		_, err = spawnGeneratorUpdater(t, m.Node, helperPID, anonymous.NodeURI(), commandID)
+		require.NoError(t, err)
+		require.NoError(t, testutil.Send(m.Node, actornames.GeneratorUpdater(anonymous.NodeURI(), commandID),
+			generator_update.StartGeneratorUpdate{GeneratorUpdate: anonymous}))
+
+		testutil.ExpectMessageWithPredicate(t, received, 10*time.Second,
+			func(msg generator_update.GeneratorUpdateFinished) bool {
+				assert.Equal(t, generator_update.GeneratorUpdateStateFailed, msg.State)
+				assert.Empty(t, msg.DrawnValue, "a refused draw carries no value")
+				assert.NotEmpty(t, msg.ErrorMessage)
+				return true
+			},
+		)
+	})
+}
+
+// The generation spec recorded for a draw is the generator's specification
+// and never the value it produced: the column it lands in is not redacted by
+// anything downstream.
+func TestGeneratorUpdater_RecordedGenerationSpecHoldsNoDrawnValue(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, def, err := test_helpers.NewTestMetastructure(t, nil)
+		defer def()
+		require.NoError(t, err)
+
+		received := make(chan any, 1)
+		helperPID, err := testutil.StartTestHelperActor(m.Node, received)
+		require.NoError(t, err)
+
+		const commandID = "cmd-spec-holds-no-value"
+		stackLabel := "spec-stack-" + util.NewID()
+		generator := persistedGenerator(t, m.Datastore, stackLabel, "db-password", 24)
+
+		draw := generator_update.NewDrawGeneratorUpdate(generator, stackLabel)
+		_, err = spawnGeneratorUpdater(t, m.Node, helperPID, draw.NodeURI(), commandID)
+		require.NoError(t, err)
+		require.NoError(t, testutil.Send(m.Node, actornames.GeneratorUpdater(draw.NodeURI(), commandID),
+			generator_update.StartGeneratorUpdate{GeneratorUpdate: draw}))
+
+		var drawnValue string
+		testutil.ExpectMessageWithPredicate(t, received, 10*time.Second,
+			func(msg generator_update.GeneratorUpdateFinished) bool {
+				require.Equal(t, generator_update.GeneratorUpdateStateSuccess, msg.State, msg.ErrorMessage)
+				drawnValue = msg.DrawnValue
+				return true
+			},
+		)
+		require.NotEmpty(t, drawnValue)
+
+		identity, err := m.Datastore.GetGeneratorIdentityByID(generator.GetID())
+		require.NoError(t, err)
+		assert.NotContains(t, string(identity.GenerationSpec), drawnValue,
+			"the recorded generation spec must never contain the value drawn under it")
+
+		stored, err := m.Datastore.GetGenerator("db-password", stackLabel)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		encoded, err := json.Marshal(stored)
+		require.NoError(t, err)
+		assert.NotContains(t, string(encoded), drawnValue,
+			"the generator row must never hold the value drawn from it")
+	})
+}

--- a/pkg/api/model/errors.go
+++ b/pkg/api/model/errors.go
@@ -14,29 +14,30 @@ import (
 type APIError string
 
 const (
-	ConflictingCommands          APIError = "ConflictingCommands"
-	PatchRejected                APIError = "PatchRejected"
-	ReconcileRejected            APIError = "ReconcileRejected"
-	CyclesDetected               APIError = "CyclesDetected"
-	EmptyStackRejected           APIError = "EmptyStackRejected"
-	TargetAlreadyExists          APIError = "TargetAlreadyExists"
-	TargetReaped                 APIError = "TargetReaped"
-	ReferencedResourcesNotFound  APIError = "ReferencedResourcesNotFound"
-	ReferencedGeneratorsNotFound APIError = "ReferencedGeneratorsNotFound"
-	RequiredFieldMissingOnCreate APIError = "RequiredFieldMissingOnCreate"
-	StackReferenceNotFound       APIError = "StackReferenceNotFound"
-	TargetReferenceNotFound      APIError = "TargetReferenceNotFound"
-	InvalidQuery                 APIError = "InvalidQueryError"
-	StackDeletedDuringApply      APIError = "StackDeletedDuringApply"
-	ReconcilePolicyRequired      APIError = "ReconcilePolicyRequired"
-	NonPortableResources         APIError = "NonPortableResources"
-	PluginNotFound               APIError = "PluginNotFound"
-	PluginVersionNotFound        APIError = "PluginVersionNotFound"
-	PluginDependencyConflict     APIError = "PluginDependencyConflict"
-	PluginRepositoryUnreachable  APIError = "PluginRepositoryUnreachable"
-	PluginSignatureInvalid       APIError = "PluginSignatureInvalid"
-	TargetHasDependents          APIError = "TargetHasDependents"
-	ResourceHasDependents        APIError = "ResourceHasDependents"
+	ConflictingCommands              APIError = "ConflictingCommands"
+	PatchRejected                    APIError = "PatchRejected"
+	ReconcileRejected                APIError = "ReconcileRejected"
+	CyclesDetected                   APIError = "CyclesDetected"
+	EmptyStackRejected               APIError = "EmptyStackRejected"
+	TargetAlreadyExists              APIError = "TargetAlreadyExists"
+	TargetReaped                     APIError = "TargetReaped"
+	ReferencedResourcesNotFound      APIError = "ReferencedResourcesNotFound"
+	ReferencedGeneratorsNotFound     APIError = "ReferencedGeneratorsNotFound"
+	RequiredFieldMissingOnCreate     APIError = "RequiredFieldMissingOnCreate"
+	StackReferenceNotFound           APIError = "StackReferenceNotFound"
+	TargetReferenceNotFound          APIError = "TargetReferenceNotFound"
+	InvalidQuery                     APIError = "InvalidQueryError"
+	StackDeletedDuringApply          APIError = "StackDeletedDuringApply"
+	ReconcilePolicyRequired          APIError = "ReconcilePolicyRequired"
+	NonPortableResources             APIError = "NonPortableResources"
+	PluginNotFound                   APIError = "PluginNotFound"
+	PluginVersionNotFound            APIError = "PluginVersionNotFound"
+	PluginDependencyConflict         APIError = "PluginDependencyConflict"
+	PluginRepositoryUnreachable      APIError = "PluginRepositoryUnreachable"
+	PluginSignatureInvalid           APIError = "PluginSignatureInvalid"
+	TargetHasDependents              APIError = "TargetHasDependents"
+	ResourceHasDependents            APIError = "ResourceHasDependents"
+	GeneratorDestinationsUnreachable APIError = "GeneratorDestinationsUnreachable"
 )
 
 type ErrorResponse[T any] struct {
@@ -121,6 +122,33 @@ type FormaReferencedGeneratorsNotFoundError struct {
 
 func (e FormaReferencedGeneratorsNotFoundError) Error() string {
 	return "forma rejected because one or more generator references were not found"
+}
+
+// UnreachableGeneratorDestination names one live resource bound to a
+// generator that has to draw, which the command being admitted does not
+// reach. GeneratorLabel and GeneratorStack identify the generator as the
+// forma names it; Stack, Label and Type are enough to find the destination.
+type UnreachableGeneratorDestination struct {
+	GeneratorLabel string `json:"GeneratorLabel"`
+	GeneratorStack string `json:"GeneratorStack"`
+	Stack          string `json:"Stack"`
+	Label          string `json:"Label"`
+	Type           string `json:"Type"`
+}
+
+// FormaGeneratorDestinationsUnreachableError refuses an apply that would draw
+// a generator's value for only some of the resources bound to it.
+//
+// formae keeps a hash of a drawn value, never the value, so a destination
+// outside the command when the draw happened can never be caught up
+// afterwards: the only way to give it a value is to draw again, which puts
+// its siblings behind. Refusing is the only outcome that converges.
+type FormaGeneratorDestinationsUnreachableError struct {
+	Unreachable []UnreachableGeneratorDestination `json:"Unreachable"`
+}
+
+func (e FormaGeneratorDestinationsUnreachableError) Error() string {
+	return "forma rejected because a generator must draw a new value and the command does not reach every resource bound to it"
 }
 
 type TargetAlreadyExistsError struct {

--- a/pkg/api/model/types.go
+++ b/pkg/api/model/types.go
@@ -136,6 +136,10 @@ const (
 	OperationDelete  = "delete"
 	OperationRead    = "read"
 	OperationReplace = "replace" // delete + create
+	// OperationDraw appears on a GeneratorUpdate only: it is a generator
+	// drawing a value, which rotates the secret every resource bound to that
+	// generator holds. No ResourceUpdate ever carries it.
+	OperationDraw = "draw"
 )
 
 const (
@@ -190,13 +194,29 @@ type PolicyUpdate struct {
 	ModifiedTs        time.Time       `json:"ModifiedTs,omitempty"`
 }
 
-// GeneratorUpdate is the API projection of a generator change: a create, an
-// update (spec change and/or rename), or a delete. GeneratorConfig and
-// OldGeneratorConfig carry the generator's declared spec only — the fields a
-// forma author writes. A generator's own identity (its KSUID) and drawn
-// generation are controller state that never reaches this projection: no
-// concrete Generator marshals its ID, and the value a generation drew does
-// not exist at plan/simulate time to project in the first place.
+// GeneratorUpdate is the API projection of one piece of generator work: a
+// create, an update (spec change and/or rename), a delete, or a draw.
+//
+// The first three change the generator's own row. A draw changes no row: it
+// produces a new value and every destination bound to the generator takes it,
+// which is a credential rotation and is why it is a plan entry of its own. A
+// generator whose spec is changing and that also draws is two entries, one per
+// operation, because the two are separate work with separate outcomes.
+//
+// GeneratorConfig and OldGeneratorConfig carry the generator's declared spec
+// only — the fields a forma author writes — and only on the operations that
+// change it; a draw carries neither. A generator's own identity (its KSUID)
+// and drawn generation are controller state that never reaches this
+// projection: no concrete Generator marshals its ID, and the value a
+// generation drew does not exist at plan/simulate time to project in the
+// first place.
+//
+// State, Duration and ErrorMessage report the operation's outcome on the three
+// that change the generator's row. On a draw they carry the plan's values and
+// do not follow the draw as it runs: a draw writes no generator row, so no
+// store holds its outcome for a status read to project. A draw that fails
+// explains itself on the ResourceUpdates it fails, which carry its reason as
+// their ErrorMessage.
 type GeneratorUpdate struct {
 	GeneratorLabel     string          `json:"GeneratorLabel"`
 	GeneratorType      string          `json:"GeneratorType"` // "password", etc.

--- a/pkg/model/gen_envelope.go
+++ b/pkg/model/gen_envelope.go
@@ -97,6 +97,53 @@ func GenGeneratorKSUID(value gjson.Result) string {
 	return value.Get("$generator").String()
 }
 
+// resourcePropertiesField is the member of a stored resource document that
+// holds its properties (Resource.Properties' JSON name). It is the only part
+// of the document a $gen binding can live in.
+const resourcePropertiesField = "Properties"
+
+// BindsGenerator reports whether the given resource document binds any
+// property to the generator with this KSUID through a translated $gen
+// envelope. It is the authoritative answer to "is this row a destination of
+// that generator": the datastores use their indexes only to narrow the
+// candidate set and confirm every candidate here, so all backends agree
+// regardless of how their SQL happens to match.
+//
+// It takes the whole stored resource document, because that is what a
+// resources row holds, and scans only that document's properties member. That
+// is the same reach as the draw rule (which reads DesiredState.Properties), so
+// the reverse index and the rule that decides what a draw rotates agree by
+// construction: a $gen appearing anywhere else in the row — read-only
+// properties, a patch document — names no destination and must not be able to
+// refuse an apply. Each backend's SQL stays deliberately broader than this, so
+// a candidate it matched for another reason is dropped here rather than
+// missed.
+//
+// The walk is shared with FindGenObjectsFromProperties rather than duplicated,
+// which is why an authored (untranslated) envelope, whose generator is named
+// by label and stack, matches nothing here.
+//
+// An empty generator KSUID binds nothing, so authored envelopes cannot match
+// it by accident.
+func BindsGenerator(document []byte, generatorKsuid string) bool {
+	if len(document) == 0 || generatorKsuid == "" {
+		return false
+	}
+
+	properties := gjson.GetBytes(document, resourcePropertiesField)
+	if !properties.Exists() {
+		return false
+	}
+
+	for _, gen := range FindGenObjectsFromProperties([]byte(properties.Raw)) {
+		if gen.Generator == generatorKsuid {
+			return true
+		}
+	}
+
+	return false
+}
+
 // KnownGeneratorOutputs enumerates every output name a currently supported
 // generator type can produce. PasswordGenerator is the only arm today, and
 // its only output is "value" (see PasswordOutputs in the PKL schema); a

--- a/pkg/model/gen_envelope_test.go
+++ b/pkg/model/gen_envelope_test.go
@@ -147,3 +147,72 @@ func TestKnownGeneratorOutputs(t *testing.T) {
 		assert.False(t, KnownGeneratorOutputs["nosuchoutput"])
 	})
 }
+
+func TestBindsGenerator(t *testing.T) {
+	const generator = "2abc123def456ghi7jk8lmno9p0"
+
+	// A stored resource document: the whole marshalled resource, with the
+	// properties document nested under Properties.
+	resourceDocument := func(properties string) []byte {
+		return []byte(`{"Label":"database","Type":"AWS::RDS::DBInstance","Stack":"app","Properties":` + properties + `}`)
+	}
+
+	t.Run("binds through a translated $gen envelope", func(t *testing.T) {
+		doc := resourceDocument(`{"MasterUserPassword":{"$gen":true,"$generator":"` + generator + `","$output":"value"}}`)
+		assert.True(t, BindsGenerator(doc, generator))
+	})
+
+	t.Run("binds through a $gen envelope nested in an array", func(t *testing.T) {
+		doc := resourceDocument(`{"Environment":[{"Name":"PW","Value":{"$gen":true,"$generator":"` + generator + `","$output":"value"}}]}`)
+		assert.True(t, BindsGenerator(doc, generator))
+	})
+
+	t.Run("does not bind a different generator", func(t *testing.T) {
+		doc := resourceDocument(`{"MasterUserPassword":{"$gen":true,"$generator":"otherksuid","$output":"value"}}`)
+		assert.False(t, BindsGenerator(doc, generator))
+	})
+
+	t.Run("a $generator key outside a $gen envelope binds nothing", func(t *testing.T) {
+		doc := resourceDocument(`{"Config":{"$generator":"` + generator + `"}}`)
+		assert.False(t, BindsGenerator(doc, generator))
+	})
+
+	t.Run("$gen false is not an envelope", func(t *testing.T) {
+		doc := resourceDocument(`{"MasterUserPassword":{"$gen":false,"$generator":"` + generator + `","$output":"value"}}`)
+		assert.False(t, BindsGenerator(doc, generator))
+	})
+
+	t.Run("the generator KSUID is matched case-sensitively", func(t *testing.T) {
+		doc := resourceDocument(`{"MasterUserPassword":{"$gen":true,"$generator":"` + generator + `","$output":"value"}}`)
+		assert.False(t, BindsGenerator(doc, "2ABC123DEF456GHI7JK8LMNO9P0"))
+	})
+
+	t.Run("a $ref to a resource binds no generator", func(t *testing.T) {
+		doc := resourceDocument(`{"RoleArn":{"$ref":"formae://` + generator + `#/Arn","$value":"arn"}}`)
+		assert.False(t, BindsGenerator(doc, generator))
+	})
+
+	t.Run("an authored envelope names its generator by label, so it binds no KSUID", func(t *testing.T) {
+		doc := resourceDocument(`{"MasterUserPassword":{"$gen":true,"$label":"db-password","$stack":"app","$output":"value"}}`)
+		assert.False(t, BindsGenerator(doc, ""))
+		assert.False(t, BindsGenerator(doc, generator))
+	})
+
+	t.Run("a $gen outside the properties document is not a binding", func(t *testing.T) {
+		envelope := `{"$gen":true,"$generator":"` + generator + `","$output":"value"}`
+		readOnly := []byte(`{"Label":"database","Type":"AWS::RDS::DBInstance","Stack":"app",` +
+			`"Properties":{"Engine":"postgres"},"ReadOnlyProperties":{"Endpoint":` + envelope + `}}`)
+		assert.False(t, BindsGenerator(readOnly, generator),
+			"only the properties document decides which resources a draw rotates")
+
+		patched := []byte(`{"Label":"database","Type":"AWS::RDS::DBInstance","Stack":"app",` +
+			`"Properties":{"Engine":"postgres"},"PatchDocument":[{"op":"replace","path":"/Pw","value":` + envelope + `}]}`)
+		assert.False(t, BindsGenerator(patched, generator),
+			"only the properties document decides which resources a draw rotates")
+	})
+
+	t.Run("an empty document binds nothing", func(t *testing.T) {
+		assert.False(t, BindsGenerator(nil, generator))
+		assert.False(t, BindsGenerator([]byte{}, generator))
+	})
+}

--- a/pkg/model/generator_draw.go
+++ b/pkg/model/generator_draw.go
@@ -6,7 +6,7 @@ package model
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -35,28 +35,67 @@ func Draw(spec Generator, src ByteSource) (string, error) {
 	}
 }
 
+// passwordClasses pairs each character class a PasswordGenerator can enable
+// with its canonical alphabet, mirroring the class-by-class walk
+// PasswordGenerator's own validated() does in formae.pkl.
+var passwordClasses = []struct {
+	name    string
+	enabled func(*PasswordGenerator) bool
+	chars   string
+}{
+	{"uppercase", func(p *PasswordGenerator) bool { return p.Uppercase }, UppercaseChars},
+	{"lowercase", func(p *PasswordGenerator) bool { return p.Lowercase }, LowercaseChars},
+	{"digits", func(p *PasswordGenerator) bool { return p.Digits }, DigitChars},
+	{"symbols", func(p *PasswordGenerator) bool { return p.Symbols }, SymbolChars},
+}
+
 func drawPassword(p *PasswordGenerator, src ByteSource) (string, error) {
-	if p.Length < 0 {
-		return "", fmt.Errorf("draw: %q has a negative length", p.Label)
+	if p.Length <= 0 {
+		return "", fmt.Errorf("draw: %q has a non-positive length", p.Label)
 	}
 
-	alphabetSet := p.alphabet()
-	if len(alphabetSet) == 0 {
-		return "", fmt.Errorf("draw: %q has no drawable characters", p.Label)
+	// Walk each enabled class individually, the same way PKL's validated()
+	// does, so a class that excludeCharacters empties entirely is caught and
+	// named here rather than surfacing 100,000 attempts later as a generic
+	// "did not satisfy requireEachIncludedType" with no indication of which
+	// class was impossible to draw.
+	anyEnabled := false
+	for _, class := range passwordClasses {
+		if !class.enabled(p) {
+			continue
+		}
+		anyEnabled = true
+		if remaining(class.chars, p.ExcludeCharacters) == "" {
+			return "", fmt.Errorf("draw: %q excludeCharacters removes every %s character", p.Label, class.name)
+		}
+	}
+	if !anyEnabled {
+		return "", fmt.Errorf("draw: %q has no character class enabled", p.Label)
 	}
 
 	// alphabet() returns a map, and Go randomizes map iteration order.
 	// Sorting makes the byte-to-character mapping deterministic, so a given
 	// ByteSource always produces the same value.
+	alphabetSet := p.alphabet()
 	chars := make([]rune, 0, len(alphabetSet))
 	for c := range alphabetSet {
 		chars = append(chars, c)
 	}
-	sort.Slice(chars, func(i, j int) bool { return chars[i] < chars[j] })
+	slices.Sort(chars)
+
+	if len(chars) < 2 {
+		// A one-character alphabet is a constant, not a random value: every
+		// draw would produce the same string regardless of the entropy spent
+		// drawing it. PKL rejects a class emptied entirely (checked above)
+		// but not this narrower case, so it is checked here.
+		return "", fmt.Errorf("draw: %q has an effective alphabet of only %d character(s)", p.Label, len(chars))
+	}
 
 	// required is the set of classes the returned value must contain. Empty
-	// unless requireEachIncludedType is set, in which case satisfiesAll below
-	// is trivially true and the loop below runs exactly once.
+	// unless requireEachIncludedType is set; when it is not set, satisfiesAll
+	// below is trivially true on the first attempt and the loop runs exactly
+	// once. When it is set, satisfiesAll is what forces a candidate missing a
+	// class to be discarded and a fresh one drawn.
 	required := p.guaranteedClasses()
 	if len(required) > p.Length {
 		// Pigeonhole: len(required) distinct classes cannot fit in fewer
@@ -83,6 +122,18 @@ func drawPassword(p *PasswordGenerator, src ByteSource) (string, error) {
 		// it — that would bias both the position and the class frequencies.
 	}
 	return "", fmt.Errorf("draw: %q did not satisfy requireEachIncludedType within %d attempts", p.Label, maxDrawAttempts)
+}
+
+// remaining returns chars with every character in exclude removed. Mirrors
+// PasswordGenerator.remaining() in formae.pkl.
+func remaining(chars, exclude string) string {
+	var b strings.Builder
+	for _, c := range chars {
+		if !strings.ContainsRune(exclude, c) {
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
 }
 
 // classOf reports which canonical alphabet c belongs to, or "" if none (not
@@ -121,8 +172,12 @@ func drawRune(chars []rune, src ByteSource) (rune, error) {
 	limit := 256 - (256 % n) // chars is never larger than the four alphabets combined, well under 256.
 	buf := make([]byte, 1)
 	for {
-		if _, err := src(buf); err != nil {
+		read, err := src(buf)
+		if err != nil {
 			return 0, fmt.Errorf("draw: reading random bytes: %w", err)
+		}
+		if read != len(buf) {
+			return 0, fmt.Errorf("draw: reading random bytes: got %d bytes, want %d", read, len(buf))
 		}
 		b := int(buf[0])
 		if b >= limit {

--- a/pkg/model/generator_draw.go
+++ b/pkg/model/generator_draw.go
@@ -1,0 +1,133 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package model
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ByteSource yields cryptographically secure random bytes. crypto/rand.Read in
+// production; a deterministic source in tests so the rejection paths are
+// reachable without relying on chance.
+type ByteSource func([]byte) (int, error)
+
+// maxDrawAttempts bounds the requireEachIncludedType rejection loop. Any spec
+// PKL accepts is satisfied well within this many attempts (each attempt has
+// an overwhelming chance of success); the cap exists only so a defensively
+// unsatisfiable spec returns an error instead of hanging an unattended agent.
+const maxDrawAttempts = 100_000
+
+// Draw produces one value satisfying the generator's spec, drawing entropy
+// from src. It never logs the discarded candidates or the returned value.
+func Draw(spec Generator, src ByteSource) (string, error) {
+	if spec == nil || isTypedNil(spec) {
+		return "", fmt.Errorf("draw: generator is nil")
+	}
+	switch g := spec.(type) {
+	case *PasswordGenerator:
+		return drawPassword(g, src)
+	default:
+		return "", fmt.Errorf("draw: unsupported generator type %q", spec.GetType())
+	}
+}
+
+func drawPassword(p *PasswordGenerator, src ByteSource) (string, error) {
+	if p.Length < 0 {
+		return "", fmt.Errorf("draw: %q has a negative length", p.Label)
+	}
+
+	alphabetSet := p.alphabet()
+	if len(alphabetSet) == 0 {
+		return "", fmt.Errorf("draw: %q has no drawable characters", p.Label)
+	}
+
+	// alphabet() returns a map, and Go randomizes map iteration order.
+	// Sorting makes the byte-to-character mapping deterministic, so a given
+	// ByteSource always produces the same value.
+	chars := make([]rune, 0, len(alphabetSet))
+	for c := range alphabetSet {
+		chars = append(chars, c)
+	}
+	sort.Slice(chars, func(i, j int) bool { return chars[i] < chars[j] })
+
+	// required is the set of classes the returned value must contain. Empty
+	// unless requireEachIncludedType is set, in which case satisfiesAll below
+	// is trivially true and the loop below runs exactly once.
+	required := p.guaranteedClasses()
+	if len(required) > p.Length {
+		// Pigeonhole: len(required) distinct classes cannot fit in fewer
+		// positions than that, no matter how many candidates are drawn.
+		return "", fmt.Errorf("draw: %q requires %d classes in a value of length %d", p.Label, len(required), p.Length)
+	}
+
+	for attempt := 0; attempt < maxDrawAttempts; attempt++ {
+		candidate := make([]rune, p.Length)
+		present := map[string]bool{}
+		for i := range candidate {
+			c, err := drawRune(chars, src)
+			if err != nil {
+				return "", err
+			}
+			candidate[i] = c
+			present[classOf(c)] = true
+		}
+		if satisfiesAll(required, present) {
+			return string(candidate), nil
+		}
+		// The candidate is missing a required class: discard it entirely and
+		// draw a fresh one. Never patch a character into a position to fix
+		// it — that would bias both the position and the class frequencies.
+	}
+	return "", fmt.Errorf("draw: %q did not satisfy requireEachIncludedType within %d attempts", p.Label, maxDrawAttempts)
+}
+
+// classOf reports which canonical alphabet c belongs to, or "" if none (not
+// reachable for a character drawn from this generator's own alphabet, since
+// that alphabet is built from exactly these four sets).
+func classOf(c rune) string {
+	switch {
+	case strings.ContainsRune(UppercaseChars, c):
+		return "uppercase"
+	case strings.ContainsRune(LowercaseChars, c):
+		return "lowercase"
+	case strings.ContainsRune(DigitChars, c):
+		return "digits"
+	case strings.ContainsRune(SymbolChars, c):
+		return "symbols"
+	default:
+		return ""
+	}
+}
+
+func satisfiesAll(required, present map[string]bool) bool {
+	for name := range required {
+		if !present[name] {
+			return false
+		}
+	}
+	return true
+}
+
+// drawRune draws one unbiased index into chars from src. A byte in the
+// modulo-biased tail — the range beyond the largest multiple of len(chars)
+// that fits in a byte — is discarded and redrawn rather than folded with %,
+// which would over-represent the first 256%len(chars) entries of chars.
+func drawRune(chars []rune, src ByteSource) (rune, error) {
+	n := len(chars)
+	limit := 256 - (256 % n) // chars is never larger than the four alphabets combined, well under 256.
+	buf := make([]byte, 1)
+	for {
+		if _, err := src(buf); err != nil {
+			return 0, fmt.Errorf("draw: reading random bytes: %w", err)
+		}
+		b := int(buf[0])
+		if b >= limit {
+			continue // biased tail; discard and redraw, never logged.
+		}
+		return chars[b%n], nil
+	}
+}

--- a/pkg/model/generator_draw_test.go
+++ b/pkg/model/generator_draw_test.go
@@ -141,6 +141,27 @@ func TestDraw_ModuloBiasedByteIsDiscardedAndRedrawn(t *testing.T) {
 // With Uppercase and Lowercase enabled, requireEachIncludedType, and Length
 // 2, a candidate drawn entirely from one class must be discarded in full and
 // a fresh candidate drawn, never patched.
+// The threshold at limit is exactly what makes drawRune unbiased: byte 250
+// must be rejected (it is the first byte in the digits alphabet's biased
+// tail, limit=250) and byte 249 must be accepted and mapped via 249%10=9 to
+// '9'. This pins the boundary itself, not just that some rejection happens —
+// a test that only proves rejection happens is satisfied by a lower, still
+// biased threshold (e.g. limit := 256 - n) or an off-by-one comparison
+// (b > limit instead of b >= limit).
+func TestDraw_RejectionBoundaryIsExactlyLimit(t *testing.T) {
+	spec := pw(func(g *pkgmodel.PasswordGenerator) {
+		g.Uppercase, g.Lowercase, g.Digits, g.Symbols = false, false, true, false
+		g.RequireEachIncludedType = false
+		g.Length = 1
+	})
+	src, calls := sequenceSource([]byte{250, 249})
+
+	value, err := pkgmodel.Draw(spec, src)
+	require.NoError(t, err)
+	assert.Equal(t, "9", value)
+	assert.Equal(t, 2, *calls, "expected byte 250 to be rejected and byte 249 to be drawn")
+}
+
 func TestDraw_RequireEachIncludedType_DiscardsWholeCandidateOnMissingClass(t *testing.T) {
 	spec := pw(func(g *pkgmodel.PasswordGenerator) {
 		g.Uppercase, g.Lowercase, g.Digits, g.Symbols = true, true, false, false
@@ -203,6 +224,56 @@ func TestDraw_ExcludeCharactersEmptyingTheOnlyEnabledClassReturnsError(t *testin
 
 // requireEachIncludedType demanding more classes than there are positions
 // can never be satisfied by any candidate, no matter how many are drawn.
+func TestDraw_ZeroLengthReturnsError(t *testing.T) {
+	spec := pw(func(g *pkgmodel.PasswordGenerator) { g.Length = 0 })
+	value, err := drawWithTimeout(t, spec, realSource)
+	require.Error(t, err)
+	assert.Empty(t, value)
+}
+
+// Uppercase and lowercase are both enabled, but excludeCharacters empties
+// only lowercase. The alphabet is not empty (26 uppercase characters remain)
+// so an alphabet-emptiness check alone would miss this; the per-class check
+// must catch it and name the class that excludeCharacters wiped out.
+func TestDraw_ExcludeCharactersEmptyingOneOfSeveralEnabledClassesNamesIt(t *testing.T) {
+	spec := pw(func(g *pkgmodel.PasswordGenerator) {
+		g.Uppercase, g.Lowercase, g.Digits, g.Symbols = true, true, false, false
+		g.ExcludeCharacters = pkgmodel.LowercaseChars
+		g.RequireEachIncludedType = true
+	})
+	value, err := drawWithTimeout(t, spec, realSource)
+	require.Error(t, err)
+	assert.Empty(t, value)
+	assert.Contains(t, err.Error(), "lowercase")
+}
+
+// Uppercase only, with excludeCharacters removing every uppercase letter but
+// one, leaves an alphabet of exactly one character. A one-character alphabet
+// is a constant, not a random value, and must be rejected even though PKL
+// only rejects a class emptied entirely.
+func TestDraw_EffectiveAlphabetOfOneCharacterReturnsError(t *testing.T) {
+	spec := pw(func(g *pkgmodel.PasswordGenerator) {
+		g.Uppercase, g.Lowercase, g.Digits, g.Symbols = true, false, false, false
+		g.ExcludeCharacters = pkgmodel.UppercaseChars[1:] // leaves only 'A'
+		g.RequireEachIncludedType = false
+	})
+	value, err := drawWithTimeout(t, spec, realSource)
+	require.Error(t, err)
+	assert.Empty(t, value)
+}
+
+// A ByteSource that returns (0, nil) — a short read with no error, the shape
+// an io.Reader adapter can produce — must not be treated as a successful
+// draw; that would silently spend zero entropy on the returned character.
+func TestDraw_ShortReadFromByteSourceReturnsError(t *testing.T) {
+	spec := pw(func(*pkgmodel.PasswordGenerator) {})
+	short := func(b []byte) (int, error) { return 0, nil }
+
+	value, err := pkgmodel.Draw(spec, short)
+	require.Error(t, err)
+	assert.Empty(t, value)
+}
+
 func TestDraw_MoreRequiredClassesThanLengthReturnsErrorRatherThanHanging(t *testing.T) {
 	spec := pw(func(g *pkgmodel.PasswordGenerator) {
 		g.Uppercase, g.Lowercase, g.Digits, g.Symbols = true, true, false, false

--- a/pkg/model/generator_draw_test.go
+++ b/pkg/model/generator_draw_test.go
@@ -224,11 +224,19 @@ func TestDraw_ExcludeCharactersEmptyingTheOnlyEnabledClassReturnsError(t *testin
 
 // requireEachIncludedType demanding more classes than there are positions
 // can never be satisfied by any candidate, no matter how many are drawn.
+// RequireEachIncludedType is turned off so the pigeonhole check
+// (len(required) > p.Length) cannot also fire on a zero length and mask
+// whether the length guard itself is doing the job; the message assertion
+// pins it to that guard specifically, not any error at all.
 func TestDraw_ZeroLengthReturnsError(t *testing.T) {
-	spec := pw(func(g *pkgmodel.PasswordGenerator) { g.Length = 0 })
+	spec := pw(func(g *pkgmodel.PasswordGenerator) {
+		g.RequireEachIncludedType = false
+		g.Length = 0
+	})
 	value, err := drawWithTimeout(t, spec, realSource)
 	require.Error(t, err)
 	assert.Empty(t, value)
+	assert.Contains(t, err.Error(), "non-positive length")
 }
 
 // Uppercase and lowercase are both enabled, but excludeCharacters empties
@@ -265,13 +273,21 @@ func TestDraw_EffectiveAlphabetOfOneCharacterReturnsError(t *testing.T) {
 // A ByteSource that returns (0, nil) — a short read with no error, the shape
 // an io.Reader adapter can produce — must not be treated as a successful
 // draw; that would silently spend zero entropy on the returned character.
+// RequireEachIncludedType is turned off: with it on (pw()'s default), a
+// candidate built entirely from repeated zero-value bytes still fails the
+// class-presence check and the outer loop just retries until maxDrawAttempts
+// is exhausted, surfacing a generic "did not satisfy requireEachIncludedType"
+// error that has nothing to do with the short read. With it off, the very
+// first short read must itself be the thing that errors, which the message
+// assertion pins down.
 func TestDraw_ShortReadFromByteSourceReturnsError(t *testing.T) {
-	spec := pw(func(*pkgmodel.PasswordGenerator) {})
+	spec := pw(func(g *pkgmodel.PasswordGenerator) { g.RequireEachIncludedType = false })
 	short := func(b []byte) (int, error) { return 0, nil }
 
 	value, err := pkgmodel.Draw(spec, short)
 	require.Error(t, err)
 	assert.Empty(t, value)
+	assert.Contains(t, err.Error(), "got 0 bytes, want 1")
 }
 
 func TestDraw_MoreRequiredClassesThanLengthReturnsErrorRatherThanHanging(t *testing.T) {

--- a/pkg/model/generator_draw_test.go
+++ b/pkg/model/generator_draw_test.go
@@ -1,0 +1,267 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package model_test
+
+import (
+	cryptorand "crypto/rand"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// realSource draws from the actual CSPRNG. Used for tests that only assert
+// invariants (length, alphabet membership, class presence) which the
+// algorithm guarantees by construction, never for a distribution assertion.
+func realSource(b []byte) (int, error) { return cryptorand.Read(b) }
+
+// expectedAlphabet reconstructs the drawable character set from the spec's
+// exported fields, independent of the unexported alphabet() helper the
+// production code uses, so the test is a check on Draw's contract rather than
+// a mirror of its implementation.
+func expectedAlphabet(p *pkgmodel.PasswordGenerator) map[rune]bool {
+	out := map[rune]bool{}
+	add := func(enabled bool, chars string) {
+		if !enabled {
+			return
+		}
+		for _, c := range chars {
+			if !strings.ContainsRune(p.ExcludeCharacters, c) {
+				out[c] = true
+			}
+		}
+	}
+	add(p.Uppercase, pkgmodel.UppercaseChars)
+	add(p.Lowercase, pkgmodel.LowercaseChars)
+	add(p.Digits, pkgmodel.DigitChars)
+	add(p.Symbols, pkgmodel.SymbolChars)
+	return out
+}
+
+func classOf(c rune) string {
+	switch {
+	case strings.ContainsRune(pkgmodel.UppercaseChars, c):
+		return "uppercase"
+	case strings.ContainsRune(pkgmodel.LowercaseChars, c):
+		return "lowercase"
+	case strings.ContainsRune(pkgmodel.DigitChars, c):
+		return "digits"
+	case strings.ContainsRune(pkgmodel.SymbolChars, c):
+		return "symbols"
+	default:
+		return ""
+	}
+}
+
+func TestDraw_CorrectLength(t *testing.T) {
+	spec := pw(func(*pkgmodel.PasswordGenerator) {})
+	value, err := pkgmodel.Draw(spec, realSource)
+	require.NoError(t, err)
+	assert.Len(t, value, spec.Length)
+}
+
+func TestDraw_EveryCharacterIsDrawable(t *testing.T) {
+	spec := pw(func(*pkgmodel.PasswordGenerator) {})
+	value, err := pkgmodel.Draw(spec, realSource)
+	require.NoError(t, err)
+
+	allowed := expectedAlphabet(spec)
+	for _, c := range value {
+		assert.True(t, allowed[c], "character %q is not drawable under the spec", c)
+	}
+}
+
+func TestDraw_RequireEachIncludedType_EveryEnabledClassIsPresent(t *testing.T) {
+	spec := pw(func(g *pkgmodel.PasswordGenerator) {
+		g.Uppercase, g.Lowercase, g.Digits, g.Symbols = true, true, true, true
+		g.RequireEachIncludedType = true
+		g.Length = 32
+	})
+	value, err := pkgmodel.Draw(spec, realSource)
+	require.NoError(t, err)
+
+	present := map[string]bool{}
+	for _, c := range value {
+		present[classOf(c)] = true
+	}
+	assert.True(t, present["uppercase"])
+	assert.True(t, present["lowercase"])
+	assert.True(t, present["digits"])
+	assert.True(t, present["symbols"])
+}
+
+// sequenceSource replays a fixed byte sequence, one byte per call (Draw only
+// ever requests a single byte at a time), so a test can steer the algorithm
+// through a specific rejection path deterministically. calls counts how many
+// times the source was read.
+func sequenceSource(bytes []byte) (src pkgmodel.ByteSource, calls *int) {
+	i := 0
+	n := 0
+	calls = &n
+	src = func(b []byte) (int, error) {
+		*calls++
+		if i >= len(bytes) {
+			return 0, fmt.Errorf("sequenceSource: exhausted after %d bytes", len(bytes))
+		}
+		copied := copy(b, bytes[i:i+1])
+		i++
+		return copied, nil
+	}
+	return src, calls
+}
+
+// A digits-only alphabet has 10 characters; 256 % 10 == 6, so bytes 250-255
+// fall in the modulo-biased tail and must be discarded rather than folded
+// with %, which would over-represent '0'-'5'.
+func TestDraw_ModuloBiasedByteIsDiscardedAndRedrawn(t *testing.T) {
+	spec := pw(func(g *pkgmodel.PasswordGenerator) {
+		g.Uppercase, g.Lowercase, g.Digits, g.Symbols = false, false, true, false
+		g.RequireEachIncludedType = false
+		g.Length = 4
+	})
+	// First byte (255) is in the biased tail and must be discarded; the
+	// second byte (0) is the one actually used for position 0.
+	src, calls := sequenceSource([]byte{255, 0, 1, 2, 3})
+
+	value, err := pkgmodel.Draw(spec, src)
+	require.NoError(t, err)
+	assert.Equal(t, "0123", value)
+	assert.Equal(t, 5, *calls, "expected the biased byte to be discarded and a 5th byte drawn")
+}
+
+// With Uppercase and Lowercase enabled, requireEachIncludedType, and Length
+// 2, a candidate drawn entirely from one class must be discarded in full and
+// a fresh candidate drawn, never patched.
+func TestDraw_RequireEachIncludedType_DiscardsWholeCandidateOnMissingClass(t *testing.T) {
+	spec := pw(func(g *pkgmodel.PasswordGenerator) {
+		g.Uppercase, g.Lowercase, g.Digits, g.Symbols = true, true, false, false
+		g.RequireEachIncludedType = true
+		g.Length = 2
+	})
+	// Sorted alphabet is A..Z (indices 0-25) then a..z (indices 26-51); 52
+	// divides 256 with room to spare (limit 208), so none of these bytes hit
+	// the modulo-biased tail and this test exercises only the whole-candidate
+	// rejection path.
+	//
+	// First candidate: byte 0, byte 1 -> "AB", uppercase only -> discarded.
+	// Second candidate: byte 0, byte 26 -> "Aa", both classes -> accepted.
+	src, calls := sequenceSource([]byte{0, 1, 0, 26})
+
+	value, err := pkgmodel.Draw(spec, src)
+	require.NoError(t, err)
+	assert.Equal(t, "Aa", value)
+	assert.Equal(t, 4, *calls, "expected the first, incomplete candidate to be discarded in full")
+}
+
+func drawWithTimeout(t *testing.T, spec pkgmodel.Generator, src pkgmodel.ByteSource) (string, error) {
+	t.Helper()
+	type result struct {
+		value string
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		value, err := pkgmodel.Draw(spec, src)
+		done <- result{value, err}
+	}()
+	select {
+	case r := <-done:
+		return r.value, r.err
+	case <-time.After(2 * time.Second):
+		t.Fatal("Draw did not return within timeout; it may be looping on an unsatisfiable spec")
+		return "", nil
+	}
+}
+
+func TestDraw_NoClassEnabledReturnsErrorRatherThanHanging(t *testing.T) {
+	spec := pw(func(g *pkgmodel.PasswordGenerator) {
+		g.Uppercase, g.Lowercase, g.Digits, g.Symbols = false, false, false, false
+	})
+	value, err := drawWithTimeout(t, spec, realSource)
+	require.Error(t, err)
+	assert.Empty(t, value)
+}
+
+func TestDraw_ExcludeCharactersEmptyingTheOnlyEnabledClassReturnsError(t *testing.T) {
+	spec := pw(func(g *pkgmodel.PasswordGenerator) {
+		g.Uppercase, g.Lowercase, g.Digits, g.Symbols = true, false, false, false
+		g.ExcludeCharacters = pkgmodel.UppercaseChars
+	})
+	value, err := drawWithTimeout(t, spec, realSource)
+	require.Error(t, err)
+	assert.Empty(t, value)
+}
+
+// requireEachIncludedType demanding more classes than there are positions
+// can never be satisfied by any candidate, no matter how many are drawn.
+func TestDraw_MoreRequiredClassesThanLengthReturnsErrorRatherThanHanging(t *testing.T) {
+	spec := pw(func(g *pkgmodel.PasswordGenerator) {
+		g.Uppercase, g.Lowercase, g.Digits, g.Symbols = true, true, false, false
+		g.RequireEachIncludedType = true
+		g.Length = 1
+	})
+	value, err := drawWithTimeout(t, spec, realSource)
+	require.Error(t, err)
+	assert.Empty(t, value)
+}
+
+func TestDraw_TypedNilGeneratorReturnsError(t *testing.T) {
+	var nilGen *pkgmodel.PasswordGenerator
+	var spec pkgmodel.Generator = nilGen
+	value, err := pkgmodel.Draw(spec, realSource)
+	require.Error(t, err)
+	assert.Empty(t, value)
+}
+
+func TestDraw_ByteSourceErrorPropagates(t *testing.T) {
+	spec := pw(func(*pkgmodel.PasswordGenerator) {})
+	boom := fmt.Errorf("byte source unavailable")
+	failing := func([]byte) (int, error) { return 0, boom }
+
+	value, err := pkgmodel.Draw(spec, failing)
+	require.Error(t, err)
+	assert.Empty(t, value)
+	assert.ErrorIs(t, err, boom)
+}
+
+// Every spec PKL's eval-time validation accepts must be one the drawer can
+// satisfy: it never rejects a valid combination of enabled classes and
+// requireEachIncludedType at the minimum PKL-accepted length.
+func TestDraw_NeverErrorsForAnySpecPKLAccepts(t *testing.T) {
+	classCombos := []struct {
+		uppercase, lowercase, digits, symbols bool
+	}{}
+	for mask := 1; mask < 16; mask++ { // skip 0: PKL rejects no class enabled
+		classCombos = append(classCombos, struct {
+			uppercase, lowercase, digits, symbols bool
+		}{
+			uppercase: mask&1 != 0,
+			lowercase: mask&2 != 0,
+			digits:    mask&4 != 0,
+			symbols:   mask&8 != 0,
+		})
+	}
+
+	for _, combo := range classCombos {
+		for _, require_ := range []bool{true, false} {
+			spec := pw(func(g *pkgmodel.PasswordGenerator) {
+				g.Uppercase, g.Lowercase, g.Digits, g.Symbols = combo.uppercase, combo.lowercase, combo.digits, combo.symbols
+				g.RequireEachIncludedType = require_
+				g.Length = 16 // PKL's minimum accepted length
+				g.ExcludeCharacters = ""
+			})
+			value, err := pkgmodel.Draw(spec, realSource)
+			require.NoErrorf(t, err, "combo %+v requireEachIncludedType=%v", combo, require_)
+			assert.Len(t, value, 16)
+		}
+	}
+}

--- a/pkg/model/generator_spec.go
+++ b/pkg/model/generator_spec.go
@@ -23,39 +23,39 @@ const (
 
 // alphabet returns the characters a spec can actually draw, i.e. the union of
 // its enabled classes with excludeCharacters removed.
-func (p *PasswordGenerator) alphabet() map[rune]bool {
+func (g *PasswordGenerator) alphabet() map[rune]bool {
 	out := map[rune]bool{}
 	add := func(enabled bool, chars string) {
 		if !enabled {
 			return
 		}
 		for _, c := range chars {
-			if !strings.ContainsRune(p.ExcludeCharacters, c) {
+			if !strings.ContainsRune(g.ExcludeCharacters, c) {
 				out[c] = true
 			}
 		}
 	}
-	add(p.Uppercase, UppercaseChars)
-	add(p.Lowercase, LowercaseChars)
-	add(p.Digits, DigitChars)
-	add(p.Symbols, SymbolChars)
+	add(g.Uppercase, UppercaseChars)
+	add(g.Lowercase, LowercaseChars)
+	add(g.Digits, DigitChars)
+	add(g.Symbols, SymbolChars)
 	return out
 }
 
 // guaranteedClasses returns the classes a value drawn under this spec is known
 // to contain. Without requireEachIncludedType a draw guarantees nothing.
-func (p *PasswordGenerator) guaranteedClasses() map[string]bool {
-	if !p.RequireEachIncludedType {
+func (g *PasswordGenerator) guaranteedClasses() map[string]bool {
+	if !g.RequireEachIncludedType {
 		return map[string]bool{}
 	}
-	return p.enabledClasses()
+	return g.enabledClasses()
 }
 
-func (p *PasswordGenerator) enabledClasses() map[string]bool {
+func (g *PasswordGenerator) enabledClasses() map[string]bool {
 	out := map[string]bool{}
 	for name, enabled := range map[string]bool{
-		"uppercase": p.Uppercase, "lowercase": p.Lowercase,
-		"digits": p.Digits, "symbols": p.Symbols,
+		"uppercase": g.Uppercase, "lowercase": g.Lowercase,
+		"digits": g.Digits, "symbols": g.Symbols,
 	} {
 		if enabled {
 			out[name] = true
@@ -121,5 +121,5 @@ func GenerationSatisfies(drawn, desired Generator) bool {
 // silently stop covering.
 func isTypedNil(g Generator) bool {
 	v := reflect.ValueOf(g)
-	return v.Kind() == reflect.Ptr && v.IsNil()
+	return v.Kind() == reflect.Pointer && v.IsNil()
 }

--- a/pkg/model/redact.go
+++ b/pkg/model/redact.go
@@ -74,6 +74,34 @@ func RedactOpaqueForLog(v any) any {
 	}
 }
 
+// RedactOpaqueJSONForLog renders a JSON document as a string that is safe to put
+// in a log line or a diagnostic message: the plaintext of every opaque envelope
+// is replaced by RedactedForLog, and the surrounding structure survives so the
+// document still names the properties it describes. An empty document renders
+// as the empty string. A document that cannot be decoded, or whose redacted form
+// cannot be re-encoded, is withheld whole: RedactedForLog stands in for it
+// rather than the bytes being rendered in the clear.
+//
+// Callers that hold a document as json.RawMessage should route it through here
+// rather than rendering it directly. A raw document reaches a log line as its
+// text under %s and as a decimal byte slice under %v or an slog attribute, and
+// the second of those spells the secret out just as completely while matching no
+// search for it.
+func RedactOpaqueJSONForLog(document json.RawMessage) string {
+	if len(document) == 0 {
+		return ""
+	}
+	var decoded any
+	if err := json.Unmarshal(document, &decoded); err != nil {
+		return RedactedForLog
+	}
+	out, err := marshalNoEscape(RedactOpaqueForLog(decoded))
+	if err != nil {
+		return RedactedForLog
+	}
+	return out
+}
+
 // redactEmbedTemplate redacts opaque $value fields carried inside the framed
 // spans of an $embed $template string, then re-frames each span so the template
 // stays structurally intact. If the template cannot be scanned (corrupt framing),

--- a/pkg/model/redact_test.go
+++ b/pkg/model/redact_test.go
@@ -154,3 +154,20 @@ func TestRedactOpaqueForLog_UnparseableByteSlicePassedThrough(t *testing.T) {
 	require.Truef(t, ok, "expected []byte, got %T", out["raw"])
 	assert.Equal(t, bad, got, "unparseable []byte must not be modified")
 }
+
+func TestRedactOpaqueJSONForLog_RedactsOpaqueValueAndKeepsStructure(t *testing.T) {
+	out := RedactOpaqueJSONForLog(json.RawMessage(`{"Password":{"$visibility":"Opaque","$value":"hunter2"}}`))
+	assert.NotContains(t, out, "hunter2")
+	assert.Contains(t, out, "Password", "the property name must survive so the line still says which field")
+	assert.Contains(t, out, RedactedForLog)
+}
+
+func TestRedactOpaqueJSONForLog_EmptyDocumentRendersEmpty(t *testing.T) {
+	assert.Equal(t, "", RedactOpaqueJSONForLog(nil))
+	assert.Equal(t, "", RedactOpaqueJSONForLog(json.RawMessage{}))
+}
+
+func TestRedactOpaqueJSONForLog_UndecodableDocumentIsWithheldWhole(t *testing.T) {
+	out := RedactOpaqueJSONForLog(json.RawMessage(`{"Password": "hunter2"`))
+	assert.Equal(t, RedactedForLog, out, "a document that cannot be decoded must never be rendered in the clear")
+}

--- a/pkg/model/uri.go
+++ b/pkg/model/uri.go
@@ -280,9 +280,11 @@ func AsResolvedReference(value gjson.Result) (ResolvedReference, bool) {
 }
 
 // CollectReferencedKSUIDs parses data as JSON, recurses through all objects
-// and arrays, and collects the KSUID authority from every object whose "$ref"
-// field holds a formae:// URI. Returns a deduplicated, sorted slice. Returns
-// a non-nil empty slice when data is empty, invalid, or contains no refs.
+// and arrays, and collects every outbound reference KSUID it carries: the
+// KSUID authority of any object whose "$ref" field holds a formae:// URI, and
+// the "$generator" KSUID of any translated $gen envelope. Returns a
+// deduplicated, sorted slice. Returns a non-nil empty slice when data is
+// empty, invalid, or carries no outbound references.
 func CollectReferencedKSUIDs(data []byte) []string {
 	if len(data) == 0 {
 		return []string{}
@@ -305,9 +307,11 @@ func CollectReferencedKSUIDs(data []byte) []string {
 }
 
 // collectKSUIDsRecursive descends into all objects and arrays, collecting
-// KSUIDs from any object whose "$ref" field is a formae:// URI string.
-// Unlike findResolvablesRecursive, it does NOT return early at a "$ref"
-// object — it continues descending into all children to catch nested refs.
+// KSUIDs from any object whose "$ref" field is a formae:// URI string, and the
+// generator KSUID of any translated $gen envelope. Unlike
+// findResolvablesRecursive and findGenObjectsRecursive, it does NOT return
+// early at a recognized envelope — it continues descending into all children
+// to catch nested references.
 func collectKSUIDsRecursive(value gjson.Result, seen map[string]struct{}) {
 	if value.IsObject() {
 		refField := value.Get("$ref")
@@ -315,6 +319,12 @@ func collectKSUIDsRecursive(value gjson.Result, seen map[string]struct{}) {
 			if ksuid := FormaeURI(refField.String()).KSUID(); ksuid != "" {
 				seen[ksuid] = struct{}{}
 			}
+		}
+
+		// An authored $gen envelope names its generator by label and stack, so
+		// GenGeneratorKSUID is empty for it and it contributes nothing.
+		if generator := GenGeneratorKSUID(value); generator != "" {
+			seen[generator] = struct{}{}
 		}
 
 		// Always recurse into all children (including $value of a resolved ref).

--- a/pkg/model/uri_test.go
+++ b/pkg/model/uri_test.go
@@ -167,3 +167,67 @@ func TestCollectReferencedKSUIDs(t *testing.T) {
 		assert.Equal(t, []string{}, got)
 	})
 }
+
+func TestCollectReferencedKSUIDs_GenEnvelopes(t *testing.T) {
+	t.Run("translated $gen envelope contributes its generator KSUID", func(t *testing.T) {
+		data := []byte(`{
+			"MasterUserPassword": {
+				"$gen": true,
+				"$generator": "2genKSUID000000000000000000",
+				"$output": "value",
+				"$visibility": "Opaque",
+				"$value": "sha256:abc",
+				"$hashed": true,
+				"$resolvedFrom": "sha256:abc"
+			}
+		}`)
+		got := CollectReferencedKSUIDs(data)
+		assert.Equal(t, []string{"2genKSUID000000000000000000"}, got)
+	})
+
+	t.Run("a document carrying both a $ref and a $gen yields both KSUIDs", func(t *testing.T) {
+		data := []byte(`{
+			"VpcId": {"$ref": "formae://2refKSUID000000000000000000#/VpcId", "$value": "vpc-1"},
+			"Password": {"$gen": true, "$generator": "2genKSUID000000000000000000", "$output": "value", "$value": "sha256:abc"}
+		}`)
+		got := CollectReferencedKSUIDs(data)
+		assert.Equal(t, []string{"2genKSUID000000000000000000", "2refKSUID000000000000000000"}, got)
+	})
+
+	t.Run("$gen nested inside an array element is collected", func(t *testing.T) {
+		data := []byte(`{
+			"Users": [
+				{"Name": "alice", "Password": {"$gen": true, "$generator": "2genAAA00000000000000000000", "$output": "value"}},
+				{"Name": "bob", "Password": {"$gen": true, "$generator": "2genBBB00000000000000000000", "$output": "value"}}
+			]
+		}`)
+		got := CollectReferencedKSUIDs(data)
+		assert.Equal(t, []string{"2genAAA00000000000000000000", "2genBBB00000000000000000000"}, got)
+	})
+
+	t.Run("untranslated $gen envelope contributes nothing", func(t *testing.T) {
+		data := []byte(`{
+			"Password": {"$gen": true, "$label": "db-password", "$stack": "default", "$output": "value", "$visibility": "Opaque"}
+		}`)
+		got := CollectReferencedKSUIDs(data)
+		assert.Equal(t, []string{}, got)
+	})
+
+	t.Run("the same generator bound to two properties is deduped", func(t *testing.T) {
+		data := []byte(`{
+			"A": {"$gen": true, "$generator": "2sameGen0000000000000000000", "$output": "value"},
+			"B": {"$gen": true, "$generator": "2sameGen0000000000000000000", "$output": "value"}
+		}`)
+		got := CollectReferencedKSUIDs(data)
+		assert.Equal(t, []string{"2sameGen0000000000000000000"}, got)
+	})
+
+	t.Run("multiple generator KSUIDs are returned sorted", func(t *testing.T) {
+		data := []byte(`{
+			"A": {"$gen": true, "$generator": "zzzGen", "$output": "value"},
+			"B": {"$gen": true, "$generator": "aaaGen", "$output": "value"}
+		}`)
+		got := CollectReferencedKSUIDs(data)
+		assert.Equal(t, []string{"aaaGen", "zzzGen"}, got)
+	})
+}


### PR DESCRIPTION
## Summary

Stacked on #713, which adds the `$gen` envelope. That branch could bind a resource property to a generator; this one makes the generator actually produce a value and get it where it belongs.

A generator draws a value, its sinks receive it in flight, only a digest survives at rest, an ordinary re-apply does not redraw, and a crash mid-command resumes correctly.

**Review #713 first** — this is 104 files against that base, and reads as nonsense without it.

## The rule everything follows from

A drawn value exists only in memory, for the duration of one command. Each sink is stamped with the generation's digest and only a hash is persisted, so once the command ends the value is unrecoverable. A sink that missed a draw can never be brought level except by drawing again, which puts its siblings behind.

Two consequences, and most of this branch is one or the other:

- **Adding a sink forces a draw, so every sink rotates.** A sink the ordinary plan found nothing to do for is planned anyway, through the normal update path, so it takes the new value with the rest. Without this, two consumers of one credential end up holding different values and each apply repairs one while breaking the other.
- **What cannot be reached is refused.** A live sink the applied forma does not declare, typically in a stack that was not applied, fails admission with an error naming it rather than a silent divergence.

## What is here

- **A `$gen` reverse index** across the four datastore backends, answering which resources bind a given generator. No migration: a generator KSUID is an outbound reference KSUID, so postgres and aurora reuse the existing indexed column and the boot-time backfill covers rows written earlier. Each backend's SQL is a coarse prefilter and one shared predicate is authoritative, so the four agree by construction rather than by four implementations happening to match.
- **Co-planning and the admission refusal**, per the rule above. The refusal asks whether the command reaches a resource at all, not whether it still binds the generator, so unbinding a sink while the generator draws for another reason stays an ordinary apply.
- **Draw visibility in the plan.** A draw is a credential rotation, so it renders as one and the confirmation prompt says every bound resource takes a new secret. A generator that both changes spec and draws shows as two entries: one Operation string would hide either the rotation or the diff.
- **Three log sites that could emit a secret**, now redacted. One rendered a `json.RawMessage` as a decimal byte array, which is present in the output and invisible to a substring assertion, so those tests decode before asserting.
- **A failed draw's reason** reaches the operator through the sinks it cascades to, instead of a failed command with no explanation.
- **Cross-stack fixes**: a generator on another stack is found when resuming, and a stable binding beside an execution-time reference no longer fails every update on a provider whose read returns the secret.

## Deliberately not here

- **Command-status observability for draws.** A draw is not persisted, so its projected state is plan-time only. Making it durable needs a column whose shape this branch would be guessing at.
- **Generator-aware extract.** Extract emits the raw `$generator` KSUID rather than an authorable declaration; tracked separately.
- **Two known interim states that self-heal**, both converging on the next apply, both tracked: a resumed command can leave one sink a generation behind, which is the accepted cost of redrawing rather than persisting a value; and two commands admitted concurrently can each draw for a shared generator.

## Verification

Full unit suite green apart from one Postgres test with a local collation assumption that fails on any branch. The aurora datastore suite was run against its emulator rather than silently skipped, and the PKL schema tests were run with the integration tag rather than reporting no tests.