### PR TITLE
feat(metastructure): generators draw named outputs, and a keypair arm

### DIFF
--- a/internal/metastructure/changeset/changeset.go
+++ b/internal/metastructure/changeset/changeset.go
@@ -913,20 +913,37 @@ func (p *ExecutionDAG) propagateResolvedTargetConfig(targetLabel string, pluginC
 // An error means some destination did not receive its value. The caller must
 // fail the draw closed rather than let a destination dispatch its undrawn
 // envelope.
-func (p *ExecutionDAG) propagateDrawnGeneratorValue(generatorKsuid string, value string, generationID string, mode pkgmodel.FormaApplyMode) error {
+func (p *ExecutionDAG) propagateDrawnGeneratorValue(generatorKsuid string, values map[string]string, generationID string, mode pkgmodel.FormaApplyMode) error {
 	if generatorKsuid == "" {
 		return fmt.Errorf("cannot deliver a drawn value: the draw names no generator")
 	}
-	if value == "" {
-		// A success carrying no value cannot be delivered: writing an empty
-		// string into a destination would hand a provider a blank credential
-		// that nothing downstream would flag.
+	if len(values) == 0 {
+		// A success carrying no values cannot be delivered.
 		return fmt.Errorf("generator %s reported a successful draw with no value", generatorKsuid)
+	}
+	for output, value := range values {
+		if value == "" {
+			// An empty output would write a blank credential into its
+			// destination and nothing downstream would flag it.
+			return fmt.Errorf("generator %s reported a successful draw with an empty %q output", generatorKsuid, output)
+		}
 	}
 	if generationID == "" {
 		return fmt.Errorf("generator %s reported a successful draw naming no generation", generatorKsuid)
 	}
 
+	// Two phases: validate and compute every destination's rewritten update,
+	// then commit only once all of them prepared. A refusal at the Nth
+	// destination must not leave the first N-1 rewritten in memory: DAG
+	// ordering happens to keep such nodes undispatchable, but credential
+	// delivery does not lean on that. Patch re-derivation during commit can
+	// still fail; the caller then fails the draw and every destination is
+	// cascade-failed, so a partially committed node is never dispatched.
+	type pendingDelivery struct {
+		ru       *resource_update.ResourceUpdate
+		prepared *resource_update.PreparedGenDelivery
+	}
+	var deliveries []pendingDelivery
 	for _, node := range p.Nodes {
 		ru, ok := node.Update.(*resource_update.ResourceUpdate)
 		if !ok {
@@ -935,10 +952,22 @@ func (p *ExecutionDAG) propagateDrawnGeneratorValue(generatorKsuid string, value
 		if ru.Operation == resource_update.OperationDelete || ru.Operation == resource_update.OperationReaped {
 			continue
 		}
-		if err := ru.ResolveGeneratorValue(generatorKsuid, value, generationID, mode); err != nil {
-			// The error names paths and identities only, never the value.
+		prepared, err := ru.PrepareGeneratorValues(generatorKsuid, values)
+		if err != nil {
+			// The error names paths and identities only, never a value.
 			return fmt.Errorf("failed to deliver the value drawn for generator %s to %s: %w",
 				generatorKsuid, ru.URI(), err)
+		}
+		if prepared == nil {
+			continue
+		}
+		deliveries = append(deliveries, pendingDelivery{ru: ru, prepared: prepared})
+	}
+
+	for _, d := range deliveries {
+		if err := d.ru.CommitGeneratorValues(d.prepared, generatorKsuid, generationID, mode); err != nil {
+			return fmt.Errorf("failed to deliver the value drawn for generator %s to %s: %w",
+				generatorKsuid, d.ru.URI(), err)
 		}
 	}
 

--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -527,12 +527,18 @@ func generatorUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, m
 				if gu.Generator != nil {
 					generatorKsuid = gu.Generator.GetID()
 				}
-				if err := data.changeset.DAG.propagateDrawnGeneratorValue(generatorKsuid, message.DrawnValue, message.GenerationID, data.changeset.Mode); err != nil {
+				if err := data.changeset.DAG.propagateDrawnGeneratorValue(generatorKsuid, message.DrawnValues, message.GenerationID, data.changeset.Mode); err != nil {
 					proc.Log().Error("Failed to deliver a drawn generator value, failing its destinations node=%s: %v",
 						message.NodeURI, err)
+					// The delivery error is structural — it names the
+					// generator, the destination and the output, never a
+					// value — and it travels as the failure reason so the
+					// refusal is visible on the command's failed resources,
+					// not only in this log line.
 					return handleUpdateFinished(from, state, data, updateFinishedEvent{
-						nodeURI:   message.NodeURI,
-						isSuccess: false,
+						nodeURI:       message.NodeURI,
+						isSuccess:     false,
+						failureReason: err.Error(),
 					}, proc)
 				}
 			}

--- a/internal/metastructure/changeset/generator_propagation_test.go
+++ b/internal/metastructure/changeset/generator_propagation_test.go
@@ -77,7 +77,7 @@ func TestGeneratorDrawFinished_DeliversTheValueInsideTheEnvelope(t *testing.T) {
 		generator_update.GeneratorUpdateFinished{
 			NodeURI:      draw.NodeURI(),
 			State:        generator_update.GeneratorUpdateStateSuccess,
-			DrawnValue:   "drawn-credential",
+			DrawnValues:  map[string]string{"value": "drawn-credential"},
 			GenerationID: "generation-1",
 		}, proc)
 
@@ -109,7 +109,7 @@ func TestGeneratorDrawFinished_MarksTheDrawSucceededAndReleasesItsDestination(t 
 		generator_update.GeneratorUpdateFinished{
 			NodeURI:      draw.NodeURI(),
 			State:        generator_update.GeneratorUpdateStateSuccess,
-			DrawnValue:   "drawn-credential",
+			DrawnValues:  map[string]string{"value": "drawn-credential"},
 			GenerationID: "generation-1",
 		}, proc)
 
@@ -197,14 +197,13 @@ func TestGeneratorDrawFinished_UndeliverableValueFailsClosed(t *testing.T) {
 	drawNode.Update.MarkInProgress()
 
 	actor, proc := testExecutorProcess(t)
-	_ = actor
 
 	data := ChangesetData{changeset: cs}
 	_, updated, _, _ := generatorUpdateFinished(gen.PID{}, StateProcessing, data,
 		generator_update.GeneratorUpdateFinished{
 			NodeURI:      draw.NodeURI(),
 			State:        generator_update.GeneratorUpdateStateSuccess,
-			DrawnValue:   "drawn-credential",
+			DrawnValues:  map[string]string{"value": "drawn-credential"},
 			GenerationID: "generation-1",
 		}, proc)
 
@@ -212,6 +211,25 @@ func TestGeneratorDrawFinished_UndeliverableValueFailsClosed(t *testing.T) {
 	assert.Nil(t, updated.changeset.DAG.Nodes[opURI])
 	assert.NotContains(t, string(ru.DesiredState.Properties), "drawn-credential",
 		"nothing is written when delivery is refused")
+
+	// The refusal must reach the operator, not only the log: the cascaded
+	// destinations are persisted with the structural delivery error as their
+	// failure reason, naming the destination — and never the value.
+	var reasons []string
+	for _, event := range actor.Events() {
+		callEvent, ok := event.(unit.CallEvent)
+		if !ok {
+			continue
+		}
+		if failed, ok := callEvent.Request.(forma_persister.MarkResourcesAsFailed); ok {
+			reasons = append(reasons, failed.FailureReason)
+		}
+	}
+	require.NotEmpty(t, reasons, "the cascaded failure must be persisted")
+	assert.Contains(t, reasons[0], "failed to deliver",
+		"the persisted reason must carry the delivery refusal, not be empty")
+	assert.NotContains(t, reasons[0], "drawn-credential",
+		"the persisted reason must never carry the value")
 }
 
 // A draw naming no generator delivers nothing. An authored, not yet
@@ -233,7 +251,7 @@ func TestPropagateDrawnGeneratorValue_WithoutAGeneratorIdentityDeliversNothing(t
 	)
 	require.NoError(t, err)
 
-	err = cs.DAG.propagateDrawnGeneratorValue("", "drawn-credential", "generation-1", pkgmodel.FormaApplyModeReconcile)
+	err = cs.DAG.propagateDrawnGeneratorValue("", map[string]string{"value": "drawn-credential"}, "generation-1", pkgmodel.FormaApplyModeReconcile)
 	require.Error(t, err, "a draw naming no generator must refuse delivery outright")
 	assert.NotContains(t, err.Error(), "drawn-credential")
 
@@ -256,7 +274,7 @@ func TestPropagateDrawnGeneratorValue_WithoutAGenerationDeliversNothing(t *testi
 	)
 	require.NoError(t, err)
 
-	err = cs.DAG.propagateDrawnGeneratorValue(generatorKsuid, "drawn-credential", "", pkgmodel.FormaApplyModeReconcile)
+	err = cs.DAG.propagateDrawnGeneratorValue(generatorKsuid, map[string]string{"value": "drawn-credential"}, "", pkgmodel.FormaApplyModeReconcile)
 	require.Error(t, err, "a draw naming no generation must refuse delivery outright")
 	assert.NotContains(t, err.Error(), "drawn-credential")
 
@@ -284,7 +302,7 @@ func TestPropagateDrawnGeneratorValue_SkipsATeardownDestination(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(generatorKsuid, "drawn-credential", "generation-1", pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(generatorKsuid, map[string]string{"value": "drawn-credential"}, "generation-1", pkgmodel.FormaApplyModeReconcile))
 
 	dying := cs.DAG.Nodes[createOperationURI(teardown.URI(), resource_update.OperationDelete)].Update.(*resource_update.ResourceUpdate)
 	assert.False(t, gjson.GetBytes(dying.DesiredState.Properties, "password.$value").Exists(),
@@ -309,7 +327,7 @@ func TestPropagateDrawnGeneratorValue_LeavesAnotherGeneratorsDestinationAlone(t 
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(firstKsuid, "first-credential", "generation-1", pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(firstKsuid, map[string]string{"value": "first-credential"}, "generation-1", pkgmodel.FormaApplyModeReconcile))
 
 	firstRU := cs.DAG.Nodes[createOperationURI(first.URI(), resource_update.OperationCreate)].Update.(*resource_update.ResourceUpdate)
 	secondRU := cs.DAG.Nodes[createOperationURI(second.URI(), resource_update.OperationCreate)].Update.(*resource_update.ResourceUpdate)
@@ -359,7 +377,7 @@ func TestPropagateDrawnGeneratorValue_RegeneratesUnderTheChangesetsMode(t *testi
 			"cmd-mode-"+string(mode), pkgmodel.CommandApply, mode,
 		)
 		require.NoError(t, err)
-		require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(generatorKsuid, "drawn", "generation-1", cs.Mode))
+		require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(generatorKsuid, map[string]string{"value": "drawn"}, "generation-1", cs.Mode))
 		return cs.DAG.Nodes[createOperationURI(ru.URI(), resource_update.OperationUpdate)].Update.(*resource_update.ResourceUpdate)
 	}
 
@@ -470,4 +488,70 @@ func TestEverySynthesizedDrawHasADestinationWaitingOnIt(t *testing.T) {
 		[]resource_update.ResourceUpdate{stable, teardown}, nil, lookup)
 	require.NoError(t, err)
 	assert.Empty(t, draws, "a generator no destination needs a value from draws nothing")
+}
+
+// A multi-output draw delivers each destination the output its envelope
+// names. One string fanned to both halves of a key pair would apply cleanly
+// with the wrong material in one of them, which is the failure output-aware
+// delivery exists to prevent.
+func TestPropagateDrawnGeneratorValue_SelectsOutputsPerDestination(t *testing.T) {
+	generatorKsuid := util.NewID()
+
+	private := genBoundSecret("private-half", generatorKsuid)
+	private.DesiredState.Properties = json.RawMessage(`{"password":{"$gen":true,"$generator":"` +
+		generatorKsuid + `","$output":"privateKey","$visibility":"Opaque"}}`)
+	public := genBoundSecret("public-half", generatorKsuid)
+	public.DesiredState.Properties = json.RawMessage(`{"password":{"$gen":true,"$generator":"` +
+		generatorKsuid + `","$output":"publicKey","$visibility":"Opaque"}}`)
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{private, public}, nil,
+		[]generator_update.GeneratorUpdate{drawOp("id-key", generatorKsuid)},
+		"cmd-two-outputs", pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, cs.DAG.propagateDrawnGeneratorValue(generatorKsuid,
+		map[string]string{"privateKey": "PRIVATE-PEM", "publicKey": "PUBLIC-PEM"},
+		"generation-1", pkgmodel.FormaApplyModeReconcile))
+
+	privateRU := cs.DAG.Nodes[createOperationURI(private.URI(), resource_update.OperationCreate)].Update.(*resource_update.ResourceUpdate)
+	publicRU := cs.DAG.Nodes[createOperationURI(public.URI(), resource_update.OperationCreate)].Update.(*resource_update.ResourceUpdate)
+	assert.Equal(t, "PRIVATE-PEM", gjson.GetBytes(privateRU.DesiredState.Properties, "password.$value").String())
+	assert.Equal(t, "PUBLIC-PEM", gjson.GetBytes(publicRU.DesiredState.Properties, "password.$value").String())
+}
+
+// A refusal at any destination leaves every destination untouched, whatever
+// order the walk visited them in. DAG ordering happens to keep half-delivered
+// nodes undispatchable, but credential delivery must not lean on that:
+// delivery is prepared for every destination before any is mutated.
+func TestPropagateDrawnGeneratorValue_RefusalMutatesNoDestination(t *testing.T) {
+	generatorKsuid := util.NewID()
+
+	deliverable := genBoundSecret("deliverable", generatorKsuid)
+	refusing := genBoundSecret("refusing", generatorKsuid)
+	refusing.DesiredState.Properties = json.RawMessage(`{"password":{"$gen":true,"$generator":"` +
+		generatorKsuid + `","$output":"privateKey","$visibility":"Opaque"}}`)
+
+	cs, err := NewChangeset(
+		[]resource_update.ResourceUpdate{deliverable, refusing}, nil,
+		[]generator_update.GeneratorUpdate{drawOp("db-password", generatorKsuid)},
+		"cmd-refusal-atomic", pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+	)
+	require.NoError(t, err)
+
+	before := string(cs.DAG.Nodes[createOperationURI(deliverable.URI(), resource_update.OperationCreate)].
+		Update.(*resource_update.ResourceUpdate).DesiredState.Properties)
+
+	err = cs.DAG.propagateDrawnGeneratorValue(generatorKsuid,
+		map[string]string{"value": "drawn-credential"}, "generation-1", pkgmodel.FormaApplyModeReconcile)
+	require.Error(t, err, "a destination naming an output the draw lacks must refuse the delivery")
+	assert.Contains(t, err.Error(), "privateKey", "the refusal must name the output")
+	assert.NotContains(t, err.Error(), "drawn-credential")
+
+	after := string(cs.DAG.Nodes[createOperationURI(deliverable.URI(), resource_update.OperationCreate)].
+		Update.(*resource_update.ResourceUpdate).DesiredState.Properties)
+	assert.Equal(t, before, after,
+		"the deliverable destination must be untouched when a sibling refuses")
+	assert.NotContains(t, after, "drawn-credential")
 }

--- a/internal/metastructure/generator_update/generator_update_generator.go
+++ b/internal/metastructure/generator_update/generator_update_generator.go
@@ -351,6 +351,12 @@ func generatorsEqual(a, b pkgmodel.Generator) bool {
 			pa.Symbols == pb.Symbols &&
 			pa.ExcludeCharacters == pb.ExcludeCharacters &&
 			pa.RequireEachIncludedType == pb.RequireEachIncludedType
+	case *pkgmodel.KeyPairGenerator:
+		pb, ok := b.(*pkgmodel.KeyPairGenerator)
+		if !ok {
+			return false
+		}
+		return pa.Bits == pb.Bits
 	default:
 		// For unknown types, assume not equal to be safe.
 		return false

--- a/internal/metastructure/generator_update/generator_updater.go
+++ b/internal/metastructure/generator_update/generator_updater.go
@@ -63,7 +63,7 @@ type generationAdvancer interface {
 //
 // The drawn value exists in exactly two places, both of them in memory and
 // both of them for the lifetime of a single draw: GeneratorUpdaterData's
-// drawnValue field, and the GeneratorUpdateFinished message this actor sends
+// drawnValues field, and the GeneratorUpdateFinished message this actor sends
 // its requester before terminating. It is never written to the datastore,
 // never placed on the GeneratorUpdate (which IS persisted, and is projected
 // to the API), and never logged.
@@ -92,7 +92,7 @@ type DrawValue struct{}
 
 // GeneratorUpdateFinished is sent back to the requester when the draw
 // completes. It is the ONLY carrier of the drawn value — the analogue of
-// TargetUpdateFinished.ResolvedConfig. DrawnValue is populated on success and
+// TargetUpdateFinished.ResolvedConfig. DrawnValues is populated on success and
 // only on success; ErrorMessage is populated on failure and only on failure,
 // always from the fixed set of reasons above.
 //
@@ -105,7 +105,7 @@ type DrawValue struct{}
 type GeneratorUpdateFinished struct {
 	NodeURI      pkgmodel.FormaeURI
 	State        GeneratorUpdateState
-	DrawnValue   string
+	DrawnValues  map[string]string
 	GenerationID string
 	ErrorMessage string
 }
@@ -128,12 +128,12 @@ type GeneratorUpdaterData struct {
 	// datastore records the generation advance. Nothing else about a
 	// generator is written from here.
 	datastore generationAdvancer
-	// drawnValue holds the live credential between the draw and the finished
+	// drawnValues holds the live credential between the draw and the finished
 	// signal. It is deliberately unexported and deliberately absent from
 	// GeneratorUpdate: the update is marshalled into the command record, this
 	// struct is not.
-	drawnValue string
-	// generationID is the identity of the generation drawnValue was drawn
+	drawnValues map[string]string
+	// generationID is the identity of the generation drawnValues was drawn
 	// under, held alongside it for the same lifetime and reported with it.
 	generationID string
 	// errorMessage is one of the fixed operator-facing reasons above, set
@@ -258,7 +258,7 @@ func handleDrawValue(from gen.PID, state gen.Atom, data GeneratorUpdaterData, me
 	// is not a digest of anything itself.
 	generationID := util.NewID()
 
-	value, err := pkgmodel.Draw(spec, data.entropy)
+	values, err := pkgmodel.Draw(spec, data.entropy)
 	if err != nil {
 		// The error names spec internals; only the fixed reason is reported.
 		proc.Log().Error("GeneratorUpdater: failed to draw a value node=%s", nodeURI)
@@ -272,7 +272,7 @@ func handleDrawValue(from gen.PID, state gen.Atom, data GeneratorUpdaterData, me
 		return StateFinishedWithError, data, nil, nil
 	}
 
-	data.drawnValue = value
+	data.drawnValues = values
 	data.generationID = generationID
 	return StateFinishedSuccessfully, data, nil, nil
 }
@@ -293,7 +293,7 @@ func onGeneratorUpdaterStateChange(oldState gen.Atom, newState gen.Atom, data Ge
 	}
 	if newState == StateFinishedSuccessfully {
 		finished.State = GeneratorUpdateStateSuccess
-		finished.DrawnValue = data.drawnValue
+		finished.DrawnValues = data.drawnValues
 		finished.GenerationID = data.generationID
 	} else {
 		finished.ErrorMessage = data.errorMessage

--- a/internal/metastructure/generator_update/generator_updater_test.go
+++ b/internal/metastructure/generator_update/generator_updater_test.go
@@ -140,7 +140,7 @@ func drawingData(t *testing.T, op GeneratorOperation, advancer *recordingAdvance
 // carries the drawn value on success, and that the actor then shuts itself down.
 func TestGeneratorUpdater_SuccessCarriesDrawnValue(t *testing.T) {
 	data := drawingData(t, GeneratorOperationCreate, &recordingAdvancer{})
-	data.drawnValue = "s3cret-value"
+	data.drawnValues = map[string]string{"value": "s3cret-value"}
 	data.generationID = "2mnoPQRstuVWxyzabcDEFghiJKL"
 
 	proc := &stubGeneratorUpdaterProcess{}
@@ -150,7 +150,7 @@ func TestGeneratorUpdater_SuccessCarriesDrawnValue(t *testing.T) {
 	finished := proc.sentFinishedMessages()
 	require.Len(t, finished, 1, "exactly one GeneratorUpdateFinished must be sent on success")
 	assert.Equal(t, GeneratorUpdateStateSuccess, finished[0].State)
-	assert.Equal(t, "s3cret-value", finished[0].DrawnValue,
+	assert.Equal(t, "s3cret-value", finished[0].DrawnValues["value"],
 		"the drawn value must reach the requester through the finished signal")
 	assert.Equal(t, "2mnoPQRstuVWxyzabcDEFghiJKL", finished[0].GenerationID,
 		"the generation the value was drawn under travels with it, so destinations can be stamped with it")
@@ -162,7 +162,7 @@ func TestGeneratorUpdater_SuccessCarriesDrawnValue(t *testing.T) {
 // value at all, even if one is somehow present in the actor's data.
 func TestGeneratorUpdater_FailureOmitsDrawnValue(t *testing.T) {
 	data := drawingData(t, GeneratorOperationCreate, &recordingAdvancer{})
-	data.drawnValue = "s3cret-value"
+	data.drawnValues = map[string]string{"value": "s3cret-value"}
 	data.generationID = "2mnoPQRstuVWxyzabcDEFghiJKL"
 	data.errorMessage = failureReasonDrawFailed
 
@@ -173,7 +173,7 @@ func TestGeneratorUpdater_FailureOmitsDrawnValue(t *testing.T) {
 	finished := proc.sentFinishedMessages()
 	require.Len(t, finished, 1, "exactly one GeneratorUpdateFinished must be sent on failure")
 	assert.Equal(t, GeneratorUpdateStateFailed, finished[0].State)
-	assert.Empty(t, finished[0].DrawnValue,
+	assert.Empty(t, finished[0].DrawnValues,
 		"a failed draw must never propagate a value")
 	assert.Empty(t, finished[0].GenerationID,
 		"a failed draw attests no generation")
@@ -194,8 +194,8 @@ func TestGeneratorUpdater_DrawRecordsGenerationUnderTheSpec(t *testing.T) {
 
 	expected, err := pkgmodel.Draw(testPasswordGenerator(), countingSource())
 	require.NoError(t, err)
-	assert.Equal(t, expected, out.drawnValue, "the draw must consume the injected entropy source")
-	assert.Len(t, out.drawnValue, 24)
+	assert.Equal(t, expected["value"], out.drawnValues["value"], "the draw must consume the injected entropy source")
+	assert.Len(t, out.drawnValues["value"], 24)
 
 	require.Len(t, advancer.calls, 1, "a successful draw records exactly one generation")
 	call := advancer.calls[0]
@@ -208,7 +208,7 @@ func TestGeneratorUpdater_DrawRecordsGenerationUnderTheSpec(t *testing.T) {
 	require.NoError(t, json.Unmarshal(call.drawnUnder, &spec),
 		"drawnUnder must be the marshalled generator spec")
 	assert.Equal(t, 24, spec.Length)
-	assert.NotContains(t, string(call.drawnUnder), out.drawnValue,
+	assert.NotContains(t, string(call.drawnUnder), out.drawnValues["value"],
 		"the drawn value must never be written to the datastore")
 }
 
@@ -224,7 +224,7 @@ func TestGeneratorUpdater_RecordingFailureDiscardsTheValue(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, StateFinishedWithError, state)
-	assert.Empty(t, out.drawnValue, "a value that could not be recorded must not be kept")
+	assert.Empty(t, out.drawnValues, "a value that could not be recorded must not be kept")
 	assert.Equal(t, failureReasonGenerationNotRecorded, out.errorMessage)
 	assert.NotContains(t, out.errorMessage, "db-host",
 		"the operator-facing message must not carry raw error text")
@@ -265,7 +265,7 @@ func TestGeneratorUpdater_DeleteDrawsNothing(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, StateFinishedSuccessfully, state)
-	assert.Empty(t, out.drawnValue)
+	assert.Empty(t, out.drawnValues)
 	assert.Empty(t, advancer.calls)
 }
 
@@ -283,7 +283,7 @@ func TestGeneratorUpdater_UnknownIdentityFailsBeforeDrawing(t *testing.T) {
 
 	assert.Equal(t, StateFinishedWithError, state)
 	assert.Equal(t, failureReasonUnknownIdentity, out.errorMessage)
-	assert.Empty(t, out.drawnValue)
+	assert.Empty(t, out.drawnValues)
 	assert.Empty(t, advancer.calls)
 }
 
@@ -314,7 +314,7 @@ func TestGeneratorUpdater_UndeliverableDrawTriggerIsNotASpecFailure(t *testing.T
 	assert.Equal(t, StateFinishedWithError, state)
 	assert.Equal(t, failureReasonDrawNotStarted, out.errorMessage)
 	assert.NotEqual(t, failureReasonDrawFailed, out.errorMessage)
-	assert.Empty(t, out.drawnValue)
+	assert.Empty(t, out.drawnValues)
 }
 
 // TestGeneratorUpdater_EachDrawGetsAFreshGeneration asserts two successive
@@ -372,7 +372,7 @@ func TestGeneratorUpdater_FaultyEntropyFailsWithoutAValue(t *testing.T) {
 			assert.Equal(t, failureReasonDrawFailed, out.errorMessage)
 			assert.NotContains(t, out.errorMessage, "urandom",
 				"the operator-facing message must not carry raw error text")
-			assert.Empty(t, out.drawnValue)
+			assert.Empty(t, out.drawnValues)
 			assert.Empty(t, advancer.calls, "a failed draw must not advance the generation")
 		})
 	}

--- a/internal/metastructure/resolver/gen_value.go
+++ b/internal/metastructure/resolver/gen_value.go
@@ -52,7 +52,15 @@ import (
 // have diverged, and writing a credential over an arbitrary node would put
 // plaintext somewhere nothing marked opaque. Errors name the path only —
 // never the value.
-func SetGenValues(properties json.RawMessage, generatorKsuid string, paths []string, value string) (json.RawMessage, error) {
+// Each occurrence receives the output its envelope names ($output; absent
+// means "value", the single-output arms' only name). An occurrence naming an
+// output the draw did not produce is a hard error naming the path and the
+// output: translation validates $output against the union across generator
+// kinds, so a destination bound to the wrong KIND's output is only catchable
+// here, where the draw's actual outputs are in hand. Skipping it would leave
+// an undrawn envelope to dispatch; substituting another output would hand a
+// provider the wrong credential with nothing anywhere erroring.
+func SetGenValues(properties json.RawMessage, generatorKsuid string, paths []string, values map[string]string) (json.RawMessage, error) {
 	result := string(properties)
 
 	for _, path := range paths {
@@ -65,6 +73,15 @@ func SetGenValues(properties json.RawMessage, generatorKsuid string, paths []str
 		}
 		if got := pkgmodel.GenGeneratorKSUID(node); got != generatorKsuid {
 			return nil, fmt.Errorf("cannot deliver a generated value: the generator reference at %q names %q, not %q", path, got, generatorKsuid)
+		}
+
+		output := node.Get("$output").String()
+		if output == "" {
+			output = "value"
+		}
+		value, ok := values[output]
+		if !ok {
+			return nil, fmt.Errorf("cannot deliver a generated value: the generator reference at %q names output %q, which this generator's draw does not produce", path, output)
 		}
 
 		envelope := make(map[string]any)

--- a/internal/metastructure/resolver/gen_value_outputs_test.go
+++ b/internal/metastructure/resolver/gen_value_outputs_test.go
@@ -1,0 +1,67 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resolver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// A multi-output draw delivers each occurrence the output it names: the
+// private half to the destination bound to privateKey, the public half to the
+// one bound to publicKey. Fanning one string to both is exactly the failure
+// mode output-aware delivery exists to prevent: both destinations would apply
+// cleanly holding the wrong key material and nothing would error.
+func TestSetGenValues_SelectsTheNamedOutputPerPath(t *testing.T) {
+	properties := json.RawMessage(`{
+		"PrivatePem": {"$gen": true, "$generator": "kp", "$output": "privateKey", "$visibility": "Opaque"},
+		"PublicPem":  {"$gen": true, "$generator": "kp", "$output": "publicKey", "$visibility": "Opaque"}
+	}`)
+
+	updated, err := SetGenValues(properties, "kp", []string{"PrivatePem", "PublicPem"},
+		map[string]string{"privateKey": "PRIVATE-PEM", "publicKey": "PUBLIC-PEM"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "PRIVATE-PEM", gjson.GetBytes(updated, "PrivatePem.$value").String())
+	assert.Equal(t, "PUBLIC-PEM", gjson.GetBytes(updated, "PublicPem.$value").String())
+}
+
+// An envelope naming no $output means the single-output arm's "value": the
+// shape every pre-multi-output forma renders, which must keep working.
+func TestSetGenValues_AbsentOutputMeansValue(t *testing.T) {
+	properties := json.RawMessage(`{
+		"SecretString": {"$gen": true, "$generator": "gen-ksuid", "$visibility": "Opaque"}
+	}`)
+
+	updated, err := SetGenValues(properties, "gen-ksuid", []string{"SecretString"},
+		map[string]string{"value": "drawn"})
+	require.NoError(t, err)
+	assert.Equal(t, "drawn", gjson.GetBytes(updated, "SecretString.$value").String())
+}
+
+// An occurrence naming an output the draw did not produce is a hard error
+// naming the path and the output, never a silent skip and never a fallback to
+// some other output's value. This is the delivery-time half of output
+// validation: translation checks names against the union across kinds, so a
+// password-bound destination asking for privateKey is only caught here.
+func TestSetGenValues_MissingOutputIsARefusalNamingPathAndOutput(t *testing.T) {
+	properties := json.RawMessage(`{
+		"Ok":    {"$gen": true, "$generator": "pw", "$output": "value", "$visibility": "Opaque"},
+		"Wrong": {"$gen": true, "$generator": "pw", "$output": "privateKey", "$visibility": "Opaque"}
+	}`)
+
+	_, err := SetGenValues(properties, "pw", []string{"Ok", "Wrong"},
+		map[string]string{"value": "drawn"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Wrong", "the error must name the path")
+	assert.Contains(t, err.Error(), "privateKey", "the error must name the output")
+	assert.NotContains(t, err.Error(), "drawn", "the error must never carry a value")
+}

--- a/internal/metastructure/resolver/gen_value_test.go
+++ b/internal/metastructure/resolver/gen_value_test.go
@@ -27,7 +27,7 @@ func TestSetGenValues_WritesTheValueInsideTheEnvelope(t *testing.T) {
 		"SecretString": {"$gen": true, "$generator": "gen-ksuid", "$output": "value", "$visibility": "Opaque"}
 	}`)
 
-	updated, err := SetGenValues(properties, "gen-ksuid", []string{"SecretString"}, "drawn-credential")
+	updated, err := SetGenValues(properties, "gen-ksuid", []string{"SecretString"}, map[string]string{"value": "drawn-credential"})
 	require.NoError(t, err)
 
 	envelope := gjson.GetBytes(updated, "SecretString")
@@ -49,7 +49,7 @@ func TestSetGenValues_WritesOnlyTheNamedPaths(t *testing.T) {
 		"Nested": {"Second": {"$gen": true, "$generator": "b", "$output": "value", "$visibility": "Opaque"}}
 	}`)
 
-	updated, err := SetGenValues(properties, "b", []string{"Nested.Second"}, "drawn")
+	updated, err := SetGenValues(properties, "b", []string{"Nested.Second"}, map[string]string{"value": "drawn"})
 	require.NoError(t, err)
 
 	assert.Equal(t, "drawn", gjson.GetBytes(updated, "Nested.Second.$value").String())
@@ -63,10 +63,10 @@ func TestSetGenValues_WritesOnlyTheNamedPaths(t *testing.T) {
 func TestSetGenValues_RefusesAPathThatIsNotAGeneratorEnvelope(t *testing.T) {
 	properties := json.RawMessage(`{"Name": "db", "Ref": {"$ref": "formae://k#/Token"}}`)
 
-	_, err := SetGenValues(properties, "gen-a", []string{"Name"}, "drawn")
+	_, err := SetGenValues(properties, "gen-a", []string{"Name"}, map[string]string{"value": "drawn"})
 	require.Error(t, err)
 
-	_, err = SetGenValues(properties, "gen-a", []string{"Ref"}, "drawn")
+	_, err = SetGenValues(properties, "gen-a", []string{"Ref"}, map[string]string{"value": "drawn"})
 	require.Error(t, err, "a $ref envelope is not a generator envelope")
 }
 
@@ -75,7 +75,7 @@ func TestSetGenValues_RefusesAPathThatIsNotAGeneratorEnvelope(t *testing.T) {
 func TestSetGenValues_RefusesAnAbsentPath(t *testing.T) {
 	properties := json.RawMessage(`{"Name": "db"}`)
 
-	_, err := SetGenValues(properties, "gen-a", []string{"SecretString"}, "drawn")
+	_, err := SetGenValues(properties, "gen-a", []string{"SecretString"}, map[string]string{"value": "drawn"})
 	require.Error(t, err)
 }
 
@@ -83,7 +83,7 @@ func TestSetGenValues_RefusesAnAbsentPath(t *testing.T) {
 func TestSetGenValues_ErrorNeverCarriesTheValue(t *testing.T) {
 	properties := json.RawMessage(`{"Name": "db"}`)
 
-	_, err := SetGenValues(properties, "gen-ksuid", []string{"SecretString"}, "drawn-credential")
+	_, err := SetGenValues(properties, "gen-ksuid", []string{"SecretString"}, map[string]string{"value": "drawn-credential"})
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "drawn-credential")
 	assert.Contains(t, err.Error(), "SecretString")
@@ -95,7 +95,7 @@ func TestSetGenValues_WritesIntoAnArrayElement(t *testing.T) {
 		"Entries": [{"$gen": true, "$generator": "a", "$output": "value", "$visibility": "Opaque"}]
 	}`)
 
-	updated, err := SetGenValues(properties, "a", []string{"Entries.0"}, "drawn")
+	updated, err := SetGenValues(properties, "a", []string{"Entries.0"}, map[string]string{"value": "drawn"})
 	require.NoError(t, err)
 	assert.Equal(t, "drawn", gjson.GetBytes(updated, "Entries.0.$value").String())
 	assert.Equal(t, "Opaque", gjson.GetBytes(updated, "Entries.0.$visibility").String())
@@ -111,7 +111,7 @@ func TestSetGenValues_RefusesAnEnvelopeNamingAnotherGenerator(t *testing.T) {
 		"SecretString": {"$gen": true, "$generator": "gen-b", "$output": "value", "$visibility": "Opaque"}
 	}`)
 
-	_, err := SetGenValues(properties, "gen-a", []string{"SecretString"}, "drawn-credential")
+	_, err := SetGenValues(properties, "gen-a", []string{"SecretString"}, map[string]string{"value": "drawn-credential"})
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "drawn-credential")
 	assert.False(t, gjson.GetBytes(properties, "SecretString.$value").Exists(),
@@ -133,7 +133,7 @@ func TestSetGenValues_RefusesAPathThroughADottedKey(t *testing.T) {
 	require.Equal(t, "labels.app.kubernetes.io/secret", occurrences[0].Path,
 		"precondition: the walk dot-joins the key, producing an unresolvable path")
 
-	_, err := SetGenValues(properties, "gen-a", []string{occurrences[0].Path}, "drawn-credential")
+	_, err := SetGenValues(properties, "gen-a", []string{occurrences[0].Path}, map[string]string{"value": "drawn-credential"})
 	require.Error(t, err, "an unaddressable destination must refuse delivery, not write elsewhere")
 	assert.NotContains(t, err.Error(), "drawn-credential")
 }

--- a/internal/metastructure/resource_update/gen_provenance_stamp_test.go
+++ b/internal/metastructure/resource_update/gen_provenance_stamp_test.go
@@ -33,7 +33,7 @@ const (
 // fire, and every re-apply then redraws with nothing reporting a fault.
 func TestResolveGeneratorValue_StampsTheDigestThePlannerComputes(t *testing.T) {
 	ru := genBoundCreate(stampGeneratorKsuid)
-	require.NoError(t, ru.ResolveGeneratorValue(stampGeneratorKsuid, "drawn-credential", stampGenerationID, pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, ru.ResolveGeneratorValue(stampGeneratorKsuid, map[string]string{"value": "drawn-credential"}, stampGenerationID, pkgmodel.FormaApplyModeReconcile))
 
 	stamped := ru.ResolvedRootDigests[generatorSourceKey(stampGeneratorKsuid, "value")]
 	require.True(t, provenance.Valid(stamped),
@@ -79,7 +79,7 @@ func TestResolveGeneratorValue_StampReachesTheStoredEnvelope(t *testing.T) {
 	ru := genBoundCreate(stampGeneratorKsuid)
 	ru.DesiredState.Schema = pkgmodel.Schema{Identifier: "Name", Fields: []string{"Name", "SecretString"}}
 
-	require.NoError(t, ru.ResolveGeneratorValue(stampGeneratorKsuid, "drawn-credential", stampGenerationID, pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, ru.ResolveGeneratorValue(stampGeneratorKsuid, map[string]string{"value": "drawn-credential"}, stampGenerationID, pkgmodel.FormaApplyModeReconcile))
 	require.NoError(t, ru.updateResourceProperties(`{"Name":"db","SecretString":"drawn-credential"}`, true))
 
 	envelope := gjson.GetBytes(ru.DesiredState.Properties, "SecretString")
@@ -95,7 +95,7 @@ func TestResolveGeneratorValue_ReadOriginMergeStampsNothing(t *testing.T) {
 	ru := genBoundCreate(stampGeneratorKsuid)
 	ru.DesiredState.Schema = pkgmodel.Schema{Identifier: "Name", Fields: []string{"Name", "SecretString"}}
 
-	require.NoError(t, ru.ResolveGeneratorValue(stampGeneratorKsuid, "drawn-credential", stampGenerationID, pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, ru.ResolveGeneratorValue(stampGeneratorKsuid, map[string]string{"value": "drawn-credential"}, stampGenerationID, pkgmodel.FormaApplyModeReconcile))
 	require.NoError(t, ru.updateResourceProperties(`{"Name":"db","SecretString":"drawn-credential"}`, false))
 
 	assert.False(t, gjson.GetBytes(ru.DesiredState.Properties, "SecretString.$resolvedFrom").Exists(),

--- a/internal/metastructure/resource_update/resolve_generator_value_test.go
+++ b/internal/metastructure/resource_update/resolve_generator_value_test.go
@@ -36,7 +36,7 @@ func genBoundCreate(generatorKsuid string) ResourceUpdate {
 func TestResolveGeneratorValue_WritesInsideTheEnvelope(t *testing.T) {
 	ru := genBoundCreate("gen-a")
 
-	require.NoError(t, ru.ResolveGeneratorValue("gen-a", "drawn-credential", "generation-1", pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, ru.ResolveGeneratorValue("gen-a", map[string]string{"value": "drawn-credential"}, "generation-1", pkgmodel.FormaApplyModeReconcile))
 
 	envelope := gjson.GetBytes(ru.DesiredState.Properties, "SecretString")
 	require.True(t, envelope.IsObject(), "the envelope must not be replaced by a bare scalar")
@@ -49,7 +49,7 @@ func TestResolveGeneratorValue_WritesInsideTheEnvelope(t *testing.T) {
 func TestResolveGeneratorValue_LeavesAnotherGeneratorsDestinationAlone(t *testing.T) {
 	ru := genBoundCreate("gen-a")
 
-	require.NoError(t, ru.ResolveGeneratorValue("gen-b", "drawn-credential", "generation-1", pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, ru.ResolveGeneratorValue("gen-b", map[string]string{"value": "drawn-credential"}, "generation-1", pkgmodel.FormaApplyModeReconcile))
 
 	assert.False(t, gjson.GetBytes(ru.DesiredState.Properties, "SecretString.$value").Exists(),
 		"only destinations naming the generator that drew may receive the value")
@@ -79,7 +79,7 @@ func TestResolveGeneratorValue_ReachesEveryDestinationIncludingAStableOne(t *tes
 		}},
 	}
 
-	require.NoError(t, ru.ResolveGeneratorValue("gen-a", "drawn-credential", "generation-1", pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, ru.ResolveGeneratorValue("gen-a", map[string]string{"value": "drawn-credential"}, "generation-1", pkgmodel.FormaApplyModeReconcile))
 
 	assert.Equal(t, "drawn-credential", gjson.GetBytes(ru.DesiredState.Properties, "Stable.$value").String(),
 		"a stable destination receives the draw its siblings receive")
@@ -115,13 +115,13 @@ func TestResolveGeneratorValue_RegeneratesUnderCommandMode(t *testing.T) {
 	}
 
 	reconcile := newUpdate()
-	require.NoError(t, reconcile.ResolveGeneratorValue("gen-a", "drawn", "generation-1", pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, reconcile.ResolveGeneratorValue("gen-a", map[string]string{"value": "drawn"}, "generation-1", pkgmodel.FormaApplyModeReconcile))
 	assert.Contains(t, string(reconcile.DesiredState.PatchDocument), "remove",
 		"reconcile regeneration must keep the remove op for the dropped Tags member")
 	assert.Contains(t, string(reconcile.DesiredState.PatchDocument), "Tags")
 
 	patchMode := newUpdate()
-	require.NoError(t, patchMode.ResolveGeneratorValue("gen-a", "drawn", "generation-1", pkgmodel.FormaApplyModePatch))
+	require.NoError(t, patchMode.ResolveGeneratorValue("gen-a", map[string]string{"value": "drawn"}, "generation-1", pkgmodel.FormaApplyModePatch))
 	assert.NotContains(t, string(patchMode.DesiredState.PatchDocument), "remove",
 		"patch-mode regeneration must leave the undeclared Tags member unchanged")
 }
@@ -138,7 +138,7 @@ func TestResolveGeneratorValue_WithNoDestinationChangesNothing(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, ru.ResolveGeneratorValue("gen-a", "drawn", "generation-1", pkgmodel.FormaApplyModeReconcile))
+	require.NoError(t, ru.ResolveGeneratorValue("gen-a", map[string]string{"value": "drawn"}, "generation-1", pkgmodel.FormaApplyModeReconcile))
 
 	assert.JSONEq(t, `{"Name": "plain"}`, string(ru.DesiredState.Properties))
 	assert.JSONEq(t, `[{"op":"replace","path":"/Name","value":"plain"}]`, string(ru.DesiredState.PatchDocument),

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -197,7 +197,27 @@ func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value strin
 // mode is the command's configured apply mode, threaded through for exactly
 // the reason ResolveValue documents: regeneration must use the semantics
 // planning used or a reconcile-planned removal silently vanishes.
-func (ru *ResourceUpdate) ResolveGeneratorValue(generatorKsuid string, value string, generationID string, mode pkgmodel.FormaApplyMode) error {
+//
+// Delivery is split into a prepare and a commit so the caller can validate
+// EVERY destination before mutating ANY: a refusal at one destination (a
+// wrong output name, a diverged document) must not leave sibling
+// destinations already rewritten in memory. DAG ordering happens to keep a
+// half-delivered node undispatchable today, but credential delivery does not
+// lean on that.
+
+// PreparedGenDelivery is one destination's computed delivery: the rewritten
+// properties and the outputs each occurrence consumed, held until every
+// destination of the draw has prepared successfully.
+type PreparedGenDelivery struct {
+	properties json.RawMessage
+	outputs    []string
+}
+
+// PrepareGeneratorValues computes this update's rewritten properties for a
+// draw without mutating anything. It returns nil when the update holds no
+// occurrence of the generator. Errors name paths and output names only,
+// never a value.
+func (ru *ResourceUpdate) PrepareGeneratorValues(generatorKsuid string, values map[string]string) (*PreparedGenDelivery, error) {
 	var paths []string
 	var outputs []string
 	for _, occurrence := range pkgmodel.FindGenObjectsFromProperties(ru.DesiredState.Properties) {
@@ -208,19 +228,38 @@ func (ru *ResourceUpdate) ResolveGeneratorValue(generatorKsuid string, value str
 		outputs = append(outputs, occurrence.Output)
 	}
 	if len(paths) == 0 {
+		return nil, nil
+	}
+
+	properties, err := resolver.SetGenValues(ru.DesiredState.Properties, generatorKsuid, paths, values)
+	if err != nil {
+		// The error names paths only; the drawn values are never in it.
+		slog.Error("Failed to deliver a generated value", "error", err)
+		return nil, fmt.Errorf("failed to deliver a generated value: %w", err)
+	}
+	return &PreparedGenDelivery{properties: properties, outputs: outputs}, nil
+}
+
+// CommitGeneratorValues installs a prepared delivery: properties, generation
+// stamps, and the re-derived patch.
+func (ru *ResourceUpdate) CommitGeneratorValues(prepared *PreparedGenDelivery, generatorKsuid string, generationID string, mode pkgmodel.FormaApplyMode) error {
+	ru.DesiredState.Properties = prepared.properties
+	ru.stampDrawnGeneration(generatorKsuid, prepared.outputs, generationID)
+	return ru.reDerivePatchAfterSubstitution(mode, "generator "+generatorKsuid)
+}
+
+// ResolveGeneratorValue prepares and commits in one step, for a caller
+// delivering to a single update. Cross-update delivery goes through the
+// split pair so a refusal at one destination mutates none.
+func (ru *ResourceUpdate) ResolveGeneratorValue(generatorKsuid string, values map[string]string, generationID string, mode pkgmodel.FormaApplyMode) error {
+	prepared, err := ru.PrepareGeneratorValues(generatorKsuid, values)
+	if err != nil {
+		return err
+	}
+	if prepared == nil {
 		return nil
 	}
-
-	properties, err := resolver.SetGenValues(ru.DesiredState.Properties, generatorKsuid, paths, value)
-	if err != nil {
-		// The error names paths only; the drawn value is never in it.
-		slog.Error("Failed to deliver a generated value", "error", err)
-		return fmt.Errorf("failed to deliver a generated value: %w", err)
-	}
-	ru.DesiredState.Properties = properties
-	ru.stampDrawnGeneration(generatorKsuid, outputs, generationID)
-
-	return ru.reDerivePatchAfterSubstitution(mode, "generator "+generatorKsuid)
+	return ru.CommitGeneratorValues(prepared, generatorKsuid, generationID, mode)
 }
 
 // stampDrawnGeneration records, for every generator output this update just

--- a/internal/schema/pkl/generator/pklGenerator.pkl
+++ b/internal/schema/pkl/generator/pklGenerator.pkl
@@ -310,6 +310,16 @@ function parseGenerators(generatorsData: List<Map<String, Any>>, stackLabelMap: 
       }
       \(camelCaseLabel)
       """
+        else if (generatorType == "keypair")
+            let (bits = generatorData["Bits"] as Number)
+            """
+
+      local \(camelCaseLabel) = new formae.KeyPairGenerator {
+        label = "\(label)"\(stackLine)\(rotationLine)
+        bits = \(bits.toInt())
+      }
+      \(camelCaseLabel)
+      """
         else
             // Unknown generator type - skip with comment
             """
@@ -471,7 +481,8 @@ function generateFormaFile(parsed: json.Value): String =
             "Digits", generator.getPropertyOrNull("Digits"),
             "Symbols", generator.getPropertyOrNull("Symbols"),
             "ExcludeCharacters", generator.getPropertyOrNull("ExcludeCharacters"),
-            "RequireEachIncludedType", generator.getPropertyOrNull("RequireEachIncludedType")
+            "RequireEachIncludedType", generator.getPropertyOrNull("RequireEachIncludedType"),
+            "Bits", generator.getPropertyOrNull("Bits")
             )
         )
     else

--- a/internal/schema/pkl/pkl_generate_keypair_test.go
+++ b/internal/schema/pkl/pkl_generate_keypair_test.go
@@ -1,0 +1,84 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package pkl
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/schema"
+	model "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// A keypair generator extracted to PKL re-evaluates to the same spec: type,
+// bits, and cadence all survive, so an extract can be re-applied without the
+// generator silently changing shape.
+func TestGenerateSourceCode_KeyPairGenerator_RoundTrips(t *testing.T) {
+	deps, pluginDir := fakeawsDeps(t)
+
+	forma := &model.Forma{
+		Stacks:  []model.Stack{{Label: "default"}},
+		Targets: []model.Target{fakeawsTarget()},
+		Resources: []model.Resource{{
+			Label:      "plain-secret",
+			Type:       "FakeAWS::SecretsManager::Secret",
+			Stack:      "default",
+			Target:     "aws",
+			Properties: []byte(`{"SecretString":{"$value":"plaintext","$visibility":"Opaque","$strategy":"Update"}}`),
+		}},
+		Generators: []json.RawMessage{
+			[]byte(`{
+				"Type": "keypair",
+				"Label": "id-key",
+				"Stack": "default",
+				"Rotation": {"EverySeconds": 86400},
+				"Bits": 3072
+			}`),
+		},
+	}
+
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "out.pkl")
+
+	options := &schema.SerializeOptions{
+		Schema:         "pkl",
+		SchemaLocation: schema.SchemaLocationLocal,
+		LocalPluginDir: pluginDir,
+		Dependencies:   deps,
+	}
+
+	_, err := PKL{}.GenerateSourceCode(forma, targetPath, nil, options)
+	require.NoError(t, err)
+
+	written, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	generated := string(written)
+
+	assert.Contains(t, generated, "new formae.KeyPairGenerator {",
+		"the emitted generator must keep its kind, not fall into the unknown-type skip")
+	assert.Contains(t, generated, "bits = 3072")
+
+	evaluated, err := PKL{}.Evaluate(targetPath, model.CommandApply, model.FormaApplyModeReconcile, nil)
+	require.NoError(t, err, "emitted PKL must itself evaluate")
+
+	require.Len(t, evaluated.Generators, 1)
+	var round struct {
+		Type     string                      `json:"Type"`
+		Bits     int                         `json:"Bits"`
+		Rotation *struct{ EverySeconds int } `json:"Rotation"`
+	}
+	require.NoError(t, json.Unmarshal(evaluated.Generators[0], &round))
+	assert.Equal(t, "keypair", round.Type)
+	assert.Equal(t, 3072, round.Bits)
+	require.NotNil(t, round.Rotation, "cadence must survive the round trip")
+	assert.Equal(t, 86400, round.Rotation.EverySeconds)
+}

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -304,6 +304,36 @@ open class PasswordGenerator extends Generator {
     }
 }
 
+/// Generates an RSA key pair: a PKCS#8 PEM private half (`gen.privateKey`)
+/// and a PKIX PEM public half (`gen.publicKey`). One draw produces both, so
+/// two destinations bound to the two outputs always hold halves of the same
+/// pair; that is what makes this a single generator with two named outputs
+/// rather than two generators.
+open class KeyPairGenerator extends Generator {
+    /// RSA modulus size. The set matches what the consuming verifiers accept
+    /// and keeps generation time bounded; a size outside it is refused at
+    /// evaluation rather than surfacing as a draw failure later.
+    bits: Int(this == 2048 || this == 3072 || this == 4096
+        || throw("KeyPairGenerator.bits: \(this) is not a supported RSA key size (2048, 3072 or 4096)")) = 2048
+
+    local self = this
+
+    hidden gen: KeyPairOutputs(self.hasStack()) = new KeyPairOutputs {
+        genLabel = self.label
+        genStack = self.stack
+    }
+
+    function type(): String = "keypair"
+    function render(): Dynamic(self.hasStack()) = new {
+        Type = "keypair"
+        Label = self.label
+        Stack = self.stack
+        Alias = self.alias
+        Rotation = self.rotation?.render()
+        Bits = bits
+    }
+}
+
 /// A reference to one named output of a generator, e.g. `pw.gen.value`.
 /// Renders the $gen envelope the agent resolves at apply time.
 ///
@@ -363,6 +393,28 @@ open class PasswordOutputs extends GeneratorOutputs {
         genLabel = self.genLabel
         genStack = self.genStack
         output = "value"
+    }
+}
+
+/// The named outputs a KeyPairGenerator produces. Both halves are Opaque:
+/// a public key stored opaquely is inert, and per-output visibility is a
+/// decision deliberately not taken yet.
+open class KeyPairOutputs extends GeneratorOutputs {
+    hidden genLabel: String?
+    hidden genStack: StackResolvable?
+
+    local self = this
+
+    hidden privateKey: GeneratorOutput = new GeneratorOutput {
+        genLabel = self.genLabel
+        genStack = self.genStack
+        output = "privateKey"
+    }
+
+    hidden publicKey: GeneratorOutput = new GeneratorOutput {
+        genLabel = self.genLabel
+        genStack = self.genStack
+        output = "publicKey"
     }
 }
 

--- a/internal/schema/pkl/schema/tests/formae.pkl
+++ b/internal/schema/pkl/schema/tests/formae.pkl
@@ -486,6 +486,23 @@ local nonRotatingGenerator = new formae.PasswordGenerator {
     stack = stackResolvable
 }
 
+local keyPairGen = new formae.KeyPairGenerator {
+    label = "id-key"
+    stack = stackResolvable
+}
+
+local wideKeyPairGen = new formae.KeyPairGenerator {
+    label = "wide-id-key"
+    stack = stackResolvable
+    bits = 4096
+}
+
+local oddKeyPairGen = new formae.KeyPairGenerator {
+    label = "odd-id-key"
+    stack = stackResolvable
+    bits = 1024
+}
+
 local cadencelessRotation = new formae.PasswordGenerator {
     label = "cadenceless-password"
     stack = stackResolvable
@@ -828,6 +845,29 @@ facts {
     ["A cadence below the scheduler's floor is rejected, naming the field"] {
         module.catch(() -> subMinuteRotation.render().Rotation.EverySeconds)
             .contains("RotationSpec.every")
+    }
+
+    ["KeyPairGenerator renders its type, default bits, and no rotation"] {
+        keyPairGen.render().Type == "keypair" &&
+        keyPairGen.render().Bits == 2048 &&
+        keyPairGen.render().Rotation == null
+    }
+
+    ["KeyPairGenerator accepts each supported size"] {
+        wideKeyPairGen.render().Bits == 4096
+    }
+
+    ["A key size outside the supported set is rejected, naming the field"] {
+        module.catch(() -> oddKeyPairGen.render().Bits)
+            .contains("KeyPairGenerator.bits")
+    }
+
+    ["KeyPairGenerator's outputs render distinct $output names"] {
+        keyPairGen.gen.privateKey.$output == "privateKey" &&
+        keyPairGen.gen.publicKey.$output == "publicKey" &&
+        keyPairGen.gen.privateKey.$visibility == "Opaque" &&
+        keyPairGen.gen.publicKey.$visibility == "Opaque" &&
+        keyPairGen.gen.privateKey.$label == "id-key"
     }
 
     ["The floor itself is a cadence"] {

--- a/internal/schema/pkl/testdata/forma/generator_keypair_test.pkl
+++ b/internal/schema/pkl/testdata/forma/generator_keypair_test.pkl
@@ -1,0 +1,47 @@
+/*
+ * © 2026 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+// Two plugin resources bound to the two halves of one key-pair generator:
+// the shape the per-installation identity keys use, where each half lands in
+// its own secret with its own readers.
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+import "@fakeaws/fakeaws.pkl"
+import "@fakeaws/secretsmanager/secret.pkl"
+
+forma {
+  local appStack = new formae.Stack {
+    label = "generator-keypair-stack"
+    description = "Stack for a key-pair-bound pair of secrets"
+  }
+  appStack
+
+  new formae.Target {
+    label = "default-aws-target"
+    config = new fakeaws.Config {
+      region = "us-west-2"
+    }
+  }
+
+  local idKey = new formae.KeyPairGenerator {
+    label = "id-key"
+    stack = appStack.res
+  }
+  idKey
+
+  new secret.Secret {
+    label = "id-key-private"
+    name = "id-key-private"
+    secretString = idKey.gen.privateKey
+  }
+
+  new secret.Secret {
+    label = "id-key-public"
+    name = "id-key-public"
+    secretString = idKey.gen.publicKey
+  }
+}

--- a/internal/workflow_tests/local/apply_forma/generator_keypair_pkl_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_keypair_pkl_test.go
@@ -1,0 +1,92 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build integration
+
+package workflow_tests_local
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/schema/pkl"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+const authoredKeyPairForma = "internal/schema/pkl/testdata/forma/generator_keypair_test.pkl"
+
+// A key-pair generator authored in PKL applies end to end: one draw, two
+// destinations, each receiving the half its binding names. The halves must be
+// the two ends of the SAME pair — one string fanned to both, or two
+// independent draws, would both apply cleanly here and fail only at the
+// consumer, which is exactly the silent outcome this asserts against.
+func TestApplyForma_PklAuthoredKeyPair_EachHalfReachesItsDestination(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		forma, err := pkl.PKL{}.Evaluate(
+			authoredKeyPairForma,
+			pkgmodel.CommandApply,
+			pkgmodel.FormaApplyModeReconcile,
+			nil,
+		)
+		require.NoError(t, err, "the authored forma must evaluate")
+		require.Len(t, forma.Resources, 2)
+		require.Len(t, forma.Generators, 1)
+		for _, r := range forma.Resources {
+			require.True(t, gjson.GetBytes(r.Properties, "SecretString.$gen").Bool(),
+				"precondition: eval must render each binding as a $gen envelope")
+		}
+
+		capture := &pklCreateCapture{}
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, capture.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		_, err = m.ApplyForma(forma, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			incomplete, loadErr := m.Datastore.LoadIncompleteFormaCommands()
+			return loadErr == nil && len(incomplete) == 0
+		}, 30*time.Second, 100*time.Millisecond, "the apply must reach a terminal state")
+
+		cmds, err := m.Datastore.LoadFormaCommands()
+		require.NoError(t, err)
+		require.Len(t, cmds, 1)
+		require.Equal(t, forma_command.CommandStateSuccess, cmds[0].State,
+			"a PKL-authored key-pair binding must apply")
+
+		privatePEM, ok := capture.valueFor("id-key-private")
+		require.True(t, ok, "the provider must have been called for the private half")
+		publicPEM, ok := capture.valueFor("id-key-public")
+		require.True(t, ok, "the provider must have been called for the public half")
+
+		privateBlock, _ := pem.Decode([]byte(privatePEM))
+		require.NotNil(t, privateBlock, "the private half must reach the provider as PEM")
+		parsedPrivate, err := x509.ParsePKCS8PrivateKey(privateBlock.Bytes)
+		require.NoError(t, err, "the private half must be PKCS#8")
+		privateKey := parsedPrivate.(*rsa.PrivateKey)
+
+		publicBlock, _ := pem.Decode([]byte(publicPEM))
+		require.NotNil(t, publicBlock, "the public half must reach the provider as PEM")
+		parsedPublic, err := x509.ParsePKIXPublicKey(publicBlock.Bytes)
+		require.NoError(t, err, "the public half must be PKIX")
+		publicKey := parsedPublic.(*rsa.PublicKey)
+
+		assert.Equal(t, 0, privateKey.PublicKey.N.Cmp(publicKey.N),
+			"the two destinations must hold halves of one pair")
+		assert.Equal(t, 2048, publicKey.N.BitLen(), "the default key size applies")
+	})
+}

--- a/internal/workflow_tests/local/generator_updater_draw_test.go
+++ b/internal/workflow_tests/local/generator_updater_draw_test.go
@@ -104,9 +104,9 @@ func TestGeneratorUpdater_DrawsAValueAndRecordsItsGeneration(t *testing.T) {
 			func(msg generator_update.GeneratorUpdateFinished) bool {
 				assert.Equal(t, generator_update.GeneratorUpdateStateSuccess, msg.State,
 					"a well-formed generator must draw: %s", msg.ErrorMessage)
-				assert.Len(t, msg.DrawnValue, declaredLen,
+				assert.Len(t, msg.DrawnValues["value"], declaredLen,
 					"the drawn value must have the declared length")
-				drawnValue = msg.DrawnValue
+				drawnValue = msg.DrawnValues["value"]
 				return true
 			},
 		)
@@ -175,7 +175,7 @@ func TestGeneratorUpdater_SameLabelInTwoStacksBothDraw(t *testing.T) {
 			testutil.ExpectMessageWithPredicate(t, received, 10*time.Second,
 				func(msg generator_update.GeneratorUpdateFinished) bool {
 					assert.Equal(t, generator_update.GeneratorUpdateStateSuccess, msg.State, msg.ErrorMessage)
-					lengths[len(msg.DrawnValue)] = true
+					lengths[len(msg.DrawnValues["value"])] = true
 					return true
 				},
 			)
@@ -222,7 +222,7 @@ func TestGeneratorUpdater_WithoutAnIdentityRefusesToDraw(t *testing.T) {
 		testutil.ExpectMessageWithPredicate(t, received, 10*time.Second,
 			func(msg generator_update.GeneratorUpdateFinished) bool {
 				assert.Equal(t, generator_update.GeneratorUpdateStateFailed, msg.State)
-				assert.Empty(t, msg.DrawnValue, "a refused draw carries no value")
+				assert.Empty(t, msg.DrawnValues, "a refused draw carries no value")
 				assert.NotEmpty(t, msg.ErrorMessage)
 				return true
 			},
@@ -257,7 +257,7 @@ func TestGeneratorUpdater_RecordedGenerationSpecHoldsNoDrawnValue(t *testing.T) 
 		testutil.ExpectMessageWithPredicate(t, received, 10*time.Second,
 			func(msg generator_update.GeneratorUpdateFinished) bool {
 				require.Equal(t, generator_update.GeneratorUpdateStateSuccess, msg.State, msg.ErrorMessage)
-				drawnValue = msg.DrawnValue
+				drawnValue = msg.DrawnValues["value"]
 				return true
 			},
 		)

--- a/pkg/model/gen_envelope.go
+++ b/pkg/model/gen_envelope.go
@@ -144,22 +144,19 @@ func BindsGenerator(document []byte, generatorKsuid string) bool {
 	return false
 }
 
-// KnownGeneratorOutputs enumerates every output name a currently supported
-// generator type can produce. PasswordGenerator is the only arm today, and
-// its only output is "value" (see PasswordOutputs in the PKL schema); a
-// $gen naming any other output is rejected at translation.
-//
-// This is a flat union across every arm because there is only one arm. A
-// second generator type introduces an output name that is valid for IT but
-// not for others (e.g. a second arm's own "value"-shaped or differently
-// named output could collide or diverge in meaning), so checking $output
-// against this union alone stops being sufficient: the resolution site would
-// need to also resolve the referenced generator's TYPE (via genKeyToKsuid's
-// declared generator, or the datastore identity) and validate $output
-// against THAT type's own output set, not the global union. Widening this
-// map to add a key is not enough on its own at that point.
+// KnownGeneratorOutputs is the union of every output name any supported
+// generator kind can produce (GeneratorOutputNames per kind). Translation
+// checks $output against this union: it runs before the referenced generator
+// is resolved, so the union is the strongest check available there, and it
+// still rejects a typo'd name outright. The per-kind check happens at
+// delivery, where the draw's named outputs are in hand: a $gen whose $output
+// the bound generator's kind does not produce fails that resource update
+// with the path and output named, so a wrong-kind binding can never receive
+// a value silently.
 var KnownGeneratorOutputs = map[string]bool{
-	"value": true,
+	"value":      true,
+	"privateKey": true,
+	"publicKey":  true,
 }
 
 // GeneratorKey identifies a generator by the pair an authored $gen envelope

--- a/pkg/model/generator.go
+++ b/pkg/model/generator.go
@@ -103,6 +103,58 @@ func (g *PasswordGenerator) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// KeyPairGenerator produces an RSA key pair: a PKCS#8 PEM private half and a
+// PKIX PEM public half, the encodings the installation identity issuer's
+// decoders accept. Fields mirror the PKL KeyPairGenerator.render() output;
+// Type is a constant discriminator injected by MarshalJSON, as for
+// PasswordGenerator.
+type KeyPairGenerator struct {
+	Label    string        `json:"Label"`
+	Stack    string        `json:"Stack,omitempty"`
+	StackID  string        `json:"-"` // Set during processing, not from PKL
+	ID       string        `json:"-"` // Set during processing (translation), not from PKL
+	Alias    string        `json:"Alias,omitempty"`
+	Rotation *RotationSpec `json:"Rotation,omitempty"`
+	Bits     int           `json:"Bits"`
+}
+
+func (g *KeyPairGenerator) GetLabel() string           { return g.Label }
+func (g *KeyPairGenerator) GetType() string            { return "keypair" }
+func (g *KeyPairGenerator) GetStack() string           { return g.Stack }
+func (g *KeyPairGenerator) SetStack(stack string)      { g.Stack = stack }
+func (g *KeyPairGenerator) GetStackID() string         { return g.StackID }
+func (g *KeyPairGenerator) SetStackID(id string)       { g.StackID = id }
+func (g *KeyPairGenerator) GetID() string              { return g.ID }
+func (g *KeyPairGenerator) SetID(id string)            { g.ID = id }
+func (g *KeyPairGenerator) GetAlias() string           { return g.Alias }
+func (g *KeyPairGenerator) GetRotation() *RotationSpec { return g.Rotation }
+
+// MarshalJSON injects the "Type": "keypair" discriminator, mirroring
+// PasswordGenerator's.
+func (g *KeyPairGenerator) MarshalJSON() ([]byte, error) {
+	type alias KeyPairGenerator
+	return json.Marshal(struct {
+		Type string `json:"Type"`
+		alias
+	}{
+		Type:  g.GetType(),
+		alias: alias(*g),
+	})
+}
+
+// GeneratorOutputNames returns the named outputs a generator's draw produces,
+// in the order the PKL outputs class declares them. Every arm's Draw returns
+// exactly these keys, and a $gen envelope's $output must be one of the bound
+// generator's names.
+func GeneratorOutputNames(g Generator) []string {
+	switch g.(type) {
+	case *KeyPairGenerator:
+		return []string{"privateKey", "publicKey"}
+	default:
+		return []string{"value"}
+	}
+}
+
 // ParseGenerator parses a single generator from JSON, dispatching on the
 // discriminated Type field the same way ParsePolicy does.
 func ParseGenerator(raw json.RawMessage) (Generator, error) {
@@ -118,6 +170,12 @@ func ParseGenerator(raw json.RawMessage) (Generator, error) {
 		var g PasswordGenerator
 		if err := json.Unmarshal(raw, &g); err != nil {
 			return nil, fmt.Errorf("failed to parse password generator: %w", err)
+		}
+		return &g, nil
+	case "keypair":
+		var g KeyPairGenerator
+		if err := json.Unmarshal(raw, &g); err != nil {
+			return nil, fmt.Errorf("failed to parse keypair generator: %w", err)
 		}
 		return &g, nil
 	default:

--- a/pkg/model/generator_draw.go
+++ b/pkg/model/generator_draw.go
@@ -21,17 +21,24 @@ type ByteSource func([]byte) (int, error)
 // unsatisfiable spec returns an error instead of hanging an unattended agent.
 const maxDrawAttempts = 100_000
 
-// Draw produces one value satisfying the generator's spec, drawing entropy
-// from src. It never logs the discarded candidates or the returned value.
-func Draw(spec Generator, src ByteSource) (string, error) {
+// Draw produces the generator's named outputs, drawing entropy from src. The
+// returned map's keys are exactly GeneratorOutputNames(spec). It never logs
+// discarded candidates or any returned value.
+func Draw(spec Generator, src ByteSource) (map[string]string, error) {
 	if spec == nil || isTypedNil(spec) {
-		return "", fmt.Errorf("draw: generator is nil")
+		return nil, fmt.Errorf("draw: generator is nil")
 	}
 	switch g := spec.(type) {
 	case *PasswordGenerator:
-		return drawPassword(g, src)
+		value, err := drawPassword(g, src)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]string{"value": value}, nil
+	case *KeyPairGenerator:
+		return drawKeyPair(g, src)
 	default:
-		return "", fmt.Errorf("draw: unsupported generator type %q", spec.GetType())
+		return nil, fmt.Errorf("draw: unsupported generator type %q", spec.GetType())
 	}
 }
 

--- a/pkg/model/generator_draw_keypair.go
+++ b/pkg/model/generator_draw_keypair.go
@@ -1,0 +1,71 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package model
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+)
+
+// sourceReader adapts a ByteSource to the io.Reader rsa.GenerateKey wants.
+//
+// Honesty about what this buys: current Go's rsa.GenerateKey draws its key
+// material from the platform CSPRNG regardless of the reader passed to it
+// (verified here by test: an erroring reader still yielded a key), so unlike
+// the password arm this one cannot promise that the drawn key is a function
+// of src. What the Draw contract still guarantees, via the explicit probe in
+// drawKeyPair, is that a failing source fails the draw, so fault injection
+// keeps working and no arm quietly ignores its entropy argument.
+type sourceReader struct{ src ByteSource }
+
+func (r sourceReader) Read(b []byte) (int, error) { return r.src(b) }
+
+// drawKeyPair generates one RSA key pair and encodes the private half as
+// PKCS#8 PEM and the public half as PKIX PEM: the encodings the installation
+// identity issuer's decoders accept (its private-key decoder also takes
+// PKCS#1; its public-key decoder takes PKIX only). The two halves land in
+// different destinations with different readers, which is the reason a
+// keypair is one draw with two named outputs rather than two generators.
+func drawKeyPair(g *KeyPairGenerator, src ByteSource) (map[string]string, error) {
+	switch g.Bits {
+	case 2048, 3072, 4096:
+	default:
+		// The schema constrains bits to this set, so a spec outside it did
+		// not come through the schema.
+		return nil, fmt.Errorf("draw: %q has unsupported key size %d (want 2048, 3072 or 4096)", g.Label, g.Bits)
+	}
+
+	// Probe the source before generating: rsa.GenerateKey ignores its reader
+	// on current Go (see sourceReader), so without this an exhausted or
+	// broken entropy source would go unnoticed here alone among the arms.
+	probe := make([]byte, 1)
+	if n, err := src(probe); err != nil || n != len(probe) {
+		if err == nil {
+			err = fmt.Errorf("got %d bytes, want %d", n, len(probe))
+		}
+		return nil, fmt.Errorf("draw: %q entropy source failed: %w", g.Label, err)
+	}
+
+	key, err := rsa.GenerateKey(sourceReader{src}, g.Bits)
+	if err != nil {
+		return nil, fmt.Errorf("draw: %q key generation failed: %w", g.Label, err)
+	}
+
+	privateDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("draw: %q private-half encoding failed: %w", g.Label, err)
+	}
+	publicDER, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("draw: %q public-half encoding failed: %w", g.Label, err)
+	}
+
+	return map[string]string{
+		"privateKey": string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateDER})),
+		"publicKey":  string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicDER})),
+	}, nil
+}

--- a/pkg/model/generator_draw_keypair_test.go
+++ b/pkg/model/generator_draw_keypair_test.go
@@ -1,0 +1,139 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package model_test
+
+import (
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// A password draw is the single-output arm expressed in the multi-output
+// contract: exactly one entry, named "value".
+func TestDraw_PasswordReturnsTheValueOutput(t *testing.T) {
+	spec := &pkgmodel.PasswordGenerator{
+		Label: "pw", Length: 24,
+		Uppercase: true, Lowercase: true, Digits: true,
+	}
+	values, err := pkgmodel.Draw(spec, realSource)
+	require.NoError(t, err)
+	require.Len(t, values, 1)
+	assert.Len(t, values["value"], 24)
+}
+
+func TestDraw_KeyPairReturnsBothHalves(t *testing.T) {
+	spec := &pkgmodel.KeyPairGenerator{Label: "id-key", Bits: 2048}
+	values, err := pkgmodel.Draw(spec, realSource)
+	require.NoError(t, err)
+	require.Len(t, values, 2)
+	require.NotEmpty(t, values["privateKey"])
+	require.NotEmpty(t, values["publicKey"])
+}
+
+// decodeConsumerPrivateKey mirrors the parse sequence the installation
+// identity issuer runs on the private half: a PEM block parsed as PKCS#1
+// first, then PKCS#8. A drawn key that fails this sequence would apply
+// successfully and then fail at mint time, which is the deployment failure
+// the fixture exists to prevent.
+func decodeConsumerPrivateKey(t *testing.T, raw string) *rsa.PrivateKey {
+	t.Helper()
+	block, _ := pem.Decode([]byte(raw))
+	require.NotNil(t, block, "the private half must be PEM")
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	require.NoError(t, err, "the private half must parse as PKCS#1 or PKCS#8")
+	key, ok := parsed.(*rsa.PrivateKey)
+	require.True(t, ok, "the private half must be an RSA key")
+	return key
+}
+
+func TestDraw_KeyPairHalvesParseWithTheConsumersSequence(t *testing.T) {
+	spec := &pkgmodel.KeyPairGenerator{Label: "id-key", Bits: 2048}
+	values, err := pkgmodel.Draw(spec, realSource)
+	require.NoError(t, err)
+
+	private := decodeConsumerPrivateKey(t, values["privateKey"])
+	assert.Equal(t, 2048, private.N.BitLen(), "the modulus must carry the declared bits")
+
+	// The public half must parse as PKIX, which is the only encoding the
+	// issuer's public-key decoder accepts.
+	block, _ := pem.Decode([]byte(values["publicKey"]))
+	require.NotNil(t, block, "the public half must be PEM")
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	require.NoError(t, err, "the public half must parse as PKIX")
+	public, ok := parsed.(*rsa.PublicKey)
+	require.True(t, ok, "the public half must be an RSA key")
+
+	assert.Equal(t, 0, private.PublicKey.N.Cmp(public.N),
+		"the two halves must be one pair, not two draws")
+}
+
+// Entropy flows from the supplied source, never from an ambient reader: a
+// failing source must fail the draw, which is what keeps fault injection and
+// deterministic tests possible for this arm too.
+func TestDraw_KeyPairEntropyComesFromTheSource(t *testing.T) {
+	broken := func(b []byte) (int, error) { return 0, errors.New("entropy exhausted") }
+	_, err := pkgmodel.Draw(&pkgmodel.KeyPairGenerator{Label: "id-key", Bits: 2048}, broken)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "entropy exhausted")
+}
+
+// The schema constrains bits to 2048/3072/4096; a spec that arrives outside
+// that set did not come through the schema and is refused rather than drawn.
+func TestDraw_KeyPairRefusesUnknownBits(t *testing.T) {
+	_, err := pkgmodel.Draw(&pkgmodel.KeyPairGenerator{Label: "id-key", Bits: 1024}, realSource)
+	require.Error(t, err)
+}
+
+func TestGeneratorOutputs_PerKind(t *testing.T) {
+	assert.Equal(t, []string{"value"},
+		pkgmodel.GeneratorOutputNames(&pkgmodel.PasswordGenerator{}))
+	assert.Equal(t, []string{"privateKey", "publicKey"},
+		pkgmodel.GeneratorOutputNames(&pkgmodel.KeyPairGenerator{}))
+}
+
+// The keypair generator round-trips through the discriminated JSON the
+// datastore persists, exactly as the password arm does.
+func TestKeyPairGenerator_MarshalRoundTrip(t *testing.T) {
+	g := &pkgmodel.KeyPairGenerator{
+		Label: "id-key", Stack: "secrets", Bits: 3072,
+		Rotation: &pkgmodel.RotationSpec{EverySeconds: 86400},
+	}
+	raw, err := json.Marshal(g)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"Type":"keypair"`)
+
+	parsed, err := pkgmodel.ParseGenerator(raw)
+	require.NoError(t, err)
+	back, ok := parsed.(*pkgmodel.KeyPairGenerator)
+	require.True(t, ok)
+	assert.Equal(t, 3072, back.Bits)
+	assert.Equal(t, "secrets", back.GetStack())
+	require.NotNil(t, back.GetRotation())
+	assert.Equal(t, 86400, back.GetRotation().EverySeconds)
+}
+
+// Two keypair draws must differ: the source is consulted, not a fixture.
+func TestDraw_KeyPairDrawsAreIndependent(t *testing.T) {
+	spec := &pkgmodel.KeyPairGenerator{Label: "id-key", Bits: 2048}
+	a, err := pkgmodel.Draw(spec, func(b []byte) (int, error) { return cryptorand.Read(b) })
+	require.NoError(t, err)
+	b, err := pkgmodel.Draw(spec, func(b []byte) (int, error) { return cryptorand.Read(b) })
+	require.NoError(t, err)
+	assert.NotEqual(t, a["privateKey"], b["privateKey"])
+}

--- a/pkg/model/generator_draw_test.go
+++ b/pkg/model/generator_draw_test.go
@@ -64,18 +64,18 @@ func classOf(c rune) string {
 
 func TestDraw_CorrectLength(t *testing.T) {
 	spec := pw(func(*pkgmodel.PasswordGenerator) {})
-	value, err := pkgmodel.Draw(spec, realSource)
+	values, err := pkgmodel.Draw(spec, realSource)
 	require.NoError(t, err)
-	assert.Len(t, value, spec.Length)
+	assert.Len(t, values["value"], spec.Length)
 }
 
 func TestDraw_EveryCharacterIsDrawable(t *testing.T) {
 	spec := pw(func(*pkgmodel.PasswordGenerator) {})
-	value, err := pkgmodel.Draw(spec, realSource)
+	values, err := pkgmodel.Draw(spec, realSource)
 	require.NoError(t, err)
 
 	allowed := expectedAlphabet(spec)
-	for _, c := range value {
+	for _, c := range values["value"] {
 		assert.True(t, allowed[c], "character %q is not drawable under the spec", c)
 	}
 }
@@ -86,11 +86,11 @@ func TestDraw_RequireEachIncludedType_EveryEnabledClassIsPresent(t *testing.T) {
 		g.RequireEachIncludedType = true
 		g.Length = 32
 	})
-	value, err := pkgmodel.Draw(spec, realSource)
+	values, err := pkgmodel.Draw(spec, realSource)
 	require.NoError(t, err)
 
 	present := map[string]bool{}
-	for _, c := range value {
+	for _, c := range values["value"] {
 		present[classOf(c)] = true
 	}
 	assert.True(t, present["uppercase"])
@@ -132,9 +132,9 @@ func TestDraw_ModuloBiasedByteIsDiscardedAndRedrawn(t *testing.T) {
 	// second byte (0) is the one actually used for position 0.
 	src, calls := sequenceSource([]byte{255, 0, 1, 2, 3})
 
-	value, err := pkgmodel.Draw(spec, src)
+	values, err := pkgmodel.Draw(spec, src)
 	require.NoError(t, err)
-	assert.Equal(t, "0123", value)
+	assert.Equal(t, "0123", values["value"])
 	assert.Equal(t, 5, *calls, "expected the biased byte to be discarded and a 5th byte drawn")
 }
 
@@ -156,9 +156,9 @@ func TestDraw_RejectionBoundaryIsExactlyLimit(t *testing.T) {
 	})
 	src, calls := sequenceSource([]byte{250, 249})
 
-	value, err := pkgmodel.Draw(spec, src)
+	values, err := pkgmodel.Draw(spec, src)
 	require.NoError(t, err)
-	assert.Equal(t, "9", value)
+	assert.Equal(t, "9", values["value"])
 	assert.Equal(t, 2, *calls, "expected byte 250 to be rejected and byte 249 to be drawn")
 }
 
@@ -177,29 +177,29 @@ func TestDraw_RequireEachIncludedType_DiscardsWholeCandidateOnMissingClass(t *te
 	// Second candidate: byte 0, byte 26 -> "Aa", both classes -> accepted.
 	src, calls := sequenceSource([]byte{0, 1, 0, 26})
 
-	value, err := pkgmodel.Draw(spec, src)
+	values, err := pkgmodel.Draw(spec, src)
 	require.NoError(t, err)
-	assert.Equal(t, "Aa", value)
+	assert.Equal(t, "Aa", values["value"])
 	assert.Equal(t, 4, *calls, "expected the first, incomplete candidate to be discarded in full")
 }
 
-func drawWithTimeout(t *testing.T, spec pkgmodel.Generator, src pkgmodel.ByteSource) (string, error) {
+func drawWithTimeout(t *testing.T, spec pkgmodel.Generator, src pkgmodel.ByteSource) (map[string]string, error) {
 	t.Helper()
 	type result struct {
-		value string
-		err   error
+		values map[string]string
+		err    error
 	}
 	done := make(chan result, 1)
 	go func() {
-		value, err := pkgmodel.Draw(spec, src)
-		done <- result{value, err}
+		values, err := pkgmodel.Draw(spec, src)
+		done <- result{values, err}
 	}()
 	select {
 	case r := <-done:
-		return r.value, r.err
+		return r.values, r.err
 	case <-time.After(2 * time.Second):
 		t.Fatal("Draw did not return within timeout; it may be looping on an unsatisfiable spec")
-		return "", nil
+		return nil, nil
 	}
 }
 
@@ -207,9 +207,9 @@ func TestDraw_NoClassEnabledReturnsErrorRatherThanHanging(t *testing.T) {
 	spec := pw(func(g *pkgmodel.PasswordGenerator) {
 		g.Uppercase, g.Lowercase, g.Digits, g.Symbols = false, false, false, false
 	})
-	value, err := drawWithTimeout(t, spec, realSource)
+	values, err := drawWithTimeout(t, spec, realSource)
 	require.Error(t, err)
-	assert.Empty(t, value)
+	assert.Empty(t, values["value"])
 }
 
 func TestDraw_ExcludeCharactersEmptyingTheOnlyEnabledClassReturnsError(t *testing.T) {
@@ -217,9 +217,9 @@ func TestDraw_ExcludeCharactersEmptyingTheOnlyEnabledClassReturnsError(t *testin
 		g.Uppercase, g.Lowercase, g.Digits, g.Symbols = true, false, false, false
 		g.ExcludeCharacters = pkgmodel.UppercaseChars
 	})
-	value, err := drawWithTimeout(t, spec, realSource)
+	values, err := drawWithTimeout(t, spec, realSource)
 	require.Error(t, err)
-	assert.Empty(t, value)
+	assert.Empty(t, values["value"])
 }
 
 // requireEachIncludedType demanding more classes than there are positions
@@ -233,9 +233,9 @@ func TestDraw_ZeroLengthReturnsError(t *testing.T) {
 		g.RequireEachIncludedType = false
 		g.Length = 0
 	})
-	value, err := drawWithTimeout(t, spec, realSource)
+	values, err := drawWithTimeout(t, spec, realSource)
 	require.Error(t, err)
-	assert.Empty(t, value)
+	assert.Empty(t, values["value"])
 	assert.Contains(t, err.Error(), "non-positive length")
 }
 
@@ -249,9 +249,9 @@ func TestDraw_ExcludeCharactersEmptyingOneOfSeveralEnabledClassesNamesIt(t *test
 		g.ExcludeCharacters = pkgmodel.LowercaseChars
 		g.RequireEachIncludedType = true
 	})
-	value, err := drawWithTimeout(t, spec, realSource)
+	values, err := drawWithTimeout(t, spec, realSource)
 	require.Error(t, err)
-	assert.Empty(t, value)
+	assert.Empty(t, values["value"])
 	assert.Contains(t, err.Error(), "lowercase")
 }
 
@@ -265,9 +265,9 @@ func TestDraw_EffectiveAlphabetOfOneCharacterReturnsError(t *testing.T) {
 		g.ExcludeCharacters = pkgmodel.UppercaseChars[1:] // leaves only 'A'
 		g.RequireEachIncludedType = false
 	})
-	value, err := drawWithTimeout(t, spec, realSource)
+	values, err := drawWithTimeout(t, spec, realSource)
 	require.Error(t, err)
-	assert.Empty(t, value)
+	assert.Empty(t, values["value"])
 }
 
 // A ByteSource that returns (0, nil) — a short read with no error, the shape
@@ -284,9 +284,9 @@ func TestDraw_ShortReadFromByteSourceReturnsError(t *testing.T) {
 	spec := pw(func(g *pkgmodel.PasswordGenerator) { g.RequireEachIncludedType = false })
 	short := func(b []byte) (int, error) { return 0, nil }
 
-	value, err := pkgmodel.Draw(spec, short)
+	values, err := pkgmodel.Draw(spec, short)
 	require.Error(t, err)
-	assert.Empty(t, value)
+	assert.Empty(t, values["value"])
 	assert.Contains(t, err.Error(), "got 0 bytes, want 1")
 }
 
@@ -296,17 +296,17 @@ func TestDraw_MoreRequiredClassesThanLengthReturnsErrorRatherThanHanging(t *test
 		g.RequireEachIncludedType = true
 		g.Length = 1
 	})
-	value, err := drawWithTimeout(t, spec, realSource)
+	values, err := drawWithTimeout(t, spec, realSource)
 	require.Error(t, err)
-	assert.Empty(t, value)
+	assert.Empty(t, values["value"])
 }
 
 func TestDraw_TypedNilGeneratorReturnsError(t *testing.T) {
 	var nilGen *pkgmodel.PasswordGenerator
 	var spec pkgmodel.Generator = nilGen
-	value, err := pkgmodel.Draw(spec, realSource)
+	values, err := pkgmodel.Draw(spec, realSource)
 	require.Error(t, err)
-	assert.Empty(t, value)
+	assert.Empty(t, values["value"])
 }
 
 func TestDraw_ByteSourceErrorPropagates(t *testing.T) {
@@ -314,9 +314,9 @@ func TestDraw_ByteSourceErrorPropagates(t *testing.T) {
 	boom := fmt.Errorf("byte source unavailable")
 	failing := func([]byte) (int, error) { return 0, boom }
 
-	value, err := pkgmodel.Draw(spec, failing)
+	values, err := pkgmodel.Draw(spec, failing)
 	require.Error(t, err)
-	assert.Empty(t, value)
+	assert.Empty(t, values["value"])
 	assert.ErrorIs(t, err, boom)
 }
 
@@ -346,9 +346,9 @@ func TestDraw_NeverErrorsForAnySpecPKLAccepts(t *testing.T) {
 				g.Length = 16 // PKL's minimum accepted length
 				g.ExcludeCharacters = ""
 			})
-			value, err := pkgmodel.Draw(spec, realSource)
+			values, err := pkgmodel.Draw(spec, realSource)
 			require.NoErrorf(t, err, "combo %+v requireEachIncludedType=%v", combo, require_)
-			assert.Len(t, value, 16)
+			assert.Len(t, values["value"], 16)
 		}
 	}
 }

--- a/pkg/model/generator_spec.go
+++ b/pkg/model/generator_spec.go
@@ -109,6 +109,15 @@ func GenerationSatisfies(drawn, desired Generator) bool {
 			}
 		}
 		return true
+	case *KeyPairGenerator:
+		w, ok := desired.(*KeyPairGenerator)
+		if !ok {
+			return false
+		}
+		// Bits is the whole spec: a key of the drawn size satisfies exactly
+		// a spec asking for that size. There is no widening relation between
+		// sizes — a 2048-bit key does not satisfy a spec asking for 3072.
+		return d.Bits == w.Bits
 	default:
 		// An unknown arm is never provably satisfied.
 		return false


### PR DESCRIPTION
## Summary

Two changes that only make sense together, per the reviewed design on the tracking issue:

**Multi-output delivery.** The pipeline was single-output end to end: `Draw` returned one string, and propagation fanned it to every bound occurrence by generator KSUID, ignoring `$output`. A second generator kind with two outputs would have handed the same string to a destination bound to `privateKey` and one bound to `publicKey` — wrong key material, no error. Now `Draw` returns named outputs (`map[string]string`), delivery selects per occurrence by `$output` (absent means `value`, the pre-multi-output shape), and an occurrence naming an output the draw did not produce is a hard refusal naming the path and the output. Translation keeps validating `$output` against the union across kinds (it runs before the generator is resolved); the per-kind check lives at delivery, where the draw's actual outputs are in hand.

Two hardening changes ride along, both benefiting the existing password arm:

- **Two-phase propagation**: every destination's rewritten update is computed and validated before any is mutated, so a refusal at one destination leaves its siblings untouched instead of half-delivered in memory.
- **Refusals reach the operator**: a delivery error now travels as the failure reason on the cascaded resources (previously it was logged and the failed resources persisted an empty reason). The reason names the destination and output, never a value.

**The keypair arm.** `KeyPairGenerator` draws one RSA key pair per generation as two named outputs — a PKCS#8 PEM private half and a PKIX PEM public half, the encodings the consuming verifiers parse — so two destinations always hold halves of the same pair. `bits` is 2048/3072/4096, default 2048. Extract renders the arm back to PKL and the emitted forma re-evaluates to the same spec. Spec-satisfaction and update-equality switches gain the arm.

One deviation from the reviewed design, found by test: on current Go, `rsa.GenerateKey` draws from the platform CSPRNG regardless of the reader passed to it (an erroring reader still produced a key), so the arm cannot promise the key is a function of the injected entropy source. What is preserved, via an explicit probe, is that a broken source fails the draw — fault injection keeps working, and no arm silently ignores its entropy argument.

**Forward-only**: a datastore holding a keypair generator cannot be read by a binary predating the kind, and restart recovery redraws rather than replaying values, so no persistence-compatibility shim exists (per the design review, the finished message is process-local and never persisted).

## Verification

- Model: keypair halves parse through the consumer's exact sequence (PKCS#1-then-PKCS#8 for private, PKIX for public), both halves are one pair, unsupported bit sizes are refused, a failing entropy source fails the draw, JSON round-trips with the `keypair` discriminator.
- Delivery: per-output selection to two destinations; a refusal mutates no destination (verified to discriminate: a single-phase implementation fails the test); the refusal reaches `MarkResourcesAsFailed.FailureReason` naming the path, never the value; absent `$output` still delivers `value`.
- Schema: 4 new PKL facts (render shape, sizes, refusal naming the field, distinct $output names); extract round-trip re-evaluates to the same spec, cadence included.
- End to end: a PKL-authored key pair applies through the real changeset executor against the test plugin — each destination receives its half, the halves are verified to be one pair by modulus comparison, at the default size.