### PR TITLE
fix(datastore): resolve the Postgres password per connection

### DIFF
--- a/internal/datastore/postgres/password_provider_test.go
+++ b/internal/datastore/postgres/password_provider_test.go
@@ -1,0 +1,221 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/demula/mksuid/v2"
+	"github.com/jackc/pgx/v5"
+	"github.com/platform-engineering-labs/formae/internal/datastore/postgres"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// adminConnect opens a connection as the container's superuser, skipping the
+// test when Postgres is not reachable.
+func adminConnect(t *testing.T) *pgx.Conn {
+	t.Helper()
+	conn, err := pgx.Connect(context.Background(), "postgres://postgres:admin@localhost:5432/postgres")
+	if err != nil {
+		t.Skipf("Postgres not available: %v", err)
+	}
+	return conn
+}
+
+// rotatableRole creates a login role with its own database, so a test can change
+// that role's password without affecting any other user of the Postgres server.
+// It returns the role name, the database name and the initial password.
+func rotatableRole(t *testing.T) (role, database, password string) {
+	t.Helper()
+	admin := adminConnect(t)
+
+	suffix := mksuid.New().String()
+	role = "rot_user_" + suffix
+	database = "rot_db_" + suffix
+	password = "initial_" + suffix
+
+	_, err := admin.Exec(context.Background(),
+		fmt.Sprintf("CREATE ROLE %s LOGIN PASSWORD %s",
+			pgx.Identifier{role}.Sanitize(), quoteLiteral(password)))
+	require.NoError(t, err)
+
+	_, err = admin.Exec(context.Background(),
+		fmt.Sprintf("CREATE DATABASE %s OWNER %s",
+			pgx.Identifier{database}.Sanitize(), pgx.Identifier{role}.Sanitize()))
+	require.NoError(t, err)
+
+	require.NoError(t, admin.Close(context.Background()))
+
+	t.Cleanup(func() {
+		cleanup := adminConnect(t)
+		defer func() { _ = cleanup.Close(context.Background()) }()
+		_, _ = cleanup.Exec(context.Background(),
+			fmt.Sprintf("DROP DATABASE IF EXISTS %s WITH (FORCE)", pgx.Identifier{database}.Sanitize()))
+		_, _ = cleanup.Exec(context.Background(),
+			fmt.Sprintf("DROP ROLE IF EXISTS %s", pgx.Identifier{role}.Sanitize()))
+	})
+
+	return role, database, password
+}
+
+// quoteLiteral renders a Postgres single-quoted string literal.
+func quoteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// setRolePassword changes a role's password using a superuser connection.
+func setRolePassword(t *testing.T, role, password string) {
+	t.Helper()
+	admin := adminConnect(t)
+	defer func() { _ = admin.Close(context.Background()) }()
+	_, err := admin.Exec(context.Background(),
+		fmt.Sprintf("ALTER ROLE %s PASSWORD %s",
+			pgx.Identifier{role}.Sanitize(), quoteLiteral(password)))
+	require.NoError(t, err)
+}
+
+// credential is a concurrency-safe answer for a PasswordProvider: it hands out
+// either a password or an error, records how often it was asked, and can be
+// changed while a pool is live.
+type credential struct {
+	mu       sync.Mutex
+	password string
+	err      error
+	calls    int
+}
+
+func (c *credential) provide(context.Context) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	if c.err != nil {
+		return "", c.err
+	}
+	return c.password, nil
+}
+
+func (c *credential) set(password string, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.password = password
+	c.err = err
+}
+
+func (c *credential) callCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+// newRotatableDatastore builds a Postgres datastore against a dedicated role and
+// database, optionally driven by a password provider.
+func newRotatableDatastore(t *testing.T, role, database, password string, provider pkgmodel.PasswordProvider) postgres.DatastorePostgres {
+	t.Helper()
+	cfg := &pkgmodel.DatastoreConfig{
+		DatastoreType: pkgmodel.PostgresDatastore,
+		Postgres: pkgmodel.PostgresConfig{
+			Host:             "localhost",
+			Port:             5432,
+			User:             role,
+			Password:         password,
+			PasswordProvider: provider,
+			Database:         database,
+		},
+	}
+	iface, err := postgres.NewDatastorePostgres(context.Background(), cfg, "test")
+	require.NoError(t, err)
+	d, ok := iface.(postgres.DatastorePostgres)
+	require.True(t, ok)
+	t.Cleanup(d.Close)
+	return d
+}
+
+// ping runs a trivial query on a freshly acquired pool connection.
+func ping(ctx context.Context, d postgres.DatastorePostgres) error {
+	conn, err := d.Pool().Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Release()
+	var one int
+	return conn.QueryRow(ctx, "SELECT 1").Scan(&one)
+}
+
+func TestPostgresDatastore_WithoutProviderUsesStaticPassword(t *testing.T) {
+	role, database, password := rotatableRole(t)
+	d := newRotatableDatastore(t, role, database, password, nil)
+
+	require.NoError(t, ping(context.Background(), d))
+
+	// A reset discards every pooled connection, so the next acquire has to open
+	// a fresh one and still authenticate with the configured password.
+	d.Pool().Reset()
+	require.NoError(t, ping(context.Background(), d))
+}
+
+func TestPostgresDatastore_PasswordProviderIsCalledPerNewConnection(t *testing.T) {
+	role, database, password := rotatableRole(t)
+	cred := &credential{password: password}
+	d := newRotatableDatastore(t, role, database, password, cred.provide)
+
+	before := cred.callCount()
+
+	first, err := d.Pool().Acquire(context.Background())
+	require.NoError(t, err)
+	second, err := d.Pool().Acquire(context.Background())
+	require.NoError(t, err)
+	first.Release()
+	second.Release()
+
+	assert.Equal(t, before+2, cred.callCount(),
+		"provider should be consulted once for each connection the pool opens")
+}
+
+func TestPostgresDatastore_RotatedPasswordIsUsedForNewConnections(t *testing.T) {
+	role, database, password := rotatableRole(t)
+	cred := &credential{password: password}
+	d := newRotatableDatastore(t, role, database, password, cred.provide)
+
+	require.NoError(t, ping(context.Background(), d))
+
+	rotated := "rotated_" + mksuid.New().String()
+	setRolePassword(t, role, rotated)
+
+	// The rotation really did invalidate the old credential.
+	_, err := pgx.Connect(context.Background(),
+		postgres.BuildConnStr("localhost", 5432, role, password, database))
+	require.Error(t, err)
+
+	cred.set(rotated, nil)
+
+	d.Pool().Reset()
+	require.NoError(t, ping(context.Background(), d),
+		"a new connection should authenticate with the password the provider returns now")
+}
+
+func TestPostgresDatastore_PasswordProviderErrorFailsTheConnection(t *testing.T) {
+	role, database, password := rotatableRole(t)
+	cred := &credential{password: password}
+	d := newRotatableDatastore(t, role, database, password, cred.provide)
+
+	require.NoError(t, ping(context.Background(), d))
+
+	sentinel := errors.New("secret store unavailable")
+	cred.set("", sentinel)
+
+	d.Pool().Reset()
+	err := ping(context.Background(), d)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+}

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -74,9 +74,29 @@ func BuildConnStr(host string, port int, user, password, database string) string
 	return u.String()
 }
 
