### PR TITLE
feat(schema): fail verification when a @FieldHint sits on a class that is not a Resource or SubResource

### DIFF
--- a/pkg/plugin/testutil/pkl/Verify.pkl
+++ b/pkg/plugin/testutil/pkl/Verify.pkl
@@ -9,6 +9,8 @@
 /// Checks:
 /// 1. No duplicate filenames across the schema
 /// 2. No duplicate resource types (via @ResourceHint annotation)
+/// 3. No @FieldHint on a class that does not extend formae.Resource or
+///    formae.SubResource (directly or transitively)
 ///
 /// Output: JSON with verification results
 module formae.testutil.Verify
@@ -49,9 +51,68 @@ function getAllResourceTypes(): Listing<ResourceType> = new Listing {
     }
 }
 
+/// A class that carries a @FieldHint on one of its own properties but does not
+/// extend formae.Resource or formae.SubResource.
+class OrphanFieldHintClass {
+    moduleName: String
+    className: String
+    fields: Listing<String>
+}
+
 /// Extract filename from module path
 function extractFileName(modulePath: String): String =
     modulePath.split("/").last
+
+/// True if `annotation` is a plugin's own re-export of formae.FieldHint. Every
+/// plugin defines one, either as `class FieldHint extends formae.FieldHint` or as
+/// a transparent `typealias FieldHint = formae.FieldHint`, so a class-name match
+/// identifies it without this module importing the formae SDK's own types -
+/// mirroring how getAllResourceTypes() above identifies `@ResourceHint`.
+function isFieldHintAnnotation(annotation: Annotation): Boolean =
+    annotation.getClass().simpleName == "FieldHint"
+
+/// True if `cls`'s superclass chain reaches a class literally named "Resource"
+/// or "SubResource". A schema class fails this by having no `extends` clause at
+/// all, or by extending some other plain class whose own chain never reaches
+/// either root.
+///
+/// Extraction (formae.pkl's `hints()`, gated by `isSubResourceClass`) only walks
+/// nested classes that satisfy this same test, so a `@FieldHint` on a class that
+/// does not is invisible to `Schema.Hints`: the annotation has no effect, and if
+/// the class is reached as a nested property of a resource, it also misses the
+/// `SubResource` render path (`subresourceProps`), including the
+/// absent/explicit-null/explicit-empty handling for nullable collections.
+function reachesResourceOrSubResource(cls: reflect.Class?): Boolean =
+    if (cls == null || cls.superclass == null)
+        false
+    else if (cls.superclass.name == "Resource" || cls.superclass.name == "SubResource")
+        true
+    else
+        reachesResourceOrSubResource(cls.superclass)
+
+/// The class's own properties that carry a @FieldHint.
+function hintedFieldsOf(cls: reflect.Class): List<String> =
+    cls.properties.toMap()
+        .filter((_, p) -> p.annotations.toList().any((a) -> isFieldHintAnnotation(a)))
+        .keys.toList()
+
+/// Find every class in the schema that carries a @FieldHint on a property but
+/// does not reach Resource or SubResource.
+function getOrphanFieldHintClasses(): Listing<OrphanFieldHintClass> = new Listing {
+    for (name, moduleValue in schemaModules.toMap()) {
+        when (reflect.Module(moduleValue).classes.length > 0) {
+            for (clsName, cls in reflect.Module(moduleValue).classes) {
+                when (!hintedFieldsOf(cls).isEmpty && !reachesResourceOrSubResource(cls)) {
+                    new OrphanFieldHintClass {
+                        moduleName = name
+                        className = clsName
+                        fields = hintedFieldsOf(cls).toListing()
+                    }
+                }
+            }
+        }
+    }
+}
 
 /// Check for duplicate filenames
 function verifyNoDuplicateFiles(): Listing<DuplicateFileError> =
