### PR TITLE
feat(schema): name a value field's envelope kinds as formae.ValueSource

### DIFF
--- a/internal/schema/pkl/generator/gen.pkl
+++ b/internal/schema/pkl/generator/gen.pkl
@@ -332,27 +332,31 @@ local function envelopeMarkerOfClass(clazz: reflect.Class): String? =
   else
     null
 
-/// The same, for a union member's declared type. A nullable member is unwrapped
-/// to its member type, a type alias to its referent, and a member that is itself
-/// a union to the family of the first of its own members that has one — a
-/// parenthesised member stays a union of its own rather than being folded into
-/// the union around it. So `formae.Resolvable?`, an alias of it and
-/// `(formae.Resolvable|String)` are all recognised as reference members.
-local function envelopeMarkerOfType(type: reflect.Type): String? =
+/// Whether a union member's declared type can hold an envelope of the family
+/// `marker` names. A nullable member is unwrapped to its member type, a type
+/// alias to its referent, and a member that is itself a union carries every
+/// family its own members carry — a parenthesised member stays a union of its
+/// own rather than being folded into the union around it. So
+/// `formae.Resolvable?`, an alias of it and `(formae.Resolvable|String)` are all
+/// recognised as reference members.
+///
+/// A member naming several families at once is a member of each of them, which
+/// is what lets a field name `formae.ValueSource` in place of spelling the
+/// families out and still have each of them preferred over a sibling that would
+/// take the envelope as data.
+local function typeCarriesMarker(type: reflect.Type, marker: String): Boolean =
   if (type is reflect.NullableType)
-    envelopeMarkerOfType((type as reflect.NullableType).member)
+    typeCarriesMarker((type as reflect.NullableType).member, marker)
   else if (type is reflect.DeclaredType)
     let (reflectee = (type as reflect.DeclaredType).referent.reflectee)
-      if (reflectee is Class) envelopeMarkerOfClass(reflect.Class(reflectee))
-      else envelopeMarkerOfType(reflect.TypeAlias(reflectee).referent)
+      if (reflectee is Class) envelopeMarkerOfClass(reflect.Class(reflectee)) == marker
+      else typeCarriesMarker(reflect.TypeAlias(reflectee).referent, marker)
   else if (type is reflect.UnionType)
-    (type as reflect.UnionType).members
-      .map((member) -> envelopeMarkerOfType(member))
-      .findOrNull((marker) -> marker != null)
+    (type as reflect.UnionType).members.any((member) -> typeCarriesMarker(member, marker))
   else
-    null
+    false
 
-/// The first union member belonging to the envelope family of `value`, or
+/// The first union member able to hold the envelope family of `value`, or
 /// `null` when `value` is not an envelope or the union declares no member of
 /// its family.
 ///
@@ -365,7 +369,7 @@ local function envelopeMemberOf(members: List<reflect.Type>, value: Any): reflec
   else
     let (marker = envelopeMarkerOf(value.toMap()))
       if (marker == null) null
-      else members.findOrNull((member) -> envelopeMarkerOfType(member) == marker)
+      else members.findOrNull((member) -> typeCarriesMarker(member, marker))
 
 /// The classes whose handlers convert a value of one of them into another: a
 /// number is read out of text, text is written from a number, a boolean is

--- a/internal/schema/pkl/generator/tests/gen.pkl
+++ b/internal/schema/pkl/generator/tests/gen.pkl
@@ -324,6 +324,26 @@ local class MapThenAliasedUnionResource extends formae.Resource {
     target: Mapping<String, Any>|RefOrText
 }
 
+/// A member naming several envelope families at once: `formae.ValueSource`, the
+/// alias a field names in place of spelling those families out. Beside a literal
+/// and beside a map member, so that a sibling able to hold the map an envelope
+/// arrives as does not take it in the alias's place.
+@formae.ResourceHint
+local class TextOrValueSourceResource extends formae.Resource {
+    type = "FakePlugin::Union::TextOrValueSource"
+
+    @formae.FieldHint
+    target: (String|formae.ValueSource)?
+}
+
+@formae.ResourceHint
+local class MapThenValueSourceResource extends formae.Resource {
+    type = "FakePlugin::Union::MapThenValueSource"
+
+    @formae.FieldHint
+    target: (Mapping<String, Any>|formae.ValueSource)?
+}
+
 /// The shape a schema gives a field holding either a literal or a secret the
 /// agent recorded — the union a reference to another resource's secret arrives
 /// at.
