### PR TITLE
fix(metastructure): name the surviving object when a persist fails after a cloud write

### DIFF
--- a/internal/metastructure/resource_update/persist_failure_reason_test.go
+++ b/internal/metastructure/resource_update/persist_failure_reason_test.go
@@ -1,0 +1,154 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"ergo.services/ergo/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// errPersistRefused is the shape a persist failure takes at the updater: the
+// call to the resource persister does not complete.
+var errPersistRefused = errors.New("persister call timed out")
+
+// persistFailingProcess fails every proc.Call, so the persist that follows a
+// successful plugin operation cannot complete. Sends still succeed, matching a
+// persister that accepts async messages but cannot commit writes.
+type persistFailingProcess struct {
+	*stubUpdaterProcess
+	log *capturingLog
+}
+
+func (p *persistFailingProcess) Log() gen.Log { return p.log }
+
+func (p *persistFailingProcess) Call(_ any, _ any) (any, error) {
+	return nil, errPersistRefused
+}
+
+func newPersistFailingProcess() *persistFailingProcess {
+	return &persistFailingProcess{stubUpdaterProcess: &stubUpdaterProcess{}, log: &capturingLog{}}
+}
+
+// A create the provider completed but formae could not persist leaves a live
+// cloud object with no record: destroy will not find it and a re-apply can
+// collide with it. The failure must carry a reason naming the surviving
+// object, not the empty ErrorMessage a reason-less failure produces when
+// every recorded plugin progress is a success.
+func TestHandleProgressUpdate_PersistFailureAfterCreate_NamesSurvivingObject(t *testing.T) {
+	const nativeID = "arn:aws:cloudfront::000000000000:response-headers-policy/abc123"
+
+	ru := &ResourceUpdate{
+		Operation: OperationCreate,
+		DesiredState: pkgmodel.Resource{
+			Label:      "edge-policy",
+			Type:       "AWS::CloudFront::ResponseHeadersPolicy",
+			Stack:      "web",
+			Properties: json.RawMessage(`{"Name":"edge-policy"}`),
+		},
+		ResourceTarget: pkgmodel.Target{Label: "us-east-1"},
+	}
+	data := ResourceUpdateData{resourceUpdate: ru, commandID: "cmd-1"}
+
+	progress := plugin.TrackedProgress{
+		ProgressResult: resource.ProgressResult{
+			Operation:          resource.OperationCreate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			NativeID:           nativeID,
+			ResourceProperties: json.RawMessage(`{"Name":"edge-policy"}`),
+		},
+	}
+
+	proc := newPersistFailingProcess()
+	state, _, _, err := handleProgressUpdate(gen.PID{}, StateCreating, data, progress, proc)
+
+	require.NoError(t, err)
+	require.Equal(t, StateFinishedWithError, state, "a failed persist must fail the resource update")
+	require.Contains(t, strings.Join(proc.log.all(), "\n"), "failed to persist resource update",
+		"the intended failure site must be the one that fired")
+
+	message := ru.MostRecentFailureMessage()
+	require.NotEmpty(t, message, "a persist failure after a successful cloud write must surface a reason")
+	assert.Contains(t, message, nativeID, "the reason must name the surviving cloud object")
+	assert.NotContains(t, message, errPersistRefused.Error(),
+		"the underlying persist error stays in the agent log, not the operator-facing reason")
+}
+
+// Recording a successful create's progress can itself fail (the provider's
+// echo does not merge), which strands the cloud object exactly the way a
+// failed persist does: created, unrecorded, invisible to destroy. The same
+// reason contract applies.
+func TestHandleProgressUpdate_RecordProgressFailureAfterCreate_NamesSurvivingObject(t *testing.T) {
+	const nativeID = "arn:aws:cloudfront::000000000000:response-headers-policy/def456"
+
+	ru := &ResourceUpdate{
+		Operation: OperationCreate,
+		DesiredState: pkgmodel.Resource{
+			Label:      "edge-policy",
+			Type:       "AWS::CloudFront::ResponseHeadersPolicy",
+			Stack:      "web",
+			Properties: json.RawMessage(`{"Name":"edge-policy"}`),
+		},
+		ResourceTarget: pkgmodel.Target{Label: "us-east-1"},
+	}
+	data := ResourceUpdateData{resourceUpdate: ru, commandID: "cmd-1"}
+
+	progress := plugin.TrackedProgress{
+		ProgressResult: resource.ProgressResult{
+			Operation:       resource.OperationCreate,
+			OperationStatus: resource.OperationStatusSuccess,
+			NativeID:        nativeID,
+			// An echo that cannot be merged into the recorded properties.
+			ResourceProperties: json.RawMessage(`{"Name":`),
+		},
+	}
+
+	proc := newPersistFailingProcess()
+	state, _, _, err := handleProgressUpdate(gen.PID{}, StateCreating, data, progress, proc)
+
+	require.NoError(t, err)
+	require.Equal(t, StateFinishedWithError, state, "a failed progress record must fail the resource update")
+
+	message := ru.MostRecentFailureMessage()
+	require.NotEmpty(t, message, "a progress-record failure after a successful cloud write must surface a reason")
+	assert.Contains(t, message, nativeID, "the reason must name the surviving cloud object")
+}
+
+// Every operation the persist can follow gets its own consequence: only a
+// create leaves an unmanaged object behind, an update leaves a stale record,
+// a delete leaves a lingering record, and a read loses only the observation.
+func TestPersistFailureReason_Categories(t *testing.T) {
+	const nativeID = "native-1"
+
+	create := persistFailureReason(resource.OperationCreate, nativeID)
+	assert.Contains(t, create, nativeID, "a create's reason must name the surviving object")
+	assert.Contains(t, create, "not under formae's management")
+
+	createNoID := persistFailureReason(resource.OperationCreate, "")
+	assert.NotContains(t, createNoID, `""`, "a missing native id must not render as an empty quote")
+	assert.Contains(t, createNoID, "not under formae's management")
+
+	update := persistFailureReason(resource.OperationUpdate, nativeID)
+	assert.Contains(t, update, "stale")
+	assert.NotContains(t, update, "not under formae's management", "an update's record still exists")
+
+	del := persistFailureReason(resource.OperationDelete, nativeID)
+	assert.Contains(t, del, "still lists it")
+
+	read := persistFailureReason(resource.OperationRead, nativeID)
+	assert.Contains(t, read, "next synchronization will retry")
+	assert.NotContains(t, read, nativeID, "a read's reason has no surviving object to name")
+}

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -747,6 +747,28 @@ const (
 	failureReasonPluginDispatchOnCreate = "cannot create this resource: formae could not complete the request to the provider plugin, so the resource may or may not have been created — check the provider before retrying."
 )
 