+// resolvePassword returns the password for a new connection: whatever the
+// configured provider answers, or the static config value when no provider is
+// set. The pool holds a single credential for the lifetime of the process, so
+// without a provider a password rotated in the database fails every connection
+// the pool opens from then on.
+func resolvePassword(ctx context.Context, cfg *pkgmodel.PostgresConfig) (string, error) {
+	if cfg.PasswordProvider == nil {
+		return cfg.Password, nil
+	}
+	password, err := cfg.PasswordProvider(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve postgres password: %w", err)
+	}
+	return password, nil
+}
+
 // This can be only used in tests or in setups where we have access to admin (non-production)
 func ensureDatabaseExists(ctx context.Context, cfg *pkgmodel.DatastoreConfig) error {
-	connStr := BuildConnStr(cfg.Postgres.Host, cfg.Postgres.Port, cfg.Postgres.User, cfg.Postgres.Password, "postgres")
+	password, err := resolvePassword(ctx, &cfg.Postgres)
+	if err != nil {
+		return err
+	}
+	connStr := BuildConnStr(cfg.Postgres.Host, cfg.Postgres.Port, cfg.Postgres.User, password, "postgres")
 
 	conn, err := pgx.Connect(ctx, connStr)
 	if err != nil {
@@ -117,7 +137,12 @@ func NewDatastorePostgresEnsureDatabase(ctx context.Context, cfg *pkgmodel.Datas
 }
 
 func NewDatastorePostgres(ctx context.Context, cfg *pkgmodel.DatastoreConfig, agentID string) (datastore.Datastore, error) {
-	connStr := BuildConnStr(cfg.Postgres.Host, cfg.Postgres.Port, cfg.Postgres.User, cfg.Postgres.Password, cfg.Postgres.Database)
+	password, err := resolvePassword(ctx, &cfg.Postgres)
+	if err != nil {
+		return nil, err
+	}
+
+	connStr := BuildConnStr(cfg.Postgres.Host, cfg.Postgres.Port, cfg.Postgres.User, password, cfg.Postgres.Database)
 
 	// Append connection parameters if provided
 	if cfg.Postgres.ConnectionParams != "" {
@@ -158,6 +183,21 @@ func NewDatastorePostgres(ctx context.Context, cfg *pkgmodel.DatastoreConfig, ag
 		// Connection details are still disabled for security
 		otelpgx.WithDisableConnectionDetailsInAttributes(),
 	)
+
+	// With a provider configured, every connection the pool opens asks for the
+	// current credential instead of reusing the one captured at startup. pgx
+	// hands BeforeConnect a copy of the connection config per new connection, so
+	// mutating it here leaves connections already open untouched.
+	if cfg.Postgres.PasswordProvider != nil {
+		poolCfg.BeforeConnect = func(ctx context.Context, connCfg *pgx.ConnConfig) error {
+			password, err := resolvePassword(ctx, &cfg.Postgres)
+			if err != nil {
+				return err
+			}
+			connCfg.Password = password
+			return nil
+		}
+	}
 
 	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
 	if err != nil {
@@ -5181,7 +5221,12 @@ func (d DatastorePostgres) Pool() *pgxpool.Pool { return d.pool }
 
 // This can be only used in tests or in setups where we have access to admin (non-production)
 func (d DatastorePostgres) CleanUp() error {
-	connStr := BuildConnStr(d.cfg.Postgres.Host, d.cfg.Postgres.Port, d.cfg.Postgres.User, d.cfg.Postgres.Password, d.cfg.Postgres.Database)
+	password, err := resolvePassword(d.ctx, &d.cfg.Postgres)
+	if err != nil {
+		return err
+	}
+
+	connStr := BuildConnStr(d.cfg.Postgres.Host, d.cfg.Postgres.Port, d.cfg.Postgres.User, password, d.cfg.Postgres.Database)
 
 	conn, err := pgx.Connect(d.ctx, connStr)
 	if err != nil {

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -5,6 +5,7 @@
 package model
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -137,11 +138,20 @@ type SqliteConfig struct {
 	FilePath string
 }
 
+// PasswordProvider resolves a datastore password. It is consulted once per new
+// database connection, so a deployment whose credential is rotated out from
+// under a long-running process can hand back the current value without the
+// process being restarted. Returning an error fails that connection attempt.
+type PasswordProvider func(context.Context) (string, error)
+
 type PostgresConfig struct {
-	Host             string
-	Port             int
-	User             string
-	Password         string
+	Host     string
+	Port     int
+	User     string
+	Password string
+	// PasswordProvider, when set, supersedes Password: it is called for every
+	// new connection the pool opens. Nil means Password is used as-is.
+	PasswordProvider PasswordProvider
 	Database         string
 	Schema           string
 	ConnectionParams string


### PR DESCRIPTION
## Summary

The agent baked its Postgres password into a connection string once, at construction. A rotated password then failed every new connection while the pool's existing ones kept working, so the agent degraded and then broke rather than failing cleanly.

The pool now resolves the credential per new connection, through an optional provider on the datastore config. With no provider set the behaviour is byte-identical to before — same static password, same connection string, no hook installed.

Every connection this package opens goes through the same resolution: the pool, the migration connection, the ensure-database path and cleanup. Doing three of the four would leave a rotation half-working in a way that is hard to see.

## Why a provider rather than re-reading the credential

Worth stating, because the obvious fix does not work. The password reaches the config from one place: the Pkl config file, read once at startup. There is no reload path — no signal handler, nothing re-invokes config loading. Re-reading it per connection would mean spawning a Pkl evaluator subprocess, and if that config delegates to `read("env:...")` the re-read yields the same value anyway, because a running process cannot see a changed environment variable.

So nothing in-process can be re-read to get a new value, and a hook wired to any existing source would fix nothing. What the pool needs is somewhere to *ask*. The provider is that seam: it defaults to today's static value, and what answers it is the deployment's choice — a file, a reloaded config, a secret store — without this layer taking a dependency on any of them.

## What this does not do

**Nothing constructs a provider yet**, so no deployment re-reads anything as a result of this change alone. This is the enabling half. Wiring a provider that resolves a fresh credential is a separate change and depends on where the deployment keeps the secret.

## Not in scope

MSSQL has the identical defect — the DSN is built once at construction. The provider type is reusable, but `database/sql` has no `BeforeConnect` equivalent, so it needs a custom `driver.Connector`. That is a different-sized change and its own decision.

## Verification

The behavioural test rotates the credential out from under a live pool with `ALTER ROLE`, asserts the old one now genuinely fails, points the provider at the new one, and forces a fresh connection. The config keeps the stale static password throughout, so only the provider can be supplying the working credential. Tests create their own login role and database rather than touching the shared superuser.

pgx 5.7.6's `BeforeConnect` signature and per-connection invocation were checked against the vendored source rather than assumed.