### PR TITLE
fix(rotation): stop a sync wedging rotation, and keep the cadence through extract

### DIFF
--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -257,7 +257,12 @@ func start(from gen.PID, state gen.Atom, data ChangesetData, message Start, proc
 	// resource before the ResourceUpdater's own sync-Read runs. Without this,
 	// the sync-Read would see no diff (sync already equalised DB and cloud)
 	// and the update would proceed when it should have been rejected.
-	if changesetHasUserUpdates(data.changeset) {
+	//
+	// The gate is "does this changeset write" rather than "is this the user's
+	// changeset": the race is between a provider write and its persist, and it
+	// does not care who asked for the write. Gating it on user updates left an
+	// agent-initiated changeset registering nothing at all.
+	if changesetWritesResources(data.changeset) {
 		data.syncExcludedResourceURIs = registerAllResourcesWithSynchronizer(data.changeset.DAG, proc)
 	}
 
@@ -1061,6 +1066,37 @@ func targetUpdateRecoveredReaped(tu *target_update.TargetUpdate) bool {
 
 // changesetHasUserUpdates checks if the changeset contains any updates from user operations.
 // Returns true if at least one update has Source == FormaCommandSourceUser.
+// changesetWritesResources reports whether the changeset will write any
+// resource through a provider.
+//
+// Sync and discovery only read, and excluding a resource from sync on behalf
+// of a sync changeset would be circular. Every other source writes, so every
+// other source needs its resources held out of a concurrent sync cycle for the
+// duration.
+//
+// The case that made this necessary is a generator rotation. A rotation runs
+// in reconcile mode, so it re-baselines the drift window each time it
+// succeeds. A sync landing between a rotation's provider write and its own
+// persist records the just-written value as out-of-band drift, in patch mode,
+// which does not re-baseline. From then on the drift window is permanently
+// non-empty, so refuseRotationOnDrift refuses every later rotation, and since
+// the rotation is itself the reconcile that would have cleared the window
+// nothing recovers it. The credential silently stops rotating.
+func changesetWritesResources(changeset Changeset) bool {
+	for _, node := range changeset.DAG.Nodes {
+		ru, ok := node.Update.(*resource_update.ResourceUpdate)
+		if !ok {
+			continue
+		}
+		if ru.Source == resource_update.FormaCommandSourceSynchronize ||
+			ru.Source == resource_update.FormaCommandSourceDiscovery {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 func changesetHasUserUpdates(changeset Changeset) bool {
 	for _, node := range changeset.DAG.Nodes {
 		if ru, ok := node.Update.(*resource_update.ResourceUpdate); ok {

--- a/internal/metastructure/changeset/changeset_executor_test.go
+++ b/internal/metastructure/changeset/changeset_executor_test.go
@@ -185,6 +185,152 @@ func TestChangesetHasUserUpdates_TargetUpdatesIgnored(t *testing.T) {
 	assert.False(t, changesetHasUserUpdates(cs))
 }
 
+// The synchronizer exclusion exists to stop a sync cycle reading and
+// persisting a resource in the window between this changeset writing it at the
+// provider and persisting it itself. That race does not care who asked for the
+// write, so the gate is "does this changeset write" rather than "is this a
+// user's changeset".
+//
+// A rotation is the case that made the distinction matter. Gated on user
+// updates alone, a rotation registers nothing, the sync records the value the
+// rotation just wrote as out-of-band drift, and because a rotation is itself
+// the reconcile that would clear the drift window every later rotation is
+// refused. The credential then stops turning over permanently, with no
+// user-visible signal beyond a repeating log line.
+
+func TestChangesetWritesResources_GeneratorRotationWrites(t *testing.T) {
+	uri := pkgmodel.NewFormaeURI(util.NewID(), "")
+	opURI := createOperationURI(uri, resource_update.OperationUpdate)
+
+	cs := Changeset{
+		CommandID: "test",
+		DAG: &ExecutionDAG{
+			Nodes: map[pkgmodel.FormaeURI]*DAGNode{
+				opURI: {
+					URI: opURI,
+					Update: &resource_update.ResourceUpdate{
+						Source: resource_update.FormaCommandSourceGeneratorRotation,
+					},
+				},
+			},
+		},
+	}
+	assert.True(t, changesetWritesResources(cs),
+		"a rotation writes resources and must exclude them from sync")
+}
+
+func TestChangesetWritesResources_AutoReconcileWrites(t *testing.T) {
+	uri := pkgmodel.NewFormaeURI(util.NewID(), "")
+	opURI := createOperationURI(uri, resource_update.OperationUpdate)
+
+	cs := Changeset{
+		CommandID: "test",
+		DAG: &ExecutionDAG{
+			Nodes: map[pkgmodel.FormaeURI]*DAGNode{
+				opURI: {
+					URI: opURI,
+					Update: &resource_update.ResourceUpdate{
+						Source: resource_update.FormaCommandSourcePolicyAutoReconcile,
+					},
+				},
+			},
+		},
+	}
+	assert.True(t, changesetWritesResources(cs),
+		"an auto-reconcile writes resources and must exclude them from sync")
+}
+
+func TestChangesetWritesResources_UserWrites(t *testing.T) {
+	uri := pkgmodel.NewFormaeURI(util.NewID(), "")
+	opURI := createOperationURI(uri, resource_update.OperationUpdate)
+
+	cs := Changeset{
+		CommandID: "test",
+		DAG: &ExecutionDAG{
+			Nodes: map[pkgmodel.FormaeURI]*DAGNode{
+				opURI: {
+					URI: opURI,
+					Update: &resource_update.ResourceUpdate{
+						Source: resource_update.FormaCommandSourceUser,
+					},
+				},
+			},
+		},
+	}
+	assert.True(t, changesetWritesResources(cs))
+}
+
+// Sync and discovery read rather than write. Excluding a resource from sync on
+// behalf of a sync changeset would be circular, and would stop sync doing the
+// only thing it is for.
+func TestChangesetWritesResources_SyncDoesNotWrite(t *testing.T) {
+	uri := pkgmodel.NewFormaeURI(util.NewID(), "")
+	opURI := createOperationURI(uri, resource_update.OperationUpdate)
+
+	cs := Changeset{
+		CommandID: "test",
+		DAG: &ExecutionDAG{
+			Nodes: map[pkgmodel.FormaeURI]*DAGNode{
+				opURI: {
+					URI: opURI,
+					Update: &resource_update.ResourceUpdate{
+						Source: resource_update.FormaCommandSourceSynchronize,
+					},
+				},
+			},
+		},
+	}
+	assert.False(t, changesetWritesResources(cs))
+}
+
+func TestChangesetWritesResources_DiscoveryDoesNotWrite(t *testing.T) {
+	uri := pkgmodel.NewFormaeURI(util.NewID(), "")
+	opURI := createOperationURI(uri, resource_update.OperationUpdate)
+
+	cs := Changeset{
+		CommandID: "test",
+		DAG: &ExecutionDAG{
+			Nodes: map[pkgmodel.FormaeURI]*DAGNode{
+				opURI: {
+					URI: opURI,
+					Update: &resource_update.ResourceUpdate{
+						Source: resource_update.FormaCommandSourceDiscovery,
+					},
+				},
+			},
+		},
+	}
+	assert.False(t, changesetWritesResources(cs))
+}
+
+func TestChangesetWritesResources_EmptyChangeset(t *testing.T) {
+	cs := Changeset{
+		CommandID: "test",
+		DAG:       &ExecutionDAG{Nodes: map[pkgmodel.FormaeURI]*DAGNode{}},
+	}
+	assert.False(t, changesetWritesResources(cs))
+}
+
+// A target update is not a resource write, so it registers nothing.
+func TestChangesetWritesResources_TargetUpdatesIgnored(t *testing.T) {
+	cs := Changeset{
+		CommandID: "test",
+		DAG: &ExecutionDAG{
+			Nodes: map[pkgmodel.FormaeURI]*DAGNode{
+				"target://t": {
+					URI: "target://t",
+					Update: &target_update.TargetUpdate{
+						Target:    pkgmodel.Target{Label: "t", Namespace: "AWS"},
+						Operation: target_update.TargetOperationCreate,
+						State:     target_update.TargetUpdateStateNotStarted,
+					},
+				},
+			},
+		},
+	}
+	assert.False(t, changesetWritesResources(cs))
+}
+
 func TestCollectStacksWithDeletes_DeleteOps(t *testing.T) {
 	uri := pkgmodel.NewFormaeURI(util.NewID(), "")
 	opURI := createOperationURI(uri, resource_update.OperationDelete)

--- a/internal/metastructure/sync_exclusion_test.go
+++ b/internal/metastructure/sync_exclusion_test.go
@@ -1,0 +1,80 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package metastructure
+
+// The sync exclusion set is claimed by every changeset that writes a resource
+// and released when that changeset finishes. A plain set cannot express two
+// writers: whichever finished first would release a claim it did not solely
+// hold, and the other changeset would carry on writing with the synchronizer
+// free to read the resource mid-write, which is the race the exclusion exists
+// to close.
+//
+// Concurrent writers on one resource are refused at admission today, so this is
+// a property held by construction rather than one exercised in production. It
+// is counted anyway because the counting is smaller than the argument for why
+// it is unnecessary, and the admission guard is not this package's to rely on.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSyncExclusion_LastWriterReleases(t *testing.T) {
+	excluded := map[string]int{}
+
+	excludeFromSync(excluded, "formae://a#")
+	excludeFromSync(excluded, "formae://a#")
+
+	releaseFromSync(excluded, "formae://a#")
+	_, stillExcluded := excluded["formae://a#"]
+	assert.True(t, stillExcluded,
+		"one writer finishing must not expose a resource another is still writing")
+
+	releaseFromSync(excluded, "formae://a#")
+	_, nowExcluded := excluded["formae://a#"]
+	assert.False(t, nowExcluded, "the last writer's release must lift the exclusion")
+}
+
+func TestSyncExclusion_SingleWriterRoundTrip(t *testing.T) {
+	excluded := map[string]int{}
+
+	excludeFromSync(excluded, "formae://a#")
+	_, isExcluded := excluded["formae://a#"]
+	assert.True(t, isExcluded)
+
+	releaseFromSync(excluded, "formae://a#")
+	_, stillThere := excluded["formae://a#"]
+	assert.False(t, stillThere)
+}
+
+// A release with no matching claim is not an error worth failing a command
+// over, but it must not leave a negative count that a later claim would have
+// to climb out of before the resource is protected again.
+func TestSyncExclusion_ReleaseWithoutClaimIsInert(t *testing.T) {
+	excluded := map[string]int{}
+
+	releaseFromSync(excluded, "formae://ghost#")
+	assert.Empty(t, excluded)
+
+	excludeFromSync(excluded, "formae://ghost#")
+	_, isExcluded := excluded["formae://ghost#"]
+	assert.True(t, isExcluded, "a claim after a stray release must still protect")
+}
+
+func TestSyncExclusion_ResourcesAreIndependent(t *testing.T) {
+	excluded := map[string]int{}
+
+	excludeFromSync(excluded, "formae://a#")
+	excludeFromSync(excluded, "formae://b#")
+	releaseFromSync(excluded, "formae://a#")
+
+	_, aExcluded := excluded["formae://a#"]
+	_, bExcluded := excluded["formae://b#"]
+	assert.False(t, aExcluded)
+	assert.True(t, bExcluded, "releasing one resource must not release another")
+}

--- a/internal/metastructure/synchronizer.go
+++ b/internal/metastructure/synchronizer.go
@@ -73,10 +73,13 @@ type SynchronizerData struct {
 	timeStarted time.Time
 	commandID   string
 
-	// excludedResources tracks resources that are currently being updated by
-	// non-sync operations (e.g., user apply/destroy commands). These resources
-	// should be excluded from synchronization to prevent race conditions.
-	excludedResources map[string]struct{}
+	// excludedResources counts, per resource, how many in-flight changesets are
+	// writing it. Anything present is held out of synchronization; a resource
+	// drops out only when the last writer releases it. It is a count rather
+	// than a set because a set cannot express two writers: the first to finish
+	// would release a claim it did not solely hold, and the other changeset
+	// would keep writing with the synchronizer free to read mid-write.
+	excludedResources map[string]int
 }
 
 // Messages processed by Synchronizer
@@ -120,7 +123,7 @@ func (s *Synchronizer) Init(args ...any) (statemachine.StateMachineSpec[Synchron
 	data := SynchronizerData{
 		datastore:         ds.(datastore.Datastore),
 		cfg:               synchronizerCfg,
-		excludedResources: make(map[string]struct{}),
+		excludedResources: make(map[string]int),
 	}
 
 	spec := statemachine.NewStateMachineSpec(StateIdle,
@@ -385,14 +388,35 @@ func changesetCompleted(from gen.PID, state gen.Atom, data SynchronizerData, mes
 	return StateIdle, data, rescheduleAction(data), nil
 }
 
+// excludeFromSync claims uri on behalf of one in-flight changeset.
+func excludeFromSync(excluded map[string]int, uri string) {
+	excluded[uri]++
+}
+
+// releaseFromSync drops one changeset's claim on uri, lifting the exclusion
+// only once the last writer has released it. A release with no matching claim
+// is inert rather than an error: it must not leave a negative count that a
+// later claim would have to climb out of before the resource is protected.
+func releaseFromSync(excluded map[string]int, uri string) {
+	remaining, claimed := excluded[uri]
+	if !claimed {
+		return
+	}
+	if remaining <= 1 {
+		delete(excluded, uri)
+		return
+	}
+	excluded[uri] = remaining - 1
+}
+
 func registerInProgressResource(from gen.PID, state gen.Atom, data SynchronizerData, message messages.RegisterInProgressResource, proc gen.Process) (gen.Atom, SynchronizerData, []statemachine.Action, error) {
-	data.excludedResources[message.ResourceURI] = struct{}{}
+	excludeFromSync(data.excludedResources, message.ResourceURI)
 	proc.Log().Debug("Resource registered as in-progress, excluded from sync resourceURI=%s", message.ResourceURI)
 	return state, data, nil, nil
 }
 
 func unregisterInProgressResource(from gen.PID, state gen.Atom, data SynchronizerData, message messages.UnregisterInProgressResource, proc gen.Process) (gen.Atom, SynchronizerData, []statemachine.Action, error) {
-	delete(data.excludedResources, message.ResourceURI)
+	releaseFromSync(data.excludedResources, message.ResourceURI)
 	proc.Log().Debug("Resource unregistered from in-progress, can be synced resourceURI=%s", message.ResourceURI)
 	return state, data, nil, nil
 }

--- a/internal/schema/pkl/generator/pklGenerator.pkl
+++ b/internal/schema/pkl/generator/pklGenerator.pkl
@@ -282,6 +282,12 @@ function parseGenerators(generatorsData: List<Map<String, Any>>, stackLabelMap: 
         else
             ""
         )
+        let (rotationEverySeconds = generatorData.getOrNull("RotationEverySeconds") as Number?)
+        let (rotationLine = if (rotationEverySeconds != null)
+            "\n        rotation = new formae.RotationSpec {\n          every = \(rotationEverySeconds.toInt()).s\n        }"
+        else
+            ""
+        )
         if (generatorType == "password")
             let (length = generatorData["Length"] as Number)
             let (uppercase = generatorData["Uppercase"] as Boolean)
@@ -293,7 +299,7 @@ function parseGenerators(generatorsData: List<Map<String, Any>>, stackLabelMap: 
             """
 
       local \(camelCaseLabel) = new formae.PasswordGenerator {
-        label = "\(label)"\(stackLine)
+        label = "\(label)"\(stackLine)\(rotationLine)
         length = \(length)
         uppercase = \(uppercase)
         lowercase = \(lowercase)
@@ -457,6 +463,8 @@ function generateFormaFile(parsed: json.Value): String =
             "Type", generator.Type,
             "Label", generator.Label,
             "Stack", generator.getPropertyOrNull("Stack"),
+            "RotationEverySeconds", generator.getPropertyOrNull("Rotation")
+                ?.getPropertyOrNull("EverySeconds"),
             "Length", generator.getPropertyOrNull("Length"),
             "Uppercase", generator.getPropertyOrNull("Uppercase"),
             "Lowercase", generator.getPropertyOrNull("Lowercase"),

--- a/internal/schema/pkl/pkl_generate_test.go
+++ b/internal/schema/pkl/pkl_generate_test.go
@@ -248,6 +248,76 @@ func generateAndEvaluate(t *testing.T, forma *model.Forma) (string, *model.Forma
 // evaluating that source back yields the same $gen envelope naming the same
 // generator and output. A resource holding an ordinary recorded value sits in
 // the same forma, so a binding invented for it would show.
+// TestGenerateSourceCode_GeneratorRotation_RoundTrips covers a generator that
+// declares a cadence. The cadence is the whole reason a generator rotates, so
+// an extract that drops it produces a forma which re-applies to a generator
+// that never rotates again, silently.
+func TestGenerateSourceCode_GeneratorRotation_RoundTrips(t *testing.T) {
+	deps, pluginDir := fakeawsDeps(t)
+
+	forma := &model.Forma{
+		Stacks:  []model.Stack{{Label: "default"}},
+		Targets: []model.Target{fakeawsTarget()},
+		Resources: []model.Resource{{
+			Label:      "plain-secret",
+			Type:       "FakeAWS::SecretsManager::Secret",
+			Stack:      "default",
+			Target:     "aws",
+			Properties: []byte(`{"SecretString":{"$value":"plaintext","$visibility":"Opaque","$strategy":"Update"}}`),
+		}},
+		Generators: []json.RawMessage{
+			[]byte(`{
+				"Type": "password",
+				"Label": "db-password",
+				"Stack": "default",
+				"Rotation": {"EverySeconds": 3600},
+				"Length": 24,
+				"Uppercase": true,
+				"Lowercase": true,
+				"Digits": true,
+				"Symbols": false,
+				"ExcludeCharacters": "",
+				"RequireEachIncludedType": true
+			}`),
+		},
+	}
+
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "out.pkl")
+
+	options := &schema.SerializeOptions{
+		Schema:         "pkl",
+		SchemaLocation: schema.SchemaLocationLocal,
+		LocalPluginDir: pluginDir,
+		Dependencies:   deps,
+	}
+
+	_, err := PKL{}.GenerateSourceCode(forma, targetPath, nil, options)
+	require.NoError(t, err)
+
+	written, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	generated := string(written)
+
+	assert.Contains(t, generated, "rotation = new formae.RotationSpec {",
+		"the emitted generator must carry its cadence, or a re-apply of an extract stops rotating it")
+	assert.Contains(t, generated, "every = 3600.s")
+
+	// The emitted cadence has to survive evaluation, not merely appear: the
+	// schema floors `every` at one minute, so a unit the floor rejects would
+	// render fine and then fail to eval.
+	evaluated, err := PKL{}.Evaluate(targetPath, model.CommandApply, model.FormaApplyModeReconcile, nil)
+	require.NoError(t, err, "emitted PKL must itself evaluate")
+
+	require.Len(t, evaluated.Generators, 1)
+	var round struct {
+		Rotation *struct{ EverySeconds int } `json:"Rotation"`
+	}
+	require.NoError(t, json.Unmarshal(evaluated.Generators[0], &round))
+	require.NotNil(t, round.Rotation, "cadence must survive the round trip")
+	assert.Equal(t, 3600, round.Rotation.EverySeconds)
+}
+
 func TestGenerateSourceCode_GeneratorBinding_RoundTripsThroughPkl(t *testing.T) {
 	forma := &model.Forma{
 		Stacks:  []model.Stack{{Label: "secrets"}},


### PR DESCRIPTION
## Summary

Two defects found by running a generator rotation end to end against a real
cloud account: a credential bound to a generator, rotating on a cadence, with a
database role consuming it. Both were invisible to the suite.

## 1. Rotation wedges itself permanently

The synchronizer exclusion was gated on the changeset containing **user**
resource updates, so an agent-initiated changeset registered nothing and ran
with a concurrent sync cycle free to read the resource it was mid-way through
writing. The race that gate exists to close does not care who asked for the
write, only that one is happening.

For rotation this is not a bad read, it is a permanent stop. A rotation runs in
reconcile mode, so each success re-baselines the drift window. A sync landing
between the rotation's provider write and its own persist sees a value that
does not match stored state and records out-of-band drift, in patch mode, which
does not re-baseline. From then on the drift window is never empty,
`refuseRotationOnDrift` refuses every later rotation, and because the rotation
is itself the reconcile that would have cleared the window, nothing recovers
it. The credential stops turning over for good and the only signal is a log
line every thirty seconds.

The gate is now "does this changeset write". Sync and discovery still register
nothing: they read, and excluding a resource from sync on behalf of a sync
would be circular.

`changesetHasUserUpdates` stays. Pausing discovery remains a user-operation
concern, and whether to widen that is a separate question from this race.

## 2. `extract` drops a generator's rotation cadence

A forma written from an extract declared a generator that never rotates, and
nothing said so: the emitted PKL evaluates and the generator is recreated. The
cadence was dropped twice over, once in the JSON-to-map projection feeding
`parseGenerators` and once in the emitter, so both halves are fixed. It renders
in seconds, the unit the generator is stored in; the schema's one-minute floor
compares across units, so `3600.s` passes and a sub-minute cadence still fails
at eval.

## Evidence

The first defect was observed, not inferred. Three rotations succeeded, a sync
landed two seconds after the third started, and all five subsequent attempts
failed with "the stack has been modified since the last reconcile". The
recorded commands show the shape exactly: three reconcile-mode rotations
followed by one patch-mode sync.

Re-run afterwards with the sync interval tightened to one minute so cycles
collide with the cadence rather than rarely meeting it:

| | before | after |
|---|---|---|
| rotations before wedging | 3, then permanent failure | 7 and counting, no failures |
| sync exclusion registrations by a rotation | 0 | 23 |
| resource rows written by a sync command | 1, the one that deadlocked it | 0 |

For the extract defect, a generator persisted with a sixty second cadence now
emits `rotation = new formae.RotationSpec { every = 60.s }` and evaluates back
to `EverySeconds: 60`. Before the change the block was absent entirely.

## Tests

Both fixes are TDD, with the failing test written first and confirmed red.

The extract round-trip test asserts the cadence survives evaluation rather than
just appearing in the text, so a rendering that looked right but failed the
floor would fail. The existing round-trip test covers a generator with no
rotation, which is why the gap survived; it still passes, so the empty arm is
exercised too.

The changeset predicate is covered per source, including the two read-only
sources that must keep registering nothing.
