### PR TITLE
fix(ownership): record recompute carries claims it cannot see

### DIFF
--- a/internal/metastructure/resource_update/ownership_record_test.go
+++ b/internal/metastructure/resource_update/ownership_record_test.go
@@ -526,3 +526,169 @@ func TestUpdate_LabelOnlyRename_DoesNotOverClaimCoActorMember(t *testing.T) {
 		"a label-only rename must not over-claim a co-actor's live member; got %#v",
 		data.resourceUpdate.DesiredState.OwnedMembers)
 }
+
+// A declared member whose reference is still unresolved at plan time
+// contributes no identity, so the plan-time recompute understates the
+// declaration. The existing claim must be carried, not erased: with the
+// carry there is no ownership delta and no update at all, where an erasing
+// recompute would have produced a record-only update wiping the claim.
+func TestNewResourceUpdateForExisting_OwnershipRecord_DeferredRefCarriesExistingClaim_NoUpdate(t *testing.T) {
+	schema := coOwnedSetSchema()
+	props := json.RawMessage(`{"Tags":[{"$res":true,"$type":"String"}]}`)
+	record := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"sg-1"`}}}
+
+	existing := newResourceForOwnershipTest(schema, "sg", "default", props, record)
+	newRes := newResourceForOwnershipTest(schema, "sg", "default", props, nil)
+	newRes.Ksuid = ""
+
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newRes,
+		ownershipTestTarget(), ownershipTestTarget(), pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.NoError(t, err)
+	assert.Empty(t, updates, "a deferred-ref declaration must carry the claim, not plan a record-only wipe")
+}
+
+// Removing a co-owned declaration entirely (field unset) never drains — the
+// drain trigger is explicit empty — so it must not unclaim either. The
+// prior entry is carried verbatim: no ownership delta, no update, and a
+// later explicit-empty declaration still finds the claims it drains.
+func TestNewResourceUpdateForExisting_OwnershipRecord_UnsetDeclarationKeepsClaim_NoUpdate(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Tags": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	record := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"u1"`}}}
+
+	existing := newResourceForOwnershipTest(schema, "sg", "default", json.RawMessage(`{"Name":"p","Tags":["u1"]}`), record)
+	newRes := newResourceForOwnershipTest(schema, "sg", "default", json.RawMessage(`{"Name":"p"}`), nil)
+	newRes.Ksuid = ""
+
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newRes,
+		ownershipTestTarget(), ownershipTestTarget(), pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.NoError(t, err)
+	assert.Empty(t, updates, "an unset declaration must carry the claim, not plan a record-only wipe")
+}
+
+// An explicitly empty declaration recomputes downward: with nothing left
+// live to drain, the remaining claims are released via a record-only
+// update, so a co-actor's later re-add of the same member is never-owned
+// and tolerated (the one-bounce convergence of the dual-writable pair).
+func TestNewResourceUpdateForExisting_OwnershipRecord_ExplicitEmptyReleasesClaims(t *testing.T) {
+	schema := coOwnedSetSchema()
+	record := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`}}}
+
+	existing := newResourceForOwnershipTest(schema, "sg", "default", json.RawMessage(`{"Tags":[]}`), record)
+	newRes := newResourceForOwnershipTest(schema, "sg", "default", json.RawMessage(`{"Tags":[]}`), nil)
+	newRes.Ksuid = ""
+
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newRes,
+		ownershipTestTarget(), ownershipTestTarget(), pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.NoError(t, err)
+	require.Len(t, updates, 1, "releasing stale claims still needs a record-only update")
+	assert.True(t, updates[0].RecordOnly)
+	assert.Empty(t, updates[0].DesiredState.OwnedMembers,
+		"an explicit empty declaration with nothing live releases the claims")
+}
+
+// A carried prior entry whose Rule no longer matches the field's hint is
+// uninterpretable for the union: a deferred-ref declaration must then fall
+// back to the plain recompute instead of merging members computed under a
+// different identity scheme.
+func TestNewResourceUpdateForExisting_OwnershipRecord_RuleMismatchedPriorNotUnioned(t *testing.T) {
+	schema := coOwnedSetSchema()
+	props := json.RawMessage(`{"Tags":[{"$res":true,"$type":"String"}]}`)
+	record := pkgmodel.OwnedMembers{"Tags": {Rule: "EntitySet/Key", Members: []string{`"sg-1"`}}}
+
+	existing := newResourceForOwnershipTest(schema, "sg", "default", props, record)
+	newRes := newResourceForOwnershipTest(schema, "sg", "default", props, nil)
+	newRes.Ksuid = ""
+
+	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newRes,
+		ownershipTestTarget(), ownershipTestTarget(), pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.NoError(t, err)
+	require.Len(t, updates, 1, "the stale record differs from the empty recompute, so it is rewritten")
+	assert.True(t, updates[0].RecordOnly)
+	assert.Empty(t, updates[0].DesiredState.OwnedMembers,
+		"members recorded under a different identity rule must not be carried into the union")
+}
+
+// Echo recompute, unset face: a genuine write whose declaration no longer
+// covers the co-owned field must carry the prior claim through the echo
+// merge instead of recomputing the path to nothing.
+func TestRecordProgress_OwnershipRecord_UnsetFieldCarriesPriorClaim(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Name", "Tags"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Tags": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+	record := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"u1"`}}}
+	ru := &ResourceUpdate{
+		Operation: OperationUpdate,
+		DesiredState: pkgmodel.Resource{
+			Properties: json.RawMessage(`{"Name":"new"}`),
+			Schema:     schema,
+		},
+		PriorState: pkgmodel.Resource{
+			Properties:   json.RawMessage(`{"Name":"old","Tags":["u1"]}`),
+			Schema:       schema,
+			OwnedMembers: record,
+		},
+		PreviousProperties: json.RawMessage(`{"Name":"old","Tags":["u1"]}`),
+	}
+
+	progress := &plugin.TrackedProgress{
+		ProgressResult: resource.ProgressResult{
+			Operation:          resource.OperationUpdate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			ResourceProperties: json.RawMessage(`{"Name":"new","Tags":["u1"]}`),
+		},
+		Attempts:    1,
+		MaxAttempts: 1,
+	}
+
+	err := ru.RecordProgress(progress)
+	require.NoError(t, err)
+
+	assert.True(t, pkgmodel.OwnedMembersEqual(record, ru.DesiredState.OwnedMembers),
+		"an unset co-owned field must carry its prior claim through the echo, got %#v", ru.DesiredState.OwnedMembers)
+}
+
+// Echo recompute, shrink face: a declaration that still covers the field
+// but dropped a member recomputes downward — the dropped member's claim is
+// released once the write lands, so a co-actor re-adding it afterwards is
+// never-owned and tolerated.
+func TestRecordProgress_OwnershipRecord_ShrinkReleasesDroppedMemberClaim(t *testing.T) {
+	record := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`, `"b"`}}}
+	ru := &ResourceUpdate{
+		Operation: OperationUpdate,
+		DesiredState: pkgmodel.Resource{
+			Properties: json.RawMessage(`{"Tags":["a"]}`),
+			Schema:     coOwnedSetSchema(),
+		},
+		PriorState: pkgmodel.Resource{
+			Properties:   json.RawMessage(`{"Tags":["a","b"]}`),
+			Schema:       coOwnedSetSchema(),
+			OwnedMembers: record,
+		},
+		PreviousProperties: json.RawMessage(`{"Tags":["a","b"]}`),
+	}
+
+	progress := &plugin.TrackedProgress{
+		ProgressResult: resource.ProgressResult{
+			Operation:          resource.OperationUpdate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			ResourceProperties: json.RawMessage(`{"Tags":["a"]}`),
+		},
+		Attempts:    1,
+		MaxAttempts: 1,
+	}
+
+	err := ru.RecordProgress(progress)
+	require.NoError(t, err)
+
+	want := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"a"`}}}
+	assert.True(t, pkgmodel.OwnedMembersEqual(want, ru.DesiredState.OwnedMembers),
+		"a shrink must release the dropped member's claim at the echo, got %#v", ru.DesiredState.OwnedMembers)
+}

