### PR TITLE
refactor(discovery): retire the legacy tag-based label keys

### DIFF
--- a/internal/cli/profile/configview/view.go
+++ b/internal/cli/profile/configview/view.go
@@ -126,7 +126,6 @@ func agentView(a pkgmodel.AgentConfig, mask string) map[string]any {
 		"discovery": map[string]any{
 			"enabled":                 a.Discovery.Enabled,
 			"interval":                dur(a.Discovery.Interval),
-			"labelTagKeys":            a.Discovery.LabelTagKeys,
 			"resourceTypesToDiscover": a.Discovery.ResourceTypesToDiscover,
 		},
 		"logging": map[string]any{

--- a/internal/metastructure/resource_update/resource_labeler.go
+++ b/internal/metastructure/resource_update/resource_labeler.go
@@ -33,31 +33,22 @@ func NewResourceLabeler(ds ResourceDataLookup) *ResourceLabeler {
 
 // LabelForUnmanagedResource generates a label for a discovered resource.
 // Uses JSONPath query from labelConfig to extract label value from properties.
-// Falls back to legacy tagLabelKeys, then to nativeID if no label can be extracted.
+// Falls back to nativeID if no label can be extracted.
 //
 // Resolution order:
 // 1. Plugin's ResourceOverrides[resourceType] (if exists)
 // 2. Plugin's DefaultQuery
-// 3. Legacy tagLabelKeys (for backwards compatibility)
-// 4. NativeID (fallback)
+// 3. NativeID (fallback)
 func (l *ResourceLabeler) LabelForUnmanagedResource(
 	nativeID string,
 	resourceType string,
 	properties json.RawMessage,
 	labelConfig pkgmodel.LabelConfig,
-	legacyTagKeys []string,
 ) string {
 	// Try JSONPath query first (from LabelConfig)
 	query := labelConfig.QueryForResourceType(resourceType)
 	if query != "" {
 		if label := l.extractLabelFromQuery(properties, query); label != "" {
-			return l.ensureUnique(label)
-		}
-	}
-
-	// Legacy fallback: use tag keys from config
-	if len(legacyTagKeys) > 0 {
-		if label := l.extractLabelFromLegacyTagKeys(properties, legacyTagKeys); label != "" {
 			return l.ensureUnique(label)
 		}
 	}
@@ -109,28 +100,6 @@ func (l *ResourceLabeler) extractLabelFromQuery(properties json.RawMessage, quer
 	}
 
 	return strings.Join(parts, labelSeparator)
-}
-
-// extractLabelFromLegacyTagKeys extracts a label using the legacy tag-based approach.
-// This is kept for backwards compatibility with existing configurations.
-func (l *ResourceLabeler) extractLabelFromLegacyTagKeys(properties json.RawMessage, tagKeys []string) string {
-	tags := pkgmodel.GetTagsFromProperties(properties)
-	tagMap := make(map[string]string)
-	for _, tag := range tags {
-		tagMap[tag.Key] = tag.Value
-	}
-
-	var labelParts []string
-	for _, key := range tagKeys {
-		if value, exists := tagMap[key]; exists && value != "" {
-			labelParts = append(labelParts, value)
-		}
-	}
-
-	if len(labelParts) > 0 {
-		return strings.Join(labelParts, labelSeparator)
-	}
-	return ""
 }
 
 // ensureUnique returns a label that no existing resource holds, incrementing

--- a/internal/metastructure/resource_update/resource_labeler_test.go
+++ b/internal/metastructure/resource_update/resource_labeler_test.go
@@ -18,12 +18,6 @@ import (
 )
 
 // Helper to create properties JSON from tags
-func tagsToProperties(tags []pkgmodel.Tag) json.RawMessage {
-	props := map[string]any{"Tags": tags}
-	data, _ := json.Marshal(props)
-	return data
-}
-
 // Tests for JSONPath-based label extraction (new LabelConfig)
 
 func TestLabelForUnmanagedResource_UsesJSONPathQuery(t *testing.T) {
@@ -34,7 +28,7 @@ func TestLabelForUnmanagedResource_UsesJSONPathQuery(t *testing.T) {
 	}
 
 	l := newResourceLabelerForTest(t)
-	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig, nil)
+	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig)
 	assert.Equal(t, "MyInstance", label)
 }
 
@@ -49,7 +43,7 @@ func TestLabelForUnmanagedResource_UsesResourceOverride(t *testing.T) {
 	}
 
 	l := newResourceLabelerForTest(t)
-	label := l.LabelForUnmanagedResource(nativeId, "AWS::IAM::Policy", properties, labelConfig, nil)
+	label := l.LabelForUnmanagedResource(nativeId, "AWS::IAM::Policy", properties, labelConfig)
 	assert.Equal(t, "MyPolicy", label)
 }
 
