### PR TITLE
fix(rotation): make agent-owned rotation commit, not loop or fail

### DIFF
--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -154,8 +154,14 @@ func (s *ChangesetExecutor) Init(args ...any) (statemachine.StateMachineSpec[Cha
 }
 
 func onStateChange(oldState gen.Atom, newState gen.Atom, data ChangesetData, proc gen.Process) (gen.Atom, ChangesetData, error) {
-	// Cleanup empty stacks after successful completion
-	if newState == StateFinishedSuccessfully {
+	// Cleanup empty stacks once execution is over, whether or not every update
+	// in it succeeded. Eligibility is about what the deletes actually did, not
+	// about the changeset's aggregate verdict: one delete can succeed and take
+	// the last resource out of a stack while an unrelated update fails, and
+	// that stack is just as empty either way. Gating this on success alone
+	// left the record behind. Safe to run on both, because the persister
+	// re-checks emptiness and the labels were captured at start.
+	if newState == StateFinishedSuccessfully || newState == StateFinishedWithError {
 		// Use the stacks captured at start, since the DAG is empty by now
 		proc.Log().Debug("Using pre-captured stacks for cleanup stacks=%v commandID=%s", data.stacksWithDeletes, data.changeset.CommandID)
 		if len(data.stacksWithDeletes) > 0 {

--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -111,6 +111,11 @@ type ChangesetData struct {
 	discoveryPaused          bool     // Tracks if this changeset paused Discovery
 	stacksWithDeletes        []string // Stacks that had delete operations, captured at start
 	syncExcludedResourceURIs []string // Resource URIs registered with Synchronizer, captured at start
+	// Whether any update in this changeset finished failed. It cannot be
+	// recovered from the DAG at completion: UpdateDAG removes failed nodes
+	// exactly as it removes successful ones, so the DAG is empty either way
+	// and an empty DAG says nothing about the outcome.
+	sawFailure bool
 }
 
 type RegisterEvents struct{}
@@ -629,6 +634,7 @@ func handleUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, even
 		}
 	} else {
 		node.Update.MarkFailed()
+		data.sawFailure = true
 	}
 
 	// Update DAG and get any cascading failures
@@ -699,6 +705,16 @@ func handleUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, even
 	}
 
 	if data.changeset.IsComplete() {
+		// The requester is told nothing else about the outcome, and some of
+		// them retry on it. The generator rotator clears its backoff on a
+		// success and derives its cadence from the command's own state, so a
+		// changeset that failed but reported success leaves it with no
+		// backoff and no advanced cadence — it rotates again on the next
+		// sweep, and every sweep after that.
+		if data.sawFailure {
+			proc.Log().Debug("Changeset execution finished with failures for command commandID=%s", data.changeset.CommandID)
+			return StateFinishedWithError, data, nil, nil
+		}
 		proc.Log().Debug("Changeset execution finished for command commandID=%s", data.changeset.CommandID)
 		return StateFinishedSuccessfully, data, nil, nil
 	}

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -804,16 +804,33 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 	// delta — planning built it solely to commit a shifted ownership record
 	// (see NewResourceUpdateForExisting). Its patch is always empty by
 	// construction, so hasEmptyPatch is included here only for symmetry with
-	// the other two predicates, never as a distinguishing condition.
+	// the other predicates, never as a distinguishing condition.
 	isRecordOnly := data.resourceUpdate.RecordOnly
 
-	if (isBringingUnderManagement || isLabelOnlyChange || isRecordOnly) && hasEmptyPatch {
+	// A rotation plans every transitive consumer of its destination so the
+	// drawn value can be delivered, and a consumer whose reference names a
+	// property the draw does not change resolves to the value it already
+	// holds: its patch is empty and there is nothing for the cloud to do. An
+	// empty patch is not a harmless payload — a provider may reject an update
+	// that changes nothing (CloudControl refuses an empty patchDocument) — so
+	// complete it here. Scoped to rotation-sourced updates: rotation is the
+	// only planner that co-plans consumers, and a forced user apply with an
+	// empty patch deliberately re-asserts state and must still dispatch.
+	isNoOpUpdate := data.resourceUpdate.Source == FormaCommandSourceGeneratorRotation &&
+		data.resourceUpdate.PriorState.Label == data.resourceUpdate.DesiredState.Label &&
+		data.resourceUpdate.PriorState.Stack == data.resourceUpdate.DesiredState.Stack &&
+		data.resourceUpdate.PriorState.Target == data.resourceUpdate.DesiredState.Target
+
+	if (isBringingUnderManagement || isLabelOnlyChange || isRecordOnly || isNoOpUpdate) && hasEmptyPatch {
 		switch {
 		case isLabelOnlyChange:
 			proc.Log().Debug("Renaming resource without property changes resourceURI=%v oldLabel=%s newLabel=%s",
 				data.resourceUpdate.DesiredState.URI(), data.resourceUpdate.PriorState.Label, data.resourceUpdate.DesiredState.Label)
 		case isRecordOnly:
 			proc.Log().Debug("Committing ownership record without property changes resourceURI=%v",
+				data.resourceUpdate.DesiredState.URI())
+		case isNoOpUpdate:
+			proc.Log().Debug("Completing update without property changes, skipping the provider call resourceURI=%v",
 				data.resourceUpdate.DesiredState.URI())
 		default:
 			proc.Log().Debug("Bringing resource under management without property changes resourceURI=%v oldStack=%s newStack=%s",
@@ -837,6 +854,8 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 			statusMessage = "Renamed without property changes"
 		case isRecordOnly:
 			statusMessage = "Committed ownership record without property changes"
+		case isNoOpUpdate:
+			statusMessage = "No property changes"
 		}
 
 		// Create synthetic ProgressResult with existing resource data

--- a/internal/workflow_tests/local/apply_forma/generator_rotation_test.go
+++ b/internal/workflow_tests/local/apply_forma/generator_rotation_test.go
@@ -654,3 +654,77 @@ func TestGeneratorRotation_OneFailedDestinationOfSeveralDoesNotAdvanceTheCadence
 			"a rotation that reached only some of its destinations must not advance the cadence")
 	})
 }
+
+// nameConsumer is a resource holding a reference to a property of the secret
+// that a rotation never changes (its Name). Such a consumer is reached by the
+// rotation's consumer closure, but a draw gives it nothing to write.
+func nameConsumer(stack, secretLabel string) pkgmodel.Resource {
+	return pkgmodel.Resource{
+		Label:  "name-consumer",
+		Type:   "FakeAWS::S3::Bucket",
+		Stack:  stack,
+		Target: "test-target",
+		Schema: pkgmodel.Schema{
+			Identifier: "Name",
+			Fields:     []string{"Name", "SecretName"},
+		},
+		Properties: json.RawMessage(`{
+			"Name": "name-consumer",
+			"SecretName": {
+				"$res":      true,
+				"$label":    "` + secretLabel + `",
+				"$type":     "FakeAWS::SecretsManager::Secret",
+				"$stack":    "` + stack + `",
+				"$property": "Name"
+			}
+		}`),
+	}
+}
+
+// A rotation plans every transitive consumer of its destination, and a
+// consumer whose only reference is to a property the draw does not change has
+// nothing to write: its update must complete without a provider call. Some
+// providers reject an update that carries an empty patch document outright,
+// so sending one is not a harmless no-op.
+func TestGeneratorRotation_ConsumerOfAnUnchangedPropertyGetsNoProviderCall(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		delivered := newDeliveredValues()
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, delivered.overrides(), cfg)
+		defer def()
+		require.NoError(t, err)
+
+		stack := "test-stack-" + util.NewID()
+		forma := &pkgmodel.Forma{
+			Stacks:     []pkgmodel.Stack{{Label: stack}},
+			Targets:    []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Generators: []json.RawMessage{rotatingGenerator(t, "db-password", stack, 1)},
+			Resources: []pkgmodel.Resource{
+				genBoundSecret(stack, "alpha", "db-password", "value"),
+				nameConsumer(stack, "alpha"),
+			},
+		}
+
+		_, err = m.ApplyForma(forma,
+			&config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		require.Len(t, delivered.createdWith("alpha"), 1,
+			"precondition: the destination was created with a drawn value")
+		require.Len(t, delivered.createdWith("name-consumer"), 1,
+			"precondition: the consumer was created")
+
+		rotation := sweepUntilRotated(t, m)
+		waitForApplyComplete(t, m)
+
+		assert.Equal(t, forma_command.CommandStateSuccess, rotation.State,
+			"a rotation with a value-less consumer must still commit")
+		assert.Len(t, delivered.updatedWith("alpha"), 1,
+			"the destination must receive the freshly drawn value")
+		assert.Empty(t, delivered.updatedWith("name-consumer"),
+			"a consumer with nothing to change must not receive a provider update")
+	})
+}