+// persistFailureReason is the operator-facing reason for a persist that failed
+// AFTER the provider finished an operation successfully: the cloud side is
+// done, but formae could not store the outcome, so the operator must be told
+// what survived. Worded per the operation that completed. Parameterized only
+// by the provider-assigned native id — never the underlying error, which
+// stays in the agent log.
+func persistFailureReason(op resource.Operation, nativeID string) string {
+	switch op {
+	case resource.OperationCreate:
+		if nativeID == "" {
+			return "cannot record this resource: the provider created it, but formae could not store its record, so it is not under formae's management. Check the provider before retrying: a re-apply may conflict with the existing object."
+		}
+		return fmt.Sprintf("cannot record this resource: the provider created it, but formae could not store its record, so it is not under formae's management. The object exists in the cloud with native id %q; check the provider before retrying, since a re-apply may conflict with it.", nativeID)
+	case resource.OperationUpdate:
+		return "cannot record this resource: the provider applied the update, but formae could not store the result, so formae's record of the resource is stale. A later synchronization will re-read it from the provider."
+	case resource.OperationDelete:
+		return "cannot record this resource: the provider deleted it, but formae could not remove its record, so formae still lists it. A later synchronization or a destroy retry will reconcile the record."
+	default:
+		return "cannot record this resource: formae read it from the provider but could not store the observation. The next synchronization will retry."
+	}
+}
+
 // isUnrecoverableOpaqueValue reports whether preparing a plugin request failed
 // because formae holds only a stored hash of an opaque value.
 func isUnrecoverableOpaqueValue(err error) bool {
@@ -1063,6 +1085,12 @@ func handleProgressUpdate(from gen.PID, state gen.Atom, data ResourceUpdateData,
 	err := data.resourceUpdate.RecordProgress(&message)
 	if err != nil {
 		proc.Log().Error("failed to record progress for resource update: %v", err)
+		// A successful plugin operation whose progress cannot be recorded
+		// strands the cloud object the same way a failed persist does:
+		// done at the provider, unrecorded here.
+		if message.FinishedSuccessfully() {
+			data.resourceUpdate.FailureReason = persistFailureReason(currentOperation(state), message.NativeID)
+		}
 		data.resourceUpdate.MarkAsFailed()
 		return StateFinishedWithError, data, nil, nil
 	}
@@ -1126,6 +1154,7 @@ func handleProgressUpdate(from gen.PID, state gen.Atom, data ResourceUpdateData,
 
 		if err != nil {
 			proc.Log().Error("failed to persist resource update: %v", err)
+			data.resourceUpdate.FailureReason = persistFailureReason(operation, data.resourceUpdate.DesiredState.NativeID)
 			data.resourceUpdate.MarkAsFailed()
 			return StateFinishedWithError, data, nil, nil
 		}


### PR DESCRIPTION
## Summary

- A resource update whose plugin operation succeeded but whose persist failed was marked failed with an **empty ErrorMessage**: every recorded plugin progress is a success, so `MostRecentFailureMessage` had nothing to fall back to. For a create this silently orphans the cloud object — it exists at the provider, formae holds no record of it, destroy reports clean with nothing to delete, and a re-apply collides with already-exists.
- Both sites in `handleProgressUpdate` that can strand a completed cloud operation (the persister call, and recording the successful progress itself) now record an operator-facing `FailureReason`, worded per the operation that completed: a **create** names the surviving object's native id and warns that a re-apply may conflict with it; an **update** points at the stale record; a **delete** at the lingering one; a **read** at the retrying synchronization.
- The underlying persist error stays in the agent log, matching the fixed-text discipline the request-preparation reasons established (an error string can carry user-authored property paths; these reasons are parameterized only by the provider-assigned native id).

The resource-before-command persist ordering already prevented the command record from showing Success for an unpersisted resource; this closes the remaining silence, where the failure surfaced with no reason and no pointer to the object left behind.