### PR TITLE
fix(metastructure): extract a generator binding in its authored shape

### DIFF
--- a/internal/metastructure/extract_resources.go
+++ b/internal/metastructure/extract_resources.go
@@ -23,7 +23,8 @@ func (m *Metastructure) ExtractResources(query string) (*pkgmodel.Forma, error) 
 		return nil, err
 	}
 
-	if err := m.reverseTranslateKSUIDsToTriplets(resources); err != nil {
+	generators, err := m.reverseTranslateKSUIDsToTriplets(resources)
+	if err != nil {
 		slog.Error("Failed to reverse translate KSUIDs to triplets", "error", err)
 		return nil, err
 	}
@@ -45,6 +46,21 @@ func (m *Metastructure) ExtractResources(query string) (*pkgmodel.Forma, error) 
 				uniqueStacks[resource.Stack] = struct{}{}
 				stackLabels = append(stackLabels, resource.Stack)
 			}
+		}
+	}
+
+	// A generator belongs to one stack and is meant to be bound from others,
+	// so the stack owning one the extracted resources reference need not hold
+	// any resource the query matched. Its stack is emitted alongside theirs,
+	// or the generator declaration names a stack the file does not declare.
+	for _, generator := range generators {
+		stack := generator.GetStack()
+		if stack == "" {
+			continue
+		}
+		if _, exists := uniqueStacks[stack]; !exists {
+			uniqueStacks[stack] = struct{}{}
+			stackLabels = append(stackLabels, stack)
 		}
 	}
 
@@ -128,6 +144,20 @@ func (m *Metastructure) ExtractResources(query string) (*pkgmodel.Forma, error) 
 				continue
 			}
 			forma.Policies = append(forma.Policies, policyJSON)
+		}
+	}
+
+	// A forma that references a generator has to declare it, or the file it is
+	// written to cannot be applied on its own.
+	if len(generators) > 0 {
+		forma.Generators = make([]json.RawMessage, 0, len(generators))
+		for _, generator := range generators {
+			generatorJSON, err := json.Marshal(generator)
+			if err != nil {
+				slog.Error("Failed to marshal generator", "label", generator.GetLabel(), "error", err)
+				continue
+			}
+			forma.Generators = append(forma.Generators, generatorJSON)
 		}
 	}
 

--- a/internal/metastructure/generator_lookup_test.go
+++ b/internal/metastructure/generator_lookup_test.go
@@ -62,7 +62,7 @@ func TestGeneratorLookupForResume_ResolvesADrawnGeneratorOnAnotherStack(t *testi
 	require.NoError(t, ds.AdvanceGeneration(ksuid, "generation-1",
 		json.RawMessage(`{"Type":"password","Label":"db-password","Stack":"secrets","Length":24}`)))
 
-	lookup := generatorLookupForResume(ds)
+	lookup := generatorLookup(ds)
 	require.NotNil(t, lookup)
 
 	generator, err := lookup(ksuid)
@@ -90,7 +90,7 @@ func TestGeneratorLookupForResume_ReturnsTheCurrentSpecNotTheGenerationsSpec(t *
 	}, "cmd-edit")
 	require.NoError(t, err)
 
-	lookup := generatorLookupForResume(ds)
+	lookup := generatorLookup(ds)
 	generator, err := lookup(ksuid)
 	require.NoError(t, err)
 	require.NotNil(t, generator)
