### PR TITLE
fix(schema): declare the metadata hash, not the zip hash, for dependents

### DIFF
--- a/scripts/fixup-schema-dependents.py
+++ b/scripts/fixup-schema-dependents.py
@@ -17,10 +17,11 @@ the same publish.
 Usage: fixup-schema-dependents.py <schema-version>
 
 Expects the freshly packaged metadata at .out/formae@<version>/formae@<version>
-(the new checksum is read from it, exactly as pkl computed it) and AWS
-credentials able to read and write the hub bucket.
+(the declared checksum is the hash of that file) and AWS credentials able to
+read and write the hub bucket.
 """
 
+import hashlib
 import json
 import os
 import re
@@ -47,9 +48,13 @@ def main() -> None:
     version = sys.argv[1]
     coordinate = f"package://{BUCKET}/plugins/pkl/schema/pkl/formae/formae@{version}"
 
-    with open(f".out/formae@{version}/formae@{version}") as f:
-        sha256 = json.load(f)["packageZipChecksums"]["sha256"]
-    print(f"formae@{version} zip sha256: {sha256}")
+    # A pkl dependency checksum covers the dependency's metadata document,
+    # not its zip: the metadata carries the zip's checksum inside it
+    # (packageZipChecksums), forming a hash chain. So the value dependents
+    # must declare is the hash of the metadata file itself.
+    with open(f".out/formae@{version}/formae@{version}", "rb") as f:
+        sha256 = hashlib.sha256(f.read()).hexdigest()
+    print(f"formae@{version} metadata sha256: {sha256}")
 
     listing = aws(
         "s3api", "list-objects-v2",


### PR DESCRIPTION
Follow-up to #739/#741, and the last piece: the previous remediation run refreshed 7 dependents but wrote the **zip's** sha256 as their declared formae checksum. pkl's dependency checksums cover the dependency's **metadata document** (`getDependencyMetadataAndComputeChecksum`; the metadata carries `packageZipChecksums` inside it, forming a hash chain), so resolves then failed with the inverted mismatch — declared = zip hash, computed = metadata hash. It also means one dependent (`aws@0.1.17`) that was already correct got made stale.

The script now hashes the freshly packaged metadata file itself. Verified in the dry-run harness: the fixture metadata hashes to exactly the value pkl computes against the live hub today (`f586744a…`), the stale fixture is rewritten to it, and a fixture already declaring it is left untouched.

After merge, dispatch `schema-prerelease` (version 0.89.0, source_branch main) once more: the republished metadata is byte-identical, so the run only rewrites the 7 mis-refreshed dependents (and anything genuinely stale) to the correct value.