### PR TITLE
fix(schema): raise the rotation cadence floor to fifteen minutes

### DIFF
--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -176,18 +176,21 @@ open class AutoReconcilePolicy extends Policy {
 /// inherit and none to guess at: a rotation spec that names no interval is an
 /// eval-time error, not a generator that rotates on some house default.
 open class RotationSpec {
-    /// One minute is the floor because it is what the scheduler can honour,
-    /// not because a faster cadence would be unwise. The rotator wakes on a
-    /// fixed sweep and rotates whatever is due, so an interval shorter than
-    /// that sweep cannot be met whatever it says. Sub-second intervals are
-    /// worse than merely unmet: the cadence is rendered in whole seconds, so
-    /// they truncate to zero, and a zero interval reads downstream as no
-    /// cadence declared at all, which is to say the credential is never
-    /// rotated by the very spec asking for it. A credential that has to turn
-    /// over faster than a minute wants short-lived credentials issued per
-    /// use, not a scheduler revisiting a long-lived one.
-    every: Duration(this >= 1.min
-        || throw("RotationSpec.every: \(this) is shorter than the one minute minimum rotation interval"))
+    /// Fifteen minutes is the floor because it is the fastest sustained
+    /// cadence the common secret store survives, with the scheduler's own
+    /// limits well inside it. AWS Secrets Manager retains every version from
+    /// the last 24 hours against a fixed quota of 100 versions per secret
+    /// and advises against sustained writes more often than once every 10
+    /// minutes, so a one-minute cadence exhausts the quota in under two
+    /// hours and every rotation after that fails. Separately, the rotator
+    /// wakes on a fixed sweep, so an interval shorter than that sweep could
+    /// not be met whatever it said, and sub-second intervals would truncate
+    /// to zero in the rendered whole-second cadence, reading downstream as
+    /// no cadence at all. A credential that has to turn over faster than
+    /// this wants short-lived credentials issued per use, not a scheduler
+    /// revisiting a long-lived one.
+    every: Duration(this >= 15.min
+        || throw("RotationSpec.every: \(this) is shorter than the fifteen minute minimum rotation interval"))
 
     local self = this
     // Output

--- a/internal/schema/pkl/schema/tests/formae.pkl
+++ b/internal/schema/pkl/schema/tests/formae.pkl
@@ -504,7 +504,7 @@ local minimumRotation = new formae.PasswordGenerator {
     label = "minimum-password"
     stack = stackResolvable
     rotation = new formae.RotationSpec {
-        every = 1.min
+        every = 15.min
     }
 }
 
@@ -831,7 +831,7 @@ facts {
     }
 
     ["The floor itself is a cadence"] {
-        minimumRotation.render().Rotation.EverySeconds == 60
+        minimumRotation.render().Rotation.EverySeconds == 900
     }
 
     ["Relative TTL policy renders TTLSeconds and no ExpiresAt"] {

--- a/internal/schema/pkl/testdata/forma/generator_rotation_test.pkl
+++ b/internal/schema/pkl/testdata/forma/generator_rotation_test.pkl
@@ -37,7 +37,7 @@ forma {
     stack = appStack.res
     length = 24
     rotation = new formae.RotationSpec {
-      every = 1.min
+      every = 15.min
     }
   }
   pw

--- a/internal/workflow_tests/local/apply_forma/generator_rotation_pkl_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_rotation_pkl_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 // authoredRotatingGeneratorForma is the forma this test applies: a
-// PasswordGenerator declaring `rotation { every = 1.min }` and a plugin
+// PasswordGenerator declaring `rotation { every = 15.min }` and a plugin
 // resource whose secret-bearing property is bound to that generator's `value`
 // output.
 const authoredRotatingGeneratorForma = "internal/schema/pkl/testdata/forma/generator_rotation_test.pkl"
@@ -33,7 +33,7 @@ const (
 	rotatingFormaGenerator   = "db-password"
 	rotatingFormaDestination = "db"
 	rotatingFormaLength      = 24
-	rotatingFormaEverySecs   = 60
+	rotatingFormaEverySecs   = 900
 )
 
 // A cadence authored in PKL rotates the credential it governs. The forma is


### PR DESCRIPTION
## Summary

The one-minute floor on `RotationSpec.every` was set by what the scheduler can honour, not by what the secret store survives. AWS Secrets Manager retains every secret version from the last 24 hours against a non-adjustable quota of 100 versions per secret, and its documentation advises against calling `PutSecretValue` at a sustained rate of more than once every 10 minutes. A one-minute cadence therefore exhausts the quota after ~100 rotations (under two hours) and every rotation after that fails with `LimitExceededException`. The sustainable steady-state ceiling is one write per 14.4 minutes; fifteen minutes clears both the guidance and the quota arithmetic.

The constraint keeps its explicit throw so a programmatic catch sees the field and the limit, and the doc comment now carries both reasons (store sustainability and the scheduler sweep). Schema facts and the rotation fixture updated to the new floor; the workflow tests pass against it.

Rotation shipped in the still-unreleased 0.89.0 line, so no released user has a declared cadence this invalidates.