### PR TITLE
fix(connect): ask whether a token exists before blaming the subscription

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -112,6 +112,7 @@ require (
 )
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 )
@@ -122,7 +123,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	ergo.services/meta v0.0.0-20240904054930-a97f6add8a78 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0 // indirect

--- a/internal/cli/connect/azureauth.go
+++ b/internal/cli/connect/azureauth.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 
@@ -48,19 +49,61 @@ const (
 // "build a credential and make one ARM call" that would let a test drive
 // every classification without a real Azure environment, the same reason
 // GCP's findCredentials is a var.
+// tokenOutcome records whether a token was obtained at all, which is a
+// different question from whether the subscription could then be read. They
+// were once inferred from a single ARM call, and that conflated them: a
+// machine with no credential source produced the same failure as a
+// subscription that does not exist, so the operator was told to check their
+// subscription id when what they actually needed was to sign in.
+type tokenOutcome int
+
+const (
+	tokenFailed tokenOutcome = iota
+	tokenObtained
+)
+
+// azureScope is the ARM scope a token is requested for. It is the audience
+// every management-plane call uses, so a token that cannot be minted for it
+// cannot do anything this command needs.
+const azureScope = "https://management.azure.com/.default"
+
 var usableCredentials = func(ctx context.Context, subscriptionID, tenantHint string) (azureCredentialState, error) {
 	cred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{TenantID: tenantHint})
 	if err != nil {
 		return azureCredentialsNeedsAuthentication, nil //nolint:nilerr // the classification is the answer, not a failure
 	}
+
+	// Ask for a token first, and on its own. When no source in the chain can
+	// even attempt one - no environment variables, no managed identity, no az,
+	// no PowerShell - azidentity reports a credentialUnavailableError, which it
+	// does not export. So this cannot be recognised by type further down; it
+	// has to be observed here, where the attempt is made.
+	if _, err := cred.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{azureScope}}); err != nil {
+		return classifyCredentialOutcome(tokenFailed, err), nil //nolint:nilerr // as above
+	}
+
 	client, err := armsubscriptions.NewClient(cred, nil)
 	if err != nil {
 		return azureCredentialsNeedsAuthentication, nil //nolint:nilerr // as above
 	}
 	if _, err := client.Get(ctx, subscriptionID, nil); err != nil {
-		return classifyAzureCredentialError(err), nil
+		return classifyCredentialOutcome(tokenObtained, err), nil
 	}
 	return azureCredentialsUsable, nil
+}
+
+// classifyCredentialOutcome turns "did a token arrive, and what failed next"
+// into one of the four states.
+//
+// A token that never arrived is always a sign-in problem, whatever the error
+// says: the alternatives - a permission this principal lacks, a subscription
+// it cannot see - are statements about a principal, and there is no principal
+// until a token exists.
+func classifyCredentialOutcome(outcome tokenOutcome, err error) azureCredentialState {
+	if outcome == tokenFailed {
+		return azureCredentialsNeedsAuthentication
+	}
+	return classifyAzureCredentialError(err)
 }
 
 // classifyAzureCredentialError turns a failed subscription read into one of

--- a/internal/cli/connect/azureauth_test.go
+++ b/internal/cli/connect/azureauth_test.go
@@ -8,11 +8,14 @@ package connect
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -175,4 +178,38 @@ func TestNeedsAuthenticationWithoutAzReportsAzMissing(t *testing.T) {
 		"an operator who will not install az needs to be told about the credential-less path")
 	_, hasCommand := f.Details["command"]
 	assert.False(t, hasCommand, "az_missing must not report a login command az cannot run")
+}
+
+// classifyCredentialOutcome is the seam the real usableCredentials routes
+// through, so these cases exercise the classification the stubbed
+// usableCredentials tests cannot reach.
+func TestNoCredentialAtAllNeedsAuthentication(t *testing.T) {
+	// What DefaultAzureCredential reports when no source in its chain can
+	// even attempt a token: the error is a credentialUnavailableError, which
+	// azidentity does not export, so it cannot be matched by type.
+	unavailable := errors.New("DefaultAzureCredential: failed to acquire a token.\n" +
+		"Attempted credentials:\n\tEnvironmentCredential: missing environment variable AZURE_TENANT_ID\n" +
+		"\tAzureCLICredential: Azure CLI not found on path")
+
+	got := classifyCredentialOutcome(tokenFailed, unavailable)
+
+	assert.Equal(t, azureCredentialsNeedsAuthentication, got,
+		"a machine with no credential source must be told to sign in, not that its subscription is unreadable")
+}
+
+func TestTokenObtainedButSubscriptionForbiddenLacksPermission(t *testing.T) {
+	denied := &azcore.ResponseError{StatusCode: 403, ErrorCode: "AuthorizationFailed"}
+
+	got := classifyCredentialOutcome(tokenObtained, denied)
+
+	assert.Equal(t, azureCredentialsLacksPermission, got)
+}
+
+func TestTokenObtainedButSubscriptionMissingIsUnreachable(t *testing.T) {
+	missing := &azcore.ResponseError{StatusCode: 404, ErrorCode: "SubscriptionNotFound"}
+
+	got := classifyCredentialOutcome(tokenObtained, missing)
+
+	assert.Equal(t, azureSubscriptionUnreachable, got,
+		"a token that works but a subscription that does not resolve is not a credential problem")
 }


### PR DESCRIPTION
## Summary

On a machine with no Azure credentials, `formae connect azure` reported:

> the subscription could not be read with these credentials; check the subscription id, and that this principal can see it

The operator has no credentials, and is told to check their subscription id. The `az_missing` remedy added for exactly this case was unreachable.

Found by running the command in a clean container, not by reading it.

## Cause

Credential state was inferred from a single ARM call, which conflated two different questions: **can a token be obtained**, and **can the subscription then be read**.

When no source in the credential chain can even attempt a token — no environment variables, no managed identity, no `az`, no PowerShell — `azidentity` reports a `credentialUnavailableError`. That type is **unexported** (`chained_token_credential.go`: *"return credentialUnavailableError iff all sources did so; return AuthenticationFailedError otherwise"*), so matching on `*AuthenticationFailedError` missed it and the call fell through to the unreachable-subscription branch.

## Fix

The two questions are asked separately. A token is requested on its own first, and a failure there is always a sign-in problem whatever the error says: the alternatives — a permission this principal lacks, a subscription it cannot see — are statements about a principal, and there is no principal until a token exists. Only once a token is in hand does a failed subscription read distinguish a missing permission from a subscription that does not resolve.

## Verified against the real binary, all four states

| machine state | code | remedy |
|---|---|---|
| no `az`, no credentials | `az_missing` | install URL, plus the template path that needs no CLI |
| `az` present, no credentials | `credentials_required` | `az login` |
| ditto, with `--tenant-id` | `credentials_required` | `az login --tenant <id>` |
| token ok, subscription unreadable | `not_authorized` / `project_unreachable` | the access that is missing |

## Why the unit tests missed it

They stub `usableCredentials` wholesale, so the classifier was never exercised — the seam sat above the thing that was wrong. The classification now lives behind its own seam and is tested directly, including the unexported-error case reproduced as the string azidentity actually returns.

## Swept for more while here

Three other things looked wrong and are **not** bugs: flag errors printing usage rather than a machine document (identical on aws and gcp), and credentials being checked before the hosted session (identical on gcp). One genuine pre-existing defect was found on the **AWS** path — a profile-mode failure emits an opaque `internal` under machine output, the same wrapping issue fixed for Azure — which is not touched here.