### PR TITLE
fix(cli): stop help rendering from creating a config store

### DIFF
--- a/internal/cli/cmd/cmd.go
+++ b/internal/cli/cmd/cmd.go
@@ -112,7 +112,10 @@ func RethemeUsage(c *cobra.Command, th *theme.Theme) {
 func ResolveConfiguredTheme(c *cobra.Command) *theme.Theme {
 	profileFlag, _ := c.Flags().GetString("profile")
 	configFlag, _ := c.Flags().GetString("config")
-	path, err := ResolveConfigPath(configFlag, profileFlag)
+	// Rendering help must not write to the store: a machine that has not signed
+	// in yet would get a localhost default profile it never asked for, and the
+	// theme is only a preference to read.
+	path, err := ResolveExistingConfigPath(configFlag, profileFlag)
 	if err != nil {
 		return theme.New("formae")
 	}
@@ -141,34 +144,6 @@ func AddConfigFlags(c *cobra.Command) {
 // file path. Exactly one of config/profile may be non-empty (cobra enforces the
 // mutual exclusion). With neither, it resolves the active profile (running
 // migration/bootstrap).
-func ResolveConfigPath(configFlag, profileFlag string) (string, error) {
-	if profileFlag != "" {
-		if err := store.ValidateName(profileFlag); err != nil {
-			return "", err // path-traversal / malformed name guard.
-		}
-		dir, err := store.ResolveConfigDir()
-		if err != nil {
-			return "", err
-		}
-		s := store.New(dir)
-		path := s.ProfilePath(profileFlag)
-		if _, err := os.Stat(path); err != nil {
-			if os.IsNotExist(err) {
-				return "", fmt.Errorf("%w: %s", store.ErrNotFound, profileFlag)
-			}
-			return "", err
-		}
-		return path, nil
-	}
-	if configFlag != "" {
-		return configFlag, nil
-	}
-	dir, err := store.ResolveConfigDir()
-	if err != nil {
-		return "", err
-	}
-	return store.New(dir).Resolve()
-}
 
 func AppFromContext(ctx context.Context, configFilePath, endpoint string, cmd *cobra.Command) (*app.App, error) {
 	if ctx.Value("app") != nil {
@@ -373,4 +348,50 @@ func ResolveOutput(c *cobra.Command) (printer.Consumer, string, error) {
 		return "", "", FlagErrorf("output-schema must be either 'json' or 'yaml' for machine consumer")
 	}
 	return consumer, schema, nil
+}
+
+// ResolveConfigPath turns the --config / --profile flags into a concrete config
+// file path, initializing an empty store if there is nothing yet. Use it from a
+// command that is about to work with the config it names.
+func ResolveConfigPath(configFlag, profileFlag string) (string, error) {
+	return resolveConfigPath(configFlag, profileFlag, true)
+}
+
+// ResolveExistingConfigPath is ResolveConfigPath for a caller that must leave
+// the store exactly as it found it, at the cost of failing where the other
+// would have created something to succeed with.
+func ResolveExistingConfigPath(configFlag, profileFlag string) (string, error) {
+	return resolveConfigPath(configFlag, profileFlag, false)
+}
+
+func resolveConfigPath(configFlag, profileFlag string, mayInitialize bool) (string, error) {
+	if profileFlag != "" {
+		if err := store.ValidateName(profileFlag); err != nil {
+			return "", err // path-traversal / malformed name guard.
+		}
+		dir, err := store.ResolveConfigDir()
+		if err != nil {
+			return "", err
+		}
+		s := store.New(dir)
+		path := s.ProfilePath(profileFlag)
+		if _, err := os.Stat(path); err != nil {
+			if os.IsNotExist(err) {
+				return "", fmt.Errorf("%w: %s", store.ErrNotFound, profileFlag)
+			}
+			return "", err
+		}
+		return path, nil
+	}
+	if configFlag != "" {
+		return configFlag, nil
+	}
+	dir, err := store.ResolveConfigDir()
+	if err != nil {
+		return "", err
+	}
+	if mayInitialize {
+		return store.New(dir).Resolve()
+	}
+	return store.New(dir).ResolveExisting()
 }

--- a/internal/cli/cmd/usage_theme_test.go
+++ b/internal/cli/cmd/usage_theme_test.go
@@ -7,6 +7,7 @@
 package cmd_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
@@ -56,5 +57,37 @@ func TestResolveConfiguredTheme_FallsBackToDefault(t *testing.T) {
 	c := &cobra.Command{Use: "demo"} // no --profile/--config flags registered
 	if got := cmd.ResolveConfiguredTheme(c); got == nil {
 		t.Fatal("ResolveConfiguredTheme must never return nil")
+	}
+}
+
+// Rendering help must not write to the config store.
+//
+// Theme resolution reads the active profile to color the banner, and it used to
+// do that through the store's initializing resolve. So `formae --help`, and any
+// mistyped command whose usage is rendered, created a localhost default profile
+// and pointed the store at it. On a machine that has not signed in yet that is
+// not a harmless convenience: it turns "unconfigured" into "configured, self
+// hosted, localhost", which is the state hosted onboarding branches on, and
+// nothing in the flow asks the user about it or tells them it happened.
+func TestResolveConfiguredTheme_DoesNotCreateAConfigStore(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("FORMAE_CONFIG_DIR", dir)
+
+	c := &cobra.Command{Use: "demo"}
+	cmd.AddConfigFlags(c)
+
+	// The theme is whatever the default is; what matters is the filesystem.
+	_ = cmd.ResolveConfiguredTheme(c)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read config dir: %v", err)
+	}
+	if len(entries) != 0 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("resolving the theme wrote to an empty config store: %v", names)
 	}
 }

--- a/internal/cli/profile/store/store.go
+++ b/internal/cli/profile/store/store.go
@@ -162,13 +162,6 @@ func (s *Store) Resolve() (string, error) {
 // Resolve creates names a local agent, and that is a decision the user has not
 // been asked about. Anything that only wants to look should not be the thing
 // that makes it.
-func (s *Store) ResolveExisting() (string, error) {
-	name, err := s.Active()
-	if err != nil {
-		return "", err
-	}
-	return s.ProfilePath(name), nil
-}
 
 // List returns all profile names in sorted order. An absent profiles/ dir
 // yields an empty slice (a clean store is not an error for introspection).
@@ -493,4 +486,59 @@ func (s *Store) validSymlinkTarget() (string, bool) {
 		return "", false
 	}
 	return name, true
+}
+
+// ResolveExisting is Resolve for a caller that must not create anything: it
+// resolves every store Resolve can resolve, and does none of the writing.
+//
+// Resolve initializes, which is right for a command about to use a config and
+// wrong for one merely reading a preference out of it. The difference is
+// load-bearing on a machine nobody has signed in on: the store Resolve creates
+// there names a local agent, and that is a decision the user has not been asked
+// about. Anything that only wants to look should not be the thing that makes it.
+//
+// The cases below mirror initialize's, in its order, minus its side effects. A
+// version that only read the active pointer would have made a configured user's
+// theme depend on some other command having migrated their legacy config first
+// - and the read-only caller is exactly the one that cannot cause that
+// migration.
+func (s *Store) ResolveExisting() (string, error) {
+	// A pointer that exists is decisive: Resolve refuses to rewrite a malformed
+	// one and reports a dangling one rather than looking further, so neither may
+	// fall through to the recovery cases.
+	if name, err := s.Active(); err == nil {
+		path := s.ProfilePath(name)
+		if _, statErr := os.Stat(path); statErr != nil {
+			return "", fmt.Errorf("%w: active profile %q not found", ErrNotInitialized, name)
+		}
+		return path, nil
+	} else if !errors.Is(err, ErrNotInitialized) {
+		return "", err
+	}
+
+	cfg := s.ConfigPath()
+	if info, lerr := os.Lstat(cfg); lerr == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			// A legacy symlink already points at a profile, so reading it needs
+			// no migration at all.
+			if name, ok := s.validSymlinkTarget(); ok {
+				return s.ProfilePath(name), nil
+			}
+		} else {
+			// A bare legacy file is itself a readable config. Resolve moves it
+			// into profiles/ and points at it; a reader can just read it where
+			// it lies.
+			return cfg, nil
+		}
+	}
+
+	if path := s.ProfilePath("default"); fileExists(path) {
+		return path, nil // an orphaned default, which Resolve adopts.
+	}
+	return "", ErrNotInitialized
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }

