### PR TITLE
feat(schema): let a plugin resource field accept a generator output

### DIFF
--- a/internal/schema/pkl/pkl_test.go
+++ b/internal/schema/pkl/pkl_test.go
@@ -341,6 +341,30 @@ func TestPkl_GeneratorReference_RendersGenEnvelope(t *testing.T) {
 	assert.Equal(t, "Opaque", gjson.Get(jsonString, "Resources.0.Properties.value.$visibility").String())
 }
 
+// TestPkl_GeneratorBinding_PluginResourceFieldRendersGenEnvelope verifies that
+// a plugin resource's secret-bearing property, whose declared union admits
+// formae.GeneratorOutput, can be bound to `pw.gen.value` from PKL and renders
+// the $gen envelope. The field keeps its Opaque schema hint, so the union that
+// admits a generator output still marks the property a secret.
+func TestPkl_GeneratorBinding_PluginResourceFieldRendersGenEnvelope(t *testing.T) {
+	p := PKL{}
+	forma, err := p.Evaluate("./testdata/forma/generator_binding_test.pkl", model.CommandApply, model.FormaApplyModeReconcile, nil)
+	require.NoError(t, err)
+
+	jsonString := forma.ToJSON()
+
+	assert.Equal(t, "FakeAWS::SecretsManager::Secret", gjson.Get(jsonString, "Resources.0.Type").String())
+	assert.True(t, gjson.Get(jsonString, "Resources.0.Properties.SecretString.$gen").Bool())
+	assert.Equal(t, "db-password", gjson.Get(jsonString, "Resources.0.Properties.SecretString.$label").String())
+	assert.Equal(t, "generator-binding-stack", gjson.Get(jsonString, "Resources.0.Properties.SecretString.$stack").String())
+	assert.Equal(t, "value", gjson.Get(jsonString, "Resources.0.Properties.SecretString.$output").String())
+	assert.Equal(t, "Opaque", gjson.Get(jsonString, "Resources.0.Properties.SecretString.$visibility").String())
+	assert.True(t, gjson.Get(jsonString, "Resources.0.Schema.Hints.SecretString.Opaque").Bool())
+
+	assert.Equal(t, "db-password", gjson.Get(jsonString, "Generators.0.Label").String())
+	assert.Equal(t, "generator-binding-stack", gjson.Get(jsonString, "Generators.0.Stack").String())
+}
+
 // TestPkl_GeneratorOutput_EnvelopeFieldsAreImmutable verifies that the $gen
 // envelope's fields cannot be amended — a plan cannot rewrite $visibility
 // away from Opaque (or forge $gen, $label, $stack, $output) once a

