### PR TITLE
feat(patch): element-level ownership partition for co-owned collections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -323,3 +323,5 @@ require (
 replace ergo.services/ergo => github.com/JeroenSoeters/ergo v1.999.320-pel.6
 
 replace github.com/apple/pkl-go => github.com/JeroenSoeters/pkl-go v0.12.1-pel.1
+
+replace github.com/platform-engineering-labs/jsonpatch => /home/jeroen/dev/pel/jsonpatch/.worktrees/co-owned

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.6
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.0.0-00010101000000-000000000000
 	github.com/platform-engineering-labs/formae/tests/testcontrol v0.0.0-00010101000000-000000000000
-	github.com/platform-engineering-labs/jsonpatch v0.0.0-20260620044942-701436c7758c
+	github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902033950-0cadda46e953
 	github.com/platform-engineering-labs/oox/provx v0.0.0-20260831005205-99489fc5e7ca // re-pin to a real tag at release time
 	github.com/platform-engineering-labs/orbital v0.2.5
 	github.com/posthog/posthog-go v1.6.3
@@ -323,5 +323,3 @@ require (
 replace ergo.services/ergo => github.com/JeroenSoeters/ergo v1.999.320-pel.6
 
 replace github.com/apple/pkl-go => github.com/JeroenSoeters/pkl-go v0.12.1-pel.1
-
-replace github.com/platform-engineering-labs/jsonpatch => /home/jeroen/dev/pel/jsonpatch/.worktrees/co-owned

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.6
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.0.0-00010101000000-000000000000
 	github.com/platform-engineering-labs/formae/tests/testcontrol v0.0.0-00010101000000-000000000000
-	github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902143404-f2d316239b75
+	github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902161127-c895b20a3c9e
 	github.com/platform-engineering-labs/oox/provx v0.0.0-20260831005205-99489fc5e7ca // re-pin to a real tag at release time
 	github.com/platform-engineering-labs/orbital v0.2.5
 	github.com/posthog/posthog-go v1.6.3

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.6
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.0.0-00010101000000-000000000000
 	github.com/platform-engineering-labs/formae/tests/testcontrol v0.0.0-00010101000000-000000000000
-	github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902033950-0cadda46e953
+	github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902143404-f2d316239b75
 	github.com/platform-engineering-labs/oox/provx v0.0.0-20260831005205-99489fc5e7ca // re-pin to a real tag at release time
 	github.com/platform-engineering-labs/orbital v0.2.5
 	github.com/posthog/posthog-go v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/sftp v1.13.6 h1:JFZT4XbOU7l77xGSpOdW+pwIMqP044IyjXX6FGyEKFo=
 github.com/pkg/sftp v1.13.6/go.mod h1:tz1ryNURKu77RL+GuCzmoJYxQczL3wLNNpPWagdg4Qk=
-github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902033950-0cadda46e953 h1:mMOu7yEpHZ0hV9eF4a2blDFldoYdrStOkwdrgUOxgVc=
-github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902033950-0cadda46e953/go.mod h1:pKZWs1WAxW55mYtE0kAtpvrIMPzaQhZoBWSKqUMndvY=
+github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902143404-f2d316239b75 h1:UTmx1TFbnzx621g1gPrh/lL7XCJdUmC9KZx3083mXIo=
+github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902143404-f2d316239b75/go.mod h1:pKZWs1WAxW55mYtE0kAtpvrIMPzaQhZoBWSKqUMndvY=
 github.com/platform-engineering-labs/oox/gcpname v0.0.0-20260825170105-3bd97cb18d15 h1:GXw4nPEfPsfSZNOla+IFrIb0gfkVUzjFW7lCXWcqRwQ=
 github.com/platform-engineering-labs/oox/gcpname v0.0.0-20260825170105-3bd97cb18d15/go.mod h1:wytVDQEOgo/0PLmMj0nOnisBzzqwemanNy9gpueH9Ik=
 github.com/platform-engineering-labs/oox/provx v0.0.0-20260831005205-99489fc5e7ca h1:ryZD/AytTmkmulsezbuBEH5BbOPpbbPU1cnHUF0OOUY=

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,6 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/sftp v1.13.6 h1:JFZT4XbOU7l77xGSpOdW+pwIMqP044IyjXX6FGyEKFo=
 github.com/pkg/sftp v1.13.6/go.mod h1:tz1ryNURKu77RL+GuCzmoJYxQczL3wLNNpPWagdg4Qk=
-github.com/platform-engineering-labs/jsonpatch v0.0.0-20260620044942-701436c7758c h1:J6V/LUUjSmYuV8A7cISFOqFgADUcvd9/QFkWIeYpyPI=
-github.com/platform-engineering-labs/jsonpatch v0.0.0-20260620044942-701436c7758c/go.mod h1:pKZWs1WAxW55mYtE0kAtpvrIMPzaQhZoBWSKqUMndvY=
 github.com/platform-engineering-labs/oox/gcpname v0.0.0-20260825170105-3bd97cb18d15 h1:GXw4nPEfPsfSZNOla+IFrIb0gfkVUzjFW7lCXWcqRwQ=
 github.com/platform-engineering-labs/oox/gcpname v0.0.0-20260825170105-3bd97cb18d15/go.mod h1:wytVDQEOgo/0PLmMj0nOnisBzzqwemanNy9gpueH9Ik=
 github.com/platform-engineering-labs/oox/provx v0.0.0-20260831005205-99489fc5e7ca h1:ryZD/AytTmkmulsezbuBEH5BbOPpbbPU1cnHUF0OOUY=

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/sftp v1.13.6 h1:JFZT4XbOU7l77xGSpOdW+pwIMqP044IyjXX6FGyEKFo=
 github.com/pkg/sftp v1.13.6/go.mod h1:tz1ryNURKu77RL+GuCzmoJYxQczL3wLNNpPWagdg4Qk=
-github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902143404-f2d316239b75 h1:UTmx1TFbnzx621g1gPrh/lL7XCJdUmC9KZx3083mXIo=
-github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902143404-f2d316239b75/go.mod h1:pKZWs1WAxW55mYtE0kAtpvrIMPzaQhZoBWSKqUMndvY=
+github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902161127-c895b20a3c9e h1:auaxKcvqOLMcmWZyKlKB3wIBrU4bEc/57ClFwIJ68Bo=
+github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902161127-c895b20a3c9e/go.mod h1:pKZWs1WAxW55mYtE0kAtpvrIMPzaQhZoBWSKqUMndvY=
 github.com/platform-engineering-labs/oox/gcpname v0.0.0-20260825170105-3bd97cb18d15 h1:GXw4nPEfPsfSZNOla+IFrIb0gfkVUzjFW7lCXWcqRwQ=
 github.com/platform-engineering-labs/oox/gcpname v0.0.0-20260825170105-3bd97cb18d15/go.mod h1:wytVDQEOgo/0PLmMj0nOnisBzzqwemanNy9gpueH9Ik=
 github.com/platform-engineering-labs/oox/provx v0.0.0-20260831005205-99489fc5e7ca h1:ryZD/AytTmkmulsezbuBEH5BbOPpbbPU1cnHUF0OOUY=

--- a/go.sum
+++ b/go.sum
@@ -477,6 +477,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/sftp v1.13.6 h1:JFZT4XbOU7l77xGSpOdW+pwIMqP044IyjXX6FGyEKFo=
 github.com/pkg/sftp v1.13.6/go.mod h1:tz1ryNURKu77RL+GuCzmoJYxQczL3wLNNpPWagdg4Qk=
+github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902033950-0cadda46e953 h1:mMOu7yEpHZ0hV9eF4a2blDFldoYdrStOkwdrgUOxgVc=
+github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902033950-0cadda46e953/go.mod h1:pKZWs1WAxW55mYtE0kAtpvrIMPzaQhZoBWSKqUMndvY=
 github.com/platform-engineering-labs/oox/gcpname v0.0.0-20260825170105-3bd97cb18d15 h1:GXw4nPEfPsfSZNOla+IFrIb0gfkVUzjFW7lCXWcqRwQ=
 github.com/platform-engineering-labs/oox/gcpname v0.0.0-20260825170105-3bd97cb18d15/go.mod h1:wytVDQEOgo/0PLmMj0nOnisBzzqwemanNy9gpueH9Ik=
 github.com/platform-engineering-labs/oox/provx v0.0.0-20260831005205-99489fc5e7ca h1:ryZD/AytTmkmulsezbuBEH5BbOPpbbPU1cnHUF0OOUY=

--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -1189,6 +1189,40 @@ func (d *DatastoreAuroraDataAPI) GetPropertiesAtLastWrite(ksuid string) (json.Ra
 	return datastore.ComposeWriteWitness(history), nil
 }
 
+// GetOwnedMembers returns the resource's stored ownership record from the
+// latest resource row (see datastore.Datastore.GetOwnedMembers).
+func (d *DatastoreAuroraDataAPI) GetOwnedMembers(ksuid string) (pkgmodel.OwnedMembers, error) {
+	ctx := context.Background()
+
+	query := `
+	SELECT data->>'OwnedMembers'
+	FROM resources
+	WHERE ksuid = :ksuid
+	ORDER BY version COLLATE "C" DESC
+	LIMIT 1
+	`
+	params := []types.SqlParameter{
+		{Name: aws.String("ksuid"), Value: &types.FieldMemberStringValue{Value: ksuid}},
+	}
+
+	output, err := d.executeStatement(ctx, query, params)
+	if err != nil {
+		return nil, err
+	}
+	if len(output.Records) == 0 || len(output.Records[0]) == 0 {
+		return nil, nil
+	}
+	raw, err := getStringField(output.Records[0][0])
+	if err != nil || raw == "" || raw == "null" {
+		return nil, err
+	}
+	var owned pkgmodel.OwnedMembers
+	if err := json.Unmarshal([]byte(raw), &owned); err != nil {
+		return nil, err
+	}
+	return owned, nil
+}
+
 func (d *DatastoreAuroraDataAPI) fetchCurrentProperties(ctx context.Context, ksuid string) (json.RawMessage, error) {
 	query := `
 	SELECT data->>'Properties'

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -306,6 +306,14 @@ type Datastore interface {
 	// discovery never advance it. Returns nil when formae never wrote the
 	// resource.
 	GetPropertiesAtLastWrite(ksuid string) (json.RawMessage, error)
+	// GetOwnedMembers returns the resource's stored ownership record — the
+	// member identities this forma last declared per co-owned collection
+	// field — read from the LATEST resource row (unlike
+	// GetPropertiesAtLastWrite, which composes a write-only witness across
+	// history; this is a plain current-state read, mirroring how
+	// fetchCurrentProperties reads Properties). A resource with no record, or
+	// a JSON null OwnedMembers field, returns (nil, nil).
+	GetOwnedMembers(ksuid string) (pkgmodel.OwnedMembers, error)
 	// QueryFormaCommands searches commands based on filter criteria
 	QueryFormaCommands(query *StatusQuery) ([]*forma_command.FormaCommand, error)
 

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -121,6 +121,7 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunFormaCommandSubjectNullRoundTrip(t, newDS)
 	RunGetPropertiesAtLastWrite(t, newDS)
 	RunGetWriteWitness_UpdateEchoDoesNotLaunderUnwrittenFields(t, newDS)
+	RunGetOwnedMembers(t, newDS)
 	RunStoreFormaCommandSyncSkipsResourceUpdates(t, newDS)
 	RunCommandSourceRoundTrip(t, newDS)
 	RunGetMostRecentFormaCommandByClientID(t, newDS)

--- a/internal/datastore/dstest/suite_get_owned_members.go
+++ b/internal/datastore/dstest/suite_get_owned_members.go
@@ -1,0 +1,89 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package dstest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/types"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// RunGetOwnedMembers verifies GetOwnedMembers reads the ownership record off
+// the LATEST resource row — a plain current-state read, unlike
+// GetPropertiesAtLastWrite's write-only witness: a version stored with no
+// record, and a resource never stored at all, both read back as (nil, nil).
+func RunGetOwnedMembers(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("GetOwnedMembers", func(t *testing.T) {
+		td := newDS(t)
+		ds := td.Datastore
+		defer td.CleanUpFn() //nolint:errcheck
+
+		applyCmd := &forma_command.FormaCommand{
+			ID:      util.NewID(),
+			Command: pkgmodel.CommandApply,
+			Config:  config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile},
+			State:   forma_command.CommandStateSuccess,
+			ResourceUpdates: []resource_update.ResourceUpdate{{
+				Operation: types.OperationCreate,
+				State:     resource_update.ResourceUpdateStateSuccess,
+				DesiredState: pkgmodel.Resource{
+					Ksuid:      util.NewID(),
+					Label:      "owned",
+					Properties: json.RawMessage(`{"labels":{"mine":"1"}}`),
+				},
+			}},
+		}
+		require.NoError(t, ds.StoreFormaCommand(applyCmd, applyCmd.ID))
+
+		ksuid := util.NewID()
+		owned := &pkgmodel.Resource{
+			Ksuid:      ksuid,
+			NativeID:   "native-owned",
+			Stack:      "stack",
+			Type:       "type",
+			Label:      "owned",
+			Target:     "target",
+			Properties: json.RawMessage(`{"labels":{"mine":"1"}}`),
+			Managed:    true,
+			OwnedMembers: pkgmodel.OwnedMembers{
+				"labels": {Rule: "Mapping", Members: []string{"mine"}},
+			},
+		}
+		_, err := ds.StoreResource(owned, applyCmd.ID)
+		require.NoError(t, err)
+
+		record, err := ds.GetOwnedMembers(ksuid)
+		require.NoError(t, err)
+		require.NotNil(t, record)
+		assert.Equal(t, pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"mine"}}}, record)
+
+		// A newer version dropping the record entirely reads back nil: the
+		// latest row is the truth, not the first one written.
+		cleared := *owned
+		cleared.OwnedMembers = nil
+		_, err = ds.StoreResource(&cleared, applyCmd.ID)
+		require.NoError(t, err)
+
+		record, err = ds.GetOwnedMembers(ksuid)
+		require.NoError(t, err)
+		assert.Nil(t, record, "the latest version carries no record")
+
+		// A resource with no stored version at all has no record.
+		record, err = ds.GetOwnedMembers(util.NewID())
+		require.NoError(t, err)
+		assert.Nil(t, record)
+	})
+}

--- a/internal/datastore/helpers.go
+++ b/internal/datastore/helpers.go
@@ -23,6 +23,13 @@ var ErrResourceWriteRejected = errors.New("resource write rejected by reaped/inc
 // ResourcesAreEqual compares two resources and returns two booleans: the first
 // one indicating whether the non-readonly properties of the resources are equal,
 // and the second one indicating whether the readonly properties are equal.
+//
+// OwnedMembers is compared as part of the first boolean: it is declared state
+// alongside Properties, not provider-observed metadata, so a resource whose
+// ownership record alone changed must not be reported identical — a
+// record-only update (see resource_update.ResourceUpdate.RecordOnly) carries
+// byte-identical Properties/ReadOnlyProperties by construction, and this is
+// the only signal that distinguishes it from a genuine no-op write.
 func ResourcesAreEqual(resource1, resource2 *pkgmodel.Resource) (bool, bool) {
 	readWriteEqual, readOnlyEqual := true, true
 
@@ -34,6 +41,10 @@ func ResourcesAreEqual(resource1, resource2 *pkgmodel.Resource) (bool, bool) {
 	}
 
 	if !util.JsonEqualRaw(resource1.Properties, resource2.Properties) {
+		readWriteEqual = false
+	}
+
+	if !pkgmodel.OwnedMembersEqual(resource1.OwnedMembers, resource2.OwnedMembers) {
 		readWriteEqual = false
 	}
 

--- a/internal/datastore/helpers_test.go
+++ b/internal/datastore/helpers_test.go
@@ -1,0 +1,68 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package datastore
+
+import (
+	"encoding/json"
+	"testing"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// A resource whose Properties and ReadOnlyProperties are byte-identical to
+// another's but whose OwnedMembers differs must not compare read-write equal:
+// a record-only update (see resource_update.ResourceUpdate.RecordOnly)
+// carries exactly this shape, and every StoreResource backend's
+// identical-resource short-circuit reads readWriteEqual/readOnlyEqual to
+// decide whether a write is needed at all. Reporting both true here would
+// make ownership-record commits silently vanish at the storage layer.
+func TestResourcesAreEqual_OwnedMembersDifference(t *testing.T) {
+	base := func(owned pkgmodel.OwnedMembers) *pkgmodel.Resource {
+		return &pkgmodel.Resource{
+			NativeID:           "native-1",
+			Stack:              "default",
+			Type:               "FakeAWS::EC2::SecurityGroup",
+			Label:              "sg",
+			Properties:         json.RawMessage(`{"Tags":["a","b"]}`),
+			ReadOnlyProperties: json.RawMessage(`{"Arn":"arn:aws:ec2:sg/test"}`),
+			OwnedMembers:       owned,
+		}
+	}
+
+	before := base(nil)
+	after := base(pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`}}})
+
+	readWriteEqual, readOnlyEqual := ResourcesAreEqual(before, after)
+	assert.False(t, readWriteEqual, "an OwnedMembers change must count as a read-write difference")
+	assert.True(t, readOnlyEqual, "ReadOnlyProperties are unchanged")
+}
+
+// Two resources with no ownership record on either side, and otherwise
+// identical, still compare fully equal — the added OwnedMembers check must
+// not turn nil-vs-nil (or nil-vs-empty) into a spurious difference.
+func TestResourcesAreEqual_NoOwnedMembersOnEitherSide(t *testing.T) {
+	r1 := &pkgmodel.Resource{
+		NativeID:           "native-1",
+		Stack:              "default",
+		Type:               "FakeAWS::EC2::SecurityGroup",
+		Label:              "sg",
+		Properties:         json.RawMessage(`{"Tags":["a","b"]}`),
+		ReadOnlyProperties: json.RawMessage(`{"Arn":"arn:aws:ec2:sg/test"}`),
+	}
+	r2 := &pkgmodel.Resource{
+		NativeID:           "native-1",
+		Stack:              "default",
+		Type:               "FakeAWS::EC2::SecurityGroup",
+		Label:              "sg",
+		Properties:         json.RawMessage(`{"Tags":["a","b"]}`),
+		ReadOnlyProperties: json.RawMessage(`{"Arn":"arn:aws:ec2:sg/test"}`),
+		OwnedMembers:       pkgmodel.OwnedMembers{},
+	}
+
+	readWriteEqual, readOnlyEqual := ResourcesAreEqual(r1, r2)
+	assert.True(t, readWriteEqual)
+	assert.True(t, readOnlyEqual)
+}

--- a/internal/datastore/mock_datastore_test.go
+++ b/internal/datastore/mock_datastore_test.go
@@ -43,6 +43,9 @@ func (m *mockDatastore) GetMostRecentFormaCommandByClientID(_ string) (*forma_co
 func (m *mockDatastore) GetPropertiesAtLastWrite(_ string) (json.RawMessage, error) {
 	return nil, nil
 }
+func (m *mockDatastore) GetOwnedMembers(_ string) (pkgmodel.OwnedMembers, error) {
+	return nil, nil
+}
 
 func (m *mockDatastore) GetResourceModificationsSinceLastReconcile(_ string) ([]ResourceModification, error) {
 	return nil, nil

--- a/internal/datastore/mssql/mssql_datastore.go
+++ b/internal/datastore/mssql/mssql_datastore.go
@@ -762,6 +762,35 @@ ORDER BY r.version %s DESC`, binColl)
 	return datastore.ComposeWriteWitness(history), nil
 }
 
+// GetOwnedMembers returns the resource's stored ownership record from the
+// latest resource row (see datastore.Datastore.GetOwnedMembers).
+func (d *DatastoreMSSQL) GetOwnedMembers(ksuid string) (pkgmodel.OwnedMembers, error) {
+	ctx, span := mssqlTracer.Start(context.Background(), "GetOwnedMembers")
+	defer span.End()
+
+	query := fmt.Sprintf(`
+SELECT TOP (1) JSON_QUERY(data, '$.OwnedMembers')
+FROM resources
+WHERE ksuid = @p1
+ORDER BY version %s DESC`, binColl)
+
+	var raw sql.NullString
+	if err := d.conn.QueryRowContext(ctx, query, ksuid).Scan(&raw); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !raw.Valid || raw.String == "" || raw.String == "null" {
+		return nil, nil
+	}
+	var owned pkgmodel.OwnedMembers
+	if err := json.Unmarshal([]byte(raw.String), &owned); err != nil {
+		return nil, err
+	}
+	return owned, nil
+}
+
 func (d *DatastoreMSSQL) fetchCurrentProperties(ctx context.Context, ksuid string) (json.RawMessage, error) {
 	query := fmt.Sprintf(`
 SELECT TOP (1) JSON_QUERY(data, '$.Properties')

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -1166,6 +1166,36 @@ LIMIT 25
 	return datastore.ComposeWriteWitness(history), nil
 }
 
+// GetOwnedMembers returns the resource's stored ownership record from the
+// latest resource row (see datastore.Datastore.GetOwnedMembers).
+func (d DatastorePostgres) GetOwnedMembers(ksuid string) (pkgmodel.OwnedMembers, error) {
+	ctx, span := tracer.Start(context.Background(), "GetOwnedMembers")
+	defer span.End()
+
+	query := `
+SELECT data->>'OwnedMembers'
+FROM resources
+WHERE ksuid = $1
+ORDER BY version COLLATE "C" DESC
+LIMIT 1
+`
+	var raw *string
+	if err := d.pool.QueryRow(ctx, query, ksuid).Scan(&raw); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if raw == nil || *raw == "" || *raw == "null" {
+		return nil, nil
+	}
+	var owned pkgmodel.OwnedMembers
+	if err := json.Unmarshal([]byte(*raw), &owned); err != nil {
+		return nil, err
+	}
+	return owned, nil
+}
+
 func (d DatastorePostgres) fetchCurrentPropertiesPG(ctx context.Context, ksuid string) (json.RawMessage, error) {
 	query := `
 SELECT data->>'Properties'

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -746,6 +746,36 @@ LIMIT 25
 	return datastore.ComposeWriteWitness(history), nil
 }
 
+// GetOwnedMembers returns the resource's stored ownership record from the
+// latest resource row (see datastore.Datastore.GetOwnedMembers).
+func (d DatastoreSQLite) GetOwnedMembers(ksuid string) (pkgmodel.OwnedMembers, error) {
+	_, span := sqliteTracer.Start(context.Background(), "GetOwnedMembers")
+	defer span.End()
+
+	query := `
+SELECT json_extract(data, '$.OwnedMembers')
+FROM resources
+WHERE ksuid = ?
+ORDER BY version DESC
+LIMIT 1
+`
+	var raw sql.NullString
+	if err := d.conn.QueryRow(query, ksuid).Scan(&raw); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !raw.Valid || raw.String == "" || raw.String == "null" {
+		return nil, nil
+	}
+	var owned pkgmodel.OwnedMembers
+	if err := json.Unmarshal([]byte(raw.String), &owned); err != nil {
+		return nil, err
+	}
+	return owned, nil
+}
+
 // fetchCurrentProperties returns the Properties JSON from the latest resource version for the given ksuid.
 func (d DatastoreSQLite) fetchCurrentProperties(ksuid string) (json.RawMessage, error) {
 	query := `

--- a/internal/metastructure/drift/confrontable.go
+++ b/internal/metastructure/drift/confrontable.go
@@ -1,0 +1,61 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package drift
+
+import (
+	"log/slog"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/patch"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// RetainConfrontable drops from an unabsorbed set the modifications whose
+// out-of-band movement a reconcile need not confront: those on a resource the
+// forma declares whose movement is confined to a co-owned collection's
+// never-owned members (a co-actor's content). It exists because the earlier
+// gate rejected any modified resource the forma also plans to change, which
+// meant a single co-actor-injected label made every edit of that resource
+// fail — the churn the ownership partition is meant to end.
+//
+// A modification is kept (still confrontable) when it has no matching forma
+// declaration (an orphan, which cannot be classified), or when
+// patch.ModificationConfrontable finds real drift: a plain-field change, a
+// witnessed provider-default move, or a declared/formerly-owned co-owned
+// member move. Classification errs toward keeping: a resource whose
+// modification cannot be read is left in the set.
+func RetainConfrontable(unabsorbed []datastore.ResourceModification, recordByKsuid map[string]pkgmodel.OwnedMembers, forma *pkgmodel.Forma) []datastore.ResourceModification {
+	kept := make([]datastore.ResourceModification, 0, len(unabsorbed))
+	for _, mod := range unabsorbed {
+		if !modificationTolerated(mod, recordByKsuid, forma) {
+			kept = append(kept, mod)
+		}
+	}
+	return kept
+}
+
+// modificationTolerated reports whether a modification is safe to drop from
+// the unabsorbed set. It is true only for an update on a declared resource
+// whose movement patch.ModificationConfrontable classifies as non-confrontable.
+// Every uncertain case (a non-update op, missing properties, no declaration,
+// a classification error) returns false so the modification is kept.
+func modificationTolerated(mod datastore.ResourceModification, recordByKsuid map[string]pkgmodel.OwnedMembers, forma *pkgmodel.Forma) bool {
+	if mod.Operation != "update" || len(mod.OldProperties) == 0 || len(mod.Properties) == 0 {
+		return false
+	}
+	decl := findDeclarationForModification(forma, mod)
+	if decl == nil {
+		return false
+	}
+	confrontable, err := patch.ModificationConfrontable(
+		mod.OldProperties, mod.Properties, decl.Properties,
+		recordByKsuid[mod.Ksuid], decl.Schema)
+	if err != nil {
+		slog.Warn("Failed to classify modification for confrontation; keeping it as drift",
+			"stack", mod.Stack, "type", mod.Type, "label", mod.Label, "error", err)
+		return false
+	}
+	return !confrontable
+}

--- a/internal/metastructure/drift/confrontable_test.go
+++ b/internal/metastructure/drift/confrontable_test.go
@@ -1,0 +1,97 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package drift
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func coOwnedNsSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"Name", "labels"},
+		Hints:  map[string]pkgmodel.FieldHint{"labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+}
+
+// A modification whose only movement is a co-actor's never-owned member is
+// dropped from the unabsorbed set, so a reconcile that also edits the
+// resource (its edit lives in the plan, not here) is not rejected.
+func TestRetainConfrontable_DropsToleratedCoOwnedMovement(t *testing.T) {
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "s", Type: "K8S::Core::Namespace", Label: "ns",
+		Properties: json.RawMessage(`{"Name":"n","labels":{"app":"web","version":"2"}}`),
+		Schema:     coOwnedNsSchema(),
+	}}}
+	mod := datastore.ResourceModification{
+		Stack: "s", Type: "K8S::Core::Namespace", Label: "ns", Operation: "update", Ksuid: "k1",
+		OldProperties: json.RawMessage(`{"Name":"n","labels":{"app":"web"}}`),
+		Properties:    json.RawMessage(`{"Name":"n","labels":{"app":"web","team":"platform"}}`),
+	}
+	records := map[string]pkgmodel.OwnedMembers{"k1": {"labels": {Rule: "Mapping", Members: []string{"app"}}}}
+
+	got := RetainConfrontable([]datastore.ResourceModification{mod}, records, forma)
+	assert.Empty(t, got, "tolerated co-owned movement must not survive as unabsorbed drift")
+}
+
+// A modification with a declared member's out-of-band change stays: real
+// drift on managed content still rejects.
+func TestRetainConfrontable_KeepsDeclaredMemberDrift(t *testing.T) {
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "s", Type: "K8S::Core::Namespace", Label: "ns",
+		Properties: json.RawMessage(`{"Name":"n","labels":{"app":"web"}}`),
+		Schema:     coOwnedNsSchema(),
+	}}}
+	mod := datastore.ResourceModification{
+		Stack: "s", Type: "K8S::Core::Namespace", Label: "ns", Operation: "update", Ksuid: "k1",
+		OldProperties: json.RawMessage(`{"Name":"n","labels":{"app":"web"}}`),
+		Properties:    json.RawMessage(`{"Name":"n","labels":{"app":"hacked"}}`),
+	}
+	records := map[string]pkgmodel.OwnedMembers{"k1": {"labels": {Rule: "Mapping", Members: []string{"app"}}}}
+
+	got := RetainConfrontable([]datastore.ResourceModification{mod}, records, forma)
+	assert.Len(t, got, 1, "a declared member's drift must remain confrontable")
+}
+
+// A modification on a resource not in the forma (an orphan) cannot be
+// classified against a declaration and is kept — the conservative default.
+func TestRetainConfrontable_KeepsNotInFormaModification(t *testing.T) {
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "s", Type: "K8S::Core::Namespace", Label: "other", Schema: coOwnedNsSchema(),
+	}}}
+	mod := datastore.ResourceModification{
+		Stack: "s", Type: "K8S::Core::Namespace", Label: "orphan", Operation: "update", Ksuid: "k1",
+		OldProperties: json.RawMessage(`{"Name":"n","labels":{"app":"web"}}`),
+		Properties:    json.RawMessage(`{"Name":"n","labels":{"app":"web","team":"x"}}`),
+	}
+	records := map[string]pkgmodel.OwnedMembers{"k1": {"labels": {Rule: "Mapping", Members: []string{"app"}}}}
+
+	got := RetainConfrontable([]datastore.ResourceModification{mod}, records, forma)
+	assert.Len(t, got, 1, "a modification with no matching declaration is kept")
+}
+
+// A witnessed provider-default move on a resource in the forma stays
+// confrontable even though nothing co-owned moved.
+func TestRetainConfrontable_KeepsWitnessedProviderDefaultMove(t *testing.T) {
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "s", Type: "AWS::KMS::Key", Label: "key",
+		Properties: json.RawMessage(`{"Name":"n"}`),
+		Schema:     kmsSchemaForDrift(),
+	}}}
+	mod := datastore.ResourceModification{
+		Stack: "s", Type: "AWS::KMS::Key", Label: "key", Operation: "update", Ksuid: "k1",
+		OldProperties: json.RawMessage(`{"Name":"n","EnableKeyRotation":false}`),
+		Properties:    json.RawMessage(`{"Name":"n","EnableKeyRotation":true}`),
+	}
+	got := RetainConfrontable([]datastore.ResourceModification{mod}, nil, forma)
+	assert.Len(t, got, 1, "a provider-default move on a declared resource stays confrontable")
+}

--- a/internal/metastructure/drift/modifications.go
+++ b/internal/metastructure/drift/modifications.go
@@ -31,11 +31,13 @@ import (
 
 // loadModificationsAndWitnesses loads one stack's drift window into the
 // submission snapshot, plus the write witness for each modified resource
-// (GetPropertiesAtLastWrite: the state formae's own last write observed).
-// Window load failures fail the submission; a witness fetch failure degrades
-// to no witness for that resource, which classifies its movement as
-// tolerated, the pre-existing behavior.
-func LoadModificationsAndWitnesses(ds datastore.Datastore, stackLabel string, modificationsByStack map[string][]datastore.ResourceModification, witnessByKsuid map[string]json.RawMessage) error {
+// (GetPropertiesAtLastWrite: the state formae's own last write observed) and
+// its stored ownership record (GetOwnedMembers: the co-owned regime's prior
+// declaration, read from the latest resource row). Window load failures fail
+// the submission; a witness or record fetch failure degrades to no witness /
+// no record for that resource, which classifies its movement as tolerated
+// (witness) or everything-undeclared (record), the pre-existing behavior.
+func LoadModificationsAndWitnesses(ds datastore.Datastore, stackLabel string, modificationsByStack map[string][]datastore.ResourceModification, witnessByKsuid map[string]json.RawMessage, recordByKsuid map[string]pkgmodel.OwnedMembers) error {
 	modifications, err := ds.GetResourceModificationsSinceLastReconcile(stackLabel)
 	if err != nil {
 		slog.Error("Failed to load modifications since last reconcile", "stack", stackLabel, "error", err)
@@ -49,15 +51,22 @@ func LoadModificationsAndWitnesses(ds datastore.Datastore, stackLabel string, mo
 		if mod.Operation != "update" || mod.Ksuid == "" {
 			continue
 		}
-		if _, done := witnessByKsuid[mod.Ksuid]; done {
-			continue
+		if _, done := witnessByKsuid[mod.Ksuid]; !done {
+			witness, werr := ds.GetPropertiesAtLastWrite(mod.Ksuid)
+			if werr != nil {
+				slog.Warn("Failed to load write witness for drift classification", "ksuid", mod.Ksuid, "error", werr)
+			} else {
+				witnessByKsuid[mod.Ksuid] = witness
+			}
 		}
-		witness, werr := ds.GetPropertiesAtLastWrite(mod.Ksuid)
-		if werr != nil {
-			slog.Warn("Failed to load write witness for drift classification", "ksuid", mod.Ksuid, "error", werr)
-			continue
+		if _, done := recordByKsuid[mod.Ksuid]; !done {
+			record, rerr := ds.GetOwnedMembers(mod.Ksuid)
+			if rerr != nil {
+				slog.Warn("Failed to load ownership record for drift classification", "ksuid", mod.Ksuid, "error", rerr)
+				continue
+			}
+			recordByKsuid[mod.Ksuid] = record
 		}
-		witnessByKsuid[mod.Ksuid] = witness
 	}
 	return nil
 }

--- a/internal/metastructure/drift/modifications.go
+++ b/internal/metastructure/drift/modifications.go
@@ -134,7 +134,10 @@ func FilterUnabsorbedModifications(
 		// state has already absorbed (e.g. a synced secret rotation reaching
 		// its consumer). It asserts no state differing from the current one,
 		// so it must not block absorbing the modification it follows from.
-		if ru.ConvergenceOnly() {
+		// A record-only update is the same shape for the ownership record:
+		// it commits a claim over current state (empty patch, current
+		// properties) — the absorb path itself — and asserts no change.
+		if ru.ConvergenceOnly() || ru.RecordOnly {
 			continue
 		}
 		resourcesWithUpdates[resourceKey{

--- a/internal/metastructure/drift/modifications_test.go
+++ b/internal/metastructure/drift/modifications_test.go
@@ -79,6 +79,34 @@ func TestFilterUnabsorbedModifications_ModificationWithPendingUpdateIsUnabsorbed
 	assert.Len(t, got, 1, "a modification with a pending update is not absorbed")
 }
 
+func TestFilterUnabsorbedModifications_RecordOnlyUpdateAbsorbs(t *testing.T) {
+	// A record-only update commits an ownership claim without asserting any
+	// state differing from the current one (empty patch, current
+	// properties): the ordinary path an absorb apply takes. It must not
+	// count as a pending change, or absorbing an out-of-band member would
+	// be rejected by the very gate the absorb exists to satisfy.
+	mods := []datastore.ResourceModification{
+		{Stack: "prod", Type: "AWS::EC2::Instance", Label: "app-server", Operation: "update"},
+	}
+	forma := &pkgmodel.Forma{
+		Resources: []pkgmodel.Resource{
+			{Stack: "prod", Type: "AWS::EC2::Instance", Label: "app-server"},
+		},
+	}
+	fa := &forma_command.FormaCommand{
+		ResourceUpdates: []resource_update.ResourceUpdate{
+			{
+				StackLabel:   "prod",
+				RecordOnly:   true,
+				DesiredState: pkgmodel.Resource{Type: "AWS::EC2::Instance", Label: "app-server"},
+			},
+		},
+	}
+
+	got := FilterUnabsorbedModifications(mods, forma, fa)
+	assert.Empty(t, got, "a record-only update asserts no state change; the modification is absorbed")
+}
+
 // Cross-type guard: same label on a different type is NOT absorbed by an
 // unrelated alias hit.
 func TestFilterUnabsorbedModifications_AliasMatchRequiresTypeMatch(t *testing.T) {

--- a/internal/metastructure/drift/witnessed.go
+++ b/internal/metastructure/drift/witnessed.go
@@ -16,15 +16,19 @@ import (
 
 // WitnessedMovedModifications returns the modifications whose out-of-band
 // movement sits on provider-default content formae's own last write
-// witnessed. Such movement is drift, exactly like drift on a declared
-// field: the caller adds these to the unabsorbed set so a soft reconcile
-// rejects showing them, and a forced reconcile reverts them via the witness
-// assertion. Candidates are the modifications FilterUnabsorbedModifications
-// absorbs (the unabsorbed ones already reject); a candidate that cannot be
-// classified (a non-update operation, a missing property blob, no matching
-// forma declaration, no write witness, or a diff error) is left absorbed,
-// which is the pre-existing tolerant behavior.
-func WitnessedMovedModifications(modifications []datastore.ResourceModification, witnessByKsuid map[string]json.RawMessage, forma *pkgmodel.Forma, fa *forma_command.FormaCommand) []datastore.ResourceModification {
+// witnessed, OR on a co-owned collection's never-owned members. Such
+// movement is drift, exactly like drift on a declared field: the caller adds
+// these to the unabsorbed set so a soft reconcile rejects showing them, and a
+// forced reconcile reverts them via the witness assertion. Candidates are
+// the modifications FilterUnabsorbedModifications absorbs (the unabsorbed
+// ones already reject); a candidate that cannot be classified (a non-update
+// operation, a missing property blob, no matching forma declaration, no
+// write witness, or a diff error) is left absorbed, which is the
+// pre-existing tolerant behavior. records, keyed by resource KSUID exactly
+// parallel to witnessByKsuid, carries each resource's stored ownership
+// record; a missing entry passes nil (witness semantics for a non-co-owned
+// path; everything-undeclared for a co-owned path).
+func WitnessedMovedModifications(modifications []datastore.ResourceModification, witnessByKsuid map[string]json.RawMessage, records map[string]pkgmodel.OwnedMembers, forma *pkgmodel.Forma, fa *forma_command.FormaCommand) []datastore.ResourceModification {
 	type modKey struct {
 		stack, typeName, label, operation string
 	}
@@ -45,11 +49,15 @@ func WitnessedMovedModifications(modifications []datastore.ResourceModification,
 		if decl == nil {
 			continue
 		}
+		// No early witness-nil exit here: a co-owned path's movement is
+		// classified by ownership partition, not by the write witness, so a
+		// resource formae never wrote (no witness) can still owe a note for
+		// its never-owned members. SuppressedFieldDiffs itself keeps every
+		// non-co-owned path gated on the witness, so this costs nothing for
+		// the witness-only case — a nil witness there still yields no diffs.
 		witness := witnessByKsuid[mod.Ksuid]
-		if witness == nil {
-			continue
-		}
-		diffs, err := patch.SuppressedFieldDiffs(mod.OldProperties, mod.Properties, decl.Properties, witness, decl.Schema)
+		priorOwned := records[mod.Ksuid]
+		diffs, err := patch.SuppressedFieldDiffs(mod.OldProperties, mod.Properties, decl.Properties, witness, priorOwned, decl.Schema)
 		if err != nil {
 			slog.Warn("Failed to classify witnessed drift for resource; treating as absorbed",
 				"stack", mod.Stack, "type", mod.Type, "label", mod.Label, "error", err)

--- a/internal/metastructure/drift/witnessed.go
+++ b/internal/metastructure/drift/witnessed.go
@@ -16,18 +16,21 @@ import (
 
 // WitnessedMovedModifications returns the modifications whose out-of-band
 // movement sits on provider-default content formae's own last write
-// witnessed, OR on a co-owned collection's never-owned members. Such
-// movement is drift, exactly like drift on a declared field: the caller adds
-// these to the unabsorbed set so a soft reconcile rejects showing them, and a
-// forced reconcile reverts them via the witness assertion. Candidates are
-// the modifications FilterUnabsorbedModifications absorbs (the unabsorbed
-// ones already reject); a candidate that cannot be classified (a non-update
-// operation, a missing property blob, no matching forma declaration, no
-// write witness, or a diff error) is left absorbed, which is the
-// pre-existing tolerant behavior. records, keyed by resource KSUID exactly
-// parallel to witnessByKsuid, carries each resource's stored ownership
-// record; a missing entry passes nil (witness semantics for a non-co-owned
-// path; everything-undeclared for a co-owned path).
+// witnessed. Such movement is drift, exactly like drift on a declared field:
+// the caller adds these to the unabsorbed set so a soft reconcile rejects
+// showing them, and a forced reconcile reverts them via the witness
+// assertion. Movement on a co-owned collection's never-owned members is the
+// one classified kind that never counts: it is tolerated by design (the
+// partition's decided trade), so its notes are display material, never a
+// reason to reject — a resource whose only movement is a co-actor's stays
+// absorbed. Candidates are the modifications FilterUnabsorbedModifications
+// absorbs (the unabsorbed ones already reject); a candidate that cannot be
+// classified (a non-update operation, a missing property blob, no matching
+// forma declaration, no write witness, or a diff error) is left absorbed,
+// which is the pre-existing tolerant behavior. records, keyed by resource
+// KSUID exactly parallel to witnessByKsuid, carries each resource's stored
+// ownership record; a missing entry passes nil (witness semantics for a
+// non-co-owned path; everything-undeclared for a co-owned path).
 func WitnessedMovedModifications(modifications []datastore.ResourceModification, witnessByKsuid map[string]json.RawMessage, records map[string]pkgmodel.OwnedMembers, forma *pkgmodel.Forma, fa *forma_command.FormaCommand) []datastore.ResourceModification {
 	type modKey struct {
 		stack, typeName, label, operation string
@@ -49,12 +52,6 @@ func WitnessedMovedModifications(modifications []datastore.ResourceModification,
 		if decl == nil {
 			continue
 		}
-		// No early witness-nil exit here: a co-owned path's movement is
-		// classified by ownership partition, not by the write witness, so a
-		// resource formae never wrote (no witness) can still owe a note for
-		// its never-owned members. SuppressedFieldDiffs itself keeps every
-		// non-co-owned path gated on the witness, so this costs nothing for
-		// the witness-only case — a nil witness there still yields no diffs.
 		witness := witnessByKsuid[mod.Ksuid]
 		priorOwned := records[mod.Ksuid]
 		diffs, err := patch.SuppressedFieldDiffs(mod.OldProperties, mod.Properties, decl.Properties, witness, priorOwned, decl.Schema)
@@ -63,8 +60,13 @@ func WitnessedMovedModifications(modifications []datastore.ResourceModification,
 				"stack", mod.Stack, "type", mod.Type, "label", mod.Label, "error", err)
 			continue
 		}
-		if len(diffs) > 0 {
-			moved = append(moved, mod)
+		for _, diff := range diffs {
+			// A co-owned note is tolerated movement (a co-actor's members);
+			// only witness-regime notes make a modification reject.
+			if !diff.CoOwned {
+				moved = append(moved, mod)
+				break
+			}
 		}
 	}
 	return moved

--- a/internal/metastructure/drift/witnessed_test.go
+++ b/internal/metastructure/drift/witnessed_test.go
@@ -52,7 +52,7 @@ func TestWitnessedMovedModifications_WitnessedMovement_IsDrift(t *testing.T) {
 		Schema:     kmsSchemaForDrift(),
 	}}}
 
-	moved := WitnessedMovedModifications(mods["prod"], driftWitnesses(mods), forma, &forma_command.FormaCommand{})
+	moved := WitnessedMovedModifications(mods["prod"], driftWitnesses(mods), nil, forma, &forma_command.FormaCommand{})
 	require.Len(t, moved, 1)
 	assert.Equal(t, "signing-key", moved[0].Label)
 }
@@ -71,7 +71,7 @@ func TestWitnessedMovedModifications_NoWitness_Tolerated(t *testing.T) {
 		Schema:     kmsSchemaForDrift(),
 	}}}
 
-	moved := WitnessedMovedModifications(mods["prod"], map[string]json.RawMessage{}, forma, &forma_command.FormaCommand{})
+	moved := WitnessedMovedModifications(mods["prod"], map[string]json.RawMessage{}, nil, forma, &forma_command.FormaCommand{})
 	assert.Empty(t, moved, "no write witness means the movement is the infrastructure's business")
 }
 
@@ -89,7 +89,7 @@ func TestWitnessedMovedModifications_AlreadyUnabsorbed_NotDoubled(t *testing.T) 
 		Stack: "prod", Type: "AWS::KMS::Key", Label: "signing-key", Schema: kmsSchemaForDrift(),
 	}}}
 
-	moved := WitnessedMovedModifications(mods["prod"], driftWitnesses(mods), forma, &forma_command.FormaCommand{})
+	moved := WitnessedMovedModifications(mods["prod"], driftWitnesses(mods), nil, forma, &forma_command.FormaCommand{})
 	assert.Empty(t, moved)
 }
 
@@ -112,8 +112,39 @@ func TestWitnessedMovedModifications_PendingUpdate_LeftToLegacyFilter(t *testing
 		DesiredState: pkgmodel.Resource{Type: "AWS::KMS::Key", Label: "signing-key"},
 	}}}
 
-	moved := WitnessedMovedModifications(mods["prod"], driftWitnesses(mods), forma, fa)
+	moved := WitnessedMovedModifications(mods["prod"], driftWitnesses(mods), nil, forma, fa)
 	assert.Empty(t, moved, "a resource with a pending update is already unabsorbed; the legacy filter owns it")
+}
+
+func coOwnedLabelsSchemaForDrift() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"Name", "labels"},
+		Hints:  map[string]pkgmodel.FieldHint{"labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+}
+
+func TestWitnessedMovedModifications_CoOwnedNeverOwnedMovement_IsDriftWithoutWitness(t *testing.T) {
+	// The co-owned regime classifies by ownership partition, not by write
+	// witness: a resource with no witness at all still owes a note for a
+	// never-owned member's movement.
+	mods := map[string][]datastore.ResourceModification{
+		"prod": {{
+			Stack: "prod", Type: "AWS::Example::Thing", Label: "shared", Operation: "update", Ksuid: "k1",
+			OldProperties: json.RawMessage(`{"Name": "n", "labels": {"mine": "1", "theirs": "a"}}`),
+			Properties:    json.RawMessage(`{"Name": "n", "labels": {"mine": "1", "theirs": "b"}}`),
+		}},
+	}
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "prod", Type: "AWS::Example::Thing", Label: "shared",
+		Properties: json.RawMessage(`{"Name": "n", "labels": {"mine": "1"}}`),
+		Schema:     coOwnedLabelsSchemaForDrift(),
+	}}}
+	records := map[string]pkgmodel.OwnedMembers{
+		"k1": {"labels": {Rule: "Mapping", Members: []string{"mine"}}},
+	}
+
+	moved := WitnessedMovedModifications(mods["prod"], map[string]json.RawMessage{}, records, forma, &forma_command.FormaCommand{})
+	require.Len(t, moved, 1)
 }
 
 func TestAssertWitnessesIntoForma_AssertsOnlyMatchedResources_AndCopies(t *testing.T) {

--- a/internal/metastructure/drift/witnessed_test.go
+++ b/internal/metastructure/drift/witnessed_test.go
@@ -123,10 +123,10 @@ func coOwnedLabelsSchemaForDrift() pkgmodel.Schema {
 	}
 }
 
-func TestWitnessedMovedModifications_CoOwnedNeverOwnedMovement_IsDriftWithoutWitness(t *testing.T) {
-	// The co-owned regime classifies by ownership partition, not by write
-	// witness: a resource with no witness at all still owes a note for a
-	// never-owned member's movement.
+func TestWitnessedMovedModifications_CoOwnedNeverOwnedMovement_Tolerated(t *testing.T) {
+	// Movement on a co-owned collection's never-owned members is a
+	// co-actor's business: it never makes a modification reject, so a
+	// reconcile-mode apply of the unchanged forma passes the gate.
 	mods := map[string][]datastore.ResourceModification{
 		"prod": {{
 			Stack: "prod", Type: "AWS::Example::Thing", Label: "shared", Operation: "update", Ksuid: "k1",
@@ -144,6 +144,40 @@ func TestWitnessedMovedModifications_CoOwnedNeverOwnedMovement_IsDriftWithoutWit
 	}
 
 	moved := WitnessedMovedModifications(mods["prod"], map[string]json.RawMessage{}, records, forma, &forma_command.FormaCommand{})
+	assert.Empty(t, moved, "a co-actor's member movement is tolerated, never confronted")
+
+	moved = WitnessedMovedModifications(mods["prod"], driftWitnesses(mods), records, forma, &forma_command.FormaCommand{})
+	assert.Empty(t, moved, "the write witness does not change the co-owned regime's answer")
+}
+
+func TestWitnessedMovedModifications_WitnessedMovementBesideCoOwned_StillRejects(t *testing.T) {
+	// A resource can move in both regimes at once; the witnessed
+	// provider-default movement keeps rejecting even though the co-owned
+	// movement beside it is tolerated.
+	mods := map[string][]datastore.ResourceModification{
+		"prod": {{
+			Stack: "prod", Type: "AWS::Example::Thing", Label: "shared", Operation: "update", Ksuid: "k1",
+			OldProperties: json.RawMessage(`{"Name": "n", "Setting": "a", "labels": {"mine": "1", "theirs": "a"}}`),
+			Properties:    json.RawMessage(`{"Name": "n", "Setting": "b", "labels": {"mine": "1", "theirs": "b"}}`),
+		}},
+	}
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Setting", "labels"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Setting": {HasProviderDefault: true},
+			"labels":  {CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "prod", Type: "AWS::Example::Thing", Label: "shared",
+		Properties: json.RawMessage(`{"Name": "n", "labels": {"mine": "1"}}`),
+		Schema:     schema,
+	}}}
+	records := map[string]pkgmodel.OwnedMembers{
+		"k1": {"labels": {Rule: "Mapping", Members: []string{"mine"}}},
+	}
+
+	moved := WitnessedMovedModifications(mods["prod"], driftWitnesses(mods), records, forma, &forma_command.FormaCommand{})
 	require.Len(t, moved, 1)
 }
 

--- a/internal/metastructure/extract_resources.go
+++ b/internal/metastructure/extract_resources.go
@@ -390,6 +390,18 @@ func coOwnedKeepFunc(fieldPath string, hint pkgmodel.FieldHint, owned pkgmodel.O
 	}
 
 	return func(identity string) bool {
+		// Member identities are pkgmodel.MemberIdentities' canonical form: a
+		// Mapping key verbatim, but an EntitySet/Set element's json-marshaled
+		// value — quoted for a string. A SystemPatterns author writes a plain
+		// glob ("aws:*") without knowing which shape they're matching against,
+		// so a JSON-string identity is unquoted before matching: it and only
+		// it can carry a leading/trailing '"' as an artifact of marshaling
+		// rather than as data. Any other JSON shape (object, array, number,
+		// bool, or a Mapping key) matches in its literal form, unchanged. This
+		// is purely a glob-matching convenience — record.Members comparison
+		// above stays on the marshaled encoding on both sides, so it never
+		// needs unquoting to agree with itself.
+		target := unquoteJSONStringIdentity(identity)
 		for _, pattern := range patterns {
 			// path.Match's glob semantics: "*" matches any sequence of
 			// non-separator ('/') characters, "?" matches any single
@@ -398,12 +410,29 @@ func coOwnedKeepFunc(fieldPath string, hint pkgmodel.FieldHint, owned pkgmodel.O
 			// ever exercised as a plain substring-style wildcard — "aws:*"
 			// matches "aws:cloudformation:stack" but "/" in an identity would
 			// not cross a "*" the way it might look like it should.
-			if matched, _ := path.Match(pattern, identity); matched {
+			if matched, _ := path.Match(pattern, target); matched {
 				return false
 			}
 		}
 		return true
 	}, true
+}
+
+// unquoteJSONStringIdentity undoes JSON string quoting on identity if, and
+// only if, identity is itself a JSON string literal (starts and ends with an
+// unescaped '"'). Any other shape — including a Mapping key, which was never
+// JSON-marshaled to begin with — is returned unchanged. Malformed input
+// (identity looks quoted but isn't valid JSON) is also returned unchanged
+// rather than erroring: this only ever feeds a best-effort glob match.
+func unquoteJSONStringIdentity(identity string) string {
+	if len(identity) < 2 || identity[0] != '"' || identity[len(identity)-1] != '"' {
+		return identity
+	}
+	var s string
+	if err := json.Unmarshal([]byte(identity), &s); err != nil {
+		return identity
+	}
+	return s
 }
 
 // filterObjectMembers drops every key of the object at fieldPath in doc for

--- a/internal/metastructure/extract_resources.go
+++ b/internal/metastructure/extract_resources.go
@@ -280,11 +280,13 @@ func (m *Metastructure) ExtractStacks() ([]*pkgmodel.Stack, error) {
 // res arrives as a shallow copy already (FormaFromResources built it by
 // dereferencing the datastore's *Resource), which means its Properties field
 // is still a slice header pointing at the very same backing array the stored
-// resource uses. sjson's Set/Delete calls can grow or shrink a []byte in
-// place when there is spare capacity, so operating on that shared array
-// could corrupt state a concurrent reader — or the datastore's own cache —
-// still holds. Cloning the byte slice here, before any filtering touches it,
-// guarantees the backing array is exclusively res's own.
+// resource uses. append(json.RawMessage(nil), res.Properties...) below always
+// allocates a fresh backing array — append onto a nil slice can never reuse
+// the source's capacity — so res.Properties is exclusively this clone's own
+// before any filtering call touches it. That makes safety here structural,
+// not a bet on how sjson's Set/Delete happen to manage capacity internally:
+// whatever they do, it lands on a backing array the stored resource never
+// had a slice header pointing at.
 func filterCoOwnedResource(res pkgmodel.Resource) pkgmodel.Resource {
 	res.Properties = append(json.RawMessage(nil), res.Properties...)
 
@@ -512,7 +514,16 @@ func singleMemberIdentity(el gjson.Result, hint pkgmodel.FieldHint) (string, boo
 // escapeGjsonPathKey escapes the gjson/sjson path metacharacters a map key
 // might contain, so a key like "a.b" addresses itself as one literal key
 // rather than being read as nested path syntax.
-const gjsonPathSpecialChars = `\.*?#@`
+//
+// The set is: '\' and '.', which sjson's path parser always treats specially
+// (escape-mode trigger and path-segment separator, handled before any
+// per-character check runs — see parsePath in sjson.go), plus every
+// character sjson's own isSimpleChar predicate rejects — '|', '#', '@', '*',
+// '?' (github.com/tidwall/sjson@v1.2.5/sjson.go:45-51). Deriving the set from
+// that predicate, rather than hand-picking characters that "look" special,
+// is what catches '|': a key containing it would otherwise fail DeleteBytes
+// and fall back to emitting the field unfiltered.
+const gjsonPathSpecialChars = `\.|#@*?`
 
 func escapeGjsonPathKey(key string) string {
 	if !strings.ContainsAny(key, gjsonPathSpecialChars) {

--- a/internal/metastructure/extract_resources.go
+++ b/internal/metastructure/extract_resources.go
@@ -6,9 +6,14 @@ package metastructure
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"path"
 	"strings"
 	"time"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 
 	"github.com/platform-engineering-labs/formae/internal/datastore"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/querier"
@@ -65,6 +70,18 @@ func (m *Metastructure) ExtractResources(query string) (*pkgmodel.Forma, error) 
 	}
 
 	forma := pkgmodel.FormaFromResources(resources)
+
+	// Extract copies live resource state into a forma declaration verbatim.
+	// A co-owned collection field's live content legitimately holds entries
+	// other writers put there (the platform, another forma), so emitting it
+	// unfiltered would hand the caller a declaration that claims members it
+	// never wrote — the next apply would then try to "own" them. Narrow each
+	// such field down to the portion this forma may actually claim, and strip
+	// the ownership bookkeeping itself: it is agent-internal and must never
+	// appear in an emitted declaration.
+	for i := range forma.Resources {
+		forma.Resources[i] = filterCoOwnedResource(forma.Resources[i])
+	}
 
 	if len(targetNames) > 0 {
 		targets, err := m.Datastore.LoadTargetsByLabels(targetNames)
@@ -254,4 +271,231 @@ func (m *Metastructure) ExtractStacks() ([]*pkgmodel.Stack, error) {
 
 	slog.Debug("ExtractStacks returning", "count", len(stacks))
 	return stacks, nil
+}
+
+// filterCoOwnedResource returns a copy of res with every CoOwned-hinted
+// collection field narrowed to the members this forma may claim, and its
+// ownership record cleared.
+//
+// res arrives as a shallow copy already (FormaFromResources built it by
+// dereferencing the datastore's *Resource), which means its Properties field
+// is still a slice header pointing at the very same backing array the stored
+// resource uses. sjson's Set/Delete calls can grow or shrink a []byte in
+// place when there is spare capacity, so operating on that shared array
+// could corrupt state a concurrent reader — or the datastore's own cache —
+// still holds. Cloning the byte slice here, before any filtering touches it,
+// guarantees the backing array is exclusively res's own.
+func filterCoOwnedResource(res pkgmodel.Resource) pkgmodel.Resource {
+	res.Properties = append(json.RawMessage(nil), res.Properties...)
+
+	filtered, err := filterCoOwnedProperties(res.Properties, res.Schema, res.OwnedMembers)
+	if err != nil {
+		// Filtering failed for this resource (malformed hint path, etc.): emit
+		// its properties unfiltered rather than dropping the resource from the
+		// extract entirely. OwnedMembers is still cleared below regardless, so
+		// the bookkeeping never leaks even on this fallback path.
+		slog.Warn("Failed to filter co-owned collection for extract; emitting unfiltered",
+			"resource", res.Label, "error", err)
+	} else {
+		res.Properties = filtered
+	}
+
+	// OwnedMembers is agent bookkeeping — the set of member identities a prior
+	// apply claimed. It must never reach an emitted declaration: a forma file
+	// only ever declares state, not the agent's internal record of what it
+	// last wrote.
+	res.OwnedMembers = nil
+
+	return res
+}
+
+// filterCoOwnedProperties narrows every CoOwned-hinted collection in
+// properties down to the members this forma may emit:
+//
+//   - An interpretable ownership record (one whose Rule still matches the
+//     field's current hint — see pkgmodel.IdentityRule) is authoritative:
+//     keep exactly the members named in record.Members.
+//   - With no interpretable record (never claimed, or the record is stale),
+//     fall back to CoOwned.SystemPatterns: drop any member whose identity
+//     matches at least one pattern, keep the rest. No patterns at all means
+//     nothing is known to be platform-injected, so nothing is dropped — the
+//     field is emitted exactly as extract emits it today.
+//
+// A field paired with Opaque is skipped entirely: its "members" would be
+// secret values rather than names, the PKL schema already refuses to author
+// that combination (see co_owned_field_opaque_test.pkl), and claimedMembers
+// never records a claim for one either — so such a hint is never treated as
+// co-owned here.
+func filterCoOwnedProperties(properties json.RawMessage, schema pkgmodel.Schema, owned pkgmodel.OwnedMembers) (json.RawMessage, error) {
+	if len(properties) == 0 {
+		return properties, nil
+	}
+
+	out := properties
+	for fieldPath, hint := range schema.Hints {
+		if hint.CoOwned == nil || hint.Opaque {
+			continue
+		}
+
+		val := gjson.GetBytes(out, fieldPath)
+		if !val.Exists() {
+			continue
+		}
+
+		keep, active := coOwnedKeepFunc(fieldPath, hint, owned)
+		if !active {
+			continue
+		}
+
+		var err error
+		switch {
+		case val.IsObject():
+			out, err = filterObjectMembers(out, fieldPath, val, keep)
+		case val.IsArray():
+			out, err = filterArrayMembers(out, fieldPath, val, hint, keep)
+		default:
+			// A CoOwned field is a collection by definition; a scalar here
+			// means the live value does not match its own schema. Nothing
+			// sensible to filter — leave it exactly as extract found it.
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return out, nil
+}
+
+// coOwnedKeepFunc returns the membership test for one CoOwned-hinted field,
+// and whether any filtering is actually called for. active is false only
+// when there is neither an interpretable record nor any SystemPatterns to
+// apply — the "emit everything" case, left as a no-op rather than a
+// keep-everything predicate so callers can skip the field untouched.
+func coOwnedKeepFunc(fieldPath string, hint pkgmodel.FieldHint, owned pkgmodel.OwnedMembers) (keep func(identity string) bool, active bool) {
+	if record, ok := owned[fieldPath]; ok && record.Rule == pkgmodel.IdentityRule(hint) {
+		members := make(map[string]struct{}, len(record.Members))
+		for _, m := range record.Members {
+			members[m] = struct{}{}
+		}
+		return func(identity string) bool {
+			_, ok := members[identity]
+			return ok
+		}, true
+	}
+
+	patterns := hint.CoOwned.SystemPatterns
+	if len(patterns) == 0 {
+		return nil, false
+	}
+
+	return func(identity string) bool {
+		for _, pattern := range patterns {
+			// path.Match's glob semantics: "*" matches any sequence of
+			// non-separator ('/') characters, "?" matches any single
+			// non-separator character. Member identities are provider names
+			// (e.g. "aws:cloudformation:stack"), not paths, so this is only
+			// ever exercised as a plain substring-style wildcard — "aws:*"
+			// matches "aws:cloudformation:stack" but "/" in an identity would
+			// not cross a "*" the way it might look like it should.
+			if matched, _ := path.Match(pattern, identity); matched {
+				return false
+			}
+		}
+		return true
+	}, true
+}
+
+// filterObjectMembers drops every key of the object at fieldPath in doc for
+// which keep reports false, leaving the surviving keys' values byte-for-byte
+// untouched. An object left with no keys serializes as "{}" — the same empty
+// Mapping extract already emits for a field with no live content.
+func filterObjectMembers(doc json.RawMessage, fieldPath string, val gjson.Result, keep func(string) bool) (json.RawMessage, error) {
+	var toDelete []string
+	val.ForEach(func(key, _ gjson.Result) bool {
+		if !keep(key.String()) {
+			toDelete = append(toDelete, key.String())
+		}
+		return true
+	})
+
+	out := doc
+	for _, key := range toDelete {
+		updated, err := sjson.DeleteBytes(out, fieldPath+"."+escapeGjsonPathKey(key))
+		if err != nil {
+			return nil, fmt.Errorf("failed to drop unowned member %q at %q: %w", key, fieldPath, err)
+		}
+		out = updated
+	}
+	return out, nil
+}
+
+// filterArrayMembers drops every element of the array at fieldPath in doc
+// whose identity (per hint's UpdateMethod — EntitySet's IndexField, or the
+// element's own canonical JSON otherwise) keep reports false for. An element
+// whose identity cannot be determined (an unresolved reference envelope) is
+// left in place: there is nothing to test it against. An array left with no
+// elements serializes as "[]" — the same empty Listing extract already emits
+// for a field with no live content.
+func filterArrayMembers(doc json.RawMessage, fieldPath string, val gjson.Result, hint pkgmodel.FieldHint, keep func(string) bool) (json.RawMessage, error) {
+	elems := val.Array()
+	var toDelete []int
+	for i, el := range elems {
+		identity, ok := singleMemberIdentity(el, hint)
+		if !ok {
+			continue
+		}
+		if !keep(identity) {
+			toDelete = append(toDelete, i)
+		}
+	}
+
+	out := doc
+	// Delete from the highest index down so earlier deletions never shift the
+	// index of an element still queued for removal.
+	for i := len(toDelete) - 1; i >= 0; i-- {
+		idx := toDelete[i]
+		updated, err := sjson.DeleteBytes(out, fmt.Sprintf("%s.%d", fieldPath, idx))
+		if err != nil {
+			return nil, fmt.Errorf("failed to drop unowned array member at %q[%d]: %w", fieldPath, idx, err)
+		}
+		out = updated
+	}
+	return out, nil
+}
+
+// singleMemberIdentity computes one array element's identity by reusing
+// pkgmodel.MemberIdentities against a synthetic one-element array holding
+// just that element — the same envelope-flattening and per-rule logic
+// MemberIdentities already applies to a whole collection, without
+// duplicating it here. Returns false if the element contributes no identity
+// at all (an envelope missing $value), matching MemberIdentities' own
+// "contributes nothing" handling of such elements.
+func singleMemberIdentity(el gjson.Result, hint pkgmodel.FieldHint) (string, bool) {
+	wrapped := gjson.Parse("[" + el.Raw + "]")
+	ids := pkgmodel.MemberIdentities(wrapped, hint)
+	if len(ids) != 1 {
+		return "", false
+	}
+	return ids[0], true
+}
+
+// escapeGjsonPathKey escapes the gjson/sjson path metacharacters a map key
+// might contain, so a key like "a.b" addresses itself as one literal key
+// rather than being read as nested path syntax.
+const gjsonPathSpecialChars = `\.*?#@`
+
+func escapeGjsonPathKey(key string) string {
+	if !strings.ContainsAny(key, gjsonPathSpecialChars) {
+		return key
+	}
+	var escaped strings.Builder
+	escaped.Grow(len(key) + 4)
+	for _, r := range key {
+		if strings.ContainsRune(gjsonPathSpecialChars, r) {
+			escaped.WriteByte('\\')
+		}
+		escaped.WriteRune(r)
+	}
+	return escaped.String()
 }

--- a/internal/metastructure/extract_resources_test.go
+++ b/internal/metastructure/extract_resources_test.go
@@ -124,6 +124,9 @@ func (m *mockExtractDatastore) GetMostRecentFormaCommandByClientID(_ string) (*f
 func (m *mockExtractDatastore) GetPropertiesAtLastWrite(_ string) (json.RawMessage, error) {
 	return nil, nil
 }
+func (m *mockExtractDatastore) GetOwnedMembers(_ string) (pkgmodel.OwnedMembers, error) {
+	return nil, nil
+}
 
 func (m *mockExtractDatastore) GetResourceModificationsSinceLastReconcile(_ string) ([]datastore.ResourceModification, error) {
 	panic("not implemented")

--- a/internal/metastructure/extract_resources_test.go
+++ b/internal/metastructure/extract_resources_test.go
@@ -922,14 +922,16 @@ func TestExtractResources_CoOwnedRecorded_EntitySetEmitsOnlyOwnedElement(t *test
 // TestExtractResources_CoOwnedRecordless_EntitySetSystemPatternsDropMatches
 // verifies that, with no interpretable record, a CoOwned EntitySet field
 // falls back to SystemPatterns matched against each element's IndexField
-// identity — the json-marshaled IndexField value, quotes included, since
-// that is the same "identity" pkgmodel.MemberIdentities already produces for
-// this hint shape and what an interpretable record's Members would hold. A
-// pattern therefore has to account for that encoding (a leading `"` for a
-// string IndexField); this is the same identity language throughout the
-// mechanism, not a different one for SystemPatterns.
+// identity, written in its natural unquoted form ("aws:*") — the same form a
+// pattern author would write against a Mapping field. A string IndexField
+// value's json-marshaled identity carries quotes internally (see
+// pkgmodel.MemberIdentities), but SystemPatterns matching unquotes a
+// JSON-string identity before applying the glob (see
+// unquoteJSONStringIdentity), so the pattern contract is uniform across
+// Mapping keys, EntitySet index values, and scalar Set members — no author
+// needs to know about the marshaled encoding.
 func TestExtractResources_CoOwnedRecordless_EntitySetSystemPatternsDropMatches(t *testing.T) {
-	hint := entitySetCoOwnedHint("Key", []string{`"aws:*`})
+	hint := entitySetCoOwnedHint("Key", []string{"aws:*"})
 	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"tagSet": hint}}
 
 	ds := &mockExtractDatastore{
@@ -1008,4 +1010,40 @@ func TestExtractResources_CoOwnedRecorded_SetListingEmitsOnlyOwnedElement(t *tes
 	require.True(t, members.Exists())
 	assert.Equal(t, []any{"mine"}, members.Value(),
 		"only the recorded whole-value element must survive")
+}
+
+// TestExtractResources_CoOwnedRecordless_SetListingSystemPatternsDropMatches
+// verifies that a plain Set listing's SystemPatterns match uses the same
+// natural, unquoted glob form as Mapping and EntitySet: a scalar Set
+// member's identity is its own json-marshaled value (quoted for a string —
+// see pkgmodel.MemberIdentities), but the pattern is still written "aws:*".
+func TestExtractResources_CoOwnedRecordless_SetListingSystemPatternsDropMatches(t *testing.T) {
+	hint := setListingCoOwnedHint([]string{"aws:*"})
+	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"members": hint}}
+
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{
+			{
+				Label:      "res-1",
+				Type:       "AWS::EC2::VPC",
+				Stack:      "default",
+				Properties: json.RawMessage(`{"members":["aws:default","team"]}`),
+				Schema:     schema,
+				// No OwnedMembers: this forma has never claimed this field.
+			},
+		},
+		stacks:   map[string]*pkgmodel.Stack{},
+		targets:  map[string]*pkgmodel.Target{},
+		policies: map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	members := gjson.GetBytes(forma.Resources[0].Properties, "members")
+	require.True(t, members.Exists())
+	assert.Equal(t, []any{"team"}, members.Value(),
+		"the member matching the SystemPatterns glob must be dropped, in its natural unquoted form")
 }

--- a/internal/metastructure/extract_resources_test.go
+++ b/internal/metastructure/extract_resources_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 // mockExtractDatastore implements datastore.Datastore with only the methods
@@ -619,4 +620,241 @@ func TestExtractResources_BatchedPolicyLookups(t *testing.T) {
 
 func (m *mockExtractDatastore) RecordAgentBoot(_ string) error {
 	return nil
+}
+
+// mappingCoOwnedSchema returns a Schema hinting fieldName as a CoOwned
+// Mapping (UpdateMethod None + CoOwned set — see pkgmodel.IdentityRule),
+// with the given SystemPatterns.
+func mappingCoOwnedSchema(fieldName string, systemPatterns []string) pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Hints: map[string]pkgmodel.FieldHint{
+			fieldName: {
+				CoOwned: &pkgmodel.CoOwnership{SystemPatterns: systemPatterns},
+			},
+		},
+	}
+}
+
+// TestExtractResources_CoOwnedRecorded_EmitsOnlyOwnedMembers verifies that a
+// CoOwned field with an interpretable ownership record emits exactly the
+// recorded members, dropping every other live entry regardless of any
+// SystemPatterns.
+func TestExtractResources_CoOwnedRecorded_EmitsOnlyOwnedMembers(t *testing.T) {
+	schema := mappingCoOwnedSchema("labels", nil)
+
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{
+			{
+				Label:      "res-1",
+				Type:       "AWS::EC2::VPC",
+				Stack:      "default",
+				Properties: json.RawMessage(`{"labels":{"mine":"a","theirs":"b"}}`),
+				Schema:     schema,
+				OwnedMembers: pkgmodel.OwnedMembers{
+					"labels": {Rule: pkgmodel.IdentityRule(schema.Hints["labels"]), Members: []string{"mine"}},
+				},
+			},
+		},
+		stacks:   map[string]*pkgmodel.Stack{},
+		targets:  map[string]*pkgmodel.Target{},
+		policies: map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	labels := gjson.GetBytes(forma.Resources[0].Properties, "labels")
+	require.True(t, labels.Exists())
+	assert.Equal(t, map[string]any{"mine": "a"}, labels.Value(),
+		"only the recorded member must survive, regardless of what else is live")
+}
+
+// TestExtractResources_CoOwnedRecordless_SystemPatternsDropMatches verifies
+// that, with no interpretable ownership record, a CoOwned field falls back to
+// SystemPatterns: a member whose identity matches a pattern is dropped, and
+// one that matches none is kept.
+func TestExtractResources_CoOwnedRecordless_SystemPatternsDropMatches(t *testing.T) {
+	schema := mappingCoOwnedSchema("tags", []string{"aws:*"})
+
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{
+			{
+				Label:      "res-1",
+				Type:       "AWS::EC2::VPC",
+				Stack:      "default",
+				Properties: json.RawMessage(`{"tags":{"aws:cloudformation:stack":"my-stack","team":"platform"}}`),
+				Schema:     schema,
+				// No OwnedMembers: this forma has never claimed this field.
+			},
+		},
+		stacks:   map[string]*pkgmodel.Stack{},
+		targets:  map[string]*pkgmodel.Target{},
+		policies: map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	tags := gjson.GetBytes(forma.Resources[0].Properties, "tags")
+	require.True(t, tags.Exists())
+	assert.Equal(t, map[string]any{"team": "platform"}, tags.Value(),
+		"a member matching a SystemPatterns glob must be dropped, the rest kept")
+}
+
+// TestExtractResources_CoOwnedRecordless_NoPatternsEmitsEverything verifies
+// that a CoOwned field with neither an interpretable record nor any
+// SystemPatterns is emitted exactly as extract emits it today: unfiltered.
+func TestExtractResources_CoOwnedRecordless_NoPatternsEmitsEverything(t *testing.T) {
+	schema := mappingCoOwnedSchema("tags", nil)
+
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{
+			{
+				Label:      "res-1",
+				Type:       "AWS::EC2::VPC",
+				Stack:      "default",
+				Properties: json.RawMessage(`{"tags":{"aws:cloudformation:stack":"my-stack","team":"platform"}}`),
+				Schema:     schema,
+			},
+		},
+		stacks:   map[string]*pkgmodel.Stack{},
+		targets:  map[string]*pkgmodel.Target{},
+		policies: map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	tags := gjson.GetBytes(forma.Resources[0].Properties, "tags")
+	require.True(t, tags.Exists())
+	assert.Equal(t, map[string]any{"aws:cloudformation:stack": "my-stack", "team": "platform"}, tags.Value(),
+		"with no record and no patterns, today's unfiltered behavior must be preserved")
+}
+
+// TestExtractResources_CoOwnedFiltering_NonCoOwnedFieldsByteIdentical
+// verifies that filtering a CoOwned field never touches any other property on
+// the same resource: an unrelated field's raw JSON survives byte-for-byte.
+func TestExtractResources_CoOwnedFiltering_NonCoOwnedFieldsByteIdentical(t *testing.T) {
+	schema := mappingCoOwnedSchema("labels", nil)
+
+	const props = `{"name":"widget-1","count":5,"nested":{"a":1,"b":[1,2,3]},"labels":{"mine":"a","theirs":"b"}}`
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{
+			{
+				Label:      "res-1",
+				Type:       "AWS::EC2::VPC",
+				Stack:      "default",
+				Properties: json.RawMessage(props),
+				Schema:     schema,
+				OwnedMembers: pkgmodel.OwnedMembers{
+					"labels": {Rule: pkgmodel.IdentityRule(schema.Hints["labels"]), Members: []string{"mine"}},
+				},
+			},
+		},
+		stacks:   map[string]*pkgmodel.Stack{},
+		targets:  map[string]*pkgmodel.Target{},
+		policies: map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	out := forma.Resources[0].Properties
+	assert.Equal(t, gjson.Get(props, "name").Raw, gjson.GetBytes(out, "name").Raw)
+	assert.Equal(t, gjson.Get(props, "count").Raw, gjson.GetBytes(out, "count").Raw)
+	assert.Equal(t, gjson.Get(props, "nested").Raw, gjson.GetBytes(out, "nested").Raw,
+		"a field with no CoOwned hint must be untouched, byte-for-byte")
+}
+
+// TestExtractResources_CoOwnedFiltering_ClearsOwnedMembers verifies that the
+// emitted resource carries no ownership record at all — neither in the Go
+// struct nor in the JSON a real serialize would feed to the PKL generator
+// (serializeWithPKL's own emission path json.Marshals the forma before
+// handing it to the generator; the generator template never references
+// OwnedMembers, so its absence from that JSON is exactly what guarantees its
+// absence from the rendered PKL text — this is the "nearest test seam" over
+// that path, without paying for a full PKL evaluation in a metastructure
+// unit test).
+func TestExtractResources_CoOwnedFiltering_ClearsOwnedMembers(t *testing.T) {
+	schema := mappingCoOwnedSchema("labels", nil)
+
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{
+			{
+				Label:      "res-1",
+				Type:       "AWS::EC2::VPC",
+				Stack:      "default",
+				Properties: json.RawMessage(`{"labels":{"mine":"a","theirs":"b"}}`),
+				Schema:     schema,
+				OwnedMembers: pkgmodel.OwnedMembers{
+					"labels": {Rule: pkgmodel.IdentityRule(schema.Hints["labels"]), Members: []string{"mine"}},
+				},
+			},
+		},
+		stacks:   map[string]*pkgmodel.Stack{},
+		targets:  map[string]*pkgmodel.Target{},
+		policies: map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	assert.Nil(t, forma.Resources[0].OwnedMembers, "the emitted resource must carry no ownership record")
+
+	jsonOut := forma.ToJSON()
+	assert.NotContains(t, jsonOut, "OwnedMembers",
+		"OwnedMembers must not appear in the JSON serializeWithPKL feeds to the PKL generator")
+}
+
+// TestExtractResources_CoOwnedFiltering_ClonesBeforeMutating verifies that
+// filtering a CoOwned collection never mutates the datastore's own resource:
+// the stored Properties byte slice must be untouched even though the
+// extracted copy was filtered down to fewer members.
+func TestExtractResources_CoOwnedFiltering_ClonesBeforeMutating(t *testing.T) {
+	schema := mappingCoOwnedSchema("labels", nil)
+	stored := &pkgmodel.Resource{
+		Label:      "res-1",
+		Type:       "AWS::EC2::VPC",
+		Stack:      "default",
+		Properties: json.RawMessage(`{"labels":{"mine":"a","theirs":"b"}}`),
+		Schema:     schema,
+		OwnedMembers: pkgmodel.OwnedMembers{
+			"labels": {Rule: pkgmodel.IdentityRule(schema.Hints["labels"]), Members: []string{"mine"}},
+		},
+	}
+	originalProperties := string(stored.Properties)
+	originalOwned := stored.OwnedMembers
+
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{stored},
+		stacks:    map[string]*pkgmodel.Stack{},
+		targets:   map[string]*pkgmodel.Target{},
+		policies:  map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	// The emitted copy was filtered...
+	labels := gjson.GetBytes(forma.Resources[0].Properties, "labels")
+	assert.Equal(t, map[string]any{"mine": "a"}, labels.Value())
+
+	// ...but the datastore's own resource — same pointer ExtractResources was
+	// handed — must be exactly as it was before the call.
+	assert.Equal(t, originalProperties, string(stored.Properties),
+		"filtering must not mutate the stored resource's Properties")
+	assert.Equal(t, originalOwned, stored.OwnedMembers,
+		"filtering must not clear OwnedMembers on the stored resource")
 }

--- a/internal/metastructure/extract_resources_test.go
+++ b/internal/metastructure/extract_resources_test.go
@@ -1047,3 +1047,178 @@ func TestExtractResources_CoOwnedRecordless_SetListingSystemPatternsDropMatches(
 	assert.Equal(t, []any{"team"}, members.Value(),
 		"the member matching the SystemPatterns glob must be dropped, in its natural unquoted form")
 }
+
+// TestExtractResources_CoOwnedRecordless_PipeInKeyStillDrops verifies that a
+// Mapping key containing '|' — a gjson/sjson path metacharacter — is still
+// correctly dropped when it matches a SystemPatterns glob. '|' has no
+// special meaning to path.Match, so the glob match itself was never at risk;
+// what was at risk is the sjson.DeleteBytes call that actually removes the
+// matched key from the object, which requires the key to be escaped for
+// sjson's own path syntax (see escapeGjsonPathKey) — an unescaped '|' fails
+// that delete and would fall back to emitting the field unfiltered.
+func TestExtractResources_CoOwnedRecordless_PipeInKeyStillDrops(t *testing.T) {
+	schema := mappingCoOwnedSchema("labels", []string{"aws:*"})
+
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{
+			{
+				Label:      "res-1",
+				Type:       "AWS::EC2::VPC",
+				Stack:      "default",
+				Properties: json.RawMessage(`{"labels":{"aws:special|thing":"x","team":"y"}}`),
+				Schema:     schema,
+				// No OwnedMembers: this forma has never claimed this field.
+			},
+		},
+		stacks:   map[string]*pkgmodel.Stack{},
+		targets:  map[string]*pkgmodel.Target{},
+		policies: map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	labels := gjson.GetBytes(forma.Resources[0].Properties, "labels")
+	require.True(t, labels.Exists())
+	assert.Equal(t, map[string]any{"team": "y"}, labels.Value(),
+		"a key containing '|' that matches a SystemPatterns glob must actually be dropped, not silently retained via a failed delete")
+}
+
+// TestExtractResources_CoOwnedRecorded_MappingFilteredToZeroRendersEmptyObject
+// verifies that filtering a Mapping down to no surviving members renders the
+// field as "{}" — the same empty-collection convention extract already uses,
+// not a new rendering.
+func TestExtractResources_CoOwnedRecorded_MappingFilteredToZeroRendersEmptyObject(t *testing.T) {
+	schema := mappingCoOwnedSchema("labels", nil)
+
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{
+			{
+				Label:      "res-1",
+				Type:       "AWS::EC2::VPC",
+				Stack:      "default",
+				Properties: json.RawMessage(`{"labels":{"mine":"a","theirs":"b"}}`),
+				Schema:     schema,
+				OwnedMembers: pkgmodel.OwnedMembers{
+					// An interpretable record that claims nothing.
+					"labels": {Rule: pkgmodel.IdentityRule(schema.Hints["labels"]), Members: []string{}},
+				},
+			},
+		},
+		stacks:   map[string]*pkgmodel.Stack{},
+		targets:  map[string]*pkgmodel.Target{},
+		policies: map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	labels := gjson.GetBytes(forma.Resources[0].Properties, "labels")
+	require.True(t, labels.Exists())
+	assert.Equal(t, "{}", labels.Raw, "a Mapping filtered to zero members must render as {}")
+}
+
+// TestExtractResources_CoOwnedRecordless_PatternsMatchingAllRendersEmptyObject
+// verifies the record-less, pattern-based path renders the same empty-object
+// convention when every live member matches a SystemPatterns glob.
+func TestExtractResources_CoOwnedRecordless_PatternsMatchingAllRendersEmptyObject(t *testing.T) {
+	schema := mappingCoOwnedSchema("tags", []string{"*"})
+
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{
+			{
+				Label:      "res-1",
+				Type:       "AWS::EC2::VPC",
+				Stack:      "default",
+				Properties: json.RawMessage(`{"tags":{"aws:cloudformation:stack":"my-stack","team":"platform"}}`),
+				Schema:     schema,
+			},
+		},
+		stacks:   map[string]*pkgmodel.Stack{},
+		targets:  map[string]*pkgmodel.Target{},
+		policies: map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	tags := gjson.GetBytes(forma.Resources[0].Properties, "tags")
+	require.True(t, tags.Exists())
+	assert.Equal(t, "{}", tags.Raw, "a Mapping with every member matching SystemPatterns must render as {}")
+}
+
+// TestExtractResources_CoOwnedRecorded_SetListingFilteredToZeroRendersEmptyArray
+// verifies that filtering a Set listing down to no surviving elements
+// renders the field as "[]" — the same empty-collection convention extract
+// already uses for a Listing, not a new rendering.
+func TestExtractResources_CoOwnedRecorded_SetListingFilteredToZeroRendersEmptyArray(t *testing.T) {
+	hint := setListingCoOwnedHint(nil)
+	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"members": hint}}
+
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{
+			{
+				Label:      "res-1",
+				Type:       "AWS::EC2::VPC",
+				Stack:      "default",
+				Properties: json.RawMessage(`{"members":["mine","theirs"]}`),
+				Schema:     schema,
+				OwnedMembers: pkgmodel.OwnedMembers{
+					// An interpretable record that claims nothing.
+					"members": {Rule: pkgmodel.IdentityRule(hint), Members: []string{}},
+				},
+			},
+		},
+		stacks:   map[string]*pkgmodel.Stack{},
+		targets:  map[string]*pkgmodel.Target{},
+		policies: map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	members := gjson.GetBytes(forma.Resources[0].Properties, "members")
+	require.True(t, members.Exists())
+	assert.Equal(t, "[]", members.Raw, "a Set listing filtered to zero elements must render as []")
+}
+
+// TestExtractResources_CoOwnedRecordless_PatternsMatchingAllRendersEmptyArray
+// verifies the record-less, pattern-based path renders the same empty-array
+// convention for a listing when every live member matches a SystemPatterns
+// glob.
+func TestExtractResources_CoOwnedRecordless_PatternsMatchingAllRendersEmptyArray(t *testing.T) {
+	hint := setListingCoOwnedHint([]string{"*"})
+	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"members": hint}}
+
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{
+			{
+				Label:      "res-1",
+				Type:       "AWS::EC2::VPC",
+				Stack:      "default",
+				Properties: json.RawMessage(`{"members":["aws:default","aws:other"]}`),
+				Schema:     schema,
+			},
+		},
+		stacks:   map[string]*pkgmodel.Stack{},
+		targets:  map[string]*pkgmodel.Target{},
+		policies: map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	members := gjson.GetBytes(forma.Resources[0].Properties, "members")
+	require.True(t, members.Exists())
+	assert.Equal(t, "[]", members.Raw, "a Set listing with every member matching SystemPatterns must render as []")
+}

--- a/internal/metastructure/extract_resources_test.go
+++ b/internal/metastructure/extract_resources_test.go
@@ -858,3 +858,154 @@ func TestExtractResources_CoOwnedFiltering_ClonesBeforeMutating(t *testing.T) {
 	assert.Equal(t, originalOwned, stored.OwnedMembers,
 		"filtering must not clear OwnedMembers on the stored resource")
 }
+
+// entitySetCoOwnedHint returns a FieldHint for a CoOwned EntitySet field —
+// an array of objects identified by indexField (e.g. AWS-style
+// [{"Key":...,"Value":...}] tag lists) — with the given SystemPatterns.
+func entitySetCoOwnedHint(indexField string, systemPatterns []string) pkgmodel.FieldHint {
+	return pkgmodel.FieldHint{
+		UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet,
+		IndexField:   indexField,
+		CoOwned:      &pkgmodel.CoOwnership{SystemPatterns: systemPatterns},
+	}
+}
+
+// TestExtractResources_CoOwnedRecorded_EntitySetEmitsOnlyOwnedElement verifies
+// that a CoOwned EntitySet field (identity = the IndexField value, not the
+// whole element — see pkgmodel.MemberIdentities) with an interpretable
+// ownership record emits exactly the recorded element, and that the surviving
+// element's position is unaffected by how the drop is implemented (deletion
+// by descending array index — see filterArrayMembers).
+func TestExtractResources_CoOwnedRecorded_EntitySetEmitsOnlyOwnedElement(t *testing.T) {
+	hint := entitySetCoOwnedHint("Key", nil)
+	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"tagSet": hint}}
+
+	// The record stores whatever MemberIdentities itself computes for the
+	// owned element (the json-marshaled IndexField value, e.g. `"mine"` with
+	// its quotes) — derived here rather than hand-typed, since that encoding
+	// is this mechanism's implementation detail, not something a test should
+	// have to reproduce by hand.
+	mineIdentities := pkgmodel.MemberIdentities(gjson.Parse(`[{"Key":"mine","Value":"a"}]`), hint)
+	require.Len(t, mineIdentities, 1)
+
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{
+			{
+				Label:      "res-1",
+				Type:       "AWS::EC2::VPC",
+				Stack:      "default",
+				Properties: json.RawMessage(`{"tagSet":[{"Key":"mine","Value":"a"},{"Key":"theirs","Value":"b"}]}`),
+				Schema:     schema,
+				OwnedMembers: pkgmodel.OwnedMembers{
+					"tagSet": {Rule: pkgmodel.IdentityRule(hint), Members: mineIdentities},
+				},
+			},
+		},
+		stacks:   map[string]*pkgmodel.Stack{},
+		targets:  map[string]*pkgmodel.Target{},
+		policies: map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	tagSet := gjson.GetBytes(forma.Resources[0].Properties, "tagSet")
+	require.True(t, tagSet.Exists())
+	elems := tagSet.Array()
+	require.Len(t, elems, 1, "only the recorded element must survive")
+	assert.Equal(t, map[string]any{"Key": "mine", "Value": "a"}, elems[0].Value(),
+		"the surviving element must be exactly the recorded one, values intact")
+}
+
+// TestExtractResources_CoOwnedRecordless_EntitySetSystemPatternsDropMatches
+// verifies that, with no interpretable record, a CoOwned EntitySet field
+// falls back to SystemPatterns matched against each element's IndexField
+// identity — the json-marshaled IndexField value, quotes included, since
+// that is the same "identity" pkgmodel.MemberIdentities already produces for
+// this hint shape and what an interpretable record's Members would hold. A
+// pattern therefore has to account for that encoding (a leading `"` for a
+// string IndexField); this is the same identity language throughout the
+// mechanism, not a different one for SystemPatterns.
+func TestExtractResources_CoOwnedRecordless_EntitySetSystemPatternsDropMatches(t *testing.T) {
+	hint := entitySetCoOwnedHint("Key", []string{`"aws:*`})
+	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"tagSet": hint}}
+
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{
+			{
+				Label:      "res-1",
+				Type:       "AWS::EC2::VPC",
+				Stack:      "default",
+				Properties: json.RawMessage(`{"tagSet":[{"Key":"aws:cloudformation:stack","Value":"my-stack"},{"Key":"team","Value":"platform"}]}`),
+				Schema:     schema,
+				// No OwnedMembers: this forma has never claimed this field.
+			},
+		},
+		stacks:   map[string]*pkgmodel.Stack{},
+		targets:  map[string]*pkgmodel.Target{},
+		policies: map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	tagSet := gjson.GetBytes(forma.Resources[0].Properties, "tagSet")
+	require.True(t, tagSet.Exists())
+	elems := tagSet.Array()
+	require.Len(t, elems, 1, "the element matching the SystemPatterns glob must be dropped")
+	assert.Equal(t, map[string]any{"Key": "team", "Value": "platform"}, elems[0].Value())
+}
+
+// setListingCoOwnedHint returns a FieldHint for a CoOwned plain Set
+// listing — an array whose whole element value (not a sub-field) is its
+// identity — with the given SystemPatterns.
+func setListingCoOwnedHint(systemPatterns []string) pkgmodel.FieldHint {
+	return pkgmodel.FieldHint{
+		UpdateMethod: pkgmodel.FieldUpdateMethodSet,
+		CoOwned:      &pkgmodel.CoOwnership{SystemPatterns: systemPatterns},
+	}
+}
+
+// TestExtractResources_CoOwnedRecorded_SetListingEmitsOnlyOwnedElement
+// verifies that a CoOwned plain Set listing (identity = each element's own
+// canonical JSON — no IndexField, unlike EntitySet) with an interpretable
+// ownership record emits exactly the recorded whole-value element.
+func TestExtractResources_CoOwnedRecorded_SetListingEmitsOnlyOwnedElement(t *testing.T) {
+	hint := setListingCoOwnedHint(nil)
+	schema := pkgmodel.Schema{Hints: map[string]pkgmodel.FieldHint{"members": hint}}
+
+	mineIdentities := pkgmodel.MemberIdentities(gjson.Parse(`["mine"]`), hint)
+	require.Len(t, mineIdentities, 1)
+
+	ds := &mockExtractDatastore{
+		resources: []*pkgmodel.Resource{
+			{
+				Label:      "res-1",
+				Type:       "AWS::EC2::VPC",
+				Stack:      "default",
+				Properties: json.RawMessage(`{"members":["mine","theirs"]}`),
+				Schema:     schema,
+				OwnedMembers: pkgmodel.OwnedMembers{
+					"members": {Rule: pkgmodel.IdentityRule(hint), Members: mineIdentities},
+				},
+			},
+		},
+		stacks:   map[string]*pkgmodel.Stack{},
+		targets:  map[string]*pkgmodel.Target{},
+		policies: map[string]pkgmodel.Policy{},
+	}
+
+	m := &Metastructure{Datastore: ds}
+	forma, err := m.ExtractResources("")
+	require.NoError(t, err)
+	require.Len(t, forma.Resources, 1)
+
+	members := gjson.GetBytes(forma.Resources[0].Properties, "members")
+	require.True(t, members.Exists())
+	assert.Equal(t, []any{"mine"}, members.Value(),
+		"only the recorded whole-value element must survive")
+}

--- a/internal/metastructure/generator_rotator.go
+++ b/internal/metastructure/generator_rotator.go
@@ -732,6 +732,7 @@ func refuseRotationOnDrift(ds datastore.Datastore, forma *pkgmodel.Forma, fc *fo
 	for label, modifications := range modificationsByStack {
 		unabsorbed := drift.FilterUnabsorbedModifications(modifications, forma, fc)
 		unabsorbed = append(unabsorbed, drift.WitnessedMovedModifications(modifications, witnessByKsuid, recordByKsuid, forma, fc)...)
+		unabsorbed = drift.RetainConfrontable(unabsorbed, recordByKsuid, forma)
 		if len(unabsorbed) == 0 {
 			continue
 		}

--- a/internal/metastructure/generator_rotator.go
+++ b/internal/metastructure/generator_rotator.go
@@ -721,8 +721,9 @@ func refuseRotationOnDrift(ds datastore.Datastore, forma *pkgmodel.Forma, fc *fo
 	// the one a user's reconcile confronts.
 	modificationsByStack := make(map[string][]datastore.ResourceModification)
 	witnessByKsuid := make(map[string]json.RawMessage)
+	recordByKsuid := make(map[string]pkgmodel.OwnedMembers)
 	for label := range stackLabels {
-		if err := drift.LoadModificationsAndWitnesses(ds, label, modificationsByStack, witnessByKsuid); err != nil {
+		if err := drift.LoadModificationsAndWitnesses(ds, label, modificationsByStack, witnessByKsuid, recordByKsuid); err != nil {
 			return err
 		}
 	}
@@ -730,7 +731,7 @@ func refuseRotationOnDrift(ds datastore.Datastore, forma *pkgmodel.Forma, fc *fo
 	modifiedStacks := map[string]apimodel.ModifiedStack{}
 	for label, modifications := range modificationsByStack {
 		unabsorbed := drift.FilterUnabsorbedModifications(modifications, forma, fc)
-		unabsorbed = append(unabsorbed, drift.WitnessedMovedModifications(modifications, witnessByKsuid, forma, fc)...)
+		unabsorbed = append(unabsorbed, drift.WitnessedMovedModifications(modifications, witnessByKsuid, recordByKsuid, forma, fc)...)
 		if len(unabsorbed) == 0 {
 			continue
 		}

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -368,8 +368,13 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 	if config.Mode == pkgmodel.FormaApplyModeReconcile && config.Force {
 		assertMods := make(map[string][]datastore.ResourceModification)
 		assertWitnesses := make(map[string]json.RawMessage)
+		// AssertWitnessesIntoForma only ever consults assertWitnesses; the
+		// ownership record has no role in witness assertion, so this map is
+		// discarded — LoadModificationsAndWitnesses still requires it to keep
+		// one shared loader for both records.
+		assertRecords := make(map[string]pkgmodel.OwnedMembers)
 		for _, stackLabel := range drift.StackLabelsFromForma(forma) {
-			if err := drift.LoadModificationsAndWitnesses(m.Datastore, stackLabel, assertMods, assertWitnesses); err != nil {
+			if err := drift.LoadModificationsAndWitnesses(m.Datastore, stackLabel, assertMods, assertWitnesses, assertRecords); err != nil {
 				return nil, err
 			}
 		}
@@ -403,20 +408,21 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 	if config.Mode == pkgmodel.FormaApplyModeReconcile && !config.Force {
 		modificationsByStack := make(map[string][]datastore.ResourceModification)
 		witnessByKsuid := make(map[string]json.RawMessage)
+		recordByKsuid := make(map[string]pkgmodel.OwnedMembers)
 		seenStacks := map[string]bool{}
 		for _, stackLabel := range append(drift.StackLabelsFromForma(forma), fa.GetStackLabels()...) {
 			if seenStacks[stackLabel] {
 				continue
 			}
 			seenStacks[stackLabel] = true
-			if err := drift.LoadModificationsAndWitnesses(m.Datastore, stackLabel, modificationsByStack, witnessByKsuid); err != nil {
+			if err := drift.LoadModificationsAndWitnesses(m.Datastore, stackLabel, modificationsByStack, witnessByKsuid, recordByKsuid); err != nil {
 				return nil, err
 			}
 		}
 		var modifiedStacks = make(map[string]apimodel.ModifiedStack)
 		for stackLabel, modifications := range modificationsByStack {
 			unabsorbed := drift.FilterUnabsorbedModifications(modifications, forma, fa)
-			unabsorbed = append(unabsorbed, drift.WitnessedMovedModifications(modifications, witnessByKsuid, forma, fa)...)
+			unabsorbed = append(unabsorbed, drift.WitnessedMovedModifications(modifications, witnessByKsuid, recordByKsuid, forma, fa)...)
 			if len(unabsorbed) > 0 {
 				modifiedResources := make([]apimodel.ResourceModification, 0, len(unabsorbed))
 				for _, modification := range unabsorbed {

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -423,6 +423,7 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 		for stackLabel, modifications := range modificationsByStack {
 			unabsorbed := drift.FilterUnabsorbedModifications(modifications, forma, fa)
 			unabsorbed = append(unabsorbed, drift.WitnessedMovedModifications(modifications, witnessByKsuid, recordByKsuid, forma, fa)...)
+			unabsorbed = drift.RetainConfrontable(unabsorbed, recordByKsuid, forma)
 			if len(unabsorbed) > 0 {
 				modifiedResources := make([]apimodel.ResourceModification, 0, len(unabsorbed))
 				for _, modification := range unabsorbed {

--- a/internal/metastructure/patch/collection_ownership_baseline_test.go
+++ b/internal/metastructure/patch/collection_ownership_baseline_test.go
@@ -48,6 +48,7 @@ func planFor(t *testing.T, actual, desired string, schemaFields, providerDefault
 		strategy,
 		nil, // converge fields
 		nil, // preserve roots
+		nil, // preserve paths
 	)
 	require.NoError(t, err)
 	out := make([]string, 0, len(ops))

--- a/internal/metastructure/patch/collection_ownership_partition_test.go
+++ b/internal/metastructure/patch/collection_ownership_partition_test.go
@@ -5,8 +5,11 @@
 package patch
 
 import (
+	"bytes"
+	"log/slog"
 	"testing"
 
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/jsonpatch"
 	"github.com/stretchr/testify/require"
@@ -209,4 +212,99 @@ func TestCoOwnedNestedMappingExplicitEmptyDrainsPriorOwnedOnly(t *testing.T) {
 		schema, priorOwned, jsonpatch.PatchStrategyExactMatch)
 
 	require.Equal(t, []string{"remove /metadata/labels/mine"}, ops)
+}
+
+// generatePatchForSchema runs the exported GeneratePatch with no stored/desired
+// envelopes, no prior ownership, and reconcile mode — the shared shape the
+// three coherence tests below need.
+func generatePatchForSchema(t *testing.T, document, patch string, schema pkgmodel.Schema) []byte {
+	t.Helper()
+	patchDoc, _, _, err := GeneratePatch([]byte(document), []byte(patch), nil, nil, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	return patchDoc
+}
+
+// CoOwned has no defined identity scheme for an Atomic field (IdentityRule
+// returns "" for it), a combination PKL validation rejects at authoring time.
+// A schema that reaches GeneratePatch as JSON and carries it anyway must
+// still produce exactly what an un-annotated Atomic field produces: a
+// whole-value replace, with no tolerance of any kind.
+func TestCoOwnedAtomicHintBehavesLikeNoAnnotation(t *testing.T) {
+	document := `{"Cfg":{"Note":"a","Extra":"x"}}`
+	desired := `{"Cfg":{"Note":"b"}}`
+
+	unannotated := pkgmodel.Schema{
+		Fields: []string{"Cfg"},
+		Hints:  map[string]pkgmodel.FieldHint{"Cfg": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic}},
+	}
+	annotated := pkgmodel.Schema{
+		Fields: []string{"Cfg"},
+		Hints:  map[string]pkgmodel.FieldHint{"Cfg": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic, CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+
+	withoutOp := generatePatchForSchema(t, document, desired, unannotated)
+	withOp := generatePatchForSchema(t, document, desired, annotated)
+
+	require.JSONEq(t, string(withoutOp), string(withOp))
+	require.Contains(t, string(withOp), `"op":"replace"`)
+	require.Contains(t, string(withOp), `"path":"/Cfg"`)
+}
+
+// Same coherence property for an Array field: CoOwned has no defined identity
+// scheme for it either (positional comparison has no member identity at
+// all), so a CoOwned+Array hint must diff exactly like a plain Array hint —
+// element-by-element replace, no drain, no tolerance.
+func TestCoOwnedArrayHintBehavesLikeNoAnnotation(t *testing.T) {
+	document := `{"Items":["a","b"]}`
+	desired := `{"Items":["b","a"]}`
+
+	unannotated := pkgmodel.Schema{
+		Fields: []string{"Items"},
+		Hints:  map[string]pkgmodel.FieldHint{"Items": {UpdateMethod: pkgmodel.FieldUpdateMethodArray}},
+	}
+	annotated := pkgmodel.Schema{
+		Fields: []string{"Items"},
+		Hints:  map[string]pkgmodel.FieldHint{"Items": {UpdateMethod: pkgmodel.FieldUpdateMethodArray, CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+
+	withoutOp := generatePatchForSchema(t, document, desired, unannotated)
+	withOp := generatePatchForSchema(t, document, desired, annotated)
+
+	require.JSONEq(t, string(withoutOp), string(withOp))
+	require.Contains(t, string(withOp), `"path":"/Items/0"`)
+	require.Contains(t, string(withOp), `"path":"/Items/1"`)
+}
+
+// A co-owned field named with a '/' cannot round-trip jsonpatch's path
+// translation, so its annotation is unusable — it degrades to un-annotated
+// Set behavior (every missing member removed unconditionally under
+// reconcile, none tolerated) and logs a warning naming the field, rather
+// than silently registering a CoOwned entry that could never activate.
+func TestCoOwnedSlashInFieldNameDegradesToNoAnnotationAndLogs(t *testing.T) {
+	document := `{"members/extra":["a","x"]}`
+	desired := `{"members/extra":["a"]}`
+
+	unannotated := pkgmodel.Schema{
+		Fields: []string{"members/extra"},
+		Hints:  map[string]pkgmodel.FieldHint{"members/extra": {UpdateMethod: pkgmodel.FieldUpdateMethodSet}},
+	}
+	annotated := pkgmodel.Schema{
+		Fields: []string{"members/extra"},
+		Hints:  map[string]pkgmodel.FieldHint{"members/extra": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+
+	withoutOp := generatePatchForSchema(t, document, desired, unannotated)
+
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	defer slog.SetDefault(previous)
+
+	withOp := generatePatchForSchema(t, document, desired, annotated)
+
+	require.JSONEq(t, string(withoutOp), string(withOp))
+	require.Contains(t, string(withOp), `"op":"remove"`,
+		"un-annotated Set semantics remove every missing member unconditionally; a working annotation would have tolerated the never-owned \"x\"")
+	require.Contains(t, logs.String(), "members/extra",
+		"the skip must be logged with the offending field name")
 }

--- a/internal/metastructure/patch/collection_ownership_partition_test.go
+++ b/internal/metastructure/patch/collection_ownership_partition_test.go
@@ -16,9 +16,9 @@ import (
 // with a priorOwned parameter and driven off a full pkgmodel.Schema (so a
 // hint's CoOwned/UpdateMethod/IndexField/HasProviderDefault all take effect).
 // Like planFor, it drives createPatchDocument directly, not GeneratePatch —
-// but it additionally computes the CoOwned partition the same way generatePatch
-// does, immediately before the createPatchDocument call, over the same
-// (actual, desired) byte pair.
+// but it additionally computes the CoOwned partition and the co-owned
+// path exemptions the same way generatePatch does, immediately before the
+// createPatchDocument call, over the same (actual, desired) byte pair.
 func planForCoOwned(t *testing.T, actual, desired string, schema pkgmodel.Schema, priorOwned pkgmodel.OwnedMembers, strategy jsonpatch.PatchStrategy) []string {
 	t.Helper()
 
@@ -36,6 +36,7 @@ func planForCoOwned(t *testing.T, actual, desired string, schema pkgmodel.Schema
 		strategy,
 		nil, // converge fields
 		nil, // preserve roots
+		coOwnedFieldPaths(schema.Hints),
 	)
 	require.NoError(t, err)
 	out := make([]string, 0, len(ops))
@@ -180,25 +181,18 @@ func TestCoOwnedEntitySetKeepsDeclaredUpdatesUnfiltered(t *testing.T) {
 }
 
 // A co-owned Mapping nested under another field — the shape the Kubernetes
-// metadata.labels case uses — should drain the same way a top-level one does:
-// the explicit-empty drain should land at the nested path, removing only the
-// member this forma previously declared and leaving a co-actor's key
-// untouched.
+// metadata.labels case uses — drains the same way a top-level one does: the
+// explicit-empty drain lands at the nested path, removing only the member
+// this forma previously declared and leaving a co-actor's key untouched.
 //
-// Currently blocked: jsonpatch itself resolves the nested co-owned path
-// correctly (verified directly against jsonpatch.CreatePatch, independent of
-// this package), but createPatchDocument's own empty-collection normalization
-// (StripNestedEmptyCollectionsExcept) strips a NESTED empty collection from
-// its parent before the diff ever runs — {"metadata":{"labels":{}}} becomes
-// {"metadata":{}} — because that pass's preserve-exemption
-// (PreserveEmptyRootFields) only covers top-level, non-dotted hint names. The
-// explicit-empty signal a nested co-owned Mapping needs is erased before
-// coOwnedCollections' whole-field-tolerance-vs-member-drain distinction ever
-// gets to see it, so the field reads as omitted and is tolerated whole
-// instead of being drained.
+// This depends on the empty-collection normalization inside createPatchDocument
+// exempting the co-owned path's OWN empty value from stripping at whatever
+// depth it lives at (stripNestedEmptyCollectionsExceptPaths / coOwnedFieldPaths):
+// without that exemption, {"metadata":{"labels":{}}} loses its "labels" key
+// before the diff ever runs, the field reads as omitted rather than
+// explicitly cleared, and the whole-field-tolerance branch swallows it
+// instead of draining the formerly-owned member.
 func TestCoOwnedNestedMappingExplicitEmptyDrainsPriorOwnedOnly(t *testing.T) {
-	t.Skip("blocked: nested empty-collection normalization erases a nested co-owned Mapping's explicit-empty state before the diff runs; see comment above")
-
 	schema := pkgmodel.Schema{
 		Fields: []string{"metadata"},
 		Hints: map[string]pkgmodel.FieldHint{

--- a/internal/metastructure/patch/collection_ownership_partition_test.go
+++ b/internal/metastructure/patch/collection_ownership_partition_test.go
@@ -1,0 +1,218 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package patch
+
+import (
+	"testing"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/jsonpatch"
+	"github.com/stretchr/testify/require"
+)
+
+// planForCoOwned is collection_ownership_baseline_test.go's planFor, extended
+// with a priorOwned parameter and driven off a full pkgmodel.Schema (so a
+// hint's CoOwned/UpdateMethod/IndexField/HasProviderDefault all take effect).
+// Like planFor, it drives createPatchDocument directly, not GeneratePatch —
+// but it additionally computes the CoOwned partition the same way generatePatch
+// does, immediately before the createPatchDocument call, over the same
+// (actual, desired) byte pair.
+func planForCoOwned(t *testing.T, actual, desired string, schema pkgmodel.Schema, priorOwned pkgmodel.OwnedMembers, strategy jsonpatch.PatchStrategy) []string {
+	t.Helper()
+
+	collections := collectionSemanticsFromFieldHints(schema.Hints)
+	collections.CoOwned = coOwnedCollections([]byte(actual), []byte(desired), schema.Hints, priorOwned)
+
+	ops, err := createPatchDocument(
+		[]byte(actual), []byte(desired),
+		schema.Fields,
+		nil, // requiredOnUpdate
+		schema.HasProviderDefault(),
+		entitySetProviderDefaultsFromHints(schema.Hints),
+		collections,
+		nil, // ignored fields
+		strategy,
+		nil, // converge fields
+		nil, // preserve roots
+	)
+	require.NoError(t, err)
+	out := make([]string, 0, len(ops))
+	for _, op := range ops {
+		out = append(out, op.Operation+" "+op.Path)
+	}
+	return out
+}
+
+// A co-owned Set field shrinks to exactly what this forma is relinquishing: a
+// member present on a prior apply but no longer declared is drained, while a
+// member neither declared now nor previously (another writer's) is tolerated
+// even though it too is absent from desired.
+func TestCoOwnedSetShrinkDrainsExactlyTheRemovedMember(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"members"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"members": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	priorOwned := pkgmodel.OwnedMembers{
+		"members": {Rule: "Set", Members: []string{"\"a\"", "\"b\""}},
+	}
+
+	ops := planForCoOwned(t,
+		`{"members":["a","b","c"]}`,
+		`{"members":["a"]}`,
+		schema, priorOwned, jsonpatch.PatchStrategyExactMatch)
+
+	require.Equal(t, []string{"remove /members/1"}, ops)
+}
+
+// A live member this forma never declared, on this apply or any prior one, is
+// tolerated whole — the co-owned annotation restricts drains to formerly-owned
+// members, it never authorizes removing a co-actor's content.
+func TestCoOwnedSetNeverOwnedMemberIsTolerated(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"members"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"members": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+
+	ops := planForCoOwned(t,
+		`{"members":["a","x"]}`,
+		`{"members":["a"]}`,
+		schema, nil, jsonpatch.PatchStrategyExactMatch)
+
+	require.Empty(t, ops)
+}
+
+// Declaring a co-owned Mapping explicitly empty drains exactly the members
+// this forma previously declared, leaving a co-actor's key untouched — the
+// gap TestExplicitlyEmptiedMapPlansNothing (collection_ownership_baseline_test.go)
+// documents for an unannotated Mapping.
+func TestCoOwnedMappingExplicitEmptyDrainsPriorOwnedOnly(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"labels"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"labels": {CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	priorOwned := pkgmodel.OwnedMembers{
+		"labels": {Rule: "Mapping", Members: []string{"mine"}},
+	}
+
+	ops := planForCoOwned(t,
+		`{"labels":{"mine":"1","theirs":"2"}}`,
+		`{"labels":{}}`,
+		schema, priorOwned, jsonpatch.PatchStrategyExactMatch)
+
+	require.Equal(t, []string{"remove /labels/mine"}, ops)
+}
+
+// A stored ownership record computed under a rule the field no longer matches
+// (its UpdateMethod changed since the record was written) is stale and must
+// not be trusted: the record is discarded rather than degrading to a
+// best-effort comparison, so a shrink after such a change drains nothing.
+func TestCoOwnedRuleMismatchDegradesToNoDrain(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"members"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"members": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	priorOwned := pkgmodel.OwnedMembers{
+		// Stale: this field is a Set now, but the record was computed under an
+		// EntitySet rule (e.g. before a schema change).
+		"members": {Rule: "EntitySet/Name", Members: []string{"\"a\"", "\"b\""}},
+	}
+
+	ops := planForCoOwned(t,
+		`{"members":["a","b"]}`,
+		`{"members":["a"]}`,
+		schema, priorOwned, jsonpatch.PatchStrategyExactMatch)
+
+	require.Empty(t, ops)
+}
+
+// A co-owned EntitySet field the forma omits entirely is tolerated whole,
+// exactly like the unannotated case in
+// TestOmittedAnnotatedFieldIsToleratedWhole (collection_ownership_baseline_test.go).
+func TestCoOwnedEntitySetOmittedFieldIsToleratedWhole(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"attrs"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"attrs": {UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Key", CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+
+	ops := planForCoOwned(t,
+		`{"attrs":[{"Key":"theirs","Value":"1"}]}`,
+		`{}`,
+		schema, nil, jsonpatch.PatchStrategyExactMatch)
+
+	require.Empty(t, ops)
+}
+
+// A co-owned EntitySet still applies the user's own element updates and skips
+// the provider-default pre-strip: op paths index the UNFILTERED document, so
+// a co-actor's untouched element (which the pre-strip would otherwise have
+// removed before the diff ran) does not shift the declared element's index.
+func TestCoOwnedEntitySetKeepsDeclaredUpdatesUnfiltered(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"attrs"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"attrs": {
+				UpdateMethod:       pkgmodel.FieldUpdateMethodEntitySet,
+				IndexField:         "Key",
+				HasProviderDefault: true,
+				CoOwned:            &pkgmodel.CoOwnership{},
+			},
+		},
+	}
+
+	ops := planForCoOwned(t,
+		`{"attrs":[{"Key":"theirs","Value":"1"},{"Key":"mine","Value":"old"}]}`,
+		`{"attrs":[{"Key":"mine","Value":"new"}]}`,
+		schema, nil, jsonpatch.PatchStrategyExactMatch)
+
+	require.Equal(t, []string{"replace /attrs/1/Value"}, ops)
+}
+
+// A co-owned Mapping nested under another field — the shape the Kubernetes
+// metadata.labels case uses — should drain the same way a top-level one does:
+// the explicit-empty drain should land at the nested path, removing only the
+// member this forma previously declared and leaving a co-actor's key
+// untouched.
+//
+// Currently blocked: jsonpatch itself resolves the nested co-owned path
+// correctly (verified directly against jsonpatch.CreatePatch, independent of
+// this package), but createPatchDocument's own empty-collection normalization
+// (StripNestedEmptyCollectionsExcept) strips a NESTED empty collection from
+// its parent before the diff ever runs — {"metadata":{"labels":{}}} becomes
+// {"metadata":{}} — because that pass's preserve-exemption
+// (PreserveEmptyRootFields) only covers top-level, non-dotted hint names. The
+// explicit-empty signal a nested co-owned Mapping needs is erased before
+// coOwnedCollections' whole-field-tolerance-vs-member-drain distinction ever
+// gets to see it, so the field reads as omitted and is tolerated whole
+// instead of being drained.
+func TestCoOwnedNestedMappingExplicitEmptyDrainsPriorOwnedOnly(t *testing.T) {
+	t.Skip("blocked: nested empty-collection normalization erases a nested co-owned Mapping's explicit-empty state before the diff runs; see comment above")
+
+	schema := pkgmodel.Schema{
+		Fields: []string{"metadata"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"metadata.labels": {CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	priorOwned := pkgmodel.OwnedMembers{
+		"metadata.labels": {Rule: "Mapping", Members: []string{"mine"}},
+	}
+
+	ops := planForCoOwned(t,
+		`{"metadata":{"labels":{"mine":"1","theirs":"2"}}}`,
+		`{"metadata":{"labels":{}}}`,
+		schema, priorOwned, jsonpatch.PatchStrategyExactMatch)
+
+	require.Equal(t, []string{"remove /metadata/labels/mine"}, ops)
+}

--- a/internal/metastructure/patch/desired_projection.go
+++ b/internal/metastructure/patch/desired_projection.go
@@ -1,0 +1,147 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package patch
+
+import (
+	"encoding/json"
+	"fmt"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ProjectDesiredForWrite returns the desired properties with each co-owned
+// collection completed to its intended post-write value: the declared
+// members plus the never-owned live members (a co-actor's content, which the
+// drainable-restricted patch deliberately plans nothing for). Formerly-owned
+// members stay absent — their absence is the drain.
+//
+// The agent hands a plugin two descriptions of one update, DesiredProperties
+// and PatchDocument, and a plugin legitimately acts on either. Without this
+// projection they disagree on a co-owned path by exactly the tolerated
+// members: the patch preserves what the desired document omits, so a
+// desired-state-driven plugin deletes what a patch-driven plugin keeps. With
+// it, DesiredProperties equals PriorProperties with the patch applied, and
+// both plugin styles produce the same cloud state.
+//
+// This is a projection for the plugin-facing copy of an update request ONLY.
+// The durable DesiredState.Properties must stay declared-only: the record
+// recompute at the write echo claims declared-intersect-echo, and a desired
+// document that already contains tolerated members would get them claimed —
+// and later drained — as this forma's own.
+//
+// Per co-owned path: an unset (absent or null) field is skipped — whole-field
+// omit tolerance already keeps every plugin's hands off it. An uninterpretable
+// record (rule mismatch) degrades to no prior, so unclassifiable live members
+// merge in as never-owned — toward tolerance, never toward a deletion. Live
+// members are copied in the stored document's own representation; the
+// plugin-format conversion downstream flattens envelopes the same way it does
+// for declared members.
+func ProjectDesiredForWrite(desired, live json.RawMessage, priorOwned pkgmodel.OwnedMembers, schema pkgmodel.Schema) (json.RawMessage, error) {
+	out := desired
+	for path, hint := range schema.Hints {
+		if hint.CoOwned == nil || hint.Opaque {
+			continue
+		}
+		// The patch layer ignores a CoOwned hint on an ineligible collection
+		// shape (no identity rule, e.g. Array); the projection must ignore
+		// exactly the same hints or the two representations diverge again.
+		if pkgmodel.IdentityRule(hint) == "" {
+			continue
+		}
+
+		desiredVal := gjson.GetBytes(out, path)
+		if !desiredVal.Exists() || desiredVal.Type == gjson.Null {
+			continue
+		}
+		liveVal := gjson.GetBytes(live, path)
+		if !liveVal.Exists() {
+			continue
+		}
+
+		declared := pkgmodel.MemberIdentities(desiredVal, hint)
+		var prior []string
+		if record, ok := priorOwned[path]; ok && record.Rule == pkgmodel.IdentityRule(hint) {
+			prior = record.Members
+		}
+		liveIDs := pkgmodel.MemberIdentities(liveVal, hint)
+		partition := pkgmodel.PartitionOwnership(declared, prior, liveIDs)
+		if len(partition.NeverOwned) == 0 {
+			continue
+		}
+
+		merged, changed, err := mergeNeverOwned(desiredVal, liveVal, hint, partition.NeverOwned)
+		if err != nil {
+			return nil, fmt.Errorf("failed to project co-owned path %q: %w", path, err)
+		}
+		if !changed {
+			continue
+		}
+		out, err = sjson.SetRawBytes(out, path, merged)
+		if err != nil {
+			return nil, fmt.Errorf("failed to write projected co-owned path %q: %w", path, err)
+		}
+	}
+	return out, nil
+}
+
+// mergeNeverOwned returns desiredVal with live's never-owned members merged
+// in: for an object (Mapping), the never-owned keys with their live values;
+// for an array (Set/EntitySet), the live elements whose identity is
+// never-owned, appended after the declared ones. Members are matched by the
+// same identity computation the partition used, so a live element that
+// contributes no identity is left out (it cannot be classified, and adding
+// it could duplicate a declared member).
+func mergeNeverOwned(desiredVal, liveVal gjson.Result, hint pkgmodel.FieldHint, neverOwned map[string]struct{}) (json.RawMessage, bool, error) {
+	switch {
+	case desiredVal.IsObject() && liveVal.IsObject():
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(desiredVal.Raw), &obj); err != nil {
+			return nil, false, err
+		}
+		if obj == nil {
+			obj = map[string]json.RawMessage{}
+		}
+		changed := false
+		liveVal.ForEach(func(key, val gjson.Result) bool {
+			if _, ok := neverOwned[key.String()]; ok {
+				obj[key.String()] = json.RawMessage(val.Raw)
+				changed = true
+			}
+			return true
+		})
+		if !changed {
+			return nil, false, nil
+		}
+		raw, err := json.Marshal(obj)
+		return raw, true, err
+	case desiredVal.IsArray() && liveVal.IsArray():
+		elements := []json.RawMessage{}
+		for _, el := range desiredVal.Array() {
+			elements = append(elements, json.RawMessage(el.Raw))
+		}
+		changed := false
+		liveVal.ForEach(func(_, el gjson.Result) bool {
+			id, ok := singleElementIdentity(el, hint)
+			if !ok {
+				return true
+			}
+			if _, keep := neverOwned[id]; keep {
+				elements = append(elements, json.RawMessage(el.Raw))
+				changed = true
+			}
+			return true
+		})
+		if !changed {
+			return nil, false, nil
+		}
+		raw, err := json.Marshal(elements)
+		return raw, true, err
+	default:
+		// Shape mismatch (or a non-collection value): nothing safe to merge.
+		return nil, false, nil
+	}
+}

--- a/internal/metastructure/patch/desired_projection_test.go
+++ b/internal/metastructure/patch/desired_projection_test.go
@@ -1,0 +1,153 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package patch
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func projectionMappingSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"labels"},
+		Hints:  map[string]pkgmodel.FieldHint{"labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+}
+
+func projectionSetSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"SecurityGroups"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"SecurityGroups": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+}
+
+// A co-actor's live members (never declared, never claimed) join the
+// declared ones; the desired document a plugin acts on then says the same
+// thing the drainable-restricted patch does.
+func TestProjectDesiredForWrite_MappingGainsNeverOwnedKeys(t *testing.T) {
+	record := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+
+	out, err := ProjectDesiredForWrite(
+		json.RawMessage(`{"labels":{"app":"web"}}`),
+		json.RawMessage(`{"labels":{"app":"web","team":"platform","opinion":"oob"}}`),
+		record, projectionMappingSchema())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"labels":{"app":"web","team":"platform","opinion":"oob"}}`, string(out))
+}
+
+// A formerly-owned member (claimed on record, no longer declared) stays
+// absent: its absence IS the drain, for a desired-state-driven plugin
+// exactly as for the patch's restricted remove.
+func TestProjectDesiredForWrite_FormerlyOwnedStaysAbsent(t *testing.T) {
+	record := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app", "team"}}}
+
+	out, err := ProjectDesiredForWrite(
+		json.RawMessage(`{"labels":{"app":"web"}}`),
+		json.RawMessage(`{"labels":{"app":"web","team":"absorbed","opinion":"oob"}}`),
+		record, projectionMappingSchema())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"labels":{"app":"web","opinion":"oob"}}`, string(out))
+}
+
+// Explicit empty drains the formerly-owned portion and preserves the rest:
+// the projected document carries exactly the co-actor's members.
+func TestProjectDesiredForWrite_ExplicitEmptyPreservesNeverOwned(t *testing.T) {
+	record := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+
+	out, err := ProjectDesiredForWrite(
+		json.RawMessage(`{"labels":{}}`),
+		json.RawMessage(`{"labels":{"app":"web","kubernetes.io/metadata.name":"ns"}}`),
+		record, projectionMappingSchema())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"labels":{"kubernetes.io/metadata.name":"ns"}}`, string(out))
+}
+
+// An unset field is skipped entirely: whole-field omit tolerance already
+// keeps every plugin's hands off it, and inventing the field would turn an
+// omitted declaration into an asserted one.
+func TestProjectDesiredForWrite_UnsetFieldUntouched(t *testing.T) {
+	out, err := ProjectDesiredForWrite(
+		json.RawMessage(`{"Name":"n"}`),
+		json.RawMessage(`{"Name":"n","labels":{"team":"platform"}}`),
+		nil, projectionMappingSchema())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"Name":"n"}`, string(out))
+}
+
+// Set listings: never-owned live elements are appended after the declared
+// ones, in the stored document's own representation.
+func TestProjectDesiredForWrite_SetGainsNeverOwnedElements(t *testing.T) {
+	record := pkgmodel.OwnedMembers{"SecurityGroups": {Rule: "Set", Members: []string{`"sg-mine"`}}}
+
+	out, err := ProjectDesiredForWrite(
+		json.RawMessage(`{"SecurityGroups":["sg-mine"]}`),
+		json.RawMessage(`{"SecurityGroups":["sg-mine","sg-oob"]}`),
+		record, projectionSetSchema())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"SecurityGroups":["sg-mine","sg-oob"]}`, string(out))
+}
+
+// A rule-mismatched record is uninterpretable and degrades to no prior:
+// live members it named merge in as never-owned - toward tolerance, never
+// toward a deletion.
+func TestProjectDesiredForWrite_RuleMismatchedRecordDegradesToTolerance(t *testing.T) {
+	record := pkgmodel.OwnedMembers{"SecurityGroups": {Rule: "EntitySet/Key", Members: []string{`"sg-old"`}}}
+
+	out, err := ProjectDesiredForWrite(
+		json.RawMessage(`{"SecurityGroups":["sg-mine"]}`),
+		json.RawMessage(`{"SecurityGroups":["sg-mine","sg-old"]}`),
+		record, projectionSetSchema())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"SecurityGroups":["sg-mine","sg-old"]}`, string(out))
+}
+
+// A declared member echoed in the stored document as a resolved reference
+// envelope must not be duplicated: the envelope's identity matches the
+// declared literal, so it is not never-owned.
+func TestProjectDesiredForWrite_ResolvedEnvelopeMemberNotDuplicated(t *testing.T) {
+	out, err := ProjectDesiredForWrite(
+		json.RawMessage(`{"SecurityGroups":["sg-mine"]}`),
+		json.RawMessage(`{"SecurityGroups":[{"$ref":"formae://resource/x#/GroupId","$value":"sg-mine"}]}`),
+		nil, projectionSetSchema())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"SecurityGroups":["sg-mine"]}`, string(out))
+}
+
+// No co-owned paths, or no never-owned content: the document passes through
+// byte-identical.
+func TestProjectDesiredForWrite_NoNeverOwnedContentPassesThrough(t *testing.T) {
+	in := json.RawMessage(`{"labels":{"app":"web"}}`)
+	out, err := ProjectDesiredForWrite(in,
+		json.RawMessage(`{"labels":{"app":"web"}}`), nil, projectionMappingSchema())
+	require.NoError(t, err)
+	assert.Equal(t, string(in), string(out))
+}
+
+// A CoOwned hint on an ineligible collection shape (no identity rule, e.g.
+// Array) is ignored by the patch layer; the projection must ignore exactly
+// the same hints, or the two representations diverge again.
+func TestProjectDesiredForWrite_IneligibleCoOwnedHintIgnored(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Ordered"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Ordered": {UpdateMethod: pkgmodel.FieldUpdateMethodArray, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+
+	in := json.RawMessage(`{"Ordered":["a"]}`)
+	out, err := ProjectDesiredForWrite(in,
+		json.RawMessage(`{"Ordered":["a","b"]}`), nil, schema)
+	require.NoError(t, err)
+	assert.Equal(t, string(in), string(out))
+}

--- a/internal/metastructure/patch/empty_value_fidelity.go
+++ b/internal/metastructure/patch/empty_value_fidelity.go
@@ -102,3 +102,19 @@ func PreserveEmptyRootFields(schema pkgmodel.Schema) map[string]bool {
 	}
 	return fields
 }
+
+// coOwnedFieldPaths returns the field-hint keys — dotted or not — of every
+// hint whose CoOwned annotation is set. Unlike PreserveEmptyRootFields, a
+// dotted (nested) key is kept rather than skipped: an explicit-empty
+// co-owned collection must reach the diff at whatever depth it lives at, not
+// only at the top level, or the field silently reads as omitted instead of
+// explicitly cleared (see stripNestedEmptyCollectionsExceptPaths).
+func coOwnedFieldPaths(hints map[string]pkgmodel.FieldHint) map[string]bool {
+	paths := map[string]bool{}
+	for name, hint := range hints {
+		if hint.CoOwned != nil {
+			paths[name] = true
+		}
+	}
+	return paths
+}

--- a/internal/metastructure/patch/empty_value_fidelity_test.go
+++ b/internal/metastructure/patch/empty_value_fidelity_test.go
@@ -122,7 +122,7 @@ func TestGeneratePatch_PreserveEmpty_ReplaceCarriesVerbatimValue(t *testing.T) {
 	document := json.RawMessage(`{"Name":"x","Spec":{"acme":{"server":"https://old"}}}`)
 	desired := json.RawMessage(`{"Name":"x","Spec":{"selfSigned":{}}}`)
 
-	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 
 	var ops []struct {
@@ -142,7 +142,7 @@ func TestGeneratePatch_PreserveEmpty_ReplaceCarriesVerbatimValue(t *testing.T) {
 func TestGeneratePatch_PreserveEmpty_IdenticalSidesPlanNothing(t *testing.T) {
 	doc := json.RawMessage(`{"Name":"x","Spec":{"selfSigned":{}}}`)
 
-	patchDoc, _, _, err := GeneratePatch(doc, doc, doc, doc, resolver.ResolvableProperties{}, fidelitySchema(), pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := GeneratePatch(doc, doc, doc, doc, resolver.ResolvableProperties{}, fidelitySchema(), nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc)
 }
@@ -153,7 +153,7 @@ func TestGeneratePatch_NonHintedFieldStillStripped(t *testing.T) {
 	document := json.RawMessage(`{"Name":"x","Other":{"acme":{"server":"https://old"}}}`)
 	desired := json.RawMessage(`{"Name":"x","Other":{"selfSigned":{}}}`)
 
-	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.NotContains(t, string(patchDoc), "selfSigned",
 		"unhinted fields keep the rendering-noise strip")
@@ -173,12 +173,12 @@ func TestGeneratePatch_ReferenceEnvelopeAddSurvives(t *testing.T) {
 	document := json.RawMessage(`{"Name":"x"}`)
 	desired := json.RawMessage(`{"Name":"x","Token":{"$ref":"formae://2ABcDeFgHiJkLmNoPqRsTuVwXyZ#/S"}}`)
 
-	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, refSchema(), pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, refSchema(), nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.JSONEq(t, `[{"op":"add","path":"/Token","value":""}]`, string(patchDoc))
 
 	plain := json.RawMessage(`{"Name":"x","Token":""}`)
-	patchDoc, _, _, err = GeneratePatch(document, plain, document, plain, resolver.ResolvableProperties{}, refSchema(), pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err = GeneratePatch(document, plain, document, plain, resolver.ResolvableProperties{}, refSchema(), nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "a plain empty string is still rendering noise")
 }
@@ -189,7 +189,7 @@ func TestGeneratePatch_MalformedEnvelopeNotKept(t *testing.T) {
 	document := json.RawMessage(`{"Name":"x"}`)
 	desired := json.RawMessage(`{"Name":"x","Token":{"$res":true}}`)
 
-	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, refSchema(), pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, refSchema(), nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.NotContains(t, string(patchDoc), `"value":""`,
 		"the keep-set must never mint an empty-string placeholder for a malformed envelope")
@@ -202,7 +202,7 @@ func TestGeneratePatch_KeptFieldEqualValuesNoOp(t *testing.T) {
 	document := json.RawMessage(`{"Name":"x","Token":"v"}`)
 	desired := json.RawMessage(`{"Name":"x","Token":{"$ref":"formae://2ABcDeFgHiJkLmNoPqRsTuVwXyZ#/S","$value":"v"}}`)
 
-	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, refSchema(), pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, refSchema(), nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc)
 }
@@ -215,7 +215,7 @@ func TestGeneratePatch_PreservedRootAbsentDesired_NoRemove(t *testing.T) {
 	document := json.RawMessage(`{"Name":"x","Spec":{}}`)
 	desired := json.RawMessage(`{"Name":"x"}`)
 
-	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.NotContains(t, string(patchDoc), "remove")
 }
@@ -225,7 +225,7 @@ func TestGeneratePatch_ReferenceAddSurvivesPatchMode(t *testing.T) {
 	document := json.RawMessage(`{"Name":"x"}`)
 	desired := json.RawMessage(`{"Name":"x","Token":{"$ref":"formae://2ABcDeFgHiJkLmNoPqRsTuVwXyZ#/S"}}`)
 
-	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, refSchema(), pkgmodel.FormaApplyModePatch)
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, refSchema(), nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.JSONEq(t, `[{"op":"add","path":"/Token","value":""}]`, string(patchDoc))
 }
@@ -242,7 +242,7 @@ func TestGeneratePatch_ReferenceOnCreateOnlyDestination_NoPlaceholder(t *testing
 	document := json.RawMessage(`{"Name":"x"}`)
 	desired := json.RawMessage(`{"Name":"x","Token":{"$ref":"formae://2ABcDeFgHiJkLmNoPqRsTuVwXyZ#/S"}}`)
 
-	patchDoc, createOnly, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnly, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnly, "no replacement may be planned from an unresolved placeholder")
 	assert.NotContains(t, string(patchDoc), "/Token")
@@ -255,7 +255,7 @@ func TestGeneratePatch_PreserveEmpty_ActualExtraEmptyChurnsAsWholeReplace(t *tes
 	document := json.RawMessage(`{"Name":"x","Spec":{"selfSigned":{},"defaulted":{}}}`)
 	desired := json.RawMessage(`{"Name":"x","Spec":{"selfSigned":{}}}`)
 
-	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.JSONEq(t, `[{"op":"replace","path":"/Spec","value":{"selfSigned":{}}}]`, string(patchDoc))
 }
@@ -272,7 +272,7 @@ func TestGeneratePatch_AtomicWithoutPreserve_KeepsStripBehavior(t *testing.T) {
 	document := json.RawMessage(`{"Name":"x","Doc":{"stmt":{"cond":{}}}}`)
 	desired := json.RawMessage(`{"Name":"x","Doc":{"stmt":{}}}`)
 
-	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc,
 		"symmetric stripping still equalizes empty-shaped differences for atomic-only fields")
@@ -288,7 +288,7 @@ func TestGeneratePatch_DottedPreserveHint_NoFidelity(t *testing.T) {
 	document := json.RawMessage(`{"Name":"x","Config":{"records":{"a":{}}}}`)
 	desired := json.RawMessage(`{"Name":"x","Config":{"records":{}}}`)
 
-	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "nested hints are out of fidelity scope; today's stripping applies")
 }
@@ -302,7 +302,7 @@ func TestGeneratePatch_PreservedRoot_EmptyOnlyDifferenceMintsReplace(t *testing.
 	document := json.RawMessage(`{"Name":"x","Spec":{}}`)
 	desired := json.RawMessage(`{"Name":"x","Spec":{"selfSigned":{}}}`)
 
-	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := GeneratePatch(document, desired, document, desired, resolver.ResolvableProperties{}, fidelitySchema(), nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.JSONEq(t, `[{"op":"replace","path":"/Spec","value":{"selfSigned":{}}}]`, string(patchDoc))
 }

--- a/internal/metastructure/patch/modification_confront.go
+++ b/internal/metastructure/patch/modification_confront.go
@@ -1,0 +1,294 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package patch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ModificationConfrontable reports whether a resource's out-of-band
+// modification (its stored state at the last reconcile, oldProps, versus its
+// current stored state, newProps) carries movement a reconcile must confront
+// before proceeding. Movement confined to a co-owned collection's never-owned
+// members — a co-actor's content, the very thing the ownership partition
+// exists to tolerate — is not confrontable; everything else is (a plain-field
+// change, a provider-default move, a declared/formerly-owned co-owned member
+// move).
+//
+// It is the gate's answer to "does this resource carry drift the user has not
+// seen", asked independently of whether the forma also plans a change to the
+// resource. The prior gate used "the forma plans a change" as a proxy for
+// "there is unconfronted drift", which rejected every edit of a resource that
+// merely carried a co-actor's tolerated content.
+//
+// The comparison keeps everything except never-owned co-owned members, so it
+// errs toward confront: only that one tolerated class is removed, and anything
+// it cannot classify as a co-owned member (an opaque or malformed co-owned
+// value, a provider-default field, a plain field) stays and confronts. A false
+// "confront" is a spurious rejection recoverable with --force, never a silent
+// overwrite of drift. Provider-default and witness handling for resources the
+// forma does NOT edit stays in the earlier drift stages (FilterUnabsorbed /
+// WitnessedMoved); this predicate only re-examines what those already flagged.
+func ModificationConfrontable(oldProps, newProps, desired json.RawMessage, priorOwned pkgmodel.OwnedMembers, schema pkgmodel.Schema) (bool, error) {
+	oldRem, oldEmptied, err := confrontableRemainder(oldProps, desired, priorOwned, schema)
+	if err != nil {
+		return false, err
+	}
+	newRem, newEmptied, err := confrontableRemainder(newProps, desired, priorOwned, schema)
+	if err != nil {
+		return false, err
+	}
+
+	// An ancestor object emptied by neutralizing a co-owned child on EITHER
+	// side is pruned from BOTH, so the comparison neither turns on which side
+	// carried the tolerated content (symmetry) nor conflates a container that
+	// neutralization emptied with one the resource holds explicitly empty (only
+	// the former is ever collected here).
+	emptied := unionSorted(oldEmptied, newEmptied)
+	oldRem = pruneAncestors(oldRem, emptied)
+	newRem = pruneAncestors(newRem, emptied)
+
+	oldCanon, err := canonicalizeRemainder(oldRem)
+	if err != nil {
+		return false, err
+	}
+	newCanon, err := canonicalizeRemainder(newRem)
+	if err != nil {
+		return false, err
+	}
+	return oldCanon != newCanon, nil
+}
+
+// confrontableRemainder returns props with never-owned co-owned members
+// removed, plus the ancestor objects that neutralizing a nested co-owned path
+// left empty (so the caller can prune them symmetrically across both sides).
+// A co-owned (non-opaque) path's value is restricted to the members this forma
+// declares or has on record (declared ∪ prior); an unclassifiable co-owned
+// value and every non-co-owned field are left intact.
+func confrontableRemainder(props, desired json.RawMessage, priorOwned pkgmodel.OwnedMembers, schema pkgmodel.Schema) (json.RawMessage, []string, error) {
+	out := props
+	if len(out) == 0 {
+		out = json.RawMessage(`{}`)
+	}
+
+	var deletedNested []string
+
+	for path, hint := range schema.Hints {
+		if hint.CoOwned == nil || hint.Opaque {
+			continue
+		}
+		val := gjson.GetBytes(out, path)
+		if !val.Exists() {
+			continue
+		}
+		// An unclassifiable shape (a scalar where a collection is expected, or
+		// an array element without its identity field) has no members to
+		// partition; leaving it in the remainder confronts its change rather
+		// than deleting it and reading distinct values as equal.
+		if !coOwnedValueClassifiable(val, hint) {
+			continue
+		}
+		keep := map[string]struct{}{}
+		for _, id := range pkgmodel.MemberIdentities(gjson.GetBytes(desired, path), hint) {
+			keep[id] = struct{}{}
+		}
+		if rec, ok := priorOwned[path]; ok && rec.Rule == pkgmodel.IdentityRule(hint) {
+			for _, id := range rec.Members {
+				keep[id] = struct{}{}
+			}
+		}
+		// restrictRawToKeep keeps exactly the members whose identity is in the
+		// supplied set — here declared ∪ prior — so never-owned members are
+		// dropped, preserving each kept member's raw JSON (so a large-integer
+		// value is not reconstructed through a lossy float64).
+		restricted, kept := restrictRawToKeep(val, hint, keep)
+		var err error
+		if !kept {
+			out, err = sjson.DeleteBytes(out, path)
+			if strings.Contains(path, ".") {
+				deletedNested = append(deletedNested, path)
+			}
+		} else {
+			out, err = sjson.SetRawBytes(out, path, restricted)
+		}
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to reduce co-owned path %q: %w", path, err)
+		}
+	}
+
+	return out, emptiedAncestors(out, deletedNested), nil
+}
+
+// emptiedAncestors returns the ancestor object paths that are now empty as a
+// result of deleting the given nested paths — walking each deleted path's
+// ancestors from the immediate parent upward, collecting empty objects and
+// stopping at the first non-empty one. An ancestor the document held
+// explicitly empty (no co-owned child was deleted under it) is never collected,
+// because only actually-deleted paths are walked.
+func emptiedAncestors(doc json.RawMessage, deletedPaths []string) []string {
+	if len(deletedPaths) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	for _, path := range deletedPaths {
+		segments := strings.Split(path, ".")
+		for i := len(segments) - 1; i >= 1; i-- {
+			ancestor := strings.Join(segments[:i], ".")
+			val := gjson.GetBytes(doc, ancestor)
+			if !val.IsObject() || len(val.Map()) != 0 {
+				break
+			}
+			if _, ok := seen[ancestor]; !ok {
+				seen[ancestor] = struct{}{}
+				out = append(out, ancestor)
+			}
+		}
+	}
+	return out
+}
+
+// pruneAncestors deletes each of the given ancestor paths from the document
+// when it is present and empty, deepest first so a parent emptied only by
+// pruning its children is removed too.
+func pruneAncestors(doc json.RawMessage, ancestors []string) json.RawMessage {
+	for _, ancestor := range ancestors {
+		val := gjson.GetBytes(doc, ancestor)
+		if !val.IsObject() || len(val.Map()) != 0 {
+			continue
+		}
+		next, err := sjson.DeleteBytes(doc, ancestor)
+		if err != nil {
+			continue
+		}
+		doc = next
+	}
+	return doc
+}
+
+// unionSorted returns the union of two path sets, sorted by descending depth
+// (most "." first) then lexically, so pruneAncestors removes a child before its
+// parent.
+func unionSorted(a, b []string) []string {
+	set := map[string]struct{}{}
+	for _, s := range a {
+		set[s] = struct{}{}
+	}
+	for _, s := range b {
+		set[s] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for s := range set {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		di, dj := strings.Count(out[i], "."), strings.Count(out[j], ".")
+		if di != dj {
+			return di > dj
+		}
+		return out[i] < out[j]
+	})
+	return out
+}
+
+// canonicalizeRemainder renders a properties document deterministically
+// (sorted object keys) so two remainders compare as strings. It decodes with
+// UseNumber so a large integer keeps its exact literal instead of collapsing
+// to a float64, which would let two distinct out-of-range integers compare
+// equal and silently pass real drift.
+func canonicalizeRemainder(doc json.RawMessage) (string, error) {
+	dec := json.NewDecoder(bytes.NewReader(doc))
+	dec.UseNumber()
+	var decoded any
+	if err := dec.Decode(&decoded); err != nil {
+		return "", err
+	}
+	return canonicalJSON(decoded), nil
+}
+
+// restrictRawToKeep returns val reduced to the members whose identity is in
+// keep, as raw JSON, and whether anything was kept. For an object (Mapping) it
+// keeps the entries whose key is in keep; for an array (Set/EntitySet) it keeps
+// the elements whose identity is in keep, sorted by their raw form for a
+// deterministic comparison. Each kept member is carried as its verbatim raw
+// JSON, so numeric precision survives. Returns (nil, false) when nothing is
+// kept, so the caller drops the whole path exactly as before.
+func restrictRawToKeep(val gjson.Result, hint pkgmodel.FieldHint, keep map[string]struct{}) (json.RawMessage, bool) {
+	switch {
+	case val.IsObject():
+		out := map[string]json.RawMessage{}
+		val.ForEach(func(key, v gjson.Result) bool {
+			if _, ok := keep[key.String()]; ok {
+				out[key.String()] = json.RawMessage(v.Raw)
+			}
+			return true
+		})
+		if len(out) == 0 {
+			return nil, false
+		}
+		raw, err := json.Marshal(out)
+		if err != nil {
+			return nil, false
+		}
+		return raw, true
+	case val.IsArray():
+		var elems []string
+		val.ForEach(func(_, el gjson.Result) bool {
+			if id, ok := singleElementIdentity(el, hint); ok {
+				if _, keepIt := keep[id]; keepIt {
+					elems = append(elems, el.Raw)
+				}
+			}
+			return true
+		})
+		if len(elems) == 0 {
+			return nil, false
+		}
+		sort.Strings(elems)
+		return json.RawMessage("[" + strings.Join(elems, ",") + "]"), true
+	default:
+		return nil, false
+	}
+}
+
+// coOwnedValueClassifiable reports whether a co-owned field's value can be
+// partitioned into members, and its SHAPE matches the hint's identity rule: a
+// Mapping's value must be an object (its keys are the identities), and a
+// Set/EntitySet's value must be an array every element of which yields an
+// identity. A shape that mismatches the rule (an object where an array is
+// expected, or the reverse), a scalar, or an EntitySet element missing its
+// index field is unclassifiable — restrictToNeverOwned would return nil for it
+// exactly as it does for a legitimately drained collection, so the caller must
+// not neutralize it.
+func coOwnedValueClassifiable(val gjson.Result, hint pkgmodel.FieldHint) bool {
+	mapShaped := pkgmodel.IdentityRule(hint) == "Mapping"
+	switch {
+	case val.IsObject():
+		return mapShaped
+	case val.IsArray():
+		if mapShaped {
+			return false
+		}
+		classifiable := true
+		val.ForEach(func(_, el gjson.Result) bool {
+			if _, ok := singleElementIdentity(el, hint); !ok {
+				classifiable = false
+				return false
+			}
+			return true
+		})
+		return classifiable
+	default:
+		return false
+	}
+}

--- a/internal/metastructure/patch/modification_confront_test.go
+++ b/internal/metastructure/patch/modification_confront_test.go
@@ -1,0 +1,311 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package patch
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// confrontMappingSchema: a co-owned Mapping label field plus a plain field.
+func confrontMappingSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"Name", "labels"},
+		Hints:  map[string]pkgmodel.FieldHint{"labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+}
+
+// confront keeps a witness parameter in its signature for call-site
+// readability, but the predicate no longer consults a witness: provider-default
+// tolerance for resources the forma does not edit lives in the earlier drift
+// stages, so this predicate confronts any non-co-owned change.
+func confront(t *testing.T, old, new, desired, witness string, prior pkgmodel.OwnedMembers, schema pkgmodel.Schema) bool {
+	t.Helper()
+	_ = witness
+	got, err := ModificationConfrontable(json.RawMessage(old), json.RawMessage(new), json.RawMessage(desired), prior, schema)
+	require.NoError(t, err)
+	return got
+}
+
+// The bug: a co-actor's never-owned member appears out of band. Nothing the
+// user manages moved, so a reconcile need not confront.
+func TestModificationConfrontable_NeverOwnedMemberAdded_Tolerated(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+	got := confront(t,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		`{"Name":"n","labels":{"app":"web","team":"platform"}}`,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		"", prior, confrontMappingSchema())
+	assert.False(t, got, "a never-owned member's appearance is tolerated")
+}
+
+func TestModificationConfrontable_NeverOwnedMemberValueChanged_Tolerated(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+	got := confront(t,
+		`{"Name":"n","labels":{"app":"web","team":"a"}}`,
+		`{"Name":"n","labels":{"app":"web","team":"b"}}`,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		"", prior, confrontMappingSchema())
+	assert.False(t, got, "a never-owned member's value change is tolerated")
+}
+
+// A member the user declares is theirs; its out-of-band change is real drift.
+func TestModificationConfrontable_DeclaredMemberChanged_Confront(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+	got := confront(t,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		`{"Name":"n","labels":{"app":"hacked"}}`,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		"", prior, confrontMappingSchema())
+	assert.True(t, got, "a declared member's out-of-band change must confront")
+}
+
+// A member on the record but no longer declared (being drained): its
+// out-of-band movement still confronts.
+func TestModificationConfrontable_FormerlyOwnedMemberChanged_Confront(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app", "team"}}}
+	got := confront(t,
+		`{"Name":"n","labels":{"app":"web","team":"a"}}`,
+		`{"Name":"n","labels":{"app":"web","team":"b"}}`,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		"", prior, confrontMappingSchema())
+	assert.True(t, got, "a formerly-owned member's out-of-band change must confront")
+}
+
+// A plain (non-co-owned) field moving out of band is always confrontable.
+func TestModificationConfrontable_PlainFieldChanged_Confront(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+	got := confront(t,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		`{"Name":"changed","labels":{"app":"web","team":"x"}}`,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		"", prior, confrontMappingSchema())
+	assert.True(t, got, "a plain field's out-of-band change must confront even beside tolerated movement")
+}
+
+// A witnessed provider-default move confronts; the witness makes it real.
+func TestModificationConfrontable_WitnessedProviderDefault_Confront(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "EnableKeyRotation"},
+		Hints:  map[string]pkgmodel.FieldHint{"EnableKeyRotation": {HasProviderDefault: true}},
+	}
+	got := confront(t,
+		`{"Name":"n","EnableKeyRotation":false}`,
+		`{"Name":"n","EnableKeyRotation":true}`,
+		`{"Name":"n"}`,
+		`{"Name":"n","EnableKeyRotation":false}`, // witness holds a real value
+		nil, schema)
+	assert.True(t, got, "a witnessed provider-default move must confront")
+}
+
+// A provider-default field moving out of band confronts at this predicate.
+// Tolerating first-time, unwitnessed provider-default population is the
+// earlier drift stages' job (a resource the forma does not edit never reaches
+// this predicate); here, everything that is not a never-owned co-owned member
+// stays and confronts.
+func TestModificationConfrontable_ProviderDefaultMove_Confront(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "EnableKeyRotation"},
+		Hints:  map[string]pkgmodel.FieldHint{"EnableKeyRotation": {HasProviderDefault: true}},
+	}
+	got := confront(t,
+		`{"Name":"n"}`,
+		`{"Name":"n","EnableKeyRotation":true}`,
+		`{"Name":"n"}`,
+		"", nil, schema)
+	assert.True(t, got, "a provider-default field's out-of-band move confronts at the predicate level")
+}
+
+func TestModificationConfrontable_NoChange_Tolerated(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+	got := confront(t,
+		`{"Name":"n","labels":{"app":"web","team":"x"}}`,
+		`{"Name":"n","labels":{"app":"web","team":"x"}}`,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		"", prior, confrontMappingSchema())
+	assert.False(t, got, "no movement at all is not confrontable")
+}
+
+// The version=2 rig repro in miniature: a never-owned member is live and the
+// modification is purely that co-actor's content, while the user's edit lives
+// in the plan (not in this modification). Must be tolerated.
+func TestModificationConfrontable_CoActorDriftBesidePendingEdit_Tolerated(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app", "owner"}}}
+	got := confront(t,
+		`{"Name":"n","labels":{"app":"probe","owner":"formae"}}`,
+		`{"Name":"n","labels":{"app":"probe","opinion":"oob","owner":"formae","team":"platform"}}`,
+		`{"Name":"n","labels":{"app":"probe","owner":"formae","version":"2"}}`,
+		"", prior, confrontMappingSchema())
+	assert.False(t, got, "co-actor drift beside a declared edit is tolerated; the edit is not in the modification")
+}
+
+// A provider-default field the user DECLARES is owned by ordinary planning,
+// not suppressed. Its out-of-band change is real drift and must confront —
+// the remainder must not neutralize a declared provider-default field.
+func TestModificationConfrontable_DeclaredProviderDefaultChanged_Confront(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "EnableKeyRotation"},
+		Hints:  map[string]pkgmodel.FieldHint{"EnableKeyRotation": {HasProviderDefault: true}},
+	}
+	got := confront(t,
+		`{"Name":"n","EnableKeyRotation":true}`,
+		`{"Name":"n","EnableKeyRotation":false}`,
+		`{"Name":"n","EnableKeyRotation":true}`, // declared
+		"", nil, schema)
+	assert.True(t, got, "a declared provider-default field's out-of-band change must confront")
+}
+
+// A nested co-owned path whose only content is never-owned must stay
+// tolerated even when neutralizing it leaves empty ancestor objects that
+// differ structurally between the two sides.
+func TestModificationConfrontable_NestedCoOwnedEmptyAncestors_Tolerated(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"meta"},
+		Hints:  map[string]pkgmodel.FieldHint{"meta.labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+	got := confront(t,
+		`{"meta":{"labels":{"team":"x"}}}`,
+		`{}`,
+		`{}`,
+		"", nil, schema)
+	assert.False(t, got, "a nested co-owned path of only never-owned members is tolerated despite empty-ancestor mismatch")
+}
+
+// A plain managed field toggling between a null/empty value and absent is
+// real drift; neutralizing co-owned content must not prune managed nulls or
+// empty containers elsewhere in the document.
+func TestModificationConfrontable_ManagedNullTogglesConfront(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"meta", "config"},
+		Hints:  map[string]pkgmodel.FieldHint{"meta.labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+	// meta.labels carries only a never-owned member (tolerated), but the plain
+	// `config` field flips from null to absent — that must still confront.
+	got := confront(t,
+		`{"meta":{"labels":{"team":"x"}},"config":null}`,
+		`{"meta":{"labels":{"team":"x"}}}`,
+		`{}`,
+		"", nil, schema)
+	assert.True(t, got, "a managed field flipping between null and absent is real drift")
+}
+
+func TestModificationConfrontable_ManagedEmptyObjectTogglesConfront(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"meta", "config"},
+		Hints:  map[string]pkgmodel.FieldHint{"meta.labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+	got := confront(t,
+		`{"meta":{"labels":{"team":"x"}},"config":{}}`,
+		`{"meta":{"labels":{"team":"x"}}}`,
+		`{}`,
+		"", nil, schema)
+	assert.True(t, got, "a managed field flipping between an empty object and absent is real drift")
+}
+
+// The mirror of the empty-ancestor case: the OLD side carries the nested
+// co-owned content and the NEW side already holds an explicitly empty
+// ancestor. Both represent only never-owned movement and must be tolerated.
+func TestModificationConfrontable_NestedCoOwnedEmptyAncestors_MirrorTolerated(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"meta"},
+		Hints:  map[string]pkgmodel.FieldHint{"meta.labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+	got := confront(t,
+		`{"meta":{"labels":{"team":"x"}}}`,
+		`{"meta":{}}`,
+		`{}`,
+		"", nil, schema)
+	assert.False(t, got, "tolerated nested movement is symmetric whether the empty ancestor is old or new")
+}
+
+// A co-owned field carrying an unexpected scalar value cannot be classified
+// into members; its out-of-band change must confront rather than be deleted
+// from both remainders and read as equal.
+func TestModificationConfrontable_CoOwnedScalarChange_Confront(t *testing.T) {
+	got := confront(t,
+		`{"Name":"n","labels":"a"}`,
+		`{"Name":"n","labels":"b"}`,
+		`{"Name":"n","labels":{}}`,
+		"", nil, confrontMappingSchema())
+	assert.True(t, got, "a malformed scalar co-owned value's change must confront")
+}
+
+// An EntitySet whose elements lack the configured identity field cannot be
+// classified; its out-of-band change must confront.
+func TestModificationConfrontable_CoOwnedEntitySetNoIdentity_Confront(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Targets"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Targets": {UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Id", CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	got := confront(t,
+		`{"Targets":[{"Port":80}]}`,
+		`{"Targets":[{"Port":81}]}`,
+		`{"Targets":[]}`,
+		"", nil, schema)
+	assert.True(t, got, "an identity-less EntitySet element's change must confront")
+}
+
+// Large integers beyond float64's exact range must not collapse to equal
+// during canonicalization, or a plain-field drift would be silently tolerated.
+func TestModificationConfrontable_LargeIntegerPrecision_Confront(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+	got := confront(t,
+		`{"Name":"n","serial":9007199254740992,"labels":{"app":"web"}}`,
+		`{"Name":"n","serial":9007199254740993,"labels":{"app":"web","team":"x"}}`,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		"", prior, confrontMappingSchema())
+	assert.True(t, got, "distinct large integers must confront, not collapse to equal")
+}
+
+// A set-shaped co-owned field carrying an object value is malformed: object
+// keys are identities only for a Mapping. Its change must confront, not be
+// neutralized as though the keys were members.
+func TestModificationConfrontable_SetShapedFieldWithObjectValue_Confront(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Groups"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Groups": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	got := confront(t,
+		`{"Groups":{"a":"1"}}`,
+		`{"Groups":{"b":"2"}}`,
+		`{"Groups":[]}`,
+		"", nil, schema)
+	assert.True(t, got, "an object value on a set-shaped co-owned field is malformed and must confront")
+}
+
+// A Mapping-shaped co-owned field carrying an array value is likewise
+// malformed and must confront.
+func TestModificationConfrontable_MappingShapedFieldWithArrayValue_Confront(t *testing.T) {
+	got := confront(t,
+		`{"Name":"n","labels":["a"]}`,
+		`{"Name":"n","labels":["b"]}`,
+		`{"Name":"n","labels":{}}`,
+		"", nil, confrontMappingSchema())
+	assert.True(t, got, "an array value on a Mapping-shaped co-owned field is malformed and must confront")
+}
+
+// A declared co-owned member whose value is a large integer beyond float64
+// precision must confront when it drifts; restriction must not reconstruct it
+// through a lossy float64.
+func TestModificationConfrontable_LargeIntMemberValue_Confront(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"serial"}}}
+	got := confront(t,
+		`{"labels":{"serial":9007199254740992}}`,
+		`{"labels":{"serial":9007199254740993}}`,
+		`{"labels":{"serial":9007199254740992}}`,
+		"", prior, confrontMappingSchema())
+	assert.True(t, got, "a declared member's large-integer drift must confront, not collapse via float64")
+}

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -183,7 +183,12 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 	collections := collectionSemanticsFromFieldHints(schema.Hints)
 	collections.CoOwned = coOwnedCollections(flattenedDocument, flattenedPatch, schema.Hints, priorOwned)
 
-	patchOps, err := createPatchDocument(flattenedDocument, flattenedPatch, schema.Fields, requiredOnUpdateFields, schema.HasProviderDefault(), entitySetProviderDefaultsFromHints(schema.Hints), collections, defaultIgnoredFields, strategy, keepFields, preserveRoots)
+	// Co-owned hints (dotted or not) are passed as exact-path exemptions so an
+	// explicit-empty co-owned collection survives normalization at whatever
+	// depth it lives at — the same treatment preserveRoots already gives an
+	// unnested preserveEmptyValues field, narrowed to the path itself rather
+	// than its whole subtree.
+	patchOps, err := createPatchDocument(flattenedDocument, flattenedPatch, schema.Fields, requiredOnUpdateFields, schema.HasProviderDefault(), entitySetProviderDefaultsFromHints(schema.Hints), collections, defaultIgnoredFields, strategy, keepFields, preserveRoots, coOwnedFieldPaths(schema.Hints))
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("failed to create patch document: %w", err)
 	}
@@ -265,7 +270,7 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 	return json.RawMessage(patchJson), createOnlyJson, onlyForceResent, nil
 }
 
-func createPatchDocument(document []byte, patch []byte, schemaFields []string, requiredOnUpdateFields []string, hasProviderDefaultFields []string, entitySetProviderDefaults map[string]string, collections jsonpatch.Collections, ignoredFields []jsonpatch.Path, strategy jsonpatch.PatchStrategy, convergeFields map[string]bool, preserveRoots map[string]bool) ([]jsonpatch.JsonPatchOperation, error) {
+func createPatchDocument(document []byte, patch []byte, schemaFields []string, requiredOnUpdateFields []string, hasProviderDefaultFields []string, entitySetProviderDefaults map[string]string, collections jsonpatch.Collections, ignoredFields []jsonpatch.Path, strategy jsonpatch.PatchStrategy, convergeFields map[string]bool, preserveRoots map[string]bool, preservePaths map[string]bool) ([]jsonpatch.JsonPatchOperation, error) {
 	patchWithSchemaFieldsOnly, err := removeNonSchemaFields(patch, schemaFields, convergeFields)
 	if err != nil {
 		return nil, err
@@ -316,7 +321,7 @@ func createPatchDocument(document []byte, patch []byte, schemaFields []string, r
 	// nullable Listing/Mapping fields as []/{}. Without stripping, EntitySet
 	// element matching fails because elements have different shapes (one has
 	// phantom empty fields, the other doesn't), causing duplicate entries.
-	cleanedDesired, err := StripNestedEmptyCollectionsExcept(patchWithSchemaFieldsOnly, preserveRoots)
+	cleanedDesired, err := stripNestedEmptyCollectionsExceptPaths(patchWithSchemaFieldsOnly, preserveRoots, preservePaths)
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +335,7 @@ func createPatchDocument(document []byte, patch []byte, schemaFields []string, r
 		return nil, err
 	}
 
-	cleanedDocument, err := StripNestedEmptyCollectionsExcept(documentMinusTopEmpties, preserveRoots)
+	cleanedDocument, err := stripNestedEmptyCollectionsExceptPaths(documentMinusTopEmpties, preserveRoots, preservePaths)
 	if err != nil {
 		return nil, err
 	}
@@ -828,8 +833,23 @@ func StripNestedEmptyCollections(data []byte) ([]byte, error) {
 // StripNestedEmptyCollectionsExcept is StripNestedEmptyCollections with an
 // exemption set: subtrees rooted at a top-level key in preserveRoots are left
 // byte-for-byte intact — their empty collections are values, not rendering
-// noise (the preserveEmptyValues field hint).
+// noise (the preserveEmptyValues field hint). Every caller outside this
+// package goes through here, so its behavior stays exactly what it always
+// was; a caller inside this package needing path-level exemptions
+// (createPatchDocument, for a co-owned collection) uses
+// stripNestedEmptyCollectionsExceptPaths directly instead.
 func StripNestedEmptyCollectionsExcept(data []byte, preserveRoots map[string]bool) ([]byte, error) {
+	return stripNestedEmptyCollectionsExceptPaths(data, preserveRoots, nil)
+}
+
+// stripNestedEmptyCollectionsExceptPaths extends StripNestedEmptyCollectionsExcept
+// with a second, narrower exemption: preservePaths names exact dotted paths
+// (the same convention as a FieldHint key, e.g. "metadata.labels") whose OWN
+// empty-collection value is preserved, without protecting the rest of the
+// subtree it sits in the way preserveRoots does. A sibling key, or a
+// collection nested inside the exempted one, is still stripped normally. A
+// nil preservePaths makes this byte-identical to StripNestedEmptyCollectionsExcept.
+func stripNestedEmptyCollectionsExceptPaths(data []byte, preserveRoots, preservePaths map[string]bool) ([]byte, error) {
 	var doc map[string]any
 	if err := json.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("StripNestedEmptyCollections: invalid JSON: %w", err)
@@ -839,7 +859,7 @@ func StripNestedEmptyCollectionsExcept(data []byte, preserveRoots map[string]boo
 		if preserveRoots[k] {
 			continue
 		}
-		doc[k] = stripEmptyCollectionsFromValue(v)
+		doc[k] = stripEmptyCollectionsFromValueAt(v, k, preservePaths)
 	}
 
 	return json.Marshal(doc)
@@ -954,6 +974,55 @@ func stripEmptyCollectionsFromValue(val any) any {
 		cleaned := make([]any, 0, len(v))
 		for _, elem := range v {
 			cleaned = append(cleaned, stripEmptyCollectionsFromValue(elem))
+		}
+		return cleaned
+	default:
+		return val
+	}
+}
+
+// stripEmptyCollectionsFromValueAt is stripEmptyCollectionsFromValue extended
+// with val's own dotted path, so an empty-collection child can be checked
+// against preservePaths before being dropped — the exact-path counterpart to
+// stripNestedEmptyCollectionsExceptPaths's top-level preserveRoots check. An
+// array element does not extend the path: a FieldHint path is index-
+// transparent (matchesFieldThroughArrays applies the same convention when
+// matching a dotted field against an indexed op path), so a co-owned
+// collection living inside a list of SubResources is still found by name.
+// A nil preservePaths makes this byte-identical to stripEmptyCollectionsFromValue.
+func stripEmptyCollectionsFromValueAt(val any, path string, preservePaths map[string]bool) any {
+	switch v := val.(type) {
+	case map[string]any:
+		cleaned := make(map[string]any, len(v))
+		for k, elem := range v {
+			childPath := k
+			if path != "" {
+				childPath = path + "." + k
+			}
+			if isEmptyCollection(elem) {
+				if preservePaths[childPath] {
+					cleaned[k] = elem
+				}
+				continue
+			}
+			stripped := stripEmptyCollectionsFromValueAt(elem, childPath, preservePaths)
+			// Re-check after recursive stripping — a map whose children were
+			// all empty collections is itself now empty and should be
+			// removed (e.g. DestinationConfig: {OnSuccess: {}, OnFailure: {}}),
+			// unless childPath is itself exempted.
+			if isEmptyCollection(stripped) {
+				if preservePaths[childPath] {
+					cleaned[k] = stripped
+				}
+				continue
+			}
+			cleaned[k] = stripped
+		}
+		return cleaned
+	case []any:
+		cleaned := make([]any, 0, len(v))
+		for _, elem := range v {
+			cleaned = append(cleaned, stripEmptyCollectionsFromValueAt(elem, path, preservePaths))
 		}
 		return cleaned
 	default:

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -7,6 +7,7 @@ package patch
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"reflect"
 	"strconv"
 	"strings"
@@ -88,6 +89,34 @@ func coOwnedCollections(document, patch []byte, hints map[string]pkgmodel.FieldH
 	coOwned := jsonpatch.CoOwned{}
 	for field, hint := range hints {
 		if hint.CoOwned == nil {
+			continue
+		}
+		// CoOwned on an Array/Atomic/Opaque field, or with no UpdateMethod at
+		// all besides an implicit Mapping, is a combination PKL validation
+		// rejects at authoring time. A schema that reaches here as JSON
+		// (plugin protocol, a stored row) bypasses that eval, so this is the
+		// Go-side backstop: IdentityRule returning "" means no drainable
+		// scheme exists for the hint's shape, and Opaque's "members" are
+		// secret values, not names (see claimedMembers). Either way the field
+		// degrades to un-annotated behavior rather than registering a path
+		// jsonpatch would otherwise treat as co-owned.
+		if pkgmodel.IdentityRule(hint) == "" || hint.Opaque {
+			continue
+		}
+		// A field name containing '/' or '~' cannot round-trip jsonpatch's
+		// path translation: this function registers the raw field name
+		// ("$."+field), but toJsonPath derives its lookup key from the RFC
+		// 6901 pointer jsonpatch builds while diffing, which escapes '/' to
+		// "~1" and '~' to "~0" — the two strings can never be equal, so the
+		// registered entry can never match and is permanently inert (verified
+		// directly against jsonpatch.CreatePatch for both a Set and a Mapping
+		// shape: the drainable set is never consulted either way). PKL
+		// property names cannot contain either character, so this guards only
+		// an exotic outputField rename reaching this function via JSON — but
+		// leaving a dead entry registered is still worth skipping and logging
+		// rather than carrying silently.
+		if strings.ContainsAny(field, "/~") {
+			slog.Warn("co-owned field name cannot round-trip jsonpatch's path translation, ignoring annotation", "field", field)
 			continue
 		}
 

--- a/internal/metastructure/patch/patch_document.go
+++ b/internal/metastructure/patch/patch_document.go
@@ -40,8 +40,8 @@ var defaultIgnoredFields = []jsonpatch.Path{}
 //     provider still requires the force-resent field in that payload.
 //
 // The two slices are disjoint. Either can be nil.
-func GeneratePatch(document []byte, patch []byte, storedEnvelopes []byte, desiredEnvelopes []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, bool, error) {
-	return generatePatch(document, patch, storedEnvelopes, desiredEnvelopes, properties, schema, mode)
+func GeneratePatch(document []byte, patch []byte, storedEnvelopes []byte, desiredEnvelopes []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, priorOwned pkgmodel.OwnedMembers, mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, bool, error) {
+	return generatePatch(document, patch, storedEnvelopes, desiredEnvelopes, properties, schema, priorOwned, mode)
 }
 
 func collectionSemanticsFromFieldHints(hints map[string]pkgmodel.FieldHint) jsonpatch.Collections {
@@ -60,10 +60,54 @@ func collectionSemanticsFromFieldHints(hints map[string]pkgmodel.FieldHint) json
 			collections.Arrays = append(collections.Arrays, path)
 		case pkgmodel.FieldUpdateMethodAtomic:
 			collections.Atomics = append(collections.Atomics, path)
+		case pkgmodel.FieldUpdateMethodSet:
+			// Set semantics are jsonpatch's default branch for an unkeyed
+			// collection (compareArray's "default: // default to set" case) —
+			// this case exists only so the hint is visibly handled here, not
+			// silently absorbed by the switch having no matching case.
 		}
 	}
 
 	return collections
+}
+
+// coOwnedCollections computes, per co-owned field, the set of member
+// identities this forma may remove (jsonpatch.Drainable): exactly the
+// members it declared on a prior apply but no longer declares now
+// (OwnershipPartition.FormerlyOwned). A member that is live but was never
+// declared by this forma (NeverOwned — another writer's, or the platform's)
+// is left out of the Drainable set, so jsonpatch tolerates it regardless of
+// the annotation.
+//
+// document/patch must be the exact byte pair createPatchDocument receives:
+// flattened and ref-resolved, with unbaselined writeOnly+createOnly fields
+// already stripped, but BEFORE any provider-default or empty-collection
+// normalization. Identities are computed over resolved $values and must
+// never see content a later pass would strip away.
+func coOwnedCollections(document, patch []byte, hints map[string]pkgmodel.FieldHint, priorOwned pkgmodel.OwnedMembers) jsonpatch.CoOwned {
+	coOwned := jsonpatch.CoOwned{}
+	for field, hint := range hints {
+		if hint.CoOwned == nil {
+			continue
+		}
+
+		declared := pkgmodel.MemberIdentities(gjson.GetBytes(patch, field), hint)
+		live := pkgmodel.MemberIdentities(gjson.GetBytes(document, field), hint)
+
+		var prior []string
+		if record, ok := priorOwned[field]; ok && record.Rule == pkgmodel.IdentityRule(hint) {
+			prior = record.Members
+		}
+
+		partition := pkgmodel.PartitionOwnership(declared, prior, live)
+		drainable := jsonpatch.Drainable{}
+		for member := range partition.FormerlyOwned {
+			drainable[member] = struct{}{}
+		}
+
+		coOwned[jsonpatch.Path(fmt.Sprintf("$.%s", field))] = drainable
+	}
+	return coOwned
 }
 
 // topLevelConvergeFields collects the schema fields whose destination path was
@@ -80,9 +124,17 @@ func topLevelConvergeFields(schemaFields []string, properties resolver.Resolvabl
 	return fields
 }
 
+// entitySetProviderDefaultsFromHints excludes hints with CoOwned != nil: the
+// provider-default pass pre-strips document elements the desired side omits,
+// which is exactly the pre-diff element filter a co-owned path must not get —
+// its removal indices need to address the unfiltered document (see
+// coOwnedCollections and the DOCUMENT STAGE comment above).
 func entitySetProviderDefaultsFromHints(hints map[string]pkgmodel.FieldHint) map[string]string {
 	result := map[string]string{}
 	for field, hint := range hints {
+		if hint.CoOwned != nil {
+			continue
+		}
 		if hint.HasProviderDefault && hint.UpdateMethod == pkgmodel.FieldUpdateMethodEntitySet && hint.IndexField != "" {
 			result[field] = hint.IndexField
 		}
@@ -90,7 +142,7 @@ func entitySetProviderDefaultsFromHints(hints map[string]pkgmodel.FieldHint) map
 	return result
 }
 
-func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desiredEnvelopes []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, bool, error) {
+func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desiredEnvelopes []byte, properties resolver.ResolvableProperties, schema pkgmodel.Schema, priorOwned pkgmodel.OwnedMembers, mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, bool, error) {
 	flattenedDocument, flattenedPatch, err := flattenAndResolveRefs(document, patch, storedEnvelopes, desiredEnvelopes, properties)
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("failed to flatten and resolve refs: %w", err)
@@ -123,7 +175,15 @@ func generatePatch(document []byte, patch []byte, storedEnvelopes []byte, desire
 	for field := range referenceEnvelopeFields(desiredEnvelopes, schema) {
 		keepFields[field] = true
 	}
-	patchOps, err := createPatchDocument(flattenedDocument, flattenedPatch, schema.Fields, requiredOnUpdateFields, schema.HasProviderDefault(), entitySetProviderDefaultsFromHints(schema.Hints), collectionSemanticsFromFieldHints(schema.Hints), defaultIgnoredFields, strategy, keepFields, preserveRoots)
+
+	// Computed on the exact byte pair createPatchDocument receives next — AFTER
+	// flattenAndResolveRefs and StripFieldsWithoutBaseline above, BEFORE any
+	// provider-default or empty-collection pass below — so identities see
+	// resolved $values and never see content a later pass strips away.
+	collections := collectionSemanticsFromFieldHints(schema.Hints)
+	collections.CoOwned = coOwnedCollections(flattenedDocument, flattenedPatch, schema.Hints, priorOwned)
+
+	patchOps, err := createPatchDocument(flattenedDocument, flattenedPatch, schema.Fields, requiredOnUpdateFields, schema.HasProviderDefault(), entitySetProviderDefaultsFromHints(schema.Hints), collections, defaultIgnoredFields, strategy, keepFields, preserveRoots)
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("failed to create patch document: %w", err)
 	}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -158,7 +158,7 @@ func TestCreatePatchDocument_PrimitiveArray(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			patches, err := createPatchDocument(tc.jsonA, tc.jsonB, []string{"label", "tags"}, nil, nil, nil, jsonpatch.Collections{}, nil, jsonpatch.PatchStrategyEnsureExists, nil, nil)
+			patches, err := createPatchDocument(tc.jsonA, tc.jsonB, []string{"label", "tags"}, nil, nil, nil, jsonpatch.Collections{}, nil, jsonpatch.PatchStrategyEnsureExists, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("Error comparing JSONs: %v", err)
 			}
@@ -230,7 +230,7 @@ func TestCreatePatchDocument_ObjectArrayWithKeyValues(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			patches, err := createPatchDocument(tc.jsonA, tc.jsonB, []string{"label", "tags"}, nil, nil, nil, jsonpatch.Collections{EntitySets: jsonpatch.EntitySets{jsonpatch.Path("$.tags"): jsonpatch.Key("key")}}, nil, jsonpatch.PatchStrategyEnsureExists, nil, nil)
+			patches, err := createPatchDocument(tc.jsonA, tc.jsonB, []string{"label", "tags"}, nil, nil, nil, jsonpatch.Collections{EntitySets: jsonpatch.EntitySets{jsonpatch.Path("$.tags"): jsonpatch.Key("key")}}, nil, jsonpatch.PatchStrategyEnsureExists, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("Error comparing JSONs: %v", err)
 			}
@@ -304,7 +304,7 @@ func TestCreatePatchDocument_ObjectArrayWithValues(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			patches, err := createPatchDocument(tc.jsonA, tc.jsonB, []string{"label", "tags"}, nil, nil, nil, jsonpatch.Collections{}, nil, jsonpatch.PatchStrategyEnsureExists, nil, nil)
+			patches, err := createPatchDocument(tc.jsonA, tc.jsonB, []string{"label", "tags"}, nil, nil, nil, jsonpatch.Collections{}, nil, jsonpatch.PatchStrategyEnsureExists, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("Error comparing JSONs: %v", err)
 			}

--- a/internal/metastructure/patch/patch_document_test.go
+++ b/internal/metastructure/patch/patch_document_test.go
@@ -359,7 +359,7 @@ func TestGeneratePatch(t *testing.T) {
 	resProps := resolver.NewResolvableProperties()
 	resProps.Add(resourceKsuid, "id", "def")
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, resProps, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, resProps, schema, nil, pkgmodel.FormaApplyModePatch)
 
 	assert.NoError(t, err)
 	// val2 is createOnly and changed → a non-empty createOnlyPatch is returned
@@ -431,7 +431,7 @@ func TestGeneratePatch_NestedCreateOnlyTriggersReplacement(t *testing.T) {
 		},
 	}
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	require.NotEmpty(t, createOnlyPatch, "nested createOnly change must produce a non-empty createOnlyPatch")
 
@@ -482,7 +482,7 @@ func TestGeneratePatch_ShouldResolveRefs(t *testing.T) {
 	props.Add(resourceKsuid, "other-id", "def")
 	props.Add(resourceKsuid, "notha-id", "ghi")
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModePatch)
 	assert.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -519,7 +519,7 @@ func TestGeneratePatch_ListResolvableMatchingLiveValue_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "ValidationRecords.0.Values", `["_7a296.acm-validations.aws"]`)
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "an unchanged list-valued resolvable must reconcile to a no-op")
@@ -543,7 +543,7 @@ func TestGeneratePatch_MultiValueListResolvableMatchingLiveValue_NoPatch(t *test
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "Values", `["10.0.0.1","10.0.0.2"]`)
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc)
@@ -567,7 +567,7 @@ func TestGeneratePatch_ListResolvableGenuineChange_EmitsReplace(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "ValidationRecords.0.Values", `["new.acm-validations.aws"]`)
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "a genuine list change must still emit a patch")
 
@@ -598,7 +598,7 @@ func TestGeneratePatch_ObjectResolvableMatchingLiveValue_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "Endpoints", `{"host":"db.internal","port":5432,"tls":true,"aliases":["a","b"],"fallback":null}`)
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc)
@@ -624,7 +624,7 @@ func TestGeneratePatch_JsonStringScalarResolvable_StaysString_NoPatch(t *testing
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "PolicyDocument", `{"Version":"2012-10-17"}`)
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "a JSON-string scalar must not be reparsed into a native structure")
@@ -650,7 +650,7 @@ func TestGeneratePatch_ArrayElementObjectResolvableMatchingLiveValue_NoPatch(t *
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "Endpoints.0", `{"host":"db.internal","port":5432}`)
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "an unchanged array of object-valued resolvables must reconcile to a no-op")
@@ -676,7 +676,7 @@ func TestGeneratePatch_StringNullResolvableAgainstArray_StaysString(t *testing.T
 	props := resolver.NewResolvableProperties()
 	props.Add(resourceKsuid, "Polymorphic", "null")
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc)
 	assert.Contains(t, string(patchDoc), `"value":"null"`, "the literal string \"null\" must not be rewritten to JSON null")
@@ -833,7 +833,7 @@ func TestGeneratePatch_MixedNestedAndFlattenedStructures(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModePatch)
 
 	assert.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
@@ -919,7 +919,7 @@ func TestGeneratePatch_RequiredOnUpdateFieldsGenerateAddOperation(t *testing.T) 
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -987,7 +987,7 @@ func TestGeneratePatch_WriteOnlyCreateOnlyFieldsNoPhantomReplacement(t *testing.
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "writeOnly+createOnly field should NOT trigger replacement")
 	assert.Nil(t, patchDoc, "No patch should be generated when only writeOnly+createOnly fields differ")
@@ -1027,7 +1027,7 @@ func TestGeneratePatch_WriteOnlyFieldUnchanged_NoAddOperation(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "writeOnly-only field unchanged should not force an add op")
@@ -1069,7 +1069,7 @@ func TestGeneratePatch_AddTagsWhileRetainingExisting(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1134,7 +1134,7 @@ func TestGeneratePatch_HasProviderDefaultFieldsNotRemoved(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1177,7 +1177,7 @@ func TestGeneratePatch_HasProviderDefaultFieldsOverridden(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1370,7 +1370,7 @@ func TestGeneratePatch_ReconcileRemovesOOBTagsWhenDesiredIsEmptyArray(t *testing
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1396,7 +1396,7 @@ func TestGeneratePatch_ReconcileRemovesOOBTagsWhenDesiredIsNull(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	require.NotNil(t, patchDoc, "expected a patch to handle the OOB tag, got nil")
@@ -1436,7 +1436,7 @@ func TestGeneratePatch_AbsentDesiredVsEmptyActualArray_NoPatch(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "expected no patch ops when desired is absent and actual is empty array")
@@ -1539,7 +1539,7 @@ func TestGeneratePatch_OuterWithOnlyNestedEmpties_NoSpuriousSuppression(t *testi
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "expected nil patch; pinning current jsonpatch behavior for {Outer:{}}-vs-{} so any future change surfaces here, not as silent drift")
 }
@@ -1565,7 +1565,7 @@ func TestGeneratePatch_AbsentDesiredVsEmptyActualArray_PatchMode_NoPatch(t *test
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "expected no patch ops in Patch mode either")
 }
@@ -1598,7 +1598,7 @@ func TestGeneratePatch_AbsentDesiredVsEmptyActual_EntitySetField_NotAWSSpecific_
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc)
 }
@@ -1745,7 +1745,7 @@ func TestGeneratePatch_ProviderDefaultInsideArray_NoPatch(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "Expected no patch when only difference is provider default Cpu inside array")
 }
@@ -1782,7 +1782,7 @@ func TestGeneratePatch_AtomicField_SingleReplace(t *testing.T) {
 		},
 	}
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -1808,7 +1808,7 @@ func TestGeneratePatch_AtomicField_NoDiffNoPatch(t *testing.T) {
 		},
 	}
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(doc, doc, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(doc, doc, nil, nil, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Empty(t, patchDoc, "Expected no patch when atomic field is identical")
@@ -1838,7 +1838,7 @@ func TestGeneratePatch_EmptyArrayOnCreateOnlyField_NoPatch(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "Empty arrays on createOnly fields should not trigger replacement")
 	assert.Empty(t, patchDoc, "Expected no patch when only difference is empty arrays on createOnly fields")
@@ -1863,7 +1863,7 @@ func TestGeneratePatch_NonEmptyArrayOnCreateOnlyField_TriggersReplacement(t *tes
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.NotEmpty(t, createOnlyPatch, "Non-empty change to createOnly field should trigger replacement")
 	assert.NotEmpty(t, patchDoc)
@@ -1889,7 +1889,7 @@ func TestGeneratePatch_EmptyArrayOnNonCreateOnlyField_NoPatch(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "Expected no patch when only difference is empty arrays on non-createOnly fields")
 }
@@ -1913,7 +1913,7 @@ func TestGeneratePatch_ReplaceNonEmptyArrayPreserved(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.NotEmpty(t, patchDoc, "Expected patch when user clears a collection via replace")
 }
@@ -2086,7 +2086,7 @@ func TestGeneratePatch_EntitySetProviderDefaults_PatchMode(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Empty(t, patchDoc, "Expected no patch when user-specified attribute matches actual")
@@ -2123,7 +2123,7 @@ func TestGeneratePatch_EntitySetProviderDefaults_WithUserChange(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	require.NotEmpty(t, patchDoc)
@@ -2173,7 +2173,7 @@ func TestGeneratePatch_ProviderDefaultInsideArray_SingleElement_NoReplace(t *tes
 	}
 
 	patchDoc, createOnlyPatch, _, err := generatePatch(
-		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2213,7 +2213,7 @@ func TestGeneratePatch_ProviderDefaultInsideArray_MixedElements_NoReplace(t *tes
 	}
 
 	patchDoc, createOnlyPatch, _, err := generatePatch(
-		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2270,7 +2270,7 @@ func TestGeneratePatch_ProviderDefaultInsideNestedArray_PortMappingHostPort_Mixe
 	}
 
 	patchDoc, createOnlyPatch, _, err := generatePatch(
-		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2326,7 +2326,7 @@ func TestGeneratePatch_ProviderDefaultInsideNestedArray_PortMappingHostPort(t *t
 	}
 
 	patchDoc, createOnlyPatch, _, err := generatePatch(
-		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2369,7 +2369,7 @@ func TestGeneratePatch_UserChangedFieldInsideArray_StillReplaces(t *testing.T) {
 	}
 
 	_, createOnlyPatch, _, err := generatePatch(
-		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2399,7 +2399,7 @@ func TestGeneratePatch_TopLevelProviderDefaultOverride_StillDiffs(t *testing.T) 
 	}
 
 	patchDoc, _, _, err := generatePatch(
-		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2437,7 +2437,7 @@ func TestGeneratePatch_EntitySetProviderDefaults_ReconcileMode(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "Expected no patch when only provider-default elements differ in reconcile mode")
 }
@@ -2496,7 +2496,7 @@ func TestGeneratePatch_NestedListOrderingInsideArrayElement_NoReplace(t *testing
 	}
 
 	patchDoc, createOnlyPatch, _, err := generatePatch(
-		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2546,7 +2546,7 @@ func TestGeneratePatch_NestedPortMappingsOrderInsideArrayElement_NoReplace(t *te
 	}
 
 	patchDoc, createOnlyPatch, _, err := generatePatch(
-		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2587,7 +2587,7 @@ func TestGeneratePatch_NestedListContentChange_StillReplaces(t *testing.T) {
 	}
 
 	_, createOnlyPatch, _, err := generatePatch(
-		document, patch, nil, nil, resolver.NewResolvableProperties(), schema,
+		document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil,
 		pkgmodel.FormaApplyModeReconcile,
 	)
 	require.NoError(t, err)
@@ -2621,7 +2621,7 @@ func TestGeneratePatch_HasProviderDefault_PlainListing_OmittedDesired(t *testing
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "user omitted hasProviderDefault Listing — strip pass must suppress remove ops for runtime-registered entries")
 }
@@ -2640,7 +2640,7 @@ func TestGeneratePatch_HasProviderDefault_NullDesired_Defensive(t *testing.T) {
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc)
 }
@@ -2674,7 +2674,7 @@ func TestGeneratePatch_HasProviderDefault_PlainListing_PR269Rendering(t *testing
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 
 	// Document the bug shape: explicit empty Listing in patch + runtime entry
@@ -2718,7 +2718,7 @@ func TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserOmits_PostRevert(t 
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "characterization: with hasProviderDefault on an EntitySet, OOB-added entries are NOT removed when user omits — see test docstring for the open question")
 }
@@ -2755,7 +2755,7 @@ func TestGeneratePatch_EntitySetProviderDefault_OOBDrift_UserDeclaresOne(t *test
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "characterization: with hasProviderDefault on an EntitySet, OOB-added entries are tolerated even when user declares others")
 }
@@ -2792,7 +2792,7 @@ func TestGeneratePatch_EntitySetProviderDefault_ExplicitEmpty_DrainsLiveEntries(
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -2831,7 +2831,7 @@ func TestGeneratePatch_EntitySetProviderDefault_ExplicitEmpty_PatchMode_NoOps(t 
 	}
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModePatch)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, patchDoc, "Patch mode must not drain: EnsureExists emits no removes")
 }
@@ -2864,7 +2864,7 @@ func TestGeneratePatch_AtomicNestedArrayProducesReplace(t *testing.T) {
 		},
 	}
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 
@@ -2897,7 +2897,7 @@ func TestGeneratePatch_BundledUpdate_DropsSerializationOnlyHintedOp(t *testing.T
 	document := []byte(`{"folderUid":"a","configJson":"{\"x\":1,\"y\":2}"}`)
 	patch := []byte(`{"folderUid":"b","configJson":"{\n  \"y\": 2,\n  \"x\": 1\n}"}`)
 
-	mutable, _, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, _, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2915,7 +2915,7 @@ func TestGeneratePatch_GenuineHintedChange_KeepsOp(t *testing.T) {
 	document := []byte(`{"configJson":"{\"x\":1}"}`)
 	patch := []byte(`{"configJson":"{\"x\":2}"}`)
 
-	mutable, _, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, _, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2929,7 +2929,7 @@ func TestGeneratePatch_FallbackKeepsOpOnInvalidJSON(t *testing.T) {
 	document := []byte(`{"configJson":"{\"x\":1}"}`)
 	patch := []byte(`{"configJson":"not json"}`)
 
-	mutable, _, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, _, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2942,7 +2942,7 @@ func TestGeneratePatch_CreateOnlyHinted_SerializationOnly_NoReplacement(t *testi
 	schema := pkgmodel.Schema{Fields: []string{"configJson"}, Hints: map[string]pkgmodel.FieldHint{"configJson": {Format: "json", CreateOnly: true}}}
 	document := []byte(`{"configJson":"{\"x\":1,\"y\":2}"}`)
 	patch := []byte(`{"configJson":"{\"y\":2,\"x\":1}"}`)
-	mutable, createOnly, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, createOnly, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2959,7 +2959,7 @@ func TestGeneratePatch_ArrayPathNeverDropped(t *testing.T) {
 	schema := pkgmodel.Schema{Fields: []string{"tags"}, Hints: map[string]pkgmodel.FieldHint{"tags": {Format: "json"}}}
 	document := []byte(`{"tags":["a","b"]}`)
 	patch := []byte(`{"tags":["a","c"]}`)
-	mutable, _, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	mutable, _, _, err := GeneratePatch(document, patch, nil, nil, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2982,7 +2982,7 @@ func TestGeneratePatch_RefResolutionMatchesApplied_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "an unchanged reference must reconcile to a no-op regardless of echo form")
@@ -3003,7 +3003,7 @@ func TestGeneratePatch_CreateOnlyRefMatchesApplied_NoReplacement(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "unchanged createOnly reference must not trigger replacement")
 	var ops []jsonpatch.JsonPatchOperation
@@ -3025,7 +3025,7 @@ func TestGeneratePatch_RefResolutionDiffersFromApplied_PlansUpdate(t *testing.T)
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", newArn)
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	var ops []jsonpatch.JsonPatchOperation
@@ -3047,7 +3047,7 @@ func TestGeneratePatch_AppliedWithoutStoredEcho_FallsBackToFresh(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3134,7 +3134,7 @@ func TestGeneratePatch_LegacyRowWithoutApplied_KeepsFreshVsEcho(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3152,7 +3152,7 @@ func TestGeneratePatch_OpaqueRefIgnoresApplied(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Value", "sent")
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3172,7 +3172,7 @@ func TestGeneratePatch_NumericRefMatchesApplied_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Port", "443")
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "numeric ref matching $applied must reconcile to no-op")
@@ -3190,7 +3190,7 @@ func TestGeneratePatch_NumericRefDiffersFromApplied_PlansUpdate(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Port", "8443")
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	var ops []jsonpatch.JsonPatchOperation
@@ -3219,7 +3219,7 @@ func TestGeneratePatch_ArrayRefCounterpartMatchedByURI_NotIndex(t *testing.T) {
 	props.Add(ksuid, "ArnA", arnA)
 	props.Add(ksuid, "ArnB", arnB)
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "reordered echoes of unchanged references must reconcile to a no-op")
@@ -3243,7 +3243,7 @@ func TestGeneratePatch_ArrayRefDuplicateURIs_FailsClosed(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "ArnA", arn)
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3264,7 +3264,7 @@ func TestGeneratePatch_ResolvedRefMatchingApplied_NoPatch(t *testing.T) {
 	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
 	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "a resolved reference matching the applied baseline must not be rewritten")
@@ -3281,7 +3281,7 @@ func TestGeneratePatch_ResolvedRefDifferingFromApplied_PlansUpdate(t *testing.T)
 	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, newArn)
 	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3302,7 +3302,7 @@ func TestGeneratePatch_LiteralReplacingRefMatchingApplied_PlansUpdate(t *testing
 	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
 	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3322,7 +3322,7 @@ func TestGeneratePatch_ResolvedRefWithDifferentURI_PlansUpdate(t *testing.T) {
 	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
 	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3338,7 +3338,7 @@ func TestGeneratePatch_ResolvedOpaqueRefIgnoresApplied(t *testing.T) {
 	patch := []byte(`{"Secret": "sent"}`)
 	schema := pkgmodel.Schema{Fields: []string{"Secret"}}
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3356,7 +3356,7 @@ func TestGeneratePatch_ResolvedStructuredRefMatchingApplied_NoPatch(t *testing.T
 	patch := []byte(`{"Hosts": ["a", "b"]}`)
 	schema := pkgmodel.Schema{Fields: []string{"Hosts"}}
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "a structured resolution matching its baseline must not be rewritten")
 }
@@ -3379,7 +3379,7 @@ func TestGeneratePatch_ResolvedArrayRefsMatchingApplied_NoPatch(t *testing.T) {
 	patch := fmt.Appendf(nil, `{"Topics": [%q, %q]}`, arnA, arnB)
 	schema := pkgmodel.Schema{Fields: []string{"Topics"}}
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "resolved array references matching their baselines must not be rewritten")
@@ -3404,7 +3404,7 @@ func TestGeneratePatch_ResolvedArrayRefPartiallyRepointed_PlansOnlyTheChange(t *
 	patch := fmt.Appendf(nil, `{"Topics": [%q, %q]}`, arnA, arnC)
 	schema := pkgmodel.Schema{Fields: []string{"Topics"}}
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc)
 	assert.Contains(t, string(patchDoc), arnC, "the repointed element must be written")
@@ -3428,7 +3428,7 @@ func TestGeneratePatch_ResolvedArrayRefsAmbiguousStored_FailsClosed(t *testing.T
 	patch := fmt.Appendf(nil, `{"Topics": [%q, %q]}`, arn, arn)
 	schema := pkgmodel.Schema{Fields: []string{"Topics"}}
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3452,7 +3452,7 @@ func TestGeneratePatch_ResolvedRefWithStaleValue_PlansFreshResolution(t *testing
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", freshArn)
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3476,7 +3476,7 @@ func TestGeneratePatch_CreateOnlyResolvedRefWithStaleValue_PlansReplacement(t *t
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", freshArn)
 
-	_, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	_, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotEmpty(t, createOnlyPatch, "a moved reference on an immutable field must still force a replacement")
 	assert.Contains(t, string(createOnlyPatch), freshArn)
@@ -3495,7 +3495,7 @@ func TestGeneratePatch_ResolvedRefFreshlyMatchingApplied_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.Nil(t, patchDoc, "an unchanged reference stays suppressed under fresh resolution")
@@ -3523,7 +3523,7 @@ func TestGeneratePatch_ResolvedArrayRefWithStaleValue_PlansFreshResolution(t *te
 	props.Add(ksuid, "ArnA", arnA)
 	props.Add(ksuid, "ArnB", arnBMoved)
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "a moved array reference must be planned")
 	assert.Contains(t, string(patchDoc), arnBMoved, "the moved element carries its current resolution")
@@ -3546,7 +3546,7 @@ func TestGeneratePatch_ResolvedRefWithUnreadableJSONPath_Fails(t *testing.T) {
 	// The source resolves, but no longer carries the path the reference reads.
 	props.Add(ksuid, "Config", `{"host":"10.0.0.2"}`)
 
-	_, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	_, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.Error(t, err, "a reference that cannot be read through its path must not be treated as unchanged")
 	assert.Contains(t, err.Error(), "address")
 }
@@ -3567,7 +3567,7 @@ func TestGeneratePatch_CreateOnlyResolvedRefWithUnreadableJSONPath_Fails(t *test
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Config", `{"name":"fn-v2"}`)
 
-	_, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	_, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.Error(t, err, "an unreadable reference on an immutable field must not silently suppress the replacement")
 }
 
@@ -3583,7 +3583,7 @@ func TestGeneratePatch_ResolvedArrayRefWithUnreadableJSONPath_Fails(t *testing.T
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Config", `{"host":"10.0.0.2"}`)
 
-	_, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	_, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.Error(t, err, "an unreadable array reference must not be treated as unchanged")
 }
 
@@ -3599,7 +3599,7 @@ func TestGeneratePatch_ResolvedRefWithUnresolvableSource_UsesRecordedValue(t *te
 	patch := fmt.Appendf(nil, `{"Endpoint": %q}`, applied)
 	schema := pkgmodel.Schema{Fields: []string{"Endpoint"}}
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "an unavailable source leaves the recorded resolution standing")
 }
@@ -3618,7 +3618,7 @@ func TestGeneratePatch_ResolvedArrayRefChangingShape_PlansFreshResolution(t *tes
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Cfg", "h2")
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "a reference resolving to a new shape must be planned")
 	assert.Contains(t, string(patchDoc), "h2", "the plan must carry the current resolution")
@@ -3638,7 +3638,7 @@ func TestGeneratePatch_CreateOnlyResolvedArrayRefChangingShape_PlansReplacement(
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Cfg", "h2")
 
-	_, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	_, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotEmpty(t, createOnlyPatch, "a shape-changing reference on an immutable field must still force a replacement")
 }
@@ -3655,7 +3655,7 @@ func TestGeneratePatch_ResolvedArrayRefObjectMatchingApplied_NoPatch(t *testing.
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Cfg", `{"host":"h1"}`)
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "an unchanged object-valued reference must not be rewritten")
 }
@@ -3678,7 +3678,7 @@ func TestGeneratePatch_AtomicObjectWithUnchangedRef_EmitsWriteForm(t *testing.T)
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "the sibling change must be planned")
 	assert.Contains(t, string(patchDoc), arn,
@@ -3712,7 +3712,7 @@ func TestGeneratePatch_OrderedArrayReorderedRefs_EmitWriteForm(t *testing.T) {
 	props.Add(ksuid, "ArnA", arnA)
 	props.Add(ksuid, "ArnB", arnB)
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "reordering an ordered list is a change")
 	assert.Contains(t, string(patchDoc), arnA)
@@ -3735,7 +3735,7 @@ func TestGeneratePatch_AtomicObjectWithResolvedRef_EmitsWriteForm(t *testing.T) 
 		Hints:  map[string]pkgmodel.FieldHint{"Cfg": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic}},
 	}
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "the sibling change must be planned")
 	assert.Contains(t, string(patchDoc), arn)
@@ -3758,7 +3758,7 @@ func TestGeneratePatch_AtomicObjectFullyUnchanged_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "an unchanged atomic object must still reconcile to a no-op")
 }
@@ -3778,7 +3778,7 @@ func TestGeneratePatch_UnchangedRefWithDriftedLiveValue_PlansRepair(t *testing.T
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3802,7 +3802,7 @@ func TestGeneratePatch_CreateOnlyUnchangedRefWithDriftedLiveValue_PlansReplaceme
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Arn", arn)
 
-	_, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	_, createOnlyPatch, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotEmpty(t, createOnlyPatch, "drift on an immutable reference-fed field must still force a replacement")
 }
@@ -3818,7 +3818,7 @@ func TestGeneratePatch_ResolvedRefWithDriftedLiveValue_PlansRepair(t *testing.T)
 	patch := fmt.Appendf(nil, `{"TargetKeyId": %q}`, arn)
 	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	var ops []jsonpatch.JsonPatchOperation
 	require.NoError(t, json.Unmarshal(patchDoc, &ops))
@@ -3847,7 +3847,7 @@ func TestGeneratePatch_ArrayRefWithDriftedLiveElement_PlansRepair(t *testing.T) 
 	props.Add(ksuid, "ArnA", arnA)
 	props.Add(ksuid, "ArnB", arnB)
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "a drifted array element must be repaired")
 	assert.Contains(t, string(patchDoc), arnB, "the repair carries the written form")
@@ -3868,7 +3868,7 @@ func TestGeneratePatch_AtomicObjectWithUnresolvableRef_EmitsWriteForm(t *testing
 		Hints:  map[string]pkgmodel.FieldHint{"Cfg": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic}},
 	}
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "the sibling change must be planned")
 	assert.Contains(t, string(patchDoc), arn, "the emitted object must carry the last written form")
@@ -3895,7 +3895,7 @@ func TestGeneratePatch_OrderedArrayUnresolvableRefsReordered_EmitWriteForm(t *te
 		Hints:  map[string]pkgmodel.FieldHint{"Topics": {UpdateMethod: pkgmodel.FieldUpdateMethodArray}},
 	}
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "reordering an ordered list is a change")
 	assert.NotContains(t, string(patchDoc), "name-a", "the provider's read form must not be sent back as a write")
@@ -3915,7 +3915,7 @@ func TestGeneratePatch_UnresolvableRefUnchanged_NoPatch(t *testing.T) {
 	patch := desired
 	schema := pkgmodel.Schema{Fields: []string{"TargetKeyId"}}
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "an unchanged reference must still reconcile to a no-op")
 }
@@ -3940,7 +3940,7 @@ func TestGeneratePatch_NumericArrayRefsUnchanged_NoPatch(t *testing.T) {
 	props.Add(ksuid, "PortA", "443")
 	props.Add(ksuid, "PortB", "8080")
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "unchanged numeric references must not be rewritten")
 }
@@ -3967,7 +3967,7 @@ func TestGeneratePatch_NumericOrderedArrayRefsReordered_EmitNumbers(t *testing.T
 	props.Add(ksuid, "PortA", "443")
 	props.Add(ksuid, "PortB", "8080")
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "reordering an ordered list is a change")
 	assert.NotContains(t, string(patchDoc), `"443"`, "a numeric reference must not be written back as text")
@@ -3985,7 +3985,7 @@ func TestGeneratePatch_BooleanRefUnchanged_NoPatch(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "Flag", "true")
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Nil(t, patchDoc, "an unchanged boolean reference must not be rewritten")
 }
@@ -4005,7 +4005,7 @@ func TestGeneratePatch_AtomicObjectWithNumericRef_EmitsNumber(t *testing.T) {
 	props := resolver.NewResolvableProperties()
 	props.Add(ksuid, "PortA", "443")
 
-	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, stored, desired, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	require.NotNil(t, patchDoc, "the sibling change must be planned")
 	assert.Contains(t, string(patchDoc), "443")
@@ -4030,7 +4030,7 @@ func TestGeneratePatch_ArrayNestedWriteOnlyCreateOnly_ChangeSurvivesTheStrip(t *
 		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
 	}
 	props := resolver.NewResolvableProperties()
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	combined := string(patchDoc) + string(createOnlyPatch)
 	assert.Contains(t, combined, "new",
@@ -4047,7 +4047,7 @@ func TestGeneratePatch_ArrayNestedWriteOnlyCreateOnly_NoBaselineStillStripped(t 
 		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
 	}
 	props := resolver.NewResolvableProperties()
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.NotContains(t, string(patchDoc)+string(createOnlyPatch), "Token")
 }
@@ -4063,7 +4063,7 @@ func TestGeneratePatch_UnkeyedArrayCreateOnlyChange_DeliveredAsMemberSwap(t *tes
 		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
 	}
 	props := resolver.NewResolvableProperties()
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch,
 		"an unkeyed member change must not trigger a resource replacement")
@@ -4088,7 +4088,7 @@ func TestGeneratePatch_EntitySetCreateOnlyChange_TriggersReplacement(t *testing.
 		},
 	}
 	props := resolver.NewResolvableProperties()
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Contains(t, string(createOnlyPatch), "/Entries/0/Token",
 		"a changed createOnly subfield on a paired member must classify as a createOnly diff")
@@ -4104,7 +4104,7 @@ func TestGeneratePatch_ArrayMemberSiblingChange_StaysMutable(t *testing.T) {
 		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
 	}
 	props := resolver.NewResolvableProperties()
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "a sibling-only member change must not trigger a replacement")
 	assert.NotEmpty(t, patchDoc)
@@ -4120,7 +4120,7 @@ func TestGeneratePatch_UnkeyedArrayCreateOnlyValuesExchanged_DeliveredAsMemberSw
 		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
 	}
 	props := resolver.NewResolvableProperties()
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.NotEmpty(t, patchDoc)
@@ -4137,7 +4137,7 @@ func TestGeneratePatch_ArrayMembershipChange_StaysMutable(t *testing.T) {
 		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
 	}
 	props := resolver.NewResolvableProperties()
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "a membership change must not trigger a replacement")
 	assert.NotEmpty(t, patchDoc)
@@ -4153,7 +4153,7 @@ func TestGeneratePatch_ArrayMemberAdded_StaysMutable(t *testing.T) {
 		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
 	}
 	props := resolver.NewResolvableProperties()
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "adding a member must not trigger a resource replacement")
 	assert.NotEmpty(t, patchDoc)
@@ -4167,7 +4167,7 @@ func TestGeneratePatch_ArrayMemberRemoved_StaysMutable(t *testing.T) {
 		Hints:  map[string]pkgmodel.FieldHint{"Entries.Token": {WriteOnly: true, CreateOnly: true}},
 	}
 	props := resolver.NewResolvableProperties()
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, desired, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "removing a member must not trigger a resource replacement")
 	assert.NotEmpty(t, patchDoc)
@@ -4232,7 +4232,7 @@ func TestGeneratePatch_StableSuppressedGenOccurrence_ProducesNoOp(t *testing.T) 
 	props := resolver.NewResolvableProperties()
 	props.SuppressStableAt("Password")
 
-	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, pkgmodel.FormaApplyModeReconcile)
+	patchDoc, _, _, err := generatePatch(document, patch, nil, nil, props, schema, nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 
 	var ops []jsonpatch.JsonPatchOperation

--- a/internal/metastructure/patch/required_on_update_decision_test.go
+++ b/internal/metastructure/patch/required_on_update_decision_test.go
@@ -37,7 +37,7 @@ func TestGeneratePatch_UnchangedRequiredOnUpdateField_ReportsOnlyForceResent(t *
 	desired := []byte(`{"Name": "n1", "Token": "t1"}`)
 
 	patchDoc, createOnlyPatch, onlyForceResent, err := generatePatch(document, desired, nil, nil,
-		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+		resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 
 	assert.Empty(t, createOnlyPatch)
@@ -66,7 +66,7 @@ func TestGeneratePatch_ChangedFieldAlongsideRequiredOnUpdateField_KeepsForceRese
 	desired := []byte(`{"Name": "n2", "Token": "t1"}`)
 
 	patchDoc, createOnlyPatch, onlyForceResent, err := generatePatch(document, desired, nil, nil,
-		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+		resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.False(t, onlyForceResent, "a real change is present, so the decision must not report force-resent-only")
@@ -107,7 +107,7 @@ func TestGeneratePatch_ChangedRequiredOnUpdateFieldItself_PlansUpdate(t *testing
 	desired := []byte(`{"Name": "n1", "Token": "t2"}`)
 
 	patchDoc, createOnlyPatch, onlyForceResent, err := generatePatch(document, desired, nil, nil,
-		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+		resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch)
 	assert.False(t, onlyForceResent, "the Token change itself is real, so the decision must not report force-resent-only")
@@ -140,7 +140,7 @@ func TestGeneratePatch_UnchangedArrayNestedRequiredOnUpdateField_ReportsOnlyForc
 	desired := []byte(`{"Name": "n1", "Items": [{"Token": "same"}]}`)
 
 	patchDoc, createOnlyPatch, onlyForceResent, err := generatePatch(document, desired, nil, nil,
-		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+		resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 
 	assert.Empty(t, createOnlyPatch)
@@ -169,7 +169,7 @@ func TestGeneratePatch_ChangedArrayNestedRequiredOnUpdateField_PlansUpdate(t *te
 	desired := []byte(`{"Name": "n1", "Items": [{"Token": "new"}]}`)
 
 	patchDoc, createOnlyPatch, onlyForceResent, err := generatePatch(document, desired, nil, nil,
-		resolver.NewResolvableProperties(), schema, pkgmodel.FormaApplyModePatch)
+		resolver.NewResolvableProperties(), schema, nil, pkgmodel.FormaApplyModePatch)
 	require.NoError(t, err)
 
 	assert.Empty(t, createOnlyPatch)

--- a/internal/metastructure/patch/suppressed_drift.go
+++ b/internal/metastructure/patch/suppressed_drift.go
@@ -39,6 +39,13 @@ type SuppressedFieldDiff struct {
 	From   json.RawMessage
 	To     json.RawMessage
 	Opaque bool
+
+	// CoOwned marks a note produced by the co-owned regime: movement on a
+	// co-owned collection's never-owned members. Such movement is tolerated
+	// by design — a co-actor's members are legitimately not this forma's —
+	// so the note exists to be shown to whoever asks, never to confront:
+	// the reconcile gate must not reject an apply on its account.
+	CoOwned bool
 }
 
 // SuppressedFieldDiffs compares two stored property documents restricted to
@@ -243,12 +250,13 @@ func coOwnedSuppressedDiff(oldProps, newProps, desired json.RawMessage, path str
 	}
 
 	if pathOpaque(schema, path) || valueHasOpaqueMarker(oldRestricted) || valueHasOpaqueMarker(newRestricted) {
-		return SuppressedFieldDiff{Path: path, Opaque: true}, true
+		return SuppressedFieldDiff{Path: path, Opaque: true, CoOwned: true}, true
 	}
 	return SuppressedFieldDiff{
-		Path: path,
-		From: renderRestrictedMembers(oldRestricted),
-		To:   renderRestrictedMembers(newRestricted),
+		Path:    path,
+		From:    renderRestrictedMembers(oldRestricted),
+		To:      renderRestrictedMembers(newRestricted),
+		CoOwned: true,
 	}, true
 }
 

--- a/internal/metastructure/patch/suppressed_drift.go
+++ b/internal/metastructure/patch/suppressed_drift.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/tidwall/gjson"
 )
 
 // SuppressedFieldDiff describes out-of-band movement on provider-default
@@ -41,18 +42,49 @@ type SuppressedFieldDiff struct {
 }
 
 // SuppressedFieldDiffs compares two stored property documents restricted to
-// the content the provider-default strip passes would hide from a diff
-// against the given desired properties. It reports one entry per suppressed
-// field whose content moved, sorted by path.
+// content a diff against the given desired properties would never see, for
+// two independent reasons, and reports one entry per such field whose
+// content moved, sorted by path.
 //
-// The suppressed content per hasProviderDefault field is exactly what the
-// strip passes suppress: the whole field when desired omits it (absent or
-// null, the fieldExistsInMap semantics of removeProviderDefaultFieldsBoth),
-// and, for an EntitySet field with one or more declared keys, the elements
-// whose key is not among the declared keys (what
-// removeProviderDefaultEntitySetElements filters). An explicit empty
+// The first reason is a hasProviderDefault field: the content is exactly
+// what the strip passes suppress — the whole field when desired omits it
+// (absent or null, the fieldExistsInMap semantics of
+// removeProviderDefaultFieldsBoth), and, for an EntitySet field with one or
+// more declared keys, the elements whose key is not among the declared keys
+// (what removeProviderDefaultEntitySetElements filters). An explicit empty
 // EntitySet declaration suppresses nothing: that is a user-initiated clear
-// the diff plans.
+// the diff plans. This content requires a WITNESSED value (see below) to be
+// reported.
+//
+// The second reason is a CoOwned field's never-owned members (see
+// pkgmodel.PartitionOwnership): a co-owned collection's live content
+// legitimately has writers other than this forma, and the diff plans only
+// the members this forma declares or once declared — a co-actor's member is
+// invisible to it by design, not by a provider-default strip. Movement here
+// is classified by ownership, not by witness: a declared or formerly-owned
+// member's movement is real drift the plan itself surfaces, so it produces
+// no note here regardless of the witness; a never-owned member's value
+// change, appearance, or disappearance produces one, whether or not formae
+// ever wrote the resource. An opaque CoOwned field is excluded from this
+// regime entirely (its members are secret values, not identities meant for
+// partitioning — see claimedMembers) and falls back to the hasProviderDefault
+// treatment above.
+//
+// Path enumeration is the sorted, deduplicated union of
+// schema.HasProviderDefault() and every CoOwned-hinted path: a CoOwned path
+// need not carry hasProviderDefault to be considered.
+//
+// A diff requires a WITNESSED value: the suppressed content was present (a
+// real scalar; a non-empty collection or leaf set) in the witness document,
+// the resource's state as recorded by formae's own last write (the
+// create/update echo), which sync never refreshes. Values that only ever
+// arrived through sync (late-populated defaults, runtime registrations,
+// co-actor content) are never witnessed and never reported: their movement
+// is the infrastructure's business and stays in the drift list. A witnessed
+// value changing or disappearing out of band is reported. A nil witness
+// document (formae never wrote the resource) witnesses nothing. This gate
+// applies ONLY to the hasProviderDefault regime; the CoOwned regime above
+// never consults the witness.
 //
 // Comparison is schema-aware so representation churn is not movement:
 // EntitySet content compares keyed by IndexField, collections without an
@@ -62,7 +94,7 @@ type SuppressedFieldDiff struct {
 // unconditionally (the ContainerDefinitions.Cpu shape, stripped from both
 // sides regardless of declaration), while a pure-object leaf is suppressed
 // only when desired omits it.
-func SuppressedFieldDiffs(oldProps, newProps, desired, witness json.RawMessage, schema pkgmodel.Schema) ([]SuppressedFieldDiff, error) {
+func SuppressedFieldDiffs(oldProps, newProps, desired, witness json.RawMessage, priorOwned pkgmodel.OwnedMembers, schema pkgmodel.Schema) ([]SuppressedFieldDiff, error) {
 	oldMap, err := unmarshalPropsObject(oldProps)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal old properties: %w", err)
@@ -80,13 +112,20 @@ func SuppressedFieldDiffs(oldProps, newProps, desired, witness json.RawMessage, 
 		return nil, fmt.Errorf("failed to unmarshal witness properties: %w", err)
 	}
 
-	paths := append([]string(nil), schema.HasProviderDefault()...)
-	sort.Strings(paths)
+	paths := suppressedDiffCandidatePaths(schema)
 
 	var diffs []SuppressedFieldDiff
 	for _, path := range paths {
-		parts := strings.Split(path, ".")
 		hint := schema.Hints[path]
+
+		if hint.CoOwned != nil && !hint.Opaque {
+			if diff, ok := coOwnedSuppressedDiff(oldProps, newProps, desired, path, hint, priorOwned, schema); ok {
+				diffs = append(diffs, diff)
+			}
+			continue
+		}
+
+		parts := strings.Split(path, ".")
 
 		var from, to json.RawMessage
 		var moved bool
@@ -145,6 +184,157 @@ func SuppressedFieldDiffs(oldProps, newProps, desired, witness json.RawMessage, 
 	}
 
 	return diffs, nil
+}
+
+// suppressedDiffCandidatePaths is the sorted, deduplicated union of
+// schema.HasProviderDefault() and every CoOwned-hinted path — the full set
+// of paths SuppressedFieldDiffs classifies, whichever regime applies to
+// each.
+func suppressedDiffCandidatePaths(schema pkgmodel.Schema) []string {
+	set := make(map[string]struct{}, len(schema.Hints))
+	for _, path := range schema.HasProviderDefault() {
+		set[path] = struct{}{}
+	}
+	for path, hint := range schema.Hints {
+		if hint.CoOwned != nil {
+			set[path] = struct{}{}
+		}
+	}
+	paths := make([]string, 0, len(set))
+	for path := range set {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// coOwnedSuppressedDiff classifies movement on a CoOwned field by ownership
+// rather than by witness: it partitions the field's member identities into
+// Declared/FormerlyOwned/NeverOwned (pkgmodel.PartitionOwnership) using
+// desired's identities as Declared, the stored record's identities as Prior
+// (discarded — see IdentityRule — when the record's Rule does not match this
+// hint, so a stale record degrades to "nothing is prior" rather than a
+// best-effort comparison), and the union of both sides' identities as Live.
+// Only NeverOwned members are compared between oldProps and newProps; a
+// Declared or FormerlyOwned member's movement is real drift the plan itself
+// surfaces and produces no note here, regardless of how it moved.
+func coOwnedSuppressedDiff(oldProps, newProps, desired json.RawMessage, path string, hint pkgmodel.FieldHint, priorOwned pkgmodel.OwnedMembers, schema pkgmodel.Schema) (SuppressedFieldDiff, bool) {
+	oldVal := gjson.GetBytes(oldProps, path)
+	newVal := gjson.GetBytes(newProps, path)
+	desiredVal := gjson.GetBytes(desired, path)
+
+	declared := pkgmodel.MemberIdentities(desiredVal, hint)
+	live := unionStrings(pkgmodel.MemberIdentities(oldVal, hint), pkgmodel.MemberIdentities(newVal, hint))
+
+	var prior []string
+	if record, ok := priorOwned[path]; ok && record.Rule == pkgmodel.IdentityRule(hint) {
+		prior = record.Members
+	}
+
+	partition := pkgmodel.PartitionOwnership(declared, prior, live)
+	if len(partition.NeverOwned) == 0 {
+		return SuppressedFieldDiff{}, false
+	}
+
+	oldRestricted := restrictToNeverOwned(oldVal, hint, partition.NeverOwned)
+	newRestricted := restrictToNeverOwned(newVal, hint, partition.NeverOwned)
+	if canonicalJSON(oldRestricted) == canonicalJSON(newRestricted) {
+		return SuppressedFieldDiff{}, false
+	}
+
+	if pathOpaque(schema, path) || valueHasOpaqueMarker(oldRestricted) || valueHasOpaqueMarker(newRestricted) {
+		return SuppressedFieldDiff{Path: path, Opaque: true}, true
+	}
+	return SuppressedFieldDiff{
+		Path: path,
+		From: renderRestrictedMembers(oldRestricted),
+		To:   renderRestrictedMembers(newRestricted),
+	}, true
+}
+
+// restrictToNeverOwned returns value's content narrowed to the members whose
+// identity is in keep: for an object (Mapping), the entries whose key is
+// kept; for an array (Set/EntitySet), the elements whose identity (computed
+// exactly as pkgmodel.MemberIdentities computes it — see
+// singleElementIdentity) is kept, sorted for a stable, order-independent
+// comparison and rendering. Returns nil when nothing is kept, so two sides
+// with no never-owned content compare equal regardless of shape.
+func restrictToNeverOwned(value gjson.Result, hint pkgmodel.FieldHint, keep map[string]struct{}) any {
+	switch {
+	case value.IsObject():
+		out := map[string]any{}
+		value.ForEach(func(key, val gjson.Result) bool {
+			if _, ok := keep[key.String()]; ok {
+				out[key.String()] = val.Value()
+			}
+			return true
+		})
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	case value.IsArray():
+		var out []any
+		value.ForEach(func(_, el gjson.Result) bool {
+			if id, ok := singleElementIdentity(el, hint); ok {
+				if _, keepIt := keep[id]; keepIt {
+					out = append(out, el.Value())
+				}
+			}
+			return true
+		})
+		if len(out) == 0 {
+			return nil
+		}
+		return sortedByKey(out, hint.IndexField)
+	default:
+		return nil
+	}
+}
+
+// singleElementIdentity computes one array element's member identity by
+// reusing pkgmodel.MemberIdentities itself — wrapping the element's raw JSON
+// as a singleton array and asking for the identity set of that array — so a
+// Set element's canonicalized-and-envelope-flattened identity, or an
+// EntitySet element's IndexField-derived identity, is computed by the exact
+// same logic that produced the identity sets fed to PartitionOwnership.
+// Returns false when the element contributes no identity (e.g. an
+// EntitySet element missing its IndexField, or an unresolvable reference
+// envelope), matching MemberIdentities' own "contributes nothing" cases.
+func singleElementIdentity(el gjson.Result, hint pkgmodel.FieldHint) (string, bool) {
+	wrapped := gjson.Parse("[" + el.Raw + "]")
+	ids := pkgmodel.MemberIdentities(wrapped, hint)
+	if len(ids) != 1 {
+		return "", false
+	}
+	return ids[0], true
+}
+
+// renderRestrictedMembers is compareWholeField's absence convention applied
+// to restricted member content: nil (no value on this side) renders as no
+// JSON at all, never a literal null.
+func renderRestrictedMembers(v any) json.RawMessage {
+	if v == nil {
+		return nil
+	}
+	return json.RawMessage(canonicalJSON(v))
+}
+
+// unionStrings returns the sorted, deduplicated union of a and b.
+func unionStrings(a, b []string) []string {
+	set := make(map[string]struct{}, len(a)+len(b))
+	for _, s := range a {
+		set[s] = struct{}{}
+	}
+	for _, s := range b {
+		set[s] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for s := range set {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func unmarshalPropsObject(raw json.RawMessage) (map[string]any, error) {

--- a/internal/metastructure/patch/suppressed_drift_test.go
+++ b/internal/metastructure/patch/suppressed_drift_test.go
@@ -16,7 +16,7 @@ import (
 
 // suppressedDiffsForTest uses the old properties as the write witness: the
 // common fixture shape where formae's last write observed the same state the
-// drift window starts from.
+// drift window starts from. No prior ownership record.
 func suppressedDiffsForTest(t *testing.T, oldProps, newProps, desired string, schema pkgmodel.Schema) []SuppressedFieldDiff {
 	t.Helper()
 	return suppressedDiffsWithWitness(t, oldProps, newProps, desired, oldProps, schema)
@@ -24,11 +24,23 @@ func suppressedDiffsForTest(t *testing.T, oldProps, newProps, desired string, sc
 
 func suppressedDiffsWithWitness(t *testing.T, oldProps, newProps, desired, witness string, schema pkgmodel.Schema) []SuppressedFieldDiff {
 	t.Helper()
+	return suppressedDiffsWithWitnessAndRecord(t, oldProps, newProps, desired, witness, nil, schema)
+}
+
+// suppressedDiffsForCoOwned drives the CoOwned regime, which never consults
+// the witness: an empty witness stands in for "irrelevant here".
+func suppressedDiffsForCoOwned(t *testing.T, oldProps, newProps, desired string, priorOwned pkgmodel.OwnedMembers, schema pkgmodel.Schema) []SuppressedFieldDiff {
+	t.Helper()
+	return suppressedDiffsWithWitnessAndRecord(t, oldProps, newProps, desired, "", priorOwned, schema)
+}
+
+func suppressedDiffsWithWitnessAndRecord(t *testing.T, oldProps, newProps, desired, witness string, priorOwned pkgmodel.OwnedMembers, schema pkgmodel.Schema) []SuppressedFieldDiff {
+	t.Helper()
 	var w json.RawMessage
 	if witness != "" {
 		w = json.RawMessage(witness)
 	}
-	diffs, err := SuppressedFieldDiffs(json.RawMessage(oldProps), json.RawMessage(newProps), json.RawMessage(desired), w, schema)
+	diffs, err := SuppressedFieldDiffs(json.RawMessage(oldProps), json.RawMessage(newProps), json.RawMessage(desired), w, priorOwned, schema)
 	require.NoError(t, err)
 	return diffs
 }
@@ -642,4 +654,86 @@ func TestAssertWitnessedSuppressed_EntitySetExplicitEmpty_NotInjected(t *testing
 		`{"Name": "r", "Tags": [{"Key": "sys", "Value": "s0"}]}`,
 		schema)
 	assert.JSONEq(t, `{"Name": "r", "Tags": []}`, out)
+}
+
+// coOwnedMappingSchema is a co-owned Mapping field (CoOwned + no
+// UpdateMethod, per pkgmodel.IdentityRule) with no HasProviderDefault hint —
+// the co-owned regime must not depend on it.
+func coOwnedMappingSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"labels"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"labels": {CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+}
+
+func TestSuppressedFieldDiffs_CoOwnedMapping_NeverOwnedMemberChanges_Reported(t *testing.T) {
+	// "theirs" is live but neither declared by this forma now nor on the
+	// prior apply (the record only ever claimed "mine"): it is NeverOwned,
+	// so its value change is suppressed movement.
+	priorOwned := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"mine"}}}
+
+	diffs := suppressedDiffsForCoOwned(t,
+		`{"labels": {"mine": "1", "theirs": "a"}}`,
+		`{"labels": {"mine": "1", "theirs": "b"}}`,
+		`{"labels": {"mine": "1"}}`,
+		priorOwned, coOwnedMappingSchema())
+
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "labels", diffs[0].Path)
+	assert.False(t, diffs[0].Opaque)
+	assert.JSONEq(t, `{"theirs": "a"}`, string(diffs[0].From))
+	assert.JSONEq(t, `{"theirs": "b"}`, string(diffs[0].To))
+}
+
+func TestSuppressedFieldDiffs_CoOwnedMapping_DeclaredMemberDisappears_NoNoteForThatMember(t *testing.T) {
+	// "mine" is still declared by this forma, so it is never NeverOwned no
+	// matter how it moves: its disappearance is real drift for the plan to
+	// surface, not a suppressed note. "theirs" is unchanged, so nothing at
+	// all is reported.
+	priorOwned := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"mine"}}}
+
+	diffs := suppressedDiffsForCoOwned(t,
+		`{"labels": {"mine": "1", "theirs": "a"}}`,
+		`{"labels": {"theirs": "a"}}`,
+		`{"labels": {"mine": "1"}}`,
+		priorOwned, coOwnedMappingSchema())
+
+	assert.Empty(t, diffs, "a declared member's own movement is plan territory, not a suppressed note")
+}
+
+func TestSuppressedFieldDiffs_CoOwnedMapping_RuleMismatchedRecord_TreatsUndeclaredAsNeverOwned(t *testing.T) {
+	// The stored record's Rule ("Set") does not match this field's current
+	// IdentityRule ("Mapping" — CoOwned with no UpdateMethod): it is stale
+	// and discarded, so "mine" — no longer declared, and no longer protected
+	// as formerly-owned — is NeverOwned like any other undeclared member, and
+	// its movement is reported instead of silently tolerated.
+	priorOwned := pkgmodel.OwnedMembers{"labels": {Rule: "Set", Members: []string{"mine"}}}
+
+	diffs := suppressedDiffsForCoOwned(t,
+		`{"labels": {"mine": "1"}}`,
+		`{"labels": {"mine": "2"}}`,
+		`{"labels": {}}`,
+		priorOwned, coOwnedMappingSchema())
+
+	require.Len(t, diffs, 1)
+	assert.Equal(t, "labels", diffs[0].Path)
+	assert.JSONEq(t, `{"mine": "1"}`, string(diffs[0].From))
+	assert.JSONEq(t, `{"mine": "2"}`, string(diffs[0].To))
+}
+
+func TestSuppressedFieldDiffs_CoOwnedPathWithoutHasProviderDefault_EntersCandidateSet(t *testing.T) {
+	// coOwnedMappingSchema's "labels" hint carries no HasProviderDefault, so
+	// schema.HasProviderDefault() alone would never enumerate it. Path
+	// enumeration is the union with every CoOwned-hinted path, so this must
+	// still be classified.
+	diffs := suppressedDiffsForCoOwned(t,
+		`{"labels": {"theirs": "a"}}`,
+		`{"labels": {"theirs": "b"}}`,
+		`{}`,
+		nil, coOwnedMappingSchema())
+
+	require.Len(t, diffs, 1, "a CoOwned path without hasProviderDefault must enter the candidate set")
+	assert.Equal(t, "labels", diffs[0].Path)
 }

--- a/internal/metastructure/patch/suppressed_drift_test.go
+++ b/internal/metastructure/patch/suppressed_drift_test.go
@@ -683,8 +683,28 @@ func TestSuppressedFieldDiffs_CoOwnedMapping_NeverOwnedMemberChanges_Reported(t 
 	require.Len(t, diffs, 1)
 	assert.Equal(t, "labels", diffs[0].Path)
 	assert.False(t, diffs[0].Opaque)
+	assert.True(t, diffs[0].CoOwned, "a co-owned regime note carries the regime marker")
 	assert.JSONEq(t, `{"theirs": "a"}`, string(diffs[0].From))
 	assert.JSONEq(t, `{"theirs": "b"}`, string(diffs[0].To))
+}
+
+func TestSuppressedFieldDiffs_WitnessRegimeNote_NotMarkedCoOwned(t *testing.T) {
+	// A hasProviderDefault note confronts at the reconcile gate; only the
+	// co-owned regime's notes are tolerated display material.
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Setting"},
+		Hints:  map[string]pkgmodel.FieldHint{"Setting": {HasProviderDefault: true}},
+	}
+
+	diffs, err := SuppressedFieldDiffs(
+		json.RawMessage(`{"Name": "n", "Setting": "a"}`),
+		json.RawMessage(`{"Name": "n", "Setting": "b"}`),
+		json.RawMessage(`{"Name": "n"}`),
+		json.RawMessage(`{"Name": "n", "Setting": "a"}`),
+		nil, schema)
+	require.NoError(t, err)
+	require.Len(t, diffs, 1)
+	assert.False(t, diffs[0].CoOwned)
 }
 
 func TestSuppressedFieldDiffs_CoOwnedMapping_DeclaredMemberDisappears_NoNoteForThatMember(t *testing.T) {

--- a/internal/metastructure/patch/writeonly_createonly_baseline_test.go
+++ b/internal/metastructure/patch/writeonly_createonly_baseline_test.go
@@ -40,7 +40,7 @@ func TestGeneratePatch_WriteOnlyCreateOnlyChanged_StoredBaseline_PlansReplacemen
 	}`)
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, writeOnlyCreateOnlySchema(), pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, writeOnlyCreateOnlySchema(), nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	if len(patchDoc) > 0 {
 		assert.JSONEq(t, "[]", string(patchDoc), "a createOnly change belongs in the createOnly patch, not the update patch")
@@ -63,7 +63,7 @@ func TestGeneratePatch_WriteOnlyCreateOnlyUnchanged_StoredBaseline_NoOp(t *testi
 	}`)
 	props := resolver.NewResolvableProperties()
 
-	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, writeOnlyCreateOnlySchema(), pkgmodel.FormaApplyModeReconcile)
+	patchDoc, createOnlyPatch, _, err := generatePatch(document, patch, nil, nil, props, writeOnlyCreateOnlySchema(), nil, pkgmodel.FormaApplyModeReconcile)
 	require.NoError(t, err)
 	assert.Empty(t, createOnlyPatch, "an unchanged writeOnly+createOnly field must not plan a replacement")
 	assert.Nil(t, patchDoc, "an unchanged writeOnly+createOnly field must not plan any op")

--- a/internal/metastructure/resource_persister/resource_persister_test.go
+++ b/internal/metastructure/resource_persister/resource_persister_test.go
@@ -324,6 +324,119 @@ func TestResourcePersister_Update(t *testing.T) {
 	assert.Equal(t, []interface{}{float64(7), float64(8)}, props["a"])
 }
 
+// TestResourcePersister_RecordOnlyUpdateChangesOwnershipRecordOnly is the
+// persistence-invariant check for a record-only update: DesiredState carries
+// the exact same Properties and ReadOnlyProperties already stored, differing
+// only in OwnedMembers. This exercises processResourceUpdate's OperationUpdate
+// path directly (the seam TestResourcePersister_Update exercises) — there is
+// no unit seam inside package resource_update itself, since the executor
+// answers PersistResourceUpdate synthetically there rather than driving this
+// function.
+func TestResourcePersister_RecordOnlyUpdateChangesOwnershipRecordOnly(t *testing.T) {
+	persister, sender, ds, err := newResourcePersisterForTest(t)
+	assert.NoError(t, err)
+
+	resourceKsuid := util.NewID()
+	schema := pkgmodel.Schema{
+		Fields: []string{"Tags"},
+		Hints:  map[string]pkgmodel.FieldHint{"Tags": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+	props := json.RawMessage(`{"Tags":["a","b"]}`)
+	readOnlyProps := json.RawMessage(`{"Arn":"arn:aws:ec2:sg/test"}`)
+
+	initialResource := resource_update.ResourceUpdate{
+		DesiredState: pkgmodel.Resource{
+			Label:              "test-resource",
+			Type:               "FakeAWS::EC2::SecurityGroup",
+			Properties:         props,
+			ReadOnlyProperties: readOnlyProps,
+			Stack:              "test-stack",
+			Ksuid:              resourceKsuid,
+			Schema:             schema,
+		},
+		ResourceTarget: pkgmodel.Target{Label: "test-target", Namespace: "test-namespace"},
+		State:          resource_update.ResourceUpdateStateSuccess,
+		StackLabel:     "test-stack",
+		ProgressResult: []plugin.TrackedProgress{
+			{
+				ProgressResult: resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          "test-request-id",
+					NativeID:           "test-native-id",
+					ResourceProperties: props,
+				},
+				ResourceType: "FakeAWS::EC2::SecurityGroup",
+				StartTs:      util.TimeNow(),
+				ModifiedTs:   util.TimeNow(),
+				Attempts:     1,
+			},
+		},
+		GroupID: "test-group-id",
+	}
+
+	createResult := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "test-command-id",
+		ResourceOperation: resource_update.OperationCreate,
+		PluginOperation:   resource.OperationCreate,
+		ResourceUpdate:    initialResource,
+	})
+	require.NoError(t, createResult.Error)
+
+	newRecord := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`}}}
+	recordOnlyResource := resource_update.ResourceUpdate{
+		DesiredState: pkgmodel.Resource{
+			Label:              "test-resource",
+			Type:               "FakeAWS::EC2::SecurityGroup",
+			Properties:         props,
+			ReadOnlyProperties: readOnlyProps,
+			Stack:              "test-stack",
+			Ksuid:              resourceKsuid,
+			Schema:             schema,
+			OwnedMembers:       newRecord,
+		},
+		ResourceTarget: pkgmodel.Target{Label: "test-target", Namespace: "test-namespace"},
+		State:          resource_update.ResourceUpdateStateSuccess,
+		StackLabel:     "test-stack",
+		RecordOnly:     true,
+		ProgressResult: []plugin.TrackedProgress{
+			{
+				ProgressResult: resource.ProgressResult{
+					Operation:          resource.OperationUpdate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					RequestID:          "test-request-id-2",
+					NativeID:           "test-native-id",
+					ResourceProperties: props,
+				},
+				ResourceType: "FakeAWS::EC2::SecurityGroup",
+				StartTs:      util.TimeNow(),
+				ModifiedTs:   util.TimeNow(),
+				Attempts:     1,
+			},
+		},
+		GroupID: "test-group-id",
+	}
+
+	updateResult := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "test-command-id-2",
+		ResourceOperation: resource_update.OperationUpdate,
+		PluginOperation:   resource.OperationUpdate,
+		ResourceUpdate:    recordOnlyResource,
+	})
+	require.NoError(t, updateResult.Error)
+
+	loaded, err := ds.LoadResource(pkgmodel.NewFormaeURI(resourceKsuid, ""))
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+
+	assert.JSONEq(t, string(props), string(loaded.Properties),
+		"Properties must be unchanged by a record-only update")
+	assert.JSONEq(t, string(readOnlyProps), string(loaded.ReadOnlyProperties),
+		"ReadOnlyProperties must be unchanged by a record-only update")
+	assert.True(t, pkgmodel.OwnedMembersEqual(newRecord, loaded.OwnedMembers),
+		"OwnedMembers must reflect the newly committed record")
+}
+
 func TestResourcePersister_Delete(t *testing.T) {
 	persister, sender, ds, err := newResourcePersisterForTest(t)
 	assert.NoError(t, err)
@@ -1535,14 +1648,14 @@ func syncReadUpdate(ksuid string, props, readOnlyProps json.RawMessage, matchFil
 func seedUnmanagedRow(t *testing.T, ds datastore.Datastore, ksuid string, props json.RawMessage, managed bool) {
 	t.Helper()
 	_, err := ds.StoreResource(&pkgmodel.Resource{
-		Label:    "discovered-resource",
-		Type:     "FakeAWS::EC2::Instance",
-		NativeID: "i-abc123",
+		Label:      "discovered-resource",
+		Type:       "FakeAWS::EC2::Instance",
+		NativeID:   "i-abc123",
 		Properties: props,
-		Stack:    "$unmanaged",
-		Target:   "test-target",
-		Ksuid:    ksuid,
-		Managed:  managed,
+		Stack:      "$unmanaged",
+		Target:     "test-target",
+		Ksuid:      ksuid,
+		Managed:    managed,
 	}, "seed-cmd")
 	require.NoError(t, err)
 }

--- a/internal/metastructure/resource_summaries_test.go
+++ b/internal/metastructure/resource_summaries_test.go
@@ -119,6 +119,9 @@ func (m *mockSummaryDatastore) GetMostRecentFormaCommandByClientID(_ string) (*f
 func (m *mockSummaryDatastore) GetPropertiesAtLastWrite(_ string) (json.RawMessage, error) {
 	return nil, nil
 }
+func (m *mockSummaryDatastore) GetOwnedMembers(_ string) (pkgmodel.OwnedMembers, error) {
+	return nil, nil
+}
 
 func (m *mockSummaryDatastore) GetResourceModificationsSinceLastReconcile(_ string) ([]datastore.ResourceModification, error) {
 	panic("not implemented")

--- a/internal/metastructure/resource_update/ownership_record_test.go
+++ b/internal/metastructure/resource_update/ownership_record_test.go
@@ -1,0 +1,287 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"testing"
+
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// coOwnedSetSchema declares one field, "Tags", as a co-owned Set: the shape
+// TestCoOwnedSetShrinkDrainsExactlyTheRemovedMember (patch package) also
+// uses, so identities are canonical-JSON-encoded array elements.
+func coOwnedSetSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Tags": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+}
+
+// plainSchema declares no co-owned fields at all.
+func plainSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{Fields: []string{"Tags"}}
+}
+
+func ownershipTestTarget() pkgmodel.Target {
+	return pkgmodel.Target{Label: "test-target", Namespace: "aws", Config: json.RawMessage(`{}`)}
+}
+
+func newResourceForOwnershipTest(schema pkgmodel.Schema, label, stack string, props json.RawMessage, owned pkgmodel.OwnedMembers) pkgmodel.Resource {
+	return pkgmodel.Resource{
+		Ksuid:        "ksuid-" + label,
+		Label:        label,
+		Type:         "FakeAWS::EC2::SecurityGroup",
+		Stack:        stack,
+		Target:       "test-target",
+		Schema:       schema,
+		Properties:   props,
+		Managed:      true,
+		OwnedMembers: owned,
+	}
+}
+
+// Carry: a real update (a non-co-owned field changes) must carry the
+// existing ownership record forward onto DesiredState untouched — the echo
+// recompute at execution time is what replaces it, not planning.
+func TestNewResourceUpdateForExisting_OwnershipRecord_CarriedOnRealUpdate(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Tags": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	record := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`, `"b"`}}}
+
+	existing := newResourceForOwnershipTest(schema, "sg", "default", json.RawMessage(`{"Name":"old","Tags":["a","b"]}`), record)
+	newRes := newResourceForOwnershipTest(schema, "sg", "default", json.RawMessage(`{"Name":"new","Tags":["a","b"]}`), nil)
+	newRes.Ksuid = "" // desired declarations never carry a KSUID of their own
+
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newRes,
+		ownershipTestTarget(), ownershipTestTarget(), pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+
+	update := updates[0]
+	assert.False(t, update.RecordOnly)
+	assert.True(t, pkgmodel.OwnedMembersEqual(record, update.DesiredState.OwnedMembers),
+		"the existing record must be carried onto DesiredState")
+	assert.True(t, pkgmodel.OwnedMembersEqual(record, update.PriorState.OwnedMembers),
+		"PriorState is the existing resource verbatim, so it must still carry the record too")
+}
+
+// Bootstrap through the identical-resources return: existing and desired are
+// byte-identical (no record yet), but the declared and live values on a
+// co-owned path intersect non-emptily. The claim check must run BEFORE the
+// identical-resources early return, or this legacy-bootstrap case is
+// swallowed and the record never gets written.
+func TestNewResourceUpdateForExisting_OwnershipRecord_BootstrapThroughIdenticalResourcesReturn(t *testing.T) {
+	schema := coOwnedSetSchema()
+	props := json.RawMessage(`{"Tags":["a","b"]}`)
+
+	existing := newResourceForOwnershipTest(schema, "sg", "default", props, nil)
+	newRes := existing // byte-for-byte identical, including nil OwnedMembers
+
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newRes,
+		ownershipTestTarget(), ownershipTestTarget(), pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.NoError(t, err)
+	require.Len(t, updates, 1, "the ownership delta must still produce exactly one update")
+
+	update := updates[0]
+	assert.True(t, update.RecordOnly)
+	assert.JSONEq(t, `[]`, string(update.DesiredState.PatchDocument))
+	assert.JSONEq(t, string(props), string(update.DesiredState.Properties))
+	want := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`, `"b"`}}}
+	assert.True(t, pkgmodel.OwnedMembersEqual(want, update.DesiredState.OwnedMembers))
+	assert.Nil(t, update.RemainingResolvables)
+}
+
+// A stored record already equal to what would be claimed produces no update
+// at all — the ownership delta is the only thing that can turn "nothing else
+// changed" into an update, and here there is no delta either.
+func TestNewResourceUpdateForExisting_OwnershipRecord_AlreadyEqualToClaim_NoUpdate(t *testing.T) {
+	schema := coOwnedSetSchema()
+	props := json.RawMessage(`{"Tags":["a","b"]}`)
+	record := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`, `"b"`}}}
+
+	existing := newResourceForOwnershipTest(schema, "sg", "default", props, record)
+	newRes := existing
+
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newRes,
+		ownershipTestTarget(), ownershipTestTarget(), pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.NoError(t, err)
+	assert.Empty(t, updates)
+}
+
+// Legacy no-op: a resource with no co-owned fields at all produces a nil
+// claim regardless of content, so the pre-existing "nothing changed, skip"
+// behavior for a resource with no ownership machinery is unaffected.
+func TestNewResourceUpdateForExisting_OwnershipRecord_LegacyNoCoOwnedFields_NoUpdate(t *testing.T) {
+	schema := plainSchema()
+	props := json.RawMessage(`{"Tags":["a","b"]}`)
+
+	existing := newResourceForOwnershipTest(schema, "sg", "default", props, nil)
+	newRes := existing
+
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newRes,
+		ownershipTestTarget(), ownershipTestTarget(), pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.NoError(t, err)
+	assert.Empty(t, updates)
+}
+
+// A declared member that is an unresolved reference (no $value) contributes
+// nothing to the claim. Here both sides carry the identical unresolved
+// envelope, so there is no other delta either: the claim is nil on both
+// sides and the update is dropped exactly like the legacy no-op case,
+// proving claimedMembers does not mistake the raw envelope object for a
+// member identity.
+func TestNewResourceUpdateForExisting_OwnershipRecord_DeferredRefContributesNothing_NoUpdate(t *testing.T) {
+	schema := coOwnedSetSchema()
+	props := json.RawMessage(`{"Tags":[{"$res":true,"$type":"String"}]}`)
+
+	existing := newResourceForOwnershipTest(schema, "sg", "default", props, nil)
+	newRes := existing
+
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newRes,
+		ownershipTestTarget(), ownershipTestTarget(), pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.NoError(t, err)
+	assert.Empty(t, updates)
+}
+
+// Echo recompute: a successful Create progress whose echo contains the
+// declared member "a" verbatim but respells "b" (declared "b", live "B")
+// must commit a record naming only "a" — the intersection of what was
+// declared going into the write with what is actually live now.
+func TestRecordProgress_OwnershipRecord_EchoRecomputeKeepsOnlyVerbatimMember(t *testing.T) {
+	ru := &ResourceUpdate{
+		Operation: OperationCreate,
+		DesiredState: pkgmodel.Resource{
+			Properties: json.RawMessage(`{"Tags":["a","b"]}`),
+			Schema:     coOwnedSetSchema(),
+		},
+	}
+
+	progress := &plugin.TrackedProgress{
+		ProgressResult: resource.ProgressResult{
+			Operation:          resource.OperationCreate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			ResourceProperties: json.RawMessage(`{"Tags":["a","B"]}`),
+		},
+		Attempts:    1,
+		MaxAttempts: 1,
+	}
+
+	err := ru.RecordProgress(progress)
+	require.NoError(t, err)
+
+	want := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`}}}
+	assert.True(t, pkgmodel.OwnedMembersEqual(want, ru.DesiredState.OwnedMembers),
+		"only the member echoed back verbatim should be claimed, got %#v", ru.DesiredState.OwnedMembers)
+}
+
+// A read-shaped merge (writeOrigin false — sync/discovery observing state
+// nobody here caused) must never move the ownership record, even when the
+// read reports live content that would otherwise change the claim.
+func TestRecordProgress_OwnershipRecord_ReadOriginLeavesRecordUntouched(t *testing.T) {
+	preset := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`, `"b"`}}}
+	ru := &ResourceUpdate{
+		Operation: OperationRead,
+		DesiredState: pkgmodel.Resource{
+			Properties:   json.RawMessage(`{"Tags":["a","b"]}`),
+			Schema:       coOwnedSetSchema(),
+			OwnedMembers: preset,
+		},
+	}
+
+	progress := &plugin.TrackedProgress{
+		ProgressResult: resource.ProgressResult{
+			Operation:          resource.OperationRead,
+			OperationStatus:    resource.OperationStatusSuccess,
+			ResourceProperties: json.RawMessage(`{"Tags":["a","b","c"]}`),
+		},
+		Attempts:    1,
+		MaxAttempts: 1,
+	}
+
+	err := ru.RecordProgress(progress)
+	require.NoError(t, err)
+
+	assert.True(t, pkgmodel.OwnedMembersEqual(preset, ru.DesiredState.OwnedMembers),
+		"a read-origin merge must leave OwnedMembers exactly as it was")
+}
+
+// recordOnlyGuardProcess drives update() through the RecordOnly synthetic
+// path while recording every message sent through proc.Call — including any
+// plugin-spawn request, which must never appear for a RecordOnly update — and
+// answers persister-shaped calls the way persistingProcess (opaque_log_redaction_test.go)
+// does, so handleProgressUpdate's persist/progress calls succeed.
+type recordOnlyGuardProcess struct {
+	*stubUpdaterProcess
+	log   *capturingLog
+	calls []any
+}
+
+func (p *recordOnlyGuardProcess) Log() gen.Log { return p.log }
+
+func (p *recordOnlyGuardProcess) Call(_ any, msg any) (any, error) {
+	p.calls = append(p.calls, msg)
+	return "resource-version-1", nil
+}
+
+func (p *recordOnlyGuardProcess) reachedPluginSpawn() bool {
+	for _, c := range p.calls {
+		if _, ok := c.(messages.SpawnPluginOperator); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Executor predicate: a RecordOnly update must skip the plugin call entirely
+// and synthesize a successful Update progress, the same way isLabelOnlyChange
+// does. There is no existing unit seam that exercises isLabelOnlyChange
+// itself (no test in this package drives update() through that branch), so
+// this test drives update() directly — the narrowest seam that exists for
+// exercising the executor's provider-skip predicates at all.
+func TestUpdate_RecordOnly_SkipsPluginCallAndSynthesizesSuccess(t *testing.T) {
+	ru := &ResourceUpdate{
+		Operation:  OperationUpdate,
+		RecordOnly: true,
+		PriorState: pkgmodel.Resource{
+			Label: "sg", Type: "FakeAWS::EC2::SecurityGroup", Stack: "default", Target: "test-target",
+			Properties:         json.RawMessage(`{"Tags":["a","b"]}`),
+			ReadOnlyProperties: json.RawMessage(`{"GroupId":"sg-1"}`),
+		},
+		DesiredState: pkgmodel.Resource{
+			Ksuid: "ksuid-sg",
+			Label: "sg", Type: "FakeAWS::EC2::SecurityGroup", Stack: "default", Target: "test-target",
+			Properties:    json.RawMessage(`{"Tags":["a","b"]}`),
+			PatchDocument: json.RawMessage(`[]`),
+			OwnedMembers:  pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`}}},
+		},
+	}
+	data := ResourceUpdateData{resourceUpdate: ru, commandID: "cmd-1"}
+	proc := &recordOnlyGuardProcess{stubUpdaterProcess: &stubUpdaterProcess{}, log: &capturingLog{}}
+
+	state, _, _, err := update(StateUpdating, data, proc)
+	require.NoError(t, err)
+
+	assert.False(t, proc.reachedPluginSpawn(), "a RecordOnly update must never spawn a plugin operator")
+	assert.Equal(t, StateFinishedSuccessfully, state)
+	assert.Equal(t, ResourceUpdateStateSuccess, data.resourceUpdate.State)
+}

--- a/internal/metastructure/resource_update/ownership_record_test.go
+++ b/internal/metastructure/resource_update/ownership_record_test.go
@@ -8,6 +8,7 @@ package resource_update
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"ergo.services/ergo/gen"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
@@ -111,6 +113,116 @@ func TestNewResourceUpdateForExisting_OwnershipRecord_BootstrapThroughIdenticalR
 	assert.Nil(t, update.RemainingResolvables)
 }
 
+// Bootstrap through the force-resent-only return: hasChanges is true (a
+// resolved reference's byte shape differs even though the value it resolves
+// to did not move), but the patch that produces suppresses entirely to a
+// single requiredOnUpdate force-resent op — the third early return inside
+// the hasChanges branch. A live ownership delta must still be routed to a
+// record-only update here rather than dropped, exactly as the two simpler
+// early returns are. This reproduces the exact state
+// TestGenerateResourceUpdates_RequiredOnUpdateConsumer_BehavesIdentically's
+// "unchanged root plans nothing" scenario puts the consumer in (hasChanges
+// true, patch onlyForceResent — confirmed by tracing that scenario), with a
+// co-owned field and an existing (nil) ownership record added on top.
+func TestNewResourceUpdateForExisting_OwnershipRecord_ForceResentOnlyReturnRoutesToRecordOnly(t *testing.T) {
+	producerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Value"},
+		Hints:      map[string]pkgmodel.FieldHint{"Name": {CreateOnly: true}},
+	}
+	consumerSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "ParentRef", "Token", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Token": {RequiredOnUpdate: true},
+			"Tags":  {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+
+	producerKsuid := util.NewID()
+	consumerKsuid := util.NewID()
+
+	existingStack := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label: "parent", Type: "FakeAWS::Occurrence::Parent",
+				Stack: "test-stack", Target: "test-target",
+				Schema: producerSchema, Ksuid: producerKsuid,
+				Properties: json.RawMessage(`{"Name": "parent-1", "Value": "hello"}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Occurrence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema, Ksuid: consumerKsuid,
+				Properties: json.RawMessage(fmt.Sprintf(
+					`{"Name": "consumer-1", "Token": "t1", "Tags": ["a","b"], "ParentRef": {"$ref": "formae://%s#/Value", "$value": "hello"}}`,
+					producerKsuid)),
+				// No ownership record yet.
+			},
+		},
+	}
+
+	ds, _ := GetDeps(t)
+	_, err := ds.StoreStack(existingStack, "previous-command")
+	require.NoError(t, err)
+
+	existingTargets := []*pkgmodel.Target{
+		{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+	}
+	forma := &pkgmodel.Forma{
+		Stacks: []pkgmodel.Stack{{Label: "test-stack"}},
+		Targets: []pkgmodel.Target{
+			{Label: "test-target", Config: json.RawMessage(`{"Region": "us-east-1"}`), Namespace: "test"},
+		},
+		Resources: []pkgmodel.Resource{
+			{
+				// Unchanged: the parent must not itself produce an update.
+				Label: "parent", Type: "FakeAWS::Occurrence::Parent",
+				Stack: "test-stack", Target: "test-target",
+				Schema:     producerSchema,
+				Properties: json.RawMessage(`{"Name": "parent-1", "Value": "hello"}`),
+			},
+			{
+				Label: "consumer", Type: "FakeAWS::Occurrence::Consumer",
+				Stack: "test-stack", Target: "test-target",
+				Schema: consumerSchema,
+				Properties: json.RawMessage(`{
+					"Name": "consumer-1",
+					"Token": "t1",
+					"Tags": ["a","b"],
+					"ParentRef": {
+						"$res":      true,
+						"$label":    "parent",
+						"$type":     "FakeAWS::Occurrence::Parent",
+						"$stack":    "test-stack",
+						"$property": "Value"
+					}
+				}`),
+			},
+		},
+	}
+
+	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+		FormaCommandSourceUser, existingTargets, ds, nil, nil, false)
+	require.NoError(t, err)
+
+	var consumerUpdates []ResourceUpdate
+	for i := range updates {
+		if updates[i].DesiredState.Label == "consumer" {
+			consumerUpdates = append(consumerUpdates, updates[i])
+		}
+	}
+	require.Len(t, consumerUpdates, 1,
+		"the force-resent-only return must not silently drop an owed ownership-record commit")
+
+	update := consumerUpdates[0]
+	assert.True(t, update.RecordOnly)
+	assert.JSONEq(t, `[]`, string(update.DesiredState.PatchDocument))
+	want := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`, `"b"`}}}
+	assert.True(t, pkgmodel.OwnedMembersEqual(want, update.DesiredState.OwnedMembers))
+}
+
 // A stored record already equal to what would be claimed produces no update
 // at all — the ownership delta is the only thing that can turn "nothing else
 // changed" into an update, and here there is no delta either.
@@ -163,6 +275,31 @@ func TestNewResourceUpdateForExisting_OwnershipRecord_DeferredRefContributesNoth
 	assert.Empty(t, updates)
 }
 
+// A field that is both CoOwned and Opaque records no claim at all: its
+// member identities would be its secret values, not names, and recording
+// them would persist a secret unhashed. PKL rejects this combination at
+// authoring time (see formae.pkl's FieldHint validation), but claimedMembers
+// applies the same rule defensively for a schema that reaches it some other
+// way. Declared and live agree here (an ordinary claim would otherwise be
+// nonempty), proving the skip is specifically about the Opaque hint.
+func TestNewResourceUpdateForExisting_OwnershipRecord_OpaqueCoOwnedFieldSkipped_NoUpdate(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Secrets"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Secrets": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}, Opaque: true},
+		},
+	}
+	props := json.RawMessage(`{"Secrets":["s1","s2"]}`)
+
+	existing := newResourceForOwnershipTest(schema, "sg", "default", props, nil)
+	newRes := existing
+
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newRes,
+		ownershipTestTarget(), ownershipTestTarget(), pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.NoError(t, err)
+	assert.Empty(t, updates, "an opaque co-owned field must never produce an ownership-delta update")
+}
+
 // Echo recompute: a successful Create progress whose echo contains the
 // declared member "a" verbatim but respells "b" (declared "b", live "B")
 // must commit a record naming only "a" — the intersection of what was
@@ -192,6 +329,43 @@ func TestRecordProgress_OwnershipRecord_EchoRecomputeKeepsOnlyVerbatimMember(t *
 	want := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`}}}
 	assert.True(t, pkgmodel.OwnedMembersEqual(want, ru.DesiredState.OwnedMembers),
 		"only the member echoed back verbatim should be claimed, got %#v", ru.DesiredState.OwnedMembers)
+}
+
+// The echo recompute must apply the same Opaque skip claimedMembers does at
+// planning: a co-owned opaque field's identities are secret values, so a
+// successful write must never populate OwnedMembers with them, even though
+// declared and echoed values agree perfectly (an ordinary field would
+// produce a claim here).
+func TestRecordProgress_OwnershipRecord_OpaqueCoOwnedFieldEchoRecordsNoClaim(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Secrets"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Secrets": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}, Opaque: true},
+		},
+	}
+	ru := &ResourceUpdate{
+		Operation: OperationCreate,
+		DesiredState: pkgmodel.Resource{
+			Properties: json.RawMessage(`{"Secrets":["s1","s2"]}`),
+			Schema:     schema,
+		},
+	}
+
+	progress := &plugin.TrackedProgress{
+		ProgressResult: resource.ProgressResult{
+			Operation:          resource.OperationCreate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			ResourceProperties: json.RawMessage(`{"Secrets":["s1","s2"]}`),
+		},
+		Attempts:    1,
+		MaxAttempts: 1,
+	}
+
+	err := ru.RecordProgress(progress)
+	require.NoError(t, err)
+
+	assert.Empty(t, ru.DesiredState.OwnedMembers,
+		"an opaque co-owned field must never be recorded, got %#v", ru.DesiredState.OwnedMembers)
 }
 
 // A read-shaped merge (writeOrigin false — sync/discovery observing state

--- a/internal/metastructure/resource_update/ownership_record_test.go
+++ b/internal/metastructure/resource_update/ownership_record_test.go
@@ -432,21 +432,40 @@ func (p *recordOnlyGuardProcess) reachedPluginSpawn() bool {
 // itself (no test in this package drives update() through that branch), so
 // this test drives update() directly — the narrowest seam that exists for
 // exercising the executor's provider-skip predicates at all.
+//
+// Stored Tags carries "x", a co-actor's member this forma never declared and
+// never claimed (the planning-time claim, preset on DesiredState.OwnedMembers,
+// names only "a"). The synthesized success progress echoes the stored
+// properties verbatim (completeProperties merges PriorState.Properties/
+// ReadOnlyProperties), which is exactly the shape that used to make the echo
+// recompute treat "declared" and "live" as the same document and claim every
+// live member — "x" included. The post-update record must still equal the
+// planning-time claim, not the live set.
 func TestUpdate_RecordOnly_SkipsPluginCallAndSynthesizesSuccess(t *testing.T) {
+	schema := coOwnedSetSchema()
+	storedProps := json.RawMessage(`{"Tags":["a","x"]}`)
+	planningClaim := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`}}}
+
 	ru := &ResourceUpdate{
 		Operation:  OperationUpdate,
 		RecordOnly: true,
 		PriorState: pkgmodel.Resource{
 			Label: "sg", Type: "FakeAWS::EC2::SecurityGroup", Stack: "default", Target: "test-target",
-			Properties:         json.RawMessage(`{"Tags":["a","b"]}`),
+			Schema:             schema,
+			Properties:         storedProps,
 			ReadOnlyProperties: json.RawMessage(`{"GroupId":"sg-1"}`),
 		},
+		PreviousProperties: storedProps,
 		DesiredState: pkgmodel.Resource{
 			Ksuid: "ksuid-sg",
 			Label: "sg", Type: "FakeAWS::EC2::SecurityGroup", Stack: "default", Target: "test-target",
-			Properties:    json.RawMessage(`{"Tags":["a","b"]}`),
+			Schema:        schema,
+			Properties:    storedProps,
 			PatchDocument: json.RawMessage(`[]`),
-			OwnedMembers:  pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`}}},
+			// The planning-time claim (this forma declares only "a"; "x" is
+			// live but a co-actor's), exactly as NewResourceUpdateForExisting
+			// would have stamped it.
+			OwnedMembers: planningClaim,
 		},
 	}
 	data := ResourceUpdateData{resourceUpdate: ru, commandID: "cmd-1"}
@@ -458,4 +477,52 @@ func TestUpdate_RecordOnly_SkipsPluginCallAndSynthesizesSuccess(t *testing.T) {
 	assert.False(t, proc.reachedPluginSpawn(), "a RecordOnly update must never spawn a plugin operator")
 	assert.Equal(t, StateFinishedSuccessfully, state)
 	assert.Equal(t, ResourceUpdateStateSuccess, data.resourceUpdate.State)
+	assert.True(t, pkgmodel.OwnedMembersEqual(planningClaim, data.resourceUpdate.DesiredState.OwnedMembers),
+		"the committed record must equal the planning-time claim, not the live set; got %#v",
+		data.resourceUpdate.DesiredState.OwnedMembers)
+}
+
+// The same over-claim risk exists for a label-only rename: it too synthesizes
+// a successful Update progress from the stored properties with no plugin
+// call, and it too must not let that synthetic echo repopulate OwnedMembers
+// from the full live set. RecordOnly is false here (this update is really a
+// rename), so the fix cannot rely on ru.RecordOnly alone — it must hold
+// because declaredDoc equals PreviousProperties (nothing about the
+// properties changed), the general condition the executor's synthetic path
+// guarantees whenever it fires.
+func TestUpdate_LabelOnlyRename_DoesNotOverClaimCoActorMember(t *testing.T) {
+	schema := coOwnedSetSchema()
+	storedProps := json.RawMessage(`{"Tags":["a","x"]}`)
+	planningClaim := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`}}}
+
+	ru := &ResourceUpdate{
+		Operation: OperationUpdate,
+		PriorState: pkgmodel.Resource{
+			Label: "sg-old", Type: "FakeAWS::EC2::SecurityGroup", Stack: "default", Target: "test-target",
+			Schema:     schema,
+			Properties: storedProps,
+		},
+		PreviousProperties: storedProps,
+		DesiredState: pkgmodel.Resource{
+			Ksuid: "ksuid-sg",
+			// Label differs from PriorState.Label; Stack/Target match — the
+			// isLabelOnlyChange shape.
+			Label: "sg-new", Type: "FakeAWS::EC2::SecurityGroup", Stack: "default", Target: "test-target",
+			Schema:        schema,
+			Properties:    storedProps,
+			PatchDocument: json.RawMessage(`[]`),
+			OwnedMembers:  planningClaim,
+		},
+	}
+	data := ResourceUpdateData{resourceUpdate: ru, commandID: "cmd-1"}
+	proc := &recordOnlyGuardProcess{stubUpdaterProcess: &stubUpdaterProcess{}, log: &capturingLog{}}
+
+	state, _, _, err := update(StateUpdating, data, proc)
+	require.NoError(t, err)
+
+	assert.False(t, proc.reachedPluginSpawn(), "a label-only rename must never spawn a plugin operator")
+	assert.Equal(t, StateFinishedSuccessfully, state)
+	assert.True(t, pkgmodel.OwnedMembersEqual(planningClaim, data.resourceUpdate.DesiredState.OwnedMembers),
+		"a label-only rename must not over-claim a co-actor's live member; got %#v",
+		data.resourceUpdate.DesiredState.OwnedMembers)
 }

--- a/internal/metastructure/resource_update/ownership_record_test.go
+++ b/internal/metastructure/resource_update/ownership_record_test.go
@@ -526,3 +526,170 @@ func TestUpdate_LabelOnlyRename_DoesNotOverClaimCoActorMember(t *testing.T) {
 		"a label-only rename must not over-claim a co-actor's live member; got %#v",
 		data.resourceUpdate.DesiredState.OwnedMembers)
 }
+
+// A declared member whose reference is still unresolved at plan time
+// contributes no identity, so the plan-time recompute understates the
+// declaration. Prior claims must be carried for members still live —
+// "sg-1" keeps its claim — while a claimed member gone from live is
+// released ("gone": the record only ever names provider-visible members,
+// so a co-actor re-adding it later is never-owned and tolerated) and a
+// co-actor's live member is never claimed ("other").
+func TestClaimedMembers_DeferredRefCarriesPriorClaimsStillLive(t *testing.T) {
+	schema := coOwnedSetSchema()
+	prior := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"gone"`, `"sg-1"`}}}
+
+	claim := claimedMembers(
+		json.RawMessage(`{"Tags":[{"$res":true,"$type":"String"}]}`),
+		json.RawMessage(`{"Tags":["sg-1","other"]}`),
+		prior, schema)
+
+	want := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"sg-1"`}}}
+	assert.True(t, pkgmodel.OwnedMembersEqual(want, claim),
+		"expected only the still-live prior claim carried, got %#v", claim)
+}
+
+// Removing a co-owned declaration entirely (field unset) never drains — the
+// drain trigger is explicit empty — so it must not unclaim either. The
+// prior entry is carried verbatim: no ownership delta, no update, and a
+// later explicit-empty declaration still finds the claims it drains.
+func TestNewResourceUpdateForExisting_OwnershipRecord_UnsetDeclarationKeepsClaim_NoUpdate(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Tags": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	record := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"u1"`}}}
+
+	existing := newResourceForOwnershipTest(schema, "sg", "default", json.RawMessage(`{"Name":"p","Tags":["u1"]}`), record)
+	newRes := newResourceForOwnershipTest(schema, "sg", "default", json.RawMessage(`{"Name":"p"}`), nil)
+	newRes.Ksuid = ""
+
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newRes,
+		ownershipTestTarget(), ownershipTestTarget(), pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.NoError(t, err)
+	assert.Empty(t, updates, "an unset declaration must carry the claim, not plan a record-only wipe")
+}
+
+// An explicitly empty declaration recomputes downward: with nothing left
+// live to drain, the remaining claims are released via a record-only
+// update, so a co-actor's later re-add of the same member is never-owned
+// and tolerated (the one-bounce convergence of the dual-writable pair).
+func TestNewResourceUpdateForExisting_OwnershipRecord_ExplicitEmptyReleasesClaims(t *testing.T) {
+	schema := coOwnedSetSchema()
+	record := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`}}}
+
+	existing := newResourceForOwnershipTest(schema, "sg", "default", json.RawMessage(`{"Tags":[]}`), record)
+	newRes := newResourceForOwnershipTest(schema, "sg", "default", json.RawMessage(`{"Tags":[]}`), nil)
+	newRes.Ksuid = ""
+
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newRes,
+		ownershipTestTarget(), ownershipTestTarget(), pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.NoError(t, err)
+	require.Len(t, updates, 1, "releasing stale claims still needs a record-only update")
+	assert.True(t, updates[0].RecordOnly)
+	assert.Empty(t, updates[0].DesiredState.OwnedMembers,
+		"an explicit empty declaration with nothing live releases the claims")
+}
+
+// A carried prior entry whose Rule no longer matches the field's hint is
+// uninterpretable for the union: a deferred-ref declaration must then fall
+// back to the plain recompute instead of merging members computed under a
+// different identity scheme.
+func TestNewResourceUpdateForExisting_OwnershipRecord_RuleMismatchedPriorNotUnioned(t *testing.T) {
+	schema := coOwnedSetSchema()
+	props := json.RawMessage(`{"Tags":[{"$res":true,"$type":"String"}]}`)
+	record := pkgmodel.OwnedMembers{"Tags": {Rule: "EntitySet/Key", Members: []string{`"sg-1"`}}}
+
+	existing := newResourceForOwnershipTest(schema, "sg", "default", props, record)
+	newRes := newResourceForOwnershipTest(schema, "sg", "default", props, nil)
+	newRes.Ksuid = ""
+
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newRes,
+		ownershipTestTarget(), ownershipTestTarget(), pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.NoError(t, err)
+	require.Len(t, updates, 1, "the stale record differs from the empty recompute, so it is rewritten")
+	assert.True(t, updates[0].RecordOnly)
+	assert.Empty(t, updates[0].DesiredState.OwnedMembers,
+		"members recorded under a different identity rule must not be carried into the union")
+}
+
+// Echo recompute, unset face: a genuine write whose declaration no longer
+// covers the co-owned field must carry the prior claim through the echo
+// merge instead of recomputing the path to nothing.
+func TestRecordProgress_OwnershipRecord_UnsetFieldCarriesPriorClaim(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Tags": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	record := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"u1"`}}}
+	ru := &ResourceUpdate{
+		Operation: OperationUpdate,
+		DesiredState: pkgmodel.Resource{
+			Properties: json.RawMessage(`{"Name":"new"}`),
+			Schema:     schema,
+		},
+		PriorState: pkgmodel.Resource{
+			Properties:   json.RawMessage(`{"Name":"old","Tags":["u1"]}`),
+			Schema:       schema,
+			OwnedMembers: record,
+		},
+		PreviousProperties: json.RawMessage(`{"Name":"old","Tags":["u1"]}`),
+	}
+
+	progress := &plugin.TrackedProgress{
+		ProgressResult: resource.ProgressResult{
+			Operation:          resource.OperationUpdate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			ResourceProperties: json.RawMessage(`{"Name":"new","Tags":["u1"]}`),
+		},
+		Attempts:    1,
+		MaxAttempts: 1,
+	}
+
+	err := ru.RecordProgress(progress)
+	require.NoError(t, err)
+
+	assert.True(t, pkgmodel.OwnedMembersEqual(record, ru.DesiredState.OwnedMembers),
+		"an unset co-owned field must carry its prior claim through the echo, got %#v", ru.DesiredState.OwnedMembers)
+}
+
+// Echo recompute, shrink face: a declaration that still covers the field
+// but dropped a member recomputes downward — the dropped member's claim is
+// released once the write lands, so a co-actor re-adding it afterwards is
+// never-owned and tolerated.
+func TestRecordProgress_OwnershipRecord_ShrinkReleasesDroppedMemberClaim(t *testing.T) {
+	record := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`, `"b"`}}}
+	ru := &ResourceUpdate{
+		Operation: OperationUpdate,
+		DesiredState: pkgmodel.Resource{
+			Properties: json.RawMessage(`{"Tags":["a"]}`),
+			Schema:     coOwnedSetSchema(),
+		},
+		PriorState: pkgmodel.Resource{
+			Properties:   json.RawMessage(`{"Tags":["a","b"]}`),
+			Schema:       coOwnedSetSchema(),
+			OwnedMembers: record,
+		},
+		PreviousProperties: json.RawMessage(`{"Tags":["a","b"]}`),
+	}
+
+	progress := &plugin.TrackedProgress{
+		ProgressResult: resource.ProgressResult{
+			Operation:          resource.OperationUpdate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			ResourceProperties: json.RawMessage(`{"Tags":["a"]}`),
+		},
+		Attempts:    1,
+		MaxAttempts: 1,
+	}
+
+	err := ru.RecordProgress(progress)
+	require.NoError(t, err)
+
+	want := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`}}}
+	assert.True(t, pkgmodel.OwnedMembersEqual(want, ru.DesiredState.OwnedMembers),
+		"a shrink must release the dropped member's claim at the echo, got %#v", ru.DesiredState.OwnedMembers)
+}

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -122,6 +122,10 @@ type ResourceUpdate struct {
 	// entry degrades to stamping nothing (provenance stays unknown), never to
 	// attesting a recomputed value.
 	ResolvedRootDigests map[string]string `json:"ResolvedRootDigests,omitempty"`
+	// RecordOnly marks an update that changes only the ownership record: no
+	// provider call; execution synthesizes successful Update progress the way
+	// a label-only update does.
+	RecordOnly bool `json:"RecordOnly,omitempty"`
 }
 
 func (ru *ResourceUpdate) URI() pkgmodel.FormaeURI {
@@ -537,10 +541,22 @@ func (ru *ResourceUpdate) updateResourceUpdateFromProgress(progress *resource.Pr
 		// The echo of our own write is a Create or Update progress; every
 		// other Read-shaped merge (sync, discovery) is read-origin.
 		writeOrigin := progress.Operation == resource.OperationCreate || progress.Operation == resource.OperationUpdate
+		// Captured before updateResourceProperties overwrites DesiredState.Properties
+		// below, so the recompute sees what THIS forma declared going into the
+		// write, not the provider's echo of it.
+		declaredDoc := ru.DesiredState.Properties
 		err := ru.updateResourceProperties(string(progress.ResourceProperties), writeOrigin)
 		if err != nil {
 			slog.Error("Failed to update resource properties", "error", err)
 			return err
+		}
+		// Only a write-origin merge commits the ownership record: it is this
+		// forma's own Create/Update landing, so the provider's echo reflects
+		// what is now live under whatever this forma just declared. A
+		// read-shaped merge (sync, discovery) observes state nobody here
+		// caused and must not move the record.
+		if writeOrigin {
+			ru.DesiredState.OwnedMembers = claimedMembers(declaredDoc, progress.ResourceProperties, ru.DesiredState.Schema)
 		}
 	}
 

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -5,6 +5,7 @@
 package resource_update
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -555,7 +556,22 @@ func (ru *ResourceUpdate) updateResourceUpdateFromProgress(progress *resource.Pr
 		// what is now live under whatever this forma just declared. A
 		// read-shaped merge (sync, discovery) observes state nobody here
 		// caused and must not move the record.
-		if writeOrigin {
+		//
+		// A further guard: this recompute is only trustworthy when declaredDoc
+		// is a genuinely fresh declaration. RecordOnly's DesiredState.OwnedMembers
+		// is already the correct planning-time claim (there is no property
+		// write behind it to recompute from), and the same is true whenever
+		// declaredDoc is byte-identical to PreviousProperties — the factory's
+		// no-property-change paths (a label-only rename, bringing a resource
+		// under management without property changes, and RecordOnly itself)
+		// all set DesiredState.Properties to the existing row's stored value,
+		// so declaredDoc there is really "what is live", not "what this forma
+		// just declared". Recomputing from it would claim every live member,
+		// including a co-actor's, as this forma's own. Skipping leaves
+		// whatever the factory already stamped onto DesiredState.OwnedMembers
+		// (the planning-time claim) in place.
+		noFreshDeclaration := ru.RecordOnly || bytes.Equal(declaredDoc, ru.PreviousProperties)
+		if writeOrigin && !noFreshDeclaration {
 			ru.DesiredState.OwnedMembers = claimedMembers(declaredDoc, progress.ResourceProperties, ru.DesiredState.Schema)
 		}
 	}

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -572,7 +572,11 @@ func (ru *ResourceUpdate) updateResourceUpdateFromProgress(progress *resource.Pr
 		// (the planning-time claim) in place.
 		noFreshDeclaration := ru.RecordOnly || bytes.Equal(declaredDoc, ru.PreviousProperties)
 		if writeOrigin && !noFreshDeclaration {
-			ru.DesiredState.OwnedMembers = claimedMembers(declaredDoc, progress.ResourceProperties, ru.DesiredState.Schema)
+			// PriorState's record is the claim being recomputed FROM: a path
+			// the declaration no longer covers (unset) or cannot identify yet
+			// (an unresolved member) carries its prior entry instead of being
+			// recomputed to nothing — see claimedMembers.
+			ru.DesiredState.OwnedMembers = claimedMembers(declaredDoc, progress.ResourceProperties, ru.PriorState.OwnedMembers, ru.DesiredState.Schema)
 		}
 	}
 

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -368,6 +368,7 @@ func (ru *ResourceUpdate) regeneratePatchDocument(mode pkgmodel.FormaApplyMode) 
 		desiredForPatch,
 		regenProperties,
 		ru.DesiredState.Schema,
+		ru.PriorState.OwnedMembers,
 		mode,
 	)
 	if err != nil {

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -15,6 +15,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
 	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/tidwall/gjson"
 )
 
 func NewResourceUpdateForExisting(
@@ -30,13 +31,38 @@ func NewResourceUpdateForExisting(
 	coPlanned CoPlannedForDraw,
 ) ([]ResourceUpdate, error) {
 
+	// filteredProps must exist before the identical-resources check below, so
+	// that check can compute the ownership claim from the effective desired
+	// properties rather than from newResource.Properties directly (they
+	// legitimately differ under setOnce).
+	var err error
+	filteredProps := effectiveDesired
+	if filteredProps == nil {
+		filteredProps, err = filterSetOnceProps(existingResource.Properties, newResource.Properties, newResource.Label)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute effective desired properties: %w", err)
+		}
+	}
+
+	// claimedMembers/ownershipDelta run BEFORE either early-return below: a
+	// co-owned collection's live membership can shift under this forma even
+	// when nothing else about the resource moved (another writer added or
+	// removed a member this forma also declares), and that is exactly the
+	// legacy-bootstrap case (no record yet, existing==desired byte-for-byte)
+	// the identical-resources return would otherwise swallow.
+	claim := claimedMembers(filteredProps, existingResource.Properties, newResource.Schema)
+	ownershipDelta := !pkgmodel.OwnedMembersEqual(
+		pkgmodel.NormalizeOwnedMembers(claim, newResource.Schema.Hints),
+		pkgmodel.NormalizeOwnedMembers(existingResource.OwnedMembers, newResource.Schema.Hints))
+
 	// The three suppressions below all say the same thing: nothing about this
 	// resource moved, so the command has nothing to do for it. coPlanned is
-	// the one case where that is true and the update is still owed — a
+	// one case where that is true and the update is still owed — a
 	// generator this resource binds to draws in this command, and only a
-	// resource that is a node in the changeset receives the drawn value. See
-	// CoPlannedForDraw.
-	if reflect.DeepEqual(existingResource, newResource) && !bool(coPlanned) {
+	// resource that is a node in the changeset receives the drawn value (see
+	// CoPlannedForDraw). ownershipDelta is the other: the record itself needs
+	// writing even though nothing else changed.
+	if reflect.DeepEqual(existingResource, newResource) && !bool(coPlanned) && !ownershipDelta {
 		slog.Debug("No changes detected between existing and new resource, skipping update")
 		return nil, nil
 	}
@@ -56,21 +82,19 @@ func NewResourceUpdateForExisting(
 	// the properties might be identical
 	stackChanged := existingResource.Stack != newResource.Stack
 
-	var err error
-	filteredProps := effectiveDesired
-	if filteredProps == nil {
-		filteredProps, err = filterSetOnceProps(existingResource.Properties, newResource.Properties, newResource.Label)
-		if err != nil {
-			return nil, fmt.Errorf("failed to compute effective desired properties: %w", err)
-		}
-	}
 	hasChanges, err := CompareFilteredResourceForUpdate(&existingResource, &newResource, newResource.Schema, filteredProps)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compare resources: %w", err)
 	}
-	if !hasChanges && !stackChanged && !labelChanged && !bool(coPlanned) {
+	if !hasChanges && !stackChanged && !labelChanged && !bool(coPlanned) && !ownershipDelta {
 		return []ResourceUpdate{}, nil
 	}
+
+	// A record-only update: no property, stack, label, or draw change — the
+	// sole reason this update exists is that the ownership record itself
+	// needs writing. Built through the same construction path as any other
+	// update below, then overridden just before it is returned.
+	recordOnly := ownershipDelta && !hasChanges && !stackChanged && !labelChanged && !bool(coPlanned)
 
 	var patchDocument json.RawMessage
 	var createOnlyPatch json.RawMessage
@@ -174,6 +198,12 @@ func NewResourceUpdateForExisting(
 			NativeID:           existingResource.NativeID,
 			ReadOnlyProperties: existingResource.ReadOnlyProperties,
 			Managed:            newResource.Managed,
+			// Carried forward on every update; a real update's echo recompute
+			// (updateResourceUpdateFromProgress) replaces this once the
+			// provider's write lands, so this is a placeholder for anything
+			// that reads DesiredState before then. A record-only update
+			// overrides it below with the freshly computed claim.
+			OwnedMembers: existingResource.OwnedMembers,
 			// Preserve the existing row's KSUID across the update. The caller
 			// has already paired `existingResource` (current managed row) with
 			// `newResource` (desired declaration); the existing KSUID is the
@@ -194,7 +224,65 @@ func NewResourceUpdateForExisting(
 		ResolvedRootDigests:  generatorDigests,
 	}
 
+	if recordOnly {
+		updateResource.DesiredState.PatchDocument = json.RawMessage(`[]`)
+		updateResource.DesiredState.Properties = existingResource.Properties
+		updateResource.DesiredState.OwnedMembers = claim
+		updateResource.RecordOnly = true
+		updateResource.RemainingResolvables = nil
+	}
+
 	return []ResourceUpdate{updateResource}, nil
+}
+
+// claimedMembers computes, per CoOwned-hinted field, the ownership record
+// this forma may claim right now: declared member identities (from declared)
+// intersected with what the provider actually shows (from live). A member
+// this forma declares but the provider does not show — or the reverse — is
+// not claimable yet, so only the intersection earns a record entry. Identity
+// extraction is envelope-flattened (see MemberIdentities): an unresolved
+// $ref/$res/$gen reference contributes nothing to either side. A field whose
+// intersection is empty gets no entry at all.
+func claimedMembers(declared, live json.RawMessage, schema pkgmodel.Schema) pkgmodel.OwnedMembers {
+	var claim pkgmodel.OwnedMembers
+	for path, hint := range schema.Hints {
+		if hint.CoOwned == nil {
+			continue
+		}
+
+		declaredMembers := pkgmodel.MemberIdentities(gjson.GetBytes(declared, path), hint)
+		liveMembers := pkgmodel.MemberIdentities(gjson.GetBytes(live, path), hint)
+		claimed := intersectIdentities(declaredMembers, liveMembers)
+		if len(claimed) == 0 {
+			continue
+		}
+
+		if claim == nil {
+			claim = pkgmodel.OwnedMembers{}
+		}
+		claim[path] = pkgmodel.OwnedPathRecord{Rule: pkgmodel.IdentityRule(hint), Members: claimed}
+	}
+	return claim
+}
+
+// intersectIdentities returns the members of a that also appear in b. Both
+// inputs are the sorted, deduplicated output of MemberIdentities, so the
+// result is sorted and deduplicated too.
+func intersectIdentities(a, b []string) []string {
+	if len(a) == 0 || len(b) == 0 {
+		return nil
+	}
+	inB := make(map[string]struct{}, len(b))
+	for _, m := range b {
+		inB[m] = struct{}{}
+	}
+	var out []string
+	for _, m := range a {
+		if _, ok := inB[m]; ok {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 func NewResourceUpdateForReplace(

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"slices"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/patch"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
@@ -50,7 +51,7 @@ func NewResourceUpdateForExisting(
 	// removed a member this forma also declares), and that is exactly the
 	// legacy-bootstrap case (no record yet, existing==desired byte-for-byte)
 	// the identical-resources return would otherwise swallow.
-	claim := claimedMembers(filteredProps, existingResource.Properties, newResource.Schema)
+	claim := claimedMembers(filteredProps, existingResource.Properties, existingResource.OwnedMembers, newResource.Schema)
 	ownershipDelta := !pkgmodel.OwnedMembersEqual(
 		pkgmodel.NormalizeOwnedMembers(claim, newResource.Schema.Hints),
 		pkgmodel.NormalizeOwnedMembers(existingResource.OwnedMembers, newResource.Schema.Hints))
@@ -260,9 +261,30 @@ func NewResourceUpdateForExisting(
 // this forma declares but the provider does not show — or the reverse — is
 // not claimable yet, so only the intersection earns a record entry. Identity
 // extraction is envelope-flattened (see MemberIdentities): an unresolved
-// $ref/$res/$gen reference contributes nothing to either side. A field whose
-// intersection is empty gets no entry at all.
-func claimedMembers(declared, live json.RawMessage, schema pkgmodel.Schema) pkgmodel.OwnedMembers {
+// $ref/$res/$gen reference contributes nothing to either side.
+//
+// The recompute never drops a claim it cannot see, only ones it can:
+//
+//   - A path absent (or null) in declared is unset. Unset never drains (the
+//     drain trigger is explicit empty), so it must not unclaim either: the
+//     prior entry is carried verbatim, and a later explicit-empty
+//     declaration still finds the claims it is supposed to drain.
+//   - A declared collection holding a member with no plan-time identity (an
+//     unresolved reference) understates the declaration, so the prior
+//     entry's still-live members are unioned in rather than dropped (a
+//     member gone from live is released — the record only ever names
+//     provider-visible members). The cost: a live member removed from the
+//     declaration in the same edit stays claimed until the next genuine
+//     write recomputes at the echo, where references are resolved.
+//   - A fully identifiable declaration recomputes downward: a shrink or an
+//     explicit empty releases claims (after its drain), which is what lets
+//     a co-actor's later re-add of the same member be tolerated.
+//
+// Carrying consults the prior entry only when its Rule matches the field's
+// current hint (a mismatched record is uninterpretable), except the unset
+// case, which copies bytes without interpreting them. A field with no entry
+// and nothing claimable gets no entry at all.
+func claimedMembers(declared, live json.RawMessage, prior pkgmodel.OwnedMembers, schema pkgmodel.Schema) pkgmodel.OwnedMembers {
 	var claim pkgmodel.OwnedMembers
 	for path, hint := range schema.Hints {
 		if hint.CoOwned == nil {
@@ -279,9 +301,26 @@ func claimedMembers(declared, live json.RawMessage, schema pkgmodel.Schema) pkgm
 			continue
 		}
 
-		declaredMembers := pkgmodel.MemberIdentities(gjson.GetBytes(declared, path), hint)
+		priorEntry, hasPrior := prior[path]
+
+		declaredVal := gjson.GetBytes(declared, path)
+		if !declaredVal.Exists() || declaredVal.Type == gjson.Null {
+			if hasPrior {
+				if claim == nil {
+					claim = pkgmodel.OwnedMembers{}
+				}
+				claim[path] = priorEntry
+			}
+			continue
+		}
+
+		declaredMembers := pkgmodel.MemberIdentities(declaredVal, hint)
 		liveMembers := pkgmodel.MemberIdentities(gjson.GetBytes(live, path), hint)
 		claimed := intersectIdentities(declaredMembers, liveMembers)
+		if hasPrior && priorEntry.Rule == pkgmodel.IdentityRule(hint) &&
+			pkgmodel.MemberIdentitiesIncomplete(declaredVal, hint) {
+			claimed = unionIdentities(claimed, intersectIdentities(priorEntry.Members, liveMembers))
+		}
 		if len(claimed) == 0 {
 			continue
 		}
@@ -292,6 +331,23 @@ func claimedMembers(declared, live json.RawMessage, schema pkgmodel.Schema) pkgm
 		claim[path] = pkgmodel.OwnedPathRecord{Rule: pkgmodel.IdentityRule(hint), Members: claimed}
 	}
 	return claim
+}
+
+// unionIdentities returns the sorted, deduplicated union of a and b.
+func unionIdentities(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for _, s := range a {
+		seen[s] = struct{}{}
+	}
+	for _, s := range b {
+		seen[s] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	slices.Sort(out)
+	return out
 }
 
 // intersectIdentities returns the members of a that also appear in b. Both

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -209,12 +209,20 @@ func NewResourceUpdateForExisting(
 			NativeID:           existingResource.NativeID,
 			ReadOnlyProperties: existingResource.ReadOnlyProperties,
 			Managed:            newResource.Managed,
-			// Carried forward on every update; a real update's echo recompute
-			// (updateResourceUpdateFromProgress) replaces this once the
-			// provider's write lands, so this is a placeholder for anything
-			// that reads DesiredState before then. A record-only update
-			// overrides it below with the freshly computed claim.
-			OwnedMembers: existingResource.OwnedMembers,
+			// The planning-time claim, not a blind carry of the existing
+			// record: whenever ownershipDelta is false the two are the same
+			// value anyway (that is what "no delta" means), and whenever it
+			// is true — most commonly a real update, but also a rename or a
+			// bring-under-management that happens to coincide with a live
+			// ownership shift — claim is the fresher, correct one. A real
+			// update's echo recompute (updateResourceUpdateFromProgress)
+			// replaces this once the provider's write lands, so for that case
+			// this is only a placeholder for anything that reads DesiredState
+			// before then. For a no-property-change update (record-only,
+			// label-only rename, bringing under management) the recompute is
+			// skipped — see updateResourceUpdateFromProgress — so this value
+			// is what survives.
+			OwnedMembers: claim,
 			// Preserve the existing row's KSUID across the update. The caller
 			// has already paired `existingResource` (current managed row) with
 			// `newResource` (desired declaration); the existing KSUID is the

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -117,6 +117,7 @@ func NewResourceUpdateForExisting(
 			desiredForPatch,
 			resolvableProperties,
 			newResource.Schema,
+			existingResource.OwnedMembers,
 			mode,
 		)
 		if err != nil {

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -93,7 +93,9 @@ func NewResourceUpdateForExisting(
 	// A record-only update: no property, stack, label, or draw change — the
 	// sole reason this update exists is that the ownership record itself
 	// needs writing. Built through the same construction path as any other
-	// update below, then overridden just before it is returned.
+	// update below, then overridden just before it is returned. Also set
+	// further down when hasChanges is true but the patch it produced
+	// suppresses to nothing — see the comment there.
 	recordOnly := ownershipDelta && !hasChanges && !stackChanged && !labelChanged && !bool(coPlanned)
 
 	var patchDocument json.RawMessage
@@ -155,7 +157,16 @@ func NewResourceUpdateForExisting(
 		// regeneratePatchDocument at execution time must never do the same, or
 		// an in-flight update would lose the force-resent field from its payload.
 		if (patchDocument == nil || onlyForceResent) && len(createOnlyPatch) == 0 && !stackChanged && !labelChanged && !bool(coPlanned) {
-			return []ResourceUpdate{}, nil
+			if !ownershipDelta {
+				return []ResourceUpdate{}, nil
+			}
+			// The patch suppressed to nothing (or purely force-resent), so the
+			// plugin has nothing to do — but a co-owned collection's membership
+			// still shifted under this forma. Route to a record-only update
+			// instead of dropping it: the override block below (recordOnly)
+			// turns this into the same empty-patch, claim-only update the two
+			// simpler suppressions above produce.
+			recordOnly = true
 		}
 	} else {
 		patchDocument = json.RawMessage(`[]`)
@@ -247,6 +258,16 @@ func claimedMembers(declared, live json.RawMessage, schema pkgmodel.Schema) pkgm
 	var claim pkgmodel.OwnedMembers
 	for path, hint := range schema.Hints {
 		if hint.CoOwned == nil {
+			continue
+		}
+		// Identities are names; an opaque field's "members" are its secret
+		// values. Recording them here would persist a secret unhashed,
+		// bypassing the opaque-hashing transformer entirely. The PKL schema
+		// validation rejects this combination at authoring time (see
+		// formae.pkl's FieldHint.validated()), but this is the defensive
+		// backstop for a schema that reaches here some other way — no claim
+		// is recorded for such a field until a hashing design exists.
+		if hint.Opaque {
 			continue
 		}
 

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -871,6 +871,25 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 	// resource. Only this copy changes; DesiredState.Properties stays the
 	// durable record of the stored hash.
 	desiredForPlugin := data.resourceUpdate.DesiredState
+	// Complete each co-owned collection to its intended post-write value
+	// (declared plus never-owned live members), so DesiredProperties and
+	// PatchDocument tell the plugin the same thing. Only this copy changes;
+	// DesiredState.Properties stays the declared-only durable record the
+	// write-echo recompute claims from.
+	projectedProperties, err := patch.ProjectDesiredForWrite(
+		desiredForPlugin.Properties,
+		data.resourceUpdate.PriorState.Properties,
+		data.resourceUpdate.PriorState.OwnedMembers,
+		desiredForPlugin.Schema,
+	)
+	if err != nil {
+		proc.Log().Error("failed to project co-owned desired properties for plugin: %v", err)
+		data.resourceUpdate.FailureReason = updateRequestFailureReason(err)
+		data.resourceUpdate.MarkAsFailed()
+		return StateFinishedWithError, data, nil, nil
+	}
+	desiredForPlugin.Properties = projectedProperties
+
 	frozenProperties, err := FreezeUnrecoverableOpaqueValues(
 		data.resourceUpdate.PriorState.Properties,
 		desiredForPlugin.Properties,

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -808,11 +808,22 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 		data.resourceUpdate.PriorState.Stack == data.resourceUpdate.DesiredState.Stack &&
 		data.resourceUpdate.PriorState.Target == data.resourceUpdate.DesiredState.Target
 
-	if (isBringingUnderManagement || isLabelOnlyChange) && hasEmptyPatch {
-		if isLabelOnlyChange {
+	// A record-only update carries no property, stack, label, or target
+	// delta — planning built it solely to commit a shifted ownership record
+	// (see NewResourceUpdateForExisting). Its patch is always empty by
+	// construction, so hasEmptyPatch is included here only for symmetry with
+	// the other two predicates, never as a distinguishing condition.
+	isRecordOnly := data.resourceUpdate.RecordOnly
+
+	if (isBringingUnderManagement || isLabelOnlyChange || isRecordOnly) && hasEmptyPatch {
+		switch {
+		case isLabelOnlyChange:
 			proc.Log().Debug("Renaming resource without property changes resourceURI=%v oldLabel=%s newLabel=%s",
 				data.resourceUpdate.DesiredState.URI(), data.resourceUpdate.PriorState.Label, data.resourceUpdate.DesiredState.Label)
-		} else {
+		case isRecordOnly:
+			proc.Log().Debug("Committing ownership record without property changes resourceURI=%v",
+				data.resourceUpdate.DesiredState.URI())
+		default:
 			proc.Log().Debug("Bringing resource under management without property changes resourceURI=%v oldStack=%s newStack=%s",
 				data.resourceUpdate.DesiredState.URI(), data.resourceUpdate.PriorState.Stack, data.resourceUpdate.DesiredState.Stack)
 		}
@@ -829,8 +840,11 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 		}
 
 		statusMessage := "Brought under management without property changes"
-		if isLabelOnlyChange {
+		switch {
+		case isLabelOnlyChange:
 			statusMessage = "Renamed without property changes"
+		case isRecordOnly:
+			statusMessage = "Committed ownership record without property changes"
 		}
 
 		// Create synthetic ProgressResult with existing resource data

--- a/internal/metastructure/transformations/persist_value_transformer.go
+++ b/internal/metastructure/transformations/persist_value_transformer.go
@@ -65,14 +65,15 @@ func (pv *PersistValueTransformer) ApplyToResource(resource *pkgmodel.Resource) 
 	}
 
 	transformedResource := &pkgmodel.Resource{
-		Label:    resource.Label,
-		Type:     resource.Type,
-		Stack:    resource.Stack,
-		Target:   resource.Target,
-		Schema:   resource.Schema,
-		NativeID: resource.NativeID,
-		Managed:  resource.Managed,
-		Ksuid:    resource.Ksuid,
+		Label:        resource.Label,
+		Type:         resource.Type,
+		Stack:        resource.Stack,
+		Target:       resource.Target,
+		Schema:       resource.Schema,
+		NativeID:     resource.NativeID,
+		Managed:      resource.Managed,
+		Ksuid:        resource.Ksuid,
+		OwnedMembers: resource.OwnedMembers,
 	}
 
 	var diagnostics []Diagnostic

--- a/internal/schema/pkl/co_owned_field_test.go
+++ b/internal/schema/pkl/co_owned_field_test.go
@@ -48,3 +48,14 @@ func TestPkl_FieldHint_CoOwned_ArrayUpdateMethodFailsEval(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "coOwned requires updateMethod")
 }
+
+// TestPkl_FieldHint_CoOwned_OpaqueFailsEval verifies that pairing coOwned
+// with opaque fails at PKL eval: an opaque field's member identities are its
+// secret values, not names, so recording them in an ownership record would
+// persist the secret unhashed.
+func TestPkl_FieldHint_CoOwned_OpaqueFailsEval(t *testing.T) {
+	p := PKL{}
+	_, err := p.Evaluate("./testdata/forma/co_owned_field_opaque_test.pkl", model.CommandEval, model.FormaApplyModeReconcile, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "coOwned cannot be combined with opaque")
+}

--- a/internal/schema/pkl/co_owned_field_test.go
+++ b/internal/schema/pkl/co_owned_field_test.go
@@ -1,0 +1,50 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build integration
+
+package pkl
+
+import (
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// TestPkl_FieldHint_CoOwned_RendersSystemPatterns verifies that a field
+// annotated with @formae.FieldHint's coOwned round-trips into Schema.Hints as
+// a CoOwned.SystemPatterns list, while a plain field alongside it renders no
+// CoOwned key at all — never an empty object, which Go would decode as a
+// non-nil, misleadingly "co-owned with no patterns" value instead of "not
+// co-owned".
+func TestPkl_FieldHint_CoOwned_RendersSystemPatterns(t *testing.T) {
+	p := PKL{}
+	forma, err := p.Evaluate("./testdata/forma/co_owned_field_test.pkl", model.CommandEval, model.FormaApplyModeReconcile, nil)
+	require.NoError(t, err)
+
+	jsonString := forma.ToJSON()
+
+	membersHint := gjson.Get(jsonString, "Resources.0.Properties.value.Hints.members")
+	assert.Equal(t, "Set", membersHint.Get("UpdateMethod").String())
+	patterns := membersHint.Get("CoOwned.SystemPatterns").Array()
+	require.Len(t, patterns, 1)
+	assert.Equal(t, "aws:*", patterns[0].String())
+
+	plainHint := gjson.Get(jsonString, "Resources.0.Properties.value.Hints.plain")
+	assert.False(t, plainHint.Get("CoOwned").Exists(),
+		"an unannotated field must render no CoOwned key at all, not an empty object")
+}
+
+// TestPkl_FieldHint_CoOwned_ArrayUpdateMethodFailsEval verifies that pairing
+// coOwned with updateMethod "Array" fails at PKL eval: a field replaced or
+// diffed wholesale has no per-member merge to reconcile co-ownership against.
+func TestPkl_FieldHint_CoOwned_ArrayUpdateMethodFailsEval(t *testing.T) {
+	p := PKL{}
+	_, err := p.Evaluate("./testdata/forma/co_owned_field_array_update_method_test.pkl", model.CommandEval, model.FormaApplyModeReconcile, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "coOwned requires updateMethod")
+}

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -494,10 +494,16 @@ open class FieldHint extends Annotation {
     // Eval-time validation: a field whose whole value is replaced or diffed
     // atomically (Array, Atomic) has no per-member merge to reconcile
     // co-ownership against, so declaring it coOwned is a schema-author
-    // mistake caught here rather than at drift/plan time.
+    // mistake caught here rather than at drift/plan time. Likewise, an
+    // opaque field's member identities are the secret values themselves, not
+    // names — recording them in an ownership record would persist the
+    // secret unhashed, bypassing the opaque-hashing transformer entirely, so
+    // coOwned+opaque is rejected the same way until a hashing design exists.
     local function validated(): Boolean =
         if (self.coOwned != null && !(self.updateMethod == null || self.updateMethod == "Set" || self.updateMethod == "EntitySet"))
             throw("FieldHint: coOwned requires updateMethod \"Set\" or \"EntitySet\" (or unset), got \"\(self.updateMethod)\"")
+        else if (self.coOwned != null && self.opaque)
+            throw("FieldHint: coOwned cannot be combined with opaque — an opaque field's member identities are its secret values, not names")
         else
             true
 

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -432,6 +432,18 @@ class ParentRef {
     childProperty: String
 }
 
+/// Declares that a field's live collection is shared with writers other than
+/// the owning forma (e.g. a security group's rule set, or a mapping the
+/// platform itself populates in part).
+class CoOwnership {
+    /// Glob patterns over member identities naming entries the platform
+    /// itself injects into this field's live collection. Consulted only by
+    /// extract on resources with no ownership record; never by plan or drift.
+    hidden systemPatterns: Listing<String> = new Listing {}
+
+    fixed SystemPatterns: Listing<String> = systemPatterns
+}
+
 typealias FieldUpdateMethod = "Array"|"Atomic"|"EntitySet"|"Set"
 
 typealias EdgeKind =
@@ -462,6 +474,12 @@ open class FieldHint extends Annotation {
     hidden edgeKind: EdgeKind = "default"        // NEW
     hidden indexField: String?
     hidden updateMethod: FieldUpdateMethod?
+    /// Marks this field a collection whose live content legitimately has
+    /// writers other than this forma. Requires updateMethod "Set" or
+    /// "EntitySet" (or left unset) — a field replaced or diffed wholesale
+    /// (Array, Atomic) has no per-member merge to reconcile co-ownership
+    /// against.
+    hidden coOwned: CoOwnership?
     /// Opts this field's subtree out of empty-value normalization: empty
     /// collections inside it are treated as values and preserved end to end.
     hidden preserveEmptyValues: Boolean = false
@@ -470,6 +488,18 @@ open class FieldHint extends Annotation {
     hidden outputField: String?
     hidden outputTransformation: ((Any) -> Any)?
     hidden outputCondition: ((Any) -> Boolean) = (_) -> true
+
+    local self = this
+
+    // Eval-time validation: a field whose whole value is replaced or diffed
+    // atomically (Array, Atomic) has no per-member merge to reconcile
+    // co-ownership against, so declaring it coOwned is a schema-author
+    // mistake caught here rather than at drift/plan time.
+    local function validated(): Boolean =
+        if (self.coOwned != null && !(self.updateMethod == null || self.updateMethod == "Set" || self.updateMethod == "EntitySet"))
+            throw("FieldHint: coOwned requires updateMethod \"Set\" or \"EntitySet\" (or unset), got \"\(self.updateMethod)\"")
+        else
+            true
 
     // Output
     fixed CreateOnly: Boolean = createOnly
@@ -482,6 +512,7 @@ open class FieldHint extends Annotation {
     fixed AttachesTo: Boolean = attachesTo
     fixed EdgeKind: String = edgeKind
     fixed UpdateMethod: String = updateMethod ?? ""
+    fixed CoOwned: CoOwnership?(validated()) = coOwned
     fixed PreserveEmptyValues: Boolean = preserveEmptyValues
     fixed IndexField: String = indexField ?? ""
     fixed Format: String = format                // NEW

--- a/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
+++ b/internal/schema/pkl/schema/tests/formae.pkl-expected.pcf
@@ -123,6 +123,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        CoOwned = null
         PreserveEmptyValues = false
         IndexField = ""
         Format = ""
@@ -138,6 +139,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        CoOwned = null
         PreserveEmptyValues = false
         IndexField = ""
         Format = ""
@@ -153,6 +155,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        CoOwned = null
         PreserveEmptyValues = false
         IndexField = ""
         Format = ""
@@ -179,6 +182,7 @@ examples {
           AttachesTo = false
           EdgeKind = "default"
           UpdateMethod = ""
+          CoOwned = null
           PreserveEmptyValues = false
           IndexField = ""
           Format = ""
@@ -194,6 +198,7 @@ examples {
           AttachesTo = false
           EdgeKind = "default"
           UpdateMethod = ""
+          CoOwned = null
           PreserveEmptyValues = false
           IndexField = ""
           Format = ""
@@ -209,6 +214,7 @@ examples {
           AttachesTo = false
           EdgeKind = "default"
           UpdateMethod = ""
+          CoOwned = null
           PreserveEmptyValues = false
           IndexField = ""
           Format = ""
@@ -266,6 +272,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            CoOwned = null
             PreserveEmptyValues = false
             IndexField = ""
             Format = ""
@@ -281,6 +288,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            CoOwned = null
             PreserveEmptyValues = false
             IndexField = ""
             Format = ""
@@ -296,6 +304,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            CoOwned = null
             PreserveEmptyValues = false
             IndexField = ""
             Format = ""
@@ -361,6 +370,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            CoOwned = null
             PreserveEmptyValues = false
             IndexField = ""
             Format = ""
@@ -376,6 +386,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            CoOwned = null
             PreserveEmptyValues = false
             IndexField = ""
             Format = ""
@@ -391,6 +402,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            CoOwned = null
             PreserveEmptyValues = false
             IndexField = ""
             Format = ""
@@ -440,6 +452,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            CoOwned = null
             PreserveEmptyValues = false
             IndexField = ""
             Format = ""
@@ -455,6 +468,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            CoOwned = null
             PreserveEmptyValues = false
             IndexField = ""
             Format = ""
@@ -470,6 +484,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            CoOwned = null
             PreserveEmptyValues = false
             IndexField = ""
             Format = ""
@@ -485,6 +500,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            CoOwned = null
             PreserveEmptyValues = false
             IndexField = ""
             Format = ""
@@ -500,6 +516,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            CoOwned = null
             PreserveEmptyValues = false
             IndexField = ""
             Format = ""
@@ -515,6 +532,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            CoOwned = null
             PreserveEmptyValues = false
             IndexField = ""
             Format = ""
@@ -530,6 +548,7 @@ examples {
             AttachesTo = false
             EdgeKind = "default"
             UpdateMethod = ""
+            CoOwned = null
             PreserveEmptyValues = false
             IndexField = ""
             Format = ""
@@ -574,6 +593,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        CoOwned = null
         PreserveEmptyValues = false
         IndexField = ""
         Format = ""
@@ -589,6 +609,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        CoOwned = null
         PreserveEmptyValues = false
         IndexField = ""
         Format = ""
@@ -604,6 +625,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        CoOwned = null
         PreserveEmptyValues = false
         IndexField = ""
         Format = ""
@@ -623,6 +645,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        CoOwned = null
         PreserveEmptyValues = false
         IndexField = ""
         Format = ""
@@ -638,6 +661,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        CoOwned = null
         PreserveEmptyValues = false
         IndexField = ""
         Format = ""
@@ -657,6 +681,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        CoOwned = null
         PreserveEmptyValues = false
         IndexField = ""
         Format = ""
@@ -672,6 +697,7 @@ examples {
         AttachesTo = false
         EdgeKind = "default"
         UpdateMethod = ""
+        CoOwned = null
         PreserveEmptyValues = false
         IndexField = ""
         Format = ""
@@ -698,6 +724,7 @@ examples {
           AttachesTo = false
           EdgeKind = "default"
           UpdateMethod = ""
+          CoOwned = null
           PreserveEmptyValues = false
           IndexField = ""
           Format = ""
@@ -713,6 +740,7 @@ examples {
           AttachesTo = false
           EdgeKind = "default"
           UpdateMethod = ""
+          CoOwned = null
           PreserveEmptyValues = false
           IndexField = ""
           Format = ""
@@ -728,6 +756,7 @@ examples {
           AttachesTo = false
           EdgeKind = "default"
           UpdateMethod = ""
+          CoOwned = null
           PreserveEmptyValues = false
           IndexField = ""
           Format = ""

--- a/internal/schema/pkl/testdata/forma/co_owned_field_array_update_method_test.pkl
+++ b/internal/schema/pkl/testdata/forma/co_owned_field_array_update_method_test.pkl
@@ -1,0 +1,48 @@
+/*
+ * © 2026 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+// Shape-misuse test: coOwned paired with updateMethod "Array" has no
+// per-member merge to reconcile co-ownership against, so PKL eval must
+// reject it rather than let a schema author declare an unenforceable hint.
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+import "@formae/debug/debug.pkl"
+import "@fakeaws/fakeaws.pkl"
+import "pkl:reflect"
+
+@formae.ResourceHint {
+  type = "Formae::Test::CoOwnedArrayResource"
+  identifier = "Id"
+}
+local open class CoOwnedArrayResource extends formae.Resource {
+  @formae.FieldHint {
+    updateMethod = "Array"
+    coOwned = new formae.CoOwnership {
+      systemPatterns { "aws:*" }
+    }
+  }
+  members: Listing<String>?
+}
+
+forma {
+  new formae.Stack {
+    label = "co-owned-array-test"
+    description = "Stack for co-owned/Array shape-misuse test"
+  }
+
+  new formae.Target {
+    label = "default-aws-target"
+    config = new fakeaws.Config {
+      region = "us-west-2"
+    }
+  }
+
+  new debug.Consumer {
+    label = "co-owned-array-debug"
+    value = formae.fq.schema(reflect.Class(CoOwnedArrayResource)).toDynamic()
+  }
+}

--- a/internal/schema/pkl/testdata/forma/co_owned_field_opaque_test.pkl
+++ b/internal/schema/pkl/testdata/forma/co_owned_field_opaque_test.pkl
@@ -1,0 +1,55 @@
+/*
+ * © 2026 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+// Shape-misuse test: coOwned paired with opaque has no sound identity
+// scheme — an opaque field's member identities are the secret values
+// themselves, not names, so recording them in an ownership record would
+// persist the secret unhashed. PKL eval must reject it rather than let a
+// schema author declare an unenforceable hint.
+//
+// opaque is not settable directly through the annotation: fq.schema()'s
+// hints() always recomputes it from the field's declared type
+// (isSecretValueType), overriding whatever the @formae.FieldHint literal
+// says. So this fixture types the field itself as a SecretValue union — the
+// documented way a field becomes opaque — with coOwned alongside it and
+// updateMethod left unset (a shape the first coOwned check already allows).
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+import "@formae/debug/debug.pkl"
+import "@fakeaws/fakeaws.pkl"
+import "pkl:reflect"
+
+@formae.ResourceHint {
+  type = "Formae::Test::CoOwnedOpaqueResource"
+  identifier = "Id"
+}
+local open class CoOwnedOpaqueResource extends formae.Resource {
+  @formae.FieldHint {
+    coOwned = new formae.CoOwnership {
+      systemPatterns { "aws:*" }
+    }
+  }
+  secret: (String|formae.SecretValue)?
+}
+
+forma {
+  new formae.Stack {
+    label = "co-owned-opaque-test"
+    description = "Stack for co-owned/opaque shape-misuse test"
+  }
+
+  new formae.Target {
+    label = "default-aws-target"
+    config = new fakeaws.Config {
+      region = "us-west-2"
+    }
+  }
+
+  new debug.Consumer {
+    label = "co-owned-opaque-debug"
+    value = formae.fq.schema(reflect.Class(CoOwnedOpaqueResource)).toDynamic()
+  }
+}

--- a/internal/schema/pkl/testdata/forma/co_owned_field_test.pkl
+++ b/internal/schema/pkl/testdata/forma/co_owned_field_test.pkl
@@ -1,0 +1,52 @@
+/*
+ * © 2026 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+// A minimal resource class with one coOwned-annotated collection field and
+// one plain field, rendered through fq.schema() the way Resource.schema()
+// does — proves CoOwned round-trips from the PKL annotation into Schema.Hints
+// without requiring a full plugin schema.
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+import "@formae/debug/debug.pkl"
+import "@fakeaws/fakeaws.pkl"
+import "pkl:reflect"
+
+@formae.ResourceHint {
+  type = "Formae::Test::CoOwnedResource"
+  identifier = "Id"
+}
+local open class CoOwnedResource extends formae.Resource {
+  @formae.FieldHint {
+    updateMethod = "Set"
+    coOwned = new formae.CoOwnership {
+      systemPatterns { "aws:*" }
+    }
+  }
+  members: Listing<String>?
+
+  @formae.FieldHint
+  plain: String?
+}
+
+forma {
+  new formae.Stack {
+    label = "co-owned-test"
+    description = "Stack for co-owned field tests"
+  }
+
+  new formae.Target {
+    label = "default-aws-target"
+    config = new fakeaws.Config {
+      region = "us-west-2"
+    }
+  }
+
+  new debug.Consumer {
+    label = "co-owned-debug"
+    value = formae.fq.schema(reflect.Class(CoOwnedResource)).toDynamic()
+  }
+}

--- a/pkg/model/ownership.go
+++ b/pkg/model/ownership.go
@@ -52,9 +52,16 @@ func IdentityRule(hint FieldHint) string {
 //   - array otherwise => the canonical JSON of each element.
 //
 // Reference envelopes ($ref/$res/$gen objects) are flattened to their $value
-// first, recursively; an element whose envelope lacks $value contributes
-// nothing to the result. The result is sorted and deduplicated.
+// first, recursively — a whole-field envelope as much as a per-element one;
+// an envelope lacking $value contributes nothing to the result. The result
+// is sorted and deduplicated.
 func MemberIdentities(value gjson.Result, hint FieldHint) []string {
+	if inner, ok := wholeFieldEnvelopeValue(value); ok {
+		if !inner.Exists() || inner.Type == gjson.Null {
+			return []string{}
+		}
+		return MemberIdentities(inner, hint)
+	}
 	switch {
 	case value.IsObject():
 		var out []string
@@ -71,6 +78,66 @@ func MemberIdentities(value gjson.Result, hint FieldHint) []string {
 	default:
 		return []string{}
 	}
+}
+
+// MemberIdentitiesIncomplete reports whether the collection holds content
+// that contributes no identity to MemberIdentities: an element (or the whole
+// field value) carrying an unresolved reference envelope, or an EntitySet
+// element without its IndexField. Identities computed from such a value
+// understate the declaration — the members are declared, their identities
+// are just not knowable yet — so a record recompute based on them must not
+// drop existing claims.
+func MemberIdentitiesIncomplete(value gjson.Result, hint FieldHint) bool {
+	if inner, ok := wholeFieldEnvelopeValue(value); ok {
+		// A resolved whole-field envelope exposes its members through
+		// $value; only an unresolved one hides them.
+		if !inner.Exists() || inner.Type == gjson.Null {
+			return true
+		}
+		return MemberIdentitiesIncomplete(inner, hint)
+	}
+	switch {
+	case value.IsObject():
+		// A plain object's identities are its keys, which are always present.
+		return false
+	case value.IsArray():
+		incomplete := false
+		value.ForEach(func(_, el gjson.Result) bool {
+			flat, ok := flattenEnvelope(el)
+			if !ok {
+				incomplete = true
+				return false
+			}
+			if hint.UpdateMethod == FieldUpdateMethodEntitySet {
+				fields, isMap := flat.(map[string]any)
+				if !isMap {
+					incomplete = true
+					return false
+				}
+				if _, present := fields[hint.IndexField]; !present {
+					incomplete = true
+					return false
+				}
+			}
+			return true
+		})
+		return incomplete
+	default:
+		return false
+	}
+}
+
+// wholeFieldEnvelopeValue reports whether value is a reference envelope at
+// the whole-field position ($ref/$res/$gen object) and, if so, returns its
+// $value (which may not exist, or be null, for an unresolved envelope).
+func wholeFieldEnvelopeValue(value gjson.Result) (gjson.Result, bool) {
+	if !value.IsObject() {
+		return gjson.Result{}, false
+	}
+	if IsResolvedReference(value) || IsResolvableObject(value) || IsGenObject(value) {
+		return value.Get("$value"), true
+	}
+	return gjson.Result{}, false
 }
 
 // entitySetIdentities extracts the json-marshaled IndexField value of every

--- a/pkg/model/ownership.go
+++ b/pkg/model/ownership.go
@@ -1,0 +1,291 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package model
+
+import (
+	"encoding/json"
+	"reflect"
+	"slices"
+
+	"github.com/tidwall/gjson"
+)
+
+// OwnedMembers records, per co-owned collection field, the set of member
+// identities a forma last declared. The key is the field path as it appears
+// in Schema.Hints.
+type OwnedMembers map[string]OwnedPathRecord
+
+// OwnedPathRecord is the declared ownership record for one co-owned
+// collection field.
+type OwnedPathRecord struct {
+	// Rule is the record-compatibility rule the members were computed under
+	// (see IdentityRule). A stored record whose Rule no longer matches the
+	// field's current hint is stale and must not be trusted for comparison.
+	Rule string `json:"Rule"`
+	// Members are member identities, sorted, in provider spelling.
+	Members []string `json:"Members"`
+}
+
+// IdentityRule derives the record-compatibility rule for a field from its
+// hint alone. The rule names the scheme MemberIdentities used (or would use)
+// to compute identities for that field, so a stored record can be checked
+// for staleness without re-deriving it from the collection value.
+func IdentityRule(hint FieldHint) string {
+	switch {
+	case hint.UpdateMethod == FieldUpdateMethodEntitySet:
+		return "EntitySet/" + hint.IndexField
+	case hint.UpdateMethod == FieldUpdateMethodSet:
+		return "Set"
+	case hint.CoOwned != nil && hint.UpdateMethod == FieldUpdateMethodNone:
+		return "Mapping"
+	default:
+		return ""
+	}
+}
+
+// MemberIdentities extracts the identity set of a collection value:
+//   - object => its keys;
+//   - array with an EntitySet hint => the json-marshaled IndexField value of
+//     each element;
+//   - array otherwise => the canonical JSON of each element.
+//
+// Reference envelopes ($ref/$res/$gen objects) are flattened to their $value
+// first, recursively; an element whose envelope lacks $value contributes
+// nothing to the result. The result is sorted and deduplicated.
+func MemberIdentities(value gjson.Result, hint FieldHint) []string {
+	switch {
+	case value.IsObject():
+		var out []string
+		value.ForEach(func(key, _ gjson.Result) bool {
+			out = append(out, key.String())
+			return true
+		})
+		return sortedUniqueStrings(out)
+	case value.IsArray():
+		if hint.UpdateMethod == FieldUpdateMethodEntitySet {
+			return entitySetIdentities(value, hint.IndexField)
+		}
+		return elementIdentities(value)
+	default:
+		return []string{}
+	}
+}
+
+// entitySetIdentities extracts the json-marshaled IndexField value of every
+// element, after flattening each element's own reference envelope (if any).
+func entitySetIdentities(value gjson.Result, indexField string) []string {
+	var out []string
+	value.ForEach(func(_, el gjson.Result) bool {
+		flat, ok := flattenEnvelope(el)
+		if !ok {
+			return true
+		}
+		fields, ok := flat.(map[string]any)
+		if !ok {
+			return true
+		}
+		id, present := fields[indexField]
+		if !present {
+			return true
+		}
+		if b, err := json.Marshal(id); err == nil {
+			out = append(out, string(b))
+		}
+		return true
+	})
+	return sortedUniqueStrings(out)
+}
+
+// elementIdentities canonicalizes each array element to JSON, after
+// flattening its reference envelope (if any).
+func elementIdentities(value gjson.Result) []string {
+	var out []string
+	value.ForEach(func(_, el gjson.Result) bool {
+		flat, ok := flattenEnvelope(el)
+		if !ok {
+			return true
+		}
+		if b, err := json.Marshal(flat); err == nil {
+			out = append(out, string(b))
+		}
+		return true
+	})
+	return sortedUniqueStrings(out)
+}
+
+// flattenEnvelope decodes value to a native Go value ([]any / map[string]any
+// / scalar), replacing every $ref/$res/$gen envelope found anywhere in it
+// with its $value (recursively, since a $value may itself be an envelope).
+// Returns false if any envelope encountered — at any depth — lacks $value
+// (missing or explicit null), which fails the whole (sub)value it lives in.
+func flattenEnvelope(value gjson.Result) (any, bool) {
+	switch {
+	case value.IsObject():
+		if IsResolvedReference(value) || IsResolvableObject(value) || IsGenObject(value) {
+			inner := value.Get("$value")
+			if !inner.Exists() || inner.Type == gjson.Null {
+				return nil, false
+			}
+			return flattenEnvelope(inner)
+		}
+
+		out := map[string]any{}
+		ok := true
+		value.ForEach(func(key, val gjson.Result) bool {
+			flat, flatOK := flattenEnvelope(val)
+			if !flatOK {
+				ok = false
+				return false
+			}
+			out[key.String()] = flat
+			return true
+		})
+		if !ok {
+			return nil, false
+		}
+		return out, true
+	case value.IsArray():
+		var out []any
+		ok := true
+		value.ForEach(func(_, val gjson.Result) bool {
+			flat, flatOK := flattenEnvelope(val)
+			if !flatOK {
+				ok = false
+				return false
+			}
+			out = append(out, flat)
+			return true
+		})
+		if !ok {
+			return nil, false
+		}
+		return out, true
+	default:
+		return value.Value(), true
+	}
+}
+
+// sortedUniqueStrings returns a sorted, deduplicated, non-nil copy of in.
+func sortedUniqueStrings(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	for _, s := range in {
+		seen[s] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// OwnershipPartition is the three-way split of a co-owned field's member
+// identities relative to what this forma declares.
+type OwnershipPartition struct {
+	// Declared is the set this forma's current source declares.
+	Declared map[string]struct{}
+	// FormerlyOwned is Declared on a prior apply but not this one — members
+	// this forma is relinquishing.
+	FormerlyOwned map[string]struct{}
+	// NeverOwned is live but neither declared now nor previously — members
+	// this forma has never claimed (another writer's, or the platform's).
+	NeverOwned map[string]struct{}
+}
+
+// PartitionOwnership splits live into FormerlyOwned and NeverOwned relative
+// to declared and prior:
+//
+//	FormerlyOwned = prior − declared
+//	NeverOwned    = live − declared − prior
+//
+// A nil prior (no ownership record on the resource) yields an empty
+// FormerlyOwned, since there is nothing to relinquish.
+func PartitionOwnership(declared, prior, live []string) OwnershipPartition {
+	declaredSet := toStringSet(declared)
+	priorSet := toStringSet(prior)
+	liveSet := toStringSet(live)
+
+	formerlyOwned := map[string]struct{}{}
+	for member := range priorSet {
+		if _, ok := declaredSet[member]; !ok {
+			formerlyOwned[member] = struct{}{}
+		}
+	}
+
+	neverOwned := map[string]struct{}{}
+	for member := range liveSet {
+		if _, ok := declaredSet[member]; ok {
+			continue
+		}
+		if _, ok := priorSet[member]; ok {
+			continue
+		}
+		neverOwned[member] = struct{}{}
+	}
+
+	return OwnershipPartition{
+		Declared:      declaredSet,
+		FormerlyOwned: formerlyOwned,
+		NeverOwned:    neverOwned,
+	}
+}
+
+func toStringSet(items []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		set[item] = struct{}{}
+	}
+	return set
+}
+
+// NormalizeOwnedMembers drops entries whose path's current hint is no longer
+// CoOwned, drops entries with no Members, and sorts+dedups each remaining
+// entry's Members. Returns nil when nothing remains, so a fully-stale or
+// empty record serializes the same as no record at all.
+func NormalizeOwnedMembers(om OwnedMembers, hints map[string]FieldHint) OwnedMembers {
+	filtered := make(OwnedMembers, len(om))
+	for path, record := range om {
+		if hints[path].CoOwned == nil {
+			continue
+		}
+		filtered[path] = record
+	}
+	return normalizeMembers(filtered)
+}
+
+// normalizeMembers applies the Members-level part of NormalizeOwnedMembers
+// (drop empty, sort+dedup) without consulting hints. It is the shared core
+// used by NormalizeOwnedMembers and OwnedMembersEqual, so equality does not
+// depend on having a hints map at hand.
+func normalizeMembers(om OwnedMembers) OwnedMembers {
+	if len(om) == 0 {
+		return nil
+	}
+
+	out := make(OwnedMembers, len(om))
+	for path, record := range om {
+		if len(record.Members) == 0 {
+			continue
+		}
+		members := slices.Clone(record.Members)
+		slices.Sort(members)
+		members = slices.Compact(members)
+		out[path] = OwnedPathRecord{Rule: record.Rule, Members: members}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// OwnedMembersEqual reports whether a and b are equal once normalized: nil
+// and an empty map are equal, member order and duplicates are ignored, and
+// entries with no Members are ignored. It does not consult hints, so it
+// cannot detect a path that has since lost CoOwned — callers comparing
+// against live schema should normalize with NormalizeOwnedMembers first.
+func OwnedMembersEqual(a, b OwnedMembers) bool {
+	return reflect.DeepEqual(normalizeMembers(a), normalizeMembers(b))
+}

--- a/pkg/model/ownership_test.go
+++ b/pkg/model/ownership_test.go
@@ -202,3 +202,50 @@ func TestResource_OwnedMembers_AbsentUnmarshalsToNil(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(`{"Label":"sg-1"}`), &decoded))
 	assert.Nil(t, decoded.OwnedMembers)
 }
+
+func TestMemberIdentitiesIncomplete(t *testing.T) {
+	setHint := FieldHint{UpdateMethod: FieldUpdateMethodSet}
+	esHint := FieldHint{UpdateMethod: FieldUpdateMethodEntitySet, IndexField: "Key"}
+	mapHint := FieldHint{}
+
+	cases := []struct {
+		name string
+		json string
+		hint FieldHint
+		want bool
+	}{
+		{"literal set members", `["a","b"]`, setHint, false},
+		{"resolved envelope member", `[{"$ref":"formae://resource/x#/Id","$value":"sg-1"}]`, setHint, false},
+		{"unresolved ref member", `[{"$ref":"formae://resource/x#/Id"}]`, setHint, true},
+		{"unresolved resolvable member", `[{"$res":true,"$type":"String"}]`, setHint, true},
+		{"entityset member with key", `[{"Key":"a","Value":"1"}]`, esHint, false},
+		{"entityset member missing key", `[{"Value":"1"}]`, esHint, true},
+		{"mapping keys always identify", `{"mine":{"$res":true,"$type":"String"}}`, mapHint, false},
+		{"whole-field unresolved envelope", `{"$res":true,"$type":"Mapping"}`, mapHint, true},
+		{"whole-field resolved envelope", `{"$res":true,"$type":"Mapping","$value":{"mine":"1"}}`, mapHint, false},
+		{"whole-field resolved set envelope", `{"$ref":"formae://resource/x#/Ids","$value":["a"]}`, setHint, false},
+		{"whole-field resolved envelope with unresolved member", `{"$ref":"formae://resource/x#/Ids","$value":[{"$ref":"formae://resource/y#/Id"}]}`, setHint, true},
+		{"empty collection", `[]`, setHint, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MemberIdentitiesIncomplete(gjson.Parse(tc.json), tc.hint)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMemberIdentities_WholeFieldEnvelopeFlattens(t *testing.T) {
+	setHint := FieldHint{UpdateMethod: FieldUpdateMethodSet}
+
+	got := MemberIdentities(gjson.Parse(`{"$ref":"formae://resource/x#/Ids","$value":["a","b"]}`), setHint)
+	assert.Equal(t, []string{`"a"`, `"b"`}, got,
+		"a resolved whole-field envelope exposes its members through $value")
+
+	got = MemberIdentities(gjson.Parse(`{"$ref":"formae://resource/x#/Ids"}`), setHint)
+	assert.Empty(t, got, "an unresolved whole-field envelope contributes nothing")
+
+	got = MemberIdentities(gjson.Parse(`{"$res":true,"$type":"Mapping","$value":{"mine":"1"}}`), FieldHint{})
+	assert.Equal(t, []string{"mine"}, got,
+		"a resolved whole-field Mapping envelope's identities are its $value's keys")
+}

--- a/pkg/model/ownership_test.go
+++ b/pkg/model/ownership_test.go
@@ -1,0 +1,204 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestIdentityRule(t *testing.T) {
+	tests := []struct {
+		name string
+		hint FieldHint
+		want string
+	}{
+		{
+			name: "EntitySet with IndexField",
+			hint: FieldHint{UpdateMethod: FieldUpdateMethodEntitySet, IndexField: "Key", CoOwned: &CoOwnership{}},
+			want: "EntitySet/Key",
+		},
+		{
+			name: "Set",
+			hint: FieldHint{UpdateMethod: FieldUpdateMethodSet, CoOwned: &CoOwnership{}},
+			want: "Set",
+		},
+		{
+			name: "CoOwned with no UpdateMethod is a Mapping",
+			hint: FieldHint{CoOwned: &CoOwnership{}},
+			want: "Mapping",
+		},
+		{
+			name: "Array is not co-ownable",
+			hint: FieldHint{UpdateMethod: FieldUpdateMethodArray},
+			want: "",
+		},
+		{
+			name: "Atomic is not co-ownable",
+			hint: FieldHint{UpdateMethod: FieldUpdateMethodAtomic},
+			want: "",
+		},
+		{
+			name: "zero-value hint is not co-ownable",
+			hint: FieldHint{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IdentityRule(tt.hint))
+		})
+	}
+}
+
+func TestMemberIdentities(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		hint  FieldHint
+		want  []string
+	}{
+		{
+			name:  "object uses keys",
+			value: `{"a":1,"b":2}`,
+			hint:  FieldHint{CoOwned: &CoOwnership{}},
+			want:  []string{"a", "b"},
+		},
+		{
+			name:  "EntitySet array uses json-marshaled IndexField values",
+			value: `[{"Key":"k1"},{"Key":"k2"}]`,
+			hint:  FieldHint{UpdateMethod: FieldUpdateMethodEntitySet, IndexField: "Key", CoOwned: &CoOwnership{}},
+			want:  []string{`"k1"`, `"k2"`},
+		},
+		{
+			name:  "scalar set canonicalizes and dedups each element",
+			value: `["x","y","x"]`,
+			hint:  FieldHint{UpdateMethod: FieldUpdateMethodSet, CoOwned: &CoOwnership{}},
+			want:  []string{`"x"`, `"y"`},
+		},
+		{
+			name:  "resolved ref flattens to its $value",
+			value: `[{"$ref":"formae://k/id","$value":"sg-1"}]`,
+			hint:  FieldHint{UpdateMethod: FieldUpdateMethodSet, CoOwned: &CoOwnership{}},
+			want:  []string{`"sg-1"`},
+		},
+		{
+			name:  "unresolved ref lacking $value contributes nothing",
+			value: `[{"$ref":"formae://k/id"}]`,
+			hint:  FieldHint{UpdateMethod: FieldUpdateMethodSet, CoOwned: &CoOwnership{}},
+			want:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MemberIdentities(gjson.Parse(tt.value), tt.hint)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPartitionOwnership(t *testing.T) {
+	partition := PartitionOwnership(
+		[]string{"a", "b"},
+		[]string{"a", "c"},
+		[]string{"a", "c", "d"},
+	)
+
+	assert.Equal(t, map[string]struct{}{"a": {}, "b": {}}, partition.Declared)
+	assert.Equal(t, map[string]struct{}{"c": {}}, partition.FormerlyOwned)
+	assert.Equal(t, map[string]struct{}{"d": {}}, partition.NeverOwned)
+}
+
+func TestPartitionOwnership_NilPrior(t *testing.T) {
+	partition := PartitionOwnership(
+		[]string{"a"},
+		nil,
+		[]string{"a", "d"},
+	)
+
+	assert.Empty(t, partition.FormerlyOwned)
+	assert.Equal(t, map[string]struct{}{"d": {}}, partition.NeverOwned)
+}
+
+func TestNormalizeOwnedMembers_DropsEmptyMembers(t *testing.T) {
+	om := OwnedMembers{
+		"Rules": {Rule: "Set", Members: []string{}},
+	}
+	hints := map[string]FieldHint{
+		"Rules": {UpdateMethod: FieldUpdateMethodSet, CoOwned: &CoOwnership{}},
+	}
+
+	got := NormalizeOwnedMembers(om, hints)
+	assert.Nil(t, got)
+}
+
+func TestNormalizeOwnedMembers_DropsPathThatLostCoOwned(t *testing.T) {
+	om := OwnedMembers{
+		"Rules": {Rule: "Set", Members: []string{"m1"}},
+	}
+	hints := map[string]FieldHint{
+		"Rules": {UpdateMethod: FieldUpdateMethodSet}, // CoOwned no longer set
+	}
+
+	got := NormalizeOwnedMembers(om, hints)
+	assert.Nil(t, got)
+}
+
+func TestNormalizeOwnedMembers_SortsAndDedupsMembers(t *testing.T) {
+	om := OwnedMembers{
+		"Rules": {Rule: "Set", Members: []string{"m2", "m1", "m2"}},
+	}
+	hints := map[string]FieldHint{
+		"Rules": {UpdateMethod: FieldUpdateMethodSet, CoOwned: &CoOwnership{}},
+	}
+
+	got := NormalizeOwnedMembers(om, hints)
+	require.Contains(t, got, "Rules")
+	assert.Equal(t, []string{"m1", "m2"}, got["Rules"].Members)
+}
+
+func TestOwnedMembersEqual_NilAndEmptyAreEqual(t *testing.T) {
+	assert.True(t, OwnedMembersEqual(nil, OwnedMembers{}))
+}
+
+func TestOwnedMembersEqual_NormalizesBeforeComparing(t *testing.T) {
+	a := OwnedMembers{"Rules": {Rule: "Set", Members: []string{"m1", "m2"}}}
+	b := OwnedMembers{"Rules": {Rule: "Set", Members: []string{"m2", "m1", "m2"}}}
+	assert.True(t, OwnedMembersEqual(a, b))
+}
+
+func TestOwnedMembersEqual_DifferentMembersAreNotEqual(t *testing.T) {
+	a := OwnedMembers{"Rules": {Rule: "Set", Members: []string{"m1"}}}
+	b := OwnedMembers{"Rules": {Rule: "Set", Members: []string{"m2"}}}
+	assert.False(t, OwnedMembersEqual(a, b))
+}
+
+func TestResource_OwnedMembers_JSONRoundTrip(t *testing.T) {
+	original := Resource{
+		Label: "sg-1",
+		OwnedMembers: OwnedMembers{
+			"Rules": {Rule: "Set", Members: []string{"m1", "m2"}},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded Resource
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, original.OwnedMembers, decoded.OwnedMembers)
+}
+
+func TestResource_OwnedMembers_AbsentUnmarshalsToNil(t *testing.T) {
+	var decoded Resource
+	require.NoError(t, json.Unmarshal([]byte(`{"Label":"sg-1"}`), &decoded))
+	assert.Nil(t, decoded.OwnedMembers)
+}

--- a/pkg/model/resource.go
+++ b/pkg/model/resource.go
@@ -33,6 +33,10 @@ type Resource struct {
 	Managed            bool            `json:"Managed,omitempty"` // Whether the resource is managed by Formae or not
 	Ksuid              string          `json:"Ksuid,omitempty"`
 	Alias              string          `json:"Alias,omitempty"` // previous label, used to rename in place
+	// OwnedMembers records, per co-owned collection field, the set of member
+	// identities this forma last declared. Absent (nil) means no field on
+	// this resource carries a declared ownership record.
+	OwnedMembers OwnedMembers `json:"OwnedMembers,omitempty"`
 	// Version is the datastore row version this resource was loaded from, set
 	// by the loaders that read it out of the resources table alongside Ksuid.
 	// It is monotonic per URI (a KSUID minted on every write), so comparing it

--- a/pkg/model/schema.go
+++ b/pkg/model/schema.go
@@ -57,6 +57,19 @@ type FieldHint struct {
 	// UpdateMethod; typically paired with Atomic on opaque document fields.
 	PreserveEmptyValues bool   `json:"PreserveEmptyValues" pkl:"PreserveEmptyValues"`
 	Format              string `json:"Format" pkl:"Format"` // "" = opaque String; "json" = serialized JSON document
+	// CoOwned marks a collection field whose live content legitimately has
+	// writers other than this forma. nil = not co-owned.
+	CoOwned *CoOwnership `json:"CoOwned,omitempty" pkl:"CoOwned"`
+}
+
+// CoOwnership declares that a field's live collection is shared with writers
+// other than the owning forma (e.g. a security group's rule set, or a
+// mapping populated in part by the platform itself).
+type CoOwnership struct {
+	// SystemPatterns are glob patterns over member identities naming entries
+	// injected by the platform itself. Consulted only by extract on resources
+	// with no ownership record; never by plan or drift.
+	SystemPatterns []string `json:"SystemPatterns,omitempty" pkl:"SystemPatterns"`
 }
 
 // UnmarshalJSON normalizes the deprecated AttachesTo alias into EdgeKind so


### PR DESCRIPTION
## Summary

This introduces element-level ownership partitioning for co-owned collections: fields that formae shares write access to with another actor (for example a Kubernetes controller populating labels formae also declares). Today, any collection field is either fully formae-owned (surplus elements get removed on reconcile) or fully tolerated (formae never touches it). Neither model fits a field where formae owns *some* elements and another actor owns others in the same collection.

Each resource now carries an ownership record (`OwnedMembers`) recording which element identities formae's own applies have claimed. The record is committed at the write echo (when the agent observes the result of its own write) and via record-only updates (a version write with an empty patch, used when an unchanged resource's live ownership claim differs from the stored record). Sync carries the record verbatim — it is never recomputed from cloud state, since cloud state cannot distinguish who put a given element there.

At plan time, a co-owned collection's live elements are partitioned three ways against the declared set and the ownership record: declared (present in the forma file — always diffed normally), formerly-owned (in the record but no longer declared, or in the record but not the annotation's identity rule — eligible for removal), and never-owned (present live but neither declared nor in the record — left alone). This partition drives a new jsonpatch collections kind, a drainable-restricted diff: removals are emitted only for formerly-owned identities, indices in those removals always address the unfiltered document (not a filtered view, which would misalign with array positions), and an omitted co-owned field is tolerated whole (no partial diff attempted) rather than either fully owned or fully ignored. These land on three consumer surfaces: drift notes classify never-owned member movement as tolerated drift rather than a plan-worthy change; extract emits exactly the owned portion of a co-owned collection (never the full live collection, and never the ownership record itself) and prunes system-pattern entries — glob-matched identities the schema author flags as noise — from resources that carry no ownership record at all.

## Behavior changes

- Shrinking a co-owned declaration (removing a member from the forma file) now drains exactly the removed member, rather than the collection's full complement of formerly-owned elements at once, since the partition only fires on the actual delta between the declared set and the record.
- An explicit empty value on a co-owned field now drains owned members only. This is a change from the previous EntitySet drain behavior, which — before this record existed — had no way to distinguish co-owned elements from ones any other actor placed there, and removed both.
- An unchanged resource whose live ownership claim differs from the stored record now produces a record-only version write (empty patch, `RecordOnly`) to reconcile the record without touching cloud state.
- Anything without the new `@formae.CoOwned` annotation is unaffected: the diff and drift paths take the same code paths they did before, and the characterization suite below runs the pre-existing test names verbatim to confirm byte-identical output.

## Conservative-degradation invariant

The mechanism is designed to degrade toward doing nothing, never toward an incorrect removal. A missing or rule-mismatched ownership record, an unresolved reference inside a co-owned identity, an opaque co-owned field (unhashable, so no identity can be computed), or a live element that doesn't match any claimed member in the echo, all degrade to the same outcome: no claim on that element, drain nothing, fall back to today's tolerate-whole behavior. The failure mode of a bug in this mechanism is a stale element that should have been removed but wasn't — never a removal of something formae doesn't own.

## Dependency note

`github.com/platform-engineering-labs/jsonpatch` is pinned to the head commit of its open PR ("feat: co-owned paths with drainable-restricted removals", jsonpatch#4: `0cadda46e95346d64cd1e5e41ff0f3fc54546701`), which adds the drainable-restricted collections kind this PR consumes. It must be re-pinned to a tagged/master commit once that PR merges.

## Verification

Full sweep (worktree at `8300eb64`, `GOTOOLCHAIN=go1.26.0`):

- `make version-semver`: OK (0.89.0)
- `go build ./...`: clean
- `go vet ./...`: clean
- `gofmt -l .`: clean for every file this branch touches (22 pre-existing unformatted files elsewhere in the tree predate this branch and are untouched by it)
- `go test ./... -count=1 -timeout 900s`: all pass
- `go test -tags=unit ./internal/... -count=1`: one failure, pre-existing and unrelated — `TestLoadResourcesByStack_ExcludesDeletedResourceWhenVersionsMixCase` fails on this machine's Postgres collation ("test precondition: default collation must treat 'U' as greater than 'f'"), reproducible on the pre-change base commit
- `go vet -tags=unit ./internal/...`: pre-existing unkeyed-field vet warnings in `internal/api` tests only, unrelated to this change

Characterization suite (`go test ./internal/metastructure/patch/ -run 'TestSurplus|TestDeclared|TestExplicit|TestOmitted|TestObjectKeys' -v -count=1`), proving fields without the new annotation are unaffected:

```
=== RUN   TestSurplusMapKeyIsNeverPlannedForRemoval
=== RUN   TestSurplusMapKeyIsNeverPlannedForRemoval/top-level,_annotated/reconcile
=== RUN   TestSurplusMapKeyIsNeverPlannedForRemoval/top-level,_annotated/patch
=== RUN   TestSurplusMapKeyIsNeverPlannedForRemoval/top-level,_not_annotated/reconcile
=== RUN   TestSurplusMapKeyIsNeverPlannedForRemoval/top-level,_not_annotated/patch
=== RUN   TestSurplusMapKeyIsNeverPlannedForRemoval/nested,_annotated/reconcile
=== RUN   TestSurplusMapKeyIsNeverPlannedForRemoval/nested,_annotated/patch
=== RUN   TestSurplusMapKeyIsNeverPlannedForRemoval/nested,_not_annotated/reconcile
=== RUN   TestSurplusMapKeyIsNeverPlannedForRemoval/nested,_not_annotated/patch
--- PASS: TestSurplusMapKeyIsNeverPlannedForRemoval (0.00s)
    --- PASS: TestSurplusMapKeyIsNeverPlannedForRemoval/top-level,_annotated/reconcile (0.00s)
    --- PASS: TestSurplusMapKeyIsNeverPlannedForRemoval/top-level,_annotated/patch (0.00s)
    --- PASS: TestSurplusMapKeyIsNeverPlannedForRemoval/top-level,_not_annotated/reconcile (0.00s)
    --- PASS: TestSurplusMapKeyIsNeverPlannedForRemoval/top-level,_not_annotated/patch (0.00s)
    --- PASS: TestSurplusMapKeyIsNeverPlannedForRemoval/nested,_annotated/reconcile (0.00s)
    --- PASS: TestSurplusMapKeyIsNeverPlannedForRemoval/nested,_annotated/patch (0.00s)
    --- PASS: TestSurplusMapKeyIsNeverPlannedForRemoval/nested,_not_annotated/reconcile (0.00s)
    --- PASS: TestSurplusMapKeyIsNeverPlannedForRemoval/nested,_not_annotated/patch (0.00s)
=== RUN   TestDeclaredMapKeyStillDiffsWhenItsValueMoves
=== RUN   TestDeclaredMapKeyStillDiffsWhenItsValueMoves/reconcile
=== RUN   TestDeclaredMapKeyStillDiffsWhenItsValueMoves/patch
--- PASS: TestDeclaredMapKeyStillDiffsWhenItsValueMoves (0.00s)
    --- PASS: TestDeclaredMapKeyStillDiffsWhenItsValueMoves/reconcile (0.00s)
    --- PASS: TestDeclaredMapKeyStillDiffsWhenItsValueMoves/patch (0.00s)
=== RUN   TestDeclaredMapKeyIsStillAddedWhenMissing
=== RUN   TestDeclaredMapKeyIsStillAddedWhenMissing/reconcile
=== RUN   TestDeclaredMapKeyIsStillAddedWhenMissing/patch
--- PASS: TestDeclaredMapKeyIsStillAddedWhenMissing (0.00s)
    --- PASS: TestDeclaredMapKeyIsStillAddedWhenMissing/reconcile (0.00s)
    --- PASS: TestDeclaredMapKeyIsStillAddedWhenMissing/patch (0.00s)
=== RUN   TestExplicitlyEmptiedMapPlansNothing
=== RUN   TestExplicitlyEmptiedMapPlansNothing/reconcile
=== RUN   TestExplicitlyEmptiedMapPlansNothing/patch
--- PASS: TestExplicitlyEmptiedMapPlansNothing (0.00s)
    --- PASS: TestExplicitlyEmptiedMapPlansNothing/reconcile (0.00s)
    --- PASS: TestExplicitlyEmptiedMapPlansNothing/patch (0.00s)
=== RUN   TestSurplusListMemberIsPlannedForRemovalUnderReconcile
=== RUN   TestSurplusListMemberIsPlannedForRemovalUnderReconcile/annotated
=== RUN   TestSurplusListMemberIsPlannedForRemovalUnderReconcile/not_annotated
--- PASS: TestSurplusListMemberIsPlannedForRemovalUnderReconcile (0.00s)
    --- PASS: TestSurplusListMemberIsPlannedForRemovalUnderReconcile/annotated (0.00s)
    --- PASS: TestSurplusListMemberIsPlannedForRemovalUnderReconcile/not_annotated (0.00s)
=== RUN   TestSurplusListMemberSurvivesPatchMode
--- PASS: TestSurplusListMemberSurvivesPatchMode (0.00s)
=== RUN   TestOmittedAnnotatedFieldIsToleratedWhole
=== RUN   TestOmittedAnnotatedFieldIsToleratedWhole/map/reconcile
=== RUN   TestOmittedAnnotatedFieldIsToleratedWhole/map/patch
=== RUN   TestOmittedAnnotatedFieldIsToleratedWhole/list/reconcile
=== RUN   TestOmittedAnnotatedFieldIsToleratedWhole/list/patch
--- PASS: TestOmittedAnnotatedFieldIsToleratedWhole (0.00s)
    --- PASS: TestOmittedAnnotatedFieldIsToleratedWhole/map/reconcile (0.00s)
    --- PASS: TestOmittedAnnotatedFieldIsToleratedWhole/map/patch (0.00s)
    --- PASS: TestOmittedAnnotatedFieldIsToleratedWhole/list/reconcile (0.00s)
    --- PASS: TestOmittedAnnotatedFieldIsToleratedWhole/list/patch (0.00s)
=== RUN   TestObjectKeysAreNeverRemovedWithOrWithoutTheAnnotation
=== RUN   TestObjectKeysAreNeverRemovedWithOrWithoutTheAnnotation/whole_field,_annotated
=== RUN   TestObjectKeysAreNeverRemovedWithOrWithoutTheAnnotation/whole_field,_not_annotated
=== RUN   TestObjectKeysAreNeverRemovedWithOrWithoutTheAnnotation/single_key,_annotated
=== RUN   TestObjectKeysAreNeverRemovedWithOrWithoutTheAnnotation/single_key,_not_annotated
--- PASS: TestObjectKeysAreNeverRemovedWithOrWithoutTheAnnotation (0.00s)
    --- PASS: TestObjectKeysAreNeverRemovedWithOrWithoutTheAnnotation/whole_field,_annotated (0.00s)
    --- PASS: TestObjectKeysAreNeverRemovedWithOrWithoutTheAnnotation/whole_field,_not_annotated (0.00s)
    --- PASS: TestObjectKeysAreNeverRemovedWithOrWithoutTheAnnotation/single_key,_annotated (0.00s)
    --- PASS: TestObjectKeysAreNeverRemovedWithOrWithoutTheAnnotation/single_key,_not_annotated (0.00s)
PASS
ok  	github.com/platform-engineering-labs/formae/internal/metastructure/patch	0.004s
```