--- a/internal/metastructure/resource_update/ownership_record_test.go
+++ b/internal/metastructure/resource_update/ownership_record_test.go
@@ -529,22 +529,23 @@ func TestUpdate_LabelOnlyRename_DoesNotOverClaimCoActorMember(t *testing.T) {
 
 // A declared member whose reference is still unresolved at plan time
 // contributes no identity, so the plan-time recompute understates the
-// declaration. The existing claim must be carried, not erased: with the
-// carry there is no ownership delta and no update at all, where an erasing
-// recompute would have produced a record-only update wiping the claim.
-func TestNewResourceUpdateForExisting_OwnershipRecord_DeferredRefCarriesExistingClaim_NoUpdate(t *testing.T) {
+// declaration. Prior claims must be carried for members still live —
+// "sg-1" keeps its claim — while a claimed member gone from live is
+// released ("gone": the record only ever names provider-visible members,
+// so a co-actor re-adding it later is never-owned and tolerated) and a
+// co-actor's live member is never claimed ("other").
+func TestClaimedMembers_DeferredRefCarriesPriorClaimsStillLive(t *testing.T) {
 	schema := coOwnedSetSchema()
-	props := json.RawMessage(`{"Tags":[{"$res":true,"$type":"String"}]}`)
-	record := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"sg-1"`}}}
+	prior := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"gone"`, `"sg-1"`}}}
 
