### PR TITLE
feat(metastructure): rotate a generator on its declared cadence

### DIFF
--- a/internal/datastore/aurora/aurora_generators.go
+++ b/internal/datastore/aurora/aurora_generators.go
@@ -472,6 +472,90 @@ func (d *DatastoreAuroraDataAPI) GetGeneratorIdentityByID(generatorID string) (d
 	return generatorIdentityFromRow(id, generationID, generationSpec), nil
 }
 
+// GetGeneratorsWithRotation returns every live generator with the instant its
+// last rotation committed. The cadence itself is read from the stored spec by
+// datastore.RotationInfoFromRows, so this query never parses JSON.
+//
+// last_committed_draw is the derivation the rotation scheduler runs on: a
+// generation row records that a value was drawn and the command that drew it,
+// and joining that command's state is what says whether the value ever reached
+// its destinations. A command that is not Success advances nothing, so a
+// failed authority-side update leaves the cadence measured from the previous
+// success.
+func (d *DatastoreAuroraDataAPI) GetGeneratorsWithRotation() ([]datastore.GeneratorRotationInfo, error) {
+	ctx := context.Background()
+
+	query := `
+		WITH latest_generators AS (
+			SELECT id, label, stack_id, generator_data, operation,
+			       ROW_NUMBER() OVER (PARTITION BY id ORDER BY version COLLATE "C" DESC) as rn
+			FROM generators
+		),
+		latest_stacks AS (
+			SELECT id, label, operation,
+			       ROW_NUMBER() OVER (PARTITION BY id ORDER BY version COLLATE "C" DESC) as rn
+			FROM stacks
+		),
+		last_committed_draw AS (
+			SELECT g.id as generator_id, MAX(fc.timestamp) as last_rotation_at
+			FROM generators g
+			JOIN forma_commands fc ON fc.command_id = g.command_id
+			WHERE g.generation_id != '' AND fc.state = 'Success'
+			GROUP BY g.id
+		)
+		SELECT g.id, g.label, s.label, g.generator_data::text, d.last_rotation_at
+		FROM latest_generators g
+		JOIN latest_stacks s ON s.id = g.stack_id
+		LEFT JOIN last_committed_draw d ON d.generator_id = g.id
+		WHERE g.rn = 1 AND g.operation != 'delete'
+		AND s.rn = 1 AND s.operation != 'delete'
+	`
+
+	result, err := d.executeStatement(ctx, query, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get generators with rotation: %w", err)
+	}
+
+	var rotationRows []datastore.GeneratorRotationRow
+	for _, record := range result.Records {
+		if len(record) < 5 {
+			continue
+		}
+		generatorID, err := getStringField(record[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to get generator id: %w", err)
+		}
+		label, err := getStringField(record[1])
+		if err != nil {
+			return nil, fmt.Errorf("failed to get generator label: %w", err)
+		}
+		stackLabel, err := getStringField(record[2])
+		if err != nil {
+			return nil, fmt.Errorf("failed to get stack label: %w", err)
+		}
+		generatorData, err := getStringField(record[3])
+		if err != nil {
+			return nil, fmt.Errorf("failed to get generator data: %w", err)
+		}
+		// A generator that has never had a committed draw yields NULL here,
+		// which getTimestampField reads as the zero instant: no rotation on
+		// record, so it is due immediately.
+		lastRotationAt, err := getTimestampField(record[4])
+		if err != nil {
+			return nil, fmt.Errorf("failed to get the instant of the last committed draw: %w", err)
+		}
+		rotationRows = append(rotationRows, datastore.GeneratorRotationRow{
+			GeneratorID:    generatorID,
+			Label:          label,
+			StackLabel:     stackLabel,
+			GeneratorData:  []byte(generatorData),
+			LastRotationAt: lastRotationAt.UTC(),
+		})
+	}
+
+	return datastore.RotationInfoFromRows(rotationRows)
+}
+
 // AdvanceGeneration records that a new generation was drawn for this
 // generator, under this spec. Writes a new version row that carries forward
 // the existing label/type/stack/generator_data unchanged — only the
@@ -483,7 +567,7 @@ func (d *DatastoreAuroraDataAPI) GetGeneratorIdentityByID(generatorID string) (d
 // (generator_update.GeneratorUpdater): it calls this once it has drawn a
 // value, so the generation the value came from is durable before any
 // destination is stamped with it.
-func (d *DatastoreAuroraDataAPI) AdvanceGeneration(generatorID, generationID string, drawnUnder json.RawMessage) error {
+func (d *DatastoreAuroraDataAPI) AdvanceGeneration(generatorID, generationID, commandID string, drawnUnder json.RawMessage) error {
 	ctx := context.Background()
 
 	if generationID == "" {
@@ -535,7 +619,7 @@ func (d *DatastoreAuroraDataAPI) AdvanceGeneration(generatorID, generationID str
 	insertParams := []types.SqlParameter{
 		{Name: aws.String("id"), Value: &types.FieldMemberStringValue{Value: generatorID}},
 		{Name: aws.String("version"), Value: &types.FieldMemberStringValue{Value: version}},
-		{Name: aws.String("command_id"), Value: &types.FieldMemberStringValue{Value: ""}},
+		{Name: aws.String("command_id"), Value: &types.FieldMemberStringValue{Value: commandID}},
 		{Name: aws.String("operation"), Value: &types.FieldMemberStringValue{Value: "update"}},
 		{Name: aws.String("label"), Value: &types.FieldMemberStringValue{Value: label}},
 		{Name: aws.String("generator_type"), Value: &types.FieldMemberStringValue{Value: generatorType}},

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -247,6 +247,28 @@ type ResourceSnapshot struct {
 // interfaces with the same method.
 type GeneratorIdentity = pkgmodel.GeneratorIdentity
 
+// GeneratorRotationInfo is one rotating generator's cadence and the instant
+// its last rotation committed.
+//
+// LastRotationAt is DERIVED at query time and stored nowhere: it is the start
+// of the most recent command that both advanced this generator's generation
+// and succeeded. Keeping it off the generator is the same choice policies
+// make with LastReconcileAt — a stored last-rotated-at would participate in
+// desired-config equality, show up as metadata drift, and be rendered into
+// formae people copy between environments.
+//
+// Zero means no rotation has ever committed for this generator, which makes it
+// due immediately. A draw whose command failed leaves the zero value in place:
+// the generation row exists, but the command that would have propagated it
+// does not read Success, so it advances no cadence.
+type GeneratorRotationInfo struct {
+	GeneratorID     string
+	Label           string
+	StackLabel      string
+	IntervalSeconds int
+	LastRotationAt  time.Time
+}
+
 // Datastore defines the persistence interface for formae.
 // It handles storage and retrieval of FormaCommands (requested changes),
 // Resources (actual cloud state), Stacks, and Targets.
@@ -560,6 +582,16 @@ type Datastore interface {
 	// with this KSUID, whichever stack owns it. Zero value plus nil error
 	// when absent.
 	GetGeneratorIdentityByID(generatorID string) (GeneratorIdentity, error)
+	// GetGeneratorsWithRotation returns every live generator that declares a
+	// rotation cadence, with the instant its last rotation committed. Modeled
+	// on GetStacksWithAutoReconcilePolicy: the cadence and the last run come
+	// back together, and the caller decides what is due.
+	//
+	// A generator whose stack has been deleted, or whose own latest row is a
+	// delete, is absent. So is one whose latest row no longer declares a
+	// cadence, which is what makes removing rotation take effect on the next
+	// sweep rather than at the next restart.
+	GetGeneratorsWithRotation() ([]GeneratorRotationInfo, error)
 	// AdvanceGeneration records that a new generation was drawn for this
 	// generator, under this spec. Writes a new version row, preserving the
 	// KSUID. Errors if generationID is empty, if drawnUnder is not valid
@@ -571,7 +603,13 @@ type Datastore interface {
 	// reports the drawn value: a value handed to a destination under a
 	// generation nobody stored is exactly the state the next apply cannot
 	// reason about.
-	AdvanceGeneration(generatorID, generationID string, drawnUnder json.RawMessage) error
+	//
+	// commandID is the command the draw belongs to. It is what makes the
+	// rotation cadence derivable: a generation row alone says a value was
+	// drawn, and the command it was drawn by says whether that value ever
+	// reached its destinations. GetGeneratorsWithRotation joins the two, so
+	// a draw whose command failed advances no cadence.
+	AdvanceGeneration(generatorID, generationID, commandID string, drawnUnder json.RawMessage) error
 
 	// Close releases database connections
 	Close()

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -264,6 +264,17 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunAdvanceGenerationOnDeletedGeneratorFailsWithoutResurrecting(t, newDS)
 	RunAdvanceGenerationRejectsMalformedSpecAndEmptyGenerationID(t, newDS)
 
+	RunGetGeneratorsWithRotation_Empty(t, newDS)
+	RunGetGeneratorsWithRotation_CadenceAndStackLabel(t, newDS)
+	RunGetGeneratorsWithRotation_WithoutCadenceExcluded(t, newDS)
+	RunGetGeneratorsWithRotation_LastRotationFromCommittedDraw(t, newDS)
+	RunGetGeneratorsWithRotation_FailedCommandAdvancesNothing(t, newDS)
+	RunGetGeneratorsWithRotation_LatestCommittedDrawWins(t, newDS)
+	RunGetGeneratorsWithRotation_PerGeneratorLastRotation(t, newDS)
+	RunGetGeneratorsWithRotation_DeletedGeneratorExcluded(t, newDS)
+	RunGetGeneratorsWithRotation_RemovedCadenceExcluded(t, newDS)
+	RunGetGeneratorsWithRotation_ChangedCadenceReadFromLatest(t, newDS)
+
 	RunFindResourcesDependingOn(t, newDS)
 	RunFindResourcesDependingOnMultipleRefs(t, newDS)
 	RunFindResourcesDependingOnNoRefs(t, newDS)

--- a/internal/datastore/dstest/suite_generator_rotation.go
+++ b/internal/datastore/dstest/suite_generator_rotation.go
@@ -1,0 +1,341 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package dstest
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// rotatingPasswordGenerator returns a password generator that declares a
+// rotation cadence.
+func rotatingPasswordGenerator(label string, stack *pkgmodel.Stack, everySeconds int) *pkgmodel.PasswordGenerator {
+	gen := testPasswordGenerator(label, stack, 24)
+	gen.Rotation = &pkgmodel.RotationSpec{EverySeconds: everySeconds}
+	return gen
+}
+
+// drawCommand stores a forma command in the given state and returns its ID and
+// the instant it started. A draw records the command it was drawn by, and
+// whether that command succeeded is what decides whether the cadence advanced.
+func drawCommand(t *testing.T, ds datastore.Datastore, state forma_command.CommandState, startOffset time.Duration) (string, time.Time) {
+	t.Helper()
+	startTs := util.TimeNow().Add(startOffset).UTC()
+	cmd := &forma_command.FormaCommand{
+		ID:         util.NewID(),
+		Command:    pkgmodel.CommandApply,
+		Config:     config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
+		State:      state,
+		StartTs:    startTs,
+		ModifiedTs: startTs,
+	}
+	require.NoError(t, ds.StoreFormaCommand(cmd, cmd.ID))
+	return cmd.ID, startTs
+}
+
+// rotationInfoFor picks one generator's rotation info out of the result, or
+// fails the test.
+func rotationInfoFor(t *testing.T, infos []datastore.GeneratorRotationInfo, generatorID string) datastore.GeneratorRotationInfo {
+	t.Helper()
+	for _, info := range infos {
+		if info.GeneratorID == generatorID {
+			return info
+		}
+	}
+	t.Fatalf("no rotation info for generator %s in %+v", generatorID, infos)
+	return datastore.GeneratorRotationInfo{}
+}
+
+// RunGetGeneratorsWithRotation_CadenceAndStackLabel verifies the happy path: a
+// generator that declares a cadence comes back with it, named by the stack
+// that owns it.
+func RunGetGeneratorsWithRotation_CadenceAndStackLabel(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetGeneratorsWithRotation_CadenceAndStackLabel", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		stack := createGeneratorStack(t, ds, "rotation-owner")
+		gen := rotatingPasswordGenerator("db-password", stack, 3600)
+		_, err := ds.CreateGenerator(gen, "cmd-create")
+		require.NoError(t, err)
+
+		identity, err := ds.GetGeneratorIdentity("db-password", stack.Label)
+		require.NoError(t, err)
+
+		infos, err := ds.GetGeneratorsWithRotation()
+		require.NoError(t, err)
+
+		info := rotationInfoFor(t, infos, identity.ID)
+		assert.Equal(t, "db-password", info.Label)
+		assert.Equal(t, stack.Label, info.StackLabel)
+		assert.Equal(t, 3600, info.IntervalSeconds)
+		assert.True(t, info.LastRotationAt.IsZero(),
+			"a generator that has never rotated must carry no last-rotation instant, got %s", info.LastRotationAt)
+	})
+}
+
+// RunGetGeneratorsWithRotation_WithoutCadenceExcluded verifies that a
+// generator declaring no cadence never appears: nothing rotates on its own.
+func RunGetGeneratorsWithRotation_WithoutCadenceExcluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetGeneratorsWithRotation_WithoutCadenceExcluded", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		stack := createGeneratorStack(t, ds, "rotation-none")
+		_, err := ds.CreateGenerator(testPasswordGenerator("db-password", stack, 24), "cmd-create")
+		require.NoError(t, err)
+
+		infos, err := ds.GetGeneratorsWithRotation()
+		require.NoError(t, err)
+		for _, info := range infos {
+			assert.NotEqual(t, "db-password", info.Label,
+				"a generator with no declared cadence must not be scheduled")
+		}
+	})
+}
+
+// RunGetGeneratorsWithRotation_LastRotationFromCommittedDraw verifies the
+// derivation: the last-rotation instant is the start of the successful command
+// that drew the generation, read back from command history rather than from
+// anything stored on the generator.
+func RunGetGeneratorsWithRotation_LastRotationFromCommittedDraw(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetGeneratorsWithRotation_LastRotationFromCommittedDraw", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		stack := createGeneratorStack(t, ds, "rotation-committed")
+		gen := rotatingPasswordGenerator("db-password", stack, 3600)
+		_, err := ds.CreateGenerator(gen, "cmd-create")
+		require.NoError(t, err)
+		identity, err := ds.GetGeneratorIdentity("db-password", stack.Label)
+		require.NoError(t, err)
+
+		commandID, startTs := drawCommand(t, ds, forma_command.CommandStateSuccess, -30*time.Minute)
+		spec, err := json.Marshal(gen)
+		require.NoError(t, err)
+		require.NoError(t, ds.AdvanceGeneration(identity.ID, "generation-1", commandID, spec))
+
+		infos, err := ds.GetGeneratorsWithRotation()
+		require.NoError(t, err)
+		info := rotationInfoFor(t, infos, identity.ID)
+		assert.WithinDuration(t, startTs, info.LastRotationAt, 2*time.Second,
+			"the last-rotation instant must be the committed draw's command")
+	})
+}
+
+// RunGetGeneratorsWithRotation_FailedCommandAdvancesNothing verifies that a
+// draw whose command did not succeed leaves the cadence where it was. The
+// generation row exists — the value was drawn — but nothing propagated it, so
+// the interval must not restart from it.
+func RunGetGeneratorsWithRotation_FailedCommandAdvancesNothing(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetGeneratorsWithRotation_FailedCommandAdvancesNothing", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		stack := createGeneratorStack(t, ds, "rotation-failed")
+		gen := rotatingPasswordGenerator("db-password", stack, 3600)
+		_, err := ds.CreateGenerator(gen, "cmd-create")
+		require.NoError(t, err)
+		identity, err := ds.GetGeneratorIdentity("db-password", stack.Label)
+		require.NoError(t, err)
+		spec, err := json.Marshal(gen)
+		require.NoError(t, err)
+
+		failedID, _ := drawCommand(t, ds, forma_command.CommandStateFailed, -10*time.Minute)
+		require.NoError(t, ds.AdvanceGeneration(identity.ID, "generation-1", failedID, spec))
+
+		infos, err := ds.GetGeneratorsWithRotation()
+		require.NoError(t, err)
+		info := rotationInfoFor(t, infos, identity.ID)
+		assert.True(t, info.LastRotationAt.IsZero(),
+			"a draw whose command failed must advance no cadence, got %s", info.LastRotationAt)
+
+		// A later successful draw does advance it, so the assertion above is
+		// about the command's outcome and not about the query finding nothing.
+		successID, successTs := drawCommand(t, ds, forma_command.CommandStateSuccess, -5*time.Minute)
+		require.NoError(t, ds.AdvanceGeneration(identity.ID, "generation-2", successID, spec))
+
+		infos, err = ds.GetGeneratorsWithRotation()
+		require.NoError(t, err)
+		info = rotationInfoFor(t, infos, identity.ID)
+		assert.WithinDuration(t, successTs, info.LastRotationAt, 2*time.Second)
+	})
+}
+
+// RunGetGeneratorsWithRotation_LatestCommittedDrawWins verifies that the
+// cadence is measured from the most recent committed draw, not the first.
+func RunGetGeneratorsWithRotation_LatestCommittedDrawWins(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetGeneratorsWithRotation_LatestCommittedDrawWins", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		stack := createGeneratorStack(t, ds, "rotation-latest")
+		gen := rotatingPasswordGenerator("db-password", stack, 3600)
+		_, err := ds.CreateGenerator(gen, "cmd-create")
+		require.NoError(t, err)
+		identity, err := ds.GetGeneratorIdentity("db-password", stack.Label)
+		require.NoError(t, err)
+		spec, err := json.Marshal(gen)
+		require.NoError(t, err)
+
+		oldID, _ := drawCommand(t, ds, forma_command.CommandStateSuccess, -3*time.Hour)
+		require.NoError(t, ds.AdvanceGeneration(identity.ID, "generation-1", oldID, spec))
+		newID, newTs := drawCommand(t, ds, forma_command.CommandStateSuccess, -1*time.Hour)
+		require.NoError(t, ds.AdvanceGeneration(identity.ID, "generation-2", newID, spec))
+
+		infos, err := ds.GetGeneratorsWithRotation()
+		require.NoError(t, err)
+		info := rotationInfoFor(t, infos, identity.ID)
+		assert.WithinDuration(t, newTs, info.LastRotationAt, 2*time.Second)
+	})
+}
+
+// RunGetGeneratorsWithRotation_PerGeneratorLastRotation verifies that one
+// generator's committed draw says nothing about another's: two generators on
+// one stack keep separate cadences.
+func RunGetGeneratorsWithRotation_PerGeneratorLastRotation(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetGeneratorsWithRotation_PerGeneratorLastRotation", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		stack := createGeneratorStack(t, ds, "rotation-per-generator")
+		drawn := rotatingPasswordGenerator("drawn-password", stack, 3600)
+		_, err := ds.CreateGenerator(drawn, "cmd-create")
+		require.NoError(t, err)
+		untouched := rotatingPasswordGenerator("untouched-password", stack, 7200)
+		_, err = ds.CreateGenerator(untouched, "cmd-create")
+		require.NoError(t, err)
+
+		drawnIdentity, err := ds.GetGeneratorIdentity("drawn-password", stack.Label)
+		require.NoError(t, err)
+		untouchedIdentity, err := ds.GetGeneratorIdentity("untouched-password", stack.Label)
+		require.NoError(t, err)
+
+		spec, err := json.Marshal(drawn)
+		require.NoError(t, err)
+		commandID, startTs := drawCommand(t, ds, forma_command.CommandStateSuccess, -20*time.Minute)
+		require.NoError(t, ds.AdvanceGeneration(drawnIdentity.ID, "generation-1", commandID, spec))
+
+		infos, err := ds.GetGeneratorsWithRotation()
+		require.NoError(t, err)
+		assert.WithinDuration(t, startTs, rotationInfoFor(t, infos, drawnIdentity.ID).LastRotationAt, 2*time.Second)
+		assert.True(t, rotationInfoFor(t, infos, untouchedIdentity.ID).LastRotationAt.IsZero(),
+			"advancing one generator must not restart another's cadence")
+		assert.Equal(t, 7200, rotationInfoFor(t, infos, untouchedIdentity.ID).IntervalSeconds)
+	})
+}
+
+// RunGetGeneratorsWithRotation_DeletedGeneratorExcluded verifies that a
+// deleted generator is not scheduled.
+func RunGetGeneratorsWithRotation_DeletedGeneratorExcluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetGeneratorsWithRotation_DeletedGeneratorExcluded", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		stack := createGeneratorStack(t, ds, "rotation-deleted")
+		_, err := ds.CreateGenerator(rotatingPasswordGenerator("db-password", stack, 3600), "cmd-create")
+		require.NoError(t, err)
+		identity, err := ds.GetGeneratorIdentity("db-password", stack.Label)
+		require.NoError(t, err)
+
+		infos, err := ds.GetGeneratorsWithRotation()
+		require.NoError(t, err)
+		rotationInfoFor(t, infos, identity.ID)
+
+		_, err = ds.DeleteGenerator("db-password", stack.Label)
+		require.NoError(t, err)
+
+		infos, err = ds.GetGeneratorsWithRotation()
+		require.NoError(t, err)
+		for _, info := range infos {
+			assert.NotEqual(t, identity.ID, info.GeneratorID,
+				"a deleted generator must not be scheduled")
+		}
+	})
+}
+
+// RunGetGeneratorsWithRotation_RemovedCadenceExcluded verifies that dropping
+// the rotation block from a generator takes it off the schedule, read from the
+// generator's latest version rather than from any version that ever declared
+// a cadence.
+func RunGetGeneratorsWithRotation_RemovedCadenceExcluded(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetGeneratorsWithRotation_RemovedCadenceExcluded", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		stack := createGeneratorStack(t, ds, "rotation-removed")
+		_, err := ds.CreateGenerator(rotatingPasswordGenerator("db-password", stack, 3600), "cmd-create")
+		require.NoError(t, err)
+		identity, err := ds.GetGeneratorIdentity("db-password", stack.Label)
+		require.NoError(t, err)
+
+		_, err = ds.UpdateGenerator(testPasswordGenerator("db-password", stack, 24), "cmd-update")
+		require.NoError(t, err)
+
+		infos, err := ds.GetGeneratorsWithRotation()
+		require.NoError(t, err)
+		for _, info := range infos {
+			assert.NotEqual(t, identity.ID, info.GeneratorID,
+				"a generator whose cadence was removed must come off the schedule")
+		}
+	})
+}
+
+// RunGetGeneratorsWithRotation_ChangedCadenceReadFromLatest verifies that an
+// edited cadence is the one that comes back.
+func RunGetGeneratorsWithRotation_ChangedCadenceReadFromLatest(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetGeneratorsWithRotation_ChangedCadenceReadFromLatest", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		stack := createGeneratorStack(t, ds, "rotation-changed")
+		_, err := ds.CreateGenerator(rotatingPasswordGenerator("db-password", stack, 3600), "cmd-create")
+		require.NoError(t, err)
+		identity, err := ds.GetGeneratorIdentity("db-password", stack.Label)
+		require.NoError(t, err)
+
+		_, err = ds.UpdateGenerator(rotatingPasswordGenerator("db-password", stack, 86400), "cmd-update")
+		require.NoError(t, err)
+
+		infos, err := ds.GetGeneratorsWithRotation()
+		require.NoError(t, err)
+		assert.Equal(t, 86400, rotationInfoFor(t, infos, identity.ID).IntervalSeconds)
+	})
+}
+
+// RunGetGeneratorsWithRotation_Empty verifies the contract on a fresh
+// datastore: no rows, no error.
+func RunGetGeneratorsWithRotation_Empty(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetGeneratorsWithRotation_Empty", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		infos, err := ds.GetGeneratorsWithRotation()
+		require.NoError(t, err)
+		assert.Empty(t, infos)
+	})
+}

