### PR TITLE
feat(schema): round-trip a generator binding through extracted PKL

### DIFF
--- a/internal/schema/pkl/generator/examples/json/generator_binding.json
+++ b/internal/schema/pkl/generator/examples/json/generator_binding.json
@@ -1,0 +1,70 @@
+{
+  "Targets": [
+    {
+      "Label": "testprovider-target",
+      "Namespace": "TestProvider",
+      "Config": {
+        "Type": "TestProvider",
+        "Region": "us-east-1"
+      }
+    }
+  ],
+  "Stacks": [
+    {
+      "Label": "shared-secrets",
+      "Description": "Stack owning the generator"
+    },
+    {
+      "Label": "app-stack",
+      "Description": "Stack holding the bound resource"
+    }
+  ],
+  "Generators": [
+    {
+      "Type": "password",
+      "Label": "db-password-gen",
+      "Stack": "shared-secrets",
+      "Length": 24,
+      "Uppercase": true,
+      "Lowercase": true,
+      "Digits": true,
+      "Symbols": false,
+      "ExcludeCharacters": "oO0",
+      "RequireEachIncludedType": true
+    }
+  ],
+  "Resources": [
+    {
+      "Label": "own-stack-secret",
+      "Type": "TestProvider::SecretsManager::Secret",
+      "Stack": "shared-secrets",
+      "Target": "testprovider-target",
+      "Properties": {
+        "Name": "app/own-stack-secret",
+        "SecretString": {
+          "$gen": true,
+          "$label": "db-password-gen",
+          "$stack": "shared-secrets",
+          "$output": "value",
+          "$visibility": "Opaque"
+        }
+      }
+    },
+    {
+      "Label": "cross-stack-secret",
+      "Type": "TestProvider::SecretsManager::Secret",
+      "Stack": "app-stack",
+      "Target": "testprovider-target",
+      "Properties": {
+        "Name": "app/cross-stack-secret",
+        "SecretString": {
+          "$gen": true,
+          "$label": "db-password-gen",
+          "$stack": "shared-secrets",
+          "$output": "value",
+          "$visibility": "Opaque"
+        }
+      }
+    }
+  ]
+}

--- a/internal/schema/pkl/generator/gen.pkl
+++ b/internal/schema/pkl/generator/gen.pkl
@@ -287,10 +287,10 @@ local function readDeeply(value: Any): Boolean =
 
 /// The envelope marker a map carries, or `null` when the map is plain data.
 ///
-/// A map is a reference only when `$res` is exactly the boolean `true`, and an
-/// embedded template only when `$embed` is exactly the boolean `true`. A map of
-/// the author's own that merely has a key of that name holding something else
-/// is data and converts as data.
+/// A map is a reference only when `$res` is exactly the boolean `true`, a
+/// generator binding only when `$gen` is, and an embedded template only when
+/// `$embed` is. A map of the author's own that merely has a key of that name
+/// holding something else is data and converts as data.
 ///
 /// The marker alone decides this. The remaining parts of a reference — the
 /// label, stack, property and recorded value — are optional: `formae.Resolvable`
@@ -301,10 +301,14 @@ local function readDeeply(value: Any): Boolean =
 /// than quietly treating the envelope as data.
 ///
 /// A recorded value has no marker of its own, so all three of the keys it is
-/// written from have to be present before a map is one.
+/// written from have to be present before a map is one. A generator binding is
+/// tested before it, because a binding the agent has resolved carries the keys
+/// of a recorded value alongside its own marker and must never be read as one.
 local function envelopeMarkerOf(valueAsMap: Map): String? =
   if (valueAsMap.getOrNull("$res") == true)
     "$res"
+  else if (valueAsMap.getOrNull("$gen") == true)
+    "$gen"
   else if (valueAsMap.containsKey("$value") && valueAsMap.containsKey("$visibility") && valueAsMap.containsKey("$strategy"))
     "$value"
   else if (valueAsMap.getOrNull("$embed") == true)
