### PR TITLE
feat(reaping): provider default reaping rides the target Config annotation

### DIFF
--- a/internal/datastore/aurora/aurora.go
+++ b/internal/datastore/aurora/aurora.go
@@ -2863,7 +2863,7 @@ func (d *DatastoreAuroraDataAPI) CreateTarget(target *pkgmodel.Target) (string, 
 	}
 
 	var configSchemaParam types.Field
-	if len(target.ConfigSchema.Hints) > 0 {
+	if !target.ConfigSchema.IsZero() {
 		csJSON, err := json.Marshal(target.ConfigSchema)
 		if err != nil {
 			return "", fmt.Errorf("failed to marshal config schema: %w", err)
@@ -2978,7 +2978,7 @@ func (d *DatastoreAuroraDataAPI) UpdateTarget(target *pkgmodel.Target) (string, 
 	}
 
 	var configSchemaParam types.Field
-	if len(target.ConfigSchema.Hints) > 0 {
+	if !target.ConfigSchema.IsZero() {
 		csJSON, err := json.Marshal(target.ConfigSchema)
 		if err != nil {
 			return "", fmt.Errorf("failed to marshal config schema: %w", err)

--- a/internal/datastore/dstest/dstest.go
+++ b/internal/datastore/dstest/dstest.go
@@ -184,6 +184,7 @@ func RunAll(t *testing.T, newDS func(t *testing.T) TestDatastore) {
 	RunCountResourcesInTargetUsesByteOrderForVersionComparison(t, newDS)
 	RunDeleteTargetSuccess(t, newDS)
 	RunUpdateTargetNotFoundReturnsError(t, newDS)
+	RunTargetProviderSchemaRoundTrip(t, newDS)
 	RunDeleteTargetNotFound(t, newDS)
 	RunTargetHealthDefaults(t, newDS)
 	RunTargetHealthStableAcrossUpdate(t, newDS)

--- a/internal/datastore/dstest/suite_targets.go
+++ b/internal/datastore/dstest/suite_targets.go
@@ -14,6 +14,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/datastore"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func setupQueryTargetsTestData(ds datastore.Datastore, t *testing.T) {
@@ -351,5 +352,30 @@ func RunDeleteTargetNotFound(t *testing.T, newDS func(t *testing.T) TestDatastor
 		_, err := ds.DeleteTarget("non-existent-target")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "does not exist")
+	})
+}
+
+// A ConfigHint can carry provider reaping without any field mutability hints.
+// Both create and update must retain that schema for subsequent admission.
+func RunTargetProviderSchemaRoundTrip(t *testing.T, newDS func(t *testing.T) TestDatastore) {
+	t.Run("Target_ProviderSchema_RoundTrip", func(t *testing.T) {
+		td := newDS(t)
+		defer td.CleanUpFn() //nolint:errcheck
+		target := &pkgmodel.Target{Label: "provider-schema", Namespace: "AWS", Config: json.RawMessage(`{"Region":"us-east-1"}`),
+			ConfigSchema: pkgmodel.ConfigSchema{DefaultReap: json.RawMessage(`{"Kind":"never"}`)}, Reaping: json.RawMessage(`{"Kind":"never"}`)}
+		_, err := td.Datastore.CreateTarget(target)
+		require.NoError(t, err)
+		loaded, err := td.Datastore.LoadTarget(target.Label)
+		require.NoError(t, err)
+		require.NotNil(t, loaded)
+		assert.JSONEq(t, `{"Kind":"never"}`, string(loaded.ConfigSchema.DefaultReap))
+		target.ConfigSchema.DefaultReap = json.RawMessage(`{"Kind":"after","MaxUnreachableSeconds":86400}`)
+		target.Reaping = json.RawMessage(`{"Kind":"after","MaxUnreachableSeconds":86400}`)
+		_, err = td.Datastore.UpdateTarget(target)
+		require.NoError(t, err)
+		loaded, err = td.Datastore.LoadTarget(target.Label)
+		require.NoError(t, err)
+		require.NotNil(t, loaded)
+		assert.JSONEq(t, `{"Kind":"after","MaxUnreachableSeconds":86400}`, string(loaded.ConfigSchema.DefaultReap))
 	})
 }

--- a/internal/datastore/mssql/mssql_targets.go
+++ b/internal/datastore/mssql/mssql_targets.go
@@ -87,7 +87,7 @@ func scanTargetColumns(scan func(dest ...any) error) (*pkgmodel.Target, error) {
 }
 
 func marshalConfigSchema(target *pkgmodel.Target) ([]byte, error) {
-	if len(target.ConfigSchema.Hints) == 0 {
+	if target.ConfigSchema.IsZero() {
 		return nil, nil
 	}
 	return json.Marshal(target.ConfigSchema)

--- a/internal/datastore/postgres/postgres.go
+++ b/internal/datastore/postgres/postgres.go
@@ -4425,7 +4425,7 @@ func (d DatastorePostgres) CreateTarget(target *pkgmodel.Target) (string, error)
 	}
 
 	var configSchemaJSON []byte
-	if len(target.ConfigSchema.Hints) > 0 {
+	if !target.ConfigSchema.IsZero() {
 		configSchemaJSON, err = json.Marshal(target.ConfigSchema)
 		if err != nil {
 			return "", err
@@ -4502,7 +4502,7 @@ func (d DatastorePostgres) UpdateTarget(target *pkgmodel.Target) (string, error)
 	}
 
 	var configSchemaJSON []byte
-	if len(target.ConfigSchema.Hints) > 0 {
+	if !target.ConfigSchema.IsZero() {
 		configSchemaJSON, err = json.Marshal(target.ConfigSchema)
 		if err != nil {
 			return "", err

--- a/internal/datastore/sqlite/sqlite.go
+++ b/internal/datastore/sqlite/sqlite.go
@@ -3706,7 +3706,7 @@ func (d DatastoreSQLite) CreateTarget(target *pkgmodel.Target) (string, error) {
 	}
 
 	var configSchemaJSON []byte
-	if len(target.ConfigSchema.Hints) > 0 {
+	if !target.ConfigSchema.IsZero() {
 		configSchemaJSON, err = json.Marshal(target.ConfigSchema)
 		if err != nil {
 			return "", err
@@ -3766,7 +3766,7 @@ func (d DatastoreSQLite) UpdateTarget(target *pkgmodel.Target) (string, error) {
 	}
 
 	var configSchemaJSON []byte
-	if len(target.ConfigSchema.Hints) > 0 {
+	if !target.ConfigSchema.IsZero() {
 		configSchemaJSON, err = json.Marshal(target.ConfigSchema)
 		if err != nil {
 			return "", err

--- a/internal/metastructure/target_update/target_update_generator.go
+++ b/internal/metastructure/target_update/target_update_generator.go
@@ -27,10 +27,6 @@ type TargetDatastore interface {
 
 type TargetUpdateGenerator struct {
 	datastore TargetDatastore
-	// manifestDefaultReap is the plugin-manifest default reaping behaviour used
-	// when a target declares none. It is nil when no manifest default is wired,
-	// in which case admission falls through to the global reaping default.
-	manifestDefaultReap pkgmodel.ReapingBehaviour
 	// minReapDuration is the floor enforced on any target's explicit reap-after
 	// duration (see resolveTargetReaping). It defaults to reaping.MinReapDuration
 	// (derived from the nominal/default sync interval); WithMinReapDuration lets
@@ -212,8 +208,9 @@ func (tp *TargetUpdateGenerator) determineTargetUpdate(target pkgmodel.Target, c
 
 	// Preserve existing ConfigSchema when the incoming target doesn't provide one.
 	// Without this, persistTargetUpdate would write an empty schema, silently
-	// clearing mutability metadata for future applies.
-	if len(target.ConfigSchema.Hints) == 0 && existing != nil && len(existing.ConfigSchema.Hints) > 0 {
+	// clearing mutability metadata (and the provider's default reaping) for
+	// future applies.
+	if target.ConfigSchema.IsZero() && existing != nil && !existing.ConfigSchema.IsZero() {
 		target.ConfigSchema = existing.ConfigSchema
 	}
 
@@ -245,7 +242,18 @@ func (tp *TargetUpdateGenerator) resolveTargetReaping(target *pkgmodel.Target) e
 		return fmt.Errorf("invalid reaping for target %s: %w", target.Label, err)
 	}
 
-	resolved := pkgmodel.ResolveReaping(explicit, tp.manifestDefaultReap)
+	// The provider default comes from the target Config class's ConfigHint,
+	// riding the ConfigSchema that eval attached to the target (or the
+	// preserved schema of the existing row). An invalid declaration is logged
+	// and skipped rather than rejecting the target: the namespace then falls
+	// to the global reaping default.
+	providerDefault, err := pkgmodel.ParseReaping(target.ConfigSchema.DefaultReap)
+	if err != nil {
+		slog.Warn("Ignoring invalid ConfigHint default reap", "target", target.Label, "error", err)
+		providerDefault = nil
+	}
+
+	resolved := pkgmodel.ResolveReaping(explicit, providerDefault)
 
 	if after, ok := resolved.(*pkgmodel.ReapAfter); ok {
 		floor := int64(tp.minReapDuration.Seconds())

--- a/internal/metastructure/target_update/target_update_generator.go
+++ b/internal/metastructure/target_update/target_update_generator.go
@@ -118,6 +118,22 @@ func (tp *TargetUpdateGenerator) determineTargetUpdate(target pkgmodel.Target, c
 		}, true, nil
 	}
 
+	// Preserve existing ConfigSchema when the incoming target doesn't provide one.
+	// Without this, persistTargetUpdate would write an empty schema, silently
+	// clearing mutability metadata (and the provider's default reaping) for
+	// future applies.
+	if target.ConfigSchema.IsZero() && existing != nil && !existing.ConfigSchema.IsZero() {
+		target.ConfigSchema = existing.ConfigSchema
+	}
+
+	// Resolve the reaping behaviour at admission: explicit per-target > provider
+	// schema default > global default. Write the resolved behaviour back onto
+	// the target so the datastore persists the concrete reap_kind /
+	// reap_max_unreachable_seconds columns.
+	if err := tp.resolveTargetReaping(&target); err != nil {
+		return TargetUpdate{}, false, err
+	}
+
 	// Extract resolvables from target config
 	resolvables := resolver.ExtractResolvableURIsFromJSON(target.Config)
 	slog.Debug("Target resolvables extracted", "label", target.Label, "count", len(resolvables), "uris", resolvables)
@@ -165,6 +181,13 @@ func (tp *TargetUpdateGenerator) determineTargetUpdate(target pkgmodel.Target, c
 		case ConfigMutableChange:
 			operation = TargetOperationUpdate
 		case ConfigNoChange:
+			// Compare effective reaping for legacy rows without a stored policy too.
+			existingEffective := *existing
+			if len(existingEffective.Reaping) == 0 || string(existingEffective.Reaping) == "null" {
+				if err := tp.resolveTargetReaping(&existingEffective); err != nil {
+					return TargetUpdate{}, false, err
+				}
+			}
 			// Resolved values are identical, but we still need to update if:
 			// - The raw config format changed (e.g., plain value ↔ $ref wrapper)
 			// - The discoverable flag changed
@@ -190,10 +213,12 @@ func (tp *TargetUpdateGenerator) determineTargetUpdate(target pkgmodel.Target, c
 				operation = TargetOperationUpdate
 			} else if existing.Discoverable != target.Discoverable {
 				operation = TargetOperationUpdate
-			} else if len(target.ConfigSchema.Hints) > 0 && !configSchemasEqual(existing.ConfigSchema, target.ConfigSchema) {
-				// Only update for schema changes when the incoming schema has hints.
+			} else if !target.ConfigSchema.IsZero() && !configSchemasEqual(existing.ConfigSchema, target.ConfigSchema) {
+				// Only update for schema changes when the incoming schema carries metadata.
 				// An empty incoming schema means the plugin/agent doesn't emit one —
 				// don't wipe existing metadata.
+				operation = TargetOperationUpdate
+			} else if !util.JsonEqualRaw(existingEffective.Reaping, target.Reaping) {
 				operation = TargetOperationUpdate
 			} else if isReaped {
 				// Config/discoverable/schema are all unchanged, but the target is
@@ -204,22 +229,6 @@ func (tp *TargetUpdateGenerator) determineTargetUpdate(target pkgmodel.Target, c
 				return TargetUpdate{}, false, nil
 			}
 		}
-	}
-
-	// Preserve existing ConfigSchema when the incoming target doesn't provide one.
-	// Without this, persistTargetUpdate would write an empty schema, silently
-	// clearing mutability metadata (and the provider's default reaping) for
-	// future applies.
-	if target.ConfigSchema.IsZero() && existing != nil && !existing.ConfigSchema.IsZero() {
-		target.ConfigSchema = existing.ConfigSchema
-	}
-
-	// Resolve the reaping behaviour at admission: explicit per-target > plugin
-	// manifest default > global default. Write the resolved behaviour back onto
-	// the target so the datastore persists the concrete reap_kind /
-	// reap_max_unreachable_seconds columns.
-	if err := tp.resolveTargetReaping(&target); err != nil {
-		return TargetUpdate{}, false, err
 	}
 
 	return TargetUpdate{
@@ -233,8 +242,8 @@ func (tp *TargetUpdateGenerator) determineTargetUpdate(target pkgmodel.Target, c
 	}, true, nil
 }
 
-// resolveTargetReaping applies the reaping precedence (explicit > manifest
-// default > global default), enforces the reap-after duration floor, and writes
+// resolveTargetReaping applies the reaping precedence (explicit > provider
+// schema default > global default), enforces the reap-after duration floor, and writes
 // the resolved behaviour back onto target.Reaping.
 func (tp *TargetUpdateGenerator) resolveTargetReaping(target *pkgmodel.Target) error {
 	explicit, err := pkgmodel.ParseReaping(target.Reaping)
@@ -248,6 +257,9 @@ func (tp *TargetUpdateGenerator) resolveTargetReaping(target *pkgmodel.Target) e
 	// and skipped rather than rejecting the target: the namespace then falls
 	// to the global reaping default.
 	providerDefault, err := pkgmodel.ParseReaping(target.ConfigSchema.DefaultReap)
+	if after, ok := providerDefault.(*pkgmodel.ReapAfter); ok && after.MaxUnreachableSeconds < int64(tp.minReapDuration.Seconds()) {
+		err = fmt.Errorf("provider reap-after of %ds is below the minimum of %ds", after.MaxUnreachableSeconds, int64(tp.minReapDuration.Seconds()))
+	}
 	if err != nil {
 		slog.Warn("Ignoring invalid ConfigHint default reap", "target", target.Label, "error", err)
 		providerDefault = nil
@@ -284,8 +296,11 @@ func isHashedAtRest(raw string) bool {
 	return parsed.Get("$hashed").Bool()
 }
 
-// configSchemasEqual returns true if two ConfigSchemas have identical hints.
+// configSchemasEqual returns true if two ConfigSchemas have identical metadata.
 func configSchemasEqual(a, b pkgmodel.ConfigSchema) bool {
+	if !util.JsonEqualRaw(a.DefaultReap, b.DefaultReap) {
+		return false
+	}
 	if len(a.Hints) != len(b.Hints) {
 		return false
 	}

--- a/internal/metastructure/target_update/target_update_generator_test.go
+++ b/internal/metastructure/target_update/target_update_generator_test.go
@@ -1527,3 +1527,50 @@ func TestGenerateTargetUpdates_RejectsSubFloorReapAfter(t *testing.T) {
 	_, err := generator.GenerateTargetUpdates(targets, pkgmodel.CommandApply, false)
 	require.Error(t, err, "a reap-after below the floor must be rejected at admission")
 }
+
+// TestGenerateTargetUpdates_ProviderDefaultReaping verifies the reaping
+// precedence around the provider default carried on ConfigSchema (from the
+// Config class ConfigHint annotation): a target with no explicit reaping
+// takes its provider's default over the global one, a target whose schema
+// carries no default falls through to the global default, and an explicit
+// per-target reaping still wins over the provider default.
+func TestGenerateTargetUpdates_ProviderDefaultReaping(t *testing.T) {
+	mockDS := &mockTargetDatastore{}
+	generator := NewTargetUpdateGenerator(mockDS)
+
+	neverReapSchema := pkgmodel.ConfigSchema{DefaultReap: json.RawMessage(`{"Kind":"never"}`)}
+	targets := []pkgmodel.Target{
+		{Label: "aws-target", Namespace: "AWS", Config: json.RawMessage(`{"Region":"us-east-1"}`), ConfigSchema: neverReapSchema},
+		{Label: "k8s-target", Namespace: "K8S", Config: json.RawMessage(`{"Context":"c"}`)},
+		{
+			Label: "aws-explicit", Namespace: "AWS", Config: json.RawMessage(`{"Region":"eu-west-1"}`),
+			ConfigSchema: neverReapSchema,
+			Reaping:      json.RawMessage(`{"Kind":"after","MaxUnreachableSeconds":86400}`),
+		},
+	}
+
+	updates, err := generator.GenerateTargetUpdates(targets, pkgmodel.CommandApply, false)
+	require.NoError(t, err)
+	require.Len(t, updates, 3)
+
+	byLabel := map[string]pkgmodel.Target{}
+	for _, u := range updates {
+		byLabel[u.Target.Label] = u.Target
+	}
+
+	awsReap, err := pkgmodel.ParseReaping(byLabel["aws-target"].Reaping)
+	require.NoError(t, err)
+	_, isNever := awsReap.(*pkgmodel.NeverReap)
+	assert.True(t, isNever, "the provider default on ConfigSchema must reach admission, got %T", awsReap)
+
+	k8sReap, err := pkgmodel.ParseReaping(byLabel["k8s-target"].Reaping)
+	require.NoError(t, err)
+	k8sAfter, isAfter := k8sReap.(*pkgmodel.ReapAfter)
+	require.True(t, isAfter, "a target without a provider default falls to the global default, got %T", k8sReap)
+	assert.Equal(t, pkgmodel.DefaultReapMaxUnreachableSeconds, k8sAfter.MaxUnreachableSeconds)
+
+	explicitReap, err := pkgmodel.ParseReaping(byLabel["aws-explicit"].Reaping)
+	require.NoError(t, err)
+	_, isAfter = explicitReap.(*pkgmodel.ReapAfter)
+	assert.True(t, isAfter, "an explicit per-target reaping must win over the provider default, got %T", explicitReap)
+}

--- a/internal/metastructure/target_update/target_update_generator_test.go
+++ b/internal/metastructure/target_update/target_update_generator_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1573,4 +1574,95 @@ func TestGenerateTargetUpdates_ProviderDefaultReaping(t *testing.T) {
 	require.NoError(t, err)
 	_, isAfter = explicitReap.(*pkgmodel.ReapAfter)
 	assert.True(t, isAfter, "an explicit per-target reaping must win over the provider default, got %T", explicitReap)
+}
+
+// Provider annotation changes must reach already-declared targets even when
+// their config and field hints do not change.
+func TestGenerateTargetUpdates_ProviderDefaultChanges(t *testing.T) {
+	for _, withHints := range []bool{false, true} {
+		for _, previous := range []string{"", `{"Kind":"after","MaxUnreachableSeconds":86400}`} {
+			t.Run(fmt.Sprintf("hints=%t/previous=%s", withHints, previous), func(t *testing.T) {
+				existing := &pkgmodel.Target{Label: "cloud", Namespace: "AWS", Config: json.RawMessage(`{"Region":"us-east-1"}`), Version: 1,
+					ConfigSchema: pkgmodel.ConfigSchema{DefaultReap: json.RawMessage(previous)},
+					Reaping:      json.RawMessage(`{"Kind":"after","MaxUnreachableSeconds":86400}`)}
+				if withHints {
+					existing.ConfigSchema.Hints = map[string]pkgmodel.ConfigFieldHint{"Region": {CreateOnly: true}}
+				}
+				desired := *existing
+				desired.Reaping = nil
+				desired.ConfigSchema.DefaultReap = json.RawMessage(`{"Kind":"never"}`)
+				ds := &mockTargetDatastore{targets: map[string]*pkgmodel.Target{"cloud": existing}}
+				updates, err := NewTargetUpdateGenerator(ds).GenerateTargetUpdates([]pkgmodel.Target{desired}, pkgmodel.CommandApply, false)
+				require.NoError(t, err)
+				require.Len(t, updates, 1, "new provider default must update an existing target")
+				assert.Equal(t, TargetOperationUpdate, updates[0].Operation)
+				assert.JSONEq(t, `{"Kind":"never"}`, string(updates[0].Target.Reaping))
+				assert.JSONEq(t, `{"Kind":"never"}`, string(updates[0].Target.ConfigSchema.DefaultReap))
+				ds.targets["cloud"] = &updates[0].Target
+				updates, err = NewTargetUpdateGenerator(ds).GenerateTargetUpdates([]pkgmodel.Target{desired}, pkgmodel.CommandApply, false)
+				require.NoError(t, err)
+				assert.Empty(t, updates, "identical reapply must remain a no-op")
+			})
+		}
+	}
+}
+
+func TestGenerateTargetUpdates_ExplicitReapingChange(t *testing.T) {
+	existing := &pkgmodel.Target{Label: "cloud", Namespace: "AWS", Config: json.RawMessage(`{"Region":"us-east-1"}`), Version: 1,
+		ConfigSchema: pkgmodel.ConfigSchema{DefaultReap: json.RawMessage(`{"Kind":"never"}`)}, Reaping: json.RawMessage(`{"Kind":"never"}`)}
+	ds := &mockTargetDatastore{targets: map[string]*pkgmodel.Target{"cloud": existing}}
+	desired := *existing
+	desired.Reaping = json.RawMessage(`{"Kind":"after","MaxUnreachableSeconds":86400}`)
+	updates, err := NewTargetUpdateGenerator(ds).GenerateTargetUpdates([]pkgmodel.Target{desired}, pkgmodel.CommandApply, false)
+	require.NoError(t, err)
+	require.Len(t, updates, 1, "explicit reaping change must persist without config changes")
+	assert.JSONEq(t, `{"Kind":"after","MaxUnreachableSeconds":86400}`, string(updates[0].Target.Reaping))
+	ds.targets["cloud"] = &updates[0].Target
+	desired.Reaping = nil
+	updates, err = NewTargetUpdateGenerator(ds).GenerateTargetUpdates([]pkgmodel.Target{desired}, pkgmodel.CommandApply, false)
+	require.NoError(t, err)
+	require.Len(t, updates, 1, "removing explicit reaping must restore the provider default")
+	assert.JSONEq(t, `{"Kind":"never"}`, string(updates[0].Target.Reaping))
+}
+
+func TestGenerateTargetUpdates_InvalidProviderReapingFallsBack(t *testing.T) {
+	for _, raw := range []string{`{"Kind":"unknown"}`, `{"Kind":"after","MaxUnreachableSeconds":1}`} {
+		t.Run(raw, func(t *testing.T) {
+			target := pkgmodel.Target{Label: "cloud", Namespace: "AWS", Config: json.RawMessage(`{"Region":"us-east-1"}`), ConfigSchema: pkgmodel.ConfigSchema{DefaultReap: json.RawMessage(raw)}}
+			updates, err := NewTargetUpdateGenerator(&mockTargetDatastore{}).GenerateTargetUpdates([]pkgmodel.Target{target}, pkgmodel.CommandApply, false)
+			require.NoError(t, err, "invalid provider annotation must not reject the apply")
+			require.Len(t, updates, 1)
+			assert.JSONEq(t, `{"Kind":"after","MaxUnreachableSeconds":86400}`, string(updates[0].Target.Reaping))
+		})
+	}
+}
+
+func TestGenerateTargetUpdates_PreservesProviderSchema(t *testing.T) {
+	for _, incomingDefault := range []json.RawMessage{nil, json.RawMessage(`null`)} {
+		t.Run(string(incomingDefault), func(t *testing.T) {
+			existing := &pkgmodel.Target{Label: "cloud", Namespace: "AWS", Config: json.RawMessage(`{"Region":"us-east-1"}`), Version: 1,
+				ConfigSchema: pkgmodel.ConfigSchema{DefaultReap: json.RawMessage(`{"Kind":"never"}`)}, Reaping: json.RawMessage(`{"Kind":"never"}`)}
+			desired := *existing
+			desired.Reaping = nil
+			desired.Discoverable = true
+			desired.ConfigSchema = pkgmodel.ConfigSchema{DefaultReap: incomingDefault}
+			updates, err := NewTargetUpdateGenerator(&mockTargetDatastore{targets: map[string]*pkgmodel.Target{"cloud": existing}}).GenerateTargetUpdates([]pkgmodel.Target{desired}, pkgmodel.CommandApply, false)
+			require.NoError(t, err)
+			require.Len(t, updates, 1)
+			assert.JSONEq(t, `{"Kind":"never"}`, string(updates[0].Target.ConfigSchema.DefaultReap))
+			assert.JSONEq(t, `{"Kind":"never"}`, string(updates[0].Target.Reaping))
+		})
+	}
+}
+
+func TestGenerateTargetUpdates_ReplacesPolicyBelowCurrentFloor(t *testing.T) {
+	existing := &pkgmodel.Target{Label: "cloud", Namespace: "AWS", Config: json.RawMessage(`{"Region":"us-east-1"}`), Version: 1,
+		Reaping: json.RawMessage(`{"Kind":"after","MaxUnreachableSeconds":3600}`)}
+	desired := *existing
+	desired.Reaping = json.RawMessage(`{"Kind":"never"}`)
+	generator := NewTargetUpdateGenerator(&mockTargetDatastore{targets: map[string]*pkgmodel.Target{"cloud": existing}}).WithMinReapDuration(7200 * time.Second)
+	updates, err := generator.GenerateTargetUpdates([]pkgmodel.Target{desired}, pkgmodel.CommandApply, false)
+	require.NoError(t, err, "a valid replacement must not validate the old policy against a changed floor")
+	require.Len(t, updates, 1)
+	assert.JSONEq(t, `{"Kind":"never"}`, string(updates[0].Target.Reaping))
 }

--- a/internal/schema/pkl/schema/formae.pkl
+++ b/internal/schema/pkl/schema/formae.pkl
@@ -587,9 +587,23 @@ open class ConfigFieldHint extends Annotation {
     fixed CreateOnly: Boolean = createOnly
 }
 
-/// Schema describing per-field mutability of a target's config.
+/// Class-level annotation for a target Config class, carrying target
+/// semantics the plugin author declares once for every target of this
+/// provider — the class-level sibling of the per-field ConfigFieldHint.
+open class ConfigHint extends Annotation {
+    /// Default reaping behaviour for this provider's targets when a target
+    /// declares none itself. A provider whose targets cannot go away out of
+    /// band (a cloud region) declares NeverReap here; providers whose
+    /// backing infrastructure can be deleted out of band leave it unset and
+    /// fall to the global default.
+    reap: Reaping?
+}
+
+/// Schema describing per-field mutability of a target's config, plus the
+/// provider-level target semantics from the Config class's ConfigHint.
 open class ConfigSchema {
     Hints: Mapping<String, ConfigFieldHint>?
+    DefaultReap: Dynamic?
 }
 
 // Schema output class
@@ -660,8 +674,12 @@ open class Target {
     fixed ConfigSchema: ConfigSchema? =
         if (config != null)
             let (hints = module.fq.configHints(reflect.Class(config.getClass())))
-            if (hints.length > 0)
-                new ConfigSchema { Hints = hints }
+            let (classHint = module.fq.findConfigHint(reflect.Class(config.getClass())))
+            if (hints.length > 0 || classHint != null)
+                new ConfigSchema {
+                    Hints = if (hints.length > 0) hints else null
+                    DefaultReap = classHint?.reap?.render()
+                }
             else null
         else null
     fixed Discoverable: Boolean = discoverable
@@ -1310,6 +1328,12 @@ class Fq {
                 else
                     Pair(key, rawValue)
             ).toDynamic()
+
+    function findConfigHint(configClass: reflect.Class?): ConfigHint? =
+      if (configClass == null)
+        null
+      else
+        configClass.annotations.filterIsInstance(ConfigHint).firstOrNull ?? findConfigHint(configClass.superclass)
 
     function configHints(configClass: reflect.Class): Mapping<String, ConfigFieldHint> =
         configClass.properties

--- a/internal/schema/pkl/schema/tests/formae.pkl
+++ b/internal/schema/pkl/schema/tests/formae.pkl
@@ -418,6 +418,26 @@ local class TestConfig {
     fixed AccountId: String? = accountId
 }
 
+// Config class with a class-level ConfigHint declaring the provider's
+// default reaping behaviour.
+@formae.ConfigHint { reap = new formae.NeverReap {} }
+local class NeverReapConfig {
+    hidden fixed type: String = "RootCloud"
+    hidden region: String
+
+    fixed Type: String = type
+    fixed Region: String = region
+}
+
+local testTargetNeverReapConfig = new formae.Target {
+    label = "never-reap-target"
+    namespace = "ROOTCLOUD"
+    discoverable = true
+    config = new NeverReapConfig {
+        region = "us-east-1"
+    }
+}
+
 // Config class with no ConfigFieldHint annotations
 local class PlainConfig {
     hidden fixed type: String = "Plain"
@@ -1018,6 +1038,17 @@ facts {
         let (rendered = testTaskDefNoContainers.render())
         let (props = rendered.Properties)
         !props.toMap().containsKey("ContainerDefinitions")
+    }
+
+    ["ConfigHint default reap rides ConfigSchema"] {
+        testTargetNeverReapConfig.ConfigSchema != null &&
+        testTargetNeverReapConfig.ConfigSchema.DefaultReap != null &&
+        testTargetNeverReapConfig.ConfigSchema.DefaultReap.Kind == "never"
+    }
+
+    ["ConfigHint absent leaves DefaultReap null"] {
+        testTargetWithSchema.ConfigSchema != null &&
+        testTargetWithSchema.ConfigSchema.DefaultReap == null
     }
 
     ["ConfigSchema generated for annotated config"] {

--- a/pkg/model/target.go
+++ b/pkg/model/target.go
@@ -54,12 +54,17 @@ type ConfigFieldHint struct {
 // ConfigSchema describes the structure and mutability of a target's config fields.
 type ConfigSchema struct {
 	Hints map[string]ConfigFieldHint `json:"Hints,omitempty" pkl:"Hints,omitempty"`
+	// DefaultReap is the provider's default reaping behaviour for its
+	// targets, declared by the plugin author as a class-level annotation on
+	// the target Config class (raw, e.g. {"Kind":"never"}). Nil when the
+	// provider declares none; admission then falls to the global default.
+	DefaultReap json.RawMessage `json:"DefaultReap,omitempty" pkl:"DefaultReap,omitempty"`
 }
 
-// IsZero reports whether the schema has no hints, used by omitzero to suppress
-// the field in JSON output for targets without schema annotations.
+// IsZero reports whether the schema carries nothing, used by omitzero to
+// suppress the field in JSON output for targets without schema annotations.
 func (cs ConfigSchema) IsZero() bool {
-	return len(cs.Hints) == 0
+	return len(cs.Hints) == 0 && len(cs.DefaultReap) == 0
 }
 
 // TargetHealth holds persisted health-observation fields for a target.

--- a/pkg/model/target.go
+++ b/pkg/model/target.go
@@ -64,7 +64,7 @@ type ConfigSchema struct {
 // IsZero reports whether the schema carries nothing, used by omitzero to
 // suppress the field in JSON output for targets without schema annotations.
 func (cs ConfigSchema) IsZero() bool {
-	return len(cs.Hints) == 0 && len(cs.DefaultReap) == 0
+	return len(cs.Hints) == 0 && (len(cs.DefaultReap) == 0 || string(cs.DefaultReap) == "null")
 }
 
 // TargetHealth holds persisted health-observation fields for a target.

--- a/pkg/plugin/manifest.go
+++ b/pkg/plugin/manifest.go
@@ -11,8 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 )
 
 // Plugin type values a manifest's Type field may hold.
@@ -57,17 +55,6 @@ type Manifest struct {
 
 	// Category is a UI filter tag, e.g. "cloud", "auth", "config" (optional)
 	Category string `json:"category,omitempty"`
-
-	// DefaultReapRaw is the plugin-level default reaping behaviour, kept as raw
-	// JSON so it can be peeked and decoded via DefaultReap(). Absent → nil.
-	DefaultReapRaw json.RawMessage `json:"defaultReap,omitempty"`
-}
-
-// DefaultReap decodes the plugin's default reaping behaviour from the manifest.
-// It returns (nil, nil) when the manifest declares no default, letting callers
-// fall through to the global reaping default.
-func (m *Manifest) DefaultReap() (pkgmodel.ReapingBehaviour, error) {
-	return pkgmodel.ParseReaping(m.DefaultReapRaw)
 }
 
 // IsAuthPlugin returns true if this manifest describes an auth plugin.

--- a/pkg/plugin/manifest_test.go
+++ b/pkg/plugin/manifest_test.go
@@ -7,12 +7,10 @@
 package plugin
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
-	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -189,35 +187,4 @@ func TestManifestValidate_OidcCredentialDoesNotRequireSingularNamespace(t *testi
 func TestNormalizedNamespaces_UppercasesEveryEntry(t *testing.T) {
 	m := Manifest{Namespaces: []string{"aws", "Gcp", "AZURE"}}
 	assert.Equal(t, []string{"AWS", "GCP", "AZURE"}, m.NormalizedNamespaces())
-}
-
-func TestManifest_DefaultReap_Absent(t *testing.T) {
-	var m Manifest
-	require.NoError(t, json.Unmarshal([]byte(`{"name":"x","version":"1","namespace":"X","license":"MIT","minFormaeVersion":"1"}`), &m))
-
-	reaping, err := m.DefaultReap()
-	require.NoError(t, err)
-	assert.Nil(t, reaping, "absent defaultReap must yield a nil reaping behaviour")
-}
-
-func TestManifest_DefaultReap_Never(t *testing.T) {
-	var m Manifest
-	require.NoError(t, json.Unmarshal([]byte(`{"name":"x","version":"1","namespace":"X","license":"MIT","minFormaeVersion":"1","defaultReap":{"Kind":"never"}}`), &m))
-
-	reaping, err := m.DefaultReap()
-	require.NoError(t, err)
-	require.NotNil(t, reaping)
-	assert.Equal(t, "never", reaping.GetKind())
-}
-
-func TestManifest_DefaultReap_After(t *testing.T) {
-	var m Manifest
-	require.NoError(t, json.Unmarshal([]byte(`{"name":"x","version":"1","namespace":"X","license":"MIT","minFormaeVersion":"1","defaultReap":{"Kind":"after","MaxUnreachableSeconds":7200}}`), &m))
-
-	reaping, err := m.DefaultReap()
-	require.NoError(t, err)
-	require.NotNil(t, reaping)
-	after, ok := reaping.(*pkgmodel.ReapAfter)
-	require.True(t, ok)
-	assert.Equal(t, int64(7200), after.MaxUnreachableSeconds)
 }


### PR DESCRIPTION
Resolve target reaping in this order: explicit target policy, provider default declared by `@formae.ConfigHint` on the target Config class, then the global 24-hour default. The provider declaration travels in ConfigSchema, including for remote plugins; remove the unused plugin-manifest field.

Provider-only schemas now persist across SQLite, Postgres, Aurora, and MSSQL. Re-applying without a schema preserves the stored provider default, while changes to provider defaults or explicit reaping policies are applied even when target configuration is unchanged. Invalid provider defaults fall back to the global policy; invalid explicit policies remain errors.

Validation: metastructure/schema unit suites pass after merging current main. Full SQLite, model/plugin unit, and Pkl tests pass; the shared datastore regression covers provider-only schema create/update round trips. Fresh GitHub CI also passed the live Postgres, MSSQL, and Aurora suites, including the provider-only schema round-trip regression in each.

AWS, Azure, and GCP must adopt ConfigHint/NeverReap and update their schema pins after the core version containing this annotation is published. This core change alone does not change unannotated provider schemas.

Current merge blocker: the final-head mutation job hit its 90-minute limit while processing SQLite, which ran for over 88 minutes without a completed result. Aurora, MSSQL, and Postgres mutation reports completed; later packages were not reached. Functional, property, and live datastore checks are green, but the mutation gate remains incomplete.