--- a/internal/schema/pkl/testdata/forma/generator_binding_test.pkl
+++ b/internal/schema/pkl/testdata/forma/generator_binding_test.pkl
@@ -1,0 +1,42 @@
+/*
+ * © 2026 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+// A plugin resource's secret-bearing property bound to a generator output.
+// The union that field declares admits formae.GeneratorOutput, so
+// `pw.gen.value` renders the $gen envelope the agent resolves at apply time.
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+import "@fakeaws/fakeaws.pkl"
+import "@fakeaws/secretsmanager/secret.pkl"
+
+forma {
+  local appStack = new formae.Stack {
+    label = "generator-binding-stack"
+    description = "Stack for a generator-bound plugin resource"
+  }
+  appStack
+
+  new formae.Target {
+    label = "default-aws-target"
+    config = new fakeaws.Config {
+      region = "us-west-2"
+    }
+  }
+
+  local pw = new formae.PasswordGenerator {
+    label = "db-password"
+    stack = appStack.res
+    length = 24
+  }
+  pw
+
+  new secret.Secret {
+    label = "db"
+    name = "db"
+    secretString = pw.gen.value
+  }
+}

--- a/internal/testplugin/fakeaws/schema/pkl/secretsmanager/secret.pkl
+++ b/internal/testplugin/fakeaws/schema/pkl/secretsmanager/secret.pkl
@@ -47,7 +47,7 @@ open class Secret extends formae.Secret {
     description: String?
 
     @fakeaws.FieldHint
-    secretString: (String|formae.Value|formae.SecretValue)?
+    secretString: (String|formae.Value|formae.SecretValue|formae.GeneratorOutput)?
 
     @fakeaws.FieldHint
     tags: Listing<fakeaws.Tag>?

--- a/internal/workflow_tests/local/apply_forma/generator_binding_pkl_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_binding_pkl_test.go
@@ -1,0 +1,107 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build integration
+
+package workflow_tests_local
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/schema/pkl"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// authoredGeneratorBindingForma is the forma this test applies: a
+// PasswordGenerator and a plugin resource whose secret-bearing property is
+// bound to that generator's `value` output, authored in PKL rather than as a
+// hand-built envelope.
+const authoredGeneratorBindingForma = "internal/schema/pkl/testdata/forma/generator_binding_test.pkl"
+
+// pklCreateCapture records the SecretString each Create reached the provider
+// with. Returning nil falls through to FakeAWS's own handling, so capturing is
+// the only behaviour it adds.
+type pklCreateCapture struct {
+	mu     sync.Mutex
+	byName map[string]string
+}
+
+func (c *pklCreateCapture) overrides() *plugin.ResourcePluginOverrides {
+	c.byName = map[string]string{}
+	return &plugin.ResourcePluginOverrides{
+		Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			props := gjson.ParseBytes(req.Properties)
+			c.byName[props.Get("Name").String()] = props.Get("SecretString").String()
+			return nil, nil
+		},
+	}
+}
+
+func (c *pklCreateCapture) valueFor(name string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	v, ok := c.byName[name]
+	return v, ok
+}
+
+// A generator binding authored in PKL applies end to end: evaluating the forma
+// renders the $gen envelope from `pw.gen.value`, and applying the evaluated
+// forma draws the value and delivers the credential itself to the provider.
+// The forma is evaluated rather than hand-built, so the binding is exercised
+// over a shape a forma author can write.
+func TestApplyForma_PklAuthoredGeneratorBinding_DrawnValueReachesTheProvider(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		forma, err := pkl.PKL{}.Evaluate(
+			authoredGeneratorBindingForma,
+			pkgmodel.CommandApply,
+			pkgmodel.FormaApplyModeReconcile,
+			nil,
+		)
+		require.NoError(t, err, "the authored forma must evaluate")
+		require.Len(t, forma.Resources, 1)
+		require.Len(t, forma.Generators, 1)
+		require.True(t, gjson.GetBytes(forma.Resources[0].Properties, "SecretString.$gen").Bool(),
+			"precondition: eval must render the binding as a $gen envelope")
+
+		capture := &pklCreateCapture{}
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, capture.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			incomplete, loadErr := m.Datastore.LoadIncompleteFormaCommands()
+			return loadErr == nil && len(incomplete) == 0
+		}, 30*time.Second, 100*time.Millisecond, "the apply must reach a terminal state")
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		require.Len(t, cmds, 1)
+		require.Equal(t, forma_command.CommandStateSuccess, cmds[0].State,
+			"a PKL-authored generator binding must apply")
+
+		drawn, ok := capture.valueFor("db")
+		require.True(t, ok, "the provider must have been called for the bound secret")
+		assert.Len(t, drawn, 24, "the provider receives the drawn value, at the authored length")
+		assert.NotContains(t, drawn, "$gen",
+			"the provider must receive the drawn value, never the envelope naming it")
+	})
+}


### PR DESCRIPTION
## Summary

Stacked on #718. A generator produces a credential and a resource property is meant to reference one of its outputs as `pw.gen.value` — but **no plugin resource field accepted the type**, so that could not be written. PKL unions are closed, and the field declared `(String|formae.Value|formae.SecretValue)?`:

```
Expected value of type `String|formae.Value|formae.SecretValue`, but got type `Formae#GeneratorOutput`.
50 | secretString: (String|formae.Value|formae.SecretValue)?
30 | secretString = pw.gen.value
```

This was invisible because every generator test in the tree builds the `$gen` envelope as JSON and submits it through the upload path, bypassing PKL entirely. The feature was green over a shape an author could not write.

This widens the in-tree fake plugin's secret field and adds the two tests that would have caught it: a PKL eval asserting the rendered envelope, and a workflow test that **evaluates a real forma file and applies it**.

## Why widen the field rather than introduce a shared alias

The alternative was an alias in `formae.pkl` that plugin fields reference, so a later envelope kind reaches every plugin without them changing. Surveying the actual surface killed it: **the alias does not save the plugins the edit.** All ~41 secret-field declarations across the published plugins have to change either way — to append the type, or to reference the alias. The alias adds, on top of that, a change to a checksummed schema surface published at a fixed coordinate, and only pays back on a *further* envelope kind that nobody has asked for.

Two further costs found rather than assumed: two aliases would be needed, not one, because the fields split into Resolvable-accepting and not, and flattening that would silently let three fields accept a resource reference they were declared to refuse. And the constraint-bearing fields cannot be a bare alias reference, so `String` sits outside the alias regardless and the alias never covers a whole field type.

The price of widening, stated plainly: every plugin repeats the type on every secret field, and a future envelope kind is another ~41-site sweep.

A third option — making the output type extend `Value` so it is accepted at every existing site for free — was tried and rejected on evidence: `Value` requires a value with no default, a minimal repro fails on the undefined property, and the envelope would carry two markers.

## What was checked because it would have been a silent regression

`Fq.isSecretValueType` walks the union, so the widened field **keeps its `Opaque` field hint** and a drawn value is still hashed at rest. That is asserted, not assumed.

## Test coverage this adds that did not exist

**No workflow test in the repo applied a PKL-authored forma.** Every one hand-builds the model struct; the blackbox suite drives the API; the CLI integration test evaluates a forma but submits to a test server, so nothing is drawn. The new test composes two existing harnesses — evaluation returns the model type that apply already takes — so it needs no new machinery, and it is the first coverage of the path an author actually uses.

## What remains, and is not in this PR

The **published AWS plugin** still declares the narrow union, so the end-to-end case and the acceptance target are blocked on that repo, not on this branch.

The **extract renderer arm** is now possible and is deliberately not built: it was impossible before because the renderer selects a union arm by declared member type and no field declared this one. Keeping this change reviewable matters more than bundling it.