### PR TITLE
fix(drift): reconcile gate consults the ownership partition

### DIFF
--- a/internal/metastructure/drift/confrontable.go
+++ b/internal/metastructure/drift/confrontable.go
@@ -1,0 +1,61 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package drift
+
+import (
+	"log/slog"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/patch"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// RetainConfrontable drops from an unabsorbed set the modifications whose
+// out-of-band movement a reconcile need not confront: those on a resource the
+// forma declares whose movement is confined to a co-owned collection's
+// never-owned members (a co-actor's content). It exists because the earlier
+// gate rejected any modified resource the forma also plans to change, which
+// meant a single co-actor-injected label made every edit of that resource
+// fail — the churn the ownership partition is meant to end.
+//
+// A modification is kept (still confrontable) when it has no matching forma
+// declaration (an orphan, which cannot be classified), or when
+// patch.ModificationConfrontable finds real drift: a plain-field change, a
+// witnessed provider-default move, or a declared/formerly-owned co-owned
+// member move. Classification errs toward keeping: a resource whose
+// modification cannot be read is left in the set.
+func RetainConfrontable(unabsorbed []datastore.ResourceModification, recordByKsuid map[string]pkgmodel.OwnedMembers, forma *pkgmodel.Forma) []datastore.ResourceModification {
+	kept := make([]datastore.ResourceModification, 0, len(unabsorbed))
+	for _, mod := range unabsorbed {
+		if !modificationTolerated(mod, recordByKsuid, forma) {
+			kept = append(kept, mod)
+		}
+	}
+	return kept
+}
+
+// modificationTolerated reports whether a modification is safe to drop from
+// the unabsorbed set. It is true only for an update on a declared resource
+// whose movement patch.ModificationConfrontable classifies as non-confrontable.
+// Every uncertain case (a non-update op, missing properties, no declaration,
+// a classification error) returns false so the modification is kept.
+func modificationTolerated(mod datastore.ResourceModification, recordByKsuid map[string]pkgmodel.OwnedMembers, forma *pkgmodel.Forma) bool {
+	if mod.Operation != "update" || len(mod.OldProperties) == 0 || len(mod.Properties) == 0 {
+		return false
+	}
+	decl := findDeclarationForModification(forma, mod)
+	if decl == nil {
+		return false
+	}
+	confrontable, err := patch.ModificationConfrontable(
+		mod.OldProperties, mod.Properties, decl.Properties,
+		recordByKsuid[mod.Ksuid], decl.Schema)
+	if err != nil {
+		slog.Warn("Failed to classify modification for confrontation; keeping it as drift",
+			"stack", mod.Stack, "type", mod.Type, "label", mod.Label, "error", err)
+		return false
+	}
+	return !confrontable
+}

--- a/internal/metastructure/drift/confrontable_test.go
+++ b/internal/metastructure/drift/confrontable_test.go
@@ -1,0 +1,97 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package drift
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func coOwnedNsSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"Name", "labels"},
+		Hints:  map[string]pkgmodel.FieldHint{"labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+}
+
+// A modification whose only movement is a co-actor's never-owned member is
+// dropped from the unabsorbed set, so a reconcile that also edits the
+// resource (its edit lives in the plan, not here) is not rejected.
+func TestRetainConfrontable_DropsToleratedCoOwnedMovement(t *testing.T) {
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "s", Type: "K8S::Core::Namespace", Label: "ns",
+		Properties: json.RawMessage(`{"Name":"n","labels":{"app":"web","version":"2"}}`),
+		Schema:     coOwnedNsSchema(),
+	}}}
+	mod := datastore.ResourceModification{
+		Stack: "s", Type: "K8S::Core::Namespace", Label: "ns", Operation: "update", Ksuid: "k1",
+		OldProperties: json.RawMessage(`{"Name":"n","labels":{"app":"web"}}`),
+		Properties:    json.RawMessage(`{"Name":"n","labels":{"app":"web","team":"platform"}}`),
+	}
+	records := map[string]pkgmodel.OwnedMembers{"k1": {"labels": {Rule: "Mapping", Members: []string{"app"}}}}
+
+	got := RetainConfrontable([]datastore.ResourceModification{mod}, records, forma)
+	assert.Empty(t, got, "tolerated co-owned movement must not survive as unabsorbed drift")
+}
+
+// A modification with a declared member's out-of-band change stays: real
+// drift on managed content still rejects.
+func TestRetainConfrontable_KeepsDeclaredMemberDrift(t *testing.T) {
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "s", Type: "K8S::Core::Namespace", Label: "ns",
+		Properties: json.RawMessage(`{"Name":"n","labels":{"app":"web"}}`),
+		Schema:     coOwnedNsSchema(),
+	}}}
+	mod := datastore.ResourceModification{
+		Stack: "s", Type: "K8S::Core::Namespace", Label: "ns", Operation: "update", Ksuid: "k1",
+		OldProperties: json.RawMessage(`{"Name":"n","labels":{"app":"web"}}`),
+		Properties:    json.RawMessage(`{"Name":"n","labels":{"app":"hacked"}}`),
+	}
+	records := map[string]pkgmodel.OwnedMembers{"k1": {"labels": {Rule: "Mapping", Members: []string{"app"}}}}
+
+	got := RetainConfrontable([]datastore.ResourceModification{mod}, records, forma)
+	assert.Len(t, got, 1, "a declared member's drift must remain confrontable")
+}
+
+// A modification on a resource not in the forma (an orphan) cannot be
+// classified against a declaration and is kept — the conservative default.
+func TestRetainConfrontable_KeepsNotInFormaModification(t *testing.T) {
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "s", Type: "K8S::Core::Namespace", Label: "other", Schema: coOwnedNsSchema(),
+	}}}
+	mod := datastore.ResourceModification{
+		Stack: "s", Type: "K8S::Core::Namespace", Label: "orphan", Operation: "update", Ksuid: "k1",
+		OldProperties: json.RawMessage(`{"Name":"n","labels":{"app":"web"}}`),
+		Properties:    json.RawMessage(`{"Name":"n","labels":{"app":"web","team":"x"}}`),
+	}
+	records := map[string]pkgmodel.OwnedMembers{"k1": {"labels": {Rule: "Mapping", Members: []string{"app"}}}}
+
+	got := RetainConfrontable([]datastore.ResourceModification{mod}, records, forma)
+	assert.Len(t, got, 1, "a modification with no matching declaration is kept")
+}
+
+// A witnessed provider-default move on a resource in the forma stays
+// confrontable even though nothing co-owned moved.
+func TestRetainConfrontable_KeepsWitnessedProviderDefaultMove(t *testing.T) {
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "s", Type: "AWS::KMS::Key", Label: "key",
+		Properties: json.RawMessage(`{"Name":"n"}`),
+		Schema:     kmsSchemaForDrift(),
+	}}}
+	mod := datastore.ResourceModification{
+		Stack: "s", Type: "AWS::KMS::Key", Label: "key", Operation: "update", Ksuid: "k1",
+		OldProperties: json.RawMessage(`{"Name":"n","EnableKeyRotation":false}`),
+		Properties:    json.RawMessage(`{"Name":"n","EnableKeyRotation":true}`),
+	}
+	got := RetainConfrontable([]datastore.ResourceModification{mod}, nil, forma)
+	assert.Len(t, got, 1, "a provider-default move on a declared resource stays confrontable")
+}