@@ -98,7 +159,8 @@ function verifyUniqueResourceTypes(): Listing<String> =
 function runVerification(): Map<String, Any> =
     let (duplicateFiles = verifyNoDuplicateFiles())
     let (duplicateTypes = verifyUniqueResourceTypes())
-    let (hasErrors = !duplicateFiles.isEmpty || !duplicateTypes.isEmpty)
+    let (orphanFieldHints = getOrphanFieldHintClasses())
+    let (hasErrors = !duplicateFiles.isEmpty || !duplicateTypes.isEmpty || !orphanFieldHints.isEmpty)
     new Mapping {
         ["hasErrors"] = hasErrors
         ["duplicateFileCount"] = duplicateFiles.length
@@ -108,6 +170,12 @@ function runVerification(): Map<String, Any> =
             ["modules"] = e.modules
         }.toMap()).toListing()
         ["duplicateTypes"] = duplicateTypes
+        ["orphanFieldHintCount"] = orphanFieldHints.length
+        ["orphanFieldHints"] = orphanFieldHints.toList().map((e) -> new Mapping {
+            ["moduleName"] = e.moduleName
+            ["className"] = e.className
+            ["fields"] = e.fields
+        }.toMap()).toListing()
         ["totalModules"] = schemaModules.length
         ["totalResourceTypes"] = getAllResourceTypes().length
         ["status"] = if (hasErrors) "FAILED" else "PASSED"

--- a/pkg/plugin/testutil/verify.go
+++ b/pkg/plugin/testutil/verify.go
@@ -24,20 +24,31 @@ var pklFiles embed.FS
 
 // VerifyResult contains the results of schema verification.
 type VerifyResult struct {
-	Status             string               `json:"status"`
-	HasErrors          bool                 `json:"hasErrors"`
-	TotalModules       int                  `json:"totalModules"`
-	TotalResourceTypes int                  `json:"totalResourceTypes"`
-	DuplicateFileCount int                  `json:"duplicateFileCount"`
-	DuplicateTypeCount int                  `json:"duplicateTypeCount"`
-	DuplicateFiles     []DuplicateFileError `json:"duplicateFiles"`
-	DuplicateTypes     []string             `json:"duplicateTypes"`
+	Status               string               `json:"status"`
+	HasErrors            bool                 `json:"hasErrors"`
+	TotalModules         int                  `json:"totalModules"`
+	TotalResourceTypes   int                  `json:"totalResourceTypes"`
+	DuplicateFileCount   int                  `json:"duplicateFileCount"`
+	DuplicateTypeCount   int                  `json:"duplicateTypeCount"`
+	DuplicateFiles       []DuplicateFileError `json:"duplicateFiles"`
+	DuplicateTypes       []string             `json:"duplicateTypes"`
+	OrphanFieldHintCount int                  `json:"orphanFieldHintCount"`
+	OrphanFieldHints     []OrphanFieldHint    `json:"orphanFieldHints"`
 }
 
 // DuplicateFileError represents a file that appears multiple times in the schema.
 type DuplicateFileError struct {
 	FileName string   `json:"fileName"`
 	Modules  []string `json:"modules"`
+}
+
+// OrphanFieldHint represents a class that carries a @FieldHint on one of its
+// properties but does not extend formae.Resource or formae.SubResource, so the
+// hint never reaches Schema.Hints.
+type OrphanFieldHint struct {
+	ModuleName string   `json:"moduleName"`
+	ClassName  string   `json:"className"`
+	Fields     []string `json:"fields"`
 }
 
 // VerifySchema runs PKL schema verification for a plugin.