--- a/internal/cli/profile/store/store.go
+++ b/internal/cli/profile/store/store.go
@@ -152,17 +152,6 @@ func (s *Store) Resolve() (string, error) {
 	return s.ProfilePath(name), nil
 }
 
-// ResolveExisting is Resolve for a caller that must not create anything: it
-// answers only from what is already on disk, and reports ErrNotInitialized
-// when there is nothing.
-//
-// Resolve initializes an empty store, which is right for a command about to
-// use a config and wrong for one merely reading a preference out of it. The
-// difference is load-bearing on a machine nobody has signed in on: the store
-// Resolve creates names a local agent, and that is a decision the user has not
-// been asked about. Anything that only wants to look should not be the thing
-// that makes it.
-
 // List returns all profile names in sorted order. An absent profiles/ dir
 // yields an empty slice (a clean store is not an error for introspection).
 //
@@ -525,9 +514,14 @@ func (s *Store) ResolveExisting() (string, error) {
 				return s.ProfilePath(name), nil
 			}
 		} else {
-			// A bare legacy file is itself a readable config. Resolve moves it
-			// into profiles/ and points at it; a reader can just read it where
-			// it lies.
+			// A bare legacy file is itself a readable config, and Resolve moves
+			// it into profiles/ and points at it - unless a default is already
+			// there. That collision is initialize's step 5b: it leaves the bare
+			// file where it lies and adopts the default instead, so returning
+			// the bare file here would resolve a config no command will use.
+			if path := s.ProfilePath("default"); fileExists(path) {
+				return path, nil
+			}
 			return cfg, nil
 		}
 	}