@@ -319,6 +323,8 @@ local function envelopeMarkerOf(valueAsMap: Map): String? =
 local function envelopeMarkerOfClass(clazz: reflect.Class): String? =
   if (clazz.isSubclassOf(reflect.Class(formae.Resolvable)))
     "$res"
+  else if (clazz.isSubclassOf(reflect.Class(formae.GeneratorOutput)))
+    "$gen"
   else if (clazz.isSubclassOf(reflect.Class(formae.Value)))
     "$value"
   else if (clazz.isSubclassOf(reflect.Class(formae.Embedded)))
@@ -653,6 +659,22 @@ class FakeEmbed {
   FakeParts: List
 }
 
+/// Carrier for a decoded $gen envelope.
+///
+/// Only the generator's label and the output name are carried, because those
+/// are the whole of the reference the renderer emits: a binding renders as the
+/// generator's local followed by its output accessor, and that local is named
+/// from the label alone. The generator's own stack is not part of the
+/// reference — the declaration the local is bound to carries it.
+///
+/// The carrier does not extend `formae.GeneratorOutput`, following `FakeEmbed`:
+/// the envelope's members there are `fixed` and derived from a `StackResolvable`
+/// the carrier has no way to build from a stack label.
+class FakeGeneratorOutput {
+  FakeGeneratorLabel: String
+  FakeOutput: String
+}
+
 function applyPropertyWithMapping(valueAsMap: Map, prop: reflect.Property, reverseMapping: Mapping<String, String>) =
     // First try the direct property name
     if (valueAsMap.containsKey(prop.name))
@@ -859,6 +881,25 @@ local function applyDynamicOrMapping(type: reflect.Class, value: Dynamic|Mapping
             })
 
             r
+    else if (marker == "$gen")
+        // A binding renders as an expression naming the generator's local, so
+        // both the label the local is named from and the output accessor must
+        // be present and be text. An envelope missing either — one whose
+        // generator no longer exists, so extraction had no label to write and
+        // left the internal identifier in place — is reported rather than
+        // rendered: there is no expression to emit, and a file naming a local
+        // that was never declared is worse than a diagnostic saying so.
+        let (l = valueAsMap.getOrNull("$label"))
+        let (o = valueAsMap.getOrNull("$output"))
+        if (!(l is String))
+            Fail("A generator reference's $label must be a String, but got \(typeNameOf(l))")
+        else if (!(o is String))
+            Fail("A generator reference's $output must be a String, but got \(typeNameOf(o))")
+        else
+            new FakeGeneratorOutput {
+                FakeGeneratorLabel = l
+                FakeOutput = o
+            }
     else if (marker == "$value")
         let (fakeValue = valueAsMap.getOrNull("$value"))
         let (visibility = valueAsMap.getOrNull("$visibility"))
@@ -1048,6 +1089,13 @@ local function parseValueEnhanced(value: Any): Any =
     // or a Dynamic/$res map — formatValueWithTypes handles the rendering).
     if (typeName == "FakeEmbed")
       Map("__type__", "FakeEmbed", "FakeParts", (value as FakeEmbed).FakeParts)
