### PR TITLE
refactor(metastructure): give the drift readers their own package

### DIFF
--- a/internal/metastructure/drift/modifications.go
+++ b/internal/metastructure/drift/modifications.go
@@ -1,0 +1,183 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+// Package drift reads what has moved out of band on a stack, and decides which
+// of those movements the forma being applied already accounts for.
+//
+// It is its own package because two kinds of caller need the same answer: an
+// ordinary apply, which refuses to overwrite a change nobody declared, and an
+// unattended actor — auto-reconcile, rotation — which refuses for the same
+// reason without a human present to confirm. Those callers cannot share code
+// while the readers live in the package that imports them, and the alternative
+// is a second copy: the rotation work produced exactly one such copy and
+// deleted it, having found it had already drifted from the original by dropping
+// an operation filter.
+//
+// One reader, therefore, rather than one per caller.
+package drift
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/patch"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// loadModificationsAndWitnesses loads one stack's drift window into the
+// submission snapshot, plus the write witness for each modified resource
+// (GetPropertiesAtLastWrite: the state formae's own last write observed).
+// Window load failures fail the submission; a witness fetch failure degrades
+// to no witness for that resource, which classifies its movement as
+// tolerated, the pre-existing behavior.
+func LoadModificationsAndWitnesses(ds datastore.Datastore, stackLabel string, modificationsByStack map[string][]datastore.ResourceModification, witnessByKsuid map[string]json.RawMessage) error {
+	modifications, err := ds.GetResourceModificationsSinceLastReconcile(stackLabel)
+	if err != nil {
+		slog.Error("Failed to load modifications since last reconcile", "stack", stackLabel, "error", err)
+		return fmt.Errorf("failed to load modifications for stack %s: %w", stackLabel, err)
+	}
+	if len(modifications) == 0 {
+		return nil
+	}
+	modificationsByStack[stackLabel] = modifications
+	for _, mod := range modifications {
+		if mod.Operation != "update" || mod.Ksuid == "" {
+			continue
+		}
+		if _, done := witnessByKsuid[mod.Ksuid]; done {
+			continue
+		}
+		witness, werr := ds.GetPropertiesAtLastWrite(mod.Ksuid)
+		if werr != nil {
+			slog.Warn("Failed to load write witness for drift classification", "ksuid", mod.Ksuid, "error", werr)
+			continue
+		}
+		witnessByKsuid[mod.Ksuid] = witness
+	}
+	return nil
+}
+
+// stackLabelsFromForma extracts unique stack labels from a forma's resources.
+func StackLabelsFromForma(forma *pkgmodel.Forma) []string {
+	seen := make(map[string]bool)
+	var labels []string
+	for _, r := range forma.Resources {
+		if !seen[r.Stack] {
+			seen[r.Stack] = true
+			labels = append(labels, r.Stack)
+		}
+	}
+	return labels
+}
+
+// toAPIResourceModification converts a datastore ResourceModification into its
+// API-model counterpart. For update operations it also computes the JSON-patch
+// document describing the drift between the properties at the last reconcile
+// and the current (cloud) properties. A failed patch computation degrades to
+// label-only display — it never fails the caller.
+func ToAPIResourceModification(modification datastore.ResourceModification) apimodel.ResourceModification {
+	patchDoc := json.RawMessage(nil)
+	if modification.Operation == "update" && len(modification.OldProperties) > 0 && len(modification.Properties) > 0 {
+		if p, perr := patch.DriftPatch(modification.OldProperties, modification.Properties); perr == nil {
+			patchDoc = p
+		} else {
+			slog.Warn("failed to compute drift patch", "stack", modification.Stack, "label", modification.Label, "error", perr)
+		}
+	}
+	return apimodel.ResourceModification{
+		Stack:         modification.Stack,
+		Type:          modification.Type,
+		Label:         modification.Label,
+		Operation:     modification.Operation,
+		PatchDocument: patchDoc,
+		Properties:    modification.Properties,
+		OldProperties: modification.OldProperties,
+	}
+}
+
+// filterUnabsorbedModifications returns only those modifications that have NOT been
+// absorbed into the provided forma. A modification is considered absorbed when:
+//   - The forma contains a resource with matching stack, type, and label
+//   - No resource update was generated for that resource (i.e. its properties already
+//     match the current state in the datastore)
+//
+// This prevents false drift rejection when the user has already incorporated
+// out-of-band changes into their forma (e.g. via extract) before applying.
+func FilterUnabsorbedModifications(
+	modifications []datastore.ResourceModification,
+	forma *pkgmodel.Forma,
+	fa *forma_command.FormaCommand,
+) []datastore.ResourceModification {
+	// Build a set of resources that have pending updates in the FormaCommand
+	type resourceKey struct {
+		stack    string
+		typeName string
+		label    string
+	}
+	resourcesWithUpdates := make(map[resourceKey]struct{})
+	for _, ru := range fa.ResourceUpdates {
+		// A convergence-only update propagates a source movement the stored
+		// state has already absorbed (e.g. a synced secret rotation reaching
+		// its consumer). It asserts no state differing from the current one,
+		// so it must not block absorbing the modification it follows from.
+		if ru.ConvergenceOnly() {
+			continue
+		}
+		resourcesWithUpdates[resourceKey{
+			stack:    ru.StackLabel,
+			typeName: ru.DesiredState.Type,
+			label:    ru.DesiredState.Label,
+		}] = struct{}{}
+	}
+
+	// Build a set of resources present in the forma
+	formaResources := make(map[resourceKey]struct{})
+	// A forma resource that declares an `alias` covers its previous
+	// label too. Index aliases by (stack, type, alias) so a drift recorded
+	// under the old label is absorbed when the forma renames the resource.
+	formaAliases := make(map[resourceKey]struct{})
+	for _, r := range forma.Resources {
+		formaResources[resourceKey{
+			stack:    r.Stack,
+			typeName: r.Type,
+			label:    r.Label,
+		}] = struct{}{}
+		if r.Alias != "" {
+			formaAliases[resourceKey{
+				stack:    r.Stack,
+				typeName: r.Type,
+				label:    r.Alias,
+			}] = struct{}{}
+		}
+	}
+
+	var unabsorbed []datastore.ResourceModification
+	for _, mod := range modifications {
+		key := resourceKey{
+			stack:    mod.Stack,
+			typeName: mod.Type,
+			label:    mod.Label,
+		}
+		// A modification is absorbed if:
+		// 1. The resource is present in the forma, AND
+		// 2. No resource update was generated for it (properties match current state)
+		_, inForma := formaResources[key]
+		_, hasUpdate := resourcesWithUpdates[key]
+		if inForma && !hasUpdate {
+			continue // absorbed
+		}
+		// Alias-aware absorption. A modification keyed by the OLD
+		// label is absorbed by a forma resource declaring `alias = <old>`.
+		// The rename update (if any) takes the modification with it.
+		if _, isAlias := formaAliases[key]; isAlias {
+			continue
+		}
+		unabsorbed = append(unabsorbed, mod)
+	}
+	return unabsorbed
+}