--- a/internal/cli/profile/store/store.go
+++ b/internal/cli/profile/store/store.go
@@ -152,6 +152,24 @@ func (s *Store) Resolve() (string, error) {
 	return s.ProfilePath(name), nil
 }
 
+// ResolveExisting is Resolve for a caller that must not create anything: it
+// answers only from what is already on disk, and reports ErrNotInitialized
+// when there is nothing.
+//
+// Resolve initializes an empty store, which is right for a command about to
+// use a config and wrong for one merely reading a preference out of it. The
+// difference is load-bearing on a machine nobody has signed in on: the store
+// Resolve creates names a local agent, and that is a decision the user has not
+// been asked about. Anything that only wants to look should not be the thing
+// that makes it.
+func (s *Store) ResolveExisting() (string, error) {
+	name, err := s.Active()
+	if err != nil {
+		return "", err
+	}
+	return s.ProfilePath(name), nil
+}
+
 // List returns all profile names in sorted order. An absent profiles/ dir
 // yields an empty slice (a clean store is not an error for introspection).
 //

--- a/internal/cli/profile/store/store_test.go
+++ b/internal/cli/profile/store/store_test.go
@@ -8,8 +8,10 @@ package store_test
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -689,4 +691,106 @@ func TestResolveDoesNotUndoAConcurrentUse(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ResolveExisting must resolve every state Resolve can resolve, minus the
+// writing. Each of these is a store a configured user really has, and reading a
+// preference out of one must not depend on some other command having migrated
+// it first: the caller that reads without writing is precisely the caller that
+// cannot cause the migration.
+func TestResolveExisting_ResolvesWhatResolveWouldWithoutWriting(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T, dir string) string // returns the path it must resolve to
+	}{
+		{
+			name: "a valid active pointer",
+			setup: func(t *testing.T, dir string) string {
+				writeProfile(t, dir, "work")
+				writeFile(t, dir, "active", "work")
+				return filepath.Join(dir, "profiles", "work.pkl")
+			},
+		},
+		{
+			name: "a legacy bare config file",
+			setup: func(t *testing.T, dir string) string {
+				legacy := filepath.Join(dir, "formae.conf.pkl")
+				writeFile(t, dir, "formae.conf.pkl", "// legacy")
+				return legacy
+			},
+		},
+		{
+			name: "a legacy symlink into profiles",
+			setup: func(t *testing.T, dir string) string {
+				writeProfile(t, dir, "linked")
+				if err := os.Symlink(filepath.Join("profiles", "linked.pkl"),
+					filepath.Join(dir, "formae.conf.pkl")); err != nil {
+					t.Fatalf("symlink: %v", err)
+				}
+				return filepath.Join(dir, "profiles", "linked.pkl")
+			},
+		},
+		{
+			name: "an orphaned default with no pointer",
+			setup: func(t *testing.T, dir string) string {
+				writeProfile(t, dir, "default")
+				return filepath.Join(dir, "profiles", "default.pkl")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			want := tc.setup(t, dir)
+			before := listTree(t, dir)
+
+			got, err := store.New(dir).ResolveExisting()
+			if err != nil {
+				t.Fatalf("ResolveExisting: %v", err)
+			}
+			if got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+			if after := listTree(t, dir); after != before {
+				t.Errorf("ResolveExisting wrote to the store:\nbefore: %s\nafter:  %s", before, after)
+			}
+		})
+	}
+}
+
+// Nothing at all is the one state it must refuse, because that is the state
+// whose only resolution is to invent a profile.
+func TestResolveExisting_RefusesAnEmptyStore(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := store.New(dir).ResolveExisting(); !errors.Is(err, store.ErrNotInitialized) {
+		t.Errorf("got %v, want ErrNotInitialized", err)
+	}
+	if entries, _ := os.ReadDir(dir); len(entries) != 0 {
+		t.Errorf("ResolveExisting created %d entries in an empty store", len(entries))
+	}
+}
+
+func writeProfile(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "profiles"), 0o755); err != nil {
+		t.Fatalf("mkdir profiles: %v", err)
+	}
+	writeFile(t, dir, filepath.Join("profiles", name+".pkl"), "// "+name)
+}
+
+// listTree renders the store's contents so a test can assert nothing changed.
+func listTree(t *testing.T, dir string) string {
+	t.Helper()
+	var out []string
+	if err := filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(dir, p)
+		out = append(out, rel)
+		return nil
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	sort.Strings(out)
+	return strings.Join(out, " ")
 }