--- a/internal/metastructure/drift/modifications.go
+++ b/internal/metastructure/drift/modifications.go
@@ -134,7 +134,10 @@ func FilterUnabsorbedModifications(
 		// state has already absorbed (e.g. a synced secret rotation reaching
 		// its consumer). It asserts no state differing from the current one,
 		// so it must not block absorbing the modification it follows from.
-		if ru.ConvergenceOnly() {
+		// A record-only update is the same shape for the ownership record:
+		// it commits a claim over current state (empty patch, current
+		// properties) — the absorb path itself — and asserts no change.
+		if ru.ConvergenceOnly() || ru.RecordOnly {
 			continue
 		}
 		resourcesWithUpdates[resourceKey{

--- a/internal/metastructure/drift/modifications_test.go
+++ b/internal/metastructure/drift/modifications_test.go
@@ -79,6 +79,34 @@ func TestFilterUnabsorbedModifications_ModificationWithPendingUpdateIsUnabsorbed
 	assert.Len(t, got, 1, "a modification with a pending update is not absorbed")
 }
 
+func TestFilterUnabsorbedModifications_RecordOnlyUpdateAbsorbs(t *testing.T) {
+	// A record-only update commits an ownership claim without asserting any
+	// state differing from the current one (empty patch, current
+	// properties): the ordinary path an absorb apply takes. It must not
+	// count as a pending change, or absorbing an out-of-band member would
+	// be rejected by the very gate the absorb exists to satisfy.
+	mods := []datastore.ResourceModification{
+		{Stack: "prod", Type: "AWS::EC2::Instance", Label: "app-server", Operation: "update"},
+	}
+	forma := &pkgmodel.Forma{
+		Resources: []pkgmodel.Resource{
+			{Stack: "prod", Type: "AWS::EC2::Instance", Label: "app-server"},
+		},
+	}
+	fa := &forma_command.FormaCommand{
+		ResourceUpdates: []resource_update.ResourceUpdate{
+			{
+				StackLabel:   "prod",
+				RecordOnly:   true,
+				DesiredState: pkgmodel.Resource{Type: "AWS::EC2::Instance", Label: "app-server"},
+			},
+		},
+	}
+
+	got := FilterUnabsorbedModifications(mods, forma, fa)
+	assert.Empty(t, got, "a record-only update asserts no state change; the modification is absorbed")
+}
+
 // Cross-type guard: same label on a different type is NOT absorbed by an
 // unrelated alias hit.
 func TestFilterUnabsorbedModifications_AliasMatchRequiresTypeMatch(t *testing.T) {

--- a/internal/metastructure/drift/witnessed.go
+++ b/internal/metastructure/drift/witnessed.go
@@ -16,18 +16,21 @@ import (
 
 // WitnessedMovedModifications returns the modifications whose out-of-band
 // movement sits on provider-default content formae's own last write
-// witnessed, OR on a co-owned collection's never-owned members. Such
-// movement is drift, exactly like drift on a declared field: the caller adds
-// these to the unabsorbed set so a soft reconcile rejects showing them, and a
-// forced reconcile reverts them via the witness assertion. Candidates are
-// the modifications FilterUnabsorbedModifications absorbs (the unabsorbed
-// ones already reject); a candidate that cannot be classified (a non-update
-// operation, a missing property blob, no matching forma declaration, no
-// write witness, or a diff error) is left absorbed, which is the
-// pre-existing tolerant behavior. records, keyed by resource KSUID exactly
-// parallel to witnessByKsuid, carries each resource's stored ownership
-// record; a missing entry passes nil (witness semantics for a non-co-owned
-// path; everything-undeclared for a co-owned path).
+// witnessed. Such movement is drift, exactly like drift on a declared field:
+// the caller adds these to the unabsorbed set so a soft reconcile rejects
+// showing them, and a forced reconcile reverts them via the witness
+// assertion. Movement on a co-owned collection's never-owned members is the
+// one classified kind that never counts: it is tolerated by design (the
+// partition's decided trade), so its notes are display material, never a
+// reason to reject — a resource whose only movement is a co-actor's stays
+// absorbed. Candidates are the modifications FilterUnabsorbedModifications
+// absorbs (the unabsorbed ones already reject); a candidate that cannot be
+// classified (a non-update operation, a missing property blob, no matching
+// forma declaration, no write witness, or a diff error) is left absorbed,
+// which is the pre-existing tolerant behavior. records, keyed by resource
+// KSUID exactly parallel to witnessByKsuid, carries each resource's stored
+// ownership record; a missing entry passes nil (witness semantics for a
+// non-co-owned path; everything-undeclared for a co-owned path).
 func WitnessedMovedModifications(modifications []datastore.ResourceModification, witnessByKsuid map[string]json.RawMessage, records map[string]pkgmodel.OwnedMembers, forma *pkgmodel.Forma, fa *forma_command.FormaCommand) []datastore.ResourceModification {
 	type modKey struct {
 		stack, typeName, label, operation string
@@ -49,12 +52,6 @@ func WitnessedMovedModifications(modifications []datastore.ResourceModification,
 		if decl == nil {
 			continue
 		}
-		// No early witness-nil exit here: a co-owned path's movement is
-		// classified by ownership partition, not by the write witness, so a
-		// resource formae never wrote (no witness) can still owe a note for
-		// its never-owned members. SuppressedFieldDiffs itself keeps every
-		// non-co-owned path gated on the witness, so this costs nothing for
-		// the witness-only case — a nil witness there still yields no diffs.
 		witness := witnessByKsuid[mod.Ksuid]
 		priorOwned := records[mod.Ksuid]
 		diffs, err := patch.SuppressedFieldDiffs(mod.OldProperties, mod.Properties, decl.Properties, witness, priorOwned, decl.Schema)
@@ -63,8 +60,13 @@ func WitnessedMovedModifications(modifications []datastore.ResourceModification,
 				"stack", mod.Stack, "type", mod.Type, "label", mod.Label, "error", err)
 			continue
 		}
-		if len(diffs) > 0 {
-			moved = append(moved, mod)
+		for _, diff := range diffs {
+			// A co-owned note is tolerated movement (a co-actor's members);
+			// only witness-regime notes make a modification reject.
+			if !diff.CoOwned {
+				moved = append(moved, mod)
+				break
+			}
 		}
 	}
 	return moved

--- a/internal/metastructure/drift/witnessed_test.go
+++ b/internal/metastructure/drift/witnessed_test.go
@@ -123,10 +123,10 @@ func coOwnedLabelsSchemaForDrift() pkgmodel.Schema {
 	}
 }
 
-func TestWitnessedMovedModifications_CoOwnedNeverOwnedMovement_IsDriftWithoutWitness(t *testing.T) {
-	// The co-owned regime classifies by ownership partition, not by write
-	// witness: a resource with no witness at all still owes a note for a
-	// never-owned member's movement.
+func TestWitnessedMovedModifications_CoOwnedNeverOwnedMovement_Tolerated(t *testing.T) {
+	// Movement on a co-owned collection's never-owned members is a
+	// co-actor's business: it never makes a modification reject, so a
+	// reconcile-mode apply of the unchanged forma passes the gate.
 	mods := map[string][]datastore.ResourceModification{
 		"prod": {{
 			Stack: "prod", Type: "AWS::Example::Thing", Label: "shared", Operation: "update", Ksuid: "k1",
@@ -144,6 +144,40 @@ func TestWitnessedMovedModifications_CoOwnedNeverOwnedMovement_IsDriftWithoutWit
 	}
 
 	moved := WitnessedMovedModifications(mods["prod"], map[string]json.RawMessage{}, records, forma, &forma_command.FormaCommand{})
+	assert.Empty(t, moved, "a co-actor's member movement is tolerated, never confronted")
+
+	moved = WitnessedMovedModifications(mods["prod"], driftWitnesses(mods), records, forma, &forma_command.FormaCommand{})
+	assert.Empty(t, moved, "the write witness does not change the co-owned regime's answer")
+}
+
+func TestWitnessedMovedModifications_WitnessedMovementBesideCoOwned_StillRejects(t *testing.T) {
+	// A resource can move in both regimes at once; the witnessed
+	// provider-default movement keeps rejecting even though the co-owned
+	// movement beside it is tolerated.
+	mods := map[string][]datastore.ResourceModification{
+		"prod": {{
+			Stack: "prod", Type: "AWS::Example::Thing", Label: "shared", Operation: "update", Ksuid: "k1",
+			OldProperties: json.RawMessage(`{"Name": "n", "Setting": "a", "labels": {"mine": "1", "theirs": "a"}}`),
+			Properties:    json.RawMessage(`{"Name": "n", "Setting": "b", "labels": {"mine": "1", "theirs": "b"}}`),
+		}},
+	}
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Setting", "labels"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Setting": {HasProviderDefault: true},
+			"labels":  {CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	forma := &pkgmodel.Forma{Resources: []pkgmodel.Resource{{
+		Stack: "prod", Type: "AWS::Example::Thing", Label: "shared",
+		Properties: json.RawMessage(`{"Name": "n", "labels": {"mine": "1"}}`),
+		Schema:     schema,
+	}}}
+	records := map[string]pkgmodel.OwnedMembers{
+		"k1": {"labels": {Rule: "Mapping", Members: []string{"mine"}}},
+	}
+
+	moved := WitnessedMovedModifications(mods["prod"], driftWitnesses(mods), records, forma, &forma_command.FormaCommand{})
 	require.Len(t, moved, 1)
 }
 

--- a/internal/metastructure/generator_rotator.go
+++ b/internal/metastructure/generator_rotator.go
@@ -732,6 +732,7 @@ func refuseRotationOnDrift(ds datastore.Datastore, forma *pkgmodel.Forma, fc *fo
 	for label, modifications := range modificationsByStack {
 		unabsorbed := drift.FilterUnabsorbedModifications(modifications, forma, fc)
 		unabsorbed = append(unabsorbed, drift.WitnessedMovedModifications(modifications, witnessByKsuid, recordByKsuid, forma, fc)...)
+		unabsorbed = drift.RetainConfrontable(unabsorbed, recordByKsuid, forma)
 		if len(unabsorbed) == 0 {
 			continue
 		}

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -423,6 +423,7 @@ func (m *Metastructure) ApplyForma(forma *pkgmodel.Forma, config *config.FormaCo
 		for stackLabel, modifications := range modificationsByStack {
 			unabsorbed := drift.FilterUnabsorbedModifications(modifications, forma, fa)
 			unabsorbed = append(unabsorbed, drift.WitnessedMovedModifications(modifications, witnessByKsuid, recordByKsuid, forma, fa)...)
+			unabsorbed = drift.RetainConfrontable(unabsorbed, recordByKsuid, forma)
 			if len(unabsorbed) > 0 {
 				modifiedResources := make([]apimodel.ResourceModification, 0, len(unabsorbed))
 				for _, modification := range unabsorbed {

--- a/internal/metastructure/patch/modification_confront.go
+++ b/internal/metastructure/patch/modification_confront.go
@@ -1,0 +1,294 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package patch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ModificationConfrontable reports whether a resource's out-of-band
+// modification (its stored state at the last reconcile, oldProps, versus its
+// current stored state, newProps) carries movement a reconcile must confront
+// before proceeding. Movement confined to a co-owned collection's never-owned
+// members — a co-actor's content, the very thing the ownership partition
+// exists to tolerate — is not confrontable; everything else is (a plain-field
+// change, a provider-default move, a declared/formerly-owned co-owned member
+// move).
+//
+// It is the gate's answer to "does this resource carry drift the user has not
+// seen", asked independently of whether the forma also plans a change to the
+// resource. The prior gate used "the forma plans a change" as a proxy for
+// "there is unconfronted drift", which rejected every edit of a resource that
+// merely carried a co-actor's tolerated content.
+//
+// The comparison keeps everything except never-owned co-owned members, so it
+// errs toward confront: only that one tolerated class is removed, and anything
+// it cannot classify as a co-owned member (an opaque or malformed co-owned
+// value, a provider-default field, a plain field) stays and confronts. A false
+// "confront" is a spurious rejection recoverable with --force, never a silent
+// overwrite of drift. Provider-default and witness handling for resources the
+// forma does NOT edit stays in the earlier drift stages (FilterUnabsorbed /
+// WitnessedMoved); this predicate only re-examines what those already flagged.
+func ModificationConfrontable(oldProps, newProps, desired json.RawMessage, priorOwned pkgmodel.OwnedMembers, schema pkgmodel.Schema) (bool, error) {
+	oldRem, oldEmptied, err := confrontableRemainder(oldProps, desired, priorOwned, schema)
+	if err != nil {
+		return false, err
+	}
+	newRem, newEmptied, err := confrontableRemainder(newProps, desired, priorOwned, schema)
+	if err != nil {
+		return false, err
+	}
+
+	// An ancestor object emptied by neutralizing a co-owned child on EITHER
+	// side is pruned from BOTH, so the comparison neither turns on which side
+	// carried the tolerated content (symmetry) nor conflates a container that
+	// neutralization emptied with one the resource holds explicitly empty (only
+	// the former is ever collected here).
+	emptied := unionSorted(oldEmptied, newEmptied)
+	oldRem = pruneAncestors(oldRem, emptied)
+	newRem = pruneAncestors(newRem, emptied)
+
+	oldCanon, err := canonicalizeRemainder(oldRem)
+	if err != nil {
+		return false, err
+	}
+	newCanon, err := canonicalizeRemainder(newRem)
+	if err != nil {
+		return false, err
+	}
+	return oldCanon != newCanon, nil
+}
+
+// confrontableRemainder returns props with never-owned co-owned members
+// removed, plus the ancestor objects that neutralizing a nested co-owned path
+// left empty (so the caller can prune them symmetrically across both sides).
+// A co-owned (non-opaque) path's value is restricted to the members this forma
+// declares or has on record (declared ∪ prior); an unclassifiable co-owned
+// value and every non-co-owned field are left intact.
+func confrontableRemainder(props, desired json.RawMessage, priorOwned pkgmodel.OwnedMembers, schema pkgmodel.Schema) (json.RawMessage, []string, error) {
+	out := props
+	if len(out) == 0 {
+		out = json.RawMessage(`{}`)
+	}
+
+	var deletedNested []string
+
+	for path, hint := range schema.Hints {
+		if hint.CoOwned == nil || hint.Opaque {
+			continue
+		}
+		val := gjson.GetBytes(out, path)
+		if !val.Exists() {
+			continue
+		}
+		// An unclassifiable shape (a scalar where a collection is expected, or
+		// an array element without its identity field) has no members to
+		// partition; leaving it in the remainder confronts its change rather
+		// than deleting it and reading distinct values as equal.
+		if !coOwnedValueClassifiable(val, hint) {
+			continue
+		}
+		keep := map[string]struct{}{}
+		for _, id := range pkgmodel.MemberIdentities(gjson.GetBytes(desired, path), hint) {
+			keep[id] = struct{}{}
+		}
+		if rec, ok := priorOwned[path]; ok && rec.Rule == pkgmodel.IdentityRule(hint) {
+			for _, id := range rec.Members {
+				keep[id] = struct{}{}
+			}
+		}
+		// restrictRawToKeep keeps exactly the members whose identity is in the
+		// supplied set — here declared ∪ prior — so never-owned members are
+		// dropped, preserving each kept member's raw JSON (so a large-integer
+		// value is not reconstructed through a lossy float64).
+		restricted, kept := restrictRawToKeep(val, hint, keep)
+		var err error
+		if !kept {
+			out, err = sjson.DeleteBytes(out, path)
+			if strings.Contains(path, ".") {
+				deletedNested = append(deletedNested, path)
+			}
+		} else {
+			out, err = sjson.SetRawBytes(out, path, restricted)
+		}
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to reduce co-owned path %q: %w", path, err)
+		}
+	}
+
+	return out, emptiedAncestors(out, deletedNested), nil
+}
+
+// emptiedAncestors returns the ancestor object paths that are now empty as a
+// result of deleting the given nested paths — walking each deleted path's
+// ancestors from the immediate parent upward, collecting empty objects and
+// stopping at the first non-empty one. An ancestor the document held
+// explicitly empty (no co-owned child was deleted under it) is never collected,
+// because only actually-deleted paths are walked.
+func emptiedAncestors(doc json.RawMessage, deletedPaths []string) []string {
+	if len(deletedPaths) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	for _, path := range deletedPaths {
+		segments := strings.Split(path, ".")
+		for i := len(segments) - 1; i >= 1; i-- {
+			ancestor := strings.Join(segments[:i], ".")
+			val := gjson.GetBytes(doc, ancestor)
+			if !val.IsObject() || len(val.Map()) != 0 {
+				break
+			}
+			if _, ok := seen[ancestor]; !ok {
+				seen[ancestor] = struct{}{}
+				out = append(out, ancestor)
+			}
+		}
+	}
+	return out
+}
+
+// pruneAncestors deletes each of the given ancestor paths from the document
+// when it is present and empty, deepest first so a parent emptied only by
+// pruning its children is removed too.
+func pruneAncestors(doc json.RawMessage, ancestors []string) json.RawMessage {
+	for _, ancestor := range ancestors {
+		val := gjson.GetBytes(doc, ancestor)
+		if !val.IsObject() || len(val.Map()) != 0 {
+			continue
+		}
+		next, err := sjson.DeleteBytes(doc, ancestor)
+		if err != nil {
+			continue
+		}
+		doc = next
+	}
+	return doc
+}
+
+// unionSorted returns the union of two path sets, sorted by descending depth
+// (most "." first) then lexically, so pruneAncestors removes a child before its
+// parent.
+func unionSorted(a, b []string) []string {
+	set := map[string]struct{}{}
+	for _, s := range a {
+		set[s] = struct{}{}
+	}
+	for _, s := range b {
+		set[s] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for s := range set {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		di, dj := strings.Count(out[i], "."), strings.Count(out[j], ".")
+		if di != dj {
+			return di > dj
+		}
+		return out[i] < out[j]
+	})
+	return out
+}
+
+// canonicalizeRemainder renders a properties document deterministically
+// (sorted object keys) so two remainders compare as strings. It decodes with
+// UseNumber so a large integer keeps its exact literal instead of collapsing
+// to a float64, which would let two distinct out-of-range integers compare
+// equal and silently pass real drift.
+func canonicalizeRemainder(doc json.RawMessage) (string, error) {
+	dec := json.NewDecoder(bytes.NewReader(doc))
+	dec.UseNumber()
+	var decoded any
+	if err := dec.Decode(&decoded); err != nil {
+		return "", err
+	}
+	return canonicalJSON(decoded), nil
+}
+
+// restrictRawToKeep returns val reduced to the members whose identity is in
+// keep, as raw JSON, and whether anything was kept. For an object (Mapping) it
+// keeps the entries whose key is in keep; for an array (Set/EntitySet) it keeps
+// the elements whose identity is in keep, sorted by their raw form for a
+// deterministic comparison. Each kept member is carried as its verbatim raw
+// JSON, so numeric precision survives. Returns (nil, false) when nothing is
+// kept, so the caller drops the whole path exactly as before.
+func restrictRawToKeep(val gjson.Result, hint pkgmodel.FieldHint, keep map[string]struct{}) (json.RawMessage, bool) {
+	switch {
+	case val.IsObject():
+		out := map[string]json.RawMessage{}
+		val.ForEach(func(key, v gjson.Result) bool {
+			if _, ok := keep[key.String()]; ok {
+				out[key.String()] = json.RawMessage(v.Raw)
+			}
+			return true
+		})
+		if len(out) == 0 {
+			return nil, false
+		}
+		raw, err := json.Marshal(out)
+		if err != nil {
+			return nil, false
+		}
+		return raw, true
+	case val.IsArray():
+		var elems []string
+		val.ForEach(func(_, el gjson.Result) bool {
+			if id, ok := singleElementIdentity(el, hint); ok {
+				if _, keepIt := keep[id]; keepIt {
+					elems = append(elems, el.Raw)
+				}
+			}
+			return true
+		})
+		if len(elems) == 0 {
+			return nil, false
+		}
+		sort.Strings(elems)
+		return json.RawMessage("[" + strings.Join(elems, ",") + "]"), true
+	default:
+		return nil, false
+	}
+}
+
+// coOwnedValueClassifiable reports whether a co-owned field's value can be
+// partitioned into members, and its SHAPE matches the hint's identity rule: a
+// Mapping's value must be an object (its keys are the identities), and a
+// Set/EntitySet's value must be an array every element of which yields an
+// identity. A shape that mismatches the rule (an object where an array is
+// expected, or the reverse), a scalar, or an EntitySet element missing its
+// index field is unclassifiable — restrictToNeverOwned would return nil for it
+// exactly as it does for a legitimately drained collection, so the caller must
+// not neutralize it.
+func coOwnedValueClassifiable(val gjson.Result, hint pkgmodel.FieldHint) bool {
+	mapShaped := pkgmodel.IdentityRule(hint) == "Mapping"
+	switch {
+	case val.IsObject():
+		return mapShaped
+	case val.IsArray():
+		if mapShaped {
+			return false
+		}
+		classifiable := true
+		val.ForEach(func(_, el gjson.Result) bool {
+			if _, ok := singleElementIdentity(el, hint); !ok {
+				classifiable = false
+				return false
+			}
+			return true
+		})
+		return classifiable
+	default:
+		return false
+	}
+}

--- a/internal/metastructure/patch/modification_confront_test.go
+++ b/internal/metastructure/patch/modification_confront_test.go
@@ -1,0 +1,311 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package patch
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+// confrontMappingSchema: a co-owned Mapping label field plus a plain field.
+func confrontMappingSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"Name", "labels"},
+		Hints:  map[string]pkgmodel.FieldHint{"labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+}
+
+// confront keeps a witness parameter in its signature for call-site
+// readability, but the predicate no longer consults a witness: provider-default
+// tolerance for resources the forma does not edit lives in the earlier drift
+// stages, so this predicate confronts any non-co-owned change.
+func confront(t *testing.T, old, new, desired, witness string, prior pkgmodel.OwnedMembers, schema pkgmodel.Schema) bool {
+	t.Helper()
+	_ = witness
+	got, err := ModificationConfrontable(json.RawMessage(old), json.RawMessage(new), json.RawMessage(desired), prior, schema)
+	require.NoError(t, err)
+	return got
+}
+
+// The bug: a co-actor's never-owned member appears out of band. Nothing the
+// user manages moved, so a reconcile need not confront.
+func TestModificationConfrontable_NeverOwnedMemberAdded_Tolerated(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+	got := confront(t,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		`{"Name":"n","labels":{"app":"web","team":"platform"}}`,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		"", prior, confrontMappingSchema())
+	assert.False(t, got, "a never-owned member's appearance is tolerated")
+}
+
+func TestModificationConfrontable_NeverOwnedMemberValueChanged_Tolerated(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+	got := confront(t,
+		`{"Name":"n","labels":{"app":"web","team":"a"}}`,
+		`{"Name":"n","labels":{"app":"web","team":"b"}}`,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		"", prior, confrontMappingSchema())
+	assert.False(t, got, "a never-owned member's value change is tolerated")
+}
+
+// A member the user declares is theirs; its out-of-band change is real drift.
+func TestModificationConfrontable_DeclaredMemberChanged_Confront(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+	got := confront(t,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		`{"Name":"n","labels":{"app":"hacked"}}`,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		"", prior, confrontMappingSchema())
+	assert.True(t, got, "a declared member's out-of-band change must confront")
+}
+
+// A member on the record but no longer declared (being drained): its
+// out-of-band movement still confronts.
+func TestModificationConfrontable_FormerlyOwnedMemberChanged_Confront(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app", "team"}}}
+	got := confront(t,
+		`{"Name":"n","labels":{"app":"web","team":"a"}}`,
+		`{"Name":"n","labels":{"app":"web","team":"b"}}`,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		"", prior, confrontMappingSchema())
+	assert.True(t, got, "a formerly-owned member's out-of-band change must confront")
+}
+
+// A plain (non-co-owned) field moving out of band is always confrontable.
+func TestModificationConfrontable_PlainFieldChanged_Confront(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+	got := confront(t,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		`{"Name":"changed","labels":{"app":"web","team":"x"}}`,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		"", prior, confrontMappingSchema())
+	assert.True(t, got, "a plain field's out-of-band change must confront even beside tolerated movement")
+}
+
+// A witnessed provider-default move confronts; the witness makes it real.
+func TestModificationConfrontable_WitnessedProviderDefault_Confront(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "EnableKeyRotation"},
+		Hints:  map[string]pkgmodel.FieldHint{"EnableKeyRotation": {HasProviderDefault: true}},
+	}
+	got := confront(t,
+		`{"Name":"n","EnableKeyRotation":false}`,
+		`{"Name":"n","EnableKeyRotation":true}`,
+		`{"Name":"n"}`,
+		`{"Name":"n","EnableKeyRotation":false}`, // witness holds a real value
+		nil, schema)
+	assert.True(t, got, "a witnessed provider-default move must confront")
+}
+
+// A provider-default field moving out of band confronts at this predicate.
+// Tolerating first-time, unwitnessed provider-default population is the
+// earlier drift stages' job (a resource the forma does not edit never reaches
+// this predicate); here, everything that is not a never-owned co-owned member
+// stays and confronts.
+func TestModificationConfrontable_ProviderDefaultMove_Confront(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "EnableKeyRotation"},
+		Hints:  map[string]pkgmodel.FieldHint{"EnableKeyRotation": {HasProviderDefault: true}},
+	}
+	got := confront(t,
+		`{"Name":"n"}`,
+		`{"Name":"n","EnableKeyRotation":true}`,
+		`{"Name":"n"}`,
+		"", nil, schema)
+	assert.True(t, got, "a provider-default field's out-of-band move confronts at the predicate level")
+}
+
+func TestModificationConfrontable_NoChange_Tolerated(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+	got := confront(t,
+		`{"Name":"n","labels":{"app":"web","team":"x"}}`,
+		`{"Name":"n","labels":{"app":"web","team":"x"}}`,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		"", prior, confrontMappingSchema())
+	assert.False(t, got, "no movement at all is not confrontable")
+}
+
+// The version=2 rig repro in miniature: a never-owned member is live and the
+// modification is purely that co-actor's content, while the user's edit lives
+// in the plan (not in this modification). Must be tolerated.
+func TestModificationConfrontable_CoActorDriftBesidePendingEdit_Tolerated(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app", "owner"}}}
+	got := confront(t,
+		`{"Name":"n","labels":{"app":"probe","owner":"formae"}}`,
+		`{"Name":"n","labels":{"app":"probe","opinion":"oob","owner":"formae","team":"platform"}}`,
+		`{"Name":"n","labels":{"app":"probe","owner":"formae","version":"2"}}`,
+		"", prior, confrontMappingSchema())
+	assert.False(t, got, "co-actor drift beside a declared edit is tolerated; the edit is not in the modification")
+}
+
+// A provider-default field the user DECLARES is owned by ordinary planning,
+// not suppressed. Its out-of-band change is real drift and must confront —
+// the remainder must not neutralize a declared provider-default field.
+func TestModificationConfrontable_DeclaredProviderDefaultChanged_Confront(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "EnableKeyRotation"},
+		Hints:  map[string]pkgmodel.FieldHint{"EnableKeyRotation": {HasProviderDefault: true}},
+	}
+	got := confront(t,
+		`{"Name":"n","EnableKeyRotation":true}`,
+		`{"Name":"n","EnableKeyRotation":false}`,
+		`{"Name":"n","EnableKeyRotation":true}`, // declared
+		"", nil, schema)
+	assert.True(t, got, "a declared provider-default field's out-of-band change must confront")
+}
+
+// A nested co-owned path whose only content is never-owned must stay
+// tolerated even when neutralizing it leaves empty ancestor objects that
+// differ structurally between the two sides.
+func TestModificationConfrontable_NestedCoOwnedEmptyAncestors_Tolerated(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"meta"},
+		Hints:  map[string]pkgmodel.FieldHint{"meta.labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+	got := confront(t,
+		`{"meta":{"labels":{"team":"x"}}}`,
+		`{}`,
+		`{}`,
+		"", nil, schema)
+	assert.False(t, got, "a nested co-owned path of only never-owned members is tolerated despite empty-ancestor mismatch")
+}
+
+// A plain managed field toggling between a null/empty value and absent is
+// real drift; neutralizing co-owned content must not prune managed nulls or
+// empty containers elsewhere in the document.
+func TestModificationConfrontable_ManagedNullTogglesConfront(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"meta", "config"},
+		Hints:  map[string]pkgmodel.FieldHint{"meta.labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+	// meta.labels carries only a never-owned member (tolerated), but the plain
+	// `config` field flips from null to absent — that must still confront.
+	got := confront(t,
+		`{"meta":{"labels":{"team":"x"}},"config":null}`,
+		`{"meta":{"labels":{"team":"x"}}}`,
+		`{}`,
+		"", nil, schema)
+	assert.True(t, got, "a managed field flipping between null and absent is real drift")
+}
+
+func TestModificationConfrontable_ManagedEmptyObjectTogglesConfront(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"meta", "config"},
+		Hints:  map[string]pkgmodel.FieldHint{"meta.labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+	got := confront(t,
+		`{"meta":{"labels":{"team":"x"}},"config":{}}`,
+		`{"meta":{"labels":{"team":"x"}}}`,
+		`{}`,
+		"", nil, schema)
+	assert.True(t, got, "a managed field flipping between an empty object and absent is real drift")
+}
+
+// The mirror of the empty-ancestor case: the OLD side carries the nested
+// co-owned content and the NEW side already holds an explicitly empty
+// ancestor. Both represent only never-owned movement and must be tolerated.
+func TestModificationConfrontable_NestedCoOwnedEmptyAncestors_MirrorTolerated(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"meta"},
+		Hints:  map[string]pkgmodel.FieldHint{"meta.labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+	got := confront(t,
+		`{"meta":{"labels":{"team":"x"}}}`,
+		`{"meta":{}}`,
+		`{}`,
+		"", nil, schema)
+	assert.False(t, got, "tolerated nested movement is symmetric whether the empty ancestor is old or new")
+}
+
+// A co-owned field carrying an unexpected scalar value cannot be classified
+// into members; its out-of-band change must confront rather than be deleted
+// from both remainders and read as equal.
+func TestModificationConfrontable_CoOwnedScalarChange_Confront(t *testing.T) {
+	got := confront(t,
+		`{"Name":"n","labels":"a"}`,
+		`{"Name":"n","labels":"b"}`,
+		`{"Name":"n","labels":{}}`,
+		"", nil, confrontMappingSchema())
+	assert.True(t, got, "a malformed scalar co-owned value's change must confront")
+}
+
+// An EntitySet whose elements lack the configured identity field cannot be
+// classified; its out-of-band change must confront.
+func TestModificationConfrontable_CoOwnedEntitySetNoIdentity_Confront(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Targets"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Targets": {UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Id", CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	got := confront(t,
+		`{"Targets":[{"Port":80}]}`,
+		`{"Targets":[{"Port":81}]}`,
+		`{"Targets":[]}`,
+		"", nil, schema)
+	assert.True(t, got, "an identity-less EntitySet element's change must confront")
+}
+
+// Large integers beyond float64's exact range must not collapse to equal
+// during canonicalization, or a plain-field drift would be silently tolerated.
+func TestModificationConfrontable_LargeIntegerPrecision_Confront(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+	got := confront(t,
+		`{"Name":"n","serial":9007199254740992,"labels":{"app":"web"}}`,
+		`{"Name":"n","serial":9007199254740993,"labels":{"app":"web","team":"x"}}`,
+		`{"Name":"n","labels":{"app":"web"}}`,
+		"", prior, confrontMappingSchema())
+	assert.True(t, got, "distinct large integers must confront, not collapse to equal")
+}
+
+// A set-shaped co-owned field carrying an object value is malformed: object
+// keys are identities only for a Mapping. Its change must confront, not be
+// neutralized as though the keys were members.
+func TestModificationConfrontable_SetShapedFieldWithObjectValue_Confront(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Groups"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Groups": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	got := confront(t,
+		`{"Groups":{"a":"1"}}`,
+		`{"Groups":{"b":"2"}}`,
+		`{"Groups":[]}`,
+		"", nil, schema)
+	assert.True(t, got, "an object value on a set-shaped co-owned field is malformed and must confront")
+}
+
+// A Mapping-shaped co-owned field carrying an array value is likewise
+// malformed and must confront.
+func TestModificationConfrontable_MappingShapedFieldWithArrayValue_Confront(t *testing.T) {
+	got := confront(t,
+		`{"Name":"n","labels":["a"]}`,
+		`{"Name":"n","labels":["b"]}`,
+		`{"Name":"n","labels":{}}`,
+		"", nil, confrontMappingSchema())
+	assert.True(t, got, "an array value on a Mapping-shaped co-owned field is malformed and must confront")
+}
+
+// A declared co-owned member whose value is a large integer beyond float64
+// precision must confront when it drifts; restriction must not reconstruct it
+// through a lossy float64.
+func TestModificationConfrontable_LargeIntMemberValue_Confront(t *testing.T) {
+	prior := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"serial"}}}
+	got := confront(t,
+		`{"labels":{"serial":9007199254740992}}`,
+		`{"labels":{"serial":9007199254740993}}`,
+		`{"labels":{"serial":9007199254740992}}`,
+		"", prior, confrontMappingSchema())
+	assert.True(t, got, "a declared member's large-integer drift must confront, not collapse via float64")
+}

--- a/internal/metastructure/patch/suppressed_drift.go
+++ b/internal/metastructure/patch/suppressed_drift.go
@@ -39,6 +39,13 @@ type SuppressedFieldDiff struct {
 	From   json.RawMessage
 	To     json.RawMessage
 	Opaque bool
+
+	// CoOwned marks a note produced by the co-owned regime: movement on a
+	// co-owned collection's never-owned members. Such movement is tolerated
+	// by design — a co-actor's members are legitimately not this forma's —
+	// so the note exists to be shown to whoever asks, never to confront:
+	// the reconcile gate must not reject an apply on its account.
+	CoOwned bool
 }
 
 // SuppressedFieldDiffs compares two stored property documents restricted to
@@ -243,12 +250,13 @@ func coOwnedSuppressedDiff(oldProps, newProps, desired json.RawMessage, path str
 	}
 
 	if pathOpaque(schema, path) || valueHasOpaqueMarker(oldRestricted) || valueHasOpaqueMarker(newRestricted) {
-		return SuppressedFieldDiff{Path: path, Opaque: true}, true
+		return SuppressedFieldDiff{Path: path, Opaque: true, CoOwned: true}, true
 	}
 	return SuppressedFieldDiff{
-		Path: path,
-		From: renderRestrictedMembers(oldRestricted),
-		To:   renderRestrictedMembers(newRestricted),
+		Path:    path,
+		From:    renderRestrictedMembers(oldRestricted),
+		To:      renderRestrictedMembers(newRestricted),
+		CoOwned: true,
 	}, true
 }
 

--- a/internal/metastructure/patch/suppressed_drift_test.go
+++ b/internal/metastructure/patch/suppressed_drift_test.go
@@ -683,8 +683,28 @@ func TestSuppressedFieldDiffs_CoOwnedMapping_NeverOwnedMemberChanges_Reported(t 
 	require.Len(t, diffs, 1)
 	assert.Equal(t, "labels", diffs[0].Path)
 	assert.False(t, diffs[0].Opaque)
+	assert.True(t, diffs[0].CoOwned, "a co-owned regime note carries the regime marker")
 	assert.JSONEq(t, `{"theirs": "a"}`, string(diffs[0].From))
 	assert.JSONEq(t, `{"theirs": "b"}`, string(diffs[0].To))
+}
+
+func TestSuppressedFieldDiffs_WitnessRegimeNote_NotMarkedCoOwned(t *testing.T) {
+	// A hasProviderDefault note confronts at the reconcile gate; only the
+	// co-owned regime's notes are tolerated display material.
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Setting"},
+		Hints:  map[string]pkgmodel.FieldHint{"Setting": {HasProviderDefault: true}},
+	}
+
+	diffs, err := SuppressedFieldDiffs(
+		json.RawMessage(`{"Name": "n", "Setting": "a"}`),
+		json.RawMessage(`{"Name": "n", "Setting": "b"}`),
+		json.RawMessage(`{"Name": "n"}`),
+		json.RawMessage(`{"Name": "n", "Setting": "a"}`),
+		nil, schema)
+	require.NoError(t, err)
+	require.Len(t, diffs, 1)
+	assert.False(t, diffs[0].CoOwned)
 }
 
 func TestSuppressedFieldDiffs_CoOwnedMapping_DeclaredMemberDisappears_NoNoteForThatMember(t *testing.T) {


### PR DESCRIPTION
## Summary

Stacked on #748. Makes the reconcile drift gate consult the ownership partition instead of treating every stored version delta as user-facing drift. Three fixes:

- **Tolerated co-owned movement no longer rejects (unchanged forma).** The gate counted every suppressed-drift note as reject-worthy, including the co-owned regime's notes for never-owned member movement (a co-actor's content, tolerated by design). One out-of-band addition to a co-owned collection made every subsequent plain reconcile of an unchanged forma fail permanently. Notes now carry the regime that produced them; the gate counts only witness-regime notes.

- **A record-only update absorbs its modification.** A record-only update commits an ownership claim over current state (empty patch, current properties) — the absorb path itself — so it must not count as a pending change, or the absorb apply is itself gate-rejected. Skipped in the absorption filter beside convergence-only updates.

- **Tolerated co-owned drift on a resource the forma also edits no longer rejects.** `FilterUnabsorbedModifications` marked a resource unabsorbed whenever it had a pending update, so the partition classifier never ran for it — the moment a user edited a resource carrying a co-actor's injected member (a Kubernetes controller label), the tolerated drift resurfaced as a rejection. `ModificationConfrontable` compares the two stored documents with only never-owned co-owned members removed, keeping everything else, so a modification confronts unless its every movement is a co-actor's tolerated member. `RetainConfrontable` applies it as a post-filter at both gate sites (apply and the unattended rotation reconcile). The predicate errs toward confront: any content it cannot prove tolerable stays and confronts, so a false result is a spurious rejection (recoverable with --force), never a silent overwrite of drift.

Verified end-to-end on a local agent built from this branch: after out-of-band co-owned labels and a sync, both a plain reconcile of the unchanged forma and a genuine edit of the same resource are accepted, and the co-actor's labels survive.