--- a/internal/metastructure/drift/modifications_test.go
+++ b/internal/metastructure/drift/modifications_test.go
@@ -4,7 +4,7 @@
 
 //go:build unit
 
-package metastructure
+package drift
 
 import (
 	"testing"
@@ -32,7 +32,7 @@ func TestFilterUnabsorbedModifications_RenameAbsorbsOldLabelModification(t *test
 	}
 	fa := &forma_command.FormaCommand{}
 
-	got := filterUnabsorbedModifications(mods, forma, fa)
+	got := FilterUnabsorbedModifications(mods, forma, fa)
 	assert.Empty(t, got, "modification under old label must be absorbed by alias")
 }
 
@@ -49,7 +49,7 @@ func TestFilterUnabsorbedModifications_ForeignModificationStillUnabsorbed(t *tes
 	}
 	fa := &forma_command.FormaCommand{}
 
-	got := filterUnabsorbedModifications(mods, forma, fa)
+	got := FilterUnabsorbedModifications(mods, forma, fa)
 	assert.Len(t, got, 1, "unrelated modification must remain unabsorbed")
 }
 
@@ -75,7 +75,7 @@ func TestFilterUnabsorbedModifications_ModificationWithPendingUpdateIsUnabsorbed
 		},
 	}
 
-	got := filterUnabsorbedModifications(mods, forma, fa)
+	got := FilterUnabsorbedModifications(mods, forma, fa)
 	assert.Len(t, got, 1, "a modification with a pending update is not absorbed")
 }
 
