### PR TITLE
fix(schema): refresh dependent plugin checksums on schema publish

### DIFF
--- a/.github/workflows/schema-prerelease.yml
+++ b/.github/workflows/schema-prerelease.yml
@@ -67,6 +67,12 @@ jobs:
       - name: Publish schema to S3
         run: aws s3 sync .out/formae@${{ inputs.version }} s3://hub.platform.engineering/plugins/pkl/schema/pkl/formae/
 
+      # Overwriting a canonical version invalidates the checksum every
+      # dependent plugin schema's metadata declares for it; refresh those
+      # declarations as part of the same publish.
+      - name: Refresh dependent plugin schema checksums
+        run: python3 scripts/fixup-schema-dependents.py '${{ inputs.version }}'
+
       - name: Summary
         run: |
           echo "## Schema Pre-release" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -115,9 +115,13 @@ gen-pkl: version-semver
 pkg-pkl:
 	pkl project package ./internal/schema/pkl/schema --skip-publish-check
 
-## publish-pkl: Publish core formae schema to S3
+## publish-pkl: Publish core formae schema to S3. Overwriting a canonical
+## version invalidates the checksum every dependent plugin schema's metadata
+## declares for it, so the publish refreshes those declarations in the same
+## step (see scripts/fixup-schema-dependents.py).
 publish-pkl:
 	aws s3 sync .out/formae@${VERSION} s3://hub.platform.engineering/plugins/pkl/schema/pkl/formae/
+	python3 scripts/fixup-schema-dependents.py ${VERSION}
 
 run:
 	go run cmd/formae/main.go

--- a/scripts/fixup-schema-dependents.py
+++ b/scripts/fixup-schema-dependents.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# © 2026 Platform Engineering Labs Inc.
+#
+# SPDX-License-Identifier: FSL-1.1-ALv2
+
+"""Refresh dependent plugin schemas after a formae schema publish.
+
+The schema coordinate formae@X.Y.Z is deliberately mutable: every dev build on
+the X.Y.Z line republishes it. A plugin schema package built against it bakes
+the then-current zip checksum into its own published metadata
+(dependencies.formae.checksums.sha256), and `pkl project resolve` rejects any
+dependency whose served zip no longer matches a declared checksum. A formae
+schema publish therefore invalidates every dependent plugin schema published
+before it, and has to bring their declared checksums back in line as part of
+the same publish.
+
+Usage: fixup-schema-dependents.py <schema-version>
+
+Expects the freshly packaged metadata at .out/formae@<version>/formae@<version>
+(the new checksum is read from it, exactly as pkl computed it) and AWS
+credentials able to read and write the hub bucket.
+"""
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+
+BUCKET = "hub.platform.engineering"
+
+# Plugin schema metadata objects: plugins/<plugin>/schema/pkl/<name>/<name>@<version>,
+# extensionless, with the package zip sitting next to them.
+METADATA_KEY = re.compile(r"^plugins/[^/]+/schema/pkl/[^/]+/[^/]+@[0-9][^/]*$")
+
+
+def aws(*args: str) -> str:
+    return subprocess.run(
+        ["aws", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit(f"usage: {sys.argv[0]} <schema-version>")
+    version = sys.argv[1]
+    coordinate = f"package://{BUCKET}/plugins/pkl/schema/pkl/formae/formae@{version}"
+
+    with open(f".out/formae@{version}/formae@{version}") as f:
+        sha256 = json.load(f)["packageZipChecksums"]["sha256"]
+    print(f"formae@{version} zip sha256: {sha256}")
+
+    listing = aws(
+        "s3api", "list-objects-v2",
+        "--bucket", BUCKET,
+        "--prefix", "plugins/",
+        "--query", "Contents[].Key",
+        "--output", "text",
+    )
+    keys = [
+        key
+        for key in listing.split()
+        if METADATA_KEY.match(key)
+        and not key.endswith(".zip")
+        and not key.endswith(".sha256")
+    ]
+
+    refreshed = 0
+    for key in keys:
+        with tempfile.NamedTemporaryFile("r+", suffix=".json") as tmp:
+            aws("s3", "cp", f"s3://{BUCKET}/{key}", tmp.name, "--only-show-errors")
+            try:
+                doc = json.load(tmp)
+            except ValueError:
+                print(f"skipping {key}: not package metadata")
+                continue
+            stale = [
+                dep
+                for dep in doc.get("dependencies", {}).values()
+                if dep.get("uri") == coordinate
+                and dep.get("checksums", {}).get("sha256") != sha256
+            ]
+            if not stale:
+                continue
+            for dep in stale:
+                dep["checksums"] = {"sha256": sha256}
+            tmp.seek(0)
+            tmp.truncate()
+            json.dump(doc, tmp, indent=2)
+            tmp.flush()
+            aws("s3", "cp", tmp.name, f"s3://{BUCKET}/{key}", "--only-show-errors")
+            print(f"refreshed {key}")
+            refreshed += 1
+
+    print(f"{refreshed} dependent(s) refreshed, {len(keys)} schema package(s) checked")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

Every dev build on an X.Y.Z line republishes the formae schema package at the canonical `formae@X.Y.Z` coordinate (deliberately: the coordinate is the contract, not the bytes). But plugin schema packages built against it bake the then-current zip checksum into their published metadata (`dependencies.formae.checksums.sha256` — `pkl project package` copies it from the build-time resolve), and pkl hard-fails a resolve when a declared checksum no longer matches the served zip. The member is required by pkl's metadata parser, so it cannot simply be dropped.

Each schema publish therefore silently invalidated every dependent plugin schema published before it. As of today the hub had **five plugin schemas declaring five different checksums** for `formae@0.89.0`, none matching the served zip — every fresh `pkl project resolve` against any of them fails, and no cache clear fixes it:

```
Computed checksum did not match declared checksum for dependency
`package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.89.0`.
```

Existing checkouts keep working off their lock + cache, which is why this stayed invisible until a cache clear or a new worktree.

## Fix

The publish refreshes what it invalidates, in the same step: `scripts/fixup-schema-dependents.py` lists the plugin schema metadata objects on the hub, and rewrites the declared checksum of any dependency whose URI is exactly the coordinate just published. Wired into both publishers — `make publish-pkl` (the tag-driven `pkg_pkl` job) and the `schema-prerelease` workflow. Idempotent; dependents pinning other formae versions are untouched; it also heals older plugin package versions that pin the same coordinate.

Plugin builds need no counterpart: `plugin-build.yml` resolves at build time, so a plugin's published checksum is correct at its own publish moment, and the next formae publish keeps it that way. A plugin build racing a formae publish can still land a just-stale checksum; the next formae publish converges it, which on a dev line is hours away.

Verified with a fake-`aws` end-to-end run against the actual stale `grafana@0.1.7` / `aws@0.1.17` metadata from the hub: both rewritten to the live checksum, formae's own metadata (no dependencies) untouched, `.zip`/opkg/non-JSON keys filtered or skipped, second run a no-op.

## Deploying the fix to the currently-broken hub

After merge, dispatch `schema-prerelease` with `version: 0.89.0`, `source_branch: main`. Main is exactly at `0.89.0-dev.17` with no schema source drift, so this republishes byte-identical schema content and the new step repairs all dependents in place. IAM needs nothing: the fixup writes with the same `github-pel` role plugin builds already publish with.