### PR TITLE
feat(connect): give the Azure trust template machine-readable output

### DIFF
--- a/internal/cli/connect/azuretemplate.go
+++ b/internal/cli/connect/azuretemplate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	clicmd "github.com/platform-engineering-labs/formae/internal/cli/cmd"
+	"github.com/platform-engineering-labs/formae/internal/cli/printer"
 )
 
 // azurePortalDeepLinkBase is Azure's template-deployment deep link. Unlike
@@ -73,58 +74,9 @@ func azureTemplateCmd() *cobra.Command {
 			return runAzureTemplate(cc)
 		},
 	}
+	clicmd.AddOutputFlags(c)
 	c.SetUsageTemplate(clicmd.SimpleCmdUsageTemplate)
 	return c
-}
-
-func runAzureTemplate(cc *cobra.Command) error {
-	opts, err := readSelection(cc)
-	if err != nil {
-		return err
-	}
-	s, err := openSession(cc.Context(), opts)
-	if err != nil {
-		return err
-	}
-	formaeTenantID, installationID, err := splitSubject(s.Setup.CloudSubject)
-	if err != nil {
-		return err
-	}
-
-	doc, err := azureTemplateWithDefaults(installationID, formaeTenantID)
-	if err != nil {
-		return err
-	}
-	if _, err := cc.OutOrStdout().Write(doc); err != nil {
-		return err
-	}
-
-	deepLink := azurePortalDeepLink(azureTemplateConsoleURL(s.ConsoleOrigin, installationID, formaeTenantID))
-
-	// Guidance goes to stderr, never stdout: stdout is the template itself,
-	// so `formae connect azure template > trust.json` must carry nothing
-	// else.
-	//
-	// The deep link is listed first because it is the only route that asks
-	// nothing of this machine at all: it opens the portal with the template
-	// already fetched and its defaults already filled in, no paste, no CLI,
-	// no local credentials. The portal editor is the fallback for whoever
-	// cannot open the link; az and a pipeline are unchanged below it.
-	// installationId and formaeTenantId are filled in as defaults precisely
-	// because the portal pre-populates its parameter form from them - the
-	// operator deploying it there never has to be told either value.
-	_, err = fmt.Fprintf(cc.ErrOrStderr(), "deploy this yourself - installationId and formaeTenantId are already "+
-		"filled in as defaults, so nothing more needs typing:\n\n"+
-		"  - one click, nothing to paste: %s\n"+
-		"  - Azure Portal: search \"Deploy a custom template\", choose \"Build your own template in the editor\", "+
-		"paste this file, deploy\n"+
-		"  - az deployment sub create --location <region> --template-file trust.json\n"+
-		"  - or your own pipeline (GitHub Actions with OIDC, Azure DevOps, Terraform), which keeps the credential "+
-		"off any machine entirely\n\n"+
-		"then register what it creates:\n\n"+
-		"  formae connect azure --subscription <id> --tenant-id <t> --client-id <c>\n\n"+
-		"<t> and <c> come from the deployment's outputs (tenantId and clientId).\n", deepLink)
-	return err
 }
 
 // azureTemplateWithDefaults returns the embedded template with
@@ -165,4 +117,88 @@ func setParameterDefault(params map[string]any, name, value string) error {
 	}
 	p["defaultValue"] = value
 	return nil