+    // FakeGeneratorOutput: the carrier is declared in this module rather than a
+    // schema package, so there is no import to look up for it.
+    else if (typeName == "FakeGeneratorOutput")
+      let (g = value as FakeGeneratorOutput)
+        Map("__type__", "FakeGeneratorOutput",
+            "FakeGeneratorLabel", g.FakeGeneratorLabel,
+            "FakeOutput", g.FakeOutput)
     else
     let (importInfo = getImportInfoForType(value.getClass(), typeName, value))
     let (defaultMap =
@@ -1160,9 +1208,11 @@ local function escapeString(str: String): String =
     .replaceAll("\r", "\\r")     // Escape carriage returns
     .replaceAll("\t", "\\t")     // Escape tabs
 
-// toCamelCase mirrors pklGenerator.toCamelCase (cannot import it — pklGenerator
-// imports this module). Used to reference the generated stack local by name.
-local function embedToCamelCase(input: String): String =
+// localNameOf mirrors pklGenerator.toCamelCase (cannot import it — pklGenerator
+// imports this module). Both modules must agree: pklGenerator names the locals
+// it declares for stacks and generators with that function, and this one emits
+// the references to them.
+local function localNameOf(input: String): String =
   if (input == "$unmanaged")
     "myStack"
   else
@@ -1173,6 +1223,34 @@ local function embedToCamelCase(input: String): String =
       parts.first + parts.drop(1).map((part) ->
         if (part.isEmpty) "" else part.substring(0, 1).toUpperCase() + part.substring(1, part.length)
       ).join("")
+
+/// Renders one envelope part of a pre-processed embedded template as the
+/// expression to interpolate for it.
+///
+/// The split the agent's extract pre-processing performs is envelope-agnostic,
+/// so a part is whichever envelope the template framed at that offset.
+local function renderEmbedEnvelopePart(envelope: Map<String, Any>, indent: String): String =
+  if (envelope.getOrNull("$gen") == true)
+    renderEmbedGenPart(envelope)
+  else
+    renderEmbedRefPart(envelope, indent)
+
+/// Renders a generator binding framed inside an embedded template. Interpolating
+/// the output accessor re-frames the very envelope the template carried, because
+/// that is what `formae.GeneratorOutput.toString()` renders.
+///
+/// A binding missing either part names no local, and there is no expression to
+/// emit for it. Throwing is what the render phase does with an unrenderable
+/// reference — the same choice `requireResolvableInfo` makes — because a part
+/// silently dropped from a template leaves a file that applies the wrong thing.
+local function renderEmbedGenPart(envelope: Map<String, Any>): String =
+  let (l = envelope.getOrNull("$label") as String?)
+  let (o = envelope.getOrNull("$output") as String?)
+  if (l == null || o == null)
+    throw("Cannot render a generator reference embedded in a string: the reference "
+      + "carries no generator label, or names no output of it.")
+  else
+    "\\(\(localNameOf(l)).gen.\(o))"
 
 local function renderEmbedRefPart(resMap: Map<String, Any>, indent: String): String =
   let (s = resMap.getOrNull("$stack") as String?)
@@ -1208,7 +1286,7 @@ local function renderEmbedRefPart(resMap: Map<String, Any>, indent: String): Str
     // `stack = ".."` to a StackResolvable, mismatching Resolvable.stack: String?)
     // leaves it alone; this is the same value the //resolvable marker yields on
     // the whole-value path.
-    "\\((\(resInfo.importName).\(resInfo.clazz.simpleName)) { stack = \(embedToCamelCase(s ?? "")).res.label; label = \"\(l)\" }.\(renderResolvableProperty(mappedProperty)))"
+    "\\((\(resInfo.importName).\(resInfo.clazz.simpleName)) { stack = \(localNameOf(s ?? "")).res.label; label = \"\(l)\" }.\(renderResolvableProperty(mappedProperty)))"
 
 local function formatValueWithTypes(value: Any, indent: String): String =
   if (value is Dynamic)
@@ -1269,6 +1347,16 @@ local function formatValueWithTypes(value: Any, indent: String): String =
           // the stored digest cannot be re-applied as plaintext.
           let (withComment = if (hashed) withStrategy + " // hashed secret value — cannot be applied as-is; re-supply the plaintext to set it" else withStrategy)
             withComment
+        else if (typeName == "FakeGeneratorOutput")
+          // A generator binding renders as the output accessor of the local
+          // pklGenerator declares for that generator — `<local>.gen.<output>`.
+          // The local is named from the generator's label, so nothing of the
+          // envelope beyond the label and the output name is emitted: the rest
+          // (the visibility above all) is derived by the class the accessor
+          // yields, and is not the author's to write.
+          let (label = value.getOrNull("FakeGeneratorLabel") as String)
+          let (output = value.getOrNull("FakeOutput") as String)
+            "\(localNameOf(label)).gen.\(output)"
         else if (typeName == "FakeEmbed")
           // Render as formae.embed("""...\(<resolvable-ref>)...""").
           // FakeParts is a List alternating String literals and $res maps.
@@ -1280,10 +1368,10 @@ local function formatValueWithTypes(value: Any, indent: String): String =
               // Literal template segment — escape for a single-line PKL string.
               acc + escapeString(part)
             else if (part is Map)
-              acc + renderEmbedRefPart(part as Map<String, Any>, indent)
+              acc + renderEmbedEnvelopePart(part as Map<String, Any>, indent)
             else if (part is Dynamic)
-              // JSON-deserialized $res envelope objects arrive as Dynamic, not Map.
-              acc + renderEmbedRefPart(part.toMap(), indent)
+              // JSON-deserialized envelope objects arrive as Dynamic, not Map.
+              acc + renderEmbedEnvelopePart(part.toMap(), indent)
             else
               acc
           ))