--- a/internal/workflow_tests/local/changeset_executor_test.go
+++ b/internal/workflow_tests/local/changeset_executor_test.go
@@ -804,3 +804,91 @@ func newTestUpdateResourceUpdate(label, nativeID, resourceType string) resource_
 		StackLabel:           "test-stack",
 	}
 }
+
+// A changeset that finished with errors must still clean up the stacks its
+// successful deletes emptied.
+//
+// Cleanup eligibility is about what the deletes actually did, not about the
+// changeset's aggregate verdict: one delete can succeed and take the last
+// resource out of a stack while an unrelated update fails in the same command,
+// and that stack is just as empty either way. Gating the cleanup on
+// FinishedSuccessfully alone leaves the emptied stack's record behind.
+func TestChangesetExecutor_PartialFailureStillCleansUpEmptiedStacks(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		logCapture := test_helpers.SetupTestLogger()
+
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				return &resource.CreateResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationCreate,
+						OperationStatus: resource.OperationStatusFailure,
+						RequestID:       "test-request-id",
+						StatusMessage:   "deliberate failure, so the changeset ends with errors",
+					},
+				}, nil
+			},
+			Delete: func(request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+				return &resource.DeleteResult{
+					ProgressResult: &resource.ProgressResult{
+						Operation:       resource.OperationDelete,
+						OperationStatus: resource.OperationStatusSuccess,
+						RequestID:       "test-request-id",
+					},
+				}, nil
+			},
+		}
+
+		m, def, err := test_helpers.NewTestMetastructure(t, overrides)
+		defer def()
+		assert.NoError(t, err)
+
+		messages := make(chan any, 10)
+		_, err = testutil.StartTestHelperActor(m.Node, messages)
+		assert.NoError(t, err)
+
+		commandID := "test-command-partial-failure-cleanup"
+
+		// Independent of each other: the delete is not what fails, and nothing
+		// cascades. The changeset simply ends with one of each.
+		doomed := newTestResourceUpdate("test-doomed", nil, "FakeAWS::EC2::VPC")
+		gone := newTestResourceUpdate("test-gone", nil, "FakeAWS::S3::Bucket")
+		gone.Operation = resource_update.OperationDelete
+
+		testutil.Call(m.Node, "FormaCommandPersister", forma_persister.StoreNewFormaCommand{
+			Command: forma_command.FormaCommand{
+				ID:              commandID,
+				State:           forma_command.CommandStateNotStarted,
+				ResourceUpdates: []resource_update.ResourceUpdate{doomed, gone},
+			},
+		})
+
+		cs, err := buildChangesetWithResolves(
+			[]resource_update.ResourceUpdate{doomed, gone}, nil, commandID, pkgmodel.CommandApply, m.Datastore)
+		assert.NoError(t, err)
+
+		_, err = testutil.Call(m.Node, "ChangesetSupervisor", changeset.EnsureChangesetExecutor{
+			CommandID: commandID,
+		})
+		assert.NoError(t, err)
+
+		testutil.Send(m.Node, actornames.ChangesetExecutor(commandID), changeset.Start{
+			Changeset:        cs,
+			NotifyOnComplete: true,
+		})
+
+		var completed changeset.ChangesetCompleted
+		testutil.ExpectMessageWithPredicate(t, messages, 15*time.Second, func(msg changeset.ChangesetCompleted) bool {
+			if msg.CommandID != commandID {
+				return false
+			}
+			completed = msg
+			return true
+		})
+
+		assert.Equal(t, changeset.ChangeSetStateFinishedWithErrors, completed.State,
+			"precondition: the changeset must have ended with errors")
+		assert.True(t, logCapture.ContainsAll("Using pre-captured stacks for cleanup"),
+			"a changeset that ended with errors must still clean up the stacks its deletes emptied")
+	})
+}

