### PR TITLE
fix(metastructure): refuse target replace that cascades across stacks

### DIFF
--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -783,19 +783,21 @@ func generateResourceUpdatesForReconcile(
 		return nil, fmt.Errorf("failed to load existing stacks: %w", err)
 	}
 
-	// Pre-flight portability check for target replace
+	// Pre-flight portability check for target replace. Every managed resource
+	// on a replaced target is deleted and recreated — including resources in
+	// stacks the forma does not reconcile, which are recreated to preserve
+	// those stacks. The only exception is a resource in a reconciled stack
+	// that the forma no longer declares: that one is implicitly deleted, and
+	// deletion needs no portability.
 	if len(replacedTargets) > 0 {
-		// In reconcile mode, check resources that are in the forma.
-		// Resources not in the forma will just be deleted (reconcile semantics), not recreated.
+		formaStacks := make(map[string]bool)
 		formaResourceKeys := make(map[string]bool)
 		for _, r := range forma.Resources {
+			formaStacks[r.Stack] = true
 			if replacedTargets[r.Target] {
 				formaResourceKeys[fmt.Sprintf("%s/%s/%s", r.Stack, r.Type, r.Label)] = true
 			}
 		}
-
-		// If no resources in forma (target-only), all DB resources will be recreated, so check all
-		checkAllResources := len(formaResourceKeys) == 0
 
 		var nonPortable []string
 		var nonPortableTarget string
@@ -807,13 +809,15 @@ func generateResourceUpdatesForReconcile(
 				if !resource.Managed || !replacedTargets[resource.Target] {
 					continue
 				}
-				if !resource.Schema.Portable {
-					key := fmt.Sprintf("%s/%s/%s", resource.Stack, resource.Type, resource.Label)
-					if checkAllResources || formaResourceKeys[key] {
-						nonPortable = append(nonPortable, fmt.Sprintf("%s/%s/%s", resource.Stack, resource.Type, resource.Label))
-						if nonPortableTarget == "" {
-							nonPortableTarget = resource.Target
-						}
+				if resource.Schema.Portable {
+					continue
+				}
+				key := fmt.Sprintf("%s/%s/%s", resource.Stack, resource.Type, resource.Label)
+				implicitlyDeleted := formaStacks[resource.Stack] && !formaResourceKeys[key]
+				if !implicitlyDeleted {
+					nonPortable = append(nonPortable, key)
+					if nonPortableTarget == "" {
+						nonPortableTarget = resource.Target
 					}
 				}
 			}

--- a/internal/metastructure/resource_update/resource_update_generator_target_replace_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_target_replace_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
@@ -132,6 +133,126 @@ func TestGenerateResourceUpdates_TargetReplace_Reconcile_StackNotInForma(t *test
 		}
 		if u.Operation == OperationCreate && u.DesiredState.Label == "api-func" {
 			createCount++
+		}
+	}
+	assert.Equal(t, 1, deleteCount, "should have 1 delete for api-func")
+	assert.Equal(t, 1, createCount, "should have 1 create for api-func")
+}
+
+func TestGenerateResourceUpdates_TargetReplace_Reconcile_NonPortableInOtherStack_Rejected(t *testing.T) {
+	ds := newMockDatastore()
+	ksuidCrd := util.NewID()
+
+	// A non-portable resource lives in stack "apps", which the forma does not
+	// reconcile. A target replace would delete and recreate it, so the apply
+	// must refuse instead of cascading onto the other stack.
+	crdSchema := pkgmodel.Schema{
+		Fields:   []string{"Spec"},
+		Portable: false,
+	}
+	existingCrd := &pkgmodel.Resource{
+		Label:      "widget-crd",
+		Type:       "K8S::Apiextensions::CustomResourceDefinition",
+		Stack:      "apps",
+		Target:     "k8s-target",
+		Ksuid:      ksuidCrd,
+		Managed:    true,
+		Properties: json.RawMessage(`{"Spec":{"group":"example.com"}}`),
+		Schema:     crdSchema,
+	}
+	ds.resourcesByStack["apps"] = []*pkgmodel.Resource{existingCrd}
+	ds.triplet[pkgmodel.TripletKey{Stack: "apps", Label: "widget-crd", Type: "K8S::Apiextensions::CustomResourceDefinition"}] = ksuidCrd
+
+	existingTargets := []*pkgmodel.Target{
+		{Label: "k8s-target", Namespace: "k8s", Config: json.RawMessage(`{"context":"cluster-a"}`)},
+	}
+
+	// The forma declares its own stack with a new resource on the replaced target.
+	forma := &pkgmodel.Forma{
+		Stacks:  []pkgmodel.Stack{{Label: "storage"}},
+		Targets: []pkgmodel.Target{{Label: "k8s-target", Namespace: "k8s", Config: json.RawMessage(`{"context":"cluster-b"}`)}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label:      "fast-class",
+				Type:       "K8S::Storage::StorageClass",
+				Stack:      "storage",
+				Target:     "k8s-target",
+				Managed:    true,
+				Properties: json.RawMessage(`{"Provisioner":"rancher.io/local-path"}`),
+				Schema:     pkgmodel.Schema{Fields: []string{"Provisioner"}, Portable: false},
+			},
+		},
+	}
+
+	replacedTargets := map[string]bool{"k8s-target": true}
+
+	_, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+		FormaCommandSourceUser, existingTargets, ds, replacedTargets, nil, false)
+
+	require.Error(t, err)
+	var nonPortableErr apimodel.NonPortableResourcesError
+	require.ErrorAs(t, err, &nonPortableErr)
+	assert.Equal(t, "k8s-target", nonPortableErr.TargetLabel)
+	assert.Contains(t, nonPortableErr.Resources, "apps/K8S::Apiextensions::CustomResourceDefinition/widget-crd")
+}
+
+func TestGenerateResourceUpdates_TargetReplace_Reconcile_PortableInOtherStack_Replaced(t *testing.T) {
+	ds := newMockDatastore()
+	ksuidFunc := util.NewID()
+
+	// A portable resource in a stack the forma does not reconcile may be
+	// recreated on the replaced target: portability is the plugin's claim
+	// that the move is safe.
+	existingFunc := &pkgmodel.Resource{
+		Label:      "api-func",
+		Type:       "AWS::Lambda::Function",
+		Stack:      "api",
+		Target:     "aws-prod",
+		Ksuid:      ksuidFunc,
+		Managed:    true,
+		Properties: json.RawMessage(`{"FunctionName":"my-api"}`),
+		Schema:     pkgmodel.Schema{Fields: []string{"FunctionName"}, Portable: true},
+	}
+	ds.resourcesByStack["api"] = []*pkgmodel.Resource{existingFunc}
+	ds.triplet[pkgmodel.TripletKey{Stack: "api", Label: "api-func", Type: "AWS::Lambda::Function"}] = ksuidFunc
+
+	existingTargets := []*pkgmodel.Target{
+		{Label: "aws-prod", Namespace: "aws", Config: json.RawMessage(`{"region":"us-east-1"}`)},
+	}
+
+	forma := &pkgmodel.Forma{
+		Stacks:  []pkgmodel.Stack{{Label: "web"}},
+		Targets: []pkgmodel.Target{{Label: "aws-prod", Namespace: "aws", Config: json.RawMessage(`{"region":"us-west-2"}`)}},
+		Resources: []pkgmodel.Resource{
+			{
+				Label:      "bucket-a",
+				Type:       "AWS::S3::Bucket",
+				Stack:      "web",
+				Target:     "aws-prod",
+				Managed:    true,
+				Properties: json.RawMessage(`{"BucketName":"my-bucket"}`),
+				Schema:     pkgmodel.Schema{Fields: []string{"BucketName"}, Portable: true},
+			},
+		},
+	}
+
+	replacedTargets := map[string]bool{"aws-prod": true}
+
+	updates, err := GenerateResourceUpdates(forma, pkgmodel.CommandApply, pkgmodel.FormaApplyModeReconcile,
+		FormaCommandSourceUser, existingTargets, ds, replacedTargets, nil, false)
+
+	require.NoError(t, err)
+
+	deleteCount := 0
+	createCount := 0
+	for _, u := range updates {
+		if u.DesiredState.Label == "api-func" {
+			switch u.Operation {
+			case OperationDelete:
+				deleteCount++
+			case OperationCreate:
+				createCount++
+			}
 		}
 	}
 	assert.Equal(t, 1, deleteCount, "should have 1 delete for api-func")


### PR DESCRIPTION
## Summary

- A reconcile-mode apply that replaces a target's config delete+recreates every managed resource on that target across **all** stacks — including stacks the forma does not reconcile, which are recreated to preserve them. The pre-flight portability gate, however, only checked resources *declared in the forma being applied*, so a forma applying a fresh stack could silently cascade a delete+recreate onto another stack riding the same target label. For a `CustomResourceDefinition` that deletes every custom resource of its type: real data loss from an apply of an unrelated forma.
- The gate now checks every managed non-portable resource on the replaced target that would be recreated, regardless of which stack it lives in. The only exemption is a resource in a reconciled stack that the forma no longer declares: that one is implicitly deleted, and deletion needs no portability. Portable resources keep the existing auto-replace behavior, and patch mode already checked all resources on the target.
- The pre-existing comment claiming non-forma resources "will just be deleted, not recreated" described behavior the code below it never had.

Verified end to end on a live agent: a stack holding a CRD + custom resource on a shared target label, then an apply of a different stack changing that target's config — previously cascaded delete+recreate onto the CRD, now refuses with the same `NonPortableResourcesError` guidance the in-forma path already produced.