+}
+
+// azureTemplateFallbackMessage stands in when a failure carries no declared
+// code. Like every other connect path, the producer's own message does not
+// travel: it can quote configuration source, and a Pkl failure quotes the
+// line it failed on, which can hold an inline password.
+const azureTemplateFallbackMessage = "formae could not produce the trust template; " +
+	"run it without --output-consumer machine to see why"
+
+func runAzureTemplate(cc *cobra.Command) error {
+	consumer, schema, err := resolveOutputOrHuman(cc)
+	if err != nil {
+		return err
+	}
+	// Every failure below has to reach a machine consumer as a failure
+	// document, not a bare non-zero exit: a caller that cannot read a code
+	// cannot tell "sign in first" from "this build is broken", and the whole
+	// value of this path is that it works on a machine holding no credentials.
+	if err := writeAzureTemplate(cc, consumer, schema); err != nil {
+		return report(cc.OutOrStdout(), consumer, schema, err, azureTemplateFallbackMessage)
+	}
+	return nil
+}
+
+func writeAzureTemplate(cc *cobra.Command, consumer printer.Consumer, schema string) error {
+	opts, err := readSelection(cc)
+	if err != nil {
+		return err
+	}
+	s, err := openSession(cc.Context(), opts)
+	if err != nil {
+		return err
+	}
+	formaeTenantID, installationID, err := splitSubject(s.Setup.CloudSubject)
+	if err != nil {
+		return err
+	}
+
+	doc, err := azureTemplateWithDefaults(installationID, formaeTenantID)
+	if err != nil {
+		return err
+	}
+
+	// A machine consumer gets one document on stdout instead of the template
+	// plus prose on two streams: the deep link is the point of this path, and
+	// stderr is not somewhere a harness can be asked to read it from.
+	if consumer == printer.ConsumerMachine {
+		v, err := newAzureTemplateView(s.ConsoleOrigin, installationID, formaeTenantID, doc)
+		if err != nil {
+			return err
+		}
+		return emitAzureTemplate(cc.OutOrStdout(), schema, v)
+	}
+
+	if _, err := cc.OutOrStdout().Write(doc); err != nil {
+		return err
+	}
+
+	deepLink := azurePortalDeepLink(azureTemplateConsoleURL(s.ConsoleOrigin, installationID, formaeTenantID))
+
+	// Guidance goes to stderr, never stdout: stdout is the template itself,
+	// so `formae connect azure template > trust.json` must carry nothing
+	// else.
+	//
+	// The deep link is listed first because it is the only route that asks
+	// nothing of this machine at all: it opens the portal with the template
+	// already fetched and its defaults already filled in, no paste, no CLI,
+	// no local credentials. The portal editor is the fallback for whoever
+	// cannot open the link; az and a pipeline are unchanged below it.
+	// installationId and formaeTenantId are filled in as defaults precisely
+	// because the portal pre-populates its parameter form from them - the
+	// operator deploying it there never has to be told either value.
+	_, err = fmt.Fprintf(cc.ErrOrStderr(), "deploy this yourself - installationId and formaeTenantId are already "+
+		"filled in as defaults, so nothing more needs typing:\n\n"+
+		"  - one click, nothing to paste: %s\n"+
+		"  - Azure Portal: search \"Deploy a custom template\", choose \"Build your own template in the editor\", "+
+		"paste this file, deploy\n"+
+		"  - az deployment sub create --location <region> --template-file trust.json\n"+
+		"  - or your own pipeline (GitHub Actions with OIDC, Azure DevOps, Terraform), which keeps the credential "+
+		"off any machine entirely\n\n"+
+		"then register what it creates:\n\n"+
+		"  formae connect azure --subscription <id> --tenant-id <t> --client-id <c>\n\n"+
+		"<t> and <c> come from the deployment's outputs (tenantId and clientId).\n", deepLink)
+	return err
 }

--- a/internal/cli/connect/azuretemplate_test.go
+++ b/internal/cli/connect/azuretemplate_test.go
@@ -188,3 +188,61 @@ func TestAzureTemplateCommandRequiresASession(t *testing.T) {
 	require.ErrorAs(t, err, &f)
 	assert.Equal(t, printer.CodeHostedRequired, f.Code)
 }
+
+// Machine output exists because the deep link is the credential-less path's
+// whole value and, without this, the only place it appeared was human-readable
+// stderr. A harness driving the connect flow cannot scrape that, so the link
+// reaches a consumer the same way AWS's quick-create URL does: a field on a
+// machine-readable document.
+func TestAzureTemplateViewCarriesTheDeepLinkAndCoordinates(t *testing.T) {
+	const (
+		consoleOrigin  = "https://console.formae.ai"
+		installationID = "3IjUFLA75bBkM4DmUp2c6TgHeu9"
+		formaeTenantID = "default"
+	)
+	tmpl, err := azureTemplateWithDefaults(installationID, formaeTenantID)
+	require.NoError(t, err)
+
+	v, err := newAzureTemplateView(consoleOrigin, installationID, formaeTenantID, tmpl)
+	require.NoError(t, err)
+
+	assert.Equal(t, connectSchemaVersion, v.SchemaVersion)
+	assert.Equal(t, "template", v.Phase, "a consumer branches on phase before reading any field")
+	assert.Equal(t, "azure", v.Cloud)
+	assert.Equal(t, installationID, v.Installation)
+	assert.Equal(t, formaeTenantID, v.FormaeTenantID)
+
+	// The link must be the portal's create-from-uri form wrapping the console
+	// URL, because that is what makes it one click: the portal fetches the
+	// template itself and pre-populates the parameter form from its defaults.
+	assert.Contains(t, v.DeepLink, "portal.azure.com")
+	assert.Contains(t, v.DeepLink, url.QueryEscape(consoleOrigin+"/azure/trust.json"))
+	assert.Contains(t, v.TemplateURL, consoleOrigin)
+	assert.Contains(t, v.TemplateURL, installationID)
+
+	// The command's contract is "give me the template". Machine mode replaces
+	// stdout with this document, so omitting it would make machine callers
+	// strictly less capable than human ones at the command's own purpose.
+	require.NotNil(t, v.Template, "machine output must still carry the template")
+	schema, _ := v.Template["$schema"].(string)
+	assert.Contains(t, schema, "subscriptionDeploymentTemplate.json")
+}
+
+// The document has to survive both schemas the output flags accept. A
+// json.RawMessage template would have marshalled as a base64 byte string under
+// yaml, so the template is held as a decoded map instead.
+func TestAzureTemplateViewMarshalsUnderBothSchemas(t *testing.T) {
+	tmpl, err := azureTemplateWithDefaults("i", "t")
+	require.NoError(t, err)
+	v, err := newAzureTemplateView("https://console.formae.ai", "i", "t", tmpl)
+	require.NoError(t, err)
+
+	for _, schema := range []string{"json", "yaml"} {
+		var buf strings.Builder
+		require.NoError(t, emitAzureTemplate(&buf, schema, v), "schema %s", schema)
+		out := buf.String()
+		assert.Contains(t, out, "deepLink", "schema %s dropped the deep link key", schema)
+		assert.Contains(t, out, "subscriptionDeploymentTemplate.json",
+			"schema %s did not render the template as structured data", schema)
+	}
+}