@@ -111,7 +111,7 @@ func TestGeneratorLookupForResume_FindsANeverDrawnGeneratorOnItsOwnStack(t *test
 	require.NoError(t, err)
 	require.Empty(t, identity.GenerationID, "precondition: nothing has been drawn")
 
-	lookup := generatorLookupForResume(ds)
+	lookup := generatorLookup(ds)
 	generator, err := lookup(ksuid)
 	require.NoError(t, err)
 	require.NotNil(t, generator, "a never-drawn generator must still be found")
@@ -129,7 +129,7 @@ func TestGeneratorLookupForResume_FindsANeverDrawnGeneratorOnAnotherStack(t *tes
 	_, err := ds.CreateStack(&pkgmodel.Stack{Label: "app"}, "cmd-stack")
 	require.NoError(t, err)
 
-	lookup := generatorLookupForResume(ds)
+	lookup := generatorLookup(ds)
 	generator, err := lookup(ksuid)
 	require.NoError(t, err)
 	require.NotNil(t, generator, "a never-drawn generator on another stack must be found by KSUID")
@@ -144,7 +144,7 @@ func TestGeneratorLookupForResume_UnknownKsuidResolvesToNothing(t *testing.T) {
 	ds := lookupTestDatastore(t)
 	createGeneratorOn(t, ds, "secrets", "db-password", 24)
 
-	lookup := generatorLookupForResume(ds)
+	lookup := generatorLookup(ds)
 	generator, err := lookup("2ZqXo0nEXAMPLEksuidNOTREAL0")
 	require.NoError(t, err)
 	assert.Nil(t, generator)

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1385,7 +1385,16 @@ func (m *Metastructure) ExtractPolicies() ([]apimodel.PolicyInventoryItem, error
 	return items, nil
 }
 
-func (m *Metastructure) reverseTranslateKSUIDsToTriplets(resources []*pkgmodel.Resource) error {
+// reverseTranslateKSUIDsToTriplets rewrites the internal identifiers a stored
+// property document names things by back into the names an author writes them
+// with: a $ref's resource KSUID into the resource's triplet, and a $gen's
+// generator KSUID into the generator's label and stack.
+//
+// The generators the $gen envelopes named are returned, because a forma that
+// references a generator has to declare it and only this pass knows which
+// ones were referenced. A caller with nowhere to put a declaration ignores
+// them; the envelopes are authored either way.
+func (m *Metastructure) reverseTranslateKSUIDsToTriplets(resources []*pkgmodel.Resource) ([]pkgmodel.Generator, error) {
 	ksuidSet := make(map[string]struct{})
 	for _, resource := range resources {
 		if resource.Properties != nil {
@@ -1395,33 +1404,117 @@ func (m *Metastructure) reverseTranslateKSUIDsToTriplets(resources []*pkgmodel.R
 			extractKSUIDs(string(resource.ReadOnlyProperties), ksuidSet)
 		}
 	}
+	generatorKsuidSet := genEnvelopeGeneratorKSUIDs(resources)
 
-	if len(ksuidSet) == 0 {
-		return nil
+	if len(ksuidSet) == 0 && len(generatorKsuidSet) == 0 {
+		return nil, nil
 	}
 
-	ksuids := make([]string, 0, len(ksuidSet))
-	for ksuid := range ksuidSet {
-		ksuids = append(ksuids, ksuid)
+	ksuidToTriplet := make(map[string]pkgmodel.TripletKey)
+	if len(ksuidSet) > 0 {
+		ksuids := make([]string, 0, len(ksuidSet))
+		for ksuid := range ksuidSet {
+			ksuids = append(ksuids, ksuid)
+		}
+
+		var err error
+		ksuidToTriplet, err = m.Datastore.BatchGetTripletsByKSUIDs(ksuids)
+		if err != nil {
+			return nil, fmt.Errorf("failed to batch lookup triplets: %w", err)
+		}
 	}
 
-	ksuidToTriplet, err := m.Datastore.BatchGetTripletsByKSUIDs(ksuids)
+	generators, generatorKeyByKsuid, err := m.resolveReferencedGenerators(generatorKsuidSet)
 	if err != nil {
-		return fmt.Errorf("failed to batch lookup triplets: %w", err)
+		return nil, err
 	}
 
 	for i, resource := range resources {
 		if resource.Properties != nil {
-			translated := replaceKSUIDs(string(resource.Properties), ksuidToTriplet)
+			translated := replaceKSUIDs(string(resource.Properties), ksuidToTriplet, generatorKeyByKsuid)
 			resources[i].Properties = json.RawMessage(translated)
 		}
 		if resource.ReadOnlyProperties != nil {
-			translated := replaceKSUIDs(string(resource.ReadOnlyProperties), ksuidToTriplet)
+			translated := replaceKSUIDs(string(resource.ReadOnlyProperties), ksuidToTriplet, generatorKeyByKsuid)
 			resources[i].ReadOnlyProperties = json.RawMessage(translated)
 		}
 	}
 
-	return nil
+	return generators, nil
+}
+
+// genEnvelopeGeneratorKSUIDs collects the generator KSUID of every translated
+// $gen envelope in the resources' property documents.
+//
+// Only the structured envelopes are collected. A $gen framed inside an
+// interpolated string is not one of them: an opaque value assembled into a
+// larger string can no longer be redacted, so validateNoOpaqueEmbed refuses
+// such a forma at plan time and no resource row can hold one.
+func genEnvelopeGeneratorKSUIDs(resources []*pkgmodel.Resource) map[string]struct{} {
+	ksuids := make(map[string]struct{})
+	collect := func(document json.RawMessage) {
+		if len(document) == 0 {
+			return
+		}
+		for _, genObject := range pkgmodel.FindGenObjectsFromProperties(document) {
+			// An authored envelope names its generator by label and stack and
+			// carries no KSUID, so it contributes nothing to resolve.
+			if genObject.Generator != "" {
+				ksuids[genObject.Generator] = struct{}{}
+			}
+		}
+	}
+	for _, resource := range resources {
+		collect(resource.Properties)
+		collect(resource.ReadOnlyProperties)
+	}
+	return ksuids
+}
+
+// resolveReferencedGenerators resolves each generator KSUID to the live
+// generator holding it. It returns the generators themselves, so an extracted
+// forma can declare them, and the label/stack pair each KSUID stands for, so
+// the envelopes naming it can be written back in their authored shape.
+//
+// The generators are ordered by stack and then label, so the same extract
+// emits the same declarations every time.
+//
+// A KSUID that reaches no live generator is left out of both: there is no
+// label to name it by, and nothing to declare.
+func (m *Metastructure) resolveReferencedGenerators(
+	ksuids map[string]struct{},
+) ([]pkgmodel.Generator, map[string]pkgmodel.GeneratorKey, error) {
+	if len(ksuids) == 0 {
+		return nil, nil, nil
+	}
+
+	lookup := generatorLookup(m.Datastore)
+	keyByKsuid := make(map[string]pkgmodel.GeneratorKey, len(ksuids))
+	generators := make([]pkgmodel.Generator, 0, len(ksuids))
+	for ksuid := range ksuids {
+		generator, err := lookup(ksuid)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to resolve generator %s: %w", ksuid, err)
+		}
+		if generator == nil {
+			slog.Warn("A generator-bound property names a generator that no longer exists",
+				"generator", ksuid)
+			continue
+		}
+		keyByKsuid[ksuid] = pkgmodel.GeneratorKey{
+			Label: generator.GetLabel(),
+			Stack: generator.GetStack(),
+		}
+		generators = append(generators, generator)
+	}
+
+	slices.SortFunc(generators, func(a, b pkgmodel.Generator) int {
+		return cmp.Or(
+			cmp.Compare(a.GetStack(), b.GetStack()),
+			cmp.Compare(a.GetLabel(), b.GetLabel()),
+		)
+	})
+	return generators, keyByKsuid, nil
 }
 
 func (m *Metastructure) ListDrift(stack string) (*apimodel.ModifiedStack, error) {
@@ -1704,7 +1797,7 @@ func (m *Metastructure) ReRunIncompleteCommands() error {
 		// here unchanged and a credential the interrupted command never meant
 		// to touch is not rotated by the resume.
 		draws, drawErr := generator_update.SynthesizeDrawGeneratorUpdates(
-			pendingUpdates, nil, generatorLookupForResume(m.Datastore))
+			pendingUpdates, nil, generatorLookup(m.Datastore))
 		if drawErr != nil {
 			slog.Error("Failed to build changeset for incomplete forma command, skipping", "commandID", fa.ID, "error", drawErr)
 			continue
@@ -1773,9 +1866,10 @@ func generatorLookupByTranslation(
 	}
 }
 
-// generatorLookupForResume is the resume path's route to the same thing. The
-// translation map lived in the planning call's stack frame and is long gone,
-// and a $gen envelope that survived to the datastore carries only a KSUID.
+// generatorLookup is the route to the same thing for every caller that holds
+// only a KSUID: resuming a command, whose translation map lived in the
+// planning call's stack frame and is long gone, and extracting a stored
+// document, whose $gen envelopes have never carried anything else.
 //
 // The KSUID is enough. GeneratorIdentity has no Label or Stack field, but its
 // GenerationSpec IS the serialized generator the current generation was drawn
@@ -1794,7 +1888,7 @@ func generatorLookupByTranslation(
 // narrowing it leaves the destination refused at the provider boundary. The
 // index is built once, on the first miss, so the ordinary case pays nothing
 // for it.
-func generatorLookupForResume(ds datastore.Datastore) func(string) (pkgmodel.Generator, error) {
+func generatorLookup(ds datastore.Datastore) func(string) (pkgmodel.Generator, error) {
 	if ds == nil {
 		return nil
 	}
@@ -1856,7 +1950,7 @@ func generatorByKsuid(ksuid string, ds datastore.Datastore) (pkgmodel.Generator,
 // The whole inventory is walked because the KSUID is all there is to go on: a
 // generator's stack is not derivable from its destinations', and the
 // cross-stack binding is the case this exists to serve. It costs one stack
-// listing plus a load and an identity read per generator, once per resume
+// listing plus a load and an identity read per generator, once per lookup
 // that has such a generator, which is a rare path over a small table.
 //
 // The stack the row was found under is stamped on each generator, since that
@@ -2932,19 +3026,27 @@ func extractKSUIDs(jsonStr string, ksuidSet map[string]struct{}) {
 	})
 }
 
-// replaceKSUIDs recursively walks the JSON structure and replaces all $ref objects
-// (containing formae URIs) with $res objects (containing resolved resource metadata).
-//
-// This handles $ref only. A $gen envelope's bare $generator KSUID is not
-// reverse-translated here, and extractKSUIDs above does not even collect it
-// (it only looks at strings that parse as formae:// URIs). Resource rows do
-// persist $gen envelopes, so extraction carries the raw $generator KSUID
-// through into what it emits instead of an authorable generator declaration.
-func replaceKSUIDs(jsonStr string, ksuidToTriplet map[string]pkgmodel.TripletKey) string {
+// replaceKSUIDs recursively walks the JSON structure and replaces the internal
+// identifiers a stored document names things by with the names an author
+// writes: a $ref object (containing a formae URI) becomes a $res object
+// (containing resolved resource metadata), and a $gen envelope's generator
+// KSUID becomes the generator's label and stack.
+func replaceKSUIDs(
+	jsonStr string,
+	ksuidToTriplet map[string]pkgmodel.TripletKey,
+	generatorKeyByKsuid map[string]pkgmodel.GeneratorKey,
+) string {
 	var replace func(value any) any
 	replace = func(value any) any {
 		switch v := value.(type) {
 		case map[string]any:
+			// A $gen envelope is recognized before anything else: at rest it
+			// also carries $value, $visibility and $strategy, which is the
+			// shape of a recorded opaque value, and it must never be read as
+			// one.
+			if isGen, ok := v["$gen"].(bool); ok && isGen {
+				return authorGenEnvelope(v, generatorKeyByKsuid)
+			}
 			// Check if this is a $ref object that needs conversion
 			if ref, ok := v["$ref"].(string); ok {
 				formaeUri := pkgmodel.FormaeURI(ref)
@@ -3021,6 +3123,48 @@ func replaceKSUIDs(jsonStr string, ksuidToTriplet map[string]pkgmodel.TripletKey
 		return jsonStr
 	}
 	return string(result)
+}
+
+// authoredGenEnvelopeMembers are the members of a $gen envelope beyond the
+// $gen marker itself that a forma author writes. They are the fixed members
+// the PKL class formae.GeneratorOutput declares, and therefore the whole of
+// what an extracted envelope may carry. Everything else a stored envelope
+// holds — the $generator KSUID, the digest in $value, the $hashed marker, the
+// $resolvedFrom provenance and the $strategy — is agent-internal.
+var authoredGenEnvelopeMembers = []string{"$label", "$stack", "$output", "$visibility"}
+
+// authorGenEnvelope rewrites one $gen envelope into the shape an author wrote
+// it in: the generator named by label and stack, and none of the internal
+// parts translation and resolution added.
+//
+// An envelope that already names its generator by label and stack (one that
+// was never translated) passes through with those names intact, so the
+// rewrite is idempotent.
+//
+// A $generator KSUID that resolves to no live generator is kept. The envelope
+// is unauthorable either way, and the KSUID is then the only thing left that
+// says which generator it named. The internal members are dropped regardless:
+// none of them is authorable, and the digest must not reach a file the
+// operator commits.
+func authorGenEnvelope(envelope map[string]any, generatorKeyByKsuid map[string]pkgmodel.GeneratorKey) map[string]any {
+	authored := map[string]any{"$gen": true}
+	for _, member := range authoredGenEnvelopeMembers {
+		if value, ok := envelope[member]; ok {
+			authored[member] = value
+		}
+	}
+
+	ksuid, _ := envelope["$generator"].(string)
+	if ksuid == "" {
+		return authored
+	}
+	if key, ok := generatorKeyByKsuid[ksuid]; ok {
+		authored["$label"] = key.Label
+		authored["$stack"] = key.Stack
+		return authored
+	}
+	authored["$generator"] = ksuid
+	return authored
 }
 
 // rewriteEmbedSpans scans a $embed.$template string for framed RS<base64>US spans,

--- a/internal/metastructure/metastructure_test.go
+++ b/internal/metastructure/metastructure_test.go
@@ -376,7 +376,7 @@ func TestReplaceKSUIDs_NestedRefInArrays(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := replaceKSUIDs(tt.inputJSON, tt.ksuidToTriplet)
+			result := replaceKSUIDs(tt.inputJSON, tt.ksuidToTriplet, nil)
 
 			for _, want := range tt.wantContains {
 				assert.Contains(t, result, want, "result should contain %s", want)
@@ -518,7 +518,7 @@ func TestReplaceKSUIDs_RewritesEmbeddedSpan(t *testing.T) {
 
 	out := replaceKSUIDs(string(in), map[string]pkgmodel.TripletKey{
 		ksuid: {Stack: "default", Label: "kvs", Type: "AWS::CloudFront::KeyValueStore"},
-	})
+	}, nil)
 
 	tmplOut := gjson.Get(out, "functionCode.$template").String()
 	spans, err := pkgmodel.ScanEmbedSpans(tmplOut)
@@ -545,8 +545,8 @@ func TestReplaceKSUIDs_RewritesEmbeddedSpan_Idempotent(t *testing.T) {
 		ksuid: {Stack: "default", Label: "kvs", Type: "AWS::CloudFront::KeyValueStore"},
 	}
 
-	out1 := replaceKSUIDs(string(in), ksuidToTriplet)
-	out2 := replaceKSUIDs(out1, ksuidToTriplet)
+	out1 := replaceKSUIDs(string(in), ksuidToTriplet, nil)
+	out2 := replaceKSUIDs(out1, ksuidToTriplet, nil)
 	assert.Equal(t, out1, out2, "replaceKSUIDs should be idempotent")
 }
 
@@ -571,7 +571,7 @@ func TestReplaceKSUIDs_RewritesMultipleEmbeddedSpans(t *testing.T) {
 	out := replaceKSUIDs(string(in), map[string]pkgmodel.TripletKey{
 		ksuid1: {Stack: "default", Label: "bucket", Type: "AWS::S3::Bucket"},
 		ksuid2: {Stack: "default", Label: "queue", Type: "AWS::SQS::Queue"},
-	})
+	}, nil)
 
 	tmplOut := gjson.Get(out, "code.$template").String()
 	spans, err := pkgmodel.ScanEmbedSpans(tmplOut)

--- a/internal/metastructure/resource_summaries.go
+++ b/internal/metastructure/resource_summaries.go
@@ -38,8 +38,10 @@ func (m *Metastructure) ExtractResourceByKsuid(ksuid string) (*pkgmodel.Resource
 		return nil, nil
 	}
 
+	// The generators the rewrite resolved are discarded: a single resource is
+	// not a forma and has nowhere to declare one.
 	resources := []*pkgmodel.Resource{res}
-	if err := m.reverseTranslateKSUIDsToTriplets(resources); err != nil {
+	if _, err := m.reverseTranslateKSUIDsToTriplets(resources); err != nil {
 		slog.Error("Failed to reverse translate KSUIDs to triplets", "ksuid", ksuid, "error", err)
 		return nil, err
 	}

--- a/internal/workflow_tests/local/apply_forma/generator_extract_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_extract_test.go
@@ -1,0 +1,294 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// assertAuthoredGenEnvelope requires that env is the envelope an author
+// writes and nothing more: the generator named by label and stack, and none
+// of the internal parts a translated envelope at rest carries. Each absence
+// is asserted on its own, because an envelope that names its generator
+// correctly AND carries the stored digest alongside it is still a digest
+// written into a file the operator commits.
+func assertAuthoredGenEnvelope(t *testing.T, env gjson.Result, generatorLabel, generatorStack, output string) {
+	t.Helper()
+	require.True(t, env.IsObject(), "the property must still be a $gen envelope, got %s", env.Raw)
+	assert.True(t, env.Get("$gen").Bool(), "$gen marker")
+	assert.Equal(t, generatorLabel, env.Get("$label").String(), "$label names the generator")
+	assert.Equal(t, generatorStack, env.Get("$stack").String(), "$stack names the generator's stack")
+	assert.Equal(t, output, env.Get("$output").String(), "$output")
+	assert.Equal(t, "Opaque", env.Get("$visibility").String(), "$visibility")
+
+	assert.False(t, env.Get("$generator").Exists(), "$generator KSUID must not reach authored output")
+	assert.False(t, env.Get("$value").Exists(), "$value digest must not reach authored output")
+	assert.False(t, env.Get("$hashed").Exists(), "$hashed must not reach authored output")
+	assert.False(t, env.Get("$resolvedFrom").Exists(), "$resolvedFrom must not reach authored output")
+	assert.False(t, env.Get("$strategy").Exists(), "$strategy must not reach authored output")
+}
+
+// applyGeneratorBoundForma applies forma and blocks until it is done, so each
+// test in this file starts from live state rather than a plan.
+func applyGeneratorBoundForma(t *testing.T, m *metastructure.Metastructure, forma *pkgmodel.Forma) {
+	t.Helper()
+	_, err := m.ApplyForma(forma,
+		&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
+		"test-client-id", "", "")
+	require.NoError(t, err)
+	waitForApplyComplete(t, m)
+}
+
+// newExtractTestMetastructure builds a metastructure with synchronization off,
+// so nothing rewrites the resource rows between the apply and the extract.
+func newExtractTestMetastructure(t *testing.T) *metastructure.Metastructure {
+	t.Helper()
+	cfg := test_helpers.NewTestMetastructureConfig()
+	cfg.Agent.Synchronization.Enabled = false
+	m, def, err := test_helpers.NewTestMetastructureWithConfig(t, nil, cfg)
+	t.Cleanup(def)
+	require.NoError(t, err)
+	return m
+}
+
+// A generator-bound property at rest names its generator by KSUID and carries
+// the digest of the drawn value and the provenance it was resolved under.
+// None of that is authorable, so extraction has to hand back the envelope the
+// author wrote: the generator named by label and stack, and nothing else.
+func TestExtractResources_GeneratorBoundSecret_EmitsTheAuthoredEnvelope(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m := newExtractTestMetastructure(t)
+
+		stack := "test-stack-" + util.NewID()
+		applyGeneratorBoundForma(t, m, &pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: stack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+			Resources:  []pkgmodel.Resource{genBoundSecret(stack, "alpha", "db-password", "value")},
+		})
+
+		extracted, err := m.ExtractResources("stack:" + stack)
+		require.NoError(t, err)
+		require.NotNil(t, extracted)
+		require.Len(t, extracted.Resources, 1)
+
+		env := gjson.GetBytes(extracted.Resources[0].Properties, "SecretString")
+		assertAuthoredGenEnvelope(t, env, "db-password", stack, "value")
+	})
+}
+
+// A forma that references a generator has to declare it, or the file it is
+// written to cannot be applied on its own.
+func TestExtractResources_GeneratorBoundSecret_DeclaresTheGenerator(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m := newExtractTestMetastructure(t)
+
+		stack := "test-stack-" + util.NewID()
+		applyGeneratorBoundForma(t, m, &pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: stack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+			Resources:  []pkgmodel.Resource{genBoundSecret(stack, "alpha", "db-password", "value")},
+		})
+
+		extracted, err := m.ExtractResources("stack:" + stack)
+		require.NoError(t, err)
+		require.NotNil(t, extracted)
+		require.Len(t, extracted.Generators, 1, "the referenced generator must be declared")
+
+		declared, err := pkgmodel.ParseGenerator(extracted.Generators[0])
+		require.NoError(t, err)
+		assert.Equal(t, "db-password", declared.GetLabel())
+		assert.Equal(t, stack, declared.GetStack())
+		assert.Equal(t, "password", declared.GetType())
+		pw, ok := declared.(*pkgmodel.PasswordGenerator)
+		require.True(t, ok)
+		assert.Equal(t, 24, pw.Length, "the declared spec must be the live one")
+	})
+}
+
+// A generator belongs to one stack and is meant to be bound from others. The
+// extract of the destination's stack therefore has to reach a generator no
+// resource in the query result sits beside, and emit both the generator and
+// the stack it names, or the declaration references a stack that is not there.
+func TestExtractResources_CrossStackGeneratorBinding_EmitsTheGeneratorAndItsStack(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m := newExtractTestMetastructure(t)
+
+		generatorStack := "gen-stack-" + util.NewID()
+		resourceStack := "res-stack-" + util.NewID()
+		applyGeneratorBoundForma(t, m, &pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: generatorStack}, {Label: resourceStack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", generatorStack)},
+			Resources: []pkgmodel.Resource{
+				crossStackGenBoundSecret(resourceStack, "alpha", generatorStack, "db-password", "cross-stack destination"),
+			},
+		})
+
+		extracted, err := m.ExtractResources("stack:" + resourceStack)
+		require.NoError(t, err)
+		require.NotNil(t, extracted)
+		require.Len(t, extracted.Resources, 1)
+
+		env := gjson.GetBytes(extracted.Resources[0].Properties, "SecretString")
+		assertAuthoredGenEnvelope(t, env, "db-password", generatorStack, "value")
+
+		require.Len(t, extracted.Generators, 1, "the cross-stack generator must be declared")
+		declared, err := pkgmodel.ParseGenerator(extracted.Generators[0])
+		require.NoError(t, err)
+		assert.Equal(t, generatorStack, declared.GetStack())
+
+		stackLabels := make([]string, 0, len(extracted.Stacks))
+		for _, s := range extracted.Stacks {
+			stackLabels = append(stackLabels, s.Label)
+		}
+		assert.Contains(t, stackLabels, resourceStack, "the destination's stack")
+		assert.Contains(t, stackLabels, generatorStack,
+			"the generator's own stack must be emitted, or its declaration names a stack that is not there")
+	})
+}
+
+// The point of an extract is a forma that can be applied again. A
+// generator-bound resource is the case where that had stopped being true, so
+// the extracted forma is applied back: it must plan nothing, and then a real
+// apply of it must leave the drawn value where it was.
+//
+// The second half is what pins the authored envelope. Its generator is named
+// by label and stack, so an apply has to resolve that pair back to the
+// generator the value was drawn from; a pair naming no live generator is
+// refused, and one naming a different generator draws again and moves the
+// digest.
+func TestExtractResources_GeneratorBoundSecret_ExtractedFormaReappliesWithNoPlan(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m := newExtractTestMetastructure(t)
+
+		stack := "test-stack-" + util.NewID()
+		applyGeneratorBoundForma(t, m, &pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: stack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+			Resources:  []pkgmodel.Resource{genBoundSecret(stack, "alpha", "db-password", "value")},
+		})
+
+		digestBefore := storedGenDigest(t, m, stack)
+
+		extracted, err := m.ExtractResources("stack:" + stack)
+		require.NoError(t, err)
+		require.NotNil(t, extracted)
+
+		resp, err := m.ApplyForma(extracted,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: true},
+			"test-client-id", "", "")
+		require.NoError(t, err, "the extracted forma must be appliable")
+		require.NotNil(t, resp.Simulation)
+		assert.False(t, resp.Simulation.ChangesRequired,
+			"re-applying the extracted forma must plan no changes")
+		assert.Empty(t, resp.Simulation.Command.ResourceUpdates,
+			"re-applying the extracted forma must plan no resource updates")
+
+		applyGeneratorBoundForma(t, m, extracted)
+
+		commands, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		for _, command := range commands {
+			assert.NotEqual(t, forma_command.CommandStateFailed, command.State,
+				"applying the extracted forma must not fail")
+		}
+		assert.Equal(t, digestBefore, storedGenDigest(t, m, stack),
+			"the extracted envelope must resolve back to the generator the value was drawn from")
+	})
+}
+
+// storedGenDigest reads the digest the generator-bound property holds at rest
+// on the single resource of a stack. A redraw moves it, so it is what says
+// whether the value a destination holds is still the one it was given.
+func storedGenDigest(t *testing.T, m *metastructure.Metastructure, stack string) string {
+	t.Helper()
+	resources, err := m.Datastore.LoadResourcesByStack(stack)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	digest := gjson.GetBytes(resources[0].Properties, "SecretString.$value").String()
+	require.NotEmpty(t, digest, "the stored envelope must carry the drawn value's digest")
+	return digest
+}
+
+// Extraction cannot know where a value came from, and a binding is the
+// author's deliberate act. An opaque literal that merely happens to hold a
+// generated value is emitted as the opaque literal it is.
+func TestExtractResources_OpaqueLiteralSecret_InventsNoGeneratorBinding(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m := newExtractTestMetastructure(t)
+
+		stack := "test-stack-" + util.NewID()
+		applyGeneratorBoundForma(t, m, &pkgmodel.Forma{
+			Stacks:  []pkgmodel.Stack{{Label: stack}},
+			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Resources: []pkgmodel.Resource{{
+				Label:      "literal",
+				Type:       "FakeAWS::SecretsManager::Secret",
+				Stack:      stack,
+				Target:     "test-target",
+				Schema:     secretSchema(),
+				Properties: json.RawMessage(`{"Name":"literal","SecretString":"TestPassword123!"}`),
+			}},
+		})
+
+		extracted, err := m.ExtractResources("stack:" + stack)
+		require.NoError(t, err)
+		require.NotNil(t, extracted)
+		require.Len(t, extracted.Resources, 1)
+
+		env := gjson.GetBytes(extracted.Resources[0].Properties, "SecretString")
+		assert.False(t, env.Get("$gen").Exists(), "no $gen binding may be invented")
+		assert.False(t, env.Get("$label").Exists(), "no generator may be named")
+		assert.True(t, env.Get("$value").Exists(), "the opaque literal must be left as it is")
+		assert.Empty(t, extracted.Generators, "no generator may be declared for a literal")
+	})
+}
+
+// The single-resource extract reads the same stored rows through its own
+// entry point, so it carries the same envelope and must author it the same
+// way.
+func TestExtractResourceByKsuid_GeneratorBoundSecret_EmitsTheAuthoredEnvelope(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m := newExtractTestMetastructure(t)
+
+		stack := "test-stack-" + util.NewID()
+		applyGeneratorBoundForma(t, m, &pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: stack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)},
+			Resources:  []pkgmodel.Resource{genBoundSecret(stack, "alpha", "db-password", "value")},
+		})
+
+		stored, err := m.Datastore.LoadResourcesByStack(stack)
+		require.NoError(t, err)
+		require.Len(t, stored, 1)
+		require.NotEmpty(t, stored[0].Ksuid)
+
+		one, err := m.ExtractResourceByKsuid(stored[0].Ksuid)
+		require.NoError(t, err)
+		require.NotNil(t, one)
+
+		env := gjson.GetBytes(one.Properties, "SecretString")
+		assertAuthoredGenEnvelope(t, env, "db-password", stack, "value")
+	})
+}


