### PR TITLE
fix(ownership): desired properties sent to plugins carry tolerated members

### DIFF
--- a/internal/metastructure/patch/desired_projection.go
+++ b/internal/metastructure/patch/desired_projection.go
@@ -46,6 +46,12 @@ func ProjectDesiredForWrite(desired, live json.RawMessage, priorOwned pkgmodel.O
 		if hint.CoOwned == nil || hint.Opaque {
 			continue
 		}
+		// The patch layer ignores a CoOwned hint on an ineligible collection
+		// shape (no identity rule, e.g. Array); the projection must ignore
+		// exactly the same hints or the two representations diverge again.
+		if pkgmodel.IdentityRule(hint) == "" {
+			continue
+		}
 
 		desiredVal := gjson.GetBytes(out, path)
 		if !desiredVal.Exists() || desiredVal.Type == gjson.Null {

--- a/internal/metastructure/patch/desired_projection.go
+++ b/internal/metastructure/patch/desired_projection.go
@@ -1,0 +1,141 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package patch
+
+import (
+	"encoding/json"
+	"fmt"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ProjectDesiredForWrite returns the desired properties with each co-owned
+// collection completed to its intended post-write value: the declared
+// members plus the never-owned live members (a co-actor's content, which the
+// drainable-restricted patch deliberately plans nothing for). Formerly-owned
+// members stay absent — their absence is the drain.
+//
+// The agent hands a plugin two descriptions of one update, DesiredProperties
+// and PatchDocument, and a plugin legitimately acts on either. Without this
+// projection they disagree on a co-owned path by exactly the tolerated
+// members: the patch preserves what the desired document omits, so a
+// desired-state-driven plugin deletes what a patch-driven plugin keeps. With
+// it, DesiredProperties equals PriorProperties with the patch applied, and
+// both plugin styles produce the same cloud state.
+//
+// This is a projection for the plugin-facing copy of an update request ONLY.
+// The durable DesiredState.Properties must stay declared-only: the record
+// recompute at the write echo claims declared-intersect-echo, and a desired
+// document that already contains tolerated members would get them claimed —
+// and later drained — as this forma's own.
+//
+// Per co-owned path: an unset (absent or null) field is skipped — whole-field
+// omit tolerance already keeps every plugin's hands off it. An uninterpretable
+// record (rule mismatch) degrades to no prior, so unclassifiable live members
+// merge in as never-owned — toward tolerance, never toward a deletion. Live
+// members are copied in the stored document's own representation; the
+// plugin-format conversion downstream flattens envelopes the same way it does
+// for declared members.
+func ProjectDesiredForWrite(desired, live json.RawMessage, priorOwned pkgmodel.OwnedMembers, schema pkgmodel.Schema) (json.RawMessage, error) {
+	out := desired
+	for path, hint := range schema.Hints {
+		if hint.CoOwned == nil || hint.Opaque {
+			continue
+		}
+
+		desiredVal := gjson.GetBytes(out, path)
+		if !desiredVal.Exists() || desiredVal.Type == gjson.Null {
+			continue
+		}
+		liveVal := gjson.GetBytes(live, path)
+		if !liveVal.Exists() {
+			continue
+		}
+
+		declared := pkgmodel.MemberIdentities(desiredVal, hint)
+		var prior []string
+		if record, ok := priorOwned[path]; ok && record.Rule == pkgmodel.IdentityRule(hint) {
+			prior = record.Members
+		}
+		liveIDs := pkgmodel.MemberIdentities(liveVal, hint)
+		partition := pkgmodel.PartitionOwnership(declared, prior, liveIDs)
+		if len(partition.NeverOwned) == 0 {
+			continue
+		}
+
+		merged, changed, err := mergeNeverOwned(desiredVal, liveVal, hint, partition.NeverOwned)
+		if err != nil {
+			return nil, fmt.Errorf("failed to project co-owned path %q: %w", path, err)
+		}
+		if !changed {
+			continue
+		}
+		out, err = sjson.SetRawBytes(out, path, merged)
+		if err != nil {
+			return nil, fmt.Errorf("failed to write projected co-owned path %q: %w", path, err)
+		}
+	}
+	return out, nil
+}
+
+// mergeNeverOwned returns desiredVal with live's never-owned members merged
+// in: for an object (Mapping), the never-owned keys with their live values;
+// for an array (Set/EntitySet), the live elements whose identity is
+// never-owned, appended after the declared ones. Members are matched by the
+// same identity computation the partition used, so a live element that
+// contributes no identity is left out (it cannot be classified, and adding
+// it could duplicate a declared member).
+func mergeNeverOwned(desiredVal, liveVal gjson.Result, hint pkgmodel.FieldHint, neverOwned map[string]struct{}) (json.RawMessage, bool, error) {
+	switch {
+	case desiredVal.IsObject() && liveVal.IsObject():
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(desiredVal.Raw), &obj); err != nil {
+			return nil, false, err
+		}
+		if obj == nil {
+			obj = map[string]json.RawMessage{}
+		}
+		changed := false
+		liveVal.ForEach(func(key, val gjson.Result) bool {
+			if _, ok := neverOwned[key.String()]; ok {
+				obj[key.String()] = json.RawMessage(val.Raw)
+				changed = true
+			}
+			return true
+		})
+		if !changed {
+			return nil, false, nil
+		}
+		raw, err := json.Marshal(obj)
+		return raw, true, err
+	case desiredVal.IsArray() && liveVal.IsArray():
+		elements := []json.RawMessage{}
+		for _, el := range desiredVal.Array() {
+			elements = append(elements, json.RawMessage(el.Raw))
+		}
+		changed := false
+		liveVal.ForEach(func(_, el gjson.Result) bool {
+			id, ok := singleElementIdentity(el, hint)
+			if !ok {
+				return true
+			}
+			if _, keep := neverOwned[id]; keep {
+				elements = append(elements, json.RawMessage(el.Raw))
+				changed = true
+			}
+			return true
+		})
+		if !changed {
+			return nil, false, nil
+		}
+		raw, err := json.Marshal(elements)
+		return raw, true, err
+	default:
+		// Shape mismatch (or a non-collection value): nothing safe to merge.
+		return nil, false, nil
+	}
+}

--- a/internal/metastructure/patch/desired_projection_test.go
+++ b/internal/metastructure/patch/desired_projection_test.go
@@ -1,0 +1,135 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package patch
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+)
+
+func projectionMappingSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"labels"},
+		Hints:  map[string]pkgmodel.FieldHint{"labels": {CoOwned: &pkgmodel.CoOwnership{}}},
+	}
+}
+
+func projectionSetSchema() pkgmodel.Schema {
+	return pkgmodel.Schema{
+		Fields: []string{"SecurityGroups"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"SecurityGroups": {UpdateMethod: pkgmodel.FieldUpdateMethodSet, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+}
+
+// A co-actor's live members (never declared, never claimed) join the
+// declared ones; the desired document a plugin acts on then says the same
+// thing the drainable-restricted patch does.
+func TestProjectDesiredForWrite_MappingGainsNeverOwnedKeys(t *testing.T) {
+	record := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+
+	out, err := ProjectDesiredForWrite(
+		json.RawMessage(`{"labels":{"app":"web"}}`),
+		json.RawMessage(`{"labels":{"app":"web","team":"platform","opinion":"oob"}}`),
+		record, projectionMappingSchema())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"labels":{"app":"web","team":"platform","opinion":"oob"}}`, string(out))
+}
+
+// A formerly-owned member (claimed on record, no longer declared) stays
+// absent: its absence IS the drain, for a desired-state-driven plugin
+// exactly as for the patch's restricted remove.
+func TestProjectDesiredForWrite_FormerlyOwnedStaysAbsent(t *testing.T) {
+	record := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app", "team"}}}
+
+	out, err := ProjectDesiredForWrite(
+		json.RawMessage(`{"labels":{"app":"web"}}`),
+		json.RawMessage(`{"labels":{"app":"web","team":"absorbed","opinion":"oob"}}`),
+		record, projectionMappingSchema())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"labels":{"app":"web","opinion":"oob"}}`, string(out))
+}
+
+// Explicit empty drains the formerly-owned portion and preserves the rest:
+// the projected document carries exactly the co-actor's members.
+func TestProjectDesiredForWrite_ExplicitEmptyPreservesNeverOwned(t *testing.T) {
+	record := pkgmodel.OwnedMembers{"labels": {Rule: "Mapping", Members: []string{"app"}}}
+
+	out, err := ProjectDesiredForWrite(
+		json.RawMessage(`{"labels":{}}`),
+		json.RawMessage(`{"labels":{"app":"web","kubernetes.io/metadata.name":"ns"}}`),
+		record, projectionMappingSchema())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"labels":{"kubernetes.io/metadata.name":"ns"}}`, string(out))
+}
+
+// An unset field is skipped entirely: whole-field omit tolerance already
+// keeps every plugin's hands off it, and inventing the field would turn an
+// omitted declaration into an asserted one.
+func TestProjectDesiredForWrite_UnsetFieldUntouched(t *testing.T) {
+	out, err := ProjectDesiredForWrite(
+		json.RawMessage(`{"Name":"n"}`),
+		json.RawMessage(`{"Name":"n","labels":{"team":"platform"}}`),
+		nil, projectionMappingSchema())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"Name":"n"}`, string(out))
+}
+
+// Set listings: never-owned live elements are appended after the declared
+// ones, in the stored document's own representation.
+func TestProjectDesiredForWrite_SetGainsNeverOwnedElements(t *testing.T) {
+	record := pkgmodel.OwnedMembers{"SecurityGroups": {Rule: "Set", Members: []string{`"sg-mine"`}}}
+
+	out, err := ProjectDesiredForWrite(
+		json.RawMessage(`{"SecurityGroups":["sg-mine"]}`),
+		json.RawMessage(`{"SecurityGroups":["sg-mine","sg-oob"]}`),
+		record, projectionSetSchema())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"SecurityGroups":["sg-mine","sg-oob"]}`, string(out))
+}
+
+// A rule-mismatched record is uninterpretable and degrades to no prior:
+// live members it named merge in as never-owned - toward tolerance, never
+// toward a deletion.
+func TestProjectDesiredForWrite_RuleMismatchedRecordDegradesToTolerance(t *testing.T) {
+	record := pkgmodel.OwnedMembers{"SecurityGroups": {Rule: "EntitySet/Key", Members: []string{`"sg-old"`}}}
+
+	out, err := ProjectDesiredForWrite(
+		json.RawMessage(`{"SecurityGroups":["sg-mine"]}`),
+		json.RawMessage(`{"SecurityGroups":["sg-mine","sg-old"]}`),
+		record, projectionSetSchema())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"SecurityGroups":["sg-mine","sg-old"]}`, string(out))
+}
+
+// A declared member echoed in the stored document as a resolved reference
+// envelope must not be duplicated: the envelope's identity matches the
+// declared literal, so it is not never-owned.
+func TestProjectDesiredForWrite_ResolvedEnvelopeMemberNotDuplicated(t *testing.T) {
+	out, err := ProjectDesiredForWrite(
+		json.RawMessage(`{"SecurityGroups":["sg-mine"]}`),
+		json.RawMessage(`{"SecurityGroups":[{"$ref":"formae://resource/x#/GroupId","$value":"sg-mine"}]}`),
+		nil, projectionSetSchema())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"SecurityGroups":["sg-mine"]}`, string(out))
+}
+
+// No co-owned paths, or no never-owned content: the document passes through
+// byte-identical.
+func TestProjectDesiredForWrite_NoNeverOwnedContentPassesThrough(t *testing.T) {
+	in := json.RawMessage(`{"labels":{"app":"web"}}`)
+	out, err := ProjectDesiredForWrite(in,
+		json.RawMessage(`{"labels":{"app":"web"}}`), nil, projectionMappingSchema())
+	require.NoError(t, err)
+	assert.Equal(t, string(in), string(out))
+}

--- a/internal/metastructure/patch/desired_projection_test.go
+++ b/internal/metastructure/patch/desired_projection_test.go
@@ -133,3 +133,21 @@ func TestProjectDesiredForWrite_NoNeverOwnedContentPassesThrough(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, string(in), string(out))
 }
+
+// A CoOwned hint on an ineligible collection shape (no identity rule, e.g.
+// Array) is ignored by the patch layer; the projection must ignore exactly
+// the same hints, or the two representations diverge again.
+func TestProjectDesiredForWrite_IneligibleCoOwnedHintIgnored(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Fields: []string{"Ordered"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Ordered": {UpdateMethod: pkgmodel.FieldUpdateMethodArray, CoOwned: &pkgmodel.CoOwnership{}},
+		},
+	}
+
+	in := json.RawMessage(`{"Ordered":["a"]}`)
+	out, err := ProjectDesiredForWrite(in,
+		json.RawMessage(`{"Ordered":["a","b"]}`), nil, schema)
+	require.NoError(t, err)
+	assert.Equal(t, string(in), string(out))
+}

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -871,6 +871,25 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 	// resource. Only this copy changes; DesiredState.Properties stays the
 	// durable record of the stored hash.
 	desiredForPlugin := data.resourceUpdate.DesiredState
+	// Complete each co-owned collection to its intended post-write value
+	// (declared plus never-owned live members), so DesiredProperties and
+	// PatchDocument tell the plugin the same thing. Only this copy changes;
+	// DesiredState.Properties stays the declared-only durable record the
+	// write-echo recompute claims from.
+	projectedProperties, err := patch.ProjectDesiredForWrite(
+		desiredForPlugin.Properties,
+		data.resourceUpdate.PriorState.Properties,
+		data.resourceUpdate.PriorState.OwnedMembers,
+		desiredForPlugin.Schema,
+	)
+	if err != nil {
+		proc.Log().Error("failed to project co-owned desired properties for plugin: %v", err)
+		data.resourceUpdate.FailureReason = updateRequestFailureReason(err)
+		data.resourceUpdate.MarkAsFailed()
+		return StateFinishedWithError, data, nil, nil
+	}
+	desiredForPlugin.Properties = projectedProperties
+
 	frozenProperties, err := FreezeUnrecoverableOpaqueValues(
 		data.resourceUpdate.PriorState.Properties,
 		desiredForPlugin.Properties,


### PR DESCRIPTION
## Summary

Stacked on #748. The update request hands a plugin two descriptions of one update, `DesiredProperties` and `PatchDocument`, and a plugin legitimately acts on either (aws is patch-driven; kubernetes is desired-state-driven). On a co-owned path they disagreed about post-write state by exactly the tolerated members: the drainable-restricted patch plans nothing for a co-actor's members, while the desired document omits them entirely. Consequences on any desired-state-driven plugin:

- an update touching an unrelated field deleted every tolerated co-actor member of a declared co-owned collection (the kubernetes metadata reconciliation treats desired as complete truth);
- an absorbed member's drain never reached the cluster (the planned remove op was ignored, and server-side apply only removes keys owned by the plugin's own field manager).

The fix makes the contract consistent instead of patching the plugin: `DesiredProperties` is now the complete intended post-write value for every field it contains. Each co-owned declared collection on the **plugin-facing copy** gains the never-owned live members; formerly-owned members stay absent, which is the drain. By construction `DesiredProperties` equals `PriorProperties ⊕ PatchDocument`, so both plugin styles produce the same cloud state, and the kubernetes plugin needs no change at all.

The durable `DesiredState.Properties` stays declared-only: the write-echo record recompute claims declared∩echo, and a desired document that already contained tolerated members would get them claimed — and later drained — as this forma's own. The projection sits at the same request-boundary seam as the opaque freezes, which already rewrite only the plugin-facing copy.

An uninterpretable ownership record (identity-rule mismatch) degrades to "no prior", so unclassifiable live members merge in as never-owned: toward tolerance, never toward a deletion.