@@ -61,7 +55,7 @@ func TestLabelForUnmanagedResource_FallsBackToNativeID_WhenQueryReturnsNoResult(
 	}
 
 	l := newResourceLabelerForTest(t)
-	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig, nil)
+	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig)
 	assert.Equal(t, nativeId, label)
 }
 
@@ -71,7 +65,7 @@ func TestLabelForUnmanagedResource_FallsBackToNativeID_WhenNoLabelConfig(t *test
 	labelConfig := pkgmodel.LabelConfig{} // Empty config
 
 	l := newResourceLabelerForTest(t)
-	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig, nil)
+	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig)
 	assert.Equal(t, nativeId, label)
 }
 
@@ -83,7 +77,7 @@ func TestLabelForUnmanagedResource_HandlesEmptyProperties(t *testing.T) {
 	}
 
 	l := newResourceLabelerForTest(t)
-	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig, nil)
+	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig)
 	assert.Equal(t, nativeId, label)
 }
 
@@ -94,7 +88,7 @@ func TestLabelForUnmanagedResource_HandlesNilProperties(t *testing.T) {
 	}
 
 	l := newResourceLabelerForTest(t)
-	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", nil, labelConfig, nil)
+	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", nil, labelConfig)
 	assert.Equal(t, nativeId, label)
 }
 
@@ -107,54 +101,12 @@ func TestLabelForUnmanagedResource_ConcatenatesMultipleQueryResults(t *testing.T
 	}
 
 	l := newResourceLabelerForTest(t)
-	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig, nil)
+	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig)
 	// Should concatenate both matching tag values with separator
 	assert.Equal(t, "MyInstance-Production", label)
 }
 
 // Tests for legacy tag-based label extraction (backwards compatibility)
-
-func TestLabelForUnmanagedResource_FallsBackToLegacyTagKeys(t *testing.T) {
-	nativeId := "i-1234567890abcdef0"
-	properties := tagsToProperties([]pkgmodel.Tag{
-		{Key: "Name", Value: "MyInstance"},
-		{Key: "Project", Value: "Alpha"},
-	})
-	labelConfig := pkgmodel.LabelConfig{} // Empty config, should fall back to legacy
-	legacyTagKeys := []string{"Name", "Project"}
-
-	l := newResourceLabelerForTest(t)
-	label := l.LabelForUnmanagedResource(nativeId, "FakeAWS::S3::Bucket", properties, labelConfig, legacyTagKeys)
-	assert.Equal(t, "MyInstance-Alpha", label)
-}
-
-func TestLabelForUnmanagedResource_ReturnsNativeIdWhenNoTagKeysAreFound(t *testing.T) {
-	nativeId := "i-1234567890abcdef0"
-	properties := tagsToProperties([]pkgmodel.Tag{
-		{Key: "Environment", Value: "Production"},
-		{Key: "Owner", Value: "Alice"},
-	})
-	labelConfig := pkgmodel.LabelConfig{}
-	legacyTagKeys := []string{"Name", "Project"}
-
-	l := newResourceLabelerForTest(t)
-	label := l.LabelForUnmanagedResource(nativeId, "FakeAWS::S3::Bucket", properties, labelConfig, legacyTagKeys)
-	assert.Equal(t, nativeId, label)
-}
-
-func TestLabelForUnmanagedResource_HandlesMissingTagValuesGracefully(t *testing.T) {
-	nativeId := "i-1234567890abcdef0"
-	properties := tagsToProperties([]pkgmodel.Tag{
-		{Key: "Name", Value: "MyInstance"},
-		{Key: "Environment", Value: "Production"},
-	})
-	labelConfig := pkgmodel.LabelConfig{}
-	legacyTagKeys := []string{"Name", "Project"}
-
-	l := newResourceLabelerForTest(t)
-	label := l.LabelForUnmanagedResource(nativeId, "FakeAWS::S3::Bucket", properties, labelConfig, legacyTagKeys)
-	assert.Equal(t, "MyInstance", label)
-}
 
 // Tests for label uniqueness
 
