### PR TITLE
fix(agent): exit when the orchestrator application stops

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -183,6 +183,15 @@ func (a *Agent) Start() error {
 			ms.AuthPluginHandle = authHandle
 		}
 
+		// An abnormal stop of the orchestrator application means every actor
+		// is gone while this process and its HTTP surface keep running and
+		// look healthy. Exit instead: the process supervisor (ECS, systemd)
+		// restarts the agent, and startup re-runs incomplete commands.
+		ms.OnApplicationStopped = func(reason error) {
+			slog.Error("Metastructure stopped; shutting down so the process supervisor restarts the agent", "reason", reason)
+			a.cancel()
+		}
+
 		imwg.Add(ms)
 
 		if err := ms.Start(); err != nil {

--- a/internal/metastructure/application.go
+++ b/internal/metastructure/application.go
@@ -5,16 +5,24 @@
 package metastructure
 
 import (
+	"errors"
+
 	"ergo.services/ergo/gen"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/changeset"
 )
 
-func CreateApplication() gen.ApplicationBehavior {
-	return &Application{}
+func CreateApplication(onAbnormalStop func(reason error)) gen.ApplicationBehavior {
+	return &Application{onAbnormalStop: onAbnormalStop}
 }
 
-type Application struct{}
+type Application struct {
+	// onAbnormalStop is invoked from Terminate when the application stops for
+	// any reason other than a deliberate shutdown. The application is
+	// permanent: when it stops, every actor under it is gone, and only the
+	// process owner can turn that into an exit.
+	onAbnormalStop func(reason error)
+}
 
 // Load invoked on loading application using method ApplicationLoad of gen.Node interface.
 func (app *Application) Load(node gen.Node, args ...any) (gen.ApplicationSpec, error) {
@@ -39,4 +47,12 @@ func (app *Application) Load(node gen.Node, args ...any) (gen.ApplicationSpec, e
 func (app *Application) Start(mode gen.ApplicationMode) {}
 
 // Terminate invoked once the application stopped
-func (app *Application) Terminate(reason error) {}
+func (app *Application) Terminate(reason error) {
+	if app.onAbnormalStop == nil {
+		return
+	}
+	if errors.Is(reason, gen.TerminateReasonNormal) || errors.Is(reason, gen.TerminateReasonShutdown) {
+		return
+	}
+	app.onAbnormalStop(reason)
+}

--- a/internal/metastructure/application_stop_test.go
+++ b/internal/metastructure/application_stop_test.go
@@ -1,0 +1,107 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package metastructure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// freePort reserves an ephemeral TCP port and returns it for the node to bind.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+// startedMetastructure builds and starts a metastructure on an in-memory
+// datastore with its own ergo ports, so tests neither collide with each other
+// nor with an agent running on the machine.
+func startedMetastructure(t *testing.T) *Metastructure {
+	t.Helper()
+	cfg := &pkgmodel.Config{
+		Agent: pkgmodel.AgentConfig{
+			Server: pkgmodel.ServerConfig{
+				Nodename:      fmt.Sprintf("app-stop-test-%d", time.Now().UnixNano()),
+				Hostname:      "localhost",
+				Secret:        "test-secret",
+				ErgoPort:      freePort(t),
+				RegistrarPort: freePort(t),
+			},
+			Datastore: pkgmodel.DatastoreConfig{
+				DatastoreType: pkgmodel.SqliteDatastore,
+				Sqlite:        pkgmodel.SqliteConfig{FilePath: ":memory:"},
+			},
+		},
+	}
+	m, err := NewMetastructure(context.Background(), cfg, nil, nil, "test")
+	require.NoError(t, err)
+	return m
+}
+
+// A collapsed supervision tree must be reported: once the orchestrator
+// application stops, the actors that execute commands, persist state, and run
+// rotations are gone, while the process's HTTP surface keeps serving. The
+// process has to learn about the stop so it can exit and be restarted by its
+// supervisor, which is the path that re-runs incomplete commands.
+func TestMetastructure_ReportsAbnormalApplicationStop(t *testing.T) {
+	m := startedMetastructure(t)
+	stopped := make(chan error, 1)
+	m.OnApplicationStopped = func(reason error) { stopped <- reason }
+
+	require.NoError(t, m.Start())
+	t.Cleanup(func() { m.Stop(false) })
+
+	// Repeated abnormal exits of one supervised child inside the supervisor's
+	// restart period exhaust its restart intensity and collapse the tree.
+	deadline := time.After(15 * time.Second)
+	for {
+		select {
+		case reason := <-stopped:
+			require.Error(t, reason, "the callback must carry the stop reason")
+			require.NotErrorIs(t, reason, gen.TerminateReasonNormal)
+			require.NotErrorIs(t, reason, gen.TerminateReasonShutdown)
+			return
+		case <-deadline:
+			t.Fatal("the application stopping abnormally was never reported")
+		default:
+		}
+		if pid, err := m.Node.ProcessPID(gen.Atom("FormaCommandPersister")); err == nil {
+			_ = m.Node.SendExit(pid, errors.New("injected failure"))
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// The same callback must stay silent on a deliberate shutdown: a process that
+// treats its own graceful stop as a failure turns every deploy into an error.
+func TestMetastructure_GracefulStopIsNotReported(t *testing.T) {
+	m := startedMetastructure(t)
+	stopped := make(chan error, 1)
+	m.OnApplicationStopped = func(reason error) { stopped <- reason }
+
+	require.NoError(t, m.Start())
+	m.Stop(false)
+
+	select {
+	case reason := <-stopped:
+		t.Fatalf("a graceful stop must not be reported, got: %v", reason)
+	case <-time.After(2 * time.Second):
+	}
+}

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -95,6 +95,13 @@ type Metastructure struct {
 	// the process) and the API server (which uses it for request validation).
 	AuthPluginHandle *auth.AuthPluginHandle
 
+	// OnApplicationStopped is invoked when the orchestrator application stops
+	// for any reason other than a deliberate shutdown. At that point every
+	// actor is gone while the process and its HTTP surface keep running, so
+	// the owner must treat the process as failed and exit; the restart is what
+	// re-runs incomplete commands. Set by the agent before Start().
+	OnApplicationStopped func(reason error)
+
 	// commandMu serializes Apply/Destroy/ForceAutoReconcile to prevent TOCTOU
 	// races between the conflict check and command storage. This will be
 	// removed once the Metastructure itself becomes an actor.
@@ -130,7 +137,7 @@ func NewMetastructureWithDataStoreAndContext(ctx context.Context, cfg *pkgmodel.
 
 	metastructure.nodeName = fmt.Sprintf("%s@%s", cfg.Agent.Server.Nodename, cfg.Agent.Server.Hostname)
 	apps := []gen.ApplicationBehavior{
-		CreateApplication(),
+		CreateApplication(metastructure.applicationStopped),
 	}
 
 	if cfg.Agent.Server.ObserverPort != 0 {
@@ -207,6 +214,15 @@ func NewMetastructureWithDataStoreAndContext(ctx context.Context, cfg *pkgmodel.
 	metastructure.options.Log.Loggers = append(metastructure.options.Log.Loggers, gen.Logger{Name: "ergo", Logger: logger})
 
 	return metastructure, nil
+}
+
+// applicationStopped relays an abnormal orchestrator-application stop to the
+// owner. It reads OnApplicationStopped at stop time, so the owner may set the
+// field any time between construction and Start().
+func (m *Metastructure) applicationStopped(reason error) {
+	if m.OnApplicationStopped != nil {
+		m.OnApplicationStopped(reason)
+	}
 }
 
 func (m *Metastructure) Start() error {


### PR DESCRIPTION
## Summary

When the metastructure's supervision tree collapses (a burst of datastore persist failures exceeding the supervisor's restart intensity, e.g. during a brief Postgres unavailability), the ergo application stops but the process and its HTTP surface keep running. The agent then looks healthy while no actor exists behind it: in-flight commands wedge with cloud/datastore divergence, rotation and sync stop, and nothing recovers, because incomplete commands are only re-run at startup.

This gives the orchestrator application an abnormal-stop callback (`gen.ApplicationBehavior.Terminate` already receives the stop reason; our implementation was an empty body) and has the agent exit through its ordinary shutdown path when it fires. The process supervisor (ECS, systemd) restarts the agent, and startup re-runs the interrupted commands, which is the recovery path that already converges. A deliberate shutdown stops the application with a normal reason and the callback stays silent, so a clean stop is unchanged.

## Verification

Two unit tests: an abnormal collapse (a supervised child killed repeatedly inside the restart period) invokes the callback with the collapse reason, and a graceful `Stop` does not. The first was written and observed failing before the change.

Also validated against a live agent on a Postgres datastore whose password rotates out from under it mid-apply (the credential provider serves the stale cached password for its TTL, so every new connection fails 28P01): before the change the supervision tree collapsed and the process kept serving with the command wedged at 2/6 while the cloud held 4/4; with the change the agent logs the stop reason and exits within seconds, and the restarted process re-runs the interrupted command to completion with the inventory converged to the cloud, no duplicates.