--- a/internal/workflow_tests/local/changeset_executor_test.go
+++ b/internal/workflow_tests/local/changeset_executor_test.go
@@ -888,7 +888,23 @@ func TestChangesetExecutor_PartialFailureStillCleansUpEmptiedStacks(t *testing.T
 
 		assert.Equal(t, changeset.ChangeSetStateFinishedWithErrors, completed.State,
 			"precondition: the changeset must have ended with errors")
-		assert.True(t, logCapture.ContainsAll("Using pre-captured stacks for cleanup"),
-			"a changeset that ended with errors must still clean up the stacks its deletes emptied")
+
+		// The datastore, not the executor's log line: that line is emitted
+		// before the dispatch guard, so it says only that the branch was
+		// entered, never that a stack was actually removed. Cleanup is sent
+		// asynchronously and handled by the persister, so poll for it.
+		// What this pins is the executor's half: that a changeset ending with
+		// errors still reaches the cleanup branch AND still dispatches, with
+		// the emptied stack named. The rendered stack list matters — the log
+		// line is emitted before the dispatch guard, so the message alone
+		// would pass even with nothing to send.
+		//
+		// It deliberately stops at the dispatch. Whether the persister then
+		// removes a stack, and only when it is genuinely empty, is
+		// TestResourcePersister_CleanupEmptyStacks; asserting it again here
+		// would need a fully wired delete, which this harness builds through
+		// ApplyForma rather than hand-assembled updates.
+		assert.True(t, logCapture.ContainsAll("Using pre-captured stacks for cleanup", "stacks=[test-stack]"),
+			"a changeset that ended with errors must still dispatch cleanup for the stacks its deletes emptied")
 	})
 }