-	existing := newResourceForOwnershipTest(schema, "sg", "default", props, record)
-	newRes := newResourceForOwnershipTest(schema, "sg", "default", props, nil)
-	newRes.Ksuid = ""
+	claim := claimedMembers(
+		json.RawMessage(`{"Tags":[{"$res":true,"$type":"String"}]}`),
+		json.RawMessage(`{"Tags":["sg-1","other"]}`),
+		prior, schema)
 
-	updates, err := NewResourceUpdateForExisting(resolver.ResolvableProperties{}, nil, existing, newRes,
-		ownershipTestTarget(), ownershipTestTarget(), pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
-	require.NoError(t, err)
-	assert.Empty(t, updates, "a deferred-ref declaration must carry the claim, not plan a record-only wipe")
+	want := pkgmodel.OwnedMembers{"Tags": {Rule: "Set", Members: []string{`"sg-1"`}}}
+	assert.True(t, pkgmodel.OwnedMembersEqual(want, claim),
+		"expected only the still-live prior claim carried, got %#v", claim)
 }
 
 // Removing a co-owned declaration entirely (field unset) never drains — the

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -572,7 +572,11 @@ func (ru *ResourceUpdate) updateResourceUpdateFromProgress(progress *resource.Pr
 		// (the planning-time claim) in place.
 		noFreshDeclaration := ru.RecordOnly || bytes.Equal(declaredDoc, ru.PreviousProperties)
 		if writeOrigin && !noFreshDeclaration {
-			ru.DesiredState.OwnedMembers = claimedMembers(declaredDoc, progress.ResourceProperties, ru.DesiredState.Schema)
+			// PriorState's record is the claim being recomputed FROM: a path
+			// the declaration no longer covers (unset) or cannot identify yet
+			// (an unresolved member) carries its prior entry instead of being
+			// recomputed to nothing — see claimedMembers.
+			ru.DesiredState.OwnedMembers = claimedMembers(declaredDoc, progress.ResourceProperties, ru.PriorState.OwnedMembers, ru.DesiredState.Schema)
 		}
 	}
 

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -271,10 +271,11 @@ func NewResourceUpdateForExisting(
 //     declaration still finds the claims it is supposed to drain.
 //   - A declared collection holding a member with no plan-time identity (an
 //     unresolved reference) understates the declaration, so the prior
-//     entry's members are unioned in rather than dropped. The cost: a
-//     member removed from the declaration in the same edit stays claimed
-//     until the next genuine write recomputes at the echo, where references
-//     are resolved.
+//     entry's still-live members are unioned in rather than dropped (a
+//     member gone from live is released — the record only ever names
+//     provider-visible members). The cost: a live member removed from the
+//     declaration in the same edit stays claimed until the next genuine
+//     write recomputes at the echo, where references are resolved.
 //   - A fully identifiable declaration recomputes downward: a shrink or an
 //     explicit empty releases claims (after its drain), which is what lets
 //     a co-actor's later re-add of the same member be tolerated.
@@ -318,7 +319,7 @@ func claimedMembers(declared, live json.RawMessage, prior pkgmodel.OwnedMembers,
 		claimed := intersectIdentities(declaredMembers, liveMembers)
 		if hasPrior && priorEntry.Rule == pkgmodel.IdentityRule(hint) &&
 			pkgmodel.MemberIdentitiesIncomplete(declaredVal, hint) {
-			claimed = unionIdentities(claimed, priorEntry.Members)
+			claimed = unionIdentities(claimed, intersectIdentities(priorEntry.Members, liveMembers))
 		}
 		if len(claimed) == 0 {
 			continue

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"slices"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/patch"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
@@ -50,7 +51,7 @@ func NewResourceUpdateForExisting(
 	// removed a member this forma also declares), and that is exactly the
 	// legacy-bootstrap case (no record yet, existing==desired byte-for-byte)
 	// the identical-resources return would otherwise swallow.
-	claim := claimedMembers(filteredProps, existingResource.Properties, newResource.Schema)
+	claim := claimedMembers(filteredProps, existingResource.Properties, existingResource.OwnedMembers, newResource.Schema)
 	ownershipDelta := !pkgmodel.OwnedMembersEqual(
 		pkgmodel.NormalizeOwnedMembers(claim, newResource.Schema.Hints),
 		pkgmodel.NormalizeOwnedMembers(existingResource.OwnedMembers, newResource.Schema.Hints))
@@ -260,9 +261,29 @@ func NewResourceUpdateForExisting(
 // this forma declares but the provider does not show — or the reverse — is
 // not claimable yet, so only the intersection earns a record entry. Identity
 // extraction is envelope-flattened (see MemberIdentities): an unresolved
-// $ref/$res/$gen reference contributes nothing to either side. A field whose
-// intersection is empty gets no entry at all.
-func claimedMembers(declared, live json.RawMessage, schema pkgmodel.Schema) pkgmodel.OwnedMembers {
+// $ref/$res/$gen reference contributes nothing to either side.
+//
+// The recompute never drops a claim it cannot see, only ones it can:
+//
+//   - A path absent (or null) in declared is unset. Unset never drains (the
+//     drain trigger is explicit empty), so it must not unclaim either: the
+//     prior entry is carried verbatim, and a later explicit-empty
+//     declaration still finds the claims it is supposed to drain.
+//   - A declared collection holding a member with no plan-time identity (an
+//     unresolved reference) understates the declaration, so the prior
+//     entry's members are unioned in rather than dropped. The cost: a
+//     member removed from the declaration in the same edit stays claimed
+//     until the next genuine write recomputes at the echo, where references
+//     are resolved.
+//   - A fully identifiable declaration recomputes downward: a shrink or an
+//     explicit empty releases claims (after its drain), which is what lets
+//     a co-actor's later re-add of the same member be tolerated.
+//
+// Carrying consults the prior entry only when its Rule matches the field's
+// current hint (a mismatched record is uninterpretable), except the unset
+// case, which copies bytes without interpreting them. A field with no entry
+// and nothing claimable gets no entry at all.
+func claimedMembers(declared, live json.RawMessage, prior pkgmodel.OwnedMembers, schema pkgmodel.Schema) pkgmodel.OwnedMembers {
 	var claim pkgmodel.OwnedMembers
 	for path, hint := range schema.Hints {
 		if hint.CoOwned == nil {
@@ -279,9 +300,26 @@ func claimedMembers(declared, live json.RawMessage, schema pkgmodel.Schema) pkgm
 			continue
 		}
 
-		declaredMembers := pkgmodel.MemberIdentities(gjson.GetBytes(declared, path), hint)
+		priorEntry, hasPrior := prior[path]
+
+		declaredVal := gjson.GetBytes(declared, path)
+		if !declaredVal.Exists() || declaredVal.Type == gjson.Null {
+			if hasPrior {
+				if claim == nil {
+					claim = pkgmodel.OwnedMembers{}
+				}
+				claim[path] = priorEntry
+			}
+			continue
+		}
+
+		declaredMembers := pkgmodel.MemberIdentities(declaredVal, hint)
 		liveMembers := pkgmodel.MemberIdentities(gjson.GetBytes(live, path), hint)
 		claimed := intersectIdentities(declaredMembers, liveMembers)
+		if hasPrior && priorEntry.Rule == pkgmodel.IdentityRule(hint) &&
+			pkgmodel.MemberIdentitiesIncomplete(declaredVal, hint) {
+			claimed = unionIdentities(claimed, priorEntry.Members)
+		}
 		if len(claimed) == 0 {
 			continue
 		}
@@ -292,6 +330,23 @@ func claimedMembers(declared, live json.RawMessage, schema pkgmodel.Schema) pkgm
 		claim[path] = pkgmodel.OwnedPathRecord{Rule: pkgmodel.IdentityRule(hint), Members: claimed}
 	}
 	return claim
+}
+
+// unionIdentities returns the sorted, deduplicated union of a and b.
+func unionIdentities(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for _, s := range a {
+		seen[s] = struct{}{}
+	}
+	for _, s := range b {
+		seen[s] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	slices.Sort(out)
+	return out
 }
 
 // intersectIdentities returns the members of a that also appear in b. Both

--- a/pkg/model/ownership.go
+++ b/pkg/model/ownership.go
@@ -52,9 +52,16 @@ func IdentityRule(hint FieldHint) string {
 //   - array otherwise => the canonical JSON of each element.
 //
 // Reference envelopes ($ref/$res/$gen objects) are flattened to their $value
-// first, recursively; an element whose envelope lacks $value contributes
-// nothing to the result. The result is sorted and deduplicated.
+// first, recursively — a whole-field envelope as much as a per-element one;
+// an envelope lacking $value contributes nothing to the result. The result
+// is sorted and deduplicated.
 func MemberIdentities(value gjson.Result, hint FieldHint) []string {
+	if inner, ok := wholeFieldEnvelopeValue(value); ok {
+		if !inner.Exists() || inner.Type == gjson.Null {
+			return []string{}
+		}
+		return MemberIdentities(inner, hint)
+	}
 	switch {
 	case value.IsObject():
 		var out []string
@@ -81,11 +88,18 @@ func MemberIdentities(value gjson.Result, hint FieldHint) []string {
 // are just not knowable yet — so a record recompute based on them must not
 // drop existing claims.
 func MemberIdentitiesIncomplete(value gjson.Result, hint FieldHint) bool {
+	if inner, ok := wholeFieldEnvelopeValue(value); ok {
+		// A resolved whole-field envelope exposes its members through
+		// $value; only an unresolved one hides them.
+		if !inner.Exists() || inner.Type == gjson.Null {
+			return true
+		}
+		return MemberIdentitiesIncomplete(inner, hint)
+	}
 	switch {
 	case value.IsObject():
-		// A whole-field envelope hides every member; a plain object's
-		// identities are its keys, which are always present.
-		return IsResolvedReference(value) || IsResolvableObject(value) || IsGenObject(value)
+		// A plain object's identities are its keys, which are always present.
+		return false
 	case value.IsArray():
 		incomplete := false
 		value.ForEach(func(_, el gjson.Result) bool {
@@ -111,6 +125,19 @@ func MemberIdentitiesIncomplete(value gjson.Result, hint FieldHint) bool {
 	default:
 		return false
 	}
+}
+
+// wholeFieldEnvelopeValue reports whether value is a reference envelope at
+// the whole-field position ($ref/$res/$gen object) and, if so, returns its
+// $value (which may not exist, or be null, for an unresolved envelope).
+func wholeFieldEnvelopeValue(value gjson.Result) (gjson.Result, bool) {
+	if !value.IsObject() {
+		return gjson.Result{}, false
+	}
+	if IsResolvedReference(value) || IsResolvableObject(value) || IsGenObject(value) {
+		return value.Get("$value"), true
+	}
+	return gjson.Result{}, false
 }
 
 // entitySetIdentities extracts the json-marshaled IndexField value of every

--- a/pkg/model/ownership.go
+++ b/pkg/model/ownership.go
@@ -73,6 +73,46 @@ func MemberIdentities(value gjson.Result, hint FieldHint) []string {
 	}
 }
 
+// MemberIdentitiesIncomplete reports whether the collection holds content
+// that contributes no identity to MemberIdentities: an element (or the whole
+// field value) carrying an unresolved reference envelope, or an EntitySet
+// element without its IndexField. Identities computed from such a value
+// understate the declaration — the members are declared, their identities
+// are just not knowable yet — so a record recompute based on them must not
+// drop existing claims.
+func MemberIdentitiesIncomplete(value gjson.Result, hint FieldHint) bool {
+	switch {
+	case value.IsObject():
+		// A whole-field envelope hides every member; a plain object's
+		// identities are its keys, which are always present.
+		return IsResolvedReference(value) || IsResolvableObject(value) || IsGenObject(value)
+	case value.IsArray():
+		incomplete := false
+		value.ForEach(func(_, el gjson.Result) bool {
+			flat, ok := flattenEnvelope(el)
+			if !ok {
+				incomplete = true
+				return false
+			}
+			if hint.UpdateMethod == FieldUpdateMethodEntitySet {
+				fields, isMap := flat.(map[string]any)
+				if !isMap {
+					incomplete = true
+					return false
+				}
+				if _, present := fields[hint.IndexField]; !present {
+					incomplete = true
+					return false
+				}
+			}
+			return true
+		})
+		return incomplete
+	default:
+		return false
+	}
+}
+
 // entitySetIdentities extracts the json-marshaled IndexField value of every
 // element, after flattening each element's own reference envelope (if any).
 func entitySetIdentities(value gjson.Result, indexField string) []string {

--- a/pkg/model/ownership_test.go
+++ b/pkg/model/ownership_test.go
@@ -222,6 +222,9 @@ func TestMemberIdentitiesIncomplete(t *testing.T) {
 		{"entityset member missing key", `[{"Value":"1"}]`, esHint, true},
 		{"mapping keys always identify", `{"mine":{"$res":true,"$type":"String"}}`, mapHint, false},
 		{"whole-field unresolved envelope", `{"$res":true,"$type":"Mapping"}`, mapHint, true},
+		{"whole-field resolved envelope", `{"$res":true,"$type":"Mapping","$value":{"mine":"1"}}`, mapHint, false},
+		{"whole-field resolved set envelope", `{"$ref":"formae://resource/x#/Ids","$value":["a"]}`, setHint, false},
+		{"whole-field resolved envelope with unresolved member", `{"$ref":"formae://resource/x#/Ids","$value":[{"$ref":"formae://resource/y#/Id"}]}`, setHint, true},
 		{"empty collection", `[]`, setHint, false},
 	}
 	for _, tc := range cases {
@@ -230,4 +233,19 @@ func TestMemberIdentitiesIncomplete(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestMemberIdentities_WholeFieldEnvelopeFlattens(t *testing.T) {
+	setHint := FieldHint{UpdateMethod: FieldUpdateMethodSet}
+
+	got := MemberIdentities(gjson.Parse(`{"$ref":"formae://resource/x#/Ids","$value":["a","b"]}`), setHint)
+	assert.Equal(t, []string{`"a"`, `"b"`}, got,
+		"a resolved whole-field envelope exposes its members through $value")
+
+	got = MemberIdentities(gjson.Parse(`{"$ref":"formae://resource/x#/Ids"}`), setHint)
+	assert.Empty(t, got, "an unresolved whole-field envelope contributes nothing")
+
+	got = MemberIdentities(gjson.Parse(`{"$res":true,"$type":"Mapping","$value":{"mine":"1"}}`), FieldHint{})
+	assert.Equal(t, []string{"mine"}, got,
+		"a resolved whole-field Mapping envelope's identities are its $value's keys")
 }

--- a/pkg/model/ownership_test.go
+++ b/pkg/model/ownership_test.go
@@ -202,3 +202,32 @@ func TestResource_OwnedMembers_AbsentUnmarshalsToNil(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(`{"Label":"sg-1"}`), &decoded))
 	assert.Nil(t, decoded.OwnedMembers)
 }
+
+func TestMemberIdentitiesIncomplete(t *testing.T) {
+	setHint := FieldHint{UpdateMethod: FieldUpdateMethodSet}
+	esHint := FieldHint{UpdateMethod: FieldUpdateMethodEntitySet, IndexField: "Key"}
+	mapHint := FieldHint{}
+
+	cases := []struct {
+		name string
+		json string
+		hint FieldHint
+		want bool
+	}{
+		{"literal set members", `["a","b"]`, setHint, false},
+		{"resolved envelope member", `[{"$ref":"formae://resource/x#/Id","$value":"sg-1"}]`, setHint, false},
+		{"unresolved ref member", `[{"$ref":"formae://resource/x#/Id"}]`, setHint, true},
+		{"unresolved resolvable member", `[{"$res":true,"$type":"String"}]`, setHint, true},
+		{"entityset member with key", `[{"Key":"a","Value":"1"}]`, esHint, false},
+		{"entityset member missing key", `[{"Value":"1"}]`, esHint, true},
+		{"mapping keys always identify", `{"mine":{"$res":true,"$type":"String"}}`, mapHint, false},
+		{"whole-field unresolved envelope", `{"$res":true,"$type":"Mapping"}`, mapHint, true},
+		{"empty collection", `[]`, setHint, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MemberIdentitiesIncomplete(gjson.Parse(tc.json), tc.hint)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #748. The ownership-record recompute derived the new record purely from plan-time-resolvable declared identities, which lost claims in two ways:

- **Reference members.** A member declared through a still-unresolved reference contributes no identity at plan time, so the next covering apply planned a record-only update whose recompute excluded it and committed the erasure. The member silently became never-owned: shrink and explicit-empty stopped draining it. Since most co-owned collection members in practice are declared via references, drains were hollow for the common case.
- **Unset declarations.** Removing the declaration entirely recomputed the path to empty, laundering every claim, even though unset never drains (the drain trigger is explicit empty). A later explicit-empty declaration then found no prior claims and drained nothing.

The recompute now never drops a claim it cannot see:

- An **unset** path carries its prior entry verbatim, so unset neither drains nor unclaims, and a later explicit-empty still finds the claims it is supposed to drain.
- A **declared collection holding a member with no plan-time identity** (an unresolved reference) unions the prior entry's **still-live** members into the recompute, only under a matching identity rule. A claimed member gone from live is released — the record only ever names provider-visible members, so a co-actor's later re-add of it stays never-owned and tolerated.
- A **fully identifiable declaration recomputes downward** exactly as before: shrinks and explicit-empty drains release claims, which is what keeps the dual-writable pair converging after one bounce.

Both commit seams share the logic: the planning-time claim (which also decides whether a record-only update is owed at all) and the write-origin echo merge. `MemberIdentitiesIncomplete` in pkg/model is the completeness probe both use, and identity extraction now flattens whole-field reference envelopes the same way it flattens per-element ones.