@@ -92,6 +92,6 @@ func TestFilterUnabsorbedModifications_AliasMatchRequiresTypeMatch(t *testing.T)
 	}
 	fa := &forma_command.FormaCommand{}
 
-	got := filterUnabsorbedModifications(mods, forma, fa)
+	got := FilterUnabsorbedModifications(mods, forma, fa)
 	assert.Len(t, got, 1, "alias match must require matching Type")
 }

--- a/internal/metastructure/drift/witnessed.go
+++ b/internal/metastructure/drift/witnessed.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: FSL-1.1-ALv2
 
-package metastructure
+package drift
 
 import (
 	"encoding/json"
@@ -14,22 +14,22 @@ import (
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
-// witnessedMovedModifications returns the modifications whose out-of-band
+// WitnessedMovedModifications returns the modifications whose out-of-band
 // movement sits on provider-default content formae's own last write
 // witnessed. Such movement is drift, exactly like drift on a declared
 // field: the caller adds these to the unabsorbed set so a soft reconcile
 // rejects showing them, and a forced reconcile reverts them via the witness
-// assertion. Candidates are the modifications filterUnabsorbedModifications
+// assertion. Candidates are the modifications FilterUnabsorbedModifications
 // absorbs (the unabsorbed ones already reject); a candidate that cannot be
 // classified (a non-update operation, a missing property blob, no matching
 // forma declaration, no write witness, or a diff error) is left absorbed,
 // which is the pre-existing tolerant behavior.
-func witnessedMovedModifications(modifications []datastore.ResourceModification, witnessByKsuid map[string]json.RawMessage, forma *pkgmodel.Forma, fa *forma_command.FormaCommand) []datastore.ResourceModification {
+func WitnessedMovedModifications(modifications []datastore.ResourceModification, witnessByKsuid map[string]json.RawMessage, forma *pkgmodel.Forma, fa *forma_command.FormaCommand) []datastore.ResourceModification {
 	type modKey struct {
 		stack, typeName, label, operation string
 	}
 	unabsorbed := map[modKey]bool{}
-	for _, mod := range filterUnabsorbedModifications(modifications, forma, fa) {
+	for _, mod := range FilterUnabsorbedModifications(modifications, forma, fa) {
 		unabsorbed[modKey{mod.Stack, mod.Type, mod.Label, mod.Operation}] = true
 	}
 
@@ -62,7 +62,7 @@ func witnessedMovedModifications(modifications []datastore.ResourceModification,
 	return moved
 }
 
-// assertWitnessesIntoForma returns a copy of the forma in which every
+// AssertWitnessesIntoForma returns a copy of the forma in which every
 // resource matching a modification with a write witness has formae's
 // witnessed values asserted onto its omitted provider-default fields (see
 // patch.AssertWitnessedSuppressed). A forced reconcile plans against the
@@ -70,7 +70,7 @@ func witnessedMovedModifications(modifications []datastore.ResourceModification,
 // same way declared drift is overwritten. Resources without a witnessed
 // modification are untouched; assertion failures degrade to the unasserted
 // declaration.
-func assertWitnessesIntoForma(forma *pkgmodel.Forma, modificationsByStack map[string][]datastore.ResourceModification, witnessByKsuid map[string]json.RawMessage) *pkgmodel.Forma {
+func AssertWitnessesIntoForma(forma *pkgmodel.Forma, modificationsByStack map[string][]datastore.ResourceModification, witnessByKsuid map[string]json.RawMessage) *pkgmodel.Forma {
 	witnessForResource := map[*pkgmodel.Resource]json.RawMessage{}
 	for _, modifications := range modificationsByStack {
 		for _, mod := range modifications {
@@ -111,7 +111,7 @@ func assertWitnessesIntoForma(forma *pkgmodel.Forma, modificationsByStack map[st
 // findDeclarationForModification resolves a modification to its forma
 // declaration by current label or by the declaration's alias (a rename
 // records the modification under the old label), mirroring the matching
-// filterUnabsorbedModifications uses for absorption.
+// FilterUnabsorbedModifications uses for absorption.
 func findDeclarationForModification(forma *pkgmodel.Forma, mod datastore.ResourceModification) *pkgmodel.Resource {
 	for i := range forma.Resources {
 		r := &forma.Resources[i]

--- a/internal/metastructure/drift/witnessed_test.go
+++ b/internal/metastructure/drift/witnessed_test.go
@@ -4,7 +4,7 @@
 
 //go:build unit
 
-package metastructure
+package drift
 
 import (
 	"encoding/json"
@@ -52,7 +52,7 @@ func TestWitnessedMovedModifications_WitnessedMovement_IsDrift(t *testing.T) {
 		Schema:     kmsSchemaForDrift(),
 	}}}
 
-	moved := witnessedMovedModifications(mods["prod"], driftWitnesses(mods), forma, &forma_command.FormaCommand{})
+	moved := WitnessedMovedModifications(mods["prod"], driftWitnesses(mods), forma, &forma_command.FormaCommand{})
 	require.Len(t, moved, 1)
 	assert.Equal(t, "signing-key", moved[0].Label)
 }
@@ -71,7 +71,7 @@ func TestWitnessedMovedModifications_NoWitness_Tolerated(t *testing.T) {
 		Schema:     kmsSchemaForDrift(),
 	}}}
 
-	moved := witnessedMovedModifications(mods["prod"], map[string]json.RawMessage{}, forma, &forma_command.FormaCommand{})
+	moved := WitnessedMovedModifications(mods["prod"], map[string]json.RawMessage{}, forma, &forma_command.FormaCommand{})
 	assert.Empty(t, moved, "no write witness means the movement is the infrastructure's business")
 }
 
@@ -89,7 +89,7 @@ func TestWitnessedMovedModifications_AlreadyUnabsorbed_NotDoubled(t *testing.T) 
 		Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key", Schema: kmsSchemaForDrift(),
 	}}}
 
-	moved := witnessedMovedModifications(mods["prod"], driftWitnesses(mods), forma, &forma_command.FormaCommand{})
+	moved := WitnessedMovedModifications(mods["prod"], driftWitnesses(mods), forma, &forma_command.FormaCommand{})
 	assert.Empty(t, moved)
 }
 
@@ -112,7 +112,7 @@ func TestWitnessedMovedModifications_PendingUpdate_LeftToLegacyFilter(t *testing
 		DesiredState: pkgmodel.Resource{Type: "AWS::KMS::Key", Label: "signing-key"},
 	}}}
 
-	moved := witnessedMovedModifications(mods["prod"], driftWitnesses(mods), forma, fa)
+	moved := WitnessedMovedModifications(mods["prod"], driftWitnesses(mods), forma, fa)
 	assert.Empty(t, moved, "a resource with a pending update is already unabsorbed; the legacy filter owns it")
 }
 
@@ -137,7 +137,7 @@ func TestAssertWitnessesIntoForma_AssertsOnlyMatchedResources_AndCopies(t *testi
 		}},
 	}
 