@@ -1634,6 +1654,23 @@ facts {
         selectedMember(MapThenNestedRefResource, reference(null)) == "FakeResolvable" &&
         selectedMember(NestedRefThenMapResource, reference(null)) == "FakeResolvable" &&
         selectedMember(MapThenAliasedUnionResource, reference(null)) == "FakeResolvable"
+    }
+
+    ["A member naming several envelope families is a member of each of them"] {
+        // formae.ValueSource names four families at once, so the member holding
+        // it is the member of whichever of them an envelope belongs to.
+        selectedMember(TextOrValueSourceResource, reference(null)) == "FakeResolvable" &&
+        selectedMember(TextOrValueSourceResource, recordedValue(null)) == "FakeValue" &&
+        selectedMember(TextOrValueSourceResource, binding(null)) == "FakeGeneratorOutput"
+    }
+
+    ["A member naming several envelope families is preferred over a map member"] {
+        // A map member holds the very map an envelope arrives as, so an envelope
+        // reaches the member naming the alias only because that member is
+        // preferred over the map beside it.
+        selectedMember(MapThenValueSourceResource, reference(null)) == "FakeResolvable" &&
+        selectedMember(MapThenValueSourceResource, recordedValue(null)) == "FakeValue" &&
+        selectedMember(MapThenValueSourceResource, binding(null)) == "FakeGeneratorOutput"
     }
 
     ["A reference missing an optional part still selects the reference member over a map member"] {

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -748,6 +748,29 @@ open class SecretValue extends Value {
     }
 }
 