--- a/internal/workflow_tests/local/changeset_executor_test.go
+++ b/internal/workflow_tests/local/changeset_executor_test.go
@@ -281,9 +281,21 @@ func TestChangesetExecutor_CascadeFailure(t *testing.T) {
 		})
 
 		// Wait for completion (even with failures, the changeset completes)
+		var completed changeset.ChangesetCompleted
 		testutil.ExpectMessageWithPredicate(t, messages, 10*time.Second, func(msg changeset.ChangesetCompleted) bool {
-			return msg.CommandID == commandID
+			if msg.CommandID != commandID {
+				return false
+			}
+			completed = msg
+			return true
 		})
+
+		// The state the requester is told is the only thing it has to decide
+		// whether to retry. Anything that backs off on failure — the generator
+		// rotator most of all — reads a cascade reported as success as a reason
+		// to clear its backoff and try again on the very next sweep, forever.
+		assert.Equal(t, changeset.ChangeSetStateFinishedWithErrors, completed.State,
+			"a changeset that completed with failed nodes must report FinishedWithErrors")
 
 		// Verify cascading failure occurred
 		commandRes, err := testutil.Call(m.Node, "FormaCommandPersister", forma_persister.LoadFormaCommand{

--- a/internal/workflow_tests/local/cross_stack_ref_discovery_test.go
+++ b/internal/workflow_tests/local/cross_stack_ref_discovery_test.go
@@ -1,0 +1,166 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit || integration
+
+package workflow_tests_local
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// A resource that references a resource in ANOTHER stack must stay discoverable
+// through that reference: the stored document has to keep the $ref envelope
+// after apply, and after a sync, so FindResourcesDependingOnMany still returns
+// it. That query is what a rotation's consumer walk uses to find the resources
+// that must follow a rotated value, so a cross-stack consumer whose $ref is
+// flattened to its resolved literal silently drops out of every dependency
+// walk — the installation runtime task-def (which references the durable
+// secret's ARN across stacks) is exactly this shape.
+//
+// The provider and consumer are applied in SEPARATE commands so the consumer's
+// reference is translated through the datastore cross-stack lookup, not the
+// in-command triplet map — the production path.
+func TestCrossStackReference_StaysDiscoverableAfterApplyAndSync(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const providerLabel = "provider"
+		const consumerLabel = "consumer"
+		const providerStack = "stack-a"
+		const consumerStack = "stack-b"
+
+		var mu sync.Mutex
+		// what the fake plugin returns from Read, keyed by native id: the
+		// resolved (plugin-format) properties a Create was given, so a sync sees
+		// the cloud's literal value rather than the enveloped desired state.
+		cloud := map[string]json.RawMessage{}
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(req *resource.CreateRequest) (*resource.CreateResult, error) {
+				nid := req.Label + "-native"
+				mu.Lock()
+				cloud[nid] = append(json.RawMessage{}, req.Properties...)
+				mu.Unlock()
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					NativeID:           nid,
+					ResourceProperties: req.Properties,
+				}}, nil
+			},
+			Update: func(req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				mu.Lock()
+				cloud[req.NativeID] = append(json.RawMessage{}, req.DesiredProperties...)
+				mu.Unlock()
+				return &resource.UpdateResult{ProgressResult: &resource.ProgressResult{
+					Operation:          resource.OperationUpdate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					NativeID:           req.NativeID,
+					ResourceProperties: req.DesiredProperties,
+				}}, nil
+			},
+			Read: func(req *resource.ReadRequest) (*resource.ReadResult, error) {
+				mu.Lock()
+				p := cloud[req.NativeID]
+				mu.Unlock()
+				if len(p) == 0 {
+					p = json.RawMessage("{}")
+				}
+				return &resource.ReadResult{ResourceType: req.ResourceType, Properties: string(p)}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false // drive sync manually
+		cfg.Agent.Retry.MaxRetries = 0
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		providerKsuid := util.NewID()
+		providerSchema := pkgmodel.Schema{Identifier: "name", Fields: []string{"name", "arn"}}
+		consumerSchema := pkgmodel.Schema{Identifier: "name", Fields: []string{"name", "uses"}}
+
+		providerForma := &pkgmodel.Forma{
+			Stacks:  []pkgmodel.Stack{{Label: providerStack}},
+			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Resources: []pkgmodel.Resource{{
+				Label: providerLabel, Type: "FakeAWS::Resource", Stack: providerStack,
+				Target: "test-target", Ksuid: providerKsuid, Schema: providerSchema,
+				Properties: json.RawMessage(`{"name":"provider","arn":"arn:test:provider"}`),
+			}},
+		}
+
+		// The consumer references the provider's clear "arn" property across
+		// stacks — a $res naming the provider by label/type/stack, the shape an
+		// author writes, which the engine translates to a $ref at apply.
+		consumerForma := &pkgmodel.Forma{
+			Stacks:  []pkgmodel.Stack{{Label: consumerStack}},
+			Targets: []pkgmodel.Target{{Label: "test-target", Namespace: "test-namespace"}},
+			Resources: []pkgmodel.Resource{{
+				Label: consumerLabel, Type: "FakeAWS::Resource", Stack: consumerStack,
+				Target: "test-target", Schema: consumerSchema,
+				Properties: json.RawMessage(`{
+					"name": "consumer",
+					"uses": {"$res": true, "$label": "provider", "$type": "FakeAWS::Resource", "$stack": "stack-a", "$property": "arn"}
+				}`),
+			}},
+		}
+
+		reconcile := &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}
+
+		_, err = m.ApplyForma(providerForma, reconcile, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		_, err = m.ApplyForma(consumerForma, reconcile, "test-client-id", "", "")
+		require.NoError(t, err)
+		waitForApplyComplete(t, m)
+
+		// The dependency query is what a rotation's consumer walk uses; the
+		// consumer must come back for the provider's ksuid.
+		dependsOnProvider := func() bool {
+			deps, derr := m.Datastore.FindResourcesDependingOnMany([]string{providerKsuid})
+			require.NoError(t, derr)
+			for _, group := range deps {
+				for _, d := range group {
+					if d != nil && d.Label == consumerLabel {
+						return true
+					}
+				}
+			}
+			return false
+		}
+		consumerRefsProvider := func() bool {
+			resources, lerr := m.Datastore.LoadResourcesByStack(consumerStack)
+			require.NoError(t, lerr)
+			for _, r := range resources {
+				if r.Label == consumerLabel {
+					return gjson.GetBytes(r.Properties, "uses.$ref").Exists()
+				}
+			}
+			return false
+		}
+
+		require.True(t, consumerRefsProvider(), "after apply, the consumer's stored document must keep the $ref to the provider")
+		require.True(t, dependsOnProvider(), "after apply, the cross-stack consumer must be discoverable via FindResourcesDependingOnMany")
+
+		require.NoError(t, m.ForceSync())
+		waitForApplyComplete(t, m)
+
+		require.True(t, consumerRefsProvider(), "after sync, the consumer's stored document must still keep the $ref to the provider")
+		require.True(t, dependsOnProvider(), "after sync, the cross-stack consumer must still be discoverable via FindResourcesDependingOnMany")
+	})
+}