### PR DESCRIPTION
## Summary

Stacked on #718. `formae extract` emitted an un-reappliable forma for any generator-bound resource: a raw internal KSUID where the generator's label and stack belong, the secret's digest and internal provenance written into a file the operator commits, and a forma referencing a generator it never declared.

Observed before the fix:

```json
"SecretString": {"$gen":true,"$generator":"3IfNF3qqHBjxMm1GEUOapM3PQgs","$hashed":true,
  "$output":"value","$resolvedFrom":"v1:7912016a…","$strategy":"Update",
  "$value":"be1185a3…","$visibility":"Opaque"}
```
…with zero generator declarations in the emitted forma. After:

```json
"SecretString":{"$gen":true,"$label":"db-password","$output":"value",
  "$stack":"gen-stack","$visibility":"Opaque"}
```
…and the generator declared alongside, including when it lives in a different stack from the resource.

Not a credential leak — a digest, not material — but extract exists to produce something you can re-apply, and the import and fix-code-drift workflows both write PKL from it.

The authored key set is taken from the schema class rather than assumed: `$gen`, `$label`, `$stack`, `$output`, `$visibility`. Everything else is stripped.

One ordering detail worth knowing: the `$gen` arm runs *before* the recorded-opaque-value arm, because a stored `$gen` also carries `$value`, `$visibility` and `$strategy`, and would otherwise be read as an opaque literal.

## What this deliberately does not do

**The PKL renderer half is not built**, because it cannot be yet: no plugin field union declares `formae.GeneratorOutput`. It appears only in the schema that defines it and in the debug test plugin, so a generator binding is not authorable in PKL against any real resource today — the existing tests construct the envelope as JSON. Adding a renderer arm now would be the second half of a bridge whose first half does not exist. Tracked separately.

**Nothing invents a binding.** A secret whose value merely came from a generator still extracts as an opaque literal, per the standing import rule that extraction cannot know provenance and binding is the author's deliberate act.

**No embed-span arm.** An Opaque-visibility span is hard-rejected at plan time, so no stored row can carry a framed `$gen`. The reason is recorded at the collection site rather than left as an unexplained omission.

## On the round-trip test

Reported rather than glossed: disabling only the reverse arm left a naive round-trip test passing, because at the Forma-struct level the planner compares against the very stored document the translated envelope came from, so a raw KSUID re-applies as cleanly as an authored label. No Forma-level test can make the arm's *presence* load-bearing.

The test was strengthened to a real re-apply asserting no command failed and the stored digest is unchanged, which makes the arm's *correctness* load-bearing: corrupting the emitted label fails it. The declaration-emission half was already load-bearing.