### PR TITLE
fix(metastructure): rotate a credential into the resources that consume it

### DIFF
--- a/internal/metastructure/generator_rotator.go
+++ b/internal/metastructure/generator_rotator.go
@@ -9,11 +9,13 @@ import (
 	"fmt"
 	"hash/fnv"
 	"log/slog"
+	"sort"
 	"time"
 
 	"ergo.services/ergo/act"
 	"ergo.services/ergo/gen"
 
+	"github.com/platform-engineering-labs/formae/internal/constants"
 	"github.com/platform-engineering-labs/formae/internal/datastore"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/changeset"
@@ -438,6 +440,63 @@ type rotationResult struct {
 	changeset changeset.Changeset
 }
 
+// findRotationConsumers walks outward from a generator's destinations to the
+// resources that consume them by reference, transitively.
+//
+// A rotation moves the value a destination holds. Anything reading that value
+// through a reference goes on holding the previous one until it is written
+// again, and delivery reaches nodes in the changeset and nothing else, so a
+// consumer absent from the changeset is a consumer that never follows. The
+// database role whose password references a rotating secret is the shape
+// production uses: after a rotation the secret carries the new credential and
+// the engine still accepts only the old one until the role is written.
+//
+// Destinations are found by their binding to the generator; a consumer is one
+// hop further out and holds a reference to the destination rather than to the
+// generator, which is why the destination query cannot see it. The walk is
+// transitive because a consumer may itself be referenced.
+//
+// Unmanaged rows are skipped and not walked through: they carry no declarations
+// to re-resolve, exactly as the delete cascade treats them. Results are sorted
+// so a rotation plans the same nodes in the same order every time.
+func findRotationConsumers(ds datastore.Datastore, destinations []*pkgmodel.Resource) ([]*pkgmodel.Resource, error) {
+	seen := make(map[string]bool, len(destinations))
+	level := make([]string, 0, len(destinations))
+	for _, destination := range destinations {
+		if destination.Ksuid == "" {
+			continue
+		}
+		seen[destination.Ksuid] = true
+		level = append(level, destination.Ksuid)
+	}
+
+	var consumers []*pkgmodel.Resource
+	for len(level) > 0 {
+		dependents, err := ds.FindResourcesDependingOnMany(level)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find the consumers of a rotation destination: %w", err)
+		}
+		var next []string
+		for _, group := range dependents {
+			for _, dependent := range group {
+				if dependent == nil || dependent.Ksuid == "" || seen[dependent.Ksuid] {
+					continue
+				}
+				seen[dependent.Ksuid] = true
+				if dependent.Stack == constants.UnmanagedStack {
+					continue
+				}
+				consumers = append(consumers, dependent)
+				next = append(next, dependent.Ksuid)
+			}
+		}
+		level = next
+	}
+
+	sort.Slice(consumers, func(i, j int) bool { return consumers[i].Ksuid < consumers[j].Ksuid })
+	return consumers, nil
+}
+
 // prepareRotation builds the apply that moves one generator's generation
 // forward. It returns nil (with no error) when there is nothing to rotate.
 //
@@ -474,7 +533,13 @@ func prepareRotation(ds datastore.Datastore, info datastore.GeneratorRotationInf
 		return nil, nil
 	}
 
-	forma := pkgmodel.FormaFromResources(destinations)
+	consumers, err := findRotationConsumers(ds, destinations)
+	if err != nil {
+		return nil, err
+	}
+	planned := append(append([]*pkgmodel.Resource{}, destinations...), consumers...)
+
+	forma := pkgmodel.FormaFromResources(planned)
 
 	existingTargets, err := ds.LoadAllTargets()
 	if err != nil {
@@ -492,10 +557,10 @@ func prepareRotation(ds datastore.Datastore, info datastore.GeneratorRotationInf
 		}
 	}
 