@@ -258,7 +269,8 @@ func (r *VerifyResult) FormatReport(namespace string) string {
 	fmt.Fprintf(&sb, "- Total modules: %d\n", r.TotalModules)
 	fmt.Fprintf(&sb, "- Total resource types: %d\n", r.TotalResourceTypes)
 	fmt.Fprintf(&sb, "- Duplicate files found: %d\n", r.DuplicateFileCount)
-	fmt.Fprintf(&sb, "- Duplicate types found: %d\n\n", r.DuplicateTypeCount)
+	fmt.Fprintf(&sb, "- Duplicate types found: %d\n", r.DuplicateTypeCount)
+	fmt.Fprintf(&sb, "- Orphan @FieldHint classes found: %d\n\n", r.OrphanFieldHintCount)
 
 	if len(r.DuplicateFiles) > 0 {
 		sb.WriteString("DUPLICATE FILES DETECTED:\n")
@@ -283,12 +295,25 @@ func (r *VerifyResult) FormatReport(namespace string) string {
 		sb.WriteString("No duplicate resource types found\n\n")
 	}
 
+	if len(r.OrphanFieldHints) > 0 {
+		sb.WriteString("ORPHAN @FieldHint CLASSES DETECTED:\n")
+		sb.WriteString("  A @FieldHint on a class that does not extend formae.Resource or\n")
+		sb.WriteString("  formae.SubResource (directly or transitively) never reaches Schema.Hints,\n")
+		sb.WriteString("  and the class also misses the SubResource render path. Add\n")
+		sb.WriteString("  \"extends formae.SubResource\" to the class.\n")
+		for _, o := range r.OrphanFieldHints {
+			fmt.Fprintf(&sb, "  %s#%s: %s\n", o.ModuleName, o.ClassName, strings.Join(o.Fields, ", "))
+		}
+		sb.WriteString("\n")
+	} else {
+		sb.WriteString("No orphan @FieldHint classes found\n\n")
+	}
+
 	if r.HasErrors {
-		sb.WriteString("VERIFICATION FAILED - Please resolve duplicate files/types before proceeding\n")
+		sb.WriteString("VERIFICATION FAILED - Please resolve the issues listed above before proceeding\n")
 	} else {
 		sb.WriteString("VERIFICATION PASSED - Schema is valid\n")
 	}
 
 	return sb.String()
 }
-

--- a/pkg/plugin/testutil/verify_test.go
+++ b/pkg/plugin/testutil/verify_test.go
@@ -173,6 +173,119 @@ func TestVerifySchemaWithNamespace_FakeAWS(t *testing.T) {
 	t.Logf("Verified %d modules, %d resource types", result.TotalModules, result.TotalResourceTypes)
 }
 
+// TestVerifySchemaWithNamespace_OrphanFieldHint confirms that VerifySchemaWithNamespace
+// flags a @FieldHint sitting on a class that does not extend formae.Resource or
+// formae.SubResource, and that it does not flag a class that reaches either root -
+// directly, or transitively through an intermediate class that itself carries no
+// hint of its own.
+func TestVerifySchemaWithNamespace_OrphanFieldHint(t *testing.T) {
+	schemaDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(schemaDir, "PklProject"), []byte(`amends "pkl:Project"
+
+dependencies {
+  ["formae"] {
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.89.0"
+  }
+}
+
+package {
+  name = "orphantest"
+  baseUri = "package://test.local/orphantest"
+  version = "0.0.1"
+  packageZipUrl = "https://test.local/orphantest@0.0.1.zip"
+}
+`), 0644); err != nil {
+		t.Fatalf("failed to write schema PklProject: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(schemaDir, "resource.pkl"), []byte(`module orphantest.resource
+
+import "@formae/formae.pkl"
+
+class FieldHint extends formae.FieldHint {}
+
+/// Orphan: no extends clause at all, but carries a @FieldHint on its own property.
+class PlainNested {
+    @FieldHint
+    value: String?
+}
+
+/// Orphan: extends a plain class (ChainRoot) whose own chain never reaches
+/// Resource or SubResource. ChainMiddle carries no hint of its own, so only
+/// ChainRoot - the class that actually carries the hint - should be reported.
+open class ChainRoot {
+    @FieldHint
+    x: String?
+}
+
+open class ChainMiddle extends ChainRoot {}
+
+/// Not an orphan: extends formae.SubResource directly.
+open class GoodNested extends formae.SubResource {
+    @FieldHint
+    value: String?
+}
+
+/// Not an orphan: reaches formae.SubResource transitively, through GoodNested.
+open class ReachesViaChain extends GoodNested {
+    @FieldHint
+    extra: String?
+}
+
+open class Widget extends formae.Resource {
+    @FieldHint
+    plain: PlainNested?
+
+    @FieldHint
+    chained: ChainMiddle?
+
+    @FieldHint
+    good: GoodNested?
+
+    @FieldHint
+    viaChain: ReachesViaChain?
+}
+`), 0644); err != nil {
+		t.Fatalf("failed to write resource.pkl: %v", err)
+	}
+
+	result, err := VerifySchemaWithNamespace(schemaDir, "orphantest")
+	if err != nil {
+		t.Fatalf("VerifySchemaWithNamespace failed: %v", err)
+	}
+
+	if !result.HasErrors {
+		t.Fatal("expected HasErrors to be true when an orphan @FieldHint class is present")
+	}
+
+	if result.OrphanFieldHintCount != 2 {
+		t.Errorf("expected 2 orphan classes (PlainNested, ChainRoot), got %d: %+v",
+			result.OrphanFieldHintCount, result.OrphanFieldHints)
+	}
+
+	gotClasses := make(map[string][]string, len(result.OrphanFieldHints))
+	for _, o := range result.OrphanFieldHints {
+		gotClasses[o.ClassName] = o.Fields
+	}
+
+	if fields, ok := gotClasses["PlainNested"]; !ok || len(fields) != 1 || fields[0] != "value" {
+		t.Errorf("expected PlainNested reported with field [value], got %v (present=%v)", fields, ok)
+	}
+	if fields, ok := gotClasses["ChainRoot"]; !ok || len(fields) != 1 || fields[0] != "x" {
+		t.Errorf("expected ChainRoot reported with field [x], got %v (present=%v)", fields, ok)
+	}
+	if _, ok := gotClasses["ChainMiddle"]; ok {
+		t.Error("ChainMiddle carries no hint of its own and should not be reported")
+	}
+	if _, ok := gotClasses["GoodNested"]; ok {
+		t.Error("GoodNested extends formae.SubResource directly and should not be reported")
+	}
+	if _, ok := gotClasses["ReachesViaChain"]; ok {
+		t.Error("ReachesViaChain reaches formae.SubResource transitively and should not be reported")
+	}
+}
+
 // TestGenerateImports_TopLevelFileIsIncluded verifies that ImportsGenerator.pkl matches
 // PKL files placed directly under the namespace root (e.g., @ns/resource.pkl), not
 // only files in subdirectories (e.g., @ns/subdir/resource.pkl).


### PR DESCRIPTION
## Why

Schema extraction (`formae.pkl`'s `hints()`, gated by `isSubResourceClass`,
`internal/schema/pkl/schema/formae.pkl:882-965`) only walks nested classes
that extend `formae.SubResource`. A `@FieldHint` on any other class - no
`extends` clause, or one that never reaches `Resource` or `SubResource` -
is silently dropped: it never reaches `Schema.Hints`, and if the class is
nested inside a resource it also misses the `SubResource` render path
(`subresourceProps`, `formae.pkl:1126`), including the absent/explicit-null/
explicit-empty handling for nullable collections. Nothing warns about this
at build or eval time - a plugin author can annotate a field and have it
silently do nothing, discoverable only as unexplained drift in a
conformance run months later.

A repo-wide sweep across the azure and gcp plugins found 86 and 6 such
classes respectively, all correctly migrated (`extends formae.SubResource`
added) in the two PRs below. This PR is the backstop: once a class carries
`@FieldHint`, it must reach `Resource` or `SubResource`, checked at
schema-verification time so this cannot recur silently.

## What

`pkg/plugin/testutil/pkl/Verify.pkl` gains a third check alongside the
existing duplicate-file and duplicate-resource-type checks. It walks every
class across the schema (via `pkl:reflect`, the same mechanism the existing
`@ResourceHint` duplicate check uses) and reports any class that:

1. Carries a `@FieldHint` on one of its own properties, identified by class
   name (`getClass().simpleName == "FieldHint"`) rather than by importing
   the formae SDK's own `FieldHint` type - every plugin defines a local
   `FieldHint` (a subclass or a transparent `typealias`), mirroring how
   `getAllResourceTypes()` already identifies `@ResourceHint`.
2. Does **not** reach a class literally named `Resource` or `SubResource`
   by walking its superclass chain (`cls.superclass`, recursively) - this
   is the same identity test `formae.pkl`'s `isSubResourceClass` uses
   (matched by name, not by cross-package identity, since this module only
   reflects over the plugin's own schema, not the formae SDK's types).

`pkg/plugin/testutil/verify.go` plumbs the result through:
`OrphanFieldHintCount` / `OrphanFieldHints` on `VerifyResult`, a new report
section in `FormatReport`, and folds into `HasErrors` (so `verify-schema`
exits 1) alongside the existing checks.

## Testing

- `pkg/plugin/testutil/verify_test.go`:
  `TestVerifySchemaWithNamespace_OrphanFieldHint` builds a small synthetic
  schema covering four shapes and asserts on all of them: a class with no
  `extends` at all (orphan), a class extending a plain intermediate class
  whose own chain never reaches `Resource`/`SubResource` (orphan - and the
  intermediate class itself, carrying no hint of its own, correctly is
  *not* reported), a class extending `formae.SubResource` directly (clean),
  and a class reaching `SubResource` transitively through another
  `SubResource`-extending class (clean, proves the walk isn't just one
  hop).
- Ran the new check against the real, already-migrated azure and gcp
  schemas from the two plugin PRs below: both PASS with
  `Orphan @FieldHint classes found: 0`.
- Ran it against azure's schema at the commit *before* migration: FAILS
  with exactly the 86 classes the migration PR fixes, confirming the check
  independently reproduces the sweep that produced that PR (via real Pkl
  reflection, not the same regex tooling used to do the sweep).
- Ran it against the aws and kubernetes plugin schemas (out of scope for
  migration - the issue's sweep found them clean): both PASS with 0
  orphans, including kubernetes' large, multi-version schema and its
  `typealias FieldHint = formae.FieldHint` re-export style (as opposed to
  azure/gcp/aws's `class FieldHint extends formae.FieldHint {}`), so the
  name-based detection generalizes across both conventions.
- `go build ./...`, `go vet ./...`, `gofmt -l` (clean on touched files;
  one pre-existing misalignment in `testutil/docs.go`, untouched by this
  PR), `go test ./...` at repo root and inside the `pkg/plugin` submodule -
  all pass. `make version-semver && make build` in a fresh worktree per
  this repo's convention.

## Sequencing - do not merge before both plugin PRs are released

- azure: https://github.com/platform-engineering-labs/formae-plugin-azure/pull/144
- gcp: https://github.com/platform-engineering-labs/formae-plugin-gcp/pull/188

This check does **not** take effect automatically for any plugin: azure and
gcp each pin `pkg/plugin` to a specific commit in their `go.mod` (not a
`replace` against `main`), so this only starts enforcing once a plugin
deliberately bumps that dependency. But whoever does that bump for azure or
gcp must do it only after the corresponding PR above has released, because
today - before those PRs - both plugins fail this exact check (86 and 6
classes respectively). Merging this core change is safe at any time; it is
the *next* `pkg/plugin` bump in azure or gcp that needs the ordering, and
this description is that record.