--- a/internal/schema/pkl/generator/tests/gen.pkl
+++ b/internal/schema/pkl/generator/tests/gen.pkl
@@ -369,6 +369,23 @@ local class EmbedThenMapResource extends formae.Resource {
     target: formae.Embedded|Mapping<String, Any>
 }
 
+/// A generator-binding-or-map field, in both member orders.
+@formae.ResourceHint
+local class MapThenGenResource extends formae.Resource {
+    type = "FakePlugin::Union::MapThenGen"
+
+    @formae.FieldHint
+    target: Mapping<String, Any>|formae.GeneratorOutput
+}
+
+@formae.ResourceHint
+local class GenThenMapResource extends formae.Resource {
+    type = "FakePlugin::Union::GenThenMap"
+
+    @formae.FieldHint
+    target: formae.GeneratorOutput|Mapping<String, Any>
+}
+
 /// Envelope-class fields with no sibling to fall through to, so what the
 /// conversion itself makes of a value is observable.
 @formae.ResourceHint
@@ -393,6 +410,14 @@ local class EmbedFieldResource extends formae.Resource {
 
     @formae.FieldHint
     target: formae.Embedded
+}
+
+@formae.ResourceHint
+local class GenFieldResource extends formae.Resource {
+    type = "FakePlugin::Field::Gen"
+
+    @formae.FieldHint
+    target: formae.GeneratorOutput
 }
 
 /// The three handlers whose contract is to pass a map through as data. An
@@ -859,6 +884,38 @@ local function recordedValue(omitted: String?): Mapping =
         "$strategy", "Update"
     ))
     (if (omitted == null) env else env.remove(omitted)).toMapping()
+
+/// The envelope a property carries when it is bound to one of a generator's
+/// outputs, in the authored shape extraction emits, optionally omitting one of
+/// its keys.
+local function binding(omitted: String?): Mapping =
+    let (env = Map(
+        "$gen", true,
+        "$label", "db-password-gen",
+        "$stack", "shared-secrets",
+        "$output", "value",
+        "$visibility", "Opaque"
+    ))
+    (if (omitted == null) env else env.remove(omitted)).toMapping()
+
+/// The same binding with the keys a recorded value is written from beside its
+/// own marker, which is the shape a binding the agent has resolved is stored in.
+local function resolvedBinding(): Mapping =
+    binding(null).toMap()
+        .put("$value", "sha256:digest")
+        .put("$strategy", "Update")
+        .toMapping()
+
+/// A binding as it arrives inside a split embedded template: the pre-processing
+/// puts the framed envelope in among the literal segments, deserialized from
+/// JSON and so a Dynamic rather than a Map.
+local function embeddedBindingPart(): Dynamic = new Dynamic {
+    ["$gen"] = true
+    ["$label"] = "db-password-gen"
+    ["$stack"] = "shared-secrets"
+    ["$output"] = "value"
+    ["$visibility"] = "Opaque"
+}
 
 /// The envelope the agent's extract pre-processing produces for a template
 /// carrying references: alternating literal segments and reference envelopes.