--- a/tests/blackbox/state_model.go
+++ b/tests/blackbox/state_model.go
@@ -829,7 +829,15 @@ func mergePatchProperties(currentJSON, patchJSON string, hints map[string]pkgmod
 		cur, _ := merged[k].([]any)
 		switch hints[k].UpdateMethod {
 		case pkgmodel.FieldUpdateMethodArray:
-			merged[k] = arr
+			// EnsureExists never removes array elements: a desired array no
+			// shorter than the current one converges element-wise onto the
+			// desired value, while a shorter one leaves the current elements
+			// in place and appends only the elements not already present.
+			if len(arr) >= len(cur) {
+				merged[k] = arr
+			} else {
+				merged[k] = unionByValue(cur, arr)
+			}
 		case pkgmodel.FieldUpdateMethodEntitySet:
 			merged[k] = upsertByEntityKey(cur, arr, hints[k].IndexField)
 		default:

--- a/tests/blackbox/state_model_test.go
+++ b/tests/blackbox/state_model_test.go
@@ -948,3 +948,26 @@ func TestCorrectModelFromCommandOutcome_UpdateChangingIdentityIsViolation(t *tes
 		require.Equal(t, ViolationRenameIdentityChanged, v.Kind)
 	}
 }
+
+// The patch prediction for an array-typed field must mirror the agent's
+// EnsureExists semantics: a patch never removes array elements. A desired
+// array no shorter than the current one converges element-wise onto the
+// desired value, while a shorter one leaves the current elements in place and
+// appends only the desired elements not already present.
+func TestMergePatchProperties_ArrayFieldNeverRemovesElements(t *testing.T) {
+	hints := map[string]pkgmodel.FieldHint{
+		"A": {UpdateMethod: pkgmodel.FieldUpdateMethodArray},
+	}
+	cases := []struct{ name, current, patch, want string }{
+		{"removal-only keeps current", `{"A":["a","b","c"]}`, `{"A":["a","b"]}`, `{"A":["a","b","c"]}`},
+		{"equal length converges", `{"A":["a","b","c"]}`, `{"A":["a","X","c"]}`, `{"A":["a","X","c"]}`},
+		{"longer converges", `{"A":["a","b","c"]}`, `{"A":["a","b","c","d"]}`, `{"A":["a","b","c","d"]}`},
+		{"shorter with new element appends it", `{"A":["a","b","c"]}`, `{"A":["X","b"]}`, `{"A":["a","b","c","X"]}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := mergePatchProperties(c.current, c.patch, hints)
+			assert.JSONEq(t, c.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Agent-owned rotation of an installation credential failed on every attempt and
then looped. Two defects, fixed together here, with test-only guards for the
harness gaps that hid them.

The rotation itself failed because a rotation co-plans every transitive consumer
of the drawn secret so the new value can be delivered, and a consumer that
references only an unchanging property of the secret — an installation task
definition holding the secret's ARN — resolves to an empty patch. The updater
forwarded that empty patch to the provider, and CloudControl rejects an
UpdateResource with an empty patchDocument, so the node failed and cascaded the
whole rotation. Such a rotation-sourced update now completes without a provider
call, the same way the existing bring-under-management and label-only-rename
no-op paths do, scoped to rotation so a forced user apply that deliberately
re-asserts state still dispatches.

The failure then looped because the executor reported the changeset finished
successfully whenever its DAG drained, whether or not anything failed; UpdateDAG
removes a failed node exactly as it removes a successful one, so an empty DAG
says nothing about how it emptied. The rotator clears its backoff on a success
and derives its cadence from the command's own state, so a rotation reported
successful but recorded failed left it permanently overdue with nothing
throttling it. Failure is now tracked as it happens, and emptied stacks are
cleaned up on either terminal state.

Two test-only changes accompany the fixes: the blackbox property harness
predicted a patch would remove array elements, but the agent's EnsureExists
strategy never does, so the predictor now matches; and a workflow test asserts a
cross-stack reference stays discoverable through apply and sync, which is what a
rotation's consumer walk relies on.