-	asserted := assertWitnessesIntoForma(original, mods, driftWitnesses(mods))
+	asserted := AssertWitnessesIntoForma(original, mods, driftWitnesses(mods))
 
 	require.NotSame(t, original, asserted)
 	assert.JSONEq(t, `{"Name": "k", "EnableKeyRotation": false}`, string(asserted.Resources[0].Properties),

--- a/internal/metastructure/generator_rotator.go
+++ b/internal/metastructure/generator_rotator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/changeset"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/drift"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_persister"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
@@ -643,7 +644,7 @@ func refuseRotationOnDrift(ds datastore.Datastore, forma *pkgmodel.Forma, fc *fo
 	}
 
 	stackLabels := map[string]bool{}
-	for _, label := range append(stackLabelsFromForma(forma), fc.GetStackLabels()...) {
+	for _, label := range append(drift.StackLabelsFromForma(forma), fc.GetStackLabels()...) {
 		if label == "" || autoReconciled[label] {
 			continue
 		}
@@ -656,21 +657,21 @@ func refuseRotationOnDrift(ds datastore.Datastore, forma *pkgmodel.Forma, fc *fo
 	modificationsByStack := make(map[string][]datastore.ResourceModification)
 	witnessByKsuid := make(map[string]json.RawMessage)
 	for label := range stackLabels {
-		if err := loadModificationsAndWitnesses(ds, label, modificationsByStack, witnessByKsuid); err != nil {
+		if err := drift.LoadModificationsAndWitnesses(ds, label, modificationsByStack, witnessByKsuid); err != nil {
 			return err
 		}
 	}
 
 	modifiedStacks := map[string]apimodel.ModifiedStack{}
 	for label, modifications := range modificationsByStack {
-		unabsorbed := filterUnabsorbedModifications(modifications, forma, fc)
-		unabsorbed = append(unabsorbed, witnessedMovedModifications(modifications, witnessByKsuid, forma, fc)...)
+		unabsorbed := drift.FilterUnabsorbedModifications(modifications, forma, fc)
+		unabsorbed = append(unabsorbed, drift.WitnessedMovedModifications(modifications, witnessByKsuid, forma, fc)...)
 		if len(unabsorbed) == 0 {
 			continue
 		}
 		modifiedResources := make([]apimodel.ResourceModification, 0, len(unabsorbed))
 		for _, modification := range unabsorbed {
-			modifiedResources = append(modifiedResources, toAPIResourceModification(modification))
+			modifiedResources = append(modifiedResources, drift.ToAPIResourceModification(modification))
 		}
 		modifiedStacks[label] = apimodel.ModifiedStack{ModifiedResources: modifiedResources}
 	}

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -31,11 +31,11 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/changeset"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/discovery"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/drift"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_persister"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
-	"github.com/platform-engineering-labs/formae/internal/metastructure/patch"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/policy_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/querier"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/reaping"
@@ -327,7 +327,7 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 	// first, we guarantee that if no incomplete commands exist, all their resources are already
 	// persisted and visible to subsequent queries.
 	if !config.Simulate {
-		if err := m.checkForConflictingCommands(stackLabelsFromForma(forma)); err != nil {
+		if err := m.checkForConflictingCommands(drift.StackLabelsFromForma(forma)); err != nil {
 			return nil, err
 		}
 
@@ -352,12 +352,12 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 	if config.Mode == pkgmodel.FormaApplyModeReconcile && config.Force {
 		assertMods := make(map[string][]datastore.ResourceModification)
 		assertWitnesses := make(map[string]json.RawMessage)
-		for _, stackLabel := range stackLabelsFromForma(forma) {
-			if err := loadModificationsAndWitnesses(m.Datastore, stackLabel, assertMods, assertWitnesses); err != nil {
+		for _, stackLabel := range drift.StackLabelsFromForma(forma) {
+			if err := drift.LoadModificationsAndWitnesses(m.Datastore, stackLabel, assertMods, assertWitnesses); err != nil {
 				return nil, err
 			}
 		}
-		forma = assertWitnessesIntoForma(forma, assertMods, assertWitnesses)
+		forma = drift.AssertWitnessesIntoForma(forma, assertMods, assertWitnesses)
 	}
 
 	fa, err := FormaCommandFromForma(forma, config, pkgmodel.CommandApply, m.Datastore, clientID, subject, subjectName, resource_update.FormaCommandSourceUser, m.Cfg.Agent.Synchronization.Interval)
@@ -388,23 +388,23 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 		modificationsByStack := make(map[string][]datastore.ResourceModification)
 		witnessByKsuid := make(map[string]json.RawMessage)
 		seenStacks := map[string]bool{}
-		for _, stackLabel := range append(stackLabelsFromForma(forma), fa.GetStackLabels()...) {
+		for _, stackLabel := range append(drift.StackLabelsFromForma(forma), fa.GetStackLabels()...) {
 			if seenStacks[stackLabel] {
 				continue
 			}
 			seenStacks[stackLabel] = true
-			if err := loadModificationsAndWitnesses(m.Datastore, stackLabel, modificationsByStack, witnessByKsuid); err != nil {
+			if err := drift.LoadModificationsAndWitnesses(m.Datastore, stackLabel, modificationsByStack, witnessByKsuid); err != nil {
 				return nil, err
 			}
 		}
 		var modifiedStacks = make(map[string]apimodel.ModifiedStack)
 		for stackLabel, modifications := range modificationsByStack {
-			unabsorbed := filterUnabsorbedModifications(modifications, forma, fa)
-			unabsorbed = append(unabsorbed, witnessedMovedModifications(modifications, witnessByKsuid, forma, fa)...)
+			unabsorbed := drift.FilterUnabsorbedModifications(modifications, forma, fa)
+			unabsorbed = append(unabsorbed, drift.WitnessedMovedModifications(modifications, witnessByKsuid, forma, fa)...)
 			if len(unabsorbed) > 0 {
 				modifiedResources := make([]apimodel.ResourceModification, 0, len(unabsorbed))
 				for _, modification := range unabsorbed {
-					modifiedResources = append(modifiedResources, toAPIResourceModification(modification))
+					modifiedResources = append(modifiedResources, drift.ToAPIResourceModification(modification))
 				}
 				modifiedStacks[stackLabel] = apimodel.ModifiedStack{
 					ModifiedResources: modifiedResources,
@@ -745,39 +745,6 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 	}, nil
 }
 
-// loadModificationsAndWitnesses loads one stack's drift window into the
-// submission snapshot, plus the write witness for each modified resource
-// (GetPropertiesAtLastWrite: the state formae's own last write observed).
-// Window load failures fail the submission; a witness fetch failure degrades
-// to no witness for that resource, which classifies its movement as
-// tolerated, the pre-existing behavior.
-func loadModificationsAndWitnesses(ds datastore.Datastore, stackLabel string, modificationsByStack map[string][]datastore.ResourceModification, witnessByKsuid map[string]json.RawMessage) error {
-	modifications, err := ds.GetResourceModificationsSinceLastReconcile(stackLabel)
-	if err != nil {
-		slog.Error("Failed to load modifications since last reconcile", "stack", stackLabel, "error", err)
-		return fmt.Errorf("failed to load modifications for stack %s: %w", stackLabel, err)
-	}
-	if len(modifications) == 0 {
-		return nil
-	}
-	modificationsByStack[stackLabel] = modifications
-	for _, mod := range modifications {
-		if mod.Operation != "update" || mod.Ksuid == "" {
-			continue
-		}
-		if _, done := witnessByKsuid[mod.Ksuid]; done {
-			continue
-		}
-		witness, werr := ds.GetPropertiesAtLastWrite(mod.Ksuid)
-		if werr != nil {
-			slog.Warn("Failed to load write witness for drift classification", "ksuid", mod.Ksuid, "error", werr)
-			continue
-		}
-		witnessByKsuid[mod.Ksuid] = witness
-	}
-	return nil
-}
-
 func translateToAPICommand(fa *forma_command.FormaCommand) apimodel.Command {
 	apiCommand := apimodel.Command{
 		CommandID:   fa.ID,
@@ -1034,7 +1001,7 @@ func (m *Metastructure) DestroyForma(forma *pkgmodel.Forma, config *config.Forma
 
 	// Check for conflicting commands before generating resource updates (same reasoning as ApplyForma).
 	if !config.Simulate {
-		stackLabels := stackLabelsFromForma(forma)
+		stackLabels := drift.StackLabelsFromForma(forma)
 
 		// For destroy commands, also check stacks affected by cascade deletes
 		cascadeStacks, err := m.findCascadeStackLabels(forma)
@@ -1561,7 +1528,7 @@ func (m *Metastructure) ListDrift(stack string) (*apimodel.ModifiedStack, error)
 
 	modifiedResources := make([]apimodel.ResourceModification, 0, len(modifications))
 	for _, modification := range modifications {
-		modifiedResources = append(modifiedResources, toAPIResourceModification(modification))
+		modifiedResources = append(modifiedResources, drift.ToAPIResourceModification(modification))
 	}
 
 	return &apimodel.ModifiedStack{ModifiedResources: modifiedResources}, nil
@@ -2107,19 +2074,6 @@ func (m *Metastructure) checkForReapedTargets(forma *pkgmodel.Forma) error {
 	return nil
 }
 
-// stackLabelsFromForma extracts unique stack labels from a forma's resources.
-func stackLabelsFromForma(forma *pkgmodel.Forma) []string {
-	seen := make(map[string]bool)
-	var labels []string
-	for _, r := range forma.Resources {
-		if !seen[r.Stack] {
-			seen[r.Stack] = true
-			labels = append(labels, r.Stack)
-		}
-	}
-	return labels
-}
-
 // findCascadeStackLabels returns stack labels that would be affected by cascade
 // deletes for the given forma's resources. It queries the datastore for
 // cross-stack dependents of resources being destroyed.
@@ -2317,113 +2271,6 @@ func findCascadeTargetDeletes(
 	}
 
 	return cascadeTargetUpdates, cascadeResourceUpdates, nil
-}
-
-// toAPIResourceModification converts a datastore ResourceModification into its
-// API-model counterpart. For update operations it also computes the JSON-patch
-// document describing the drift between the properties at the last reconcile
-// and the current (cloud) properties. A failed patch computation degrades to
-// label-only display — it never fails the caller.
-func toAPIResourceModification(modification datastore.ResourceModification) apimodel.ResourceModification {
-	patchDoc := json.RawMessage(nil)
-	if modification.Operation == "update" && len(modification.OldProperties) > 0 && len(modification.Properties) > 0 {
-		if p, perr := patch.DriftPatch(modification.OldProperties, modification.Properties); perr == nil {
-			patchDoc = p
-		} else {
-			slog.Warn("failed to compute drift patch", "stack", modification.Stack, "label", modification.Label, "error", perr)
-		}
-	}
-	return apimodel.ResourceModification{
-		Stack:         modification.Stack,
-		Type:          modification.Type,
-		Label:         modification.Label,
-		Operation:     modification.Operation,
-		PatchDocument: patchDoc,
-		Properties:    modification.Properties,
-		OldProperties: modification.OldProperties,
-	}
-}
-
-// filterUnabsorbedModifications returns only those modifications that have NOT been
-// absorbed into the provided forma. A modification is considered absorbed when:
-//   - The forma contains a resource with matching stack, type, and label
-//   - No resource update was generated for that resource (i.e. its properties already
-//     match the current state in the datastore)
-//
-// This prevents false drift rejection when the user has already incorporated
-// out-of-band changes into their forma (e.g. via extract) before applying.
-func filterUnabsorbedModifications(
-	modifications []datastore.ResourceModification,
-	forma *pkgmodel.Forma,
-	fa *forma_command.FormaCommand,
-) []datastore.ResourceModification {
-	// Build a set of resources that have pending updates in the FormaCommand
-	type resourceKey struct {
-		stack    string
-		typeName string
-		label    string
-	}
-	resourcesWithUpdates := make(map[resourceKey]struct{})
-	for _, ru := range fa.ResourceUpdates {
-		// A convergence-only update propagates a source movement the stored
-		// state has already absorbed (e.g. a synced secret rotation reaching
-		// its consumer). It asserts no state differing from the current one,
-		// so it must not block absorbing the modification it follows from.
-		if ru.ConvergenceOnly() {
-			continue
-		}
-		resourcesWithUpdates[resourceKey{
-			stack:    ru.StackLabel,
-			typeName: ru.DesiredState.Type,
-			label:    ru.DesiredState.Label,
-		}] = struct{}{}
-	}
-
-	// Build a set of resources present in the forma
-	formaResources := make(map[resourceKey]struct{})
-	// A forma resource that declares an `alias` covers its previous
-	// label too. Index aliases by (stack, type, alias) so a drift recorded
-	// under the old label is absorbed when the forma renames the resource.
-	formaAliases := make(map[resourceKey]struct{})
-	for _, r := range forma.Resources {
-		formaResources[resourceKey{
-			stack:    r.Stack,
-			typeName: r.Type,
-			label:    r.Label,
-		}] = struct{}{}
-		if r.Alias != "" {
-			formaAliases[resourceKey{
-				stack:    r.Stack,
-				typeName: r.Type,
-				label:    r.Alias,
-			}] = struct{}{}
-		}
-	}
-
-	var unabsorbed []datastore.ResourceModification
-	for _, mod := range modifications {
-		key := resourceKey{
-			stack:    mod.Stack,
-			typeName: mod.Type,
-			label:    mod.Label,
-		}
-		// A modification is absorbed if:
-		// 1. The resource is present in the forma, AND
-		// 2. No resource update was generated for it (properties match current state)
-		_, inForma := formaResources[key]
-		_, hasUpdate := resourcesWithUpdates[key]
-		if inForma && !hasUpdate {
-			continue // absorbed
-		}
-		// Alias-aware absorption. A modification keyed by the OLD
-		// label is absorbed by a forma resource declaring `alias = <old>`.
-		// The rename update (if any) takes the modification with it.
-		if _, isAlias := formaAliases[key]; isAlias {
-			continue
-		}
-		unabsorbed = append(unabsorbed, mod)
-	}
-	return unabsorbed
 }
 
 func formaTouchesStacks(forma *forma_command.FormaCommand, stackLabels []string) bool {


### PR DESCRIPTION
## Summary

Five functions that read what has moved out of band on a stack lived in the
metastructure root, where the actors that need them cannot reach them: the root
imports its subpackages, so a subpackage importing the root is a cycle. That is
what kept the rotation scheduler in the root beside its two scheduled siblings,
and it is the mechanism by which the root becomes where shared helpers
accumulate.

They now live in `internal/metastructure/drift`, which both the apply path and
any unattended actor can import.

**This is a move. Nothing about the reading changed**, and the apply path's drift
tests were re-run rather than assumed.

## Why a package and not a copy

The alternative was duplication, and there is evidence against it rather than
just a preference. The rotation work already produced one such copy and deleted
it — the copy had drifted from the original by dropping an
`Operation != "update"` filter. A helper reachable from everywhere is how that
happens. One reader now, rather than one per caller.

## What it unblocks, measured rather than claimed

After the move, `generator_rotator.go` references **no** symbol defined in the
metastructure root. Neither do `auto_reconciler.go` or `stack_expirer.go`.

So extracting the three scheduled actors into their own packages — following
`target_reaper`, which already breaks the root's pattern by being a periodic
actor in its own package — is now mechanical. **That is deliberately left to its
own change**, because it also rewires the supervisor, and a diff that moved the
readers *and* three actors *and* the wiring would be harder to review than
either half alone.

## Scope notes

Two files in this directory were already unformatted before this branch and are
left that way. Reformatting them here would put unrelated churn in a refactor,
and an earlier version of this diff did exactly that before it was reverted.

The nine tests covering these functions moved with the code they test, and run in
the new package. The metastructure root keeps its other 77.