--- a/internal/cli/profile/store/store_test.go
+++ b/internal/cli/profile/store/store_test.go
@@ -731,6 +731,17 @@ func TestResolveExisting_ResolvesWhatResolveWouldWithoutWriting(t *testing.T) {
 			},
 		},
 		{
+			// initialize's step 5b: it leaves the bare file alone and adopts the
+			// existing default, so a reader must resolve the default too or it
+			// would render from a config no command uses.
+			name: "a legacy bare file colliding with an existing default",
+			setup: func(t *testing.T, dir string) string {
+				writeFile(t, dir, "formae.conf.pkl", "// legacy")
+				writeProfile(t, dir, "default")
+				return filepath.Join(dir, "profiles", "default.pkl")
+			},
+		},
+		{
 			name: "an orphaned default with no pointer",
 			setup: func(t *testing.T, dir string) string {
 				writeProfile(t, dir, "default")


### PR DESCRIPTION
## Summary

Theme resolution reads the active profile so the banner and usage text can be drawn in the user's configured colors, and it did that through the store's initializing resolve. So rendering help wrote to the config store. `formae --help`, `formae <command> --help`, and any mistyped command whose usage gets rendered all created a localhost default profile and pointed the store at it.

On a machine nobody has signed in on yet, that is not a harmless convenience. It converts *unconfigured* into *configured, self hosted, localhost* — and unconfigured is the state hosted onboarding branches on. Nothing asks the user about the profile and nothing tells them it appeared, so someone who reads the help before signing in is silently moved onto a path that then reports a local agent which is not running.

## The fix

- `Store.ResolveExisting` answers only from what is on disk and reports `ErrNotInitialized` when there is nothing.
- `ResolveExistingConfigPath` is the `ResolveConfigPath` variant over it; both now share one implementation.
- Theme resolution uses the non-creating variant. It already falls back to the default theme on any error, so an empty store now yields default colors instead of a new profile.

Commands that genuinely resolve a config to work with are unchanged and still initialize an empty store.

## Behaviour, measured before and after

Each row is one command against an empty `FORMAE_CONFIG_DIR`:

| command | before | after |
|---|---|---|
| `formae --help` | seeds | clean |
| `formae login --help` | seeds | clean |
| `formae stack list` (unknown command) | seeds | clean |
| `formae --version` | clean | clean |
| `formae profile list` | clean | clean |
| `formae command list` (resolves a config) | initializes | initializes |

`formae status` and `formae agent stats` also stop seeding. Both are parent commands that only print usage, and their output is byte-identical before and after, so the sole difference is that they no longer write while rendering it.

## Verification

New test asserts an empty config dir stays empty across theme resolution; it fails on the parent commit with `[active init.lock profiles]`. Unit suite and `make lint` (0 issues) green. The one unit failure in `internal/datastore/postgres` is pre-existing and unrelated: it fails identically on the parent commit with `test precondition: default collation must treat 'U' as greater than 'f'`, a locale property of the local container.