--- a/internal/cli/connect/machine.go
+++ b/internal/cli/connect/machine.go
@@ -5,6 +5,8 @@
 package connect
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/platform-engineering-labs/formae/internal/cli/printer"
@@ -198,4 +200,52 @@ type profilesView struct {
 
 func emitProfiles(w io.Writer, schema string, v profilesView) error {
 	return printer.NewMachineReadablePrinter[profilesView](w, schema).Print(&v)
+}
+
+// azureTemplateView is the credential-less path's emit: the deep link a
+// consumer shows the user, the coordinates baked into it, and the template
+// itself.
+//
+// It mirrors linksView's job for AWS. The link is the field that matters: it
+// is the only route that asks nothing of the machine running this, and before
+// this document existed it appeared solely in human-readable stderr, where a
+// harness driving the flow could not reach it without scraping.
+//
+// Template is a decoded map rather than raw JSON bytes so it renders as
+// structured data under both output schemas; as json.RawMessage it would have
+// marshalled to a base64 string under yaml.
+type azureTemplateView struct {
+	SchemaVersion  int            `json:"schemaVersion" yaml:"schemaVersion"`
+	Phase          string         `json:"phase" yaml:"phase"` // "template"
+	Cloud          string         `json:"cloud" yaml:"cloud"`
+	Installation   string         `json:"installation" yaml:"installation"`
+	FormaeTenantID string         `json:"formaeTenantId" yaml:"formaeTenantId"`
+	DeepLink       string         `json:"deepLink" yaml:"deepLink"`
+	TemplateURL    string         `json:"templateUrl" yaml:"templateUrl"`
+	Template       map[string]any `json:"template" yaml:"template"`
+}
+
+// newAzureTemplateView assembles the emit from the same inputs the human
+// rendering uses, so the two cannot describe different deployments.
+func newAzureTemplateView(consoleOrigin, installationID, formaeTenantID string,
+	template []byte) (azureTemplateView, error) {
+	var decoded map[string]any
+	if err := json.Unmarshal(template, &decoded); err != nil {
+		return azureTemplateView{}, fmt.Errorf("decoding the ARM template for machine output: %w", err)
+	}
+	templateURL := azureTemplateConsoleURL(consoleOrigin, installationID, formaeTenantID)
+	return azureTemplateView{
+		SchemaVersion:  connectSchemaVersion,
+		Phase:          "template",
+		Cloud:          "azure",
+		Installation:   installationID,
+		FormaeTenantID: formaeTenantID,
+		DeepLink:       azurePortalDeepLink(templateURL),
+		TemplateURL:    templateURL,
+		Template:       decoded,
+	}, nil
+}
+
+func emitAzureTemplate(w io.Writer, schema string, v azureTemplateView) error {
+	return printer.NewMachineReadablePrinter[azureTemplateView](w, schema).Print(&v)
 }


### PR DESCRIPTION
## Summary

Azure's credential-less connect path hands the operator a portal deep link: it opens the ARM template with the installation's coordinates already filled in as defaults, so establishing trust needs no CLI, no credential, and nothing pasted on the machine they are working from. It is the only connect route that asks nothing of the local machine at all.

That link only ever appeared in human-readable guidance on stderr. So the one path that needs nothing locally was the one path a harness driving the connect flow could not offer, short of scraping prose off a stream it has no business parsing.

`connect azure template` now takes the same output flags every other connect subcommand already has. Under `--output-consumer machine` it emits one document on stdout — the deep link, the template URL, the installation and formae tenant coordinates, and the template itself — instead of the template-on-stdout plus guidance-on-stderr split that human output keeps unchanged.

This is deliberately the shape AWS already uses: its quick-create URL reaches a consumer as `stackUrl` on a `links` document. Both clouds now hand over a console link the same way, and a consumer branches on `phase` before reading anything else.

## Notes on two choices

**The template rides as decoded structured data, not raw JSON bytes.** The output flags accept `yaml` as well as `json`, and a `json.RawMessage` would have marshalled to a base64 string under yaml. Machine mode replaces stdout, so omitting the template would have left machine callers less capable than human ones at the command's own purpose.

**Failures emit a failure document, not a bare non-zero exit.** Same reason the sibling paths do it: a caller that can only see an exit code cannot tell "sign in first" from "this build is broken", and on this path that caller is typically a harness with no terminal to fall back to.

## Verification

Unit suite and `make lint` (0 issues) green. Both paths checked against a live hosted session:

- success emits `phase: "template"` with a working deep link, under both `json` and `yaml`
- a profile-less run emits `{"schemaVersion":1,"code":"hosted_required", ...}` — a declared code, not an opaque exit