### PR TITLE
feat(connect): derive the Azure tenant instead of asking for it

### DIFF
--- a/internal/cli/connect/azure.go
+++ b/internal/cli/connect/azure.go
@@ -91,12 +91,14 @@ func decideAzureMode(opts azureOptions) (azureMode, error) {
 		return azureModeLocal, nil
 	}
 
-	if opts.TenantID == "" {
-		return 0, clicmd.FlagErrorf("--client-id names an existing managed identity; pass --tenant-id too, " +
-			"so both coordinates the control plane needs are registered")
-	}
-	if err := validateAzureUUID(opts.TenantID, "--tenant-id"); err != nil {
-		return 0, err
+	// --tenant-id is optional here: ARM names the subscription's tenant in the
+	// challenge it returns to an unauthenticated request, so the register-only
+	// path derives it rather than asking the operator to copy a second guid.
+	// A supplied value still wins, and still has to be well formed.
+	if opts.TenantID != "" {
+		if err := validateAzureUUID(opts.TenantID, "--tenant-id"); err != nil {
+			return 0, err
+		}
 	}
 	if err := validateAzureUUID(opts.ClientID, "--client-id"); err != nil {
 		return 0, err
@@ -267,6 +269,19 @@ func runAzureRegisterOnly(cc *cobra.Command, opts azureOptions, consumer printer
 	s, err := openSession(cc.Context(), options{ConfigFlag: opts.ConfigFlag, ProfileFlag: opts.ProfileFlag})
 	if err != nil {
 		return err
+	}
+
+	// Derived only when the operator did not supply one. The probe needs no
+	// credential, but it does need the network, so a failure names the flag
+	// rather than stranding a path whose point is to need nothing local.
+	if opts.TenantID == "" {
+		tenant, derr := discoverAzureTenant(cc.Context(), opts.Subscription)
+		if derr != nil {
+			return printer.Fail(printer.CodeCredentialsRequired,
+				"could not work out which Entra tenant owns subscription "+opts.Subscription+
+					"; pass --tenant-id with the tenantId from the deployment outputs", nil)
+		}
+		opts.TenantID = tenant
 	}
 
 	warnings := append([]string{}, s.Warnings...)

--- a/internal/cli/connect/azure_test.go
+++ b/internal/cli/connect/azure_test.go
@@ -27,8 +27,9 @@ const (
 // the one coordinate that can never be a mere hint); tenant-id alone is
 // accepted as a provisioning-mode authentication hint, forwarded verbatim
 // into provx's New(), which is exactly what "New() accepts an empty
-// azTenantID" is for; client-id without tenant-id cannot name a complete
-// external identity and fails.
+// azTenantID" is for. client-id selects register-only whether or not a tenant
+// is supplied: an absent tenant is derived from the subscription when the run
+// executes, so it is no longer a flag-validation concern.
 func TestAzureModeSelection(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -38,7 +39,10 @@ func TestAzureModeSelection(t *testing.T) {
 	}{
 		{"subscription alone provisions", azureOptions{Subscription: testSubscription}, azureModeLocal, false},
 		{"tenant hint alone still provisions", azureOptions{Subscription: testSubscription, TenantID: testAzureTenant}, azureModeLocal, false},
-		{"client id alone fails", azureOptions{Subscription: testSubscription, ClientID: testAzureClient}, 0, true},
+		// --client-id alone is now a register-only run: the tenant is derived
+		// from the subscription at execute time, so the flag pair is no longer
+		// the only way to name a complete external identity.
+		{"client id alone registers, tenant derived later", azureOptions{Subscription: testSubscription, ClientID: testAzureClient}, azureModeRegisterOnly, false},
 		{"both coordinates register", azureOptions{Subscription: testSubscription, TenantID: testAzureTenant, ClientID: testAzureClient}, azureModeRegisterOnly, false},
 	}
 	for _, tc := range tests {
@@ -65,9 +69,14 @@ func TestAzureTenantHintMustBeAUUIDEvenAlone(t *testing.T) {
 
 // One coordinate without the other fails outright: a bare client id cannot
 // name a complete external identity.
-func TestAzureRegisterOnlyRequiresBothCoordinates(t *testing.T) {
-	_, err := decideAzureMode(azureOptions{Subscription: testSubscription, ClientID: testAzureClient})
-	require.Error(t, err)
+func TestAzureRegisterOnlyAcceptsAClientIDAlone(t *testing.T) {
+	// The tenant is derived from the subscription when the run executes, so a
+	// client id on its own is a complete register-only invocation. Requiring
+	// both flags made the operator copy a second guid that ARM will name for
+	// free.
+	mode, err := decideAzureMode(azureOptions{Subscription: testSubscription, ClientID: testAzureClient})
+	require.NoError(t, err)
+	assert.Equal(t, azureModeRegisterOnly, mode)
 }
 
 // A tenant or client id that is not a UUID is refused before any

--- a/internal/cli/connect/azuretenant.go
+++ b/internal/cli/connect/azuretenant.go
@@ -1,0 +1,99 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package connect
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// The credential-less path asks the operator for two coordinates the template
+// deployment outputs: a tenant id and a client id. Only one of them has to be
+// asked for.
+//
+// The client id is a guid Azure generates, so nothing here can know it. The
+// tenant is different: ARM names it in the challenge it returns to an
+// unauthenticated request for the subscription, so it can be derived from the
+// subscription the operator has already given us. Deriving it halves what they
+// have to carry by hand, and a value nobody types is a value nobody mistypes.
+//
+// This is the same trick the Azure SDKs use to discover an authority, and it
+// needs no credential: the request is expected to fail, and the useful part is
+// the 401's WWW-Authenticate header.
+
+// armSubscriptionProbe is the URL whose challenge names the tenant.
+const armSubscriptionProbe = "https://management.azure.com/subscriptions/%s?api-version=2022-12-01"
+
+// tenantProbeTimeout bounds the probe. It runs before any provisioning, on a
+// path whose whole promise is that it asks nothing of this machine, so it must
+// fail fast and let the operator supply the value instead of hanging.
+const tenantProbeTimeout = 10 * time.Second
+
+// authorizationURIPattern pulls the authority out of a Bearer challenge.
+var authorizationURIPattern = regexp.MustCompile(`authorization_uri="([^"]+)"`)
+
+// azureGUIDPattern matches the canonical guid form Azure uses for tenant ids.
+var azureGUIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// tenantFromChallenge reads the tenant out of a WWW-Authenticate value, or
+// returns "" when the header names none.
+//
+// The tenant is the first path segment of the authority, whichever login host
+// it names - sovereign clouds use their own. Anything that is not a guid yields
+// "": `common` and `organizations` are valid authorities but not tenants, and
+// registering a placeholder would fail later and further from the cause.
+func tenantFromChallenge(header string) string {
+	m := authorizationURIPattern.FindStringSubmatch(header)
+	if m == nil {
+		return ""
+	}
+	u, err := url.Parse(m[1])
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	// Only the first segment can be the tenant. A guid deeper in the path would
+	// be some other identifier, so this does not go looking for one.
+	first := strings.Split(strings.Trim(u.Path, "/"), "/")[0]
+	if !azureGUIDPattern.MatchString(first) {
+		return ""
+	}
+	return first
+}
+
+// discoverAzureTenant asks ARM which tenant owns a subscription, without a
+// credential.
+//
+// A var so tests can replace it: the real one makes a network call whose whole
+// purpose is to be rejected.
+var discoverAzureTenant = func(ctx context.Context, subscriptionID string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, tenantProbeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		fmt.Sprintf(armSubscriptionProbe, url.PathEscape(subscriptionID)), nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// A 401 is the expected answer and the one that carries the tenant. Any
+	// other status means the probe told us nothing, including a 200, which
+	// would mean the request was somehow authorized and no challenge was sent.
+	tenant := tenantFromChallenge(resp.Header.Get("WWW-Authenticate"))
+	if tenant == "" {
+		return "", fmt.Errorf("ARM did not name a tenant for subscription %s (status %d)", subscriptionID, resp.StatusCode)
+	}
+	return tenant, nil
+}

--- a/internal/cli/connect/azuretenant_test.go
+++ b/internal/cli/connect/azuretenant_test.go
@@ -1,0 +1,78 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package connect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ARM names the subscription's tenant in the challenge it returns to an
+// unauthenticated request, which is what lets the credential-less path stop
+// asking the operator to copy it. The deployment outputs it too, but a value
+// the operator has to transport by hand is a value they can transport wrongly,
+// and it is one of only two things that path asks of them.
+func TestTenantFromChallenge(t *testing.T) {
+	const tenant = "416727bd-1d5d-4540-81d7-d391007ed660"
+
+	for _, tc := range []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{
+			name:   "the shape ARM actually returns",
+			header: `Bearer authorization_uri="https://login.windows.net/` + tenant + `", error="invalid_token", error_description="The authentication failed because of missing 'Authorization' header."`,
+			want:   tenant,
+		},
+		{
+			// The login host is not fixed: sovereign clouds use their own, and
+			// the tenant is the last path segment whichever it is.
+			name:   "a sovereign login host",
+			header: `Bearer authorization_uri="https://login.microsoftonline.us/` + tenant + `"`,
+			want:   tenant,
+		},
+		{
+			name:   "a trailing slash on the uri",
+			header: `Bearer authorization_uri="https://login.windows.net/` + tenant + `/"`,
+			want:   tenant,
+		},
+		{
+			name:   "oauth2 path segments after the tenant",
+			header: `Bearer authorization_uri="https://login.windows.net/` + tenant + `/oauth2/authorize"`,
+			want:   tenant,
+		},
+		{
+			// Anything that is not a tenant guid must yield nothing rather than
+			// a guess: registering the wrong tenant fails later and further
+			// away, where it is harder to attribute.
+			name:   "a common tenant alias rather than a guid",
+			header: `Bearer authorization_uri="https://login.windows.net/common"`,
+			want:   "",
+		},
+		{
+			name:   "a challenge with no authorization_uri",
+			header: `Bearer error="invalid_token"`,
+			want:   "",
+		},
+		{
+			name:   "no challenge at all",
+			header: "",
+			want:   "",
+		},
+		{
+			name:   "an authorization_uri that is not a url",
+			header: `Bearer authorization_uri="not a url at all"`,
+			want:   "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tenantFromChallenge(tc.header))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The credential-less Azure path asked the operator to carry two coordinates out of the ARM template deployment's outputs: a tenant id and a client id. Only one of them has to be asked for.

The client id is a GUID Azure generates when it creates the managed identity, so nothing local can compute it. The tenant is different — ARM names it in the challenge it returns to an *unauthenticated* request for the subscription:

```
$ curl -i https://management.azure.com/subscriptions/<id>?api-version=2022-12-01
HTTP/2 401
www-authenticate: Bearer authorization_uri="https://login.windows.net/<tenant>", error="invalid_token", ...
```

Since the operator has already supplied the subscription, the tenant follows from it. This is the same authority discovery the Azure SDKs perform, and it needs no credential: the request is *expected* to be rejected, and the 401 is the useful part.

So `connect azure --subscription <id> --client-id <id>` is now a complete register-only invocation. `--tenant-id` still works and still wins; it is simply no longer required.

## Why it is worth doing

Halving what the operator transports by hand also halves what they can transport wrongly — and on this path the other half is checked by nothing until a later command fails against the wrong directory. It also removes the more confusing of the two values: the deployment outputs a `tenantId` that is an Azure Entra tenant, while the same flow elsewhere refers to a *formae* tenant, and they are unrelated.

## Care taken

- **The tenant is read only from the authority's first path segment, and only when it is a GUID.** `common` and `organizations` are valid authorities but not tenants; registering a placeholder would fail further from its cause. Sovereign login hosts (`login.microsoftonline.us`, `.cn`) work because the host is not matched, only the segment.
- **A failure names `--tenant-id` as the remedy.** The probe needs the network even though it needs no credential, so a machine without one degrades to the previous behaviour rather than losing the path entirely. Bounded at ten seconds.
- **Two existing tests asserted the rule this removes.** They are rewritten to state the new contract rather than deleted, so the intent stays pinned.

## Verification

Eight parsing cases including sovereign hosts, trailing slashes, `oauth2` suffixes, the `common` alias, a missing header, and a non-URL. Verified end to end against a live subscription: derived the correct tenant in 0.1s with no credential and no `az` present. `make lint` 0 issues, CLI unit suite green.