### PR TITLE
fix(schema): floor the rotation cadence at one minute

### DIFF
--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -176,7 +176,18 @@ open class AutoReconcilePolicy extends Policy {
 /// inherit and none to guess at: a rotation spec that names no interval is an
 /// eval-time error, not a generator that rotates on some house default.
 open class RotationSpec {
-    every: Duration
+    /// One minute is the floor because it is what the scheduler can honour,
+    /// not because a faster cadence would be unwise. The rotator wakes on a
+    /// fixed sweep and rotates whatever is due, so an interval shorter than
+    /// that sweep cannot be met whatever it says. Sub-second intervals are
+    /// worse than merely unmet: the cadence is rendered in whole seconds, so
+    /// they truncate to zero, and a zero interval reads downstream as no
+    /// cadence declared at all, which is to say the credential is never
+    /// rotated by the very spec asking for it. A credential that has to turn
+    /// over faster than a minute wants short-lived credentials issued per
+    /// use, not a scheduler revisiting a long-lived one.
+    every: Duration(this >= 1.min
+        || throw("RotationSpec.every: \(this) is shorter than the one minute minimum rotation interval"))
 
     local self = this
     // Output

--- a/internal/schema/pkl/schema/tests/formae.pkl
+++ b/internal/schema/pkl/schema/tests/formae.pkl
@@ -492,6 +492,22 @@ local cadencelessRotation = new formae.PasswordGenerator {
     rotation = new formae.RotationSpec {}
 }
 
+local subMinuteRotation = new formae.PasswordGenerator {
+    label = "sub-minute-password"
+    stack = stackResolvable
+    rotation = new formae.RotationSpec {
+        every = 500.ms
+    }
+}
+
+local minimumRotation = new formae.PasswordGenerator {
+    label = "minimum-password"
+    stack = stackResolvable
+    rotation = new formae.RotationSpec {
+        every = 1.min
+    }
+}
+
 // Schema classes that sit under an intermediate base rather than extending
 // formae.SubResource / formae.Resource directly. The subclasses inherit the
 // base's annotated fields, redeclare one of them (narrowing String? to String),
@@ -807,6 +823,15 @@ facts {
 
     ["A rotation spec without a cadence is rejected"] {
         module.catch(() -> cadencelessRotation.render().Rotation.EverySeconds) != null
+    }
+
+    ["A cadence below the scheduler's floor is rejected, naming the field"] {
+        module.catch(() -> subMinuteRotation.render().Rotation.EverySeconds)
+            .contains("RotationSpec.every")
+    }
+
+    ["The floor itself is a cadence"] {
+        minimumRotation.render().Rotation.EverySeconds == 60
     }
 
     ["Relative TTL policy renders TTLSeconds and no ExpiresAt"] {

--- a/internal/schema/pkl/testdata/forma/generator_rotation_test.pkl
+++ b/internal/schema/pkl/testdata/forma/generator_rotation_test.pkl
@@ -9,10 +9,9 @@
 // cadence lives on the generator rather than on the secret, so one interval
 // governs every destination that shares the credential.
 //
-// `every` is one second because the scheduler's sweep is driven directly in
-// the test: the interval only has to be short enough that the generator comes
-// due, and `RotationSpec.every` is an unconstrained Duration rendered to whole
-// seconds, so a second is the shortest cadence the schema admits.
+// `every` is one minute, the shortest cadence the schema admits. The test does
+// not wait for it: it backdates the anchor the cadence is measured from and
+// drives the scheduler's sweep directly.
 
 amends "@formae/forma.pkl"
 import "@formae/formae.pkl"
@@ -38,7 +37,7 @@ forma {
     stack = appStack.res
     length = 24
     rotation = new formae.RotationSpec {
-      every = 1.s
+      every = 1.min
     }
   }
   pw

--- a/internal/workflow_tests/local/apply_forma/generator_rotation_pkl_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_rotation_pkl_test.go
@@ -22,8 +22,9 @@ import (
 )
 
 // authoredRotatingGeneratorForma is the forma this test applies: a
-// PasswordGenerator declaring `rotation { every = 1.s }` and a plugin resource
-// whose secret-bearing property is bound to that generator's `value` output.
+// PasswordGenerator declaring `rotation { every = 1.min }` and a plugin
+// resource whose secret-bearing property is bound to that generator's `value`
+// output.
 const authoredRotatingGeneratorForma = "internal/schema/pkl/testdata/forma/generator_rotation_test.pkl"
 
 // The stack, generator and destination the authored forma declares.
@@ -32,6 +33,7 @@ const (
 	rotatingFormaGenerator   = "db-password"
 	rotatingFormaDestination = "db"
 	rotatingFormaLength      = 24
+	rotatingFormaEverySecs   = 60
 )
 
 // A cadence authored in PKL rotates the credential it governs. The forma is
@@ -65,7 +67,8 @@ func TestApplyForma_PklAuthoredRotatingGenerator_RotatesOnItsDeclaredCadence(t *
 		require.Len(t, forma.Generators, 1)
 		require.True(t, gjson.GetBytes(forma.Resources[0].Properties, "SecretString.$gen").Bool(),
 			"precondition: eval must render the binding as a $gen envelope")
-		require.Equal(t, int64(1), gjson.GetBytes(forma.Generators[0], "Rotation.EverySeconds").Int(),
+		require.Equal(t, int64(rotatingFormaEverySecs),
+			gjson.GetBytes(forma.Generators[0], "Rotation.EverySeconds").Int(),
 			"precondition: the authored cadence must reach the model as an interval in seconds")
 
 		delivered := newDeliveredValues()
@@ -93,9 +96,10 @@ func TestApplyForma_PklAuthoredRotatingGenerator_RotatesOnItsDeclaredCadence(t *
 		require.NoError(t, err)
 		require.NotEmpty(t, identityBefore.GenerationID)
 
-		// Waiting first is what makes the sweep below say something about the
-		// scheduler rather than about the clock.
-		waitUntilRotationDue(t, m, rotatingFormaStack, rotatingFormaGenerator)
+		// Putting the cadence behind the generator first is what makes the
+		// sweep below say something about the scheduler rather than about the
+		// clock.
+		makeRotationDue(t, m, rotatingFormaStack, rotatingFormaGenerator)
 		rotation := sweepUntilRotated(t, m)
 		require.Equal(t, forma_command.CommandStateSuccess, rotation.State,
 			"the rotation of a PKL-authored cadence must succeed")

--- a/internal/workflow_tests/local/apply_forma/generator_rotation_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_rotation_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
+	"github.com/platform-engineering-labs/formae/internal/datastore"
 	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
 	"github.com/platform-engineering-labs/formae/internal/metastructure"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
@@ -327,30 +328,60 @@ func newRotationAgent(t *testing.T, overrides *plugin.ResourcePluginOverrides, c
 // opaque reference to the generated secret's value.
 const consumerLabel = "my-bucket"
 
-// waitUntilRotationDue blocks until the generator's cadence has certainly
-// elapsed, so that a sweep which produces no rotation says something about the
-// sweep rather than about the clock. It waits two full intervals past the
-// derived anchor, which strictly covers the jitter (a tenth of the interval).
-//
-// Without this a "rotation was refused" assertion passes on a generator that
-// was simply not due yet, which is the same result for the wrong reason.
-func waitUntilRotationDue(t *testing.T, m *metastructure.Metastructure, stack, label string) {
+// rotationInfoFor returns the scheduler's view of one generator's cadence.
+func rotationInfoFor(t *testing.T, m *metastructure.Metastructure, stack, label string) datastore.GeneratorRotationInfo {
 	t.Helper()
 	infos, err := m.Datastore.GetGeneratorsWithRotation()
 	require.NoError(t, err)
 	for _, info := range infos {
-		if info.Label != label || info.StackLabel != stack {
-			continue
+		if info.Label == label && info.StackLabel == stack {
+			return info
 		}
-		require.False(t, info.LastRotationAt.IsZero(),
-			"precondition: the generator must have a committed draw to measure from")
-		interval := time.Duration(info.IntervalSeconds) * time.Second
-		if wait := time.Until(info.LastRotationAt.Add(2 * interval)); wait > 0 {
-			time.Sleep(wait)
-		}
-		return
 	}
 	t.Fatalf("no rotation info for generator %q on stack %q", label, stack)
+	return datastore.GeneratorRotationInfo{}
+}
+
+// makeRotationDue puts the generator's cadence behind it, so that a sweep
+// which produces no rotation says something about the sweep rather than about
+// the clock. Without it a "rotation was refused" assertion passes on a
+// generator that was simply not due yet, which is the same result for the
+// wrong reason.
+//
+// The cadence is derived rather than stored: the last-rotation instant is the
+// start of the successful command that drew the generator's current
+// generation. So the generator becomes due when that command is old, and the
+// intervention is to move that one instant back. No clock is faked and no
+// interval is shortened below what the schema admits. Two intervals back
+// covers the cadence and the jitter on top of it, which is a tenth of the
+// interval.
+//
+// A backdated command is the ordinary state of a datastore whose apply ran a
+// while ago, which is every datastore that has been up longer than one
+// cadence. Nothing else in rotation reads a command's start instant.
+func makeRotationDue(t *testing.T, m *metastructure.Metastructure, stack, label string) {
+	t.Helper()
+
+	info := rotationInfoFor(t, m, stack, label)
+	require.False(t, info.LastRotationAt.IsZero(),
+		"precondition: the generator must have a committed draw to measure from")
+	interval := time.Duration(info.IntervalSeconds) * time.Second
+	anchor := time.Now().UTC().Add(-2 * interval)
+
+	sqlite, ok := m.Datastore.(dssqlite.DatastoreSQLite)
+	require.True(t, ok, "the agent under test must run on SQLite for its command history to be aged")
+	result, err := sqlite.Conn().Exec(
+		`UPDATE forma_commands SET timestamp = ? WHERE command_id IN (
+			SELECT command_id FROM generators WHERE id = ? AND generation_id != ''
+		)`, anchor, info.GeneratorID)
+	require.NoError(t, err)
+	affected, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.Positive(t, affected, "the draw's own command is what carries the cadence anchor")
+
+	aged := rotationInfoFor(t, m, stack, label)
+	require.GreaterOrEqual(t, time.Since(aged.LastRotationAt), 2*interval,
+		"the derived anchor must read as two intervals old")
 }
 
 // A rotation is an ordinary update, so it confronts drift rather than writing
@@ -379,7 +410,7 @@ func TestGeneratorRotation_RefusesADriftedStack(t *testing.T) {
 				// A patch records a modification since the last reconcile,
 				// which is the drift a soft reconcile confronts.
 				driftStack(t, m, stack, drifted)
-				waitUntilRotationDue(t, m, stack, "db-password")
+				makeRotationDue(t, m, stack, "db-password")
 
 				for i := 0; i < 10; i++ {
 					sweepRotations(t, m)
@@ -520,15 +551,7 @@ func failingUpdatesFor(delivered *deliveredValues, labels ...string) *plugin.Res
 // measured from, as the scheduler derives it.
 func rotationAnchorFor(t *testing.T, m *metastructure.Metastructure, stack, label string) time.Time {
 	t.Helper()
-	infos, err := m.Datastore.GetGeneratorsWithRotation()
-	require.NoError(t, err)
-	for _, info := range infos {
-		if info.Label == label && info.StackLabel == stack {
-			return info.LastRotationAt
-		}
-	}
-	t.Fatalf("no rotation info for generator %q on stack %q", label, stack)
-	return time.Time{}
+	return rotationInfoFor(t, m, stack, label).LastRotationAt
 }
 
 // The cadence advances on one milestone and one only: every authority-side
@@ -561,13 +584,12 @@ func TestGeneratorRotation_AFailedAuthorityUpdateDoesNotAdvanceTheCadence(t *tes
 		waitForApplyComplete(t, m)
 		require.Len(t, delivered.createdWith("alpha"), 1, "precondition: the destination was drawn for")
 
+		makeRotationDue(t, m, stack, "db-password")
 		anchorBefore := rotationAnchorFor(t, m, stack, "db-password")
-		require.False(t, anchorBefore.IsZero(), "precondition: the first apply committed a draw")
 		generationBefore, err := m.Datastore.GetGeneratorIdentity("db-password", stack)
 		require.NoError(t, err)
 		digestBefore := storedBinding(t, m, stack, "alpha").Get("$value").String()
 
-		waitUntilRotationDue(t, m, stack, "db-password")
 		rotation := sweepUntilRotated(t, m)
 		require.Equal(t, forma_command.CommandStateFailed, rotation.State,
 			"precondition: the authority-side update must have failed")
@@ -617,10 +639,9 @@ func TestGeneratorRotation_OneFailedDestinationOfSeveralDoesNotAdvanceTheCadence
 		require.Len(t, delivered.createdWith("alpha"), 1, "precondition: both destinations were drawn for")
 		require.Len(t, delivered.createdWith("beta"), 1)
 
+		makeRotationDue(t, m, stack, "db-password")
 		anchorBefore := rotationAnchorFor(t, m, stack, "db-password")
-		require.False(t, anchorBefore.IsZero())
 
-		waitUntilRotationDue(t, m, stack, "db-password")
 		rotation := sweepUntilRotated(t, m)
 		require.Equal(t, forma_command.CommandStateFailed, rotation.State,
 			"precondition: one destination's write must have failed")


### PR DESCRIPTION
## Summary

A rotation interval had no lower bound, and the two consequences pull the same way.

**A sub-second interval silently meant never rotate.** The rendered interval truncates to whole seconds, so half a second becomes zero, and a zero interval is treated as *no cadence declared* — established in two places, the decisive one being that such a generator never enters the sweep's candidate list at all. So the spec asking for the fastest possible rotation is the one that gets none.

**And an interval below the sweep period cannot be honoured**, because nothing can rotate more often than the scheduler checks. The sweep is thirty seconds.

The floor is therefore one minute: what the scheduler can actually meet, comfortably clear of the sweep, and still short enough to watch a rotation happen without contriving anything. It is not advice about what interval to choose — a credential that needs turning over more often than that wants short-lived credentials rather than scheduled rotation, and that belongs in guidance rather than in a constraint.

The constraint carries an explicit message rather than relying on the bare type constraint. The plain form does name the field in a CLI stack trace, but a caller catching the error programmatically sees only the message, which would name neither the field nor the limit.

## The test stops sleeping

The rotation workflow test used a one-second interval and waited two of them in wall-clock, which the floor makes illegal and which was the weaker choice anyway.

Last rotation is derived rather than stored, so making a generator due is a matter of the recorded history being old enough rather than of time passing. The test now ages exactly one field — the start instant of the command that recorded the generation — to two intervals ago, then requires the derived anchor to read that way before sweeping.

That is an ordinary state rather than an impossible fixture: it is what the rows look like two minutes after an apply, on any datastore that has been up longer than one cadence. No clock is faked and no interval goes below the floor. The helper also fails if it updates nothing, so a change that moved the anchor elsewhere breaks the helper rather than quietly making the test vacuous.

The sleeping helper is deleted rather than left beside the new one, and its other three call sites converted. That surfaced a real coupling: two failure-mode tests read the anchor *before* making the generator due, so they were comparing against a value the ageing then changed. Reading it after is what "a failed rotation must not move the anchor" actually means.

The test still proves rotation happened rather than that a command ran: a second value, distinct from the first, of the declared length, with the stored digest moved and the generation advanced. Disabling the sweep's selection makes it fail.

## Timing

| | before | after |
|---|---|---|
| the authored-forma rotation test | 2.42s | 0.48s |
| all nine rotation tests | 18.71s | 9.44s |

## Scope

One testdata forma authored a sub-minute cadence and is raised; nothing else in the tree constructs a rotation spec. The Go-struct fixtures keep their one-second intervals, which remain legal at the model level and no longer affect timing now that nothing sleeps on them.