### PR TITLE
fix(metastructure): delete generators with their stack and refuse dangling references

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -412,6 +412,13 @@ func (c *Client) parseSubmitCommandErrorResponse(body io.ReadCloser) (*apimodel.
 		}
 		return nil, &errResp
 
+	case apimodel.GeneratorHasDependents:
+		var errResp apimodel.ErrorResponse[apimodel.FormaGeneratorHasDependentsError]
+		if err := json.Unmarshal(bodyBytes, &errResp); err != nil {
+			return nil, fmt.Errorf("failed to parse GeneratorHasDependents error: %w", err)
+		}
+		return nil, &errResp
+
 	case apimodel.RequiredFieldMissingOnCreate:
 		var errResp apimodel.ErrorResponse[apimodel.RequiredFieldMissingOnCreateError]
 		if err := json.Unmarshal(bodyBytes, &errResp); err != nil {

--- a/internal/api/destroy_generator_dependents_test.go
+++ b/internal/api/destroy_generator_dependents_test.go
@@ -1,0 +1,65 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/api/apitest"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// A destroy refused because a generator it deletes still has dependents has to
+// reach the caller as the typed refusal, not as an opaque error. The client's
+// destroy entry points decode a narrower set of statuses than its apply one
+// does — 400 and 409 only, where apply also accepts 422 — so the status the
+// server maps this refusal to has to be one of that narrower set. This runs
+// the whole way through the real server and the real client to pin that.
+func TestDestroyForma_GeneratorHasDependents_DecodesOnTheDestroyPath(t *testing.T) {
+	refusal := apimodel.FormaGeneratorHasDependentsError{
+		Dependents: []apimodel.GeneratorDependent{{
+			GeneratorLabel: "db-password",
+			GeneratorStack: "platform",
+			ResourceLabel:  "api-secret",
+			ResourceType:   "AWS::SecretsManager::Secret",
+			Stack:          "web",
+		}},
+	}
+
+	fake := &apitest.FakeMetastructure{
+		DestroyResponses: []apitest.WrappedCommandResponse{
+			{SubmitCommandResponse: &apimodel.SubmitCommandResponse{}, Error: refusal},
+			{SubmitCommandResponse: &apimodel.SubmitCommandResponse{}, Error: refusal},
+		},
+	}
+
+	srv := NewServer(t.Context(), fake, nil, nil, nil, nil)
+	baseURL := apitest.NewTestServer(t, srv.Handler())
+	client := NewClient(&pkgmodel.ClassicConnection{URL: baseURL, Port: 80}, nil, nil)
+
+	assertDecoded := func(t *testing.T, err error) {
+		t.Helper()
+		require.Error(t, err)
+		errResp, ok := err.(*apimodel.ErrorResponse[apimodel.FormaGeneratorHasDependentsError])
+		require.True(t, ok, "the refusal must decode into its typed error, got %T: %v", err, err)
+		assert.Equal(t, apimodel.GeneratorHasDependents, errResp.ErrorType)
+		require.Len(t, errResp.Data.Dependents, 1)
+		assert.Equal(t, "api-secret", errResp.Data.Dependents[0].ResourceLabel)
+		assert.Equal(t, "web", errResp.Data.Dependents[0].Stack)
+		assert.Equal(t, "db-password", errResp.Data.Dependents[0].GeneratorLabel)
+	}
+
+	_, err := client.DestroyForma(&pkgmodel.Forma{}, false, "abort", "test-client-id")
+	assertDecoded(t, err)
+
+	_, err = client.DestroyByQuery("stack:platform", false, "abort", "test-client-id")
+	assertDecoded(t, err)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -853,6 +853,14 @@ func mapError(c echo.Context, err error) error {
 		return apiError(c, http.StatusConflict, apimodel.ResourceHasDependents, resourceHasDependentsError)
 	}
 
+	// Conflict, not 422: the client's destroy entry points decode only 400 and
+	// 409, so a 422 would reach the caller as an opaque error on the very path
+	// this refusal exists for.
+	var generatorHasDependentsError apimodel.FormaGeneratorHasDependentsError
+	if errors.As(err, &generatorHasDependentsError) {
+		return apiError(c, http.StatusConflict, apimodel.GeneratorHasDependents, generatorHasDependentsError)
+	}
+
 	var requiredFieldMissingError apimodel.RequiredFieldMissingOnCreateError
 	if errors.As(err, &requiredFieldMissingError) {
 		return apiError(c, http.StatusBadRequest, apimodel.RequiredFieldMissingOnCreate, requiredFieldMissingError)

--- a/internal/cli/tui/errfmt/errfmt.go
+++ b/internal/cli/tui/errfmt/errfmt.go
@@ -180,6 +180,10 @@ func (r *renderer) render(err error) (string, error) {
 		msg = r.renderResourceHasDependents(&errResp.Data)
 	}
 
+	if errResp, ok := err.(*apimodel.ErrorResponse[apimodel.FormaGeneratorHasDependentsError]); ok {
+		msg = r.renderGeneratorHasDependents(&errResp.Data)
+	}
+
 	if errResp, ok := err.(*apimodel.ErrorResponse[apimodel.PluginNotFoundError]); ok {
 		msg = r.errorf("plugin '%s' not found\n", errResp.Data.Name)
 	}
@@ -463,6 +467,31 @@ func (r *renderer) renderResourceHasDependents(data *apimodel.FormaResourceHasDe
 		"it would be torn down too.\n\n") +
 		"To proceed and tear the dependent resource(s) down as well, re-run with\n" +
 		"--on-dependents=cascade.\n"
+	return message
+}
+
+// renderGeneratorHasDependents formats FormaGeneratorHasDependentsError: a
+// delete of a generator that a live resource still binds a property to, either
+// a destroy of the generator's stack or a reconcile that drops its
+// declaration.
+func (r *renderer) renderGeneratorHasDependents(data *apimodel.FormaGeneratorHasDependentsError) string {
+	var message string
+	if len(data.Dependents) == 1 {
+		d := data.Dependents[0]
+		message = r.errorf("deleting generator '%s' in stack '%s' would leave '%s' in stack '%s' bound to nothing.\n\n",
+			d.GeneratorLabel, d.GeneratorStack, d.ResourceLabel, d.Stack)
+	} else {
+		message = r.error("this delete would leave the following resources bound to a deleted generator:\n\n")
+		for _, d := range data.Dependents {
+			message += fmt.Sprintf("  - %s (%s, stack %s; bound to generator %s in stack %s)\n",
+				d.ResourceLabel, d.ResourceType, d.Stack, d.GeneratorLabel, d.GeneratorStack)
+		}
+		message += "\n"
+	}
+	message += r.warning("A generated value is never recoverable once the generator is gone, so a resource left\n"+
+		"bound to one can never be given a value again.\n\n") +
+		"To proceed and tear the bound resource(s) down as well, re-run with\n" +
+		"--on-dependents=cascade. To keep them, stop them binding this generator first.\n"
 	return message
 }
 

--- a/internal/cli/tui/errfmt/errfmt_test.go
+++ b/internal/cli/tui/errfmt/errfmt_test.go
@@ -128,6 +128,37 @@ func TestRender_GeneratorBoundToSetOnceField_Golden(t *testing.T) {
 	tuitest.RequireGolden(t, []byte(out))
 }
 
+// ── 3e. FormaGeneratorHasDependentsError ────────────────────────────────
+
+func TestRender_GeneratorHasDependents_Single_Golden(t *testing.T) {
+	err := &apimodel.ErrorResponse[apimodel.FormaGeneratorHasDependentsError]{
+		ErrorType: apimodel.GeneratorHasDependents,
+		Data: apimodel.FormaGeneratorHasDependentsError{
+			Dependents: []apimodel.GeneratorDependent{
+				{GeneratorLabel: "db-password", GeneratorStack: "platform", ResourceLabel: "api-secret", ResourceType: "AWS::SecretsManager::Secret", Stack: "web"},
+			},
+		},
+	}
+	out, rerr := Render(err)
+	require.NoError(t, rerr)
+	tuitest.RequireGolden(t, []byte(out))
+}
+
+func TestRender_GeneratorHasDependents_Multiple_Golden(t *testing.T) {
+	err := &apimodel.ErrorResponse[apimodel.FormaGeneratorHasDependentsError]{
+		ErrorType: apimodel.GeneratorHasDependents,
+		Data: apimodel.FormaGeneratorHasDependentsError{
+			Dependents: []apimodel.GeneratorDependent{
+				{GeneratorLabel: "db-password", GeneratorStack: "platform", ResourceLabel: "api-secret", ResourceType: "AWS::SecretsManager::Secret", Stack: "web"},
+				{GeneratorLabel: "db-password", GeneratorStack: "platform", ResourceLabel: "worker-secret", ResourceType: "AWS::SecretsManager::Secret", Stack: "jobs"},
+			},
+		},
+	}
+	out, rerr := Render(err)
+	require.NoError(t, rerr)
+	tuitest.RequireGolden(t, []byte(out))
+}
+
 // ── 4. FormaPatchRejectedError ────────────────────────────────────────────────
 
 func TestRender_PatchRejected_Golden(t *testing.T) {

--- a/internal/cli/tui/errfmt/testdata/TestRender_GeneratorHasDependents_Multiple_Golden.golden
+++ b/internal/cli/tui/errfmt/testdata/TestRender_GeneratorHasDependents_Multiple_Golden.golden
@@ -1,0 +1,10 @@
+[38;2;248;113;113mthis delete would leave the following resources bound to a deleted generator:[0m
+[38;2;248;113;113m[0m                                                                             
+[38;2;248;113;113m[0m                                                                               - api-secret (AWS::SecretsManager::Secret, stack web; bound to generator db-password in stack platform)
+  - worker-secret (AWS::SecretsManager::Secret, stack jobs; bound to generator db-password in stack platform)
+
+[38;2;181;181;91mA generated value is never recoverable once the generator is gone, so a resource left[0m
+[38;2;181;181;91mbound to one can never be given a value again.[0m                                       
+[38;2;181;181;91m[0m                                                                                     
+[38;2;181;181;91m[0m                                                                                     To proceed and tear the bound resource(s) down as well, re-run with
+--on-dependents=cascade. To keep them, stop them binding this generator first.

--- a/internal/cli/tui/errfmt/testdata/TestRender_GeneratorHasDependents_Single_Golden.golden
+++ b/internal/cli/tui/errfmt/testdata/TestRender_GeneratorHasDependents_Single_Golden.golden
@@ -1,0 +1,7 @@
+[38;2;248;113;113mdeleting generator 'db-password' in stack 'platform' would leave 'api-secret' in stack 'web' bound to nothing.[0m
+[38;2;248;113;113m[0m                                                                                                              
+[38;2;248;113;113m[0m                                                                                                              [38;2;181;181;91mA generated value is never recoverable once the generator is gone, so a resource left[0m
+[38;2;181;181;91mbound to one can never be given a value again.[0m                                       
+[38;2;181;181;91m[0m                                                                                     
+[38;2;181;181;91m[0m                                                                                     To proceed and tear the bound resource(s) down as well, re-run with
+--on-dependents=cascade. To keep them, stop them binding this generator first.

--- a/internal/metastructure/generator_delete_cascade.go
+++ b/internal/metastructure/generator_delete_cascade.go
@@ -1,0 +1,285 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package metastructure
+
+import (
+	"cmp"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// generatorDeletesForDestroy plans the generator deletes a destroy owes.
+//
+// A generator has no standalone form: it belongs to one stack, and it goes
+// when that stack goes. That is what an inline policy does too, but a policy
+// gets there by a route a generator has no access to — DeleteStack cascades to
+// the policies table and not to the generators one — so nothing removed a
+// generator's row until this ran. A destroy left the row live, and because the
+// reverse index and the identity lookup both window on the generator's KSUID
+// rather than on its stack, a resource in another stack went on resolving its
+// binding against a generator whose stack no longer existed.
+//
+// A stack goes when the command empties it, which is the same test
+// cleanupEmptyStacks applies once the changeset is done: no resources left.
+// Asking it here rather than there is what makes the delete possible at all —
+// DeleteGenerator resolves the stack label to a stack id, so a delete issued
+// after the stack is tombstoned is a silent no-op — and it is also what lets
+// the refusal below be planned from the same set the deletes are.
+//
+// Only the stacks this command deletes something from are considered: a
+// destroy that removes some of a stack's resources leaves the stack, and its
+// generators, alone.
+func generatorDeletesForDestroy(
+	resourceUpdates []resource_update.ResourceUpdate,
+	ds datastore.Datastore,
+) ([]generator_update.GeneratorUpdate, error) {
+	deletedPerStack := make(map[string]map[string]bool)
+	for i := range resourceUpdates {
+		ru := &resourceUpdates[i]
+		if ru.Operation != resource_update.OperationDelete || ru.DesiredState.Ksuid == "" {
+			continue
+		}
+		stack := ru.DesiredState.Stack
+		if stack == "" {
+			continue
+		}
+		if deletedPerStack[stack] == nil {
+			deletedPerStack[stack] = make(map[string]bool)
+		}
+		deletedPerStack[stack][ru.DesiredState.Ksuid] = true
+	}
+	if len(deletedPerStack) == 0 {
+		return nil, nil
+	}
+
+	stacks := make([]string, 0, len(deletedPerStack))
+	for stack := range deletedPerStack {
+		stacks = append(stacks, stack)
+	}
+	// The map iteration order is not the order the updates are read in, and
+	// the deletes reach an operator through the simulated plan.
+	slices.Sort(stacks)
+
+	now := util.TimeNow()
+	var deletes []generator_update.GeneratorUpdate
+	for _, stack := range stacks {
+		generators, err := ds.LoadGeneratorsByStack(stack)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load the generators owned by stack %q: %w", stack, err)
+		}
+		if len(generators) == 0 {
+			continue
+		}
+
+		live, err := ds.CountResourcesInStack(stack)
+		if err != nil {
+			return nil, fmt.Errorf("failed to count the resources in stack %q: %w", stack, err)
+		}
+		// Every delete is derived from a live row, so the two counts can only
+		// agree when the command takes the whole stack.
+		if live != len(deletedPerStack[stack]) {
+			slog.Debug("Stack survives this destroy, leaving its generators in place",
+				"stack", stack, "liveResources", live, "deleted", len(deletedPerStack[stack]))
+			continue
+		}
+
+		for _, generator := range generators {
+			deletes = append(deletes, generator_update.GeneratorUpdate{
+				Generator:  generator,
+				Operation:  generator_update.GeneratorOperationDelete,
+				State:      generator_update.GeneratorUpdateStateNotStarted,
+				StackLabel: stack,
+				StartTs:    now,
+				ModifiedTs: now,
+			})
+		}
+	}
+
+	return deletes, nil
+}
+
+// planGeneratorDeleteCascade answers, for every generator this command
+// deletes, which live resources would be left binding it, and what destroying
+// those resources alongside it would look like.
+//
+// It returns both because the caller has to choose between them: naming the
+// dependents in a refusal, or planning the cascade. The two are one walk over
+// one set of rows, and computing them apart would let them disagree about what
+// a dependent is.
+//
+// A dependent is a live destination of the generator that this command does
+// NOT tear down and that still binds the generator when the command is done:
+//
+//   - a resource the command deletes is going anyway, which is what makes
+//     destroying a self-contained stack — generator and destination together —
+//     an ordinary destroy rather than a refusal;
+//   - a resource the command plans a write for is judged on its DESIRED
+//     document, so an apply that drops a generator and rewrites its
+//     destination to a literal in the same forma is not a dangling reference
+//     and is not refused;
+//   - a resource the command does not reach at all keeps what it has stored,
+//     which is a binding to a generator that is about to stop existing.
+//
+// This is the one place both arms of a generator delete are judged. A destroy
+// of the generator's stack and a reconcile that drops the generator's
+// declaration produce the same GeneratorOperationDelete, so they get the same
+// answer here without either arm carrying a rule of its own.
+func planGeneratorDeleteCascade(
+	generatorUpdates []generator_update.GeneratorUpdate,
+	resourceUpdates []resource_update.ResourceUpdate,
+	existingTargets []*pkgmodel.Target,
+	source resource_update.FormaCommandSource,
+	ds datastore.Datastore,
+) ([]resource_update.ResourceUpdate, []apimodel.GeneratorDependent, error) {
+	var deletes []*generator_update.GeneratorUpdate
+	for i := range generatorUpdates {
+		if generatorUpdates[i].Operation == generator_update.GeneratorOperationDelete &&
+			generatorUpdates[i].Generator != nil {
+			deletes = append(deletes, &generatorUpdates[i])
+		}
+	}
+	if len(deletes) == 0 {
+		return nil, nil, nil
+	}
+
+	beingDeleted := make(map[string]bool, len(resourceUpdates))
+	planned := make(map[string]bool, len(resourceUpdates))
+	desiredByKsuid := make(map[string][]byte, len(resourceUpdates))
+	for i := range resourceUpdates {
+		ru := &resourceUpdates[i]
+		for _, ksuid := range []string{ru.PriorState.Ksuid, ru.DesiredState.Ksuid} {
+			if ksuid == "" {
+				continue
+			}
+			planned[ksuid] = true
+			if ru.Operation == resource_update.OperationDelete || ru.Operation == resource_update.OperationReaped {
+				beingDeleted[ksuid] = true
+			}
+		}
+		if ru.DesiredState.Ksuid != "" && ru.Operation != resource_update.OperationDelete {
+			desiredByKsuid[ru.DesiredState.Ksuid] = ru.DesiredState.Properties
+		}
+	}
+
+	existingTargetMap := make(map[string]*pkgmodel.Target, len(existingTargets))
+	for _, target := range existingTargets {
+		existingTargetMap[target.Label] = target
+	}
+
+	var cascade []resource_update.ResourceUpdate
+	var dependents []apimodel.GeneratorDependent
+	cascaded := make(map[string]bool)
+
+	for _, gu := range deletes {
+		label := gu.Generator.GetLabel()
+		// A generator loaded from the datastore carries no KSUID of its own —
+		// PasswordGenerator.ID is json:"-", so it lives only in the generators
+		// table — and a delete update is always built from a load, on both
+		// arms. Resolving it here, from the label and stack the update is
+		// filed under, is what gives both arms the same identity to ask the
+		// reverse index about.
+		identity, err := ds.GetGeneratorIdentity(label, gu.StackLabel)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to resolve the identity of generator %q in stack %q: %w",
+				label, gu.StackLabel, err)
+		}
+		if identity.ID == "" {
+			continue
+		}
+
+		bound, err := ds.FindResourcesReferencingGenerator(identity.ID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to find the resources bound to generator %q in stack %q: %w",
+				label, gu.StackLabel, err)
+		}
+
+		for _, destination := range bound {
+			if destination == nil || destination.Ksuid == "" || beingDeleted[destination.Ksuid] {
+				continue
+			}
+			if planned[destination.Ksuid] &&
+				!bindsGenerator(desiredByKsuid[destination.Ksuid], identity.ID) {
+				continue
+			}
+
+			dependents = append(dependents, apimodel.GeneratorDependent{
+				GeneratorLabel: label,
+				GeneratorStack: gu.StackLabel,
+				ResourceLabel:  destination.Label,
+				ResourceType:   destination.Type,
+				Stack:          destination.Stack,
+			})
+
+			// One resource can bind two generators this command deletes, and
+			// the changeset keeps one node per operation URI: a second delete
+			// for it would be dropped on the floor with nothing terminalizing
+			// it.
+			if cascaded[destination.Ksuid] {
+				continue
+			}
+			cascaded[destination.Ksuid] = true
+
+			target, ok := existingTargetMap[destination.Target]
+			if !ok {
+				// Refusing beats cascading into a resource we cannot plan a
+				// delete for: leaving it bound to a deleted generator is the
+				// state this whole check exists to prevent.
+				return nil, nil, fmt.Errorf(
+					"cannot destroy resource %q in stack %q alongside generator %q: its target %q is unknown",
+					destination.Label, destination.Stack, label, destination.Target)
+			}
+
+			destroy, err := resource_update.NewResourceUpdateForDestroy(*destination, *target, source)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to plan the destroy of %q bound to generator %q: %w",
+					destination.Label, label, err)
+			}
+			destroy.IsCascade = true
+			destroy.CascadeSource = label
+			cascade = append(cascade, destroy)
+		}
+	}
+
+	// The list is read by an operator who has to go and find each resource,
+	// and no datastore backend orders the rows it answers with, so two runs of
+	// the same refused command would otherwise name them in a different order.
+	slices.SortFunc(dependents, func(a, b apimodel.GeneratorDependent) int {
+		return cmp.Or(
+			strings.Compare(a.GeneratorStack, b.GeneratorStack),
+			strings.Compare(a.GeneratorLabel, b.GeneratorLabel),
+			strings.Compare(a.Stack, b.Stack),
+			strings.Compare(a.ResourceLabel, b.ResourceLabel),
+			strings.Compare(a.ResourceType, b.ResourceType),
+		)
+	})
+
+	return cascade, dependents, nil
+}
+
+// bindsGenerator reports whether a resource's desired properties still bind
+// any property to this generator. It reads the properties document directly
+// rather than through pkgmodel.BindsGenerator, which takes a whole stored
+// resource row; the walk underneath is the same one, so the answer is the same
+// as the reverse index's.
+func bindsGenerator(properties []byte, generatorKsuid string) bool {
+	if len(properties) == 0 || generatorKsuid == "" {
+		return false
+	}
+	for _, occurrence := range pkgmodel.FindGenObjectsFromProperties(properties) {
+		if occurrence.Generator == generatorKsuid {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/metastructure/generator_update/generator_update_generator.go
+++ b/internal/metastructure/generator_update/generator_update_generator.go
@@ -49,11 +49,13 @@ func NewGeneratorUpdateGenerator(ds GeneratorDatastore) *GeneratorUpdateGenerato
 // translation saw, but defensive regardless) keeps GetID()=="", and
 // CreateGenerator mints its own KSUID exactly as it always has.
 func (gg *GeneratorUpdateGenerator) GenerateGeneratorUpdates(forma *pkgmodel.Forma, command pkgmodel.Command, mode pkgmodel.FormaApplyMode, genKeyToKsuid map[pkgmodel.GeneratorKey]string) ([]GeneratorUpdate, error) {
-	// A generator has no standalone form: it is always owned by exactly one
-	// stack, and it is deleted implicitly when that stack is destroyed —
-	// mirroring how an inline policy is handled on Destroy, and unlike a
-	// standalone policy, there is nothing left for a destroy command to do
-	// here.
+	// A destroy's forma is a list of rows to remove, not a desired state, so
+	// there is nothing here to diff it against: a generator it takes with it
+	// is one owned by a stack it empties, which is a property of the resource
+	// deletes rather than of Forma.Generators.
+	// metastructure.generatorDeletesForDestroy plans those, and the check
+	// beside it judges them and the reconcile-driven deletes below on the same
+	// terms.
 	if command == pkgmodel.CommandDestroy {
 		return nil, nil
 	}

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -1102,6 +1102,28 @@ func (m *Metastructure) DestroyForma(forma *pkgmodel.Forma, config *config.Forma
 		}
 	}
 
+	// The generators owned by the stacks this destroy empties. They must be
+	// removed BEFORE the changeset runs: DeleteGenerator resolves the stack
+	// label to a stack id, and cleanupEmptyStacks tombstones the stack as soon
+	// as its last resource is gone, after which the delete would find no stack
+	// and silently do nothing. No StackIDMap is needed — a delete is addressed
+	// by label and stack, the same way the policy deletes above are.
+	if len(fa.GeneratorUpdates) > 0 {
+		_, err = m.callActor(
+			gen.ProcessID{Name: actornames.ResourcePersister, Node: m.Node.Name()},
+			generator_update.PersistGeneratorUpdates{
+				GeneratorUpdates: fa.GeneratorUpdates,
+				CommandID:        fa.ID,
+				StackIDMap:       nil,
+			},
+		)
+		if err != nil {
+			slog.Error("Failed to persist generator updates", "error", err)
+			return nil, fmt.Errorf("failed to persist generator updates: %w", err)
+		}
+		m.Node.Log().Debug("Successfully persisted generator updates count=%d", len(fa.GeneratorUpdates))
+	}
+
 	if len(fa.ResourceUpdates) > 0 || len(fa.TargetUpdates) > 0 {
 		synth, synthErr := target_update.SynthesizeResolveTargetUpdates(
 			resource_update.ReferencedTargetLabels(fa.ResourceUpdates),
@@ -2534,6 +2556,19 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 		return nil, err
 	}
 
+	// A destroy plans no generator work of its own — the generator diff has
+	// nothing to diff against, since a destroy's forma is a list of rows to
+	// remove — so the generators its stacks own are derived from the resource
+	// deletes instead. Doing it here, beside the reconcile-driven deletes the
+	// diff produced, is what lets one check below judge both arms.
+	if command == pkgmodel.CommandDestroy {
+		destroyGeneratorDeletes, err := generatorDeletesForDestroy(resourceUpdates, ds)
+		if err != nil {
+			return nil, err
+		}
+		generatorUpdates = append(generatorUpdates, destroyGeneratorDeletes...)
+	}
+
 	// The draws are derived from the DESTINATIONS that still need a value,
 	// not from the generator diff above: a generator whose spec is unchanged
 	// produces no GeneratorUpdate, yet a resource newly bound to it still
@@ -2593,6 +2628,33 @@ func FormaCommandFromForma(forma *pkgmodel.Forma,
 			drawGeneratorUpdates, liveDestinations, resourceUpdates, ds); err != nil {
 			return nil, err
 		}
+	}
+
+	// Default to abort on a generator delete with dependents: a resource left
+	// bound to a deleted generator can never be given a value again, because
+	// formae keeps a hash of a drawn value and never the value. Unless the
+	// command carries on-dependents=cascade, reject it and name the
+	// dependents, mirroring the target and resource cascade-abort defaults
+	// above.
+	//
+	// A destroy's SIMULATION is let through carrying the cascade, exactly as
+	// those two are, so the CLI can render what would go and elevate to
+	// cascade on the operator's confirmation. An apply's is not: --on-dependents
+	// is a destroy flag, so there is no confirmation that could make the same
+	// plan applicable, and rendering a plan that can never be applied is worse
+	// than a refusal naming what is in the way.
+	generatorCascade, generatorDependents, err := planGeneratorDeleteCascade(
+		generatorUpdates, resourceUpdates, existingTargets, source, ds)
+	if err != nil {
+		return nil, err
+	}
+	if len(generatorDependents) > 0 {
+		elevated := formaCommandConfig.OnDependents == "cascade"
+		surfacing := formaCommandConfig.Simulate && command == pkgmodel.CommandDestroy
+		if !elevated && !surfacing {
+			return nil, apimodel.FormaGeneratorHasDependentsError{Dependents: generatorDependents}
+		}
+		resourceUpdates = append(resourceUpdates, generatorCascade...)
 	}
 
 	fc := forma_command.NewFormaCommand(

--- a/internal/workflow_tests/local/apply_forma/generator_destroy_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_destroy_test.go
@@ -1,0 +1,468 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// A generator belongs to one stack and is meant to be referenced from others,
+// so deleting one is a cross-stack event: every resource that binds a property
+// to it loses the only thing that can give that property a value. These tests
+// pin what happens when a delete of a generator's stack meets a resource
+// elsewhere that still binds it, under both --on-dependents settings, and pin
+// that the generator's row actually goes when the delete is allowed.
+
+// generatorDestroyFixture is the shape these tests start from: a generator and
+// one destination in its own stack, and a second destination in another stack.
+type generatorDestroyFixture struct {
+	generatorStack string
+	otherStack     string
+	generator      json.RawMessage
+}
+
+func newGeneratorDestroyFixture(t *testing.T) generatorDestroyFixture {
+	t.Helper()
+	id := util.NewID()
+	generatorStack := "gen-destroy-stack-" + id
+	return generatorDestroyFixture{
+		generatorStack: generatorStack,
+		otherStack:     "gen-destroy-other-" + id,
+		generator: rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+			Label: "db-password", Stack: generatorStack,
+			Length: 24, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+		}),
+	}
+}
+
+func (f generatorDestroyFixture) targets() []pkgmodel.Target {
+	return []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}}
+}
+
+// bothStacks declares the generator, a destination beside it and a
+// destination in another stack.
+func (f generatorDestroyFixture) bothStacks() *pkgmodel.Forma {
+	return &pkgmodel.Forma{
+		Stacks:     []pkgmodel.Stack{{Label: f.generatorStack}, {Label: f.otherStack}},
+		Targets:    f.targets(),
+		Generators: []json.RawMessage{f.generator},
+		Resources: []pkgmodel.Resource{
+			crossStackGenBoundSecret(f.generatorStack, "alpha", f.generatorStack, "db-password", "alpha"),
+			crossStackGenBoundSecret(f.otherStack, "beta", f.generatorStack, "db-password", "beta"),
+		},
+	}
+}
+
+// generatorStackOnly is the destroy input: it names the generator's stack and
+// everything in it, and nothing of the other stack.
+func (f generatorDestroyFixture) generatorStackOnly() *pkgmodel.Forma {
+	return &pkgmodel.Forma{
+		Stacks:     []pkgmodel.Stack{{Label: f.generatorStack}},
+		Targets:    f.targets(),
+		Generators: []json.RawMessage{f.generator},
+		Resources: []pkgmodel.Resource{
+			crossStackGenBoundSecret(f.generatorStack, "alpha", f.generatorStack, "db-password", "alpha"),
+		},
+	}
+}
+
+// generatorKsuid is the generator's stable identity, read while its stack is
+// still alive. Every "is the row gone" assertion has to be made against this
+// and never against the label: GetGenerator resolves the stack label to a
+// stack id first, so once the stack is tombstoned it answers nil for a
+// generator whose row is still very much there.
+func generatorKsuid(t *testing.T, m *metastructure.Metastructure, label, stackLabel string) string {
+	t.Helper()
+	identity, err := m.Datastore.GetGeneratorIdentity(label, stackLabel)
+	require.NoError(t, err)
+	require.NotEmpty(t, identity.ID, "the generator must be persisted before its identity is read")
+	return identity.ID
+}
+
+// requireGeneratorRowGone asserts the generator's row is tombstoned, by id.
+func requireGeneratorRowGone(t *testing.T, m *metastructure.Metastructure, ksuid string) {
+	t.Helper()
+	identity, err := m.Datastore.GetGeneratorIdentityByID(ksuid)
+	require.NoError(t, err)
+	assert.Empty(t, identity.ID,
+		"the generator row must be tombstoned, not left behind for a surviving reference to resolve against")
+}
+
+func newGeneratorDestroyMetastructure(t *testing.T) (*metastructure.Metastructure, *deliveredValues, func()) {
+	t.Helper()
+	delivered := newDeliveredValues()
+	cfg := test_helpers.NewTestMetastructureConfig()
+	cfg.Agent.Synchronization.Enabled = false
+	m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+	require.NoError(t, err)
+	return m, delivered, def
+}
+
+// Destroying the stack that owns a generator, while a resource in another
+// stack still binds it, is refused under the default --on-dependents=abort,
+// and the refusal names the referencing resource.
+func TestDestroyForma_GeneratorBoundFromAnotherStack_IsRefusedUnderAbort(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, _, def := newGeneratorDestroyMetastructure(t)
+		defer def()
+
+		f := newGeneratorDestroyFixture(t)
+		_, err := m.ApplyForma(f.bothStacks(),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		ksuid := generatorKsuid(t, m, "db-password", f.generatorStack)
+
+		_, err = m.DestroyForma(f.generatorStackOnly(),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.Error(t, err, "destroying a generator's stack while another stack binds it must be refused")
+
+		var dependents apimodel.FormaGeneratorHasDependentsError
+		require.ErrorAs(t, err, &dependents)
+		require.Len(t, dependents.Dependents, 1)
+		assert.Equal(t, "beta", dependents.Dependents[0].ResourceLabel,
+			"the refusal must name the resource that still binds the generator")
+		assert.Equal(t, f.otherStack, dependents.Dependents[0].Stack)
+		assert.Equal(t, "FakeAWS::SecretsManager::Secret", dependents.Dependents[0].ResourceType)
+		assert.Equal(t, "db-password", dependents.Dependents[0].GeneratorLabel)
+		assert.Equal(t, f.generatorStack, dependents.Dependents[0].GeneratorStack)
+
+		identity, err := m.Datastore.GetGeneratorIdentityByID(ksuid)
+		require.NoError(t, err)
+		assert.Equal(t, ksuid, identity.ID, "a refused destroy must leave the generator in place")
+
+		commands, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		assert.Len(t, commands, 1, "a refused destroy must persist no command")
+	})
+}
+
+// Under --on-dependents=cascade the referencing resource is destroyed
+// alongside the generator's stack, and the generator's row goes with it.
+func TestDestroyForma_GeneratorBoundFromAnotherStack_CascadeDestroysTheDependentAndTheGenerator(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, _, def := newGeneratorDestroyMetastructure(t)
+		defer def()
+
+		f := newGeneratorDestroyFixture(t)
+		_, err := m.ApplyForma(f.bothStacks(),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		ksuid := generatorKsuid(t, m, "db-password", f.generatorStack)
+
+		_, err = m.DestroyForma(f.generatorStackOnly(),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, OnDependents: "cascade"},
+			"test-client-id", "", "")
+		require.NoError(t, err, "cascade must let the destroy through")
+		waitForApplyComplete(t, m)
+
+		requireGeneratorRowGone(t, m, ksuid)
+
+		remaining, err := m.Datastore.LoadResourcesByStack(f.otherStack)
+		require.NoError(t, err)
+		assert.Empty(t, remaining, "the resource that bound the generator must be destroyed with it")
+
+		bound, err := m.Datastore.FindResourcesReferencingGenerator(ksuid)
+		require.NoError(t, err)
+		assert.Empty(t, bound, "nothing may be left binding a destroyed generator")
+	})
+}
+
+// A generator and its only destination in one stack, destroyed together, must
+// succeed: the destination is going with the generator, so there is nothing
+// left to dangle. Without this a self-contained stack could not be destroyed
+// at all.
+func TestDestroyForma_GeneratorAndItsDestinationInOneStack_AreDestroyedTogether(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, _, def := newGeneratorDestroyMetastructure(t)
+		defer def()
+
+		id := util.NewID()
+		stack := "gen-same-stack-" + id
+		generator := rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+			Label: "db-password", Stack: stack,
+			Length: 24, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+		})
+		forma := &pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: stack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{generator},
+			Resources: []pkgmodel.Resource{
+				crossStackGenBoundSecret(stack, "alpha", stack, "db-password", "alpha"),
+			},
+		}
+
+		_, err := m.ApplyForma(forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		ksuid := generatorKsuid(t, m, "db-password", stack)
+
+		_, err = m.DestroyForma(forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err, "a stack holding both a generator and its only destination must destroy cleanly")
+		waitForApplyComplete(t, m)
+
+		requireGeneratorRowGone(t, m, ksuid)
+	})
+}
+
+// A generator nothing binds is destroyed with its stack under the default.
+func TestDestroyForma_GeneratorWithNoDestinations_IsDestroyedUnderTheDefault(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, _, def := newGeneratorDestroyMetastructure(t)
+		defer def()
+
+		id := util.NewID()
+		stack := "gen-unbound-stack-" + id
+		generator := rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+			Label: "db-password", Stack: stack,
+			Length: 24, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+		})
+		// A stack cannot be created empty, so the generator needs an anchor
+		// resource beside it. It binds nothing.
+		forma := &pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: stack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{generator},
+			Resources: []pkgmodel.Resource{{
+				Label:      "anchor",
+				Type:       "FakeAWS::Versioned::Parent",
+				Stack:      stack,
+				Target:     "test-target",
+				Properties: json.RawMessage(`{"Name": "anchor", "Value": "v1"}`),
+			}},
+		}
+
+		_, err := m.ApplyForma(forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		ksuid := generatorKsuid(t, m, "db-password", stack)
+
+		_, err = m.DestroyForma(forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err, "a generator nothing binds must be destroyed without an opt-in")
+		waitForApplyComplete(t, m)
+
+		requireGeneratorRowGone(t, m, ksuid)
+	})
+}
+
+// Simulating the refused destroy renders the cascade instead of refusing, so
+// the CLI can show the operator what would go and elevate to cascade on
+// confirmation. The cascade delete of the dependent is marked as a cascade and
+// names the generator as its source, which is what the CLI reads to decide it
+// has a cascade to confirm.
+func TestDestroyForma_GeneratorBoundFromAnotherStack_SimulationSurfacesTheCascade(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, _, def := newGeneratorDestroyMetastructure(t)
+		defer def()
+
+		f := newGeneratorDestroyFixture(t)
+		_, err := m.ApplyForma(f.bothStacks(),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		ksuid := generatorKsuid(t, m, "db-password", f.generatorStack)
+
+		res, err := m.DestroyForma(f.generatorStackOnly(),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, Simulate: true},
+			"test-client-id", "", "")
+		require.NoError(t, err, "a simulation must render the cascade rather than refuse it")
+		require.NotNil(t, res)
+		assert.True(t, res.Simulation.ChangesRequired)
+
+		var cascade *apimodel.ResourceUpdate
+		for i := range res.Simulation.Command.ResourceUpdates {
+			if res.Simulation.Command.ResourceUpdates[i].ResourceLabel == "beta" {
+				cascade = &res.Simulation.Command.ResourceUpdates[i]
+			}
+		}
+		require.NotNil(t, cascade, "the simulation must show the dependent being torn down")
+		assert.True(t, cascade.IsCascade, "the dependent's delete must be marked a cascade")
+		assert.Equal(t, "db-password", cascade.CascadeSource,
+			"the cascade must name the generator it follows from")
+
+		identity, err := m.Datastore.GetGeneratorIdentityByID(ksuid)
+		require.NoError(t, err)
+		assert.Equal(t, ksuid, identity.ID, "a simulation must change nothing")
+	})
+}
+
+// The query destroy reaches the same conclusion. It is the common CLI path and
+// it never carries a generators block — the forma is synthesized from the rows
+// the query matched — so the generators a query destroy takes with it can only
+// come from the resource deletes, which is where they do come from.
+//
+// Its resources are declared managed because DestroyByQuery drops unmanaged
+// rows before it builds the forma.
+func TestDestroyByQuery_GeneratorBoundFromAnotherStack_RefusesThenCascades(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, _, def := newGeneratorDestroyMetastructure(t)
+		defer def()
+
+		id := util.NewID()
+		generatorStack := "gen-query-stack-" + id
+		otherStack := "gen-query-other-" + id
+		generator := rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+			Label: "db-password", Stack: generatorStack,
+			Length: 24, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+		})
+		managed := func(stack, label string) pkgmodel.Resource {
+			r := crossStackGenBoundSecret(stack, label, generatorStack, "db-password", label)
+			r.Managed = true
+			return r
+		}
+
+		_, err := m.ApplyForma(&pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: generatorStack}, {Label: otherStack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{generator},
+			Resources: []pkgmodel.Resource{
+				managed(generatorStack, "alpha"),
+				managed(otherStack, "beta"),
+			},
+		}, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		ksuid := generatorKsuid(t, m, "db-password", generatorStack)
+
+		_, err = m.DestroyByQuery("stack:"+generatorStack,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.Error(t, err, "a query destroy of the generator's stack must be refused too")
+
+		var dependents apimodel.FormaGeneratorHasDependentsError
+		require.ErrorAs(t, err, &dependents)
+		require.Len(t, dependents.Dependents, 1)
+		assert.Equal(t, "beta", dependents.Dependents[0].ResourceLabel)
+		assert.Equal(t, otherStack, dependents.Dependents[0].Stack)
+
+		_, err = m.DestroyByQuery("stack:"+generatorStack,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile, OnDependents: "cascade"},
+			"test-client-id", "", "")
+		require.NoError(t, err, "cascade must let the query destroy through")
+		waitForApplyComplete(t, m)
+
+		requireGeneratorRowGone(t, m, ksuid)
+
+		remaining, err := m.Datastore.LoadResourcesByStack(otherStack)
+		require.NoError(t, err)
+		assert.Empty(t, remaining, "the resource that bound the generator must be destroyed with it")
+	})
+}
+
+// An ordinary reconcile that drops a generator declaration is a delete too,
+// and it is refused on the same terms while a resource still binds it. The
+// resource here is declared and unchanged, so the command plans nothing for
+// it: its stored binding is what would be left pointing at nothing.
+func TestApplyForma_ReconcileDroppingABoundGenerator_IsRefused(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, _, def := newGeneratorDestroyMetastructure(t)
+		defer def()
+
+		f := newGeneratorDestroyFixture(t)
+		_, err := m.ApplyForma(f.bothStacks(),
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		ksuid := generatorKsuid(t, m, "db-password", f.generatorStack)
+
+		// The same forma with the generator declaration dropped. Under
+		// reconcile that is a delete of the generator, while both
+		// destinations stay declared and still bind it.
+		withoutGenerator := f.bothStacks()
+		withoutGenerator.Generators = nil
+
+		_, err = m.ApplyForma(withoutGenerator,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.Error(t, err, "dropping a generator a live resource still binds must be refused")
+
+		var dependents apimodel.FormaGeneratorHasDependentsError
+		require.ErrorAs(t, err, &dependents)
+		labels := make([]string, 0, len(dependents.Dependents))
+		for _, d := range dependents.Dependents {
+			labels = append(labels, d.ResourceLabel)
+		}
+		assert.ElementsMatch(t, []string{"alpha", "beta"}, labels,
+			"the refusal must name every resource left binding the dropped generator")
+
+		identity, err := m.Datastore.GetGeneratorIdentityByID(ksuid)
+		require.NoError(t, err)
+		assert.Equal(t, ksuid, identity.ID, "a refused apply must leave the generator in place")
+	})
+}
+
+// Dropping a generator declaration together with every resource that binds it
+// is the consistent counterpart of destroying a self-contained stack: nothing
+// is left to dangle, so the reconcile proceeds and the row goes.
+func TestApplyForma_ReconcileDroppingAGeneratorAndItsDestinations_Succeeds(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		m, _, def := newGeneratorDestroyMetastructure(t)
+		defer def()
+
+		id := util.NewID()
+		stack := "gen-drop-stack-" + id
+		generator := rawPasswordGenerator(t, &pkgmodel.PasswordGenerator{
+			Label: "db-password", Stack: stack,
+			Length: 24, Uppercase: true, Lowercase: true, Digits: true, RequireEachIncludedType: true,
+		})
+		anchor := pkgmodel.Resource{
+			Label:      "anchor",
+			Type:       "FakeAWS::Versioned::Parent",
+			Stack:      stack,
+			Target:     "test-target",
+			Properties: json.RawMessage(`{"Name": "anchor", "Value": "v1"}`),
+		}
+
+		_, err := m.ApplyForma(&pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: stack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{generator},
+			Resources: []pkgmodel.Resource{
+				anchor,
+				crossStackGenBoundSecret(stack, "alpha", stack, "db-password", "alpha"),
+			},
+		}, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		ksuid := generatorKsuid(t, m, "db-password", stack)
+
+		// The generator and its destination both go; the anchor keeps the
+		// stack alive so this is a generator delete and not a stack teardown.
+		_, err = m.ApplyForma(&pkgmodel.Forma{
+			Stacks:    []pkgmodel.Stack{{Label: stack}},
+			Targets:   []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Resources: []pkgmodel.Resource{anchor},
+		}, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err, "dropping a generator and its only destination together must be allowed")
+		waitForApplyComplete(t, m)
+
+		requireGeneratorRowGone(t, m, ksuid)
+	})
+}

--- a/pkg/api/model/errors.go
+++ b/pkg/api/model/errors.go
@@ -39,6 +39,7 @@ const (
 	ResourceHasDependents            APIError = "ResourceHasDependents"
 	GeneratorDestinationsUnreachable APIError = "GeneratorDestinationsUnreachable"
 	GeneratorBoundToSetOnceField     APIError = "GeneratorBoundToSetOnceField"
+	GeneratorHasDependents           APIError = "GeneratorHasDependents"
 )
 
 type ErrorResponse[T any] struct {
@@ -352,6 +353,44 @@ func (e FormaResourceHasDependentsError) Error() string {
 		labels[i] = d.ResourceLabel
 	}
 	return fmt.Sprintf("this delete would cascade-delete %d dependent resource(s) %v; re-run with --on-dependents=cascade to proceed",
+		len(e.Dependents), labels)
+}
+
+// GeneratorDependent names a resource that binds a property to a generator
+// being deleted, along with the generator it binds. The resource is very often
+// in a different stack from the generator: that is what a generator is for.
+type GeneratorDependent struct {
+	GeneratorLabel string `json:"GeneratorLabel"`
+	GeneratorStack string `json:"GeneratorStack"`
+	ResourceLabel  string `json:"ResourceLabel"`
+	ResourceType   string `json:"ResourceType"`
+	Stack          string `json:"Stack"`
+}
+
+// FormaGeneratorHasDependentsError is returned when a command would delete a
+// generator that a live resource still binds a property to, but was not run
+// with on-dependents=cascade. A destroy of the generator's stack and a
+// reconcile that drops the generator's declaration are both deletes and both
+// refused on these terms.
+//
+// The default is to abort because the reference cannot survive the generator:
+// formae keeps a hash of a drawn value and never the value, so a resource left
+// bound to a deleted generator has no way back to a value on any later apply.
+type FormaGeneratorHasDependentsError struct {
+	Dependents []GeneratorDependent `json:"Dependents"`
+}
+
+func (e FormaGeneratorHasDependentsError) Error() string {
+	if len(e.Dependents) == 1 {
+		d := e.Dependents[0]
+		return fmt.Sprintf("deleting generator %q in stack %q would leave resource %q in stack %q bound to nothing; re-run with --on-dependents=cascade to proceed",
+			d.GeneratorLabel, d.GeneratorStack, d.ResourceLabel, d.Stack)
+	}
+	labels := make([]string, len(e.Dependents))
+	for i, d := range e.Dependents {
+		labels[i] = d.ResourceLabel
+	}
+	return fmt.Sprintf("this delete would leave %d resource(s) %v bound to a deleted generator; re-run with --on-dependents=cascade to proceed",
 		len(e.Dependents), labels)
 }
 


### PR DESCRIPTION
## Summary

Stacked on #718. Destroying a stack that owns a generator **silently succeeded and orphaned the generator row**, leaving resources in other stacks bound to a generator whose owning stack no longer exists.

Reproduced before any change: generator in stack A, one secret in A bound to it, one in stack B bound to it. Destroy A. The command returns no error, the stack is deleted as empty, and the generator row is still live — proven by looking it up by identity rather than by label, since the by-identity query filters out tombstones and still returned it. The resource in B is still bound.

Two causes: the generator diff returned nothing for a destroy on the stated grounds that a generator "is deleted implicitly when that stack is destroyed", which is false — the stack delete cascades to policies only; and the destroy path never persisted generator updates at all.

## What it does now

Uses the existing `--on-dependents` vocabulary rather than inventing any. Abort, the default, refuses and names the referencing resources. Cascade destroys them alongside the generator. A dangling generator reference is never silently absorbed.

A generator is deleted when the stack that owns it empties, decided by comparing the resources in that stack against the deletes planned for it — so a partial destroy leaves the stack and its generators alone.

## A false green worth knowing about

The obvious assertion — look the generator up after the destroy and expect nil — **passes on the broken tree.** The label-scoped lookups resolve stack label to stack row first and return nil once the stack is gone, so "not found" means "its stack is gone", not "the row is deleted". Every row assertion here is by identity for that reason.

The same fact settles where the delete belongs: a generator delete issued after empty-stack cleanup is a silent no-op, so it has to be planned and persisted before the changeset starts.

## The reconcile arm was half-done, not missing

Dropping a generator declaration from a forma already produced a delete and already persisted it. What it lacked was the refusal, and it inherits that by producing the same delete operation the destroy arm now produces — one check, two arms, no per-arm rule.

That forced a refinement worth reviewing. "Is the referencing resource in this command", which the sibling unreachable-destinations refusal uses, is right for destroy and **wrong** for reconcile: a still-bound secret is in the command, so the reference would be absorbed silently. The predicate is instead: not being deleted, and still binding the generator on its desired document where the command plans a write. Same-stack destroy passes because the secret is deleted; dropping the generator while a secret still binds it refuses; and dropping the generator while rewriting that property to a literal in the same edit is correctly **not** refused.

## Status code, established by running it

The client's destroy gates decode 400 and 409 only, where apply also accepts 422. With 422 the payload was correct and the caller could not see it — the round trip surfaced a bare string carrying the raw body. With 409 it decodes. Both destroy entry points are asserted, including the query-driven one.

## Simulation

A destroy simulation surfaces the cascade rather than refusing, matching the neighbouring cascade-abort blocks, and the cascade rows carry the flags the CLI's existing confirm-then-elevate flow already reads — so that flow needs no change. An **apply** simulation still refuses, because `--on-dependents` is a destroy flag and no confirmation could make such a plan applicable.

## Boundaries declined in this pass, stated rather than hidden

A cascade-destroyed dependent's own downstream references are not walked, because the existing cascade traversal runs before this check. If a generator cascade empties a second generator-owning stack, that stack's generators are not chained. And the concurrent-command admission check does not include stacks reached only by a generator cascade, since it runs on the raw forma before resource updates exist. All three need a compound arrangement to reach; the first is the most plausible if it ever needs revisiting.