+/// Every way formae can supply a resource field's value other than as a literal:
+/// a reference to another resource's property, a value formae has recorded, a
+/// secret value, or one of a generator's named outputs. A field names this in
+/// place of spelling the four out, so a field that accepts anything formae can
+/// supply says so once and goes on saying it when a new envelope kind is added.
+///
+/// Because `SecretValue` is a member, a field naming this alias is marked opaque
+/// in its schema `FieldHint`, and the agent hashes its value at rest.
+///
+/// `String` is deliberately not a member: a field declares its own literal type
+/// beside the alias, as `(String|formae.ValueSource)?`. That is what keeps a
+/// constraint on the literal meaningful — with a bare `String` inside the alias,
+/// `(String(matches(Regex(#"…"#)))|formae.ValueSource)` would accept any string
+/// at all, since the alias's own unconstrained `String` arm would take it.
+///
+/// A field naming this alias accepts a generator binding. One that must not take
+/// a generated value spells out the members it does accept instead.
+typealias ValueSource =
+    Resolvable        // $res, another resource's property
+  | Value             // $value, a value formae has recorded
+  | SecretValue       // $value, and what marks the field opaque
+  | GeneratorOutput   // $gen, one of a generator's named outputs
+
 open class Prop {
     hidden flag: String?
     hidden default: (String|Boolean|Int|Float)?

--- a/internal/schema/pkl/schema/tests/formae.pkl
+++ b/internal/schema/pkl/schema/tests/formae.pkl
@@ -333,6 +333,72 @@ local testSecretAliasResource = new TestSecretAliasResource {
     secretAliased = "shh-alias"
 }
 
+// Test a field that names formae.ValueSource in place of spelling the envelope
+// members out: the field is still marked Opaque, it takes each member of the
+// alias, and it rejects a value belonging to none of them. A second field pairs
+// the alias with a constrained String literal, so that the constraint is shown
+// to survive the alias beside it.
+@formae.ResourceHint {
+    type = "Test::ValueSource"
+    identifier = "Ref"
+}
+local class TestValueSourceResource extends formae.Resource {
+    @formae.FieldHint
+    supplied: (String|formae.ValueSource)?
+
+    @formae.FieldHint
+    constrained: (String(matches(Regex(#"ok-.*"#)))|formae.ValueSource)?
+
+    @formae.FieldHint
+    plain: String
+}
+
+local testValueSourceResource = new TestValueSourceResource {
+    label = "test-value-source"
+    supplied = "literal"
+    plain = "value"
+}
+
+// One instance per member of the alias, so a member the alias fails to admit is
+// an eval-time type error on that instance rather than a silent pass.
+local valueSourceLiteral = (testValueSourceResource) { supplied = "literal" }
+
+local valueSourceValue = (testValueSourceResource) {
+    supplied = new formae.Value { value = "recorded" }
+}
+
+local valueSourceSecret = (testValueSourceResource) {
+    supplied = new formae.SecretValue { value = "shh" }
+}
+
+local valueSourceResolvable = (testValueSourceResource) {
+    supplied = new formae.Resolvable {
+        label = "bucket"
+        stack = "storage"
+        type = "namespace::resource::s3bucket"
+        property = "BucketName"
+    }
+}
+
+local valueSourceGenerated = (testValueSourceResource) {
+    supplied = new formae.GeneratorOutput {
+        genLabel = "db-password-gen"
+        output = "value"
+    }
+}
+
+// A member of no envelope family the alias names, so the alias is shown to be a
+// closed set rather than anything at all.
+local valueSourceForeign = (testValueSourceResource) {
+    supplied = formae.embed("a-template")
+}
+
+local constrainedMatching = (testValueSourceResource) { constrained = "ok-literal" }
+local constrainedViolating = (testValueSourceResource) { constrained = "BAD" }
+local constrainedEnvelope = (testValueSourceResource) {
+    constrained = new formae.SecretValue { value = "shh" }
+}
+
 // Test config class with ConfigFieldHint annotations
 local class TestConfig {
     hidden fixed type: String = "TestProvider"
@@ -951,6 +1017,53 @@ facts {
     ["Opaque hint set for typealias-typed SecretValue field"] {
         let (hints = testSecretAliasResource.hints())
         hints["secretAliased"].Opaque == true
+    }
+
+    ["Opaque hint set for a field naming ValueSource"] {
+        let (hints = testValueSourceResource.hints())
+        hints["supplied"].Opaque == true &&
+        hints["constrained"].Opaque == true &&
+        hints["plain"].Opaque == false
+    }
+
+    ["A field naming ValueSource takes a literal String"] {
+        valueSourceLiteral.supplied == "literal"
+    }
+
+    ["A field naming ValueSource takes a recorded Value"] {
+        (valueSourceValue.supplied as formae.Value).$value == "recorded"
+    }
+
+    ["A field naming ValueSource takes a SecretValue"] {
+        (valueSourceSecret.supplied as formae.SecretValue).$value == "shh"
+    }
+
+    ["A field naming ValueSource takes a Resolvable"] {
+        (valueSourceResolvable.supplied as formae.Resolvable).$property == "BucketName"
+    }
+
+    ["A field naming ValueSource takes a GeneratorOutput"] {
+        (valueSourceGenerated.supplied as formae.GeneratorOutput).$output == "value"
+    }
+
+    ["A field naming ValueSource rejects an envelope of no member's family"] {
+        module.catch(() -> valueSourceForeign.supplied)
+            .contains("String|formae.ValueSource")
+    }
+
+    ["A constrained literal beside ValueSource takes a matching String"] {
+        constrainedMatching.constrained == "ok-literal"
+    }
+
+    // The constraint is what breaks were String a member of the alias: the
+    // alias's own unconstrained String arm would take this value.
+    ["A constrained literal beside ValueSource rejects a violating String"] {
+        module.catch(() -> constrainedViolating.constrained)
+            .contains("matches(Regex(#\"ok-.*\"#))")
+    }
+
+    ["A constrained literal beside ValueSource still takes an envelope"] {
+        (constrainedEnvelope.constrained as formae.SecretValue).$value == "shh"
     }
 
     ["FieldHint exposes AttachesTo"] {

--- a/internal/testplugin/fakeaws/schema/pkl/rds/dbinstance.pkl
+++ b/internal/testplugin/fakeaws/schema/pkl/rds/dbinstance.pkl
@@ -50,7 +50,7 @@ open class DBInstance extends formae.Resource {
     masterUsername: String?
 
     @fakeaws.FieldHint
-    masterUserPassword: (String|formae.Resolvable)?
+    masterUserPassword: (String|formae.ValueSource)?
 
     @fakeaws.FieldHint
     storageEncrypted: Boolean?

--- a/internal/testplugin/fakeaws/schema/pkl/secretsmanager/secret.pkl
+++ b/internal/testplugin/fakeaws/schema/pkl/secretsmanager/secret.pkl
@@ -47,7 +47,7 @@ open class Secret extends formae.Secret {
     description: String?
 
     @fakeaws.FieldHint
-    secretString: (String|formae.Value|formae.SecretValue|formae.GeneratorOutput)?
+    secretString: (String|formae.ValueSource)?
 
     @fakeaws.FieldHint
     tags: Listing<fakeaws.Tag>?


### PR DESCRIPTION
## Summary

A plugin field that can hold a value from somewhere other than a literal spells out every envelope kind it accepts, and every plugin repeats that union on every such field — roughly 41 declarations across the published plugins, in five shapes, two of which are the same member set in a different order. Adding a kind means editing all of them, which just happened for generator outputs and will happen again.

This names the set once. A field becomes `(String|formae.ValueSource)?` instead of listing four members.

Doing it now rather than later is the point: those 41 sites have to change anyway to accept a generator output, so the alias costs nothing extra at this moment and would cost a second sweep at any other.

## The three decisions

**One alias, not two.** 38 of the 41 sites name the same four kinds; 3 omit resolvables. Whether that omission is load-bearing was checked rather than assumed — no agent-side logic requires a resolvable to be absent from a value-bearing field, and the secret-value resolvable type exists precisely so secrets can be referenced. So the narrowing is a declaration choice. Those 3 keep spelling their union out, which makes an unusual narrowing look unusual; a second near-identical alias would be a per-field decision with no diagnostic when chosen wrong.

**`String` stays outside, and this was settled by evaluation rather than taste.** With a bare `String` inside the alias, a constrained field written as `(String(matches(…))|Alias)` **accepts a value the constraint forbids** — the alias's unconstrained arm satisfies the union and the constraint is silently dead. With `String` outside, the same value is rejected and the constraint is named. On a published surface that footgun is worse than repeating five characters, and a string is not an envelope kind anyway.

**The name says what it is.** It is where a value comes from when it is not a literal. Naming it for secrets would be wrong: resolvables and values are not necessarily secrets.

## What was fixed along the way, and why it was not left as a note

The extract renderer resolves typealiases, but it mapped each union member to a *single* envelope family, so a multi-family alias reported only its first member's family. Measured: a field declared `(String|ValueSource)` works, because a string cannot swallow a mapping and declaration-order fallthrough reaches the alias. A field declared `(Mapping|ValueSource)` **silently resolved as a mapping** — the envelope stored as plain data — where the spelled-out union resolved correctly.

Unreachable today, since all 41 real sites lead with a string. Fixed anyway, because the alias's whole purpose is that authors stop seeing the member list, which is exactly what makes a mapping-sibling adoption an ordinary edit rather than an exotic one, and the failure mode is silent corruption of a value-bearing field. Single-family members behave identically under the new predicate, so no existing schema changes behaviour.

## The safety property, proven rather than argued

A field's `opaque` hint is what causes a drawn value to be hashed at rest, and it is derived by walking the declared type. If that walk could not see through an alias, adopting the alias would silently stop secrets being hashed.

It can, and the test that says so is load-bearing: breaking the walker's typealias arm fails both the new assertion and a pre-existing one. Checked on the real fake-plugin resources rather than only on test classes.

One consequence worth naming: the fake plugin's database password field did **not** accept a secret value before, so it was not opaque. Adopting the alias makes it opaque — a real behaviour change, and the correct one for a database master password. Any published plugin field in that position will gain opacity the same way, which should be a deliberate choice per field when those are converted.

## Not in scope

The published plugins. They need the alias to exist in a released schema before they can name it, and they carry their own release mechanics.