--- a/internal/datastore/dstest/suite_generators.go
+++ b/internal/datastore/dstest/suite_generators.go
@@ -348,7 +348,7 @@ func RunAdvanceGenerationRecordsIdentityAndDrawingSpec(t *testing.T, newDS func(
 
 		spec, err := json.Marshal(gen)
 		require.NoError(t, err)
-		require.NoError(t, ds.AdvanceGeneration(before.ID, "generation-1", spec))
+		require.NoError(t, ds.AdvanceGeneration(before.ID, "generation-1", "cmd-draw", spec))
 
 		after, err := ds.GetGeneratorIdentity("db-password", stack.Label)
 		require.NoError(t, err)
@@ -376,7 +376,7 @@ func RunGenerationSurvivesASpecUpdate(t *testing.T, newDS func(t *testing.T) Tes
 
 		spec, err := json.Marshal(gen)
 		require.NoError(t, err)
-		require.NoError(t, ds.AdvanceGeneration(before.ID, "generation-1", spec))
+		require.NoError(t, ds.AdvanceGeneration(before.ID, "generation-1", "cmd-draw", spec))
 
 		_, err = ds.UpdateGenerator(testPasswordGenerator("db-password", stack, 40), "cmd-2")
 		require.NoError(t, err)
@@ -413,7 +413,7 @@ func RunGenerationSurvivesARename(t *testing.T, newDS func(t *testing.T) TestDat
 
 		spec, err := json.Marshal(gen)
 		require.NoError(t, err)
-		require.NoError(t, ds.AdvanceGeneration(before.ID, "generation-1", spec))
+		require.NoError(t, ds.AdvanceGeneration(before.ID, "generation-1", "cmd-draw", spec))
 
 		renamed := testPasswordGenerator("new-label", stack, 32)
 		renamed.Alias = "old-label"
@@ -448,7 +448,7 @@ func RunGetGeneratorIdentityByIDFindsTheLiveRow(t *testing.T, newDS func(t *test
 
 		spec, err := json.Marshal(gen)
 		require.NoError(t, err)
-		require.NoError(t, ds.AdvanceGeneration(before.ID, "generation-1", spec))
+		require.NoError(t, ds.AdvanceGeneration(before.ID, "generation-1", "cmd-draw", spec))
 
 		// Write a further version row so the row GetGeneratorIdentityByID
 		// must resolve is not the one the id was originally minted on.
@@ -565,7 +565,7 @@ func RunGenerationSurvivesRenameBackToOriginalLabel(t *testing.T, newDS func(t *
 
 		spec, err := json.Marshal(gen)
 		require.NoError(t, err)
-		require.NoError(t, ds.AdvanceGeneration(before.ID, "generation-1", spec))
+		require.NoError(t, ds.AdvanceGeneration(before.ID, "generation-1", "cmd-draw", spec))
 
 		backToA := testPasswordGenerator("A", stack, 32)
 		backToA.Alias = "B"
@@ -599,12 +599,12 @@ func RunAdvanceGenerationTwiceSecondWins(t *testing.T, newDS func(t *testing.T) 
 
 		specOne, err := json.Marshal(gen)
 		require.NoError(t, err)
-		require.NoError(t, ds.AdvanceGeneration(id.ID, "generation-1", specOne))
+		require.NoError(t, ds.AdvanceGeneration(id.ID, "generation-1", "cmd-draw", specOne))
 
 		gen.Length = 40
 		specTwo, err := json.Marshal(gen)
 		require.NoError(t, err)
-		require.NoError(t, ds.AdvanceGeneration(id.ID, "generation-2", specTwo))
+		require.NoError(t, ds.AdvanceGeneration(id.ID, "generation-2", "cmd-draw", specTwo))
 
 		after, err := ds.GetGeneratorIdentity("db-password", stack.Label)
 		require.NoError(t, err)
@@ -638,7 +638,7 @@ func RunAdvanceGenerationDoesNotAffectOtherGenerator(t *testing.T, newDS func(t 
 
 		spec, err := json.Marshal(genA)
 		require.NoError(t, err)
-		require.NoError(t, ds.AdvanceGeneration(idA.ID, "generation-1", spec))
+		require.NoError(t, ds.AdvanceGeneration(idA.ID, "generation-1", "cmd-draw", spec))
 
 		afterA, err := ds.GetGeneratorIdentity("db-password", stack.Label)
 		require.NoError(t, err)
@@ -676,12 +676,12 @@ func RunAdvanceGenerationOnDeletedGeneratorFailsWithoutResurrecting(t *testing.T
 
 		spec, err := json.Marshal(gen)
 		require.NoError(t, err)
-		require.NoError(t, ds.AdvanceGeneration(id.ID, "generation-1", spec))
+		require.NoError(t, ds.AdvanceGeneration(id.ID, "generation-1", "cmd-draw", spec))
 
 		_, err = ds.DeleteGenerator("db-password", stack.Label)
 		require.NoError(t, err)
 
-		err = ds.AdvanceGeneration(id.ID, "generation-2", spec)
+		err = ds.AdvanceGeneration(id.ID, "generation-2", "cmd-draw", spec)
 		assert.Error(t, err, "advancing a deleted generator must fail")
 
 		byID, err := ds.GetGeneratorIdentityByID(id.ID)
@@ -716,10 +716,10 @@ func RunAdvanceGenerationRejectsMalformedSpecAndEmptyGenerationID(t *testing.T, 
 		validSpec, err := json.Marshal(gen)
 		require.NoError(t, err)
 
-		err = ds.AdvanceGeneration(id.ID, "generation-1", json.RawMessage(`{not valid json`))
+		err = ds.AdvanceGeneration(id.ID, "generation-1", "cmd-draw", json.RawMessage(`{not valid json`))
 		assert.Error(t, err, "a malformed drawnUnder spec must be rejected")
 
-		err = ds.AdvanceGeneration(id.ID, "", validSpec)
+		err = ds.AdvanceGeneration(id.ID, "", "cmd-draw", validSpec)
 		assert.Error(t, err, "an empty generationID must be rejected")
 
 		after, err := ds.GetGeneratorIdentity("db-password", stack.Label)

--- a/internal/datastore/generator_rotation.go
+++ b/internal/datastore/generator_rotation.go
@@ -1,0 +1,56 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package datastore
+
+import (
+	"time"
+)
+
+// GeneratorRotationRow is one row a backend's GetGeneratorsWithRotation query
+// produces, before the cadence is read out of the stored spec.
+//
+// Each backend's SQL answers only what SQL is good at — which generator rows
+// are live, which stack owns them, and when the latest committed draw
+// happened — and hands the stored spec over untouched. Whether that spec
+// declares a cadence, and what the cadence is, is decided once in
+// RotationInfoFromRows rather than in four dialects of JSON path extraction
+// that would eventually disagree with each other and with the Go model.
+type GeneratorRotationRow struct {
+	GeneratorID    string
+	Label          string
+	StackLabel     string
+	GeneratorData  []byte
+	LastRotationAt time.Time
+}
+
+// RotationInfoFromRows keeps the rows whose stored spec declares a rotation
+// cadence and projects them to GeneratorRotationInfo.
+//
+// A non-positive interval is dropped rather than scheduled: PKL requires
+// `every`, so no authored generator produces one, and treating it as a cadence
+// would mean "rotate on every sweep". A spec that cannot be parsed at all is
+// dropped too — the cadence is unknowable, and guessing at one would rotate a
+// live credential on a guess.
+func RotationInfoFromRows(rows []GeneratorRotationRow) ([]GeneratorRotationInfo, error) {
+	var infos []GeneratorRotationInfo
+	for _, row := range rows {
+		gen, err := GeneratorFromData(row.GeneratorData)
+		if err != nil {
+			return nil, err
+		}
+		rotation := gen.GetRotation()
+		if rotation == nil || rotation.EverySeconds <= 0 {
+			continue
+		}
+		infos = append(infos, GeneratorRotationInfo{
+			GeneratorID:     row.GeneratorID,
+			Label:           row.Label,
+			StackLabel:      row.StackLabel,
+			IntervalSeconds: rotation.EverySeconds,
+			LastRotationAt:  row.LastRotationAt,
+		})
+	}
+	return infos, nil
+}

--- a/internal/datastore/mock_datastore_test.go
+++ b/internal/datastore/mock_datastore_test.go
@@ -177,6 +177,10 @@ func (m *mockDatastore) DeleteInlinePolicy(_, _, _ string) (string, error) {
 }
 func (m *mockDatastore) DeletePoliciesForStack(_, _ string) error      { return nil }
 func (m *mockDatastore) GetExpiredStacks() ([]ExpiredStackInfo, error) { return nil, nil }
+func (m *mockDatastore) GetGeneratorsWithRotation() ([]GeneratorRotationInfo, error) {
+	return nil, nil
+}
+
 func (m *mockDatastore) GetStacksWithAutoReconcilePolicy() ([]StackReconcileInfo, error) {
 	return nil, nil
 }
@@ -200,7 +204,7 @@ func (m *mockDatastore) GetGeneratorIdentity(_, _ string) (GeneratorIdentity, er
 func (m *mockDatastore) GetGeneratorIdentityByID(_ string) (GeneratorIdentity, error) {
 	return GeneratorIdentity{}, nil
 }
-func (m *mockDatastore) AdvanceGeneration(_, _ string, _ json.RawMessage) error { return nil }
+func (m *mockDatastore) AdvanceGeneration(_, _, _ string, _ json.RawMessage) error { return nil }
 func (m *mockDatastore) LoadGeneratorsByStack(_ string) ([]pkgmodel.Generator, error) {
 	return nil, nil
 }

--- a/internal/datastore/mssql/mssql_generators.go
+++ b/internal/datastore/mssql/mssql_generators.go
@@ -358,6 +358,73 @@ func (d *DatastoreMSSQL) GetGeneratorIdentityByID(generatorID string) (datastore
 	return generatorIdentityFromRow(id, generationID, generationSpec), nil
 }
 
+// GetGeneratorsWithRotation returns every live generator with the instant its
+// last rotation committed. The cadence itself is read from the stored spec by
+// datastore.RotationInfoFromRows, so this query never parses JSON.
+//
+// last_committed_draw is the derivation the rotation scheduler runs on: a
+// generation row records that a value was drawn and the command that drew it,
+// and joining that command's state is what says whether the value ever reached
+// its destinations. A command that is not Success advances nothing, so a
+// failed authority-side update leaves the cadence measured from the previous
+// success.
+func (d *DatastoreMSSQL) GetGeneratorsWithRotation() ([]datastore.GeneratorRotationInfo, error) {
+	ctx, span := mssqlTracer.Start(context.Background(), "GetGeneratorsWithRotation")
+	defer span.End()
+
+	query := `
+		WITH latest_generators AS (
+			SELECT id, label, stack_id, generator_data, operation,
+			       ROW_NUMBER() OVER (PARTITION BY id ORDER BY version COLLATE Latin1_General_BIN2 DESC) as rn
+			FROM generators
+		),
+		latest_stacks AS (
+			SELECT id, label, operation,
+			       ROW_NUMBER() OVER (PARTITION BY id ORDER BY version COLLATE Latin1_General_BIN2 DESC) as rn
+			FROM stacks
+		),
+		last_committed_draw AS (
+			SELECT g.id as generator_id, MAX(fc.timestamp) as last_rotation_at
+			FROM generators g
+			JOIN forma_commands fc ON fc.command_id = g.command_id
+			WHERE g.generation_id != '' AND fc.state = 'Success'
+			GROUP BY g.id
+		)
+		SELECT g.id, g.label, s.label, g.generator_data, d.last_rotation_at
+		FROM latest_generators g
+		JOIN latest_stacks s ON s.id = g.stack_id
+		LEFT JOIN last_committed_draw d ON d.generator_id = g.id
+		WHERE g.rn = 1 AND g.operation != 'delete'
+		AND s.rn = 1 AND s.operation != 'delete'`
+
+	rows, err := d.conn.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var rotationRows []datastore.GeneratorRotationRow
+	for rows.Next() {
+		var row datastore.GeneratorRotationRow
+		var generatorData string
+		var lastRotationAt sql.NullTime
+		if err := rows.Scan(&row.GeneratorID, &row.Label, &row.StackLabel, &generatorData, &lastRotationAt); err != nil {
+			return nil, err
+		}
+		row.GeneratorData = []byte(generatorData)
+		if lastRotationAt.Valid {
+			row.LastRotationAt = lastRotationAt.Time.UTC()
+		}
+		rotationRows = append(rotationRows, row)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return datastore.RotationInfoFromRows(rotationRows)
+}
+
 // AdvanceGeneration records that a new generation was drawn for this
 // generator, under this spec. Writes a new version row that carries forward
 // the existing label/type/stack/generator_data unchanged — only the
@@ -369,7 +436,7 @@ func (d *DatastoreMSSQL) GetGeneratorIdentityByID(generatorID string) (datastore
 // (generator_update.GeneratorUpdater): it calls this once it has drawn a
 // value, so the generation the value came from is durable before any
 // destination is stamped with it.
-func (d *DatastoreMSSQL) AdvanceGeneration(generatorID, generationID string, drawnUnder json.RawMessage) error {
+func (d *DatastoreMSSQL) AdvanceGeneration(generatorID, generationID, commandID string, drawnUnder json.RawMessage) error {
 	ctx, span := mssqlTracer.Start(context.Background(), "AdvanceGeneration")
 	defer span.End()
 
@@ -395,7 +462,7 @@ func (d *DatastoreMSSQL) AdvanceGeneration(generatorID, generationID string, dra
 	version := mksuid.New().String()
 	insertQuery := `INSERT INTO generators (id, version, command_id, operation, label, generator_type, stack_id, generator_data, generation_id, generation_spec)
 	                VALUES (@p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9, @p10)`
-	_, err = d.conn.ExecContext(ctx, insertQuery, generatorID, version, "", "update", label, generatorType, stackID, generatorData, generationID, string(drawnUnder))
+	_, err = d.conn.ExecContext(ctx, insertQuery, generatorID, version, commandID, "update", label, generatorType, stackID, generatorData, generationID, string(drawnUnder))
 	if err != nil {
 		return fmt.Errorf("failed to advance generation: %w", err)
 	}

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -3238,6 +3238,73 @@ func (d DatastorePostgres) GetStacksWithAutoReconcilePolicy() ([]datastore.Stack
 	return result, nil
 }
 
+// GetGeneratorsWithRotation returns every live generator with the instant its
+// last rotation committed. The cadence itself is read from the stored spec by
+// datastore.RotationInfoFromRows, so this query never parses JSON.
+//
+// last_committed_draw is the derivation the rotation scheduler runs on: a
+// generation row records that a value was drawn and the command that drew it,
+// and joining that command's state is what says whether the value ever reached
+// its destinations. A command that is not Success advances nothing, so a
+// failed authority-side update leaves the cadence measured from the previous
+// success.
+func (d DatastorePostgres) GetGeneratorsWithRotation() ([]datastore.GeneratorRotationInfo, error) {
+	ctx, span := tracer.Start(context.Background(), "GetGeneratorsWithRotation")
+	defer span.End()
+
+	query := `
+		WITH latest_generators AS (
+			SELECT id, label, stack_id, generator_data, operation,
+			       ROW_NUMBER() OVER (PARTITION BY id ORDER BY version COLLATE "C" DESC) as rn
+			FROM generators
+		),
+		latest_stacks AS (
+			SELECT id, label, operation,
+			       ROW_NUMBER() OVER (PARTITION BY id ORDER BY version COLLATE "C" DESC) as rn
+			FROM stacks
+		),
+		last_committed_draw AS (
+			SELECT g.id as generator_id, MAX(fc.timestamp) as last_rotation_at
+			FROM generators g
+			JOIN forma_commands fc ON fc.command_id = g.command_id
+			WHERE g.generation_id != '' AND fc.state = 'Success'
+			GROUP BY g.id
+		)
+		SELECT g.id, g.label, s.label, g.generator_data::text, d.last_rotation_at
+		FROM latest_generators g
+		JOIN latest_stacks s ON s.id = g.stack_id
+		LEFT JOIN last_committed_draw d ON d.generator_id = g.id
+		WHERE g.rn = 1 AND g.operation != 'delete'
+		AND s.rn = 1 AND s.operation != 'delete'
+	`
+
+	rows, err := d.pool.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var rotationRows []datastore.GeneratorRotationRow
+	for rows.Next() {
+		var row datastore.GeneratorRotationRow
+		var generatorData string
+		var lastRotationAt *time.Time
+		if err := rows.Scan(&row.GeneratorID, &row.Label, &row.StackLabel, &generatorData, &lastRotationAt); err != nil {
+			return nil, err
+		}
+		row.GeneratorData = []byte(generatorData)
+		if lastRotationAt != nil {
+			row.LastRotationAt = lastRotationAt.UTC()
+		}
+		rotationRows = append(rotationRows, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return datastore.RotationInfoFromRows(rotationRows)
+}
+
 func (d DatastorePostgres) GetResourcesAtLastReconcile(stackLabel string) ([]datastore.ResourceSnapshot, error) {
 	ctx, span := tracer.Start(context.Background(), "GetResourcesAtLastReconcile")
 	defer span.End()

--- a/internal/datastore/postgres/postgres_generators.go
+++ b/internal/datastore/postgres/postgres_generators.go
@@ -372,7 +372,7 @@ func (d DatastorePostgres) GetGeneratorIdentityByID(generatorID string) (datasto
 // (generator_update.GeneratorUpdater): it calls this once it has drawn a
 // value, so the generation the value came from is durable before any
 // destination is stamped with it.
-func (d DatastorePostgres) AdvanceGeneration(generatorID, generationID string, drawnUnder json.RawMessage) error {
+func (d DatastorePostgres) AdvanceGeneration(generatorID, generationID, commandID string, drawnUnder json.RawMessage) error {
 	ctx, span := tracer.Start(context.Background(), "AdvanceGeneration")
 	defer span.End()
 
@@ -398,7 +398,7 @@ func (d DatastorePostgres) AdvanceGeneration(generatorID, generationID string, d
 	version := mksuid.New().String()
 	insertQuery := `INSERT INTO generators (id, version, command_id, operation, label, generator_type, stack_id, generator_data, generation_id, generation_spec)
 	                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
-	_, err = d.pool.Exec(ctx, insertQuery, generatorID, version, "", "update", label, generatorType, stackID, generatorData, generationID, string(drawnUnder))
+	_, err = d.pool.Exec(ctx, insertQuery, generatorID, version, commandID, "update", label, generatorType, stackID, generatorData, generationID, string(drawnUnder))
 	if err != nil {
 		return fmt.Errorf("failed to advance generation: %w", err)
 	}

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -3181,7 +3181,7 @@ func (d DatastoreSQLite) GetGeneratorIdentityByID(generatorID string) (datastore
 // (generator_update.GeneratorUpdater): it calls this once it has drawn a
 // value, so the generation the value came from is durable before any
 // destination is stamped with it.
-func (d DatastoreSQLite) AdvanceGeneration(generatorID, generationID string, drawnUnder json.RawMessage) error {
+func (d DatastoreSQLite) AdvanceGeneration(generatorID, generationID, commandID string, drawnUnder json.RawMessage) error {
 	_, span := sqliteTracer.Start(context.Background(), "AdvanceGeneration")
 	defer span.End()
 
@@ -3207,7 +3207,7 @@ func (d DatastoreSQLite) AdvanceGeneration(generatorID, generationID string, dra
 	version := mksuid.New().String()
 	insertQuery := `INSERT INTO generators (id, version, command_id, operation, label, generator_type, stack_id, generator_data, generation_id, generation_spec)
 	                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-	_, err = d.conn.Exec(insertQuery, generatorID, version, "", "update", label, generatorType, stackID, generatorData, generationID, string(drawnUnder))
+	_, err = d.conn.Exec(insertQuery, generatorID, version, commandID, "update", label, generatorType, stackID, generatorData, generationID, string(drawnUnder))
 	if err != nil {
 		return fmt.Errorf("failed to advance generation: %w", err)
 	}
@@ -3457,6 +3457,79 @@ func (d DatastoreSQLite) GetStacksWithAutoReconcilePolicy() ([]datastore.StackRe
 	}
 
 	return result, nil
+}
+
+// GetGeneratorsWithRotation returns every live generator with the instant its
+// last rotation committed. The cadence itself is read from the stored spec by
+// datastore.RotationInfoFromRows, so this query never parses JSON.
+//
+// last_committed_draw is the derivation the rotation scheduler runs on: a
+// generation row records that a value was drawn and the command that drew it,
+// and joining that command's state is what says whether the value ever reached
+// its destinations. A command that is not Success advances nothing, so a
+// failed authority-side update leaves the cadence measured from the previous
+// success. The command's start is the instant used, matching how the
+// auto-reconcile schedule reads fc.timestamp.
+func (d DatastoreSQLite) GetGeneratorsWithRotation() ([]datastore.GeneratorRotationInfo, error) {
+	_, span := sqliteTracer.Start(context.Background(), "GetGeneratorsWithRotation")
+	defer span.End()
+
+	query := `
+		WITH latest_generators AS (
+			SELECT id, label, stack_id, generator_data, operation,
+			       ROW_NUMBER() OVER (PARTITION BY id ORDER BY version DESC) as rn
+			FROM generators
+		),
+		latest_stacks AS (
+			SELECT id, label, operation,
+			       ROW_NUMBER() OVER (PARTITION BY id ORDER BY version DESC) as rn
+			FROM stacks
+		),
+		last_committed_draw AS (
+			SELECT g.id as generator_id, MAX(fc.timestamp) as last_rotation_at
+			FROM generators g
+			JOIN forma_commands fc ON fc.command_id = g.command_id
+			WHERE g.generation_id != '' AND fc.state = 'Success'
+			GROUP BY g.id
+		)
+		SELECT g.id, g.label, s.label, g.generator_data,
+		       COALESCE(d.last_rotation_at, '') as last_rotation_at
+		FROM latest_generators g
+		JOIN latest_stacks s ON s.id = g.stack_id
+		LEFT JOIN last_committed_draw d ON d.generator_id = g.id
+		WHERE g.rn = 1 AND g.operation != 'delete'
+		AND s.rn = 1 AND s.operation != 'delete'
+	`
+
+	rows, err := d.conn.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var rotationRows []datastore.GeneratorRotationRow
+	for rows.Next() {
+		var row datastore.GeneratorRotationRow
+		var lastRotationStr string
+		if err := rows.Scan(&row.GeneratorID, &row.Label, &row.StackLabel, &row.GeneratorData, &lastRotationStr); err != nil {
+			return nil, err
+		}
+		if lastRotationStr != "" {
+			row.LastRotationAt = parseSQLiteTimestamp(lastRotationStr)
+			if row.LastRotationAt.IsZero() {
+				// An unreadable instant must not read as "never rotated":
+				// that would rotate the credential on every sweep.
+				return nil, fmt.Errorf("generator %s: cannot read the instant of its last committed draw", row.GeneratorID)
+			}
+			row.LastRotationAt = row.LastRotationAt.UTC()
+		}
+		rotationRows = append(rotationRows, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return datastore.RotationInfoFromRows(rotationRows)
 }
 
 func (d DatastoreSQLite) GetResourcesAtLastReconcile(stackLabel string) ([]datastore.ResourceSnapshot, error) {

--- a/internal/metastructure/actornames/names.go
+++ b/internal/metastructure/actornames/names.go
@@ -16,6 +16,7 @@ const (
 	ChangesetSupervisor   = gen.Atom("ChangesetSupervisor")
 	Discovery             = gen.Atom("Discovery")
 	FormaCommandPersister = gen.Atom("FormaCommandPersister")
+	GeneratorRotator      = gen.Atom("GeneratorRotator")
 	MetastructureBridge   = gen.Atom("MetastructureBridge")
 	PluginCoordinator     = gen.Atom("PluginCoordinator")
 	RateLimiter           = gen.Atom("RateLimiter")

--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -818,6 +818,7 @@ func startGeneratorUpdate(gu *generator_update.GeneratorUpdate, commandID string
 	err = proc.Send(gen.ProcessID{Name: name, Node: proc.Node().Name()},
 		generator_update.StartGeneratorUpdate{
 			GeneratorUpdate: *gu,
+			CommandID:       commandID,
 		})
 	if err != nil {
 		proc.Log().Error("Failed to send start message to generator updater: %v", err)

--- a/internal/metastructure/extract_resources_test.go
+++ b/internal/metastructure/extract_resources_test.go
@@ -273,6 +273,10 @@ func (m *mockExtractDatastore) DeletePoliciesForStack(_ string, _ string) error 
 func (m *mockExtractDatastore) GetExpiredStacks() ([]datastore.ExpiredStackInfo, error) {
 	panic("not implemented")
 }
+func (m *mockExtractDatastore) GetGeneratorsWithRotation() ([]datastore.GeneratorRotationInfo, error) {
+	return nil, nil
+}
+
 func (m *mockExtractDatastore) GetStacksWithAutoReconcilePolicy() ([]datastore.StackReconcileInfo, error) {
 	panic("not implemented")
 }
@@ -303,7 +307,7 @@ func (m *mockExtractDatastore) GetGeneratorIdentity(_, _ string) (datastore.Gene
 func (m *mockExtractDatastore) GetGeneratorIdentityByID(_ string) (datastore.GeneratorIdentity, error) {
 	panic("not implemented")
 }
-func (m *mockExtractDatastore) AdvanceGeneration(_, _ string, _ json.RawMessage) error {
+func (m *mockExtractDatastore) AdvanceGeneration(_, _, _ string, _ json.RawMessage) error {
 	panic("not implemented")
 }
 func (m *mockExtractDatastore) Close() {}

--- a/internal/metastructure/forma_command/forma_command.go
+++ b/internal/metastructure/forma_command/forma_command.go
@@ -35,11 +35,12 @@ const (
 type Source string
 
 const (
-	SourceUser           Source = "user"
-	SourceSynchronizer   Source = "synchronizer"
-	SourceDiscovery      Source = "discovery"
-	SourceAutoReconciler Source = "auto-reconciler"
-	SourceStackExpirer   Source = "stack-expirer"
+	SourceUser             Source = "user"
+	SourceSynchronizer     Source = "synchronizer"
+	SourceDiscovery        Source = "discovery"
+	SourceAutoReconciler   Source = "auto-reconciler"
+	SourceStackExpirer     Source = "stack-expirer"
+	SourceGeneratorRotator Source = "generator-rotator"
 )
 
 type FormaCommand struct {

--- a/internal/metastructure/generator_lookup_test.go
+++ b/internal/metastructure/generator_lookup_test.go
@@ -59,7 +59,7 @@ func TestGeneratorLookupForResume_ResolvesADrawnGeneratorOnAnotherStack(t *testi
 	ds := lookupTestDatastore(t)
 	ksuid := createGeneratorOn(t, ds, "secrets", "db-password", 24)
 
-	require.NoError(t, ds.AdvanceGeneration(ksuid, "generation-1",
+	require.NoError(t, ds.AdvanceGeneration(ksuid, "generation-1", "cmd-draw",
 		json.RawMessage(`{"Type":"password","Label":"db-password","Stack":"secrets","Length":24}`)))
 
 	lookup := generatorLookup(ds)
@@ -79,7 +79,7 @@ func TestGeneratorLookupForResume_ReturnsTheCurrentSpecNotTheGenerationsSpec(t *
 	ds := lookupTestDatastore(t)
 	ksuid := createGeneratorOn(t, ds, "secrets", "db-password", 24)
 
-	require.NoError(t, ds.AdvanceGeneration(ksuid, "generation-1",
+	require.NoError(t, ds.AdvanceGeneration(ksuid, "generation-1", "cmd-draw",
 		json.RawMessage(`{"Type":"password","Label":"db-password","Stack":"secrets","Length":24}`)))
 	secrets, err := ds.GetStackByLabel("secrets")
 	require.NoError(t, err)

--- a/internal/metastructure/generator_rotator.go
+++ b/internal/metastructure/generator_rotator.go
@@ -1,0 +1,696 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package metastructure
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"log/slog"
+	"time"
+
+	"ergo.services/ergo/act"
+	"ergo.services/ergo/gen"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/changeset"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_persister"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// GeneratorRotator is the actor that rotates generators on their declared
+// cadence. It is the third scheduled actor, beside the StackExpirer and the
+// AutoReconciler, and it works the same way: a fixed sweep asks the datastore
+// what is due and submits one command per item.
+//
+// The cadence is DERIVED, never stored. GetGeneratorsWithRotation reads the
+// interval off the generator's declared spec and the last-rotation instant out
+// of command history, exactly as the auto-reconcile schedule derives
+// LastReconcileAt. A stored last-rotated-at would participate in
+// desired-config equality, read as metadata drift, and get rendered into
+// formae people copy between environments.
+const (
+	// DefaultGeneratorRotatorInterval is how often the rotator asks what is
+	// due. Rotation cadences are hours and days, so the sweep only has to be
+	// fine enough that a due generator is not left waiting noticeably longer
+	// than its jitter.
+	DefaultGeneratorRotatorInterval = 30 * time.Second
+
+	// maxRotationJitter caps the per-generator offset. Without a cap an
+	// annual cadence would drift by weeks, which is a schedule nobody can
+	// reason about. An hour is wide enough that a large fleet on a daily
+	// cadence is spread thin, and narrow enough that the cadence an operator
+	// declared is still the cadence they get.
+	maxRotationJitter = time.Hour
+
+	// rotationJitterDivisor makes the jitter bound a tenth of the cadence, so
+	// the offset is always small next to the interval it spreads.
+	rotationJitterDivisor = 10
+
+	// rotationRetryBaseDelay is the delay before a first retry. Doubling from
+	// here, and saturating at one cadence, is what keeps a generator whose
+	// rotation keeps failing from either hammering its provider or being
+	// abandoned.
+	rotationRetryBaseDelay = 30 * time.Second
+
+	// maxRotationRetryAttempts is where the backoff stops growing. Beyond it
+	// the generator is retried once per cadence: rotation is not optional
+	// work that can be dropped, so there is no attempt count at which the
+	// credential stops being rotated altogether.
+	maxRotationRetryAttempts = 5
+)
+
+// rotationClientID is what a rotation command records as its client, mirroring
+// the auto-reconciler's and the stack expirer's.
+const rotationClientID = "generator-rotator"
+
+type GeneratorRotator struct {
+	act.Actor
+
+	datastore datastore.Datastore
+	interval  time.Duration
+
+	// inFlight tracks the generators with a rotation command in progress.
+	//
+	// This lives in actor memory, with no datastore lease and no
+	// compare-and-swap, and that is deliberate rather than an omission. An
+	// agent runs a single task, and the metastructure actor serializes
+	// command mutation, so there is no second rotator to race with: the only
+	// concurrency a lease would protect against cannot occur. Neither of the
+	// other two scheduled actors has one either, and requiring one here would
+	// hold rotation to a bar the mechanisms beside it do not meet, for a race
+	// the deployment shape rules out.
+	inFlight map[string]rotationAttempt
+
+	// attempts counts consecutive failed rotation attempts per generator, and
+	// nextAttemptAt holds the instant each may next be tried. Both are actor
+	// memory: a restart resets the backoff and the generator is retried at
+	// once. That is accepted as annoying rather than dangerous — the worst
+	// case is one extra attempt at the failure that was already failing, and
+	// the cadence itself, which is what must not be lost, is derived from the
+	// datastore and survives the restart.
+	attempts      map[string]int
+	nextAttemptAt map[string]time.Time
+}
+
+// rotationAttempt is one in-flight rotation: the command executing it and the
+// cadence it was submitted under. The cadence is carried here because the
+// completion message names only a command, and the retry backoff is bounded by
+// the generator's own interval — a generator that rotates every thirty seconds
+// must not be retried eight minutes later.
+type rotationAttempt struct {
+	commandID string
+	interval  time.Duration
+}
+
+func NewGeneratorRotator() gen.ProcessBehavior {
+	return &GeneratorRotator{}
+}
+
+// CheckGeneratorRotations is the rotator's sweep tick.
+type CheckGeneratorRotations struct{}
+
+func (g *GeneratorRotator) Init(args ...any) error {
+	ds, ok := g.Env("Datastore")
+	if !ok {
+		g.Log().Error("Missing 'Datastore' environment variable")
+		return fmt.Errorf("generator_rotator: missing 'Datastore' environment variable")
+	}
+
+	g.datastore = ds.(datastore.Datastore)
+	g.interval = DefaultGeneratorRotatorInterval
+	g.inFlight = make(map[string]rotationAttempt)
+	g.attempts = make(map[string]int)
+	g.nextAttemptAt = make(map[string]time.Time)
+
+	if _, err := g.SendAfter(g.PID(), CheckGeneratorRotations{}, g.interval); err != nil {
+		return fmt.Errorf("failed to send initial rotation check message: %s", err)
+	}
+	g.Log().Info("Generator rotator ready, interval=%s", g.interval)
+
+	return nil
+}
+
+func (g *GeneratorRotator) HandleMessage(from gen.PID, message any) error {
+	switch msg := message.(type) {
+	case CheckGeneratorRotations:
+		g.checkRotations()
+	case changeset.ChangesetCompleted:
+		g.rotationCompleted(msg)
+	default:
+		g.Log().Warning("Received unknown message type: %T", message)
+	}
+	return nil
+}
+
+// checkRotations submits a rotation for every generator whose cadence has
+// elapsed. Each is submitted once: a generator whose cadence elapsed ten times
+// over is one command, because the next committed rotation moves the anchor to
+// now and nothing counts the windows that were missed.
+func (g *GeneratorRotator) checkRotations() {
+	defer g.scheduleNextRotationCheck()
+
+	infos, err := g.datastore.GetGeneratorsWithRotation()
+	if err != nil {
+		g.Log().Error("Failed to query generators with rotation: %v", err)
+		return
+	}
+
+	now := time.Now().UTC()
+	for _, info := range rotationsDueNow(infos, g.inFlight, g.nextAttemptAt, now) {
+		g.Log().Info("Rotating generator label=%s stack=%s interval=%ds lastRotationAt=%s",
+			info.Label, info.StackLabel, info.IntervalSeconds, rotationAnchor(info))
+
+		commandID, err := g.startRotation(info)
+		if err != nil {
+			g.Log().Error("Failed to start rotation generator=%s: %v", info.GeneratorID, err)
+			g.recordFailedAttempt(info)
+			continue
+		}
+		if commandID == "" {
+			// Nothing to rotate right now, and not a failure: the generator
+			// moved under us, has no destination, or its stack is busy. The
+			// next sweep re-reads and decides again.
+			continue
+		}
+		g.inFlight[info.GeneratorID] = rotationAttempt{
+			commandID: commandID,
+			interval:  time.Duration(info.IntervalSeconds) * time.Second,
+		}
+	}
+}
+
+// rotationCompleted clears the in-flight guard and, on failure, arms the
+// backoff. Success clears the backoff outright: the cadence itself is derived
+// from the command that just succeeded, so there is nothing to remember.
+func (g *GeneratorRotator) rotationCompleted(msg changeset.ChangesetCompleted) {
+	var generatorID string
+	var interval time.Duration
+	for id, attempt := range g.inFlight {
+		if attempt.commandID == msg.CommandID {
+			generatorID = id
+			interval = attempt.interval
+			break
+		}
+	}
+	if generatorID == "" {
+		g.Log().Debug("Received ChangesetCompleted for a command that is not a rotation commandID=%s", msg.CommandID)
+		return
+	}
+
+	delete(g.inFlight, generatorID)
+
+	if msg.State == changeset.ChangeSetStateFinishedSuccessfully {
+		g.Log().Info("Rotation complete generator=%s command=%s", generatorID, msg.CommandID)
+		delete(g.attempts, generatorID)
+		delete(g.nextAttemptAt, generatorID)
+		return
+	}
+
+	// The cadence does not move: it is derived from the command's state, and
+	// this command is not a success, so the next sweep still measures from
+	// the previous committed rotation. Only the retry delay changes.
+	g.Log().Warning("Rotation did not commit, cadence unchanged generator=%s command=%s state=%s",
+		generatorID, msg.CommandID, msg.State)
+	g.recordFailedAttemptByID(generatorID, interval)
+}
+
+// recordFailedAttempt arms the backoff for a generator whose rotation could
+// not be submitted or did not commit.
+func (g *GeneratorRotator) recordFailedAttempt(info datastore.GeneratorRotationInfo) {
+	g.recordFailedAttemptByID(info.GeneratorID, time.Duration(info.IntervalSeconds)*time.Second)
+}
+
+// recordFailedAttemptByID arms the backoff by generator id. A zero interval
+// means the cadence is not in hand; the backoff then grows from the base delay
+// with nothing to saturate at, which maxRotationRetryAttempts still bounds.
+func (g *GeneratorRotator) recordFailedAttemptByID(generatorID string, interval time.Duration) {
+	g.attempts[generatorID]++
+	delay := rotationBackoff(g.attempts[generatorID], interval)
+	g.nextAttemptAt[generatorID] = time.Now().UTC().Add(delay)
+	g.Log().Debug("Armed rotation backoff generator=%s attempts=%d delay=%s",
+		generatorID, g.attempts[generatorID], delay)
+}
+
+func (g *GeneratorRotator) scheduleNextRotationCheck() {
+	if _, err := g.SendAfter(g.PID(), CheckGeneratorRotations{}, g.interval); err != nil {
+		g.Log().Error("Failed to schedule next rotation check: %v", err)
+	}
+}
+
+// startRotation prepares and submits one generator's rotation, returning the
+// command id. An empty command id and a nil error mean there was nothing to do.
+func (g *GeneratorRotator) startRotation(info datastore.GeneratorRotationInfo) (string, error) {
+	// A user command on the stack takes priority, exactly as it does for
+	// auto-reconcile: the rotation is not urgent to the second, and planning
+	// against a stack that is mid-apply reads state that is about to move.
+	hasActive, err := g.datastore.StackHasActiveCommands(info.StackLabel)
+	if err != nil {
+		return "", fmt.Errorf("failed to check for active commands: %w", err)
+	}
+	if hasActive {
+		g.Log().Info("Skipping rotation, stack has active commands stack=%s", info.StackLabel)
+		return "", nil
+	}
+
+	result, err := prepareRotation(g.datastore, info)
+	if err != nil {
+		return "", err
+	}
+	if result == nil {
+		return "", nil
+	}
+
+	_, err = g.Call(
+		gen.ProcessID{Name: actornames.FormaCommandPersister, Node: g.Node().Name()},
+		forma_persister.StoreNewFormaCommand{Command: *result.command},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to store rotation command: %w", err)
+	}
+
+	_, err = g.Call(
+		gen.ProcessID{Name: actornames.ChangesetSupervisor, Node: g.Node().Name()},
+		changeset.EnsureChangesetExecutor{CommandID: result.command.ID},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to ensure changeset executor: %w", err)
+	}
+
+	// NotifyOnComplete is what makes the milestone observable here: the
+	// completion tells the rotator whether every authority-side update
+	// succeeded, which is the one thing that decides whether the cadence
+	// advanced.
+	err = g.Send(
+		gen.ProcessID{Name: actornames.ChangesetExecutor(result.command.ID), Node: g.Node().Name()},
+		changeset.Start{Changeset: result.changeset, NotifyOnComplete: true},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to start changeset executor: %w", err)
+	}
+
+	return result.command.ID, nil
+}
+
+// rotationJitterBound is the width of the window a generator's rotation may
+// slip into: a tenth of its cadence, capped.
+func rotationJitterBound(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return 0
+	}
+	bound := interval / rotationJitterDivisor
+	if bound > maxRotationJitter {
+		bound = maxRotationJitter
+	}
+	return bound
+}
+
+// rotationJitter is the offset added to one generator's cadence so a fleet
+// does not rotate in lockstep.
+//
+// It is derived from the generator's identity rather than drawn at random, and
+// that is the point rather than a shortcut. A fleet stood up by one apply
+// shares a last-rotation instant to the second, so an offset that is a
+// function of the generator spreads them permanently, while a redrawn random
+// offset would reshuffle the schedule on every restart and give an operator
+// nothing to predict. The identity is a KSUID, so the hash spreads across the
+// window rather than clustering.
+func rotationJitter(generatorID string, interval time.Duration) time.Duration {
+	bound := rotationJitterBound(interval)
+	if bound <= 0 {
+		return 0
+	}
+	hash := fnv.New64a()
+	_, _ = hash.Write([]byte(generatorID))
+	return time.Duration(hash.Sum64() % uint64(bound))
+}
+
+// nextRotationDue returns the instant this generator is next due. The zero
+// instant means due now.
+//
+// The delay is fixed and measured from the last rotation that COMMITTED, which
+// is what GetGeneratorRotationInfo derives: a failed attempt leaves the anchor
+// where it was, so a run of failures does not push the cadence out.
+func nextRotationDue(info datastore.GeneratorRotationInfo) time.Time {
+	if info.LastRotationAt.IsZero() {
+		// No rotation on record. Attaching rotation to a credential nobody
+		// has rotated is a request to rotate it, so it is due now — and
+		// deliberately without jitter, which exists to break up a RECURRING
+		// alignment rather than to delay a first run.
+		return time.Time{}
+	}
+	interval := time.Duration(info.IntervalSeconds) * time.Second
+	return info.LastRotationAt.Add(interval + rotationJitter(info.GeneratorID, interval))
+}
+
+// rotationIsDue reports whether this generator's cadence has elapsed as of now.
+func rotationIsDue(info datastore.GeneratorRotationInfo, now time.Time) bool {
+	due := nextRotationDue(info)
+	return !now.Before(due)
+}
+
+// rotationsDueNow selects the generators this sweep should submit a rotation
+// for, in the order the datastore returned them.
+//
+// It is the whole of the sweep's decision, separated from the submission so
+// that "what a tick does" is answerable without a running node. Three things
+// take a generator out of this sweep:
+//
+//   - an attempt already in flight. This is the guard that makes a repeated
+//     tick a no-op: a rotation takes as long as the provider writes take, which
+//     is many sweeps, and submitting a second command for the same generator
+//     would draw twice and leave the two halves of one credential's
+//     destinations on different generations.
+//   - a backoff still running after a failed attempt.
+//   - a cadence that has not elapsed.
+//
+// A generator whose cadence elapsed many times over appears ONCE, like any
+// other due generator: there is no queue of missed windows to work through,
+// and the next committed rotation moves the anchor to now.
+func rotationsDueNow(
+	infos []datastore.GeneratorRotationInfo,
+	inFlight map[string]rotationAttempt,
+	nextAttemptAt map[string]time.Time,
+	now time.Time,
+) []datastore.GeneratorRotationInfo {
+	var due []datastore.GeneratorRotationInfo
+	for _, info := range infos {
+		if _, running := inFlight[info.GeneratorID]; running {
+			continue
+		}
+		if retryAt, backing := nextAttemptAt[info.GeneratorID]; backing && now.Before(retryAt) {
+			continue
+		}
+		if !rotationIsDue(info, now) {
+			continue
+		}
+		due = append(due, info)
+	}
+	return due
+}
+
+// rotationAnchor renders the instant a generator's cadence is measured from,
+// for the log line that explains a rotation.
+func rotationAnchor(info datastore.GeneratorRotationInfo) string {
+	if info.LastRotationAt.IsZero() {
+		return "never"
+	}
+	return info.LastRotationAt.UTC().Format(time.RFC3339)
+}
+
+// rotationBackoff is the delay before the next attempt for a generator that
+// has failed this many times in a row.
+//
+// It doubles from rotationRetryBaseDelay and saturates at one cadence, so the
+// retry rate never falls below the rate the credential is supposed to rotate
+// at, and never exceeds it either. Zero attempts means no backoff.
+func rotationBackoff(attempts int, interval time.Duration) time.Duration {
+	if attempts < 1 {
+		return 0
+	}
+	if attempts >= maxRotationRetryAttempts {
+		if interval > 0 {
+			return interval
+		}
+		return rotationRetryBaseDelay << (maxRotationRetryAttempts - 1)
+	}
+	delay := rotationRetryBaseDelay << (attempts - 1)
+	if interval > 0 && delay > interval {
+		return interval
+	}
+	return delay
+}
+
+// rotationResult holds the prepared rotation command and changeset, ready for
+// persistence and execution.
+type rotationResult struct {
+	command   *forma_command.FormaCommand
+	changeset changeset.Changeset
+}
+
+// prepareRotation builds the apply that moves one generator's generation
+// forward. It returns nil (with no error) when there is nothing to rotate.
+//
+// The command's resource updates are its destinations, planned by the
+// co-planning pass the apply path already uses for the same obligation: once a
+// generator draws, every live destination of it has to be a node in the
+// changeset, because delivery reaches nodes and nothing else and formae keeps
+// only a hash of a drawn value. Everything downstream — the draw op, the
+// delivery to each destination, the generation stamp — is the ordinary apply
+// path.
+//
+// The forma is built from the destinations the datastore records as bound to
+// this generator, rather than from a stack snapshot the way a reconcile is:
+// rotation is about one credential, and its destinations may sit in several
+// stacks.
+func prepareRotation(ds datastore.Datastore, info datastore.GeneratorRotationInfo) (*rotationResult, error) {
+	generator, err := admitRotation(ds, info)
+	if err != nil {
+		return nil, err
+	}
+	if generator == nil {
+		return nil, nil
+	}
+
+	destinations, err := ds.FindResourcesReferencingGenerator(info.GeneratorID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find the destinations of generator %s: %w", info.GeneratorID, err)
+	}
+	if len(destinations) == 0 {
+		// A generator nothing binds has no credential in place to rotate.
+		// Drawing would advance its generation and write nowhere.
+		slog.Debug("Skipping rotation: the generator has no destination",
+			"generator", info.Label, "stack", info.StackLabel)
+		return nil, nil
+	}
+
+	forma := pkgmodel.FormaFromResources(destinations)
+
+	existingTargets, err := ds.LoadAllTargets()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load targets: %w", err)
+	}
+	// FormaFromResources only names the targets; substitute the real ones so
+	// the co-planning pass has the config it needs.
+	existingTargetMap := make(map[string]*pkgmodel.Target, len(existingTargets))
+	for _, target := range existingTargets {
+		existingTargetMap[target.Label] = target
+	}
+	for i, formaTarget := range forma.Targets {
+		if existing, ok := existingTargetMap[formaTarget.Label]; ok {
+			forma.Targets[i] = *existing
+		}
+	}
+
+	coPlanKsuids := make(map[string]bool, len(destinations))
+	for _, destination := range destinations {
+		if destination.Ksuid != "" {
+			coPlanKsuids[destination.Ksuid] = true
+		}
+	}
+
+	// force stays false. A forced apply deliberately does NOT touch a
+	// generator binding (see ClassifyOccurrence), so forcing here would
+	// suppress the very rotation this command exists to perform. Drift is
+	// handled by the refusal below, not by forcing over it.
+	resourceUpdates, err := resource_update.CoPlanGeneratorDestinations(
+		forma, coPlanKsuids, pkgmodel.FormaApplyModeReconcile,
+		resource_update.FormaCommandSourceGeneratorRotation, existingTargets, ds, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to plan the destinations of generator %s: %w", info.GeneratorID, err)
+	}
+	if len(resourceUpdates) == 0 {
+		slog.Debug("Skipping rotation: no destination of the generator could be planned",
+			"generator", info.Label, "stack", info.StackLabel)
+		return nil, nil
+	}
+
+	draws := []generator_update.GeneratorUpdate{
+		generator_update.NewDrawGeneratorUpdate(generator, info.StackLabel),
+	}
+
+	rotationCommand := forma_command.NewFormaCommand(
+		forma,
+		&config.FormaCommandConfig{
+			Mode: pkgmodel.FormaApplyModeReconcile,
+		},
+		pkgmodel.CommandApply,
+		resourceUpdates,
+		nil, // No target updates
+		nil, // No stack updates
+		nil, // No policy updates
+		nil, // No generator row writes: the spec is unchanged, only its generation moves
+		rotationClientID,
+		"",
+		"",
+		forma_command.SourceGeneratorRotator,
+	)
+	rotationCommand.DrawGeneratorUpdates = draws
+
+	if err := refuseRotationOnDrift(ds, forma, rotationCommand); err != nil {
+		return nil, err
+	}
+
+	synth, err := target_update.SynthesizeResolveTargetUpdates(
+		resource_update.ReferencedTargetLabels(resourceUpdates),
+		resource_update.SourceTargetByKsuid(resourceUpdates),
+		nil, ds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create changeset: %w", err)
+	}
+	cs, err := changeset.NewChangeset(resourceUpdates, synth, draws,
+		rotationCommand.ID, pkgmodel.CommandApply, rotationCommand.Config.Mode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create changeset: %w", err)
+	}
+
+	return &rotationResult{command: rotationCommand, changeset: cs}, nil
+}
+
+// admitRotation re-reads the generator the sweep decided to rotate and returns
+// it stamped with the identity and stack the draw is filed under, or nil when
+// the rotation must not proceed.
+//
+// This is the admission check, and it is where a user apply landing between the
+// sweep's read and the submission is caught. The sweep's view is a snapshot: by
+// the time the command is built the generator may have been deleted, renamed,
+// had its cadence removed, or had its spec edited. Planning against the
+// snapshot would rotate a credential under a spec the user has already
+// replaced, or rotate one they have just detached. Re-reading here means the
+// worst case is a skipped sweep, and the next one acts on what is actually
+// declared.
+//
+// The generator returned is the CURRENT one, so an edited spec is what the
+// value is drawn under.
+func admitRotation(ds datastore.Datastore, info datastore.GeneratorRotationInfo) (pkgmodel.Generator, error) {
+	identity, err := ds.GetGeneratorIdentity(info.Label, info.StackLabel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to re-read the identity of generator %q in stack %q: %w",
+			info.Label, info.StackLabel, err)
+	}
+	if identity.ID != info.GeneratorID {
+		// Either the generator is gone (zero identity) or something else
+		// holds its label now. Neither is the generator the sweep read.
+		slog.Debug("Skipping rotation: the generator moved between the sweep and admission",
+			"generator", info.Label, "stack", info.StackLabel,
+			"expected", info.GeneratorID, "found", identity.ID)
+		return nil, nil
+	}
+
+	generator, err := ds.GetGenerator(info.Label, info.StackLabel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to re-read generator %q in stack %q: %w",
+			info.Label, info.StackLabel, err)
+	}
+	if generator == nil {
+		return nil, nil
+	}
+
+	rotation := generator.GetRotation()
+	if rotation == nil || rotation.EverySeconds <= 0 {
+		slog.Debug("Skipping rotation: the generator no longer declares a cadence",
+			"generator", info.Label, "stack", info.StackLabel)
+		return nil, nil
+	}
+	// The cadence itself may have been widened since the sweep read it, in
+	// which case the generator is no longer due and must not be rotated on
+	// the old interval.
+	current := info
+	current.IntervalSeconds = rotation.EverySeconds
+	if !rotationIsDue(current, time.Now().UTC()) {
+		slog.Debug("Skipping rotation: the cadence was widened and the generator is no longer due",
+			"generator", info.Label, "stack", info.StackLabel, "everySeconds", rotation.EverySeconds)
+		return nil, nil
+	}
+
+	// A loaded generator carries neither its KSUID (PasswordGenerator.ID is
+	// json:"-") nor reliably its stack, and the draw records the generation
+	// against both.
+	generator.SetID(info.GeneratorID)
+	generator.SetStack(info.StackLabel)
+	return generator, nil
+}
+
+// refuseRotationOnDrift refuses a rotation whose destinations, or anything
+// beside them in their stacks, has moved out of band.
+//
+// A rotation is an ordinary update, so it confronts drift like one: writing a
+// fresh credential over a resource somebody changed outside formae would
+// silently discard that change. The gate is the same pair of readings a soft
+// reconcile uses — filterUnabsorbedModifications for declared movement and
+// witnessedMovedModifications for movement on content formae's own write
+// witnessed — so a drifted secret and a drifted consumer of that secret are
+// both refusals, and neither is a special case here.
+//
+// A stack carrying an auto-reconcile policy is exempt. That policy IS the
+// operator's standing instruction to overwrite out-of-band change on the
+// stack, so there is nothing left for rotation to ask about and it proceeds.
+// The exemption is per stack, because a generator's destinations may sit in
+// several and only the stack holding the drift has opted in.
+func refuseRotationOnDrift(ds datastore.Datastore, forma *pkgmodel.Forma, fc *forma_command.FormaCommand) error {
+	autoReconciled, err := stacksWithAutoReconcilePolicy(ds)
+	if err != nil {
+		return err
+	}
+
+	stackLabels := map[string]bool{}
+	for _, label := range append(stackLabelsFromForma(forma), fc.GetStackLabels()...) {
+		if label == "" || autoReconciled[label] {
+			continue
+		}
+		stackLabels[label] = true
+	}
+
+	// The same drift window the apply path loads, through the same function:
+	// a second reading of it here would eventually classify differently from
+	// the one a user's reconcile confronts.
+	modificationsByStack := make(map[string][]datastore.ResourceModification)
+	witnessByKsuid := make(map[string]json.RawMessage)
+	for label := range stackLabels {
+		if err := loadModificationsAndWitnesses(ds, label, modificationsByStack, witnessByKsuid); err != nil {
+			return err
+		}
+	}
+
+	modifiedStacks := map[string]apimodel.ModifiedStack{}
+	for label, modifications := range modificationsByStack {
+		unabsorbed := filterUnabsorbedModifications(modifications, forma, fc)
+		unabsorbed = append(unabsorbed, witnessedMovedModifications(modifications, witnessByKsuid, forma, fc)...)
+		if len(unabsorbed) == 0 {
+			continue
+		}
+		modifiedResources := make([]apimodel.ResourceModification, 0, len(unabsorbed))
+		for _, modification := range unabsorbed {
+			modifiedResources = append(modifiedResources, toAPIResourceModification(modification))
+		}
+		modifiedStacks[label] = apimodel.ModifiedStack{ModifiedResources: modifiedResources}
+	}
+	if len(modifiedStacks) > 0 {
+		return apimodel.FormaReconcileRejectedError{ModifiedStacks: modifiedStacks}
+	}
+
+	return nil
+}
+
+// stacksWithAutoReconcilePolicy indexes the stacks whose auto-reconcile policy
+// stands as an opt-in to overwriting out-of-band change.
+func stacksWithAutoReconcilePolicy(ds datastore.Datastore) (map[string]bool, error) {
+	policies, err := ds.GetStacksWithAutoReconcilePolicy()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the auto-reconcile policies: %w", err)
+	}
+	labels := make(map[string]bool, len(policies))
+	for _, policy := range policies {
+		labels[policy.StackLabel] = true
+	}
+	return labels, nil
+}

--- a/internal/metastructure/generator_rotator_admission_test.go
+++ b/internal/metastructure/generator_rotator_admission_test.go
@@ -1,0 +1,189 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package metastructure
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func rotationTestDatastore(t *testing.T) datastore.Datastore {
+	t.Helper()
+	ds, err := dssqlite.NewDatastoreSQLite(context.Background(), &pkgmodel.DatastoreConfig{
+		DatastoreType: pkgmodel.SqliteDatastore,
+		Sqlite:        pkgmodel.SqliteConfig{FilePath: ":memory:"},
+	}, "test")
+	require.NoError(t, err)
+	return ds
+}
+
+// createRotatingGenerator persists a generator declaring a cadence and returns
+// the rotation info a sweep would have read for it.
+func createRotatingGenerator(t *testing.T, ds datastore.Datastore, stackLabel, label string, everySeconds int) datastore.GeneratorRotationInfo {
+	t.Helper()
+	stack := &pkgmodel.Stack{Label: stackLabel}
+	_, err := ds.CreateStack(stack, "cmd-stack")
+	require.NoError(t, err)
+
+	_, err = ds.CreateGenerator(&pkgmodel.PasswordGenerator{
+		Label: label, Stack: stackLabel, StackID: stack.ID,
+		Length: 24, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+		Rotation: &pkgmodel.RotationSpec{EverySeconds: everySeconds},
+	}, "cmd-generator")
+	require.NoError(t, err)
+
+	infos, err := ds.GetGeneratorsWithRotation()
+	require.NoError(t, err)
+	for _, info := range infos {
+		if info.Label == label && info.StackLabel == stackLabel {
+			return info
+		}
+	}
+	t.Fatalf("no rotation info for generator %q on stack %q", label, stackLabel)
+	return datastore.GeneratorRotationInfo{}
+}
+
+// A generator the sweep read and a user then deleted is caught at admission.
+// The sweep's view is a snapshot; planning against it would draw a value for a
+// generator that no longer exists and try to advance a tombstoned row.
+func TestAdmitRotation_RefusesAGeneratorDeletedAfterTheSweep(t *testing.T) {
+	ds := rotationTestDatastore(t)
+	info := createRotatingGenerator(t, ds, "secrets", "db-password", 3600)
+
+	admitted, err := admitRotation(ds, info)
+	require.NoError(t, err)
+	require.NotNil(t, admitted, "precondition: the generator is admitted while it exists")
+
+	_, err = ds.DeleteGenerator("db-password", "secrets")
+	require.NoError(t, err)
+
+	admitted, err = admitRotation(ds, info)
+	require.NoError(t, err)
+	assert.Nil(t, admitted, "a generator deleted after the sweep must not be rotated")
+}
+
+// A generator whose cadence a user removed after the sweep is caught at
+// admission: nothing rotates a credential unless its current declaration says
+// how often to.
+func TestAdmitRotation_RefusesAGeneratorWhoseCadenceWasRemoved(t *testing.T) {
+	ds := rotationTestDatastore(t)
+	info := createRotatingGenerator(t, ds, "secrets", "db-password", 3600)
+
+	stack, err := ds.GetStackByLabel("secrets")
+	require.NoError(t, err)
+	_, err = ds.UpdateGenerator(&pkgmodel.PasswordGenerator{
+		Label: "db-password", Stack: "secrets", StackID: stack.ID,
+		Length: 24, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+	}, "cmd-user-edit")
+	require.NoError(t, err)
+
+	admitted, err := admitRotation(ds, info)
+	require.NoError(t, err)
+	assert.Nil(t, admitted, "a generator whose cadence was removed must not be rotated")
+}
+
+// A generator whose cadence a user widened after the sweep is caught at
+// admission: it was due on the interval the sweep read, and is not due on the
+// interval that is now declared.
+func TestAdmitRotation_RefusesAGeneratorWhoseCadenceWasWidened(t *testing.T) {
+	ds := rotationTestDatastore(t)
+	info := createRotatingGenerator(t, ds, "secrets", "db-password", 60)
+	// The sweep saw a one-minute cadence last satisfied an hour ago, so it is
+	// due.
+	info.LastRotationAt = time.Now().UTC().Add(-time.Hour)
+	require.True(t, rotationIsDue(info, time.Now().UTC()), "precondition: due on the cadence the sweep read")
+
+	stack, err := ds.GetStackByLabel("secrets")
+	require.NoError(t, err)
+	_, err = ds.UpdateGenerator(&pkgmodel.PasswordGenerator{
+		Label: "db-password", Stack: "secrets", StackID: stack.ID,
+		Length: 24, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+		Rotation: &pkgmodel.RotationSpec{EverySeconds: 30 * 24 * 3600},
+	}, "cmd-user-edit")
+	require.NoError(t, err)
+
+	admitted, err := admitRotation(ds, info)
+	require.NoError(t, err)
+	assert.Nil(t, admitted, "a generator whose cadence was widened past its due date must not be rotated")
+}
+
+// The value is drawn under the spec that is declared NOW, not the one the
+// sweep read: a user apply that edits the generator between the two must not
+// have a value drawn under the spec it replaced.
+func TestAdmitRotation_DrawsUnderTheCurrentSpec(t *testing.T) {
+	ds := rotationTestDatastore(t)
+	info := createRotatingGenerator(t, ds, "secrets", "db-password", 3600)
+
+	stack, err := ds.GetStackByLabel("secrets")
+	require.NoError(t, err)
+	_, err = ds.UpdateGenerator(&pkgmodel.PasswordGenerator{
+		Label: "db-password", Stack: "secrets", StackID: stack.ID,
+		Length: 48, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+		Rotation: &pkgmodel.RotationSpec{EverySeconds: 3600},
+	}, "cmd-user-edit")
+	require.NoError(t, err)
+
+	admitted, err := admitRotation(ds, info)
+	require.NoError(t, err)
+	require.NotNil(t, admitted)
+
+	password, ok := admitted.(*pkgmodel.PasswordGenerator)
+	require.True(t, ok)
+	assert.Equal(t, 48, password.Length, "the draw must run under the edited spec")
+	assert.Equal(t, info.GeneratorID, admitted.GetID(),
+		"the generator must carry the identity the generation is recorded against")
+	assert.Equal(t, "secrets", admitted.GetStack(),
+		"the generator must carry the stack the draw op is filed under")
+}
+
+// A label reused by a different generator is not the generator the sweep read.
+// Identity is the row's KSUID, so a delete followed by a create under the same
+// label must not be rotated on the deleted generator's schedule.
+func TestAdmitRotation_RefusesAReusedLabel(t *testing.T) {
+	ds := rotationTestDatastore(t)
+	info := createRotatingGenerator(t, ds, "secrets", "db-password", 3600)
+
+	_, err := ds.DeleteGenerator("db-password", "secrets")
+	require.NoError(t, err)
+
+	stack, err := ds.GetStackByLabel("secrets")
+	require.NoError(t, err)
+	_, err = ds.CreateGenerator(&pkgmodel.PasswordGenerator{
+		Label: "db-password", Stack: "secrets", StackID: stack.ID,
+		Length: 24, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+		Rotation: &pkgmodel.RotationSpec{EverySeconds: 3600},
+	}, "cmd-recreate")
+	require.NoError(t, err)
+
+	replacement, err := ds.GetGeneratorIdentity("db-password", "secrets")
+	require.NoError(t, err)
+	require.NotEqual(t, info.GeneratorID, replacement.ID, "precondition: the replacement is a different row")
+
+	admitted, err := admitRotation(ds, info)
+	require.NoError(t, err)
+	assert.Nil(t, admitted, "a label now held by a different generator must not be rotated")
+}
+
+// A generator nothing binds has no credential in place, so there is nothing to
+// rotate and no command to submit. Drawing anyway would advance the generation
+// and write the value nowhere.
+func TestPrepareRotation_SkipsAGeneratorWithNoDestination(t *testing.T) {
+	ds := rotationTestDatastore(t)
+	info := createRotatingGenerator(t, ds, "secrets", "db-password", 3600)
+
+	result, err := prepareRotation(ds, info)
+	require.NoError(t, err)
+	assert.Nil(t, result, "a generator with no destination must produce no command")
+}

--- a/internal/metastructure/generator_rotator_schedule_test.go
+++ b/internal/metastructure/generator_rotator_schedule_test.go
@@ -1,0 +1,217 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package metastructure
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+)
+
+func rotationInfo(generatorID string, intervalSeconds int, lastRotationAt time.Time) datastore.GeneratorRotationInfo {
+	return datastore.GeneratorRotationInfo{
+		GeneratorID:     generatorID,
+		Label:           "db-password",
+		StackLabel:      "secrets",
+		IntervalSeconds: intervalSeconds,
+		LastRotationAt:  lastRotationAt,
+	}
+}
+
+// A generator with no committed rotation on record is due now. Attaching
+// rotation to a credential nobody has rotated is a request to rotate it, not a
+// request to wait one interval first.
+func TestNextRotationDue_NeverRotatedIsDueImmediately(t *testing.T) {
+	due := nextRotationDue(rotationInfo("gen-a", 3600, time.Time{}))
+	assert.True(t, due.IsZero(), "a generator that has never rotated must be due now, got %s", due)
+
+	now := time.Now().UTC()
+	assert.True(t, rotationIsDue(rotationInfo("gen-a", 3600, time.Time{}), now))
+}
+
+// The cadence is a fixed delay measured from the last committed rotation.
+func TestNextRotationDue_FixedDelayFromTheLastCommittedRotation(t *testing.T) {
+	last := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	info := rotationInfo("gen-a", 3600, last)
+
+	due := nextRotationDue(info)
+	assert.False(t, due.Before(last.Add(time.Hour)),
+		"the next rotation must be at least one interval after the last one")
+
+	assert.False(t, rotationIsDue(info, last.Add(30*time.Minute)),
+		"a generator inside its interval is not due")
+	assert.True(t, rotationIsDue(info, last.Add(2*time.Hour)),
+		"a generator past its interval and its jitter is due")
+}
+
+// Jitter is what stops a fleet rotating in lockstep. Every generator in a
+// fleet created by one apply shares a last-rotation instant to the second, so
+// without an offset derived from the generator itself they would all come due
+// together on every cadence, forever.
+//
+// The offset is derived from the generator's identity rather than drawn at
+// random, so a restart does not reshuffle the fleet's schedule and this
+// assertion cannot fail by chance.
+func TestRotationJitter_SpreadsAFleetAcrossTheCadence(t *testing.T) {
+	const fleet = 500
+	interval := time.Hour
+
+	offsets := make(map[time.Duration]bool, fleet)
+	bound := rotationJitterBound(interval)
+	require.Positive(t, bound)
+
+	for i := 0; i < fleet; i++ {
+		offset := rotationJitter(fmt.Sprintf("2generator%019d", i), interval)
+		assert.GreaterOrEqual(t, offset, time.Duration(0))
+		assert.Less(t, offset, bound, "jitter must stay inside its bound")
+		offsets[offset] = true
+	}
+
+	assert.Greater(t, len(offsets), fleet/2,
+		"a fleet of %d generators must land on more than %d distinct offsets, got %d",
+		fleet, fleet/2, len(offsets))
+}
+
+// The same generator always gets the same offset: the schedule is stable
+// across sweeps and across restarts.
+func TestRotationJitter_StableForOneGenerator(t *testing.T) {
+	first := rotationJitter("2generatoraaaaaaaaaaaaaaaaaa", time.Hour)
+	second := rotationJitter("2generatoraaaaaaaaaaaaaaaaaa", time.Hour)
+	assert.Equal(t, first, second)
+}
+
+// The jitter bound is a fraction of the cadence, capped so an annual rotation
+// does not drift by weeks.
+func TestRotationJitterBound_FractionOfTheCadenceUpToACap(t *testing.T) {
+	assert.Equal(t, 6*time.Minute, rotationJitterBound(time.Hour))
+	assert.Equal(t, maxRotationJitter, rotationJitterBound(365*24*time.Hour))
+	assert.Equal(t, time.Duration(0), rotationJitterBound(0))
+}
+
+// A missed window collapses to one run. A generator whose cadence elapsed ten
+// times over is due once, not ten times: the next successful rotation moves
+// the anchor to now, and nothing counts up the intervals that were missed.
+func TestRotationIsDue_MissedIntervalsCollapseToOne(t *testing.T) {
+	last := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	info := rotationInfo("gen-a", 3600, last)
+	now := last.Add(10 * time.Hour)
+
+	require.True(t, rotationIsDue(info, now))
+
+	// Having rotated once, the generator is not due again until a further
+	// interval has passed — the nine missed windows are gone, not queued.
+	rotated := rotationInfo("gen-a", 3600, now)
+	assert.False(t, rotationIsDue(rotated, now.Add(30*time.Minute)))
+	assert.True(t, rotationIsDue(rotated, now.Add(2*time.Hour)))
+}
+
+// Backoff grows with the attempt count and saturates at one cadence, so a
+// generator whose rotation keeps failing is retried at its own interval rather
+// than either hammering the provider or giving up on the credential for good.
+func TestRotationBackoff_GrowsThenSaturatesAtOneCadence(t *testing.T) {
+	interval := time.Hour
+
+	assert.Equal(t, time.Duration(0), rotationBackoff(0, interval))
+	first := rotationBackoff(1, interval)
+	second := rotationBackoff(2, interval)
+	assert.Equal(t, rotationRetryBaseDelay, first)
+	assert.Greater(t, second, first)
+
+	for attempts := 1; attempts <= maxRotationRetryAttempts+3; attempts++ {
+		assert.LessOrEqual(t, rotationBackoff(attempts, interval), interval,
+			"backoff must never exceed one cadence")
+	}
+	assert.Equal(t, interval, rotationBackoff(maxRotationRetryAttempts, interval))
+	assert.Equal(t, interval, rotationBackoff(maxRotationRetryAttempts+5, interval))
+}
+
+// A cadence shorter than the base retry delay must not be retried more slowly
+// than it rotates.
+func TestRotationBackoff_NeverExceedsAShortCadence(t *testing.T) {
+	assert.Equal(t, time.Second, rotationBackoff(1, time.Second))
+	assert.Equal(t, time.Second, rotationBackoff(4, time.Second))
+}
+
+// A tick that lands while a rotation is already in flight for a generator
+// skips it. A rotation runs for as long as the provider writes take, which is
+// many sweeps, and a second command for the same generator would draw a second
+// value and leave one credential's destinations split across two generations.
+func TestRotationsDueNow_SkipsAGeneratorWithAnAttemptInFlight(t *testing.T) {
+	last := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := last.Add(10 * time.Hour)
+	infos := []datastore.GeneratorRotationInfo{rotationInfo("gen-a", 3600, last)}
+
+	require.Len(t, rotationsDueNow(infos, nil, nil, now), 1,
+		"precondition: the generator is due")
+
+	inFlight := map[string]rotationAttempt{"gen-a": {commandID: "command-1", interval: time.Hour}}
+	assert.Empty(t, rotationsDueNow(infos, inFlight, nil, now),
+		"a generator with an attempt in flight must be skipped")
+
+	// Repeated ticks keep skipping it for as long as the attempt is running.
+	assert.Empty(t, rotationsDueNow(infos, inFlight, nil, now.Add(time.Hour)))
+	assert.Empty(t, rotationsDueNow(infos, inFlight, nil, now.Add(5*time.Hour)))
+
+	// Once the attempt clears, the generator is due again.
+	assert.Len(t, rotationsDueNow(infos, map[string]rotationAttempt{}, nil, now.Add(5*time.Hour)), 1)
+}
+
+// An in-flight attempt for one generator says nothing about another's.
+func TestRotationsDueNow_InFlightGuardIsPerGenerator(t *testing.T) {
+	last := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := last.Add(10 * time.Hour)
+	infos := []datastore.GeneratorRotationInfo{
+		rotationInfo("gen-a", 3600, last),
+		rotationInfo("gen-b", 3600, last),
+	}
+
+	due := rotationsDueNow(infos, map[string]rotationAttempt{"gen-a": {commandID: "command-1", interval: time.Hour}}, nil, now)
+	require.Len(t, due, 1)
+	assert.Equal(t, "gen-b", due[0].GeneratorID)
+}
+
+// A generator inside its retry backoff is skipped, and comes back once the
+// delay has elapsed.
+func TestRotationsDueNow_SkipsAGeneratorInsideItsBackoff(t *testing.T) {
+	last := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := last.Add(10 * time.Hour)
+	infos := []datastore.GeneratorRotationInfo{rotationInfo("gen-a", 3600, last)}
+	nextAttemptAt := map[string]time.Time{"gen-a": now.Add(5 * time.Minute)}
+
+	assert.Empty(t, rotationsDueNow(infos, nil, nextAttemptAt, now))
+	assert.Len(t, rotationsDueNow(infos, nil, nextAttemptAt, now.Add(10*time.Minute)), 1)
+}
+
+// A sweep over a cadence that elapsed many times produces exactly one
+// rotation for that generator, not one per missed window.
+func TestRotationsDueNow_MissedWindowsProduceOneRotation(t *testing.T) {
+	last := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	infos := []datastore.GeneratorRotationInfo{rotationInfo("gen-a", 3600, last)}
+
+	due := rotationsDueNow(infos, nil, nil, last.Add(240*time.Hour))
+	assert.Len(t, due, 1, "240 missed hourly windows must collapse to one rotation")
+}
+
+// An agent that restarts reads the cadence back out of the datastore, so a
+// generator that has just rotated is not rotated again. The rotator's own
+// memory holds nothing that would have told it so: a fresh instance has an
+// empty in-flight map and an empty backoff table, and the only thing standing
+// between a restart and a second rotation is the derived last-rotation
+// instant.
+func TestRotationsDueNow_ARestartDoesNotRerotate(t *testing.T) {
+	rotatedAt := time.Now().UTC().Add(-time.Minute)
+	infos := []datastore.GeneratorRotationInfo{rotationInfo("gen-a", 3600, rotatedAt)}
+
+	// A fresh rotator: no in-flight attempts, no backoff, nothing remembered.
+	assert.Empty(t, rotationsDueNow(infos, map[string]rotationAttempt{}, map[string]time.Time{}, time.Now().UTC()),
+		"a generator that rotated a minute ago must not rotate again after a restart")
+}

--- a/internal/metastructure/generator_update/generator_updater.go
+++ b/internal/metastructure/generator_update/generator_updater.go
@@ -55,7 +55,7 @@ const (
 // rather than taking datastore.Datastore because internal/datastore imports
 // this package (through forma_command), so importing it back would cycle.
 type generationAdvancer interface {
-	AdvanceGeneration(generatorID, generationID string, drawnUnder json.RawMessage) error
+	AdvanceGeneration(generatorID, generationID, commandID string, drawnUnder json.RawMessage) error
 }
 
 // GeneratorUpdater is an FSM actor that draws one generator's value, records
@@ -73,13 +73,15 @@ type GeneratorUpdater struct {
 
 // StartGeneratorUpdate is sent to the GeneratorUpdater to begin a draw.
 //
-// It carries no CommandID, unlike StartTargetUpdate: a TargetUpdater needs one
-// to address the per-command ResolveCache actor and to stamp the persist
-// message it sends the ResourcePersister, and this actor sends neither. The
-// command is already in the actor's registered name (see
-// actornames.GeneratorUpdater), which is the caller's to build.
+// CommandID is recorded against the generation this draw advances to, and is
+// what makes the rotation cadence derivable: a generation row says a value was
+// drawn, and the command it was drawn by says whether that value ever reached
+// its destinations. It is carried on the message rather than parsed back out
+// of the actor's registered name, which encodes it for uniqueness, not for
+// reading.
 type StartGeneratorUpdate struct {
 	GeneratorUpdate GeneratorUpdate
+	CommandID       string
 }
 
 // DrawValue is sent by the actor to itself to leave StateNotStarted before
@@ -115,7 +117,10 @@ type Shutdown struct{}
 // and is never persisted.
 type GeneratorUpdaterData struct {
 	generatorUpdate GeneratorUpdate
-	requestedBy     gen.PID
+	// commandID is the command this draw belongs to, recorded against the
+	// generation so a failed command's draw advances no cadence.
+	commandID   string
+	requestedBy gen.PID
 	// entropy is the source Draw reads random bytes from: crypto/rand.Read in
 	// production, a deterministic source in tests so a specific drawn value is
 	// reproducible without relying on chance.
@@ -184,6 +189,7 @@ func (g *GeneratorUpdater) Init(args ...any) (statemachine.StateMachineSpec[Gene
 // itself, so the FSM reports the state it is actually in while drawing.
 func handleStartGeneratorUpdate(from gen.PID, state gen.Atom, data GeneratorUpdaterData, message StartGeneratorUpdate, proc gen.Process) (gen.Atom, GeneratorUpdaterData, []statemachine.Action, error) {
 	data.generatorUpdate = message.GeneratorUpdate
+	data.commandID = message.CommandID
 
 	if err := proc.Send(proc.PID(), DrawValue{}); err != nil {
 		proc.Log().Error("GeneratorUpdater: failed to send draw message node=%s: %v", data.generatorUpdate.NodeURI(), err)
@@ -260,7 +266,7 @@ func handleDrawValue(from gen.PID, state gen.Atom, data GeneratorUpdaterData, me
 		return StateFinishedWithError, data, nil, nil
 	}
 
-	if err := data.datastore.AdvanceGeneration(generatorID, generationID, drawnUnder); err != nil {
+	if err := data.datastore.AdvanceGeneration(generatorID, generationID, data.commandID, drawnUnder); err != nil {
 		proc.Log().Error("GeneratorUpdater: failed to record the generation node=%s generation=%s", nodeURI, generationID)
 		data.errorMessage = failureReasonGenerationNotRecorded
 		return StateFinishedWithError, data, nil, nil

--- a/internal/metastructure/generator_update/generator_updater_test.go
+++ b/internal/metastructure/generator_update/generator_updater_test.go
@@ -80,6 +80,7 @@ func (p *stubGeneratorUpdaterProcess) sentShutdowns() int {
 type advanceCall struct {
 	generatorID  string
 	generationID string
+	commandID    string
 	drawnUnder   json.RawMessage
 }
 
@@ -89,8 +90,8 @@ type recordingAdvancer struct {
 	err   error
 }
 
-func (r *recordingAdvancer) AdvanceGeneration(generatorID, generationID string, drawnUnder json.RawMessage) error {
-	r.calls = append(r.calls, advanceCall{generatorID, generationID, drawnUnder})
+func (r *recordingAdvancer) AdvanceGeneration(generatorID, generationID, commandID string, drawnUnder json.RawMessage) error {
+	r.calls = append(r.calls, advanceCall{generatorID, generationID, commandID, drawnUnder})
 	return r.err
 }
 

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -340,7 +340,7 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 		assertMods := make(map[string][]datastore.ResourceModification)
 		assertWitnesses := make(map[string]json.RawMessage)
 		for _, stackLabel := range stackLabelsFromForma(forma) {
-			if err := m.loadModificationsAndWitnesses(stackLabel, assertMods, assertWitnesses); err != nil {
+			if err := loadModificationsAndWitnesses(m.Datastore, stackLabel, assertMods, assertWitnesses); err != nil {
 				return nil, err
 			}
 		}
@@ -380,7 +380,7 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 				continue
 			}
 			seenStacks[stackLabel] = true
-			if err := m.loadModificationsAndWitnesses(stackLabel, modificationsByStack, witnessByKsuid); err != nil {
+			if err := loadModificationsAndWitnesses(m.Datastore, stackLabel, modificationsByStack, witnessByKsuid); err != nil {
 				return nil, err
 			}
 		}
@@ -738,8 +738,8 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 // Window load failures fail the submission; a witness fetch failure degrades
 // to no witness for that resource, which classifies its movement as
 // tolerated, the pre-existing behavior.
-func (m *Metastructure) loadModificationsAndWitnesses(stackLabel string, modificationsByStack map[string][]datastore.ResourceModification, witnessByKsuid map[string]json.RawMessage) error {
-	modifications, err := m.Datastore.GetResourceModificationsSinceLastReconcile(stackLabel)
+func loadModificationsAndWitnesses(ds datastore.Datastore, stackLabel string, modificationsByStack map[string][]datastore.ResourceModification, witnessByKsuid map[string]json.RawMessage) error {
+	modifications, err := ds.GetResourceModificationsSinceLastReconcile(stackLabel)
 	if err != nil {
 		slog.Error("Failed to load modifications since last reconcile", "stack", stackLabel, "error", err)
 		return fmt.Errorf("failed to load modifications for stack %s: %w", stackLabel, err)
@@ -755,7 +755,7 @@ func (m *Metastructure) loadModificationsAndWitnesses(stackLabel string, modific
 		if _, done := witnessByKsuid[mod.Ksuid]; done {
 			continue
 		}
-		witness, werr := m.Datastore.GetPropertiesAtLastWrite(mod.Ksuid)
+		witness, werr := ds.GetPropertiesAtLastWrite(mod.Ksuid)
 		if werr != nil {
 			slog.Warn("Failed to load write witness for drift classification", "ksuid", mod.Ksuid, "error", werr)
 			continue

--- a/internal/metastructure/resource_summaries_test.go
+++ b/internal/metastructure/resource_summaries_test.go
@@ -260,6 +260,10 @@ func (m *mockSummaryDatastore) DeletePoliciesForStack(_ string, _ string) error 
 func (m *mockSummaryDatastore) GetExpiredStacks() ([]datastore.ExpiredStackInfo, error) {
 	panic("not implemented")
 }
+func (m *mockSummaryDatastore) GetGeneratorsWithRotation() ([]datastore.GeneratorRotationInfo, error) {
+	return nil, nil
+}
+
 func (m *mockSummaryDatastore) GetStacksWithAutoReconcilePolicy() ([]datastore.StackReconcileInfo, error) {
 	panic("not implemented")
 }
@@ -290,7 +294,7 @@ func (m *mockSummaryDatastore) GetGeneratorIdentity(_, _ string) (datastore.Gene
 func (m *mockSummaryDatastore) GetGeneratorIdentityByID(_ string) (datastore.GeneratorIdentity, error) {
 	panic("not implemented")
 }
-func (m *mockSummaryDatastore) AdvanceGeneration(_, _ string, _ json.RawMessage) error {
+func (m *mockSummaryDatastore) AdvanceGeneration(_, _, _ string, _ json.RawMessage) error {
 	panic("not implemented")
 }
 func (m *mockSummaryDatastore) Close() {}

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -38,6 +38,7 @@ const (
 	FormaCommandSourceSynchronize         = types.FormaCommandSourceSynchronize
 	FormaCommandSourceDiscovery           = types.FormaCommandSourceDiscovery
 	FormaCommandSourcePolicyAutoReconcile = types.FormaCommandSourcePolicyAutoReconcile
+	FormaCommandSourceGeneratorRotation   = types.FormaCommandSourceGeneratorRotation
 
 	OperationCreate  = types.OperationCreate
 	OperationUpdate  = types.OperationUpdate

--- a/internal/metastructure/supervisor.go
+++ b/internal/metastructure/supervisor.go
@@ -76,6 +76,10 @@ func (sup *Supervisor) Init(args ...any) (act.SupervisorSpec, error) {
 			Name:    "AutoReconciler",
 			Factory: NewAutoReconciler,
 		},
+		{
+			Name:    "GeneratorRotator",
+			Factory: NewGeneratorRotator,
+		},
 	}
 
 	spec.Restart.Strategy = act.SupervisorStrategyTransient

--- a/internal/metastructure/types/types.go
+++ b/internal/metastructure/types/types.go
@@ -12,6 +12,13 @@ const (
 	FormaCommandSourceSynchronize         FormaCommandSource = "synchronize"
 	FormaCommandSourceDiscovery           FormaCommandSource = "discovery"
 	FormaCommandSourcePolicyAutoReconcile FormaCommandSource = "policy:auto-reconcile"
+	// FormaCommandSourceGeneratorRotation marks the resource updates a
+	// scheduled generator rotation plans. It is deliberately not
+	// FormaCommandSourceUser: the reconcile baseline is read from user-source
+	// rows, and a rotation plans only one generator's destinations, so
+	// counting it would shrink the baseline to those and leave the rest of
+	// the stack unenforced.
+	FormaCommandSourceGeneratorRotation FormaCommandSource = "generator-rotation"
 )
 
 // OperationType is the high-level operation being performed on a resource or target.

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -54,8 +54,10 @@ open class Resource {
 }
 
 /// Base for first-class secret resources. A provider's secret (aws.Secret, the
-/// Azure Key Vault Secret, ...) extends this and names its value property. The
-/// rotation field is intentionally absent in this stage (deferred to Stage 2).
+/// Azure Key Vault Secret, ...) extends this and names its value property. A
+/// secret carries no cadence of its own: rotation is declared on the Generator
+/// the secret's value is bound to, so one cadence governs every destination
+/// that shares the credential.
 abstract class Secret extends Resource {
     hidden valueProperty: String
 }
@@ -167,6 +169,22 @@ open class AutoReconcilePolicy extends Policy {
     }
 }
 
+/// The cadence on which a generator draws a fresh value.
+///
+/// `every` has no default. Attaching rotation to a generator is a statement
+/// about how often its credential turns over, so there is no cadence to
+/// inherit and none to guess at: a rotation spec that names no interval is an
+/// eval-time error, not a generator that rotates on some house default.
+open class RotationSpec {
+    every: Duration
+
+    local self = this
+    // Output
+    function render(): Dynamic = new {
+        EverySeconds = self.every.toUnit("s").value.toInt()
+    }
+}
+
 /// A source of generated values. Belongs to a stack; referenced by the
 /// resources whose properties take the generated value.
 abstract class Generator {
@@ -178,6 +196,11 @@ abstract class Generator {
     /// (same stack) and renames the matched row in place. Mirrors
     /// Resource.alias.
     alias: String?
+
+    /// Rotate this generator's value on a fixed cadence. Absent means the
+    /// value is drawn only when an apply needs one: nothing rotates a
+    /// credential on its own unless this says how often to.
+    rotation: RotationSpec?
 
     /// The named outputs this generator produces. A destination binds to one
     /// of them, e.g. `pw.gen.value`. Outputs are typed properties, so an
@@ -259,6 +282,7 @@ open class PasswordGenerator extends Generator {
         Label = self.label
         Stack = self.stack
         Alias = self.alias
+        Rotation = self.rotation?.render()
         Length = length
         Uppercase = uppercase
         Lowercase = lowercase

--- a/internal/schema/pkl/schema/tests/formae.pkl
+++ b/internal/schema/pkl/schema/tests/formae.pkl
@@ -407,6 +407,25 @@ local neitherVariantTTL = new formae.TTLPolicy {
     label = "neither-ttl"
 }
 
+local rotatingGenerator = new formae.PasswordGenerator {
+    label = "rotating-password"
+    stack = stackResolvable
+    rotation = new formae.RotationSpec {
+        every = 24.h
+    }
+}
+
+local nonRotatingGenerator = new formae.PasswordGenerator {
+    label = "steady-password"
+    stack = stackResolvable
+}
+
+local cadencelessRotation = new formae.PasswordGenerator {
+    label = "cadenceless-password"
+    stack = stackResolvable
+    rotation = new formae.RotationSpec {}
+}
+
 // Schema classes that sit under an intermediate base rather than extending
 // formae.SubResource / formae.Resource directly. The subclasses inherit the
 // base's annotated fields, redeclare one of them (narrowing String? to String),
@@ -700,9 +719,30 @@ examples {
     ["TTL policy with neither ttl nor expiresAt is rejected"] {
         module.catch(() -> neitherVariantTTL.render())
     }
+
+    ["Generator with rotation render()"] {
+        rotatingGenerator.render()
+    }
+
+    ["Generator without rotation render()"] {
+        nonRotatingGenerator.render()
+    }
 }
 
 facts {
+    ["Rotation renders its cadence in seconds"] {
+        rotatingGenerator.render().Rotation.EverySeconds == 86400
+    }
+
+    ["A generator without rotation renders no cadence"] {
+        rotatingGenerator.render().toMap().containsKey("Rotation") &&
+        nonRotatingGenerator.render().Rotation == null
+    }
+
+    ["A rotation spec without a cadence is rejected"] {
+        module.catch(() -> cadencelessRotation.render().Rotation.EverySeconds) != null
+    }
+
     ["Relative TTL policy renders TTLSeconds and no ExpiresAt"] {
         relativeTTL.render().toMap().containsKey("TTLSeconds") &&
         !relativeTTL.render().toMap().containsKey("ExpiresAt") &&

--- a/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
+++ b/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
@@ -749,4 +749,52 @@ examples {
   ["TTL policy with neither ttl nor expiresAt is rejected"] {
     "TTLPolicy: set either ttl or expiresAt"
   }
+  ["Generator with rotation render()"] {
+    new {
+      Type = "password"
+      Label = "rotating-password"
+      Stack {
+        $label = "test-stack"
+        $property = null
+        $stack = null
+        $type = "Formae::Stack"
+        $res = true
+        $visibility = "Clear"
+      }
+      Alias = null
+      Rotation {
+        EverySeconds = 86400
+      }
+      Length = 32
+      Uppercase = true
+      Lowercase = true
+      Digits = true
+      Symbols = false
+      ExcludeCharacters = ""
+      RequireEachIncludedType = true
+    }
+  }
+  ["Generator without rotation render()"] {
+    new {
+      Type = "password"
+      Label = "steady-password"
+      Stack {
+        $label = "test-stack"
+        $property = null
+        $stack = null
+        $type = "Formae::Stack"
+        $res = true
+        $visibility = "Clear"
+      }
+      Alias = null
+      Rotation = null
+      Length = 32
+      Uppercase = true
+      Lowercase = true
+      Digits = true
+      Symbols = false
+      ExcludeCharacters = ""
+      RequireEachIncludedType = true
+    }
+  }
 }

--- a/internal/schema/pkl/testdata/forma/generator_rotation_test.pkl
+++ b/internal/schema/pkl/testdata/forma/generator_rotation_test.pkl
@@ -1,0 +1,51 @@
+/*
+ * © 2026 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+// A generator that declares a rotation cadence, and a plugin resource whose
+// secret-bearing property is bound to that generator's `value` output. The
+// cadence lives on the generator rather than on the secret, so one interval
+// governs every destination that shares the credential.
+//
+// `every` is one second because the scheduler's sweep is driven directly in
+// the test: the interval only has to be short enough that the generator comes
+// due, and `RotationSpec.every` is an unconstrained Duration rendered to whole
+// seconds, so a second is the shortest cadence the schema admits.
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+import "@fakeaws/fakeaws.pkl"
+import "@fakeaws/secretsmanager/secret.pkl"
+
+forma {
+  local appStack = new formae.Stack {
+    label = "generator-rotation-stack"
+    description = "Stack for a rotating generator and its destination"
+  }
+  appStack
+
+  new formae.Target {
+    label = "default-aws-target"
+    config = new fakeaws.Config {
+      region = "us-west-2"
+    }
+  }
+
+  local pw = new formae.PasswordGenerator {
+    label = "db-password"
+    stack = appStack.res
+    length = 24
+    rotation = new formae.RotationSpec {
+      every = 1.s
+    }
+  }
+  pw
+
+  new secret.Secret {
+    label = "db"
+    name = "db"
+    secretString = pw.gen.value
+  }
+}

--- a/internal/workflow_tests/local/apply_forma/generator_delivery_scope_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_delivery_scope_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: FSL-1.1-ALv2
 
-//go:build unit
+//go:build unit || integration
 
 package workflow_tests_local
 

--- a/internal/workflow_tests/local/apply_forma/generator_draw_delivery_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_draw_delivery_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: FSL-1.1-ALv2
 
-//go:build unit
+//go:build unit || integration
 
 package workflow_tests_local
 

--- a/internal/workflow_tests/local/apply_forma/generator_moved_generation_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_moved_generation_test.go
@@ -102,7 +102,7 @@ func TestApplyForma_MovedGeneration_PlansOnlyItsOwnDestinations(t *testing.T) {
 		// and the other generator is not touched at all.
 		movedGenerationID := util.NewID()
 		require.NoError(t, m.Datastore.AdvanceGeneration(
-			movedBefore.ID, movedGenerationID, movedBefore.GenerationSpec))
+			movedBefore.ID, movedGenerationID, "cmd-out-of-band", movedBefore.GenerationSpec))
 		steadyUnmoved, err := m.Datastore.GetGeneratorIdentity("steady-password", stack)
 		require.NoError(t, err)
 		require.Equal(t, steadyBefore.GenerationID, steadyUnmoved.GenerationID,

--- a/internal/workflow_tests/local/apply_forma/generator_reference_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_reference_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: FSL-1.1-ALv2
 
-//go:build unit
+//go:build unit || integration
 
 package workflow_tests_local
 

--- a/internal/workflow_tests/local/apply_forma/generator_resume_redraw_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_resume_redraw_test.go
@@ -274,7 +274,7 @@ type stalledGenerationDatastore struct {
 	once    sync.Once
 }
 
-func (d *stalledGenerationDatastore) AdvanceGeneration(_, _ string, _ json.RawMessage) error {
+func (d *stalledGenerationDatastore) AdvanceGeneration(_, _, _ string, _ json.RawMessage) error {
 	d.once.Do(func() { close(d.reached) })
 	// The node is force-stopped while this call is outstanding, after its
 	// datastore has been closed, so nothing this returns can reach a row. The

--- a/internal/workflow_tests/local/apply_forma/generator_rotation_pkl_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_rotation_pkl_test.go
@@ -1,0 +1,138 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build integration
+
+package workflow_tests_local
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/schema/pkl"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// authoredRotatingGeneratorForma is the forma this test applies: a
+// PasswordGenerator declaring `rotation { every = 1.s }` and a plugin resource
+// whose secret-bearing property is bound to that generator's `value` output.
+const authoredRotatingGeneratorForma = "internal/schema/pkl/testdata/forma/generator_rotation_test.pkl"
+
+// The stack, generator and destination the authored forma declares.
+const (
+	rotatingFormaStack       = "generator-rotation-stack"
+	rotatingFormaGenerator   = "db-password"
+	rotatingFormaDestination = "db"
+	rotatingFormaLength      = 24
+)
+
+// A cadence authored in PKL rotates the credential it governs. The forma is
+// evaluated rather than hand-built, so the whole path a forma author actually
+// writes is exercised: `rotation { every = ... }` on a generator, a resource
+// property bound to that generator's output, and the scheduler moving the
+// generation forward once the interval has elapsed.
+//
+// The two halves of this are each covered on their own — a binding authored in
+// PKL applies, and a scheduler sweep rotates a generator built from model
+// structs — and neither says the crossing works. A cadence that never reaches
+// the model, or a destination the eval path renders in a shape the rotator
+// cannot plan, fails here and nowhere else.
+//
+// The rotation is asserted through the value the provider received, not only
+// through the generation counter: the second value has to be a fresh draw of
+// the authored length, so neither a build that advanced the counter without
+// writing anything nor one that wrote the same value twice can pass.
+func TestApplyForma_PklAuthoredRotatingGenerator_RotatesOnItsDeclaredCadence(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		logCapture := test_helpers.SetupTestLogger()
+
+		forma, err := pkl.PKL{}.Evaluate(
+			authoredRotatingGeneratorForma,
+			pkgmodel.CommandApply,
+			pkgmodel.FormaApplyModeReconcile,
+			nil,
+		)
+		require.NoError(t, err, "the authored forma must evaluate")
+		require.Len(t, forma.Resources, 1)
+		require.Len(t, forma.Generators, 1)
+		require.True(t, gjson.GetBytes(forma.Resources[0].Properties, "SecretString.$gen").Bool(),
+			"precondition: eval must render the binding as a $gen envelope")
+		require.Equal(t, int64(1), gjson.GetBytes(forma.Generators[0], "Rotation.EverySeconds").Int(),
+			"precondition: the authored cadence must reach the model as an interval in seconds")
+
+		delivered := newDeliveredValues()
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		_, err = m.ApplyForma(forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		created := delivered.createdWith(rotatingFormaDestination)
+		require.Len(t, created, 1, "the destination must be created with a drawn value")
+		assert.Len(t, created[0], rotatingFormaLength,
+			"the provider receives the drawn value, at the authored length")
+		assert.NotContains(t, created[0], "$gen",
+			"the provider must receive the drawn value, never the envelope naming it")
+
+		digestBefore := storedBinding(t, m, rotatingFormaStack, rotatingFormaDestination).Get("$value").String()
+		require.NotEmpty(t, digestBefore)
+		identityBefore, err := m.Datastore.GetGeneratorIdentity(rotatingFormaGenerator, rotatingFormaStack)
+		require.NoError(t, err)
+		require.NotEmpty(t, identityBefore.GenerationID)
+
+		// Waiting first is what makes the sweep below say something about the
+		// scheduler rather than about the clock.
+		waitUntilRotationDue(t, m, rotatingFormaStack, rotatingFormaGenerator)
+		rotation := sweepUntilRotated(t, m)
+		require.Equal(t, forma_command.CommandStateSuccess, rotation.State,
+			"the rotation of a PKL-authored cadence must succeed")
+		assert.Equal(t, forma_command.SourceGeneratorRotator, rotation.Source)
+		waitForApplyComplete(t, m)
+
+		updates := delivered.updatedWith(rotatingFormaDestination)
+		require.Len(t, updates, 1, "the rotation must write the destination exactly once")
+		assert.Len(t, updates[0], rotatingFormaLength,
+			"the rotated value must be drawn at the authored length")
+		assert.NotEqual(t, created[0], updates[0],
+			"the rotation must deliver a second, freshly drawn value")
+
+		bindingAfter := storedBinding(t, m, rotatingFormaStack, rotatingFormaDestination)
+		assert.True(t, bindingAfter.Get("$hashed").Bool(),
+			"the rewritten destination must store a digest")
+		assert.NotEqual(t, digestBefore, bindingAfter.Get("$value").String(),
+			"the destination's stored digest must move with the rotated value")
+		assert.Equal(t, pkgmodel.ComputeValueHash(updates[0]), bindingAfter.Get("$value").String(),
+			"the stored digest must be the digest of the value the provider received")
+
+		identityAfter, err := m.Datastore.GetGeneratorIdentity(rotatingFormaGenerator, rotatingFormaStack)
+		require.NoError(t, err)
+		assert.NotEqual(t, identityBefore.GenerationID, identityAfter.GenerationID,
+			"the rotation must advance the generator's generation")
+
+		for _, value := range append(created, updates...) {
+			assertNoPlaintextInResourceUpdates(t, m, rotation.ID, value)
+			assertNoPlaintextInLogs(t, logCapture, value)
+		}
+		resources, err := m.Datastore.LoadResourcesByStack(rotatingFormaStack)
+		require.NoError(t, err)
+		for i := range resources {
+			for _, value := range append(created, updates...) {
+				assert.NotContains(t, string(resources[i].Properties), value,
+					"resources.properties leaked a rotated value for %s", resources[i].Label)
+			}
+		}
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/generator_rotation_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_rotation_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: FSL-1.1-ALv2
 
-//go:build unit
+//go:build unit || integration
 
 package workflow_tests_local
 

--- a/internal/workflow_tests/local/apply_forma/generator_rotation_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_rotation_test.go
@@ -1,0 +1,635 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
+	"github.com/platform-engineering-labs/formae/internal/metastructure"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// rotatingGenerator renders a password generator that declares a cadence, in
+// the shape PKL produces.
+func rotatingGenerator(t *testing.T, label, stack string, everySeconds int) json.RawMessage {
+	t.Helper()
+	return rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+		Label: label, Stack: stack,
+		Length: 24, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+		Rotation: &pkgmodel.RotationSpec{EverySeconds: everySeconds},
+	})
+}
+
+// sweepRotations drives one rotation sweep. The rotator's own timer is far
+// coarser than a test wants to wait for, so the tick is sent directly: the
+// sweep is the actor's whole decision, and driving it is what makes these
+// tests about rotation rather than about how long they slept.
+func sweepRotations(t *testing.T, m *metastructure.Metastructure) {
+	t.Helper()
+	require.NoError(t, m.Node.Send(
+		gen.ProcessID{Name: actornames.GeneratorRotator, Node: m.Node.Name()},
+		metastructure.CheckGeneratorRotations{},
+	))
+}
+
+// commandCount returns how many forma commands the datastore holds.
+func commandCount(t *testing.T, m *metastructure.Metastructure) int {
+	t.Helper()
+	commands, err := m.Datastore.LoadFormaCommands()
+	require.NoError(t, err)
+	return len(commands)
+}
+
+// rotationCommands returns the commands a generator rotation produced.
+func rotationCommands(t *testing.T, m *metastructure.Metastructure) []*forma_command.FormaCommand {
+	t.Helper()
+	commands, err := m.Datastore.LoadFormaCommands()
+	require.NoError(t, err)
+	var rotations []*forma_command.FormaCommand
+	for _, command := range commands {
+		if command.Source == forma_command.SourceGeneratorRotator {
+			rotations = append(rotations, command)
+		}
+	}
+	return rotations
+}
+
+// sweepUntilRotated drives sweeps until one rotation command has run to a
+// terminal state, then returns it.
+func sweepUntilRotated(t *testing.T, m *metastructure.Metastructure) *forma_command.FormaCommand {
+	t.Helper()
+	var rotation *forma_command.FormaCommand
+	require.Eventually(t, func() bool {
+		sweepRotations(t, m)
+		rotations := rotationCommands(t, m)
+		if len(rotations) == 0 {
+			return false
+		}
+		rotation = rotations[0]
+		return rotation.State == forma_command.CommandStateSuccess ||
+			rotation.State == forma_command.CommandStateFailed
+	}, 20*time.Second, 200*time.Millisecond, "a rotation must be submitted and reach a terminal state")
+	return rotation
+}
+
+// A generator whose cadence has elapsed is rotated, and the destination bound
+// to it is rewritten with a freshly drawn value: the provider receives new
+// material, and the digest and the generation stamp the destination holds at
+// rest both move.
+func TestGeneratorRotation_RotatesOnScheduleAndRewritesTheDestination(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		logCapture := test_helpers.SetupTestLogger()
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := &pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: stack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{rotatingGenerator(t, "db-password", stack, 1)},
+			Resources:  []pkgmodel.Resource{genBoundSecret(stack, "alpha", "db-password", "value")},
+		}
+
+		_, err = m.ApplyForma(forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		created := delivered.createdWith("alpha")
+		require.Len(t, created, 1, "precondition: the destination was created with a drawn value")
+		bindingBefore := storedBinding(t, m, stack, "alpha")
+		digestBefore := bindingBefore.Get("$value").String()
+		resolvedBefore := bindingBefore.Get("$resolvedFrom").String()
+		require.NotEmpty(t, digestBefore)
+		require.NotEmpty(t, resolvedBefore)
+		identityBefore, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		require.NotEmpty(t, identityBefore.GenerationID)
+
+		rotation := sweepUntilRotated(t, m)
+		assert.Equal(t, forma_command.CommandStateSuccess, rotation.State)
+		waitForApplyComplete(t, m)
+
+		updates := delivered.updatedWith("alpha")
+		require.Len(t, updates, 1, "the rotation must write the destination exactly once")
+		assert.Len(t, updates[0], 24, "the rewritten value must match the generator's spec")
+		assert.NotEqual(t, created[0], updates[0], "the rotation must deliver a freshly drawn value")
+
+		bindingAfter := storedBinding(t, m, stack, "alpha")
+		assert.True(t, bindingAfter.Get("$hashed").Bool(), "the rewritten destination must store a digest")
+		assert.Equal(t, pkgmodel.ComputeValueHash(updates[0]), bindingAfter.Get("$value").String(),
+			"the stored digest must be the digest of the value the provider received")
+		assert.NotEqual(t, resolvedBefore, bindingAfter.Get("$resolvedFrom").String(),
+			"the destination must be stamped with the generation it was rotated to")
+
+		identityAfter, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		assert.NotEqual(t, identityBefore.GenerationID, identityAfter.GenerationID,
+			"the rotation must advance the generator's generation")
+
+		// The rotation is not a user command: it must not be attributed to one,
+		// and it must not become the stack's reconcile baseline.
+		assert.Equal(t, forma_command.SourceGeneratorRotator, rotation.Source)
+
+		for _, value := range append(created, updates...) {
+			assertNoPlaintextInResourceUpdates(t, m, rotation.ID, value)
+			assertNoPlaintextInLogs(t, logCapture, value)
+		}
+		resources, err := m.Datastore.LoadResourcesByStack(stack)
+		require.NoError(t, err)
+		for i := range resources {
+			for _, value := range append(created, updates...) {
+				assert.NotContains(t, string(resources[i].Properties), value,
+					"resources.properties leaked a rotated value for %s", resources[i].Label)
+			}
+		}
+	})
+}
+
+// The rotation leaves nothing behind that a later apply reads as a change. A
+// last-rotation instant kept on the generator would be part of its desired
+// spec, so the very next apply of the unchanged forma would plan a generator
+// update and, through it, rewrite the credential again.
+func TestGeneratorRotation_LeavesNoSpuriousChangeBehind(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		buildForma := func() *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:     []pkgmodel.Stack{{Label: stack}},
+				Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				Generators: []json.RawMessage{rotatingGenerator(t, "db-password", stack, 1)},
+				Resources:  []pkgmodel.Resource{genBoundSecret(stack, "alpha", "db-password", "value")},
+			}
+		}
+
+		_, err = m.ApplyForma(buildForma(),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		rotation := sweepUntilRotated(t, m)
+		require.Equal(t, forma_command.CommandStateSuccess, rotation.State)
+		waitForApplyComplete(t, m)
+
+		sim, err := m.ApplyForma(buildForma(), &config.FormaCommandConfig{
+			Mode:     pkgmodel.FormaApplyModeReconcile,
+			Simulate: true,
+		}, "test-client-id", "", "")
+		require.NoError(t, err)
+		assert.False(t, sim.Simulation.ChangesRequired,
+			"a rotation must leave the declared state unchanged, got %d resource updates and %d generator updates",
+			len(sim.Simulation.Command.ResourceUpdates), len(sim.Simulation.Command.GeneratorUpdates))
+
+		// The instant of the last rotation must not be readable off the
+		// generator's stored spec, which is what a diff compares.
+		stored, err := m.Datastore.GetGenerator("db-password", stack)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		storedSpec, err := json.Marshal(stored)
+		require.NoError(t, err)
+		declaredSpec := rotatingGenerator(t, "db-password", stack, 1)
+		declared, err := pkgmodel.ParseGenerator(declaredSpec)
+		require.NoError(t, err)
+		declared.SetStack(stack)
+		declaredBytes, err := json.Marshal(declared)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(declaredBytes), string(storedSpec),
+			"the stored generator spec must be exactly what was declared, with no rotation bookkeeping added")
+	})
+}
+
+// The cadence survives a restart, because it is derived from the datastore
+// rather than held in the rotator's memory.
+//
+// This is the assertion an implementation that kept the last-rotation instant
+// in actor memory fails and no other assertion catches: such an
+// implementation leaves the declared state clean and produces no spurious
+// diff, and only losing its memory reveals that it never knew when the
+// credential was last rotated.
+func TestGeneratorRotation_DerivedCadenceSurvivesARestart(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		// The database has to outlive the first agent, so it is created here
+		// and cleaned up here. "no-reset" in the path is what stops the test
+		// helper's own cleanup removing the file when the first agent stops.
+		dbFile, err := os.CreateTemp("", "formae_test_no-reset_*.db")
+		require.NoError(t, err)
+		require.NoError(t, dbFile.Close())
+		defer func() { _ = os.Remove(dbFile.Name()) }()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		cfg.Agent.Datastore = pkgmodel.DatastoreConfig{
+			DatastoreType: pkgmodel.SqliteDatastore,
+			Sqlite:        pkgmodel.SqliteConfig{FilePath: dbFile.Name()},
+		}
+
+		stack := "test-stack-" + util.NewID()
+		forma := func() *pkgmodel.Forma {
+			return &pkgmodel.Forma{
+				Stacks:  []pkgmodel.Stack{{Label: stack}},
+				Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+				// An hour's cadence, so the generator is decidedly NOT due
+				// again once the first apply has drawn for it.
+				Generators: []json.RawMessage{rotatingGenerator(t, "db-password", stack, 3600)},
+				Resources:  []pkgmodel.Resource{genBoundSecret(stack, "alpha", "db-password", "value")},
+			}
+		}
+
+		first, stopFirst, err := newRotationAgent(t, delivered.overrides(), cfg)
+		require.NoError(t, err)
+
+		_, err = first.ApplyForma(forma(),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, first)
+		require.Len(t, delivered.createdWith("alpha"), 1, "precondition: the destination was drawn for")
+		commandsBefore := commandCount(t, first)
+		bindingBefore := storedBinding(t, first, stack, "alpha").Get("$value").String()
+		require.NotEmpty(t, bindingBefore)
+
+		stopFirst()
+
+		// A new agent on the same datastore: nothing about the previous one's
+		// memory survives.
+		second, stopSecond, err := newRotationAgent(t, delivered.overrides(), cfg)
+		require.NoError(t, err)
+		defer stopSecond()
+
+		for i := 0; i < 5; i++ {
+			sweepRotations(t, second)
+			time.Sleep(100 * time.Millisecond)
+		}
+		waitForApplyComplete(t, second)
+
+		assert.Empty(t, rotationCommands(t, second),
+			"a restarted agent must not rotate a credential whose cadence has not elapsed")
+		assert.Equal(t, commandsBefore, commandCount(t, second),
+			"a restart must produce no further commands")
+		assert.Empty(t, delivered.updatedWith("alpha"),
+			"the destination must not be rewritten by a restart")
+		assert.Equal(t, bindingBefore, storedBinding(t, second, stack, "alpha").Get("$value").String(),
+			"the credential at rest must be untouched by a restart")
+	})
+}
+
+// newRotationAgent starts an agent on the datastore the config names, without
+// the test helper's file cleanup: the caller owns the database file so it can
+// be handed to a second agent.
+func newRotationAgent(t *testing.T, overrides *plugin.ResourcePluginOverrides, cfg *pkgmodel.Config) (*metastructure.Metastructure, func(), error) {
+	t.Helper()
+	db, err := dssqlite.NewDatastoreSQLite(context.Background(), &cfg.Agent.Datastore, "test")
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return test_helpers.NewTestMetastructureWithEverything(t, overrides, db, cfg)
+}
+
+// consumerLabel is the label secretConsumer gives the resource that holds an
+// opaque reference to the generated secret's value.
+const consumerLabel = "my-bucket"
+
+// waitUntilRotationDue blocks until the generator's cadence has certainly
+// elapsed, so that a sweep which produces no rotation says something about the
+// sweep rather than about the clock. It waits two full intervals past the
+// derived anchor, which strictly covers the jitter (a tenth of the interval).
+//
+// Without this a "rotation was refused" assertion passes on a generator that
+// was simply not due yet, which is the same result for the wrong reason.
+func waitUntilRotationDue(t *testing.T, m *metastructure.Metastructure, stack, label string) {
+	t.Helper()
+	infos, err := m.Datastore.GetGeneratorsWithRotation()
+	require.NoError(t, err)
+	for _, info := range infos {
+		if info.Label != label || info.StackLabel != stack {
+			continue
+		}
+		require.False(t, info.LastRotationAt.IsZero(),
+			"precondition: the generator must have a committed draw to measure from")
+		interval := time.Duration(info.IntervalSeconds) * time.Second
+		if wait := time.Until(info.LastRotationAt.Add(2 * interval)); wait > 0 {
+			time.Sleep(wait)
+		}
+		return
+	}
+	t.Fatalf("no rotation info for generator %q on stack %q", label, stack)
+}
+
+// A rotation is an ordinary update, so it confronts drift rather than writing
+// over it. Both halves of a generated credential's blast radius are covered:
+// the destination formae writes the value into, and a resource beside it that
+// consumes the same secret.
+func TestGeneratorRotation_RefusesADriftedStack(t *testing.T) {
+	for _, drifted := range []string{"alpha", consumerLabel} {
+		t.Run("drifted_"+drifted, func(t *testing.T) {
+			testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+				delivered := newDeliveredValues()
+
+				cfg := test_helpers.NewTestMetastructureConfig()
+				cfg.Agent.Synchronization.Enabled = false
+				m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+				defer def()
+				require.NoError(t, err)
+
+				stack := "test-stack-" + util.NewID()
+				_, err = m.ApplyForma(driftableRotationForma(t, stack),
+					&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+				require.NoError(t, err)
+				waitForApplyComplete(t, m)
+				require.Len(t, delivered.createdWith("alpha"), 1, "precondition: the destination was drawn for")
+
+				// A patch records a modification since the last reconcile,
+				// which is the drift a soft reconcile confronts.
+				driftStack(t, m, stack, drifted)
+				waitUntilRotationDue(t, m, stack, "db-password")
+
+				for i := 0; i < 10; i++ {
+					sweepRotations(t, m)
+					time.Sleep(100 * time.Millisecond)
+				}
+				waitForApplyComplete(t, m)
+
+				assert.Empty(t, rotationCommands(t, m),
+					"rotation must refuse while %s carries out-of-band change", drifted)
+				assert.Empty(t, delivered.updatedWith("alpha"),
+					"a refused rotation must not write the destination")
+			})
+		})
+	}
+}
+
+// A stack carrying an auto-reconcile policy has already opted in to having
+// out-of-band change overwritten, so rotation proceeds there rather than
+// asking again.
+func TestGeneratorRotation_ProceedsOnADriftedAutoReconciledStack(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := driftableRotationForma(t, stack)
+		// A long interval, so the auto-reconciler itself does not run inside
+		// the test window: the policy is here as the operator's standing
+		// instruction, not to have it act.
+		forma.Stacks[0].Policies = []json.RawMessage{
+			json.RawMessage(`{"Type":"auto-reconcile","Label":"stay-level","IntervalSeconds":86400}`),
+		}
+
+		_, err = m.ApplyForma(forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+		require.Len(t, delivered.createdWith("alpha"), 1, "precondition: the destination was drawn for")
+
+		policies, err := m.Datastore.GetStacksWithAutoReconcilePolicy()
+		require.NoError(t, err)
+		var attached bool
+		for _, policy := range policies {
+			if policy.StackLabel == stack {
+				attached = true
+			}
+		}
+		require.True(t, attached, "precondition: the stack carries an auto-reconcile policy")
+
+		driftStack(t, m, stack, consumerLabel)
+
+		rotation := sweepUntilRotated(t, m)
+		assert.Equal(t, forma_command.CommandStateSuccess, rotation.State,
+			"rotation must proceed on a stack whose auto-reconcile policy already overwrites drift")
+		waitForApplyComplete(t, m)
+		assert.Len(t, delivered.updatedWith("alpha"), 1,
+			"the destination must be rewritten with the rotated credential")
+	})
+}
+
+// driftableRotationForma is a rotating generator, the secret its value lands
+// in, and a consumer holding an opaque reference to that secret's property.
+// Either resource can be moved out of band to produce the drift a rotation has
+// to confront: the source the credential is written into, and a consumer of the
+// same credential.
+//
+// The consumer is not part of a rotation command — a rotation plans the
+// generator's own destinations — which is exactly why drift on it has to be
+// confronted rather than silently written past.
+func driftableRotationForma(t *testing.T, stack string) *pkgmodel.Forma {
+	t.Helper()
+	return &pkgmodel.Forma{
+		Stacks:     []pkgmodel.Stack{{Label: stack}},
+		Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+		Generators: []json.RawMessage{rotatingGenerator(t, "db-password", stack, 1)},
+		Resources: []pkgmodel.Resource{
+			genBoundSecret(stack, "alpha", "db-password", "value"),
+			secretConsumer(stack, "alpha"),
+		},
+	}
+}
+
+// driftStack moves one resource out of band, through a patch apply: the patch
+// records a modification since the last reconcile, which is exactly the drift
+// a soft reconcile refuses to write over.
+func driftStack(t *testing.T, m *metastructure.Metastructure, stack, label string) {
+	t.Helper()
+	var patched pkgmodel.Resource
+	if label == consumerLabel {
+		patched = secretConsumer(stack, "alpha")
+		patched.Properties = json.RawMessage(strings.Replace(string(patched.Properties),
+			`"AccessControl": "Private"`, `"AccessControl": "PublicRead"`, 1))
+	} else {
+		patched = genBoundSecret(stack, label, "db-password", "value")
+		patched.Properties = json.RawMessage(strings.Replace(string(patched.Properties),
+			`"Name": "`+label+`"`, `"Name": "`+label+`-moved-out-of-band"`, 1))
+	}
+
+	_, err := m.ApplyForma(&pkgmodel.Forma{
+		Stacks:    []pkgmodel.Stack{{Label: stack}},
+		Targets:   []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+		Resources: []pkgmodel.Resource{patched},
+	}, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModePatch}, "test-client-id", "", "")
+	require.NoError(t, err)
+	waitForApplyComplete(t, m)
+
+	modifications, err := m.Datastore.GetResourceModificationsSinceLastReconcile(stack)
+	require.NoError(t, err)
+	require.NotEmpty(t, modifications, "precondition: the patch must record out-of-band movement on %s", label)
+}
+
+// failingUpdatesFor wraps a fake secret store so that the provider Update for
+// the named labels fails. Creates still succeed, so the destinations exist and
+// hold a credential before the rotation is attempted.
+func failingUpdatesFor(delivered *deliveredValues, labels ...string) *plugin.ResourcePluginOverrides {
+	failing := map[string]bool{}
+	for _, label := range labels {
+		failing[label] = true
+	}
+	overrides := delivered.overrides()
+	succeed := overrides.Update
+	overrides.Update = func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+		label := gjson.ParseBytes(req.DesiredProperties).Get("Name").String()
+		if failing[label] {
+			return nil, errors.New("the provider refused the write")
+		}
+		return succeed(req)
+	}
+	return overrides
+}
+
+// rotationAnchorFor returns the instant the generator's cadence is currently
+// measured from, as the scheduler derives it.
+func rotationAnchorFor(t *testing.T, m *metastructure.Metastructure, stack, label string) time.Time {
+	t.Helper()
+	infos, err := m.Datastore.GetGeneratorsWithRotation()
+	require.NoError(t, err)
+	for _, info := range infos {
+		if info.Label == label && info.StackLabel == stack {
+			return info.LastRotationAt
+		}
+	}
+	t.Fatalf("no rotation info for generator %q on stack %q", label, stack)
+	return time.Time{}
+}
+
+// The cadence advances on one milestone and one only: every authority-side
+// update in the rotation succeeded. An authority update that fails leaves the
+// cadence measured from the previous success, so the credential is still owed
+// a rotation.
+//
+// The generation is asserted to have moved while the cadence stood still,
+// which is what separates this milestone from the draw. An implementation that
+// advanced the cadence when the value was drawn would satisfy every other
+// assertion here.
+func TestGeneratorRotation_AFailedAuthorityUpdateDoesNotAdvanceTheCadence(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, failingUpdatesFor(delivered, "alpha"), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		_, err = m.ApplyForma(&pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: stack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{rotatingGenerator(t, "db-password", stack, 1)},
+			Resources:  []pkgmodel.Resource{genBoundSecret(stack, "alpha", "db-password", "value")},
+		}, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+		require.Len(t, delivered.createdWith("alpha"), 1, "precondition: the destination was drawn for")
+
+		anchorBefore := rotationAnchorFor(t, m, stack, "db-password")
+		require.False(t, anchorBefore.IsZero(), "precondition: the first apply committed a draw")
+		generationBefore, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		digestBefore := storedBinding(t, m, stack, "alpha").Get("$value").String()
+
+		waitUntilRotationDue(t, m, stack, "db-password")
+		rotation := sweepUntilRotated(t, m)
+		require.Equal(t, forma_command.CommandStateFailed, rotation.State,
+			"precondition: the authority-side update must have failed")
+
+		generationAfter, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
+		require.NoError(t, err)
+		assert.NotEqual(t, generationBefore.GenerationID, generationAfter.GenerationID,
+			"precondition: the value was drawn, so the generation moved")
+
+		assert.Equal(t, anchorBefore, rotationAnchorFor(t, m, stack, "db-password"),
+			"a rotation whose authority update failed must not advance the cadence")
+		assert.Equal(t, digestBefore, storedBinding(t, m, stack, "alpha").Get("$value").String(),
+			"a failed write must leave the credential at rest where it was")
+	})
+}
+
+// One destination of several failing is the same milestone, reached from a
+// different direction: propagation is committed only when EVERY authority-side
+// update succeeded, so a rotation that wrote one of two destinations has not
+// committed and must not advance the cadence.
+//
+// This is a distinct failure mode from a single destination failing: an
+// implementation that advanced the cadence as soon as any destination was
+// written would pass the single-destination test and fail here.
+func TestGeneratorRotation_OneFailedDestinationOfSeveralDoesNotAdvanceTheCadence(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, failingUpdatesFor(delivered, "beta"), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		_, err = m.ApplyForma(&pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: stack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{rotatingGenerator(t, "db-password", stack, 1)},
+			Resources: []pkgmodel.Resource{
+				genBoundSecret(stack, "alpha", "db-password", "value"),
+				genBoundSecret(stack, "beta", "db-password", "value"),
+			},
+		}, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+		require.Len(t, delivered.createdWith("alpha"), 1, "precondition: both destinations were drawn for")
+		require.Len(t, delivered.createdWith("beta"), 1)
+
+		anchorBefore := rotationAnchorFor(t, m, stack, "db-password")
+		require.False(t, anchorBefore.IsZero())
+
+		waitUntilRotationDue(t, m, stack, "db-password")
+		rotation := sweepUntilRotated(t, m)
+		require.Equal(t, forma_command.CommandStateFailed, rotation.State,
+			"precondition: one destination's write must have failed")
+
+		assert.NotEmpty(t, delivered.updatedWith("alpha"),
+			"precondition: the other destination WAS written, so this is a partial propagation")
+		assert.Empty(t, delivered.updatedWith("beta"))
+
+		assert.Equal(t, anchorBefore, rotationAnchorFor(t, m, stack, "db-password"),
+			"a rotation that reached only some of its destinations must not advance the cadence")
+	})
+}

--- a/internal/workflow_tests/local/apply_forma/generator_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: FSL-1.1-ALv2
 
-//go:build unit
+//go:build unit || integration
 
 package workflow_tests_local
 

--- a/internal/workflow_tests/local/apply_forma/secret_consumer_convergence_test.go
+++ b/internal/workflow_tests/local/apply_forma/secret_consumer_convergence_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: FSL-1.1-ALv2
 
-//go:build unit
+//go:build unit || integration
 
 package workflow_tests_local
 

--- a/internal/workflow_tests/local/apply_forma/secret_hashing_test.go
+++ b/internal/workflow_tests/local/apply_forma/secret_hashing_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: FSL-1.1-ALv2
 
-//go:build unit
+//go:build unit || integration
 
 package workflow_tests_local
 

--- a/pkg/model/generator.go
+++ b/pkg/model/generator.go
@@ -28,6 +28,10 @@ type Generator interface {
 	// invents independently. "" until translation assigns one.
 	GetID() string
 	SetID(id string)
+	// GetRotation returns the cadence on which this generator draws a fresh
+	// value, or nil when it declares none. A generator with no cadence draws
+	// only when an apply needs a value; nothing rotates it on its own.
+	GetRotation() *RotationSpec
 	// GetAlias returns the generator's previous label, if any. Identity is
 	// the datastore row's KSUID, not the label, so a generator that is
 	// renamed (its label changed) needs some way to say "this is still the
@@ -38,23 +42,39 @@ type Generator interface {
 	GetAlias() string
 }
 
+// RotationSpec is the cadence on which a generator draws a fresh value.
+// Mirrors the PKL RotationSpec.render() output.
+//
+// EverySeconds has no zero-value meaning: PKL requires `every`, so a spec that
+// reaches here always names an interval. A non-positive interval is a spec
+// nothing authored through the schema can produce, and the rotation scheduler
+// treats it as no cadence at all rather than as "rotate continuously".
+type RotationSpec struct {
+	EverySeconds int `json:"EverySeconds"`
+}
+
 // PasswordGenerator produces a random password value. Fields mirror the
 // PKL PasswordGenerator.render() output. Type is not a field: it is a
 // constant discriminator, injected by MarshalJSON, so there is exactly one
 // place that says what type this generator is.
 type PasswordGenerator struct {
-	Label                   string `json:"Label"`
-	Stack                   string `json:"Stack,omitempty"`
-	StackID                 string `json:"-"` // Set during processing, not from PKL
-	ID                      string `json:"-"` // Set during processing (translation), not from PKL
-	Alias                   string `json:"Alias,omitempty"`
-	Length                  int    `json:"Length"`
-	Uppercase               bool   `json:"Uppercase"`
-	Lowercase               bool   `json:"Lowercase"`
-	Digits                  bool   `json:"Digits"`
-	Symbols                 bool   `json:"Symbols"`
-	ExcludeCharacters       string `json:"ExcludeCharacters,omitempty"`
-	RequireEachIncludedType bool   `json:"RequireEachIncludedType"`
+	Label   string `json:"Label"`
+	Stack   string `json:"Stack,omitempty"`
+	StackID string `json:"-"` // Set during processing, not from PKL
+	ID      string `json:"-"` // Set during processing (translation), not from PKL
+	Alias   string `json:"Alias,omitempty"`
+	// Rotation is omitted when absent rather than marshalled as null: the
+	// marshalled spec is what a drawn generation is recorded under, so a key
+	// that appears only as null is one more way two identical specs can
+	// differ.
+	Rotation                *RotationSpec `json:"Rotation,omitempty"`
+	Length                  int           `json:"Length"`
+	Uppercase               bool          `json:"Uppercase"`
+	Lowercase               bool          `json:"Lowercase"`
+	Digits                  bool          `json:"Digits"`
+	Symbols                 bool          `json:"Symbols"`
+	ExcludeCharacters       string        `json:"ExcludeCharacters,omitempty"`
+	RequireEachIncludedType bool          `json:"RequireEachIncludedType"`
 }
 
 func (g *PasswordGenerator) GetLabel() string      { return g.Label }
@@ -66,6 +86,8 @@ func (g *PasswordGenerator) SetStackID(id string)  { g.StackID = id }
 func (g *PasswordGenerator) GetID() string         { return g.ID }
 func (g *PasswordGenerator) SetID(id string)       { g.ID = id }
 func (g *PasswordGenerator) GetAlias() string      { return g.Alias }
+
+func (g *PasswordGenerator) GetRotation() *RotationSpec { return g.Rotation }
 
 // MarshalJSON injects the "Type": "password" discriminator that
 // ParseGenerator dispatches on, so callers never set Type by hand and there

--- a/pkg/model/generator_test.go
+++ b/pkg/model/generator_test.go
@@ -111,3 +111,58 @@ func TestParseGenerators_Multiple(t *testing.T) {
 	assert.Equal(t, "one", generators[0].GetLabel())
 	assert.Equal(t, "two", generators[1].GetLabel())
 }
+
+// A generator's rotation cadence round-trips through the JSON the PKL schema
+// renders: the nested Rotation object carries the interval in seconds, and a
+// generator that declares no cadence carries no rotation at all.
+func TestParseGenerator_Rotation(t *testing.T) {
+	raw := json.RawMessage(`{
+		"Type": "password",
+		"Label": "db-password",
+		"Stack": "default",
+		"Rotation": {"EverySeconds": 86400},
+		"Length": 24,
+		"Uppercase": true,
+		"Lowercase": true,
+		"Digits": true,
+		"Symbols": false,
+		"RequireEachIncludedType": true
+	}`)
+
+	generator, err := ParseGenerator(raw)
+	require.NoError(t, err)
+
+	rotation := generator.GetRotation()
+	require.NotNil(t, rotation, "a declared cadence must reach the model")
+	assert.Equal(t, 86400, rotation.EverySeconds)
+
+	roundTripped, err := json.Marshal(generator)
+	require.NoError(t, err)
+	reparsed, err := ParseGenerator(roundTripped)
+	require.NoError(t, err)
+	require.NotNil(t, reparsed.GetRotation())
+	assert.Equal(t, 86400, reparsed.GetRotation().EverySeconds)
+}
+
+func TestParseGenerator_NoRotation(t *testing.T) {
+	raw := json.RawMessage(`{
+		"Type": "password",
+		"Label": "db-password",
+		"Stack": "default",
+		"Rotation": null,
+		"Length": 24,
+		"RequireEachIncludedType": true
+	}`)
+
+	generator, err := ParseGenerator(raw)
+	require.NoError(t, err)
+	assert.Nil(t, generator.GetRotation(),
+		"a generator that declares no cadence must hold none")
+
+	// The absent cadence must also stay out of the marshalled spec: the spec
+	// is what a drawn generation is recorded under, and a key that only
+	// appears as null is one more thing two specs can differ by.
+	roundTripped, err := json.Marshal(generator)
+	require.NoError(t, err)
+	assert.NotContains(t, string(roundTripped), "Rotation")
+}


### PR DESCRIPTION
## Summary

Stacked on #718. This is the piece that makes the feature rotation rather than generation: a generator declares a cadence, and an actor moves its generation forward when that cadence has elapsed. Everything downstream is the ordinary apply path already on the base branch.

## The schema gains a cadence, because it had none

`Generator` carried no schedule field of any kind, and `Secret` said in source that rotation was deferred. So this adds `RotationSpec { every: Duration }` and an optional `rotation` on `Generator`. `every` is required when a spec is present: attaching rotation should always state its interval, and a default cadence for a credential is not a thing to guess.

Note this is a published, checksummed schema surface.

## Cadence is derived, never stored

Following the auto-reconcile precedent exactly. A stored last-rotated-at would participate in diffs, create metadata drift, get rendered into formae people copy between environments, and need merge semantics. Instead: `MAX(command.timestamp)` over this generator's generation rows joined to commands in a succeeded state. Never rotated reads as due immediately.

**No migration was needed.** `generators.command_id` already existed and `AdvanceGeneration` was writing it as the empty string; threading the real command id through gives the join something to stand on.

A deliberate split, worth knowing when reading the four implementations: the SQL answers only what SQL is good at — which rows are live, which stack owns them, when the last committed draw was — and hands the generator spec back untouched. A shared Go helper decides whether that spec declares a cadence. Four dialects of JSON-path extraction would eventually disagree with each other and with the Go model.

## The milestone is propagation committed

A command in a succeeded state means every one of its resource updates succeeded, and those updates *are* the authority-side writes. There is no second milestone: the consumer-refresh half of the design was deferred, so nothing here waits on a consumer or claims to know one converged.

## Failure and concurrency

In-flight guard in actor memory, mirroring auto-reconcile's active set. No datastore lease and no compare-and-swap: every agent runs a single task and the metastructure actor serializes command mutation, so neither sibling scheduled actor has one either.

Backoff doubles from 30s and saturates at one cadence, so a persistently failing rotation keeps retrying at the rate the credential is meant to rotate at. There is no attempt count at which formae stops rotating a credential — a rotation that cannot proceed is a condition to fix, not one to give up on, and it self-heals once fixed.

Admission re-reads the generator and re-checks that it still exists, still declares a cadence, and is still due. A user apply that removes or widens the cadence between the sweep and admission is caught there rather than applying stale material.

## Jitter is deterministic, not random

Derived from the generator's identity into a bounded fraction of the interval. A random offset would reshuffle a fleet's schedule on every restart and gives an operator nothing to predict; a per-generator derivation breaks lockstep, which is the actual goal, and is stable across restarts. A newly attached generator is due immediately with no jitter — lockstep forms on the recurring cadence, not the first run.

## Drift

Rotation is an ordinary update, so it refuses on a drifted stack, and an auto-reconcile policy is the existing opt-in to overwrite drift. Rather than carry a second copy of the drift reading, the apply path's own loader was lifted from a method to a free function so both callers use it. The duplicate in the first draft had already drifted from the original — it was missing an operation filter.

Consumer drift is covered as well as source drift. The code path is the same either way, and that is the point: a consumer is not part of a rotation command, so drift on it is unabsorbed and refuses.

## Verification worth reading

**A mutation check caught a vacuous test.** The drifted-stack refusal initially passed *with the refusal removed*, because the test swept before the cadence had elapsed — "no rotation" meant "not due yet", not "refused". It now waits past the derived anchor and is red without the code.

The derived-cadence query was deliberately broken so every generator reads as never-rotated: the restart test fails on all four assertions, including that the credential at rest must be untouched. Restored and verified byte-identical.

Where tests were written after the code rather than before, that is stated in the branch's own report rather than presented as test-first.

## One finding declined, and flagged rather than fixed

Two protections — pausing discovery, and registering a changeset's resources with the synchronizer — are gated on a command's source being a user apply. A rotation changeset fails that gate. **So does an auto-reconcile changeset, today, on shipped code.** The consequence is a narrow window where drift appearing between submission and the provider write is overwritten rather than refused, which the apply path already documents as pre-existing. Fixing it means widening that predicate to "writes infrastructure", which changes a shipped mechanism's behaviour and deserves its own review.