### PR TITLE
feat(metastructure): refuse a generator that reaches a setOnce field

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -370,6 +370,13 @@ func (c *Client) parseSubmitCommandErrorResponse(body io.ReadCloser) (*apimodel.
 		}
 		return nil, &errResp
 
+	case apimodel.GeneratorBoundToSetOnceField:
+		var errResp apimodel.ErrorResponse[apimodel.FormaGeneratorBoundToSetOnceFieldError]
+		if err := json.Unmarshal(bodyBytes, &errResp); err != nil {
+			return nil, fmt.Errorf("failed to parse GeneratorBoundToSetOnceField error: %w", err)
+		}
+		return nil, &errResp
+
 	case apimodel.TargetAlreadyExists:
 		var errResp apimodel.ErrorResponse[apimodel.TargetAlreadyExistsError]
 		if err := json.Unmarshal(bodyBytes, &errResp); err != nil {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -102,6 +102,36 @@ func TestParseSubmitCommandErrorResponse_GeneratorDestinationsUnreachable(t *tes
 	assert.Equal(t, "AWS::SecretsManager::Secret", got.Data.Unreachable[0].Type)
 }
 
+// TestParseSubmitCommandErrorResponse_GeneratorBoundToSetOnceField asserts the
+// client decodes a GeneratorBoundToSetOnceField body into its typed error with
+// the field name intact, so the CLI can tell the operator what to edit rather
+// than printing "unknown error type".
+func TestParseSubmitCommandErrorResponse_GeneratorBoundToSetOnceField(t *testing.T) {
+	body, err := json.Marshal(apimodel.ErrorResponse[apimodel.FormaGeneratorBoundToSetOnceFieldError]{
+		ErrorType: apimodel.GeneratorBoundToSetOnceField,
+		Data: apimodel.FormaGeneratorBoundToSetOnceFieldError{
+			Fields: []apimodel.SetOnceGeneratorField{
+				{GeneratorLabel: "db-password", GeneratorStack: "app", Stack: "web", Label: "api", Type: "AWS::S3::Bucket", Field: "DbPassword"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	c := &Client{}
+	_, perr := c.parseSubmitCommandErrorResponse(io.NopCloser(bytes.NewReader(body)))
+	require.Error(t, perr)
+
+	var got *apimodel.ErrorResponse[apimodel.FormaGeneratorBoundToSetOnceFieldError]
+	require.ErrorAs(t, perr, &got, "must decode into a typed FormaGeneratorBoundToSetOnceFieldError")
+	require.Len(t, got.Data.Fields, 1)
+	assert.Equal(t, "db-password", got.Data.Fields[0].GeneratorLabel)
+	assert.Equal(t, "app", got.Data.Fields[0].GeneratorStack)
+	assert.Equal(t, "api", got.Data.Fields[0].Label)
+	assert.Equal(t, "web", got.Data.Fields[0].Stack)
+	assert.Equal(t, "AWS::S3::Bucket", got.Data.Fields[0].Type)
+	assert.Equal(t, "DbPassword", got.Data.Fields[0].Field)
+}
+
 // TestGetFormaCommandsStatusNotFoundReturnsConcreteEmptyResult verifies a 404
 // from the commands/status endpoint resolves to a well-formed empty result
 // (non-nil, zero Commands), not a bare nil that forces every caller to

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -823,6 +823,11 @@ func mapError(c echo.Context, err error) error {
 		return apiError(c, http.StatusUnprocessableEntity, apimodel.GeneratorDestinationsUnreachable, unreachableDestinationsError)
 	}
 
+	var setOnceGeneratorFieldError apimodel.FormaGeneratorBoundToSetOnceFieldError
+	if errors.As(err, &setOnceGeneratorFieldError) {
+		return apiError(c, http.StatusUnprocessableEntity, apimodel.GeneratorBoundToSetOnceField, setOnceGeneratorFieldError)
+	}
+
 	var targetExistsError apimodel.TargetAlreadyExistsError
 	if errors.As(err, &targetExistsError) {
 		return apiError(c, http.StatusConflict, apimodel.TargetAlreadyExists, targetExistsError)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -459,6 +459,62 @@ func TestServer_ApplyFormaGeneratorDestinationsUnreachableError(t *testing.T) {
 	}
 }
 
+// A refusal to draw a generator into a field that will not accept the value
+// must reach the operator as its own typed 422, with the field named, not as
+// an opaque 500.
+func TestServer_ApplyFormaGeneratorBoundToSetOnceFieldError(t *testing.T) {
+	meta := &apitest.FakeMetastructure{}
+	setOnce := apimodel.FormaGeneratorBoundToSetOnceFieldError{
+		Fields: []apimodel.SetOnceGeneratorField{
+			{GeneratorLabel: "db-password", GeneratorStack: "app", Stack: "web", Label: "api", Type: "AWS::S3::Bucket", Field: "DbPassword"},
+		},
+	}
+	meta.ApplyResponses = []apitest.WrappedCommandResponse{{&apimodel.SubmitCommandResponse{}, setOnce}}
+
+	server := NewServer(t.Context(), meta, nil, nil, nil, nil)
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	_ = writer.WriteField("command", "apply")
+	_ = writer.WriteField("mode", "reconcile")
+	_ = writer.WriteField("simulate", "false")
+
+	part, err := writer.CreateFormFile("file", "forma.json")
+	if err != nil {
+		t.Fatalf("failed to create form file: %v", err)
+	}
+
+	jsonData, err := json.Marshal(&pkgmodel.Forma{})
+	if err != nil {
+		t.Fatalf("failed to marshal JSON: %v", err)
+	}
+	_, err = part.Write(jsonData)
+	if err != nil {
+		t.Fatalf("failed to write JSON data to form file: %v", err)
+	}
+	writer.Close()
+
+	req := httptest.NewRequest("POST", "/commands", body)
+	req.Header.Set("Client-ID", "test-client-id")
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	rec := httptest.NewRecorder()
+	c := server.echo.NewContext(req, rec)
+
+	if assert.NoError(t, server.SubmitFormaCommand(c)) {
+		assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+
+		var errorResponse apimodel.ErrorResponse[apimodel.FormaGeneratorBoundToSetOnceFieldError]
+		err = json.Unmarshal(rec.Body.Bytes(), &errorResponse)
+		assert.NoError(t, err)
+		assert.Equal(t, apimodel.GeneratorBoundToSetOnceField, errorResponse.ErrorType)
+		require.Len(t, errorResponse.Data.Fields, 1)
+		assert.Equal(t, "DbPassword", errorResponse.Data.Fields[0].Field)
+		assert.Equal(t, "api", errorResponse.Data.Fields[0].Label)
+	}
+}
+
 func TestServer_ApplyFormaStackReferenceNotFoundError(t *testing.T) {
 	meta := &apitest.FakeMetastructure{}
 	stackRefNotFound := apimodel.StackReferenceNotFoundError{

--- a/internal/cli/tui/errfmt/errfmt.go
+++ b/internal/cli/tui/errfmt/errfmt.go
@@ -104,6 +104,14 @@ func (r *renderer) render(err error) (string, error) {
 		}
 	}
 
+	if errResp, ok := err.(*apimodel.ErrorResponse[apimodel.FormaGeneratorBoundToSetOnceFieldError]); ok {
+		var e error
+		msg, e = r.renderGeneratorBoundToSetOnceField(&errResp.Data)
+		if e != nil {
+			return "", e
+		}
+	}
+
 	if errResp, ok := err.(*apimodel.ErrorResponse[apimodel.FormaPatchRejectedError]); ok {
 		var e error
 		msg, e = r.renderPatchRejected(&errResp.Data)
@@ -292,6 +300,26 @@ func (r *renderer) renderGeneratorDestinationsUnreachable(data *apimodel.FormaGe
 	}
 	b.WriteString("\n")
 	b.WriteString(r.warning("A generated value is never recoverable once the command that drew it ends, so apply every stack that binds the generator in one command.\n"))
+	return b.String(), nil
+}
+
+// renderGeneratorBoundToSetOnceField formats
+// FormaGeneratorBoundToSetOnceFieldError as an indented list of the fields
+// that will not accept the value the generator is about to draw, naming each
+// field so the operator knows what to edit.
+func (r *renderer) renderGeneratorBoundToSetOnceField(data *apimodel.FormaGeneratorBoundToSetOnceFieldError) (string, error) {
+	var b strings.Builder
+	_, _ = fmt.Fprintln(&b, r.error("forma rejected because a generator must draw a new value and a field it reaches will not accept one:"))
+	for _, field := range data.Fields {
+		_, _ = fmt.Fprintf(&b, "  %s%s\n", r.subtle("field "), field.Field)
+		_, _ = fmt.Fprintf(&b, "    %s%s\n", r.subtle("on "), field.Label)
+		_, _ = fmt.Fprintf(&b, "    %s%s\n", r.subtle("of type "), field.Type)
+		_, _ = fmt.Fprintf(&b, "    %s%s\n", r.subtle("from stack "), field.Stack)
+		_, _ = fmt.Fprintf(&b, "    %s%s%s%s\n", r.subtle("reached from generator "), field.GeneratorLabel,
+			r.subtle(" in stack "), field.GeneratorStack)
+	}
+	b.WriteString("\n")
+	b.WriteString(r.warning("A setOnce field keeps the value it was created with, so a drawn credential would move at the generator and stay put here. Drop setOnce from these fields, or stop routing the generator through them.\n"))
 	return b.String(), nil
 }
 

--- a/internal/cli/tui/errfmt/errfmt_test.go
+++ b/internal/cli/tui/errfmt/errfmt_test.go
@@ -111,6 +111,23 @@ func TestRender_GeneratorDestinationsUnreachable_Golden(t *testing.T) {
 	tuitest.RequireGolden(t, []byte(out))
 }
 
+// ── 3d. FormaGeneratorBoundToSetOnceFieldError ────────────────────────────────
+
+func TestRender_GeneratorBoundToSetOnceField_Golden(t *testing.T) {
+	err := &apimodel.ErrorResponse[apimodel.FormaGeneratorBoundToSetOnceFieldError]{
+		ErrorType: apimodel.GeneratorBoundToSetOnceField,
+		Data: apimodel.FormaGeneratorBoundToSetOnceFieldError{
+			Fields: []apimodel.SetOnceGeneratorField{
+				{GeneratorLabel: "db-password", GeneratorStack: "app", Stack: "web", Label: "api", Type: "AWS::S3::Bucket", Field: "DbPassword"},
+				{GeneratorLabel: "db-password", GeneratorStack: "app", Stack: "jobs", Label: "worker", Type: "AWS::ECS::TaskDefinition", Field: "ContainerDefinitions.0.Environment.1.Value"},
+			},
+		},
+	}
+	out, rerr := Render(err)
+	require.NoError(t, rerr)
+	tuitest.RequireGolden(t, []byte(out))
+}
+
 // ── 4. FormaPatchRejectedError ────────────────────────────────────────────────
 
 func TestRender_PatchRejected_Golden(t *testing.T) {

--- a/internal/cli/tui/errfmt/testdata/TestRender_GeneratorBoundToSetOnceField_Golden.golden
+++ b/internal/cli/tui/errfmt/testdata/TestRender_GeneratorBoundToSetOnceField_Golden.golden
@@ -1,0 +1,14 @@
+[38;2;248;113;113mforma rejected because a generator must draw a new value and a field it reaches will not accept one:[0m
+  [38;2;153;153;153mfield [0mDbPassword
+    [38;2;153;153;153mon [0mapi
+    [38;2;153;153;153mof type [0mAWS::S3::Bucket
+    [38;2;153;153;153mfrom stack [0mweb
+    [38;2;153;153;153mreached from generator [0mdb-password[38;2;153;153;153m in stack [0mapp
+  [38;2;153;153;153mfield [0mContainerDefinitions.0.Environment.1.Value
+    [38;2;153;153;153mon [0mworker
+    [38;2;153;153;153mof type [0mAWS::ECS::TaskDefinition
+    [38;2;153;153;153mfrom stack [0mjobs
+    [38;2;153;153;153mreached from generator [0mdb-password[38;2;153;153;153m in stack [0mapp
+
+[38;2;181;181;91mA setOnce field keeps the value it was created with, so a drawn credential would move at the generator and stay put here. Drop setOnce from these fields, or stop routing the generator through them.[0m
+[38;2;181;181;91m[0m                                                                                                                                                                                                     

--- a/internal/metastructure/generator_setonce_refusal.go
+++ b/internal/metastructure/generator_setonce_refusal.go
@@ -1,0 +1,415 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package metastructure
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// setOnceConsumerLookup reads the live resources that reference a resource
+// through a $ref envelope. It is the one edge the credential graph is built
+// from beyond the command's own documents, and it is a one-method interface
+// rather than the whole datastore so that the walk can be exercised over a
+// graph a test writes down.
+type setOnceConsumerLookup interface {
+	FindResourcesDependingOn(ksuid string) ([]*pkgmodel.Resource, error)
+}
+
+// graphOccurrence identifies one place a credential arrives: a resource, and
+// the dotted property path of the envelope it arrives in.
+type graphOccurrence struct {
+	Ksuid string
+	Path  string
+}
+
+// graphResource is one resource in a generator's reachable graph, with every
+// property document this admission can read for it.
+//
+// There are up to two, and both matter. The desired document is what the
+// author wrote; the stored one is what resolution will honour, and it is
+// where a SetOnce strategy usually lives, because a consumer's envelope
+// INHERITS the strategy of the value it resolved from and keeps it from then
+// on. Reading only the desired document would miss every consumer that
+// acquired its strategy that way, which is the whole population this refusal
+// exists for.
+type graphResource struct {
+	Ksuid     string
+	Stack     string
+	Label     string
+	Type      string
+	Documents []json.RawMessage
+	// GenBindings and Refs are the envelopes the walk follows, derived once as
+	// each document is indexed. The walk reaches a fixpoint over the whole
+	// resource set, so deriving them per round would re-traverse every
+	// document as many times as the graph is deep.
+	GenBindings []pkgmodel.GenObject
+	Refs        []refOccurrence
+}
+
+// refuseSetOnceGeneratorFields rejects a command that would draw a
+// generator's value into a field whose value strategy is SetOnce.
+//
+// A generator exists to move a credential; a SetOnce field is one whose value
+// is written once and never updated. Put in the same graph they contradict
+// each other, and the contradiction is silent: the generator advances, the
+// SetOnce field keeps what it has, no operation fails, and no later apply can
+// level the two, because formae keeps a digest of a drawn value rather than
+// the value. The only outcome that converges is to refuse the command and
+// name the fields.
+//
+// The scope is the generator's REACHABLE GRAPH, per generator. Refusing a
+// SetOnce on the destination the generator writes to directly is necessary
+// and not sufficient: a destination that accepts the value can carry it on to
+// a consumer that will not, and the credential stops there just as surely. So
+// the walk starts at the $gen envelopes naming the generator and follows $ref
+// edges outwards, checking the strategy of every envelope it arrives at.
+//
+// It is NOT stack-wide, and that boundary is load-bearing. A deployment can
+// hold setOnce credentials throughout; reading the check over the stacks the
+// command touches would turn replacing one hand-managed seed with a generator
+// into a migration of every credential beside it. Nothing outside the
+// generator's graph is looked at, and the datastore is not even asked about
+// it.
+//
+// An edge is followed only when the consumer reads the property the credential
+// actually arrives at. A resource holding a setOnce reference to the SECRET's
+// ARN is not a consumer of the credential and must not be refused, so the
+// reference's source property has to name the arrival path, or an ancestor of
+// it.
+//
+// It fires on the generators that will DRAW, not on every generator the forma
+// declares, and it reuses the draws and the live destination index that
+// co-planning and the unreachable-destination refusal already computed. The
+// harm is a value that moves at the generator and stops at the field; an apply
+// that draws nothing moves nothing. That also keeps a deployment that carries
+// the contradiction from failing every unrelated apply: the refusal lands on
+// the apply that would actually mis-propagate.
+//
+// Like the unreachable-destination refusal beside it, it DOES fire under
+// simulation. There is no confirmation that makes a credential that stops
+// halfway correct, and rendering a plan that cannot be applied is worse than
+// a refusal naming what to edit. And like it, it is an admission check for a
+// NEW command only: a resumed command rebuilds its changeset from what a
+// crashed one still owes and never comes through here.
+func refuseSetOnceGeneratorFields(
+	draws []generator_update.GeneratorUpdate,
+	liveDestinations map[string][]*pkgmodel.Resource,
+	resourceUpdates []resource_update.ResourceUpdate,
+	consumers setOnceConsumerLookup,
+) error {
+	if len(draws) == 0 {
+		return nil
+	}
+
+	graph := newSetOnceGraph(resourceUpdates, liveDestinations, consumers)
+
+	var offending []apimodel.SetOnceGeneratorField
+	for i := range draws {
+		generator := draws[i].Generator
+		if generator == nil || generator.GetID() == "" {
+			continue
+		}
+		reached, err := graph.reachableFrom(generator.GetID())
+		if err != nil {
+			return fmt.Errorf("failed to walk the resources reached by generator %q in stack %q: %w",
+				generator.GetLabel(), draws[i].StackLabel, err)
+		}
+		for occurrence := range reached {
+			resource := graph.byKsuid[occurrence.Ksuid]
+			if resource == nil || !setOnceAt(resource, occurrence.Path) {
+				continue
+			}
+			offending = append(offending, apimodel.SetOnceGeneratorField{
+				GeneratorLabel: generator.GetLabel(),
+				GeneratorStack: draws[i].StackLabel,
+				Stack:          resource.Stack,
+				Label:          resource.Label,
+				Type:           resource.Type,
+				Field:          occurrence.Path,
+			})
+		}
+	}
+	if len(offending) == 0 {
+		return nil
+	}
+
+	// Sorted, because the graph is walked over maps and the datastore orders
+	// nothing it answers with, and an operator reading this list has to go and
+	// find every entry on it.
+	slices.SortFunc(offending, func(a, b apimodel.SetOnceGeneratorField) int {
+		return cmp.Or(
+			strings.Compare(a.GeneratorStack, b.GeneratorStack),
+			strings.Compare(a.GeneratorLabel, b.GeneratorLabel),
+			strings.Compare(a.Stack, b.Stack),
+			strings.Compare(a.Label, b.Label),
+			strings.Compare(a.Type, b.Type),
+			strings.Compare(a.Field, b.Field),
+		)
+	})
+	return apimodel.FormaGeneratorBoundToSetOnceFieldError{Fields: offending}
+}
+
+// setOnceGraph holds the resources the walk knows about and grows as it
+// discovers live consumers.
+type setOnceGraph struct {
+	resources []*graphResource
+	byKsuid   map[string]*graphResource
+	consumers setOnceConsumerLookup
+	// expanded records the resources whose live consumers have been read, so
+	// the datastore is asked once per resource however many occurrences of it
+	// the graph holds.
+	expanded map[string]bool
+}
+
+// newSetOnceGraph indexes what the command already carries: the desired and
+// stored documents of every resource it plans, and the stored documents of the
+// live destinations the drawing generators are indexed against.
+//
+// A delete is left out. It writes no property, GeneratorsNeedingDraw skips it
+// for the same reason, and a resource being torn down cannot hold a credential
+// that fails to rotate. A replace still contributes, through the create half
+// the changeset splits it into.
+func newSetOnceGraph(
+	resourceUpdates []resource_update.ResourceUpdate,
+	liveDestinations map[string][]*pkgmodel.Resource,
+	consumers setOnceConsumerLookup,
+) *setOnceGraph {
+	graph := &setOnceGraph{
+		byKsuid:   make(map[string]*graphResource),
+		consumers: consumers,
+		expanded:  make(map[string]bool),
+	}
+
+	for i := range resourceUpdates {
+		update := &resourceUpdates[i]
+		if update.Operation == resource_update.OperationDelete ||
+			update.Operation == resource_update.OperationReaped {
+			continue
+		}
+		identity := &update.DesiredState
+		if identity.Ksuid == "" {
+			identity = &update.PriorState
+		}
+		graph.add(identity, update.DesiredState.Properties, update.PriorState.Properties)
+	}
+
+	for _, destinations := range liveDestinations {
+		for _, destination := range destinations {
+			if destination == nil {
+				continue
+			}
+			graph.add(destination, destination.Properties)
+		}
+	}
+
+	return graph
+}
+
+func (g *setOnceGraph) add(identity *pkgmodel.Resource, documents ...json.RawMessage) {
+	if identity.Ksuid == "" {
+		return
+	}
+	resource, known := g.byKsuid[identity.Ksuid]
+	if !known {
+		resource = &graphResource{
+			Ksuid: identity.Ksuid,
+			Stack: identity.Stack,
+			Label: identity.Label,
+			Type:  identity.Type,
+		}
+		g.byKsuid[identity.Ksuid] = resource
+		g.resources = append(g.resources, resource)
+	}
+	for _, document := range documents {
+		if len(document) == 0 {
+			continue
+		}
+		resource.Documents = append(resource.Documents, document)
+		resource.GenBindings = append(resource.GenBindings, pkgmodel.FindGenObjectsFromProperties(document)...)
+		resource.Refs = append(resource.Refs, findRefOccurrences(document)...)
+	}
+}
+
+// reachableFrom returns every occurrence the generator's value reaches: the
+// $gen envelopes naming it, and every $ref envelope that reads one of those
+// occurrences, transitively.
+//
+// It is a fixpoint rather than a single pass because the resource set grows as
+// live consumers are read, and a consumer discovered late can reference an
+// occurrence reached early. Both sets only ever grow and both are bounded by
+// the graph, so the loop terminates.
+func (g *setOnceGraph) reachableFrom(generatorKsuid string) (map[graphOccurrence]bool, error) {
+	reached := make(map[graphOccurrence]bool)
+	for _, resource := range g.resources {
+		for _, binding := range resource.GenBindings {
+			if binding.Generator == generatorKsuid {
+				reached[graphOccurrence{Ksuid: resource.Ksuid, Path: binding.Path}] = true
+			}
+		}
+	}
+	if len(reached) == 0 {
+		return nil, nil
+	}
+
+	for {
+		grew, err := g.readLiveConsumers(reached)
+		if err != nil {
+			return nil, err
+		}
+		if g.followRefs(reached) {
+			grew = true
+		}
+		if !grew {
+			return reached, nil
+		}
+	}
+}
+
+// readLiveConsumers pulls the live consumers of every reached resource into
+// the graph, so a consumer the command does not declare is walked like any
+// other. Only resources the credential actually reaches are ever asked about.
+func (g *setOnceGraph) readLiveConsumers(reached map[graphOccurrence]bool) (bool, error) {
+	if g.consumers == nil {
+		return false, nil
+	}
+	pending := make([]string, 0, len(reached))
+	for occurrence := range reached {
+		if !g.expanded[occurrence.Ksuid] {
+			g.expanded[occurrence.Ksuid] = true
+			pending = append(pending, occurrence.Ksuid)
+		}
+	}
+
+	grew := false
+	for _, ksuid := range pending {
+		live, err := g.consumers.FindResourcesDependingOn(ksuid)
+		if err != nil {
+			return false, fmt.Errorf("failed to find the resources referencing resource %s: %w", ksuid, err)
+		}
+		for _, consumer := range live {
+			if consumer == nil || consumer.Ksuid == "" {
+				continue
+			}
+			if _, known := g.byKsuid[consumer.Ksuid]; known {
+				continue
+			}
+			g.add(consumer, consumer.Properties)
+			grew = true
+		}
+	}
+	return grew, nil
+}
+
+// followRefs extends reached by one round of $ref edges, and reports whether
+// it added anything.
+func (g *setOnceGraph) followRefs(reached map[graphOccurrence]bool) bool {
+	grew := false
+	for _, resource := range g.resources {
+		for _, reference := range resource.Refs {
+			occurrence := graphOccurrence{Ksuid: resource.Ksuid, Path: reference.Path}
+			if reached[occurrence] {
+				continue
+			}
+			if !readsAReachedOccurrence(reached, reference) {
+				continue
+			}
+			reached[occurrence] = true
+			grew = true
+		}
+	}
+	return grew
+}
+
+// refOccurrence is one $ref envelope: where it sits in the consuming document,
+// and which resource and property it reads.
+type refOccurrence struct {
+	// Path is the consumer-side dotted path of the envelope.
+	Path string
+	// SourceKsuid and SourceProperty are the resource and property it reads.
+	SourceKsuid    string
+	SourceProperty string
+}
+
+// readsAReachedOccurrence reports whether a reference reads a property the
+// credential arrives at. The reference must name the arrival path itself, or a
+// container the arrival sits inside: a reference to some OTHER property of the
+// same resource carries no credential, and refusing it would refuse formae's
+// ordinary way of consuming a secret's identifier.
+func readsAReachedOccurrence(reached map[graphOccurrence]bool, reference refOccurrence) bool {
+	for occurrence := range reached {
+		if occurrence.Ksuid != reference.SourceKsuid {
+			continue
+		}
+		if occurrence.Path == reference.SourceProperty ||
+			strings.HasPrefix(occurrence.Path, reference.SourceProperty+".") {
+			return true
+		}
+	}
+	return false
+}
+
+// findRefOccurrences lists every translated $ref envelope in a property
+// document with the path it sits at.
+//
+// Only the translated shape is read. Admission translates $res triplets to
+// $ref KSUID URIs before any of this runs, and the stored documents the live
+// graph is read from hold the translated shape too; the paths that skip
+// translation (synchronize, discovery, destroy) never compute a draw, so this
+// is never called for them.
+func findRefOccurrences(document json.RawMessage) []refOccurrence {
+	var found []refOccurrence
+	collectRefOccurrences("", gjson.ParseBytes(document), &found)
+	return found
+}
+
+func collectRefOccurrences(path string, value gjson.Result, found *[]refOccurrence) {
+	if value.IsObject() {
+		if ref := value.Get("$ref"); ref.Exists() {
+			uri := pkgmodel.FormaeURI(ref.String())
+			if ksuid := uri.KSUID(); ksuid != "" {
+				*found = append(*found, refOccurrence{
+					Path:           path,
+					SourceKsuid:    ksuid,
+					SourceProperty: uri.PropertyPath(),
+				})
+			}
+			return
+		}
+	} else if !value.IsArray() {
+		return
+	}
+	value.ForEach(func(key, child gjson.Result) bool {
+		childPath := key.String()
+		if path != "" {
+			childPath = path + "." + childPath
+		}
+		collectRefOccurrences(childPath, child, found)
+		return true
+	})
+}
+
+// setOnceAt reports whether any document of the resource declares a SetOnce
+// value strategy at this path. Either document refuses: the desired one is
+// what the author wrote, and the stored one is what resolution reads when it
+// decides whether the field accepts a new value.
+func setOnceAt(resource *graphResource, path string) bool {
+	for _, document := range resource.Documents {
+		if gjson.GetBytes(document, path).Get("$strategy").String() == pkgmodel.StrategySetOnce {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/metastructure/generator_setonce_refusal_test.go
+++ b/internal/metastructure/generator_setonce_refusal_test.go
@@ -1,0 +1,233 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package metastructure
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// A drawing generator, with the KSUID its $gen envelopes name.
+func setOnceTestDraw() []generator_update.GeneratorUpdate {
+	generator := &pkgmodel.PasswordGenerator{Label: "db-password", Stack: "gen-stack"}
+	generator.SetID("gen1")
+	return []generator_update.GeneratorUpdate{{Generator: generator, StackLabel: "gen-stack"}}
+}
+
+func setOnceTestResource(ksuid, stack, label, properties string) pkgmodel.Resource {
+	return pkgmodel.Resource{
+		Ksuid: ksuid, Stack: stack, Label: label,
+		Type:       "FakeAWS::SecretsManager::Secret",
+		Properties: json.RawMessage(properties),
+	}
+}
+
+// An update whose desired and stored documents differ, which is the ordinary
+// shape of an apply over a resource that already exists.
+func setOnceTestUpdate(desired, prior pkgmodel.Resource) resource_update.ResourceUpdate {
+	return resource_update.ResourceUpdate{
+		Operation:    resource_update.OperationUpdate,
+		DesiredState: desired,
+		PriorState:   prior,
+	}
+}
+
+const (
+	// The destination shape translation produces: a $gen envelope naming the
+	// generator by KSUID.
+	genBinding = `{"$gen":true,"$generator":"gen1","$output":"value","$visibility":"Opaque"}`
+	// A consumer's envelope after it has resolved once, carrying the SetOnce
+	// strategy it inherited from the value it read.
+	setOnceRefToSeed = `{"$ref":"formae://res1#/SecretString","$visibility":"Opaque","$strategy":"SetOnce","$value":"digest"}`
+	// The same consumer as the applied forma declares it, before resolution
+	// puts a strategy or a value on it.
+	refToSeed = `{"$ref":"formae://res1#/SecretString","$visibility":"Opaque"}`
+)
+
+// A lookup over a fixed live graph, which also records what it was asked, so a
+// test can pin that a scope was never widened by a query nobody needed.
+type fakeConsumerLookup struct {
+	byKsuid map[string][]*pkgmodel.Resource
+	asked   []string
+}
+
+func (f *fakeConsumerLookup) FindResourcesDependingOn(ksuid string) ([]*pkgmodel.Resource, error) {
+	f.asked = append(f.asked, ksuid)
+	return f.byKsuid[ksuid], nil
+}
+
+func requireSetOnceRefusal(t *testing.T, err error) []apimodel.SetOnceGeneratorField {
+	t.Helper()
+	var refusal apimodel.FormaGeneratorBoundToSetOnceFieldError
+	require.ErrorAs(t, err, &refusal)
+	return refusal.Fields
+}
+
+// The field the generator writes into directly is a node of the graph like any
+// other, so a SetOnce strategy on it refuses the command and the field is named.
+func TestRefuseSetOnceGeneratorFields_RefusesTheDestinationFieldAndNamesIt(t *testing.T) {
+	setOnceBinding := `{"$gen":true,"$generator":"gen1","$output":"value","$visibility":"Opaque","$strategy":"SetOnce"}`
+	seed := setOnceTestResource("res1", "app", "seed", `{"SecretString":`+setOnceBinding+`}`)
+
+	err := refuseSetOnceGeneratorFields(
+		setOnceTestDraw(), nil,
+		[]resource_update.ResourceUpdate{setOnceTestUpdate(seed, seed)},
+		&fakeConsumerLookup{})
+
+	fields := requireSetOnceRefusal(t, err)
+	assert.Equal(t, []apimodel.SetOnceGeneratorField{{
+		GeneratorLabel: "db-password", GeneratorStack: "gen-stack",
+		Stack: "app", Label: "seed", Type: "FakeAWS::SecretsManager::Secret",
+		Field: "SecretString",
+	}}, fields)
+}
+
+// The refusal is graph-wide. A destination that accepts the drawn value can
+// still carry it on to a consumer that will not, and the drawn credential
+// stops there just as surely, so the consumer's field is what gets named.
+func TestRefuseSetOnceGeneratorFields_RefusesADownstreamConsumerField(t *testing.T) {
+	seed := setOnceTestResource("res1", "app", "seed", `{"SecretString":`+genBinding+`}`)
+	consumerDesired := setOnceTestResource("res2", "app", "api", `{"DbPassword":`+refToSeed+`}`)
+	consumerPrior := setOnceTestResource("res2", "app", "api", `{"DbPassword":`+setOnceRefToSeed+`}`)
+
+	err := refuseSetOnceGeneratorFields(
+		setOnceTestDraw(), nil,
+		[]resource_update.ResourceUpdate{
+			setOnceTestUpdate(seed, seed),
+			setOnceTestUpdate(consumerDesired, consumerPrior),
+		},
+		&fakeConsumerLookup{})
+
+	fields := requireSetOnceRefusal(t, err)
+	assert.Equal(t, []apimodel.SetOnceGeneratorField{{
+		GeneratorLabel: "db-password", GeneratorStack: "gen-stack",
+		Stack: "app", Label: "api", Type: "FakeAWS::SecretsManager::Secret",
+		Field: "DbPassword",
+	}}, fields, "the consumer's own field is the one that refuses the value")
+}
+
+// A consumer the command does not declare is still a node of the graph: the
+// value it holds diverges from the seed's the moment the seed rotates, and no
+// later apply can level them.
+func TestRefuseSetOnceGeneratorFields_RefusesALiveConsumerOutsideTheCommand(t *testing.T) {
+	seed := setOnceTestResource("res1", "app", "seed", `{"SecretString":`+genBinding+`}`)
+	live := setOnceTestResource("res2", "jobs", "worker", `{"DbPassword":`+setOnceRefToSeed+`}`)
+
+	lookup := &fakeConsumerLookup{byKsuid: map[string][]*pkgmodel.Resource{"res1": {&live}}}
+	err := refuseSetOnceGeneratorFields(
+		setOnceTestDraw(), nil,
+		[]resource_update.ResourceUpdate{setOnceTestUpdate(seed, seed)},
+		lookup)
+
+	fields := requireSetOnceRefusal(t, err)
+	require.Len(t, fields, 1)
+	assert.Equal(t, "worker", fields[0].Label)
+	assert.Equal(t, "jobs", fields[0].Stack)
+	assert.Equal(t, "DbPassword", fields[0].Field)
+}
+
+// The scope is the generator's reachable graph, not the stacks the command
+// touches. A forma full of setOnce credentials that the generator does not
+// reach is applied, or replacing one seed with a generator becomes a migration
+// of every credential beside it.
+func TestRefuseSetOnceGeneratorFields_AdmitsSetOnceFieldsTheGeneratorDoesNotReach(t *testing.T) {
+	seed := setOnceTestResource("res1", "app", "seed", `{"SecretString":`+genBinding+`}`)
+	reachedConsumer := setOnceTestResource("res2", "app", "api", `{"DbPassword":`+refToSeed+`}`)
+
+	otherSeed := setOnceTestResource("res3", "app", "legacy-seed",
+		`{"SecretString":{"$value":"digest","$visibility":"Opaque","$strategy":"SetOnce"}}`)
+	otherConsumer := setOnceTestResource("res4", "app", "legacy-api",
+		`{"DbPassword":{"$ref":"formae://res3#/SecretString","$visibility":"Opaque","$strategy":"SetOnce","$value":"digest"}}`)
+	liveOther := setOnceTestResource("res5", "jobs", "legacy-worker",
+		`{"DbPassword":{"$ref":"formae://res3#/SecretString","$visibility":"Opaque","$strategy":"SetOnce","$value":"digest"}}`)
+
+	lookup := &fakeConsumerLookup{byKsuid: map[string][]*pkgmodel.Resource{"res3": {&liveOther}}}
+	err := refuseSetOnceGeneratorFields(
+		setOnceTestDraw(), nil,
+		[]resource_update.ResourceUpdate{
+			setOnceTestUpdate(seed, seed),
+			setOnceTestUpdate(reachedConsumer, reachedConsumer),
+			setOnceTestUpdate(otherSeed, otherSeed),
+			setOnceTestUpdate(otherConsumer, otherConsumer),
+		},
+		lookup)
+
+	require.NoError(t, err, "a setOnce credential graph beside the generator's own is none of its business")
+	assert.NotContains(t, lookup.asked, "res3",
+		"a resource outside the generator's graph must not even be expanded")
+}
+
+// A forma that draws nothing has no graph to walk, and the datastore is never
+// asked about one.
+func TestRefuseSetOnceGeneratorFields_AdmitsAFormaWithNoGenerator(t *testing.T) {
+	plain := setOnceTestResource("res1", "app", "config",
+		`{"SecretString":{"$value":"digest","$visibility":"Opaque","$strategy":"SetOnce"}}`)
+
+	lookup := &fakeConsumerLookup{}
+	err := refuseSetOnceGeneratorFields(nil, nil,
+		[]resource_update.ResourceUpdate{setOnceTestUpdate(plain, plain)}, lookup)
+
+	require.NoError(t, err)
+	assert.Empty(t, lookup.asked)
+}
+
+// Every offending field goes into one refusal, in an order that does not
+// depend on the order the datastore answered in: an operator has to go and
+// find each one, and two runs of the same refused apply must name them the
+// same way.
+func TestRefuseSetOnceGeneratorFields_NamesEveryFieldInAStableOrder(t *testing.T) {
+	seed := setOnceTestResource("res1", "app", "seed", `{"SecretString":`+genBinding+`}`)
+	consumer := func(ksuid, stack, label string) pkgmodel.Resource {
+		return setOnceTestResource(ksuid, stack, label, `{"DbPassword":`+setOnceRefToSeed+`}`)
+	}
+
+	refuse := func(order []*pkgmodel.Resource) []apimodel.SetOnceGeneratorField {
+		lookup := &fakeConsumerLookup{byKsuid: map[string][]*pkgmodel.Resource{"res1": order}}
+		return requireSetOnceRefusal(t, refuseSetOnceGeneratorFields(
+			setOnceTestDraw(), nil,
+			[]resource_update.ResourceUpdate{setOnceTestUpdate(seed, seed)},
+			lookup))
+	}
+
+	gamma := consumer("res2", "jobs", "gamma")
+	alpha := consumer("res3", "app", "alpha")
+	beta := consumer("res4", "app", "beta")
+
+	want := []apimodel.SetOnceGeneratorField{
+		{GeneratorLabel: "db-password", GeneratorStack: "gen-stack", Stack: "app", Label: "alpha", Type: "FakeAWS::SecretsManager::Secret", Field: "DbPassword"},
+		{GeneratorLabel: "db-password", GeneratorStack: "gen-stack", Stack: "app", Label: "beta", Type: "FakeAWS::SecretsManager::Secret", Field: "DbPassword"},
+		{GeneratorLabel: "db-password", GeneratorStack: "gen-stack", Stack: "jobs", Label: "gamma", Type: "FakeAWS::SecretsManager::Secret", Field: "DbPassword"},
+	}
+	assert.Equal(t, want, refuse([]*pkgmodel.Resource{&gamma, &alpha, &beta}))
+	assert.Equal(t, want, refuse([]*pkgmodel.Resource{&beta, &gamma, &alpha}))
+}
+
+// A live destination the datastore indexes for the generator seeds the walk
+// too, so a consumer of a destination whose own document the command never
+// re-declares is still reached.
+func TestRefuseSetOnceGeneratorFields_SeedsFromLiveDestinationsAsWell(t *testing.T) {
+	liveSeed := setOnceTestResource("res1", "app", "seed", `{"SecretString":`+genBinding+`}`)
+	liveConsumer := setOnceTestResource("res2", "app", "api", `{"DbPassword":`+setOnceRefToSeed+`}`)
+
+	lookup := &fakeConsumerLookup{byKsuid: map[string][]*pkgmodel.Resource{"res1": {&liveConsumer}}}
+	err := refuseSetOnceGeneratorFields(
+		setOnceTestDraw(),
+		map[string][]*pkgmodel.Resource{"gen1": {&liveSeed}},
+		nil, lookup)
+
+	fields := requireSetOnceRefusal(t, err)
+	require.Len(t, fields, 1)
+	assert.Equal(t, "DbPassword", fields[0].Field)
+}

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -2584,6 +2584,15 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 			drawGeneratorUpdates, liveDestinations, resourceUpdates); err != nil {
 			return nil, err
 		}
+
+		// A draw that CAN reach every destination can still be a draw nothing
+		// downstream will accept. This runs after the reach refusal so the
+		// graph it walks is the settled one: every live destination of a
+		// drawing generator is either planned or already refused above.
+		if err := refuseSetOnceGeneratorFields(
+			drawGeneratorUpdates, liveDestinations, resourceUpdates, ds); err != nil {
+			return nil, err
+		}
 	}
 
 	fc := forma_command.NewFormaCommand(

--- a/internal/workflow_tests/local/apply_forma/generator_setonce_field_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_setonce_field_test.go
@@ -1,0 +1,146 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// setOnceSeedSecret is a secret whose opaque value is written once and never
+// updated afterwards: the shape a hand-managed credential takes before anyone
+// puts a generator behind it.
+func setOnceSeedSecret(stack, label, value string) pkgmodel.Resource {
+	return pkgmodel.Resource{
+		Label:  label,
+		Type:   "FakeAWS::SecretsManager::Secret",
+		Stack:  stack,
+		Target: "test-target",
+		Schema: secretSchema(),
+		Properties: json.RawMessage(`{
+			"Name": "` + label + `",
+			"SecretString": {"$value":"` + value + `","$visibility":"Opaque","$strategy":"SetOnce"}
+		}`),
+	}
+}
+
+// storedStrategy returns the value strategy a stored resource carries at one
+// property path.
+func storedStrategy(t *testing.T, m *metastructure.Metastructure, stack, label, path string) string {
+	t.Helper()
+	resources, err := m.Datastore.LoadResourcesByStack(stack)
+	require.NoError(t, err)
+	for i := range resources {
+		if resources[i].Label == label {
+			return gjson.GetBytes(resources[i].Properties, path).Get("$strategy").String()
+		}
+	}
+	t.Fatalf("no stored resource %q in stack %q", label, stack)
+	return ""
+}
+
+// Putting a generator behind a credential that something downstream holds
+// setOnce is refused, and refused before anything is drawn.
+//
+// A consumer's stored envelope inherits the value strategy of the value it
+// resolved from, so a consumer of a setOnce secret is itself setOnce from its
+// first apply onwards. Binding that secret to a generator makes the two
+// contradictory: the secret takes each newly drawn value and the consumer
+// keeps the first one it ever saw. Nothing fails while that happens — the
+// secret rotates and the consumer is not even dispatched — and formae keeps a
+// digest of a drawn value rather than the value, so no later apply can bring
+// the two level again.
+//
+// The middle apply is half the test. The generator draws for a destination of
+// its own while a setOnce credential graph sits beside it in the same stack,
+// and that apply must succeed: the refusal is scoped to what the generator
+// reaches, not to the stacks the command carries. A stack-wide reading of the
+// same rule would turn replacing one seed into a migration of every credential
+// around it.
+func TestApplyForma_GeneratorReachingASetOnceConsumer_IsRefusedWithoutDrawing(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		var consumerUpdates atomic.Int32
+		var consumerProps atomic.Value
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(
+			t, secretConsumerOverrides(&consumerUpdates, &consumerProps), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		apply := func(generators []json.RawMessage, resources ...pkgmodel.Resource) error {
+			_, applyErr := m.ApplyForma(&pkgmodel.Forma{
+				Stacks:     []pkgmodel.Stack{{Label: stack}},
+				Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: generators,
+				Resources:  resources,
+			}, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+			return applyErr
+		}
+		generator := func() []json.RawMessage {
+			return []json.RawMessage{passwordGeneratorFor(t, "db-password", stack)}
+		}
+
+		// A hand-managed credential and a consumer of it. The consumer is
+		// setOnce from here on, by inheritance.
+		seed := setOnceSeedSecret(stack, "seed", "seed-v1")
+		consumer := secretConsumer(stack, "seed")
+
+		require.NoError(t, apply(nil, seed, consumer))
+		waitForApplyComplete(t, m)
+		require.Equal(t, "SetOnce", storedStrategy(t, m, stack, "my-bucket", "DbPassword"),
+			"the consumer must have inherited the seed's strategy, or this test proves nothing")
+
+		// A destination of the generator's own, in the same stack as the
+		// setOnce graph and reaching none of it. FakeAWS gives every secret it
+		// creates the same native id, so the two secrets are created by
+		// separate commands.
+		vault := genBoundSecret(stack, "vault", "db-password", "value")
+		require.NoError(t, apply(generator(), seed, consumer, vault),
+			"a setOnce credential graph the generator does not reach must not stop it drawing")
+		waitForApplyComplete(t, m)
+
+		drawn, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, drawn.GenerationID, "the generator must have drawn for its own destination")
+
+		// Now put the generator behind the seed, which makes the setOnce
+		// consumer a node of the generator's graph.
+		err = apply(generator(), genBoundSecret(stack, "seed", "db-password", "value"), consumer, vault)
+
+		var refusal apimodel.FormaGeneratorBoundToSetOnceFieldError
+		require.ErrorAs(t, err, &refusal)
+		assert.Equal(t, []apimodel.SetOnceGeneratorField{{
+			GeneratorLabel: "db-password",
+			GeneratorStack: stack,
+			Stack:          stack,
+			Label:          "my-bucket",
+			Type:           "FakeAWS::S3::Bucket",
+			Field:          "DbPassword",
+		}}, refusal.Fields)
+
+		refused, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		assert.Equal(t, drawn.GenerationID, refused.GenerationID,
+			"a refused command must not have drawn: the generation the generator held is the one it still holds")
+	})
+}

--- a/pkg/api/model/errors.go
+++ b/pkg/api/model/errors.go
@@ -38,6 +38,7 @@ const (
 	TargetHasDependents              APIError = "TargetHasDependents"
 	ResourceHasDependents            APIError = "ResourceHasDependents"
 	GeneratorDestinationsUnreachable APIError = "GeneratorDestinationsUnreachable"
+	GeneratorBoundToSetOnceField     APIError = "GeneratorBoundToSetOnceField"
 )
 
 type ErrorResponse[T any] struct {
@@ -149,6 +150,36 @@ type FormaGeneratorDestinationsUnreachableError struct {
 
 func (e FormaGeneratorDestinationsUnreachableError) Error() string {
 	return "forma rejected because a generator must draw a new value and the command does not reach every resource bound to it"
+}
+
+// SetOnceGeneratorField names one field in a drawing generator's reachable
+// graph whose value strategy is SetOnce. GeneratorLabel and GeneratorStack
+// identify the generator; Stack, Label and Type locate the resource; Field is
+// the property path on it, which is the thing the operator has to edit.
+type SetOnceGeneratorField struct {
+	GeneratorLabel string `json:"GeneratorLabel"`
+	GeneratorStack string `json:"GeneratorStack"`
+	Stack          string `json:"Stack"`
+	Label          string `json:"Label"`
+	Type           string `json:"Type"`
+	Field          string `json:"Field"`
+}
+
+// FormaGeneratorBoundToSetOnceFieldError refuses an apply that would draw a
+// generator's value into a field whose strategy is SetOnce.
+//
+// A generator exists to move a credential. A SetOnce field is one whose value
+// is written once and never updated afterwards. The two together are
+// contradictory by construction: the credential moves at the generator and
+// stays put at the field, and no later apply can level them, because formae
+// keeps a digest of a drawn value rather than the value. Nothing fails while
+// that happens, which is what makes it worth refusing rather than reporting.
+type FormaGeneratorBoundToSetOnceFieldError struct {
+	Fields []SetOnceGeneratorField `json:"Fields"`
+}
+
+func (e FormaGeneratorBoundToSetOnceFieldError) Error() string {
+	return "forma rejected because a generator must draw a new value and a field it reaches will not accept one"
 }
 
 type TargetAlreadyExistsError struct {


### PR DESCRIPTION
## Summary

Stacked on #718. A generator's value moving at the source but stopping at a field that refuses updates silently splits a credential. This refuses that at admission, before anything is drawn.

## The harm, reproduced before anything was written

Two applies against the real metastructure:

1. A secret whose value carries the setOnce strategy, and a consumer referencing that secret's property. The consumer's stored envelope came back **carrying the strategy it inherited from the value it resolved from**.
2. Rebind the secret to a generator. The secret rotated to a freshly drawn value under a new generation; the consumer kept the **old digest and old provenance**, its plugin `Update` was called **zero times**, and the apply returned **no error**.

That is the whole defect: the credential now differs between the secret and its consumer, nothing said so, and no later apply repairs it because the consumer's own envelope refuses updates.

## What the tree said that the plan did not

**There is no setOnce field-level schema hint.** The field hints are createOnly, writeOnly, required, opaque, edgeKind, updateMethod, preserveEmptyValues and format — setOnce is not among them. In this codebase setOnce is a **value strategy** on a property's value envelope, authorable through the value and secret helpers. The check is built over that instead.

That also makes the direct case — a generator bound straight to a setOnce field — **unrepresentable today**, established rather than assumed: the generator-output class emits no strategy and offers no setOnce accessor, translation rewrites every generator node to exactly four keys and discards anything else at that path, and an interpolated generator inside a setOnce value is already rejected pre-translation because a generated value's visibility is always opaque. A probe confirmed a drawn destination stores the ordinary update strategy.

So only the downstream case is reachable, and that is the one verified above. The walk tests the strategy at every occurrence it visits, seeds included, so if a field-level hint is ever introduced the direct case is covered with no change.

## Scope: per-generator, and it fires only when something draws

The walk seeds from the generator's own destinations and follows reference edges outward to a fixpoint. An edge is followed only when the referencing property **is** the arrival path or an ancestor of it, so a setOnce reference to a secret's ARN is not mistaken for a consumer of the secret's value.

A setOnce credential graph elsewhere in the forma, not reachable from the generator, is **admitted**. That is what stops this being a stack-wide check that would turn a one-field change into a credential-graph migration, and it is pinned by a test that fails when the reachability test is dropped.

It fires only for generators that will actually draw: an apply that draws nothing moves nothing, so there is nothing to refuse. It also reuses the destination set already computed for co-planning and the reach refusal rather than adding a datastore read per generator per apply.

## Verification note, stated rather than glossed

The five refusal unit tests were written first and failed against a stub. The two "admits" tests pass against a stub by construction, so they were checked by the opposite weakening — widening the walk to stack-wide, which makes the scope test fail. The end-to-end test was written after the implementation, so its evidence is the weakening run rather than a first-failure; saying so plainly.

## Merge note

This inserts into the same generator block of the admission function that a scheduler branch is likely to touch. Adjacent-line conflict is likely and wants a human merge rather than a mechanical one.