-	coPlanKsuids := make(map[string]bool, len(destinations))
-	for _, destination := range destinations {
-		if destination.Ksuid != "" {
-			coPlanKsuids[destination.Ksuid] = true
+	coPlanKsuids := make(map[string]bool, len(planned))
+	for _, resource := range planned {
+		if resource.Ksuid != "" {
+			coPlanKsuids[resource.Ksuid] = true
 		}
 	}
 

--- a/internal/metastructure/generator_rotator_admission_test.go
+++ b/internal/metastructure/generator_rotator_admission_test.go
@@ -8,12 +8,14 @@ package metastructure
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/demula/mksuid/v2"
 	"github.com/platform-engineering-labs/formae/internal/datastore"
 	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
@@ -186,4 +188,99 @@ func TestPrepareRotation_SkipsAGeneratorWithNoDestination(t *testing.T) {
 	result, err := prepareRotation(ds, info)
 	require.NoError(t, err)
 	assert.Nil(t, result, "a generator with no destination must produce no command")
+}
+
+// storeRotationResource persists one resource on the rotation test target.
+func storeRotationResource(t *testing.T, ds datastore.Datastore, stack, label, resourceType, props string) string {
+	t.Helper()
+	ksuid := mksuid.New().String()
+	_, err := ds.StoreResource(&pkgmodel.Resource{
+		Ksuid:      ksuid,
+		NativeID:   label + "-native",
+		Stack:      stack,
+		Label:      label,
+		Type:       resourceType,
+		Target:     "rotation-target",
+		Properties: json.RawMessage(props),
+	}, "cmd-resource")
+	require.NoError(t, err)
+	return ksuid
+}
+
+// A rotated credential reaches the generator's destination, but the resources
+// that consume that destination by reference have to move with it. A database
+// role whose password is a reference to a rotating secret is the shape
+// production uses: the secret holds the new value and the engine still holds
+// the old one until the role is written, so a rotation that plans only the
+// secret leaves the credential and the database disagreeing.
+func TestPrepareRotation_PlansTheConsumersOfADestination(t *testing.T) {
+	ds := rotationTestDatastore(t)
+	_, err := ds.CreateTarget(&pkgmodel.Target{
+		Label: "rotation-target", Namespace: "AWS", Config: json.RawMessage(`{}`),
+	})
+	require.NoError(t, err)
+
+	info := createRotatingGenerator(t, ds, "secrets", "db-password", 3600)
+
+	secretKsuid := storeRotationResource(t, ds, "secrets", "db-password-secret",
+		"AWS::SecretsManager::Secret",
+		`{"SecretString":{"$gen":true,"$generator":"`+info.GeneratorID+
+			`","$output":"value","$visibility":"Opaque","$hashed":true,"$value":"sha256:digest"}}`)
+
+	storeRotationResource(t, ds, "secrets", "db-role",
+		"AWS::RDS::DatabaseRole",
+		`{"RoleName":"app","Password":{"$ref":"formae://`+secretKsuid+
+			`#/SecretValue","$visibility":"Opaque"}}`)
+
+	result, err := prepareRotation(ds, info)
+	require.NoError(t, err)
+	require.NotNil(t, result, "a generator with a destination must produce a command")
+
+	planned := map[string]bool{}
+	for _, ru := range result.command.ResourceUpdates {
+		planned[ru.DesiredState.Label] = true
+	}
+	assert.True(t, planned["db-password-secret"], "the generator's destination must be planned")
+	assert.True(t, planned["db-role"],
+		"a resource consuming the destination by reference must be planned, or the rotation leaves it holding the old credential")
+}
+
+// The control for the case above: widening the rotation to a destination's
+// consumers must not widen it to the whole stack. A resource that references
+// nothing the rotation moves is left out, so a credential rotating on a short
+// cadence does not re-plan unrelated infrastructure every cycle.
+func TestPrepareRotation_LeavesUnrelatedResourcesOutOfThePlan(t *testing.T) {
+	ds := rotationTestDatastore(t)
+	_, err := ds.CreateTarget(&pkgmodel.Target{
+		Label: "rotation-target", Namespace: "AWS", Config: json.RawMessage(`{}`),
+	})
+	require.NoError(t, err)
+
+	info := createRotatingGenerator(t, ds, "secrets", "db-password", 3600)
+
+	secretKsuid := storeRotationResource(t, ds, "secrets", "db-password-secret",
+		"AWS::SecretsManager::Secret",
+		`{"SecretString":{"$gen":true,"$generator":"`+info.GeneratorID+
+			`","$output":"value","$visibility":"Opaque","$hashed":true,"$value":"sha256:digest"}}`)
+
+	storeRotationResource(t, ds, "secrets", "db-role",
+		"AWS::RDS::DatabaseRole",
+		`{"RoleName":"app","Password":{"$ref":"formae://`+secretKsuid+
+			`#/SecretValue","$visibility":"Opaque"}}`)
+
+	// Same stack, references nothing that rotates.
+	storeRotationResource(t, ds, "secrets", "unrelated-bucket",
+		"AWS::S3::Bucket", `{"BucketName":"unrelated"}`)
+
+	result, err := prepareRotation(ds, info)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	planned := map[string]bool{}
+	for _, ru := range result.command.ResourceUpdates {
+		planned[ru.DesiredState.Label] = true
+	}
+	assert.True(t, planned["db-role"], "the consumer is still planned")
+	assert.False(t, planned["unrelated-bucket"],
+		"a resource that references nothing the rotation moves must stay out of the changeset")
 }


### PR DESCRIPTION
## Summary

A generator's rotation planned only the resources bound to the generator itself.
Anything consuming one of those destinations by reference was absent from the
changeset, and delivery reaches nodes in the changeset and nothing else, so the
consumer went on holding the previous credential indefinitely. A user apply
planned the repair, which is why this looked like it worked: it self-healed on
apply and never on rotation.

The shape production uses is a database role whose password references a rotating
secret. Measured against a real Aurora cluster before this change: across thirteen
rotation-sourced commands every resource update went to the secret and none to the
role, the secret's `lastChanged` tracked each rotation, and authenticating as the
role with the secret's current value failed with `28P01` while `pg_roles` showed
the role present with `rolcanlogin = true`. The secret had moved thirteen times and
the engine had not moved once.

Destinations are found by their binding to the generator. A consumer holds a
reference to the destination rather than to the generator, one hop further out,
which is why the destination query structurally cannot see it. Rotation now walks
outward from its destinations to their consumers, transitively, reusing the same
batched dependent lookup the delete cascade already walks, and co-plans them
alongside the destinations.

The walk is bounded by the reference graph rather than by the stack: a resource
referencing nothing the rotation moves is not planned, so a credential on a short
cadence does not re-plan unrelated infrastructure every cycle. Unmanaged rows are
skipped and not walked through, as the delete cascade treats them, since they carry
no declarations to re-resolve. Results are sorted so a rotation plans the same nodes
in the same order every time.

## Verification

Three unit tests: the consumer is planned, an unrelated resource on the same stack
is not, and the existing no-destination case still holds. The first fails without
the change.

End to end against the same cluster, after: the rotation command drives
`rds: updating database role`, the role's resource update reaches `Success`, and
authenticating with the secret's current value now returns
`current_user = rotation_e2e_role`.

## One behavioural consequence

The drift refusal now sees the consumers as well as the destinations, so a rotation
refuses when a consumer has drifted rather than writing into it. That is the
intended direction, but it widens what can stop a rotation.

Separately, `StackHasActiveCommands` is still checked only for the generator's own
stack. That guard was already incomplete for destinations, which may themselves span
stacks; this change makes a cross-stack participant more likely without addressing
it. Left as is: it is pre-existing, unexercised by the single-stack shape production
uses, and bounded by the drift refusal and the rotation's retry.