@@ -170,7 +122,7 @@ func TestLabelForUnmanagedResource_AppendsIncrementingNumberForDuplicates(t *tes
 		assert.NoError(t, err)
 	})
 
-	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig, nil)
+	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig)
 	assert.Equal(t, "MyInstance-1", label)
 }
 
@@ -186,7 +138,7 @@ func TestLabelForUnmanagedResource_IncrementsExistingVersion(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig, nil)
+	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig)
 	assert.Equal(t, "MyInstance-6", label)
 }
 
@@ -206,7 +158,7 @@ func TestLabelForUnmanagedResource_DoesNotMintTakenNumericNeighbor(t *testing.T)
 		}
 	})
 
-	label := l.LabelForUnmanagedResource("i-00000000000000002", "AWS::EC2::Instance", properties, labelConfig, nil)
+	label := l.LabelForUnmanagedResource("i-00000000000000002", "AWS::EC2::Instance", properties, labelConfig)
 	assert.NotEqual(t, "server-1", label)
 	assert.NotEqual(t, "server-2", label)
 }
@@ -229,7 +181,7 @@ func TestLabelForUnmanagedResource_RepeatedDuplicateNamesStayUnique(t *testing.T
 
 	seen := make(map[string]bool)
 	for i := 0; i < 3; i++ {
-		label := l.LabelForUnmanagedResource("i-00000000000000000", "AWS::EC2::Instance", properties, labelConfig, nil)
+		label := l.LabelForUnmanagedResource("i-00000000000000000", "AWS::EC2::Instance", properties, labelConfig)
 		assert.False(t, seen[label], "label %q minted twice", label)
 		seen[label] = true
 
@@ -239,20 +191,6 @@ func TestLabelForUnmanagedResource_RepeatedDuplicateNamesStayUnique(t *testing.T
 }
 
 // Tests for LabelConfig priority (JSONPath query takes precedence over legacy tag keys)
-
-func TestLabelForUnmanagedResource_JSONPathQueryTakesPrecedenceOverLegacyTagKeys(t *testing.T) {
-	nativeId := "i-1234567890abcdef0"
-	properties := json.RawMessage(`{"Tags":[{"Key":"Name","Value":"FromJSONPath"},{"Key":"LegacyTag","Value":"FromLegacy"}]}`)
-	labelConfig := pkgmodel.LabelConfig{
-		DefaultQuery: `$.Tags[?(@.Key=='Name')].Value`,
-	}
-	legacyTagKeys := []string{"LegacyTag"}
-
-	l := newResourceLabelerForTest(t)
-	label := l.LabelForUnmanagedResource(nativeId, "AWS::EC2::Instance", properties, labelConfig, legacyTagKeys)
-	// Should use JSONPath query result, not legacy tag keys
-	assert.Equal(t, "FromJSONPath", label)
-}
 
 func newResourceLabelerForTest(t *testing.T, setup ...func(datastore.Datastore)) *resource_update.ResourceLabeler {
 	t.Helper()

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -218,7 +218,6 @@ type ResourceUpdateData struct {
 	resourceUpdate  *ResourceUpdate
 	commandID       string
 	labelConfig     pkgmodel.LabelConfig // JSONPath-based label extraction config from plugin
-	labelTagKeys    []string             // Legacy tag-based label keys for backwards compatibility
 	resourceLabeler *ResourceLabeler
 	retryConfig     pkgmodel.RetryConfig
 	requestedBy     gen.PID
@@ -269,13 +268,6 @@ func (r *ResourceUpdater) Init(args ...any) (statemachine.StateMachineSpec[Resou
 		return statemachine.StateMachineSpec[ResourceUpdateData]{}, fmt.Errorf("resourceUpdater: missing 'RetryConfig' environment variable")
 	}
 	data.retryConfig = pluginCfg.(pkgmodel.RetryConfig)
-
-	discoveryCfg, ok := r.Env("DiscoveryConfig")
-	if !ok {
-		r.Log().Error("ResourceUpdater: missing 'DiscoveryConfig' environment variable")
-		return statemachine.StateMachineSpec[ResourceUpdateData]{}, fmt.Errorf("resourceUpdater: missing 'DiscoveryConfig' environment variable")
-	}
-	data.labelTagKeys = discoveryCfg.(pkgmodel.DiscoveryConfig).LabelTagKeys
 
 	ds, ok := r.Env("Datastore")
 	if !ok {
@@ -1112,7 +1104,6 @@ func handleProgressUpdate(from gen.PID, state gen.Atom, data ResourceUpdateData,
 				data.resourceUpdate.DesiredState.Type,
 				data.resourceUpdate.DesiredState.Properties,
 				data.labelConfig,
-				data.labelTagKeys,
 			)
 		}
 

--- a/internal/schema/pkl/assets/formae/Config.pkl
+++ b/internal/schema/pkl/assets/formae/Config.pkl
@@ -122,10 +122,6 @@ class RetryConfig {
 class DiscoveryConfig {
     enabled: Boolean = true
 
-    labelTagKeys: Listing<String> = new Listing<String> {
-        "Name"
-    }
-
     interval: Duration = 10.min
 
     resourceTypesToDiscover: Listing<String> = new Listing<String> { }

--- a/internal/schema/pkl/model/config.go
+++ b/internal/schema/pkl/model/config.go
@@ -140,7 +140,6 @@ type User struct {
 type DiscoveryConfig struct {
 	Enabled                 bool          `pkl:"enabled"`
 	Interval                *pkl.Duration `pkl:"interval"`
-	LabelTagKeys            []string      `pkl:"labelTagKeys"`
 	ResourceTypesToDiscover []string      `pkl:"resourceTypesToDiscover"`
 }
 

--- a/internal/schema/pkl/pkl.go
+++ b/internal/schema/pkl/pkl.go
@@ -231,7 +231,6 @@ func translateConfig(config *pklmodel.Config) (*pkgmodel.Config, error) {
 			Discovery: pkgmodel.DiscoveryConfig{
 				Enabled:                 config.Agent.Discovery.Enabled,
 				Interval:                config.Agent.Discovery.Interval.GoDuration(),
-				LabelTagKeys:            config.Agent.Discovery.LabelTagKeys,
 				ResourceTypesToDiscover: config.Agent.Discovery.ResourceTypesToDiscover,
 			},
 			Logging: pkgmodel.LoggingConfig{

--- a/internal/schema/pkl/pkl_test.go
+++ b/internal/schema/pkl/pkl_test.go
@@ -233,7 +233,6 @@ func TestPkl_FormaeConfig(t *testing.T) {
 
 	assert.True(t, config.Agent.Discovery.Enabled)
 	assert.Equal(t, 20*time.Minute, config.Agent.Discovery.Interval)
-	assert.Equal(t, []string{"Name", "Environment"}, config.Agent.Discovery.LabelTagKeys)
 
 	assert.Equal(t, "/var/log/formae.log", config.Agent.Logging.FilePath)
 	assert.Equal(t, slog.LevelDebug, config.Agent.Logging.FileLogLevel)

--- a/internal/schema/pkl/testdata/config/test_config.pkl
+++ b/internal/schema/pkl/testdata/config/test_config.pkl
@@ -42,10 +42,6 @@ agent {
     }
     discovery {
         enabled = true
-        labelTagKeys = new Listing<String> {
-            "Name"
-            "Environment"
-        }
         interval = 20.min
     }
     logging {

--- a/internal/workflow_tests/local/discovery_test.go
+++ b/internal/workflow_tests/local/discovery_test.go
@@ -505,7 +505,7 @@ func TestDiscovery_OverlapProtection(t *testing.T) {
 	})
 }
 
-func TestDiscovery_NoTagKeysAreFound_LabelIsSetToNativeId(t *testing.T) {
+func TestDiscovery_NoLabelQueryMatch_LabelIsSetToNativeId(t *testing.T) {
 	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
 		overrides := &plugin.ResourcePluginOverrides{
 			List: func(req *resource.ListRequest) (*resource.ListResult, error) {
@@ -550,7 +550,6 @@ func TestDiscovery_NoTagKeysAreFound_LabelIsSetToNativeId(t *testing.T) {
 		}
 
 		cfg := test_helpers.NewTestMetastructureConfig()
-		cfg.Agent.Discovery.LabelTagKeys = []string{"Name"}
 
 		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
 		defer def()

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -211,7 +211,6 @@ type LoggingConfig struct {
 type DiscoveryConfig struct {
 	Enabled                 bool
 	Interval                time.Duration
-	LabelTagKeys            []string
 	ResourceTypesToDiscover []string
 }
 


### PR DESCRIPTION
Discovered resources get their label from a JSONPath query the plugin supplies, falling back to a tag-key list from agent config (`agent.discovery.labelTagKeys`), then to the native id. The tag-key list predates the query mechanism. This removes it.

## Why it is safe

- All 13 resource plugins declare a `DefaultQuery`, so the fallback is shadowed whenever the query matches.
- Where an AWS-shaped query misses, the fallback misses with it: the config default is `["Name"]`, and the query it backs up is `$.Tags[?(@.Key=='Name')].Value` — the same tag. Redundant, not a second chance.
- The only plugins with no query are the Kubernetes ones, and `GetTagsFromProperties` reads an AWS-style `Tags` array that Kubernetes objects do not carry, so those already fall through to the native id.

The workflow test that covered this path is the evidence: renamed to `TestDiscovery_NoLabelQueryMatch_LabelIsSetToNativeId`, with the `labelTagKeys` config line dropped, it still passes. A bucket with a Name tag labels as `pretty-bucket` via the plugin query, one without falls back to the native id. The fake plugin declares the same query as the real AWS plugin.

## The one behaviour change

A config that set `labelTagKeys` to keys **other** than the default loses a real lookup: newly discovered resources the plugin query cannot label take the native id instead of those tag values. Already-persisted labels are untouched. This is the line for the release notes.

`labelTagKeys` is removed from `Config.pkl`, so a config still setting it will fail to evaluate rather than be silently ignored.

## Also

Removing the field left the resource updater holding a `DiscoveryConfig` lookup with no reader — an existence check for a value it no longer used, so it goes too. Discovery and the resource persister still read and validate that config.

130 deletions, 14 insertions. Build clean, lint `0 issues.`, affected unit tests pass. One unrelated pre-existing failure on this machine (`TestAppThemeOmarchyFallsBackWhenAbsent`) reproduces identically on unmodified main.