@@ -1700,6 +1757,78 @@ facts {
     ["An embedded template carrying no parts at all reports a failure"] {
         let (message = renderFailure(EmbedFieldResource, embedded(null)))
         message != null && message.contains("$templateParts")
+    }
+
+    // --- A generator binding ---
+
+    ["A generator binding selects the generator-output member however the union orders its members"] {
+        selectedMember(MapThenGenResource, binding(null)) == "FakeGeneratorOutput" &&
+        selectedMember(GenThenMapResource, binding(null)) == "FakeGeneratorOutput"
+    }
+
+    ["A binding carrying the keys of a recorded value is still read as a binding"] {
+        // A resolved binding is stored with the digest of the drawn value, and
+        // with the visibility and strategy it was recorded under, which is the
+        // shape of a recorded value. Its own marker decides, so it is never
+        // read as the value written beside it.
+        selectedMember(GenFieldResource, resolvedBinding()) == "FakeGeneratorOutput" &&
+        selectedMember(MapThenGenResource, resolvedBinding()) == "FakeGeneratorOutput"
+    }
+
+    ["A $gen key holding false or text is not a binding"] {
+        selectedMember(MapThenGenResource, binding(null).toMap().put("$gen", false).toMapping()) == "Mapping" &&
+        selectedMember(MapThenGenResource, binding(null).toMap().put("$gen", "yes").toMapping()) == "Mapping"
+    }
+
+    ["A generator-output-typed field given plain data reports a failure"] {
+        let (message = renderFailure(GenFieldResource, new Mapping { ["recipient"] = "#alerts" }))
+        message != null && message.contains("$gen")
+    }
+
+    ["A binding naming no generator or no output reports a failure"] {
+        // Both parts are required, because the rendered reference is an
+        // expression built from them and there is nothing to emit without one.
+        let (noLabel = renderFailure(GenFieldResource, binding("$label")))
+        let (noOutput = renderFailure(GenFieldResource, binding("$output")))
+        noLabel != null && noLabel.contains("$label") &&
+        noOutput != null && noOutput.contains("$output")
+    }
+
+    ["A binding renders as the output accessor of the local declared for its generator"] {
+        // pklGenerator names the local it declares for a generator from that
+        // generator's label in camel case, so the rendered reference has to
+        // agree with the same derivation or it names a local that was never
+        // declared.
+        let (rendered = gen.genMapToPklStringWithTypes(
+            "GenFieldResource",
+            gen.genPklToMap(new Dynamic { target = renderedTarget(GenFieldResource, binding(null)) }),
+            "test"))
+        rendered.contains("target = dbPasswordGen.gen.value")
+    }
+
+    ["A rendered binding emits nothing of the envelope the accessor derives"] {
+        // The envelope's members are fixed on formae.GeneratorOutput, so
+        // emitting any of them yields a file that cannot be assigned to.
+        let (rendered = gen.genMapToPklStringWithTypes(
+            "GenFieldResource",
+            gen.genPklToMap(new Dynamic { target = renderedTarget(GenFieldResource, resolvedBinding()) }),
+            "test"))
+        !rendered.contains("$gen") &&
+        !rendered.contains("$visibility") &&
+        !rendered.contains("shared-secrets") &&
+        !rendered.contains("sha256:digest")
+    }
+
+    ["A binding framed inside an embedded template renders as an interpolation of its accessor"] {
+        // Interpolating the accessor reproduces the framed envelope, because
+        // that is what formae.GeneratorOutput renders when read as text.
+        let (fakeEmbedMap = new Dynamic {
+            ["__type__"] = "FakeEmbed"
+            ["FakeParts"] = List("PGPASSWORD=", embeddedBindingPart(), " psql")
+        })
+        let (rendered = gen.genMapToPklStringWithTypes(
+            "TestResource", Map("code", fakeEmbedMap), "test"))
+        rendered.contains("formae.embed(\"PGPASSWORD=\\(dbPasswordGen.gen.value) psql\")")
     }
 
     // --- Map conversion ---

--- a/internal/schema/pkl/generator/tests/schema/secretsmanager/secret.pkl
+++ b/internal/schema/pkl/generator/tests/schema/secretsmanager/secret.pkl
@@ -35,7 +35,7 @@ open class Secret extends formae.Secret {
     description: String?
 
     @testprovider.FieldHint
-    secretString: (String|formae.Value|formae.SecretValue)?
+    secretString: (String|formae.Value|formae.SecretValue|formae.GeneratorOutput)?
 
     @testprovider.FieldHint
     tags: Listing<testprovider.Tag>?

--- a/internal/schema/pkl/pkl_generate_test.go
+++ b/internal/schema/pkl/pkl_generate_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 
 	"github.com/platform-engineering-labs/formae/internal/schema"
 	model "github.com/platform-engineering-labs/formae/pkg/model"
@@ -177,4 +178,149 @@ func TestGenerateSourceCode_Generator_RoundTrips(t *testing.T) {
 
 	_, err = PKL{}.Evaluate(targetPath, model.CommandApply, model.FormaApplyModeReconcile, nil)
 	require.NoError(t, err, "emitted PKL must itself evaluate")
+}
+
+// genBoundProps builds a properties blob whose secret-bearing field carries the
+// authored $gen envelope extraction emits: the generator named by label and
+// stack, one of its outputs, and nothing internal.
+func genBoundProps(t *testing.T, generatorLabel, generatorStack string) json.RawMessage {
+	t.Helper()
+	props := map[string]any{
+		"Name": "app/db-password",
+		"SecretString": map[string]any{
+			"$gen":        true,
+			"$label":      generatorLabel,
+			"$stack":      generatorStack,
+			"$output":     "value",
+			"$visibility": "Opaque",
+		},
+	}
+	b, err := json.Marshal(props)
+	require.NoError(t, err)
+	return b
+}
+
+// passwordGenerator builds the stored shape of a PasswordGenerator declaration,
+// as ExtractResources emits it alongside the resources bound to it.
+func passwordGenerator(label, stack string) json.RawMessage {
+	return json.RawMessage(`{
+		"Type": "password",
+		"Label": "` + label + `",
+		"Stack": "` + stack + `",
+		"Length": 24,
+		"Uppercase": true,
+		"Lowercase": true,
+		"Digits": true,
+		"Symbols": false,
+		"ExcludeCharacters": "",
+		"RequireEachIncludedType": true
+	}`)
+}
+
+// generateAndEvaluate writes forma out as PKL source and evaluates that source
+// back through the real eval path, returning the emitted text and the forma the
+// emitted text evaluates to.
+func generateAndEvaluate(t *testing.T, forma *model.Forma) (string, *model.Forma) {
+	t.Helper()
+	deps, pluginDir := fakeawsDeps(t)
+	targetPath := filepath.Join(t.TempDir(), "out.pkl")
+
+	_, err := PKL{}.GenerateSourceCode(forma, targetPath, nil, &schema.SerializeOptions{
+		Schema:         "pkl",
+		SchemaLocation: schema.SchemaLocationLocal,
+		LocalPluginDir: pluginDir,
+		Dependencies:   deps,
+	})
+	require.NoError(t, err)
+
+	written, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+
+	evaluated, err := PKL{}.Evaluate(targetPath, model.CommandApply, model.FormaApplyModeReconcile, nil)
+	require.NoError(t, err, "emitted PKL must itself evaluate:\n%s", string(written))
+
+	return string(written), evaluated
+}
+
+// TestGenerateSourceCode_GeneratorBinding_RoundTripsThroughPkl verifies that a
+// resource whose secret-bearing property is bound to a generator is written out
+// as PKL source that references the generator's output accessor, and that
+// evaluating that source back yields the same $gen envelope naming the same
+// generator and output. A resource holding an ordinary recorded value sits in
+// the same forma, so a binding invented for it would show.
+func TestGenerateSourceCode_GeneratorBinding_RoundTripsThroughPkl(t *testing.T) {
+	forma := &model.Forma{
+		Stacks:  []model.Stack{{Label: "secrets"}},
+		Targets: []model.Target{fakeawsTarget()},
+		Resources: []model.Resource{
+			{
+				Label:      "db",
+				Type:       "FakeAWS::SecretsManager::Secret",
+				Stack:      "secrets",
+				Target:     "aws",
+				Properties: genBoundProps(t, "db-password-gen", "secrets"),
+			},
+			{
+				Label:      "api-key",
+				Type:       "FakeAWS::SecretsManager::Secret",
+				Stack:      "secrets",
+				Target:     "aws",
+				Properties: []byte(`{"Name":"app/api-key","SecretString":{"$value":"plaintext","$visibility":"Opaque","$strategy":"Update"}}`),
+			},
+		},
+		Generators: []json.RawMessage{passwordGenerator("db-password-gen", "secrets")},
+	}
+
+	generated, evaluated := generateAndEvaluate(t, forma)
+
+	// The emitted source declares the generator local it references.
+	assert.Contains(t, generated, "local dbPasswordGen = new formae.PasswordGenerator {")
+	assert.Contains(t, generated, "secretString = dbPasswordGen.gen.value")
+	assert.Equal(t, 1, strings.Count(generated, ".gen."),
+		"only the bound property may reference a generator output")
+
+	jsonString := evaluated.ToJSON()
+	bound := gjson.Get(jsonString, `Resources.#(Label=="db").Properties.SecretString`)
+	assert.True(t, bound.Get("$gen").Bool(), "the re-evaluated property must be a $gen envelope")
+	assert.Equal(t, "db-password-gen", bound.Get("$label").String())
+	assert.Equal(t, "secrets", bound.Get("$stack").String())
+	assert.Equal(t, "value", bound.Get("$output").String())
+
+	// The recorded value beside it stays a recorded value.
+	literal := gjson.Get(jsonString, `Resources.#(Label=="api-key").Properties.SecretString`)
+	assert.Equal(t, "plaintext", literal.Get("$value").String())
+	assert.False(t, literal.Get("$gen").Exists(), "a recorded value must not become a generator reference")
+}
+
+// TestGenerateSourceCode_CrossStackGeneratorBinding_RoundTripsThroughPkl
+// verifies the same for a resource bound to a generator that lives on another
+// stack: the binding names the generator's local, not its stack, so the
+// reference survives the round trip with the generator's own stack intact.
+func TestGenerateSourceCode_CrossStackGeneratorBinding_RoundTripsThroughPkl(t *testing.T) {
+	forma := &model.Forma{
+		Stacks:  []model.Stack{{Label: "app"}, {Label: "shared-secrets"}},
+		Targets: []model.Target{fakeawsTarget()},
+		Resources: []model.Resource{{
+			Label:      "db",
+			Type:       "FakeAWS::SecretsManager::Secret",
+			Stack:      "app",
+			Target:     "aws",
+			Properties: genBoundProps(t, "db-password-gen", "shared-secrets"),
+		}},
+		Generators: []json.RawMessage{passwordGenerator("db-password-gen", "shared-secrets")},
+	}
+
+	generated, evaluated := generateAndEvaluate(t, forma)
+
+	assert.Contains(t, generated, "local dbPasswordGen = new formae.PasswordGenerator {")
+	assert.Contains(t, generated, "stack = sharedSecrets.res")
+	assert.Contains(t, generated, "secretString = dbPasswordGen.gen.value")
+
+	jsonString := evaluated.ToJSON()
+	bound := gjson.Get(jsonString, `Resources.#(Label=="db").Properties.SecretString`)
+	assert.True(t, bound.Get("$gen").Bool())
+	assert.Equal(t, "db-password-gen", bound.Get("$label").String())
+	assert.Equal(t, "shared-secrets", bound.Get("$stack").String(),
+		"the envelope must name the generator's own stack, not the bound resource's")
+	assert.Equal(t, "value", bound.Get("$output").String())
 }


### PR DESCRIPTION
## Summary

Completes extract for generator-bound resources, so a stack that uses one can be extracted and re-applied. Three commits, and the first two are #721 and #723 — this PR carries them because the renderer needs both. Once those merge it rebases to a single commit.

`formae extract` emits PKL as well as JSON. The PKL renderer had no arm for a generator reference, so a bound property rendered as a literal envelope construction:

```pkl
secretString = new formae.GeneratorOutput {
  $gen = true
  $label = "db-password-gen"
  $stack = secrets.res      // the stack localizer rewrote this too
  ...
}
```

…which does not evaluate: `Cannot assign to fixed property $gen`. It now renders `dbPasswordGen.gen.value` — the generator's local binding, its outputs accessor, and the output name.

## Union selection does not work the way the plan assumed

Worth reading, because it changes what the fixture widening is for. The expectation was that a field whose union omits the generator-output type simply has no arm to select, so nothing renders. What actually happens: selection finds no matching member, then falls through to the first envelope-class member, and the dispatch keys on the **value's** marker rather than the declared class. So the carrier is built and the accessor renders correctly even against a narrow union.

The emitted file then fails to *evaluate*, on the field's declared type. So widening the generator's own fixture schema is required for the round trip, not for the render — established by trying it without.

This is pre-existing behaviour shared with the other envelope families; there is already a fact asserting that an envelope-class field accepts an envelope of another family.

## The local name is derived from the label alone

The generator parser emits `local <camelCase(label)> = new formae.PasswordGenerator {…}`, splitting on hyphens only and never consulting the stack. The renderer's derivation is a character-for-character copy of it, because it cannot import that module without a cycle. If the two ever disagree, the emitted PKL references a local that does not exist — it evaluates as a name error rather than silently doing the wrong thing, but the coupling is worth knowing.

## Three things worth a look

**An unresolvable generator reference now fails the render rather than degrading.** When extraction cannot resolve the identity it keeps the raw KSUID with no label; the JSON extract emits that, and the PKL extract refuses the whole resource with a message naming the field. Loud was chosen because there is no expression to emit and a file naming an undeclared local is worse than a diagnostic. Reversible if you would rather it degrade.

**Two generators sharing a label on different stacks emit duplicate locals.** Pre-existing: the parser names locals from the label alone, and stacks, targets and policies have the same shape in the same function. The renderer inherits it by agreeing with the parser. Not fixed here — a real fix needs cross-kind knowledge the renderer does not have and should cover all four at once.

**The embedded-string arm is unreachable today and built anyway.** A framed envelope whose visibility is opaque is refused at plan time, and no shipping outputs class declares anything else, so no stored resource can hold a generator reference inside a template. But the template splitter is envelope-agnostic and the schema explicitly anticipates a non-secret arm, and the pre-existing code would have rendered such a part as **empty text** — a silent secret-shaped hole. Four lines against that. Its coverage is a module-level fact rather than an end-to-end test, because no end-to-end path can produce the input.

## Verification

The acceptance test is a round trip, not a render assertion: extract to PKL source, evaluate that source back through the real path, and assert the resulting forma carries the authored envelope naming the same generator and output. Same for the cross-stack case.

The generator's own suite is 131/131 (was 124), the full pipeline generates and evaluates 13/13 examples including a new generator-binding fixture, and no golden moved.