### PR TITLE
fix(metastructure): answer failed requests instead of terminating the persisters

### DIFF
--- a/internal/metastructure/auto_reconciler.go
+++ b/internal/metastructure/auto_reconciler.go
@@ -421,10 +421,10 @@ func startReconcile(proc gen.Process, data *AutoReconcilerData, stackLabel strin
 	proc.Log().Debug("Generated resource updates for stack=%s, starting reconcile command=%s", stackLabel, result.command.ID)
 
 	// Store the forma command
-	_, err = proc.Call(
+	_, err = messages.UnwrapCall(proc.Call(
 		gen.ProcessID{Name: actornames.FormaCommandPersister, Node: proc.Node().Name()},
 		forma_persister.StoreNewFormaCommand{Command: *result.command},
-	)
+	))
 	if err != nil {
 		return "", fmt.Errorf("failed to store reconcile command: %w", err)
 	}

--- a/internal/metastructure/changeset/changeset_executor.go
+++ b/internal/metastructure/changeset/changeset_executor.go
@@ -359,10 +359,10 @@ func resume(from gen.PID, state gen.Atom, data ChangesetData, message Resume, pr
 func cancelBeforeStart(from gen.PID, state gen.Atom, data ChangesetData, message Cancel, proc gen.Process) (gen.Atom, ChangesetData, CancelResponse, []statemachine.Action, error) {
 	proc.Log().Debug("ChangesetExecutor received cancel before start commandID=%s force=%t", message.CommandID, message.Force)
 
-	_, err := proc.Call(
+	_, err := messages.UnwrapCall(proc.Call(
 		gen.ProcessID{Node: proc.Node().Name(), Name: gen.Atom("FormaCommandPersister")},
 		forma_persister.MarkCommandResourcesAsCanceled{CommandID: message.CommandID},
-	)
+	))
 	if err != nil {
 		proc.Log().Error("Failed to cancel command before start commandID=%s: %v", message.CommandID, err)
 		return state, data, CancelResponse{ErrorMessage: fmt.Sprintf("cancel-before-start persist failed: %v", err)}, nil, nil
@@ -430,7 +430,7 @@ func targetUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, mess
 	node, exists := data.changeset.DAG.Nodes[message.NodeURI]
 	if exists {
 		if tu, ok := node.Update.(*target_update.TargetUpdate); ok && tu.Operation != target_update.TargetOperationResolve {
-			_, err := proc.Call(
+			_, err := messages.UnwrapCall(proc.Call(
 				gen.ProcessID{Name: gen.Atom("FormaCommandPersister"), Node: proc.Node().Name()},
 				messages.MarkTargetUpdateAsComplete{
 					CommandID:       data.changeset.CommandID,
@@ -439,7 +439,7 @@ func targetUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, mess
 					FinalState:      message.State,
 					ModifiedTs:      util.TimeNow(),
 				},
-			)
+			))
 			if err != nil {
 				proc.Log().Error("Failed to update target state in persister target=%s: %v", tu.Target.Label, err)
 			}
@@ -675,23 +675,23 @@ func handleUpdateFinished(from gen.PID, state gen.Atom, data ChangesetData, even
 		now := util.TimeNow()
 
 		if len(failedResources) > 0 {
-			_, err = proc.Call(persisterPID, forma_persister.MarkResourcesAsFailed{
+			_, err = messages.UnwrapCall(proc.Call(persisterPID, forma_persister.MarkResourcesAsFailed{
 				CommandID:          data.changeset.CommandID,
 				Resources:          failedResources,
 				ResourceModifiedTs: now,
 				FailureReason:      event.failureReason,
-			})
+			}))
 			if err != nil {
 				proc.Log().Error("Failed to mark resources as failed in persister commandID=%s: %v", data.changeset.CommandID, err)
 			}
 		}
 
 		if len(failedTargets) > 0 {
-			_, err = proc.Call(persisterPID, forma_persister.MarkTargetsAsFailed{
+			_, err = messages.UnwrapCall(proc.Call(persisterPID, forma_persister.MarkTargetsAsFailed{
 				CommandID:        data.changeset.CommandID,
 				Targets:          failedTargets,
 				TargetModifiedTs: now,
-			})
+			}))
 			if err != nil {
 				proc.Log().Error("Failed to mark targets as failed in persister commandID=%s: %v", data.changeset.CommandID, err)
 			}
@@ -880,13 +880,13 @@ func cancel(from gen.PID, state gen.Atom, data ChangesetData, message Cancel, pr
 
 	// Mark NotStarted resources as canceled
 	if len(resourcesToCancel) > 0 {
-		_, err := proc.Call(
+		_, err := messages.UnwrapCall(proc.Call(
 			gen.ProcessID{Node: proc.Node().Name(), Name: gen.Atom("FormaCommandPersister")},
 			forma_persister.MarkResourcesAsCanceled{
 				CommandID: data.changeset.CommandID,
 				Resources: resourcesToCancel,
 			},
-		)
+		))
 		if err != nil {
 			proc.Log().Error("Failed to mark resources as canceled commandID=%s: %v", data.changeset.CommandID, err)
 		}
@@ -965,14 +965,14 @@ func forceCancel(state gen.Atom, data ChangesetData, message Cancel, proc gen.Pr
 
 	// Persist FIRST. BulkForceCancel terminalizes all in-flight resource and target
 	// updates and recomputes the command's derived state to terminal Canceled at commit.
-	result, err := proc.Call(
+	result, err := messages.UnwrapCall(proc.Call(
 		gen.ProcessID{Node: proc.Node().Name(), Name: gen.Atom("FormaCommandPersister")},
 		forma_persister.BulkForceCancel{
 			CommandID: data.changeset.CommandID,
 			Resources: resourcesToCancel,
 			Targets:   targetsToCancel,
 		},
-	)
+	))
 	if err != nil {
 		// Persist-before-terminate: on persister error, terminate NO actors and stay
 		// in the current state. The durable DB state is still non-terminal; the user

--- a/internal/metastructure/changeset/resolve_cache.go
+++ b/internal/metastructure/changeset/resolve_cache.go
@@ -135,20 +135,22 @@ func (r *ResolveCache) startResolve(from gen.PID, resourceURI pkgmodel.FormaeURI
 
 	// Load the resource from the stack to get the native id
 	r.Log().Debug("Cache miss for resource URI uri=%v", resourceURI)
-	stackerResult, err := r.Call(
+	stackerResult, err := messages.UnwrapCall(r.Call(
 		gen.ProcessID{Name: actornames.ResourcePersister, Node: r.Node().Name()},
 		messages.LoadResource{
 			ResourceURI: resourceURI.Stripped(),
-		})
+		}))
 	if err != nil {
 		r.Log().Error("Failed to load resource from resource persister resourceURI=%v: %v", resourceURI, err)
-		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI})
+		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI,
+			Reason: fmt.Sprintf("could not resolve reference %q: %v", string(resourceURI), err)})
 		return
 	}
 	loadResourceResult, ok := stackerResult.(messages.LoadResourceResult)
 	if !ok {
 		r.Log().Error("Unexpected result type from resource persister resultType=%v", reflect.TypeOf(stackerResult))
-		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI})
+		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI,
+			Reason: fmt.Sprintf("could not resolve reference %q: unexpected reply from the resource store", string(resourceURI))})
 		return
 	}
 

--- a/internal/metastructure/discovery/discovery.go
+++ b/internal/metastructure/discovery/discovery.go
@@ -297,10 +297,10 @@ func resumeDiscovery(from gen.PID, state gen.Atom, data DiscoveryData, message m
 
 // getPluginInfo fetches plugin info from PluginCoordinator
 func getPluginInfo(proc gen.Process, namespace string) (*messages.PluginInfoResponse, error) {
-	result, err := proc.Call(
+	result, err := messages.UnwrapCall(proc.Call(
 		gen.ProcessID{Name: actornames.PluginCoordinator, Node: proc.Node().Name()},
 		messages.GetPluginInfo{Namespace: namespace},
-	)
+	))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get plugin info for %s: %w", namespace, err)
 	}
@@ -570,7 +570,7 @@ func scanTargetForResourceType(target pkgmodel.Target, op ListOperation, data Di
 	}
 
 	// Spawn PluginOperator via PluginCoordinator
-	spawnResult, err := proc.Call(
+	spawnResult, err := messages.UnwrapCall(proc.Call(
 		gen.ProcessID{Name: actornames.PluginCoordinator, Node: proc.Node().Name()},
 		messages.SpawnPluginOperator{
 			Namespace:   target.Namespace,
@@ -578,7 +578,7 @@ func scanTargetForResourceType(target pkgmodel.Target, op ListOperation, data Di
 			Operation:   string(operation),
 			OperationID: operationID,
 			RequestedBy: proc.PID(),
-		})
+		}))
 	if err != nil {
 		delete(data.outstandingListOperations, mapKey)
 		return fmt.Errorf("failed to spawn PluginOperator for %s: %w", uri, err)
@@ -782,9 +782,9 @@ func synchronizeResources(op ListOperation, namespace string, target pkgmodel.Ta
 	)
 
 	// store the forma command
-	_, err = proc.Call(actornames.FormaCommandPersister, forma_persister.StoreNewFormaCommand{
+	_, err = messages.UnwrapCall(proc.Call(actornames.FormaCommandPersister, forma_persister.StoreNewFormaCommand{
 		Command: *syncCommand,
-	})
+	}))
 	if err != nil {
 		proc.Log().Error("failed to store sync command: %v", err)
 		return "", err
@@ -1144,16 +1144,16 @@ func finalizeFailedSyncCommand(cmd *forma_command.FormaCommand, proc gen.Process
 	}
 	persister := actornames.FormaCommandPersister
 	if len(refs) > 0 {
-		if _, err := proc.Call(persister, forma_persister.MarkResourcesAsFailed{
+		if _, err := messages.UnwrapCall(proc.Call(persister, forma_persister.MarkResourcesAsFailed{
 			CommandID:          cmd.ID,
 			Resources:          refs,
 			ResourceModifiedTs: time.Now(),
-		}); err != nil {
+		})); err != nil {
 			slog.Error("Discovery: failed to mark resources as failed for aborted command", "commandID", cmd.ID, "error", err)
 			return
 		}
 	}
-	if _, err := proc.Call(persister, forma_persister.FinalizeIncompleteCommand{CommandID: cmd.ID}); err != nil {
+	if _, err := messages.UnwrapCall(proc.Call(persister, forma_persister.FinalizeIncompleteCommand{CommandID: cmd.ID})); err != nil {
 		slog.Error("Discovery: failed to finalize aborted command", "commandID", cmd.ID, "error", err)
 	}
 }

--- a/internal/metastructure/forma_persister/forma_command_persister.go
+++ b/internal/metastructure/forma_persister/forma_command_persister.go
@@ -7,6 +7,7 @@ package forma_persister
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -43,6 +44,14 @@ type cachedCommand struct {
 	ksuidOpToIndex     map[string]int  // O(1) lookup: "ksuid:operation" -> ResourceUpdates index
 	pendingCompletions int             // Number of MarkResourceUpdateAsComplete messages expected
 	terminalizedByBulk map[string]bool // Resources terminalized by bulkUpdateResourceState (counter already decremented)
+	// dirty marks a command whose cached state a DATASTORE WRITE failed to
+	// make durable: the cache is ahead of the datastore. The next request
+	// touching the command flushes the cached state before being served, so
+	// a failed final write cannot leave the stored command non-terminal
+	// until an agent restart. Only actual write failures set it — an arm
+	// that fails before writing (validation, hashing) must NOT, or the
+	// flush would persist the partial mutation that arm rejected.
+	dirty bool
 }
 
 // resourceUpdateKey creates a composite key for looking up a ResourceUpdate by ksuid and operation.
@@ -147,9 +156,34 @@ func (f *FormaCommandPersister) Init(args ...any) error {
 // getOrLoadCommand retrieves a command from cache or loads it from the database.
 // The command is cached for subsequent accesses until it reaches a final state.
 func (f *FormaCommandPersister) getOrLoadCommand(commandID string) (*cachedCommand, error) {
-	// Check cache first
+	// Check cache first. A dirty entry holds mutations an earlier failed
+	// write never made durable; flush it before serving anything from it. A
+	// terminal command flushes through finalizeAndPersist so the original
+	// finalization semantics are preserved: an empty sync command is deleted
+	// rather than stored, and a completed command is evicted rather than
+	// retained. A failed flush fails the request — acknowledging work
+	// against state the datastore does not hold would let a retried request
+	// hit a no-op guard and report success for a command that was never
+	// made durable. The entry stays dirty and the next touch retries.
 	if cached, ok := f.activeCommands[commandID]; ok {
-		return cached, nil
+		if cached.dirty {
+			var err error
+			if cached.command.IsInFinalState() {
+				err = f.finalizeAndPersist(cached)
+			} else {
+				err = f.persistCommand(cached)
+			}
+			if err != nil {
+				return nil, fmt.Errorf("cannot serve command %s: flushing earlier unpersisted state failed: %w", commandID, err)
+			}
+			// finalizeAndPersist may have evicted (or deleted) the entry;
+			// fall through to a fresh load when it is gone.
+			if again, stillCached := f.activeCommands[commandID]; stillCached {
+				return again, nil
+			}
+		} else {
+			return cached, nil
+		}
 	}
 
 	// Load from DB
@@ -177,8 +211,10 @@ func (f *FormaCommandPersister) persistCommand(cached *cachedCommand) error {
 
 	if err := f.datastore.StoreFormaCommand(cmd, cmd.ID); err != nil {
 		f.Log().Error("Failed to store command commandID=%s: %v", cmd.ID, err)
+		cached.dirty = true
 		return fmt.Errorf("failed to store command: %w", err)
 	}
+	cached.dirty = false
 
 	return nil
 }
@@ -198,6 +234,7 @@ func (f *FormaCommandPersister) finalizeAndPersist(cached *cachedCommand) error 
 	if shouldDelete {
 		if err := f.datastore.DeleteFormaCommand(cmd, cmd.ID); err != nil {
 			f.Log().Error("Failed to delete sync command commandID=%s: %v", cmd.ID, err)
+			cached.dirty = true
 			return fmt.Errorf("failed to delete sync command: %w", err)
 		}
 		delete(f.activeCommands, cmd.ID)
@@ -206,8 +243,10 @@ func (f *FormaCommandPersister) finalizeAndPersist(cached *cachedCommand) error 
 
 	if err := f.datastore.StoreFormaCommand(cmd, cmd.ID); err != nil {
 		f.Log().Error("Failed to store command commandID=%s: %v", cmd.ID, err)
+		cached.dirty = true
 		return fmt.Errorf("failed to store command: %w", err)
 	}
+	cached.dirty = false
 
 	// Evict from cache if command is complete.
 	// We must wait for all completion messages before evicting because
@@ -326,6 +365,41 @@ type FinalizeIncompleteCommand struct {
 	CommandID string
 }
 
+// CommandPersistResult is the reply to the command-mutation requests: OK
+// carries the handler's boolean outcome, Error the failure that refused the
+// request.
+type CommandPersistResult struct {
+	OK    bool
+	Error string
+}
+
+func (r CommandPersistResult) CallError() string { return r.Error }
+
+// LoadFormaCommandResult is the reply to a LoadFormaCommand call.
+type LoadFormaCommandResult struct {
+	Command *forma_command.FormaCommand
+	Error   string
+}
+
+func (r LoadFormaCommandResult) CallError() string { return r.Error }
+
+// errInvariantViolation marks a failure that indicates a programming error
+// rather than a request-scoped outcome. Handlers wrap such failures with it,
+// and HandleCall lets them terminate the actor: a violated invariant means
+// the in-memory state cannot be trusted, and a supervised restart that
+// rebuilds it from the datastore is the right medicine.
+var errInvariantViolation = errors.New("invariant violation")
+
+// HandleCall answers every request with a typed result carrying its own
+// success/failure status. Returning an error here would terminate the actor
+// without a reply: the caller times out, every request queued in the mailbox
+// dies with it, and the supervisor respawns the actor only for the next bad
+// request to repeat the cycle. The error return keeps the meaning ergo
+// assigns to it — terminate — and is reserved for genuine faults: invariant
+// violations and unknown request types. The activeCommands cache deliberately
+// survives a failed store: it accumulates progress write-through, so after a
+// failure it is ahead of the datastore, marked dirty at the failed write, and
+// flushed by the next request that touches the command.
 func (f *FormaCommandPersister) HandleCall(from gen.PID, ref gen.Ref, message any) (any, error) {
 	start := time.Now()
 	defer func() {
@@ -333,38 +407,65 @@ func (f *FormaCommandPersister) HandleCall(from gen.PID, ref gen.Ref, message an
 	}()
 	switch msg := message.(type) {
 	case StoreNewFormaCommand:
-		return f.storeNewFormaCommand(&msg.Command)
+		return f.ack(f.storeNewFormaCommand(&msg.Command))
 	case LoadFormaCommand:
-		return f.loadFormaCommand(msg.CommandID)
+		cmd, err := f.loadFormaCommand(msg.CommandID)
+		if err != nil {
+			f.Log().Error("FormaCommandPersister: request %T failed: %s", message, err)
+			return LoadFormaCommandResult{Error: err.Error()}, nil
+		}
+		return LoadFormaCommandResult{Command: cmd}, nil
 	case messages.UpdateResourceProgress:
-		return f.updateCommandFromProgress(&msg)
+		return f.ack(f.updateCommandFromProgress(&msg))
 	case target_update.UpdateTargetStates:
-		return f.updateTargetStates(&msg)
+		return f.ack(f.updateTargetStates(&msg))
 	case messages.UpdateStackStates:
-		return f.updateStackStates(&msg)
+		return f.ack(f.updateStackStates(&msg))
 	case messages.UpdatePolicyStates:
-		return f.updatePolicyStates(&msg)
+		return f.ack(f.updatePolicyStates(&msg))
 	case MarkResourcesAsRejected:
-		return f.markResourcesAsRejected(&msg)
+		return f.ack(f.markResourcesAsRejected(&msg))
 	case MarkResourcesAsFailed:
-		return f.markResourcesAsFailed(&msg)
+		return f.ack(f.markResourcesAsFailed(&msg))
 	case MarkTargetsAsFailed:
-		return f.markTargetsAsFailed(&msg)
+		return f.ack(f.markTargetsAsFailed(&msg))
 	case MarkResourcesAsCanceled:
-		return f.markResourcesAsCanceled(&msg)
+		return f.ack(f.markResourcesAsCanceled(&msg))
 	case MarkCommandResourcesAsCanceled:
-		return f.markCommandResourcesAsCanceled(&msg)
+		return f.ack(f.markCommandResourcesAsCanceled(&msg))
 	case BulkForceCancel:
-		return f.bulkForceCancel(&msg)
+		// BulkForceCancel carries failures in its own response envelope so the
+		// executor can apply its persist-before-terminate retry semantics; a
+		// handler error is folded into that envelope, never a termination.
+		resp, err := f.bulkForceCancel(&msg)
+		if err != nil {
+			f.Log().Error("FormaCommandPersister: request %T failed: %s", message, err)
+			return BulkForceCancelResponse{ErrorMessage: err.Error()}, nil
+		}
+		return resp, nil
 	case messages.MarkResourceUpdateAsComplete:
-		return f.markResourceUpdateAsComplete(&msg)
+		return f.ack(f.markResourceUpdateAsComplete(&msg))
 	case FinalizeIncompleteCommand:
-		return f.finalizeIncompleteCommand(&msg)
+		return f.ack(f.finalizeIncompleteCommand(&msg))
 	case messages.MarkTargetUpdateAsComplete:
-		return f.markTargetUpdateAsComplete(&msg)
+		return f.ack(f.markTargetUpdateAsComplete(&msg))
 	default:
+		f.Log().Error("FormaCommandPersister: unhandled message type %T", msg)
 		return nil, fmt.Errorf("unhandled message type: %T", msg)
 	}
+}
+
+// ack folds a command-mutation outcome into its reply, letting invariant
+// violations terminate the actor.
+func (f *FormaCommandPersister) ack(ok bool, err error) (any, error) {
+	if err != nil {
+		if errors.Is(err, errInvariantViolation) {
+			return nil, err
+		}
+		f.Log().Error("FormaCommandPersister: request failed: %s", err)
+		return CommandPersistResult{Error: err.Error()}, nil
+	}
+	return CommandPersistResult{OK: ok}, nil
 }
 
 func (f *FormaCommandPersister) storeNewFormaCommand(command *forma_command.FormaCommand) (bool, error) {
@@ -431,14 +532,6 @@ func (f *FormaCommandPersister) updateCommandFromProgress(progress *messages.Upd
 			return true, nil
 		}
 
-		res.State = progress.ResourceState
-		res.StartTs = progress.ResourceStartTs
-		res.ModifiedTs = progress.ResourceModifiedTs
-
-		// NOTE: Do NOT decrement pendingCompletions here!
-		// pendingCompletions tracks expected MarkResourceUpdateAsComplete messages, not state transitions.
-		// Progress updates can set state to Success, but completion messages arrive separately.
-
 		// progress.Progress is already a TrackedProgress from the PluginOperator
 		tracked := progress.Progress
 		tracked.StartTs = progress.ResourceStartTs
@@ -450,6 +543,11 @@ func (f *FormaCommandPersister) updateCommandFromProgress(progress *messages.Upd
 		// The in-memory res.DesiredState.Properties below stays plaintext — it is only
 		// hashed at final state (hashSensitiveDataIfComplete) so a resumed command can
 		// still execute with the real secret value.
+		//
+		// Hashing runs BEFORE any cached state is mutated: this arm answers its
+		// failures instead of terminating, and a half-applied mutation would make
+		// a retried update hit the terminality guard above and be dropped
+		// without ever becoming durable.
 		if tracked.ResourceProperties != nil {
 			hashedProps, diagnostics, err := hashReadActualProps(tracked.ResourceProperties, res.DesiredState.Schema, res.DesiredState.Type)
 			if err != nil {
@@ -458,6 +556,14 @@ func (f *FormaCommandPersister) updateCommandFromProgress(progress *messages.Upd
 			f.logOpaqueDiagnostics(progress.CommandID, &res.DesiredState, diagnostics)
 			tracked.ResourceProperties = hashedProps
 		}
+
+		res.State = progress.ResourceState
+		res.StartTs = progress.ResourceStartTs
+		res.ModifiedTs = progress.ResourceModifiedTs
+
+		// NOTE: Do NOT decrement pendingCompletions here!
+		// pendingCompletions tracks expected MarkResourceUpdateAsComplete messages, not state transitions.
+		// Progress updates can set state to Success, but completion messages arrive separately.
 
 		index := slices.IndexFunc(res.ProgressResult, func(p plugin.TrackedProgress) bool {
 			return p.Operation == progress.Progress.Operation
@@ -523,6 +629,7 @@ func (f *FormaCommandPersister) updateCommandFromProgress(progress *messages.Upd
 	// ResourceUpdates are already persisted via UpdateResourceUpdateProgress above
 	if err := f.datastore.UpdateFormaCommandProgress(command.ID, command.State, command.ModifiedTs); err != nil {
 		f.Log().Error("Failed to update Forma command meta from resource progress commandID=%s: %v", progress.CommandID, err)
+		cached.dirty = true
 		return false, fmt.Errorf("failed to update Forma command meta from resource progress: %w", err)
 	}
 
@@ -656,6 +763,7 @@ func (f *FormaCommandPersister) markTargetUpdateAsComplete(msg *messages.MarkTar
 		}
 		if err := f.datastore.UpdateFormaCommandTargetUpdates(command.ID, targetUpdatesJSON, command.State, command.ModifiedTs); err != nil {
 			f.Log().Error("Failed to update Forma command target updates commandID=%s: %v", msg.CommandID, err)
+			cached.dirty = true
 			return false, fmt.Errorf("failed to update Forma command target updates: %w", err)
 		}
 	}
@@ -750,6 +858,7 @@ func (f *FormaCommandPersister) markTargetsAsFailed(msg *MarkTargetsAsFailed) (b
 	} else {
 		if err := f.datastore.UpdateFormaCommandProgress(command.ID, command.State, command.ModifiedTs); err != nil {
 			f.Log().Error("Failed to update Forma command meta commandID=%s: %v", msg.CommandID, err)
+			cached.dirty = true
 			return false, fmt.Errorf("failed to update Forma command meta: %w", err)
 		}
 	}
@@ -1079,7 +1188,7 @@ func (f *FormaCommandPersister) markResourceUpdateAsComplete(msg *messages.MarkR
 		f.Log().Debug("MarkResourceUpdateAsComplete: decremented pendingCompletions commandID=%s ksuid=%s operation=%s finalState=%s pendingCompletions=%d totalResourceUpdates=%d",
 			msg.CommandID, msg.ResourceURI.KSUID(), msg.Operation, msg.FinalState, cached.pendingCompletions, len(cmd.ResourceUpdates))
 		if cached.pendingCompletions < 0 {
-			return false, fmt.Errorf("unexpected completion for command %s resource %s: pendingCompletions went below zero, this indicates a programming error", msg.CommandID, msg.ResourceURI.KSUID())
+			return false, fmt.Errorf("%w: unexpected completion for command %s resource %s: pendingCompletions went below zero, this indicates a programming error", errInvariantViolation, msg.CommandID, msg.ResourceURI.KSUID())
 		}
 
 		cmd.ModifiedTs = msg.ResourceModifiedTs
@@ -1100,6 +1209,7 @@ func (f *FormaCommandPersister) markResourceUpdateAsComplete(msg *messages.MarkR
 			// ResourceUpdate is already persisted via UpdateResourceUpdateState above
 			if err := f.datastore.UpdateFormaCommandProgress(cmd.ID, cmd.State, cmd.ModifiedTs); err != nil {
 				f.Log().Error("Failed to update Forma command meta commandID=%s: %v", msg.CommandID, err)
+				cached.dirty = true
 				return false, fmt.Errorf("failed to update Forma command meta: %w", err)
 			}
 		}
@@ -1189,7 +1299,7 @@ func (f *FormaCommandPersister) bulkUpdateResourceState(
 			if isResourceInFinalState(state) {
 				cached.pendingCompletions--
 				if cached.pendingCompletions < 0 {
-					return false, fmt.Errorf("unexpected state transition for command %s: pendingCompletions went below zero, this indicates a programming error", commandID)
+					return false, fmt.Errorf("%w: unexpected state transition for command %s: pendingCompletions went below zero, this indicates a programming error", errInvariantViolation, commandID)
 				}
 				key := resourceUpdateKey(ref.URI.KSUID(), ref.Operation)
 				if cached.terminalizedByBulk == nil {
@@ -1235,6 +1345,7 @@ func (f *FormaCommandPersister) bulkUpdateResourceState(
 		// ResourceUpdates are already persisted via BatchUpdateResourceUpdateState above
 		if err := f.datastore.UpdateFormaCommandProgress(command.ID, command.State, command.ModifiedTs); err != nil {
 			f.Log().Error("Failed to update Forma command meta commandID=%s: %v", commandID, err)
+			cached.dirty = true
 			return false, fmt.Errorf("failed to update Forma command meta: %w", err)
 		}
 	}

--- a/internal/metastructure/forma_persister/forma_command_persister_replies_test.go
+++ b/internal/metastructure/forma_persister/forma_command_persister_replies_test.go
@@ -1,0 +1,354 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package forma_persister
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	dssqlite "github.com/platform-engineering-labs/formae/internal/datastore/sqlite"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// A progress update for a command the datastore does not hold is a
+// request-scoped failure: the caller must get an answer and the persister
+// must keep serving. Terminating instead kills every request queued in the
+// mailbox.
+func TestFormaCommandPersister_UnknownCommand_RepliesAndStaysAlive(t *testing.T) {
+	persister, sender, err := newFormaCommandPersisterForTest(t)
+	require.NoError(t, err)
+
+	result := persister.Call(sender, messages.UpdateResourceProgress{
+		CommandID:   "no-such-command",
+		ResourceURI: pkgmodel.NewFormaeURI(util.NewID(), ""),
+		Operation:   resource_update.OperationCreate,
+		Progress: plugin.TrackedProgress{
+			ProgressResult: resource.ProgressResult{
+				Operation:       resource.OperationCreate,
+				OperationStatus: resource.OperationStatusSuccess,
+			},
+		},
+	})
+
+	require.NoError(t, result.Error, "an unknown command must be answered, not terminate the persister")
+	failed, ok := result.Response.(CommandPersistResult)
+	require.True(t, ok, "the caller must receive a typed reply, got %T", result.Response)
+	require.NotEmpty(t, failed.Error)
+
+	// The same actor instance must keep serving: storing and loading a real
+	// command still works.
+	cmd := newFormaCommandWithCreateResourceUpdate()
+	stored := persister.Call(sender, StoreNewFormaCommand{Command: *cmd})
+	require.NoError(t, stored.Error, "the persister must still serve after a failed request")
+	storedRes, ok := stored.Response.(CommandPersistResult)
+	require.True(t, ok, "expected a typed reply, got %T", stored.Response)
+	assert.Empty(t, storedRes.Error, "a valid request after a failure must succeed")
+}
+
+func newTestDatastoreForReplies() (datastore.Datastore, error) {
+	return dssqlite.NewDatastoreSQLite(context.Background(), &pkgmodel.DatastoreConfig{
+		DatastoreType: pkgmodel.SqliteDatastore,
+		Sqlite:        pkgmodel.SqliteConfig{FilePath: ":memory:"},
+	}, "test-agent-id")
+}
+
+// commandStoreFailingOnce wraps a real datastore and fails StoreFormaCommand
+// while failures remain, the shape of a transient write failure.
+type commandStoreFailingOnce struct {
+	datastore.Datastore
+	failures int
+}
+
+func (s *commandStoreFailingOnce) StoreFormaCommand(command *forma_command.FormaCommand, commandID string) error {
+	if s.failures > 0 {
+		s.failures--
+		return errors.New("transient store failure")
+	}
+	return s.Datastore.StoreFormaCommand(command, commandID)
+}
+
+// A completion whose command write fails leaves the cached command mutated
+// (terminal) while the datastore still holds the old state. Surviving the
+// failure must not strand that divergence: the next request touching the
+// command has to flush the cached state to the datastore before it is
+// acknowledged, or the stored command stays non-terminal forever, locking its
+// stack until an agent restart.
+func TestFormaCommandPersister_FailedFinalWrite_FlushedOnNextTouch(t *testing.T) {
+	real, err := newTestDatastoreForReplies()
+	require.NoError(t, err)
+	store := &commandStoreFailingOnce{Datastore: real}
+
+	persister, sender, err := newFormaCommandPersisterWithDatastore(t, store)
+	require.NoError(t, err)
+
+	cmd := newFormaCommandWithCreateResourceUpdate()
+	stored := persister.Call(sender, StoreNewFormaCommand{Command: *cmd})
+	require.NoError(t, stored.Error)
+	require.True(t, stored.Response.(CommandPersistResult).OK)
+
+	// The command's only resource completes, but the final command write fails.
+	store.failures = 2
+	completion := messages.MarkResourceUpdateAsComplete{
+		CommandID:          cmd.ID,
+		ResourceURI:        cmd.ResourceUpdates[0].DesiredState.URI(),
+		Operation:          cmd.ResourceUpdates[0].Operation,
+		FinalState:         resource_update.ResourceUpdateStateSuccess,
+		ResourceStartTs:    util.TimeNow(),
+		ResourceModifiedTs: util.TimeNow(),
+		ResourceProperties: cmd.ResourceUpdates[0].DesiredState.Properties,
+		Version:            "v1",
+	}
+	result := persister.Call(sender, completion)
+	require.NoError(t, result.Error, "the failed write must be answered, not terminate the persister")
+	completionRes, ok := result.Response.(CommandPersistResult)
+	require.True(t, ok, "expected a typed reply, got %T", result.Response)
+	require.NotEmpty(t, completionRes.Error, "the failed write must be reported to the caller")
+
+	// The datastore still holds the pre-completion state.
+	stale, err := real.GetFormaCommandByCommandID(cmd.ID)
+	require.NoError(t, err)
+	require.False(t, stale.IsInFinalState(), "the failed write must not have reached the datastore")
+
+	// While the datastore is still failing, a touch must not be acknowledged
+	// from the undurable cache: the flush failure fails the request.
+	blocked := persister.Call(sender, LoadFormaCommand{CommandID: cmd.ID})
+	require.NoError(t, blocked.Error)
+	blockedRes, ok := blocked.Response.(LoadFormaCommandResult)
+	require.True(t, ok, "expected a typed reply, got %T", blocked.Response)
+	require.NotEmpty(t, blockedRes.Error, "a touch while the flush still fails must be answered with the failure")
+
+	// Once the datastore recovers, the next touch flushes the cached state.
+	load := persister.Call(sender, LoadFormaCommand{CommandID: cmd.ID})
+	require.NoError(t, load.Error)
+	loadRes, ok := load.Response.(LoadFormaCommandResult)
+	require.True(t, ok, "expected a typed reply, got %T", load.Response)
+	require.Empty(t, loadRes.Error, "the load itself must succeed")
+
+	flushed, err := real.GetFormaCommandByCommandID(cmd.ID)
+	require.NoError(t, err)
+	assert.True(t, flushed.IsInFinalState(),
+		"the cached terminal state must reach the datastore on the next touch, not wait for a restart")
+}
+
+// deleteFailingOnce wraps a real datastore and fails the next
+// DeleteFormaCommand while armed.
+type deleteFailingOnce struct {
+	datastore.Datastore
+	armed bool
+}
+
+func (s *deleteFailingOnce) DeleteFormaCommand(command *forma_command.FormaCommand, commandID string) error {
+	if s.armed {
+		s.armed = false
+		return errors.New("transient delete failure")
+	}
+	return s.Datastore.DeleteFormaCommand(command, commandID)
+}
+
+// An empty sync command is deleted at finalization. When that delete fails
+// transiently, the flush on the next touch must preserve the finalization
+// semantics and delete the command, not store a command that should not
+// exist.
+func TestFormaCommandPersister_FailedSyncDelete_DeletedOnNextTouch(t *testing.T) {
+	real, err := newTestDatastoreForReplies()
+	require.NoError(t, err)
+	store := &deleteFailingOnce{Datastore: real}
+
+	persister, sender, err := newFormaCommandPersisterWithDatastore(t, store)
+	require.NoError(t, err)
+
+	cmd := newSyncFormaCommand()
+	stored := persister.Call(sender, StoreNewFormaCommand{Command: *cmd})
+	require.NoError(t, stored.Error)
+	require.True(t, stored.Response.(CommandPersistResult).OK)
+
+	// The sync command's only resource completes with no version, which makes
+	// the command an empty sync command due for deletion; the delete fails.
+	store.armed = true
+	result := persister.Call(sender, messages.MarkResourceUpdateAsComplete{
+		CommandID:          cmd.ID,
+		ResourceURI:        cmd.ResourceUpdates[0].DesiredState.URI(),
+		Operation:          cmd.ResourceUpdates[0].Operation,
+		FinalState:         resource_update.ResourceUpdateStateSuccess,
+		ResourceStartTs:    util.TimeNow(),
+		ResourceModifiedTs: util.TimeNow(),
+		ResourceProperties: cmd.ResourceUpdates[0].DesiredState.Properties,
+		Version:            "",
+	})
+	require.NoError(t, result.Error)
+	deleteRes, ok := result.Response.(CommandPersistResult)
+	require.True(t, ok, "expected a typed reply, got %T", result.Response)
+	require.NotEmpty(t, deleteRes.Error, "the failed delete must be reported")
+
+	// The next touch must delete the command, not store it.
+	load := persister.Call(sender, LoadFormaCommand{CommandID: cmd.ID})
+	require.NoError(t, load.Error)
+	loadRes, ok := load.Response.(LoadFormaCommandResult)
+	require.True(t, ok, "expected a typed reply, got %T", load.Response)
+	assert.Contains(t, loadRes.Error, "not found")
+
+	_, err = real.GetFormaCommandByCommandID(cmd.ID)
+	require.Error(t, err, "the sync command must be deleted from the datastore, not stored")
+}
+
+// An unknown request type is a protocol bug, not a request-scoped outcome:
+// the error return keeps the meaning ergo assigns to it and terminates the
+// actor, so supervision surfaces the defect instead of a reply masking it.
+func TestFormaCommandPersister_UnknownRequestType_Terminates(t *testing.T) {
+	persister, sender, err := newFormaCommandPersisterForTest(t)
+	require.NoError(t, err)
+
+	type notARequest struct{}
+	result := persister.Call(sender, notARequest{})
+	require.Error(t, result.Error, "an unknown request type must terminate the actor")
+}
+
+// progressWriteFailingOnce wraps a real datastore and fails the next
+// command-meta progress write while failures remain.
+type progressWriteFailingOnce struct {
+	datastore.Datastore
+	failures int
+}
+
+func (s *progressWriteFailingOnce) UpdateFormaCommandProgress(commandID string, state forma_command.CommandState, modifiedTs time.Time) error {
+	if s.failures > 0 {
+		s.failures--
+		return errors.New("transient progress-write failure")
+	}
+	return s.Datastore.UpdateFormaCommandProgress(commandID, state, modifiedTs)
+}
+
+// A NON-final completion (other resources still pending) whose command-meta
+// write fails leaves the cached command state ahead of the datastore. The
+// failure must mark the cache dirty so the next touch flushes it; otherwise
+// the stored command row stays stale until some later write happens to
+// rewrite it.
+func TestFormaCommandPersister_FailedNonFinalMetaWrite_FlushedOnNextTouch(t *testing.T) {
+	real, err := newTestDatastoreForReplies()
+	require.NoError(t, err)
+	store := &progressWriteFailingOnce{Datastore: real}
+
+	persister, sender, err := newFormaCommandPersisterWithDatastore(t, store)
+	require.NoError(t, err)
+
+	// Two resources, so completing one leaves the command non-final.
+	cmd := newFormaCommandWithCreateResourceUpdate()
+	second := cmd.ResourceUpdates[0]
+	second.DesiredState.Label = "second-resource"
+	second.DesiredState.Ksuid = util.NewID()
+	cmd.ResourceUpdates = append(cmd.ResourceUpdates, second)
+
+	stored := persister.Call(sender, StoreNewFormaCommand{Command: *cmd})
+	require.NoError(t, stored.Error)
+	require.True(t, stored.Response.(CommandPersistResult).OK)
+
+	store.failures = 1
+	result := persister.Call(sender, messages.MarkResourceUpdateAsComplete{
+		CommandID:          cmd.ID,
+		ResourceURI:        cmd.ResourceUpdates[0].DesiredState.URI(),
+		Operation:          cmd.ResourceUpdates[0].Operation,
+		FinalState:         resource_update.ResourceUpdateStateSuccess,
+		ResourceStartTs:    util.TimeNow(),
+		ResourceModifiedTs: util.TimeNow(),
+		ResourceProperties: cmd.ResourceUpdates[0].DesiredState.Properties,
+		Version:            "v1",
+	})
+	require.NoError(t, result.Error, "the failed meta write must be answered, not terminate the persister")
+	completionRes, ok := result.Response.(CommandPersistResult)
+	require.True(t, ok, "expected a typed reply, got %T", result.Response)
+	require.NotEmpty(t, completionRes.Error, "the failed meta write must be reported to the caller")
+
+	staleCmd, err := real.GetFormaCommandByCommandID(cmd.ID)
+	require.NoError(t, err)
+	require.Equal(t, forma_command.CommandStateNotStarted, staleCmd.State,
+		"the failed meta write must not have advanced the stored command state")
+
+	// The next touch must flush the cached state to the datastore.
+	load := persister.Call(sender, LoadFormaCommand{CommandID: cmd.ID})
+	require.NoError(t, load.Error)
+	loadRes, ok := load.Response.(LoadFormaCommandResult)
+	require.True(t, ok, "expected a typed reply, got %T", load.Response)
+	require.Empty(t, loadRes.Error)
+
+	flushedCmd, err := real.GetFormaCommandByCommandID(cmd.ID)
+	require.NoError(t, err)
+	assert.Equal(t, forma_command.CommandStateInProgress, flushedCmd.State,
+		"the cached command state must reach the datastore on the next touch")
+}
+
+// A progress update whose read-snapshot hashing fails must leave the cached
+// command untouched: the failure is answered, and the retried update (with a
+// well-formed snapshot) must land instead of being dropped by the terminality
+// guard against a half-applied first attempt.
+func TestFormaCommandPersister_FailedProgressHash_LeavesCacheUntouched(t *testing.T) {
+	persister, sender, err := newFormaCommandPersisterForTest(t)
+	require.NoError(t, err)
+
+	cmd := newFormaCommandWithCreateResourceUpdate()
+	cmd.ResourceUpdates[0].DesiredState.Schema = pkgmodel.Schema{
+		Fields: []string{"Secret"},
+		Hints:  map[string]pkgmodel.FieldHint{"Secret": {Opaque: true}},
+	}
+	stored := persister.Call(sender, StoreNewFormaCommand{Command: *cmd})
+	require.NoError(t, stored.Error)
+	require.True(t, stored.Response.(CommandPersistResult).OK)
+
+	update := func(props json.RawMessage) messages.UpdateResourceProgress {
+		return messages.UpdateResourceProgress{
+			CommandID:          cmd.ID,
+			ResourceURI:        cmd.ResourceUpdates[0].DesiredState.URI(),
+			Operation:          cmd.ResourceUpdates[0].Operation,
+			ResourceState:      resource_update.ResourceUpdateStateSuccess,
+			ResourceStartTs:    util.TimeNow(),
+			ResourceModifiedTs: util.TimeNow(),
+			Progress: plugin.TrackedProgress{
+				ProgressResult: resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					ResourceProperties: props,
+				},
+			},
+		}
+	}
+
+	// A snapshot the hasher cannot process fails the request.
+	broken := persister.Call(sender, update(json.RawMessage(`{"Secret":`)))
+	require.NoError(t, broken.Error, "a hashing failure must be answered, not terminate the persister")
+	brokenRes, ok := broken.Response.(CommandPersistResult)
+	require.True(t, ok, "expected a typed reply, got %T", broken.Response)
+	require.NotEmpty(t, brokenRes.Error, "the hashing failure must be reported")
+
+	// The retry with a well-formed snapshot must land, not be dropped by the
+	// terminality guard against state the failed attempt half-applied.
+	retry := persister.Call(sender, update(json.RawMessage(`{"Secret":"s3cret"}`)))
+	require.NoError(t, retry.Error)
+	retryRes, ok := retry.Response.(CommandPersistResult)
+	require.True(t, ok, "expected a typed reply, got %T", retry.Response)
+	require.Empty(t, retryRes.Error, "the retried progress update must succeed")
+
+	load := persister.Call(sender, LoadFormaCommand{CommandID: cmd.ID})
+	require.NoError(t, load.Error)
+	loaded := load.Response.(LoadFormaCommandResult).Command
+	require.NotNil(t, loaded)
+	assert.Equal(t, resource_update.ResourceUpdateStateSuccess, loaded.ResourceUpdates[0].State,
+		"the retried progress must be recorded")
+	assert.NotEmpty(t, loaded.ResourceUpdates[0].MostRecentProgressResult.ResourceProperties,
+		"the retried snapshot must be recorded")
+}

--- a/internal/metastructure/forma_persister/forma_command_persister_test.go
+++ b/internal/metastructure/forma_persister/forma_command_persister_test.go
@@ -38,11 +38,15 @@ func TestFormaCommandPersister_StoresNewFormaCommand(t *testing.T) {
 
 	storeResult := operator.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
 	assert.NoError(t, storeResult.Error)
-	assert.True(t, storeResult.Response.(bool))
+	assert.True(t, storeResult.Response.(CommandPersistResult).OK)
 
 	loadResult := operator.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loadedCommand, ok := loadResult.Response.(*forma_command.FormaCommand)
+	loadedCommandLoadRes, ok := loadResult.Response.(LoadFormaCommandResult)
+	var loadedCommand *forma_command.FormaCommand
+	if ok {
+		loadedCommand = loadedCommandLoadRes.Command
+	}
 	assert.True(t, ok)
 
 	assert.Equal(t, formaCommand.ID, loadedCommand.ID)
@@ -55,7 +59,7 @@ func TestFormaCommandPersister_RecordsResourceProgress(t *testing.T) {
 
 	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
 	assert.NoError(t, storeResult.Error)
-	assert.True(t, storeResult.Response.(bool))
+	assert.True(t, storeResult.Response.(CommandPersistResult).OK)
 
 	// Use the KSUID from the resource
 	resourceURI := formaCommand.ResourceUpdates[0].DesiredState.URI()
@@ -77,11 +81,15 @@ func TestFormaCommandPersister_RecordsResourceProgress(t *testing.T) {
 	}
 	res := formaPersister.Call(sender, updateResourceProgress)
 	assert.NoError(t, res.Error)
-	assert.True(t, res.Response.(bool))
+	assert.True(t, res.Response.(CommandPersistResult).OK)
 
 	loadCommandResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadCommandResult.Error)
-	loadedCommand, ok := loadCommandResult.Response.(*forma_command.FormaCommand)
+	loadedCommandLoadRes, ok := loadCommandResult.Response.(LoadFormaCommandResult)
+	var loadedCommand *forma_command.FormaCommand
+	if ok {
+		loadedCommand = loadedCommandLoadRes.Command
+	}
 	assert.True(t, ok)
 
 	assert.Equal(t, resource_update.ResourceUpdateStateInProgress, loadedCommand.ResourceUpdates[0].State)
@@ -110,14 +118,18 @@ func TestFormaCommandPersister_RecordsResourceProgress(t *testing.T) {
 	}
 	secondRes := formaPersister.Call(sender, secondProgressUpdate)
 	assert.NoError(t, secondRes.Error)
-	assert.True(t, secondRes.Response.(bool))
+	assert.True(t, secondRes.Response.(CommandPersistResult).OK)
 
 	// After a terminal progress update, the command should still be InProgress.
 	// The command only transitions to a terminal state via MarkResourceUpdateAsComplete,
 	// which in production runs after the ResourcePersister has stored the resource.
 	secondLoadCommandResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, secondLoadCommandResult.Error)
-	secondLoadedCommand, ok := secondLoadCommandResult.Response.(*forma_command.FormaCommand)
+	secondLoadedCommandLoadRes, ok := secondLoadCommandResult.Response.(LoadFormaCommandResult)
+	var secondLoadedCommand *forma_command.FormaCommand
+	if ok {
+		secondLoadedCommand = secondLoadedCommandLoadRes.Command
+	}
 	assert.True(t, ok)
 
 	assert.Equal(t, forma_command.CommandStateInProgress, secondLoadedCommand.State)
@@ -135,11 +147,15 @@ func TestFormaCommandPersister_RecordsResourceProgress(t *testing.T) {
 	}
 	markRes := formaPersister.Call(sender, markComplete)
 	assert.NoError(t, markRes.Error)
-	assert.True(t, markRes.Response.(bool))
+	assert.True(t, markRes.Response.(CommandPersistResult).OK)
 
 	finalLoadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, finalLoadResult.Error)
-	finalCommand, ok := finalLoadResult.Response.(*forma_command.FormaCommand)
+	finalCommandLoadRes, ok := finalLoadResult.Response.(LoadFormaCommandResult)
+	var finalCommand *forma_command.FormaCommand
+	if ok {
+		finalCommand = finalCommandLoadRes.Command
+	}
 	assert.True(t, ok)
 
 	assert.Equal(t, forma_command.CommandStateSuccess, finalCommand.State)
@@ -209,11 +225,11 @@ func TestFormaCommandPersister_BulkUpdateResourceState(t *testing.T) {
 
 	updateResult := formaPersister.Call(sender, failResources)
 	assert.NoError(t, updateResult.Error)
-	assert.True(t, updateResult.Response.(bool))
+	assert.True(t, updateResult.Response.(CommandPersistResult).OK)
 
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loadedCommand := loadResult.Response.(*forma_command.FormaCommand)
+	loadedCommand := loadResult.Response.(LoadFormaCommandResult).Command
 
 	// Build a map of KSUID -> ResourceUpdate for order-agnostic assertions
 	ruByKsuid := make(map[string]*resource_update.ResourceUpdate)
@@ -268,11 +284,11 @@ func TestFormaCommandPersister_MarkCommandResourcesAsCanceled(t *testing.T) {
 
 	cancelResult := formaPersister.Call(sender, MarkCommandResourcesAsCanceled{CommandID: formaCommand.ID})
 	assert.NoError(t, cancelResult.Error)
-	assert.True(t, cancelResult.Response.(bool))
+	assert.True(t, cancelResult.Response.(CommandPersistResult).OK)
 
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loadedCommand := loadResult.Response.(*forma_command.FormaCommand)
+	loadedCommand := loadResult.Response.(LoadFormaCommandResult).Command
 
 	ruByKsuid := make(map[string]*resource_update.ResourceUpdate)
 	for i := range loadedCommand.ResourceUpdates {
@@ -294,7 +310,7 @@ func TestFormaCommandPersister_DeletesSyncCommandWithNoVersions(t *testing.T) {
 	// Store the sync command
 	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
 	assert.NoError(t, storeResult.Error)
-	assert.True(t, storeResult.Response.(bool))
+	assert.True(t, storeResult.Response.(CommandPersistResult).OK)
 
 	// Mark the resource update as complete WITHOUT a version (no changes detected)
 	resourceURI := formaCommand.ResourceUpdates[0].DesiredState.URI()
@@ -311,12 +327,14 @@ func TestFormaCommandPersister_DeletesSyncCommandWithNoVersions(t *testing.T) {
 	}
 	res := formaPersister.Call(sender, markComplete)
 	assert.NoError(t, res.Error)
-	assert.True(t, res.Response.(bool))
+	assert.True(t, res.Response.(CommandPersistResult).OK)
 
-	// Verify the command was deleted (LoadFormaCommand should return an error)
+	// Verify the command was deleted (LoadFormaCommand is answered with a failure)
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
-	assert.Error(t, loadResult.Error, "Sync command with no versions should be deleted")
-	assert.Contains(t, loadResult.Error.Error(), "forma command not found")
+	assert.NoError(t, loadResult.Error)
+	failed, ok := loadResult.Response.(LoadFormaCommandResult)
+	assert.True(t, ok, "expected a typed reply, got %T", loadResult.Response)
+	assert.Contains(t, failed.Error, "forma command not found")
 }
 
 func TestFormaCommandPersister_KeepsSyncCommandWithVersions(t *testing.T) {
@@ -327,7 +345,7 @@ func TestFormaCommandPersister_KeepsSyncCommandWithVersions(t *testing.T) {
 	// Store the sync command
 	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
 	assert.NoError(t, storeResult.Error)
-	assert.True(t, storeResult.Response.(bool))
+	assert.True(t, storeResult.Response.(CommandPersistResult).OK)
 
 	// Mark the resource update as complete WITH a version (changes detected)
 	resourceURI := formaCommand.ResourceUpdates[0].DesiredState.URI()
@@ -344,12 +362,16 @@ func TestFormaCommandPersister_KeepsSyncCommandWithVersions(t *testing.T) {
 	}
 	res := formaPersister.Call(sender, markComplete)
 	assert.NoError(t, res.Error)
-	assert.True(t, res.Response.(bool))
+	assert.True(t, res.Response.(CommandPersistResult).OK)
 
 	// Verify the command was kept
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loadedCommand, ok := loadResult.Response.(*forma_command.FormaCommand)
+	loadedCommandLoadRes, ok := loadResult.Response.(LoadFormaCommandResult)
+	var loadedCommand *forma_command.FormaCommand
+	if ok {
+		loadedCommand = loadedCommandLoadRes.Command
+	}
 	assert.True(t, ok, "Sync command with versions should be kept")
 	assert.NotNil(t, loadedCommand)
 	assert.Equal(t, forma_command.CommandStateSuccess, loadedCommand.State)
@@ -366,7 +388,7 @@ func TestFormaCommandPersister_KeepsApplyCommandWithNoVersions(t *testing.T) {
 	// Store the apply command
 	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
 	assert.NoError(t, storeResult.Error)
-	assert.True(t, storeResult.Response.(bool))
+	assert.True(t, storeResult.Response.(CommandPersistResult).OK)
 
 	// Mark the resource update as complete WITHOUT a version
 	resourceURI := formaCommand.ResourceUpdates[0].DesiredState.URI()
@@ -383,12 +405,16 @@ func TestFormaCommandPersister_KeepsApplyCommandWithNoVersions(t *testing.T) {
 	}
 	res := formaPersister.Call(sender, markComplete)
 	assert.NoError(t, res.Error)
-	assert.True(t, res.Response.(bool))
+	assert.True(t, res.Response.(CommandPersistResult).OK)
 
 	// Verify the command was kept (apply commands should not be deleted)
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loadedCommand, ok := loadResult.Response.(*forma_command.FormaCommand)
+	loadedCommandLoadRes, ok := loadResult.Response.(LoadFormaCommandResult)
+	var loadedCommand *forma_command.FormaCommand
+	if ok {
+		loadedCommand = loadedCommandLoadRes.Command
+	}
 	assert.True(t, ok, "Apply command should always be kept")
 	assert.NotNil(t, loadedCommand)
 	assert.Equal(t, forma_command.CommandStateSuccess, loadedCommand.State)
@@ -415,12 +441,12 @@ func TestFormaCommandPersister_ProgressUpdate_HashesReadActualProperties(t *test
 
 	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
 	assert.NoError(t, storeResult.Error)
-	assert.True(t, storeResult.Response.(bool))
+	assert.True(t, storeResult.Response.(CommandPersistResult).OK)
 
 	// Resume exemption: the initial store must NOT hash the user's DesiredState input.
 	storedLoad := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, storedLoad.Error)
-	storedCommand := storedLoad.Response.(*forma_command.FormaCommand)
+	storedCommand := storedLoad.Response.(LoadFormaCommandResult).Command
 	assert.JSONEq(t, `{"SecretString":"initial-secret"}`, string(storedCommand.ResourceUpdates[0].DesiredState.Properties),
 		"DesiredState input must remain plaintext at initial store to support resume-to-completion")
 
@@ -444,11 +470,11 @@ func TestFormaCommandPersister_ProgressUpdate_HashesReadActualProperties(t *test
 	}
 	res := formaPersister.Call(sender, updateProgress)
 	assert.NoError(t, res.Error)
-	assert.True(t, res.Response.(bool))
+	assert.True(t, res.Response.(CommandPersistResult).OK)
 
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loaded := loadResult.Response.(*forma_command.FormaCommand)
+	loaded := loadResult.Response.(LoadFormaCommandResult).Command
 
 	persistedProgress := loaded.ResourceUpdates[0].MostRecentProgressResult.ResourceProperties
 	assert.NotContains(t, string(persistedProgress), "polled-secret",
@@ -670,7 +696,7 @@ func TestFormaCommandPersister_CacheEvictionOnFinalState(t *testing.T) {
 	// Load the command again - this should work (from DB since cache was evicted)
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loadedCommand := loadResult.Response.(*forma_command.FormaCommand)
+	loadedCommand := loadResult.Response.(LoadFormaCommandResult).Command
 	assert.Equal(t, forma_command.CommandStateSuccess, loadedCommand.State)
 }
 
@@ -738,7 +764,7 @@ func TestFormaCommandPersister_MultipleProgressUpdatesUseCacheHit(t *testing.T) 
 	// Verify both resources are updated
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loadedCommand := loadResult.Response.(*forma_command.FormaCommand)
+	loadedCommand := loadResult.Response.(LoadFormaCommandResult).Command
 
 	assert.Equal(t, resource_update.ResourceUpdateStateInProgress, loadedCommand.ResourceUpdates[0].State)
 	assert.Equal(t, resource_update.ResourceUpdateStateInProgress, loadedCommand.ResourceUpdates[1].State)
@@ -780,7 +806,7 @@ func TestFormaCommandPersister_ProgressUpdate_PreservesPropertiesAndVersion(t *t
 	// Load and assert fields were updated
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loaded := loadResult.Response.(*forma_command.FormaCommand)
+	loaded := loadResult.Response.(LoadFormaCommandResult).Command
 
 	assert.JSONEq(t, string(updatedProperties), string(loaded.ResourceUpdates[0].DesiredState.Properties))
 	assert.JSONEq(t, string(updatedReadOnlyProperties), string(loaded.ResourceUpdates[0].DesiredState.ReadOnlyProperties))
@@ -812,12 +838,12 @@ func TestFormaCommandPersister_Completion_PreservesProperties(t *testing.T) {
 	}
 	res := formaPersister.Call(sender, markComplete)
 	assert.NoError(t, res.Error)
-	assert.True(t, res.Response.(bool))
+	assert.True(t, res.Response.(CommandPersistResult).OK)
 
 	// Command is now in final state and persisted; load it back
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loaded := loadResult.Response.(*forma_command.FormaCommand)
+	loaded := loadResult.Response.(LoadFormaCommandResult).Command
 
 	assert.JSONEq(t, string(finalProperties), string(loaded.ResourceUpdates[0].DesiredState.Properties))
 	assert.JSONEq(t, string(finalReadOnlyProperties), string(loaded.ResourceUpdates[0].DesiredState.ReadOnlyProperties))
@@ -847,7 +873,7 @@ func TestFormaCommandPersister_DuplicateCompletion_IsNoOp(t *testing.T) {
 	// First completion: valid, should succeed
 	res1 := formaPersister.Call(sender, markComplete)
 	assert.NoError(t, res1.Error)
-	assert.True(t, res1.Response.(bool))
+	assert.True(t, res1.Response.(CommandPersistResult).OK)
 
 	// Second completion for the same resource: the monotonic terminality guard treats this as
 	// a no-op. The resource is already in a terminal state (Success) so the late message is
@@ -855,7 +881,7 @@ func TestFormaCommandPersister_DuplicateCompletion_IsNoOp(t *testing.T) {
 	// when the command was evicted from cache and reloaded (countNonFinalResources=0).
 	res2 := formaPersister.Call(sender, markComplete)
 	assert.NoError(t, res2.Error, "duplicate completion must be a no-op, not an error")
-	assert.True(t, res2.Response.(bool))
+	assert.True(t, res2.Response.(CommandPersistResult).OK)
 }
 
 func TestIsResourceInFinalState_Success(t *testing.T) {
@@ -961,7 +987,7 @@ func TestFormaCommandPersister_TargetUpdateState_PersistedToDB(t *testing.T) {
 	// Store the command (target=NotStarted, resource=NotStarted).
 	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
 	assert.NoError(t, storeResult.Error)
-	assert.True(t, storeResult.Response.(bool))
+	assert.True(t, storeResult.Response.(CommandPersistResult).OK)
 
 	// Mark the target update as complete (Success).
 	// The resource update is still NotStarted, so the overall command stays InProgress
@@ -975,7 +1001,7 @@ func TestFormaCommandPersister_TargetUpdateState_PersistedToDB(t *testing.T) {
 	}
 	res := formaPersister.Call(sender, markTargetComplete)
 	assert.NoError(t, res.Error)
-	assert.True(t, res.Response.(bool))
+	assert.True(t, res.Response.(CommandPersistResult).OK)
 
 	// Spin up a second persister against the same database.
 	// This simulates a cache-miss (e.g. persister restart) and forces a fresh load from DB.
@@ -984,7 +1010,7 @@ func TestFormaCommandPersister_TargetUpdateState_PersistedToDB(t *testing.T) {
 
 	loadResult := secondPersister.Call(sender2, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loaded := loadResult.Response.(*forma_command.FormaCommand)
+	loaded := loadResult.Response.(LoadFormaCommandResult).Command
 
 	// The target update state must be Success, not reverted to NotStarted.
 	assert.Equal(t, types.TargetUpdateStateSuccess, loaded.TargetUpdates[0].State,
@@ -1041,7 +1067,7 @@ func TestFormaCommandPersister_LateCompletion_TerminalResourceGuard(t *testing.T
 	// Store the command: pendingCompletions=2
 	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
 	assert.NoError(t, storeResult.Error)
-	assert.True(t, storeResult.Response.(bool))
+	assert.True(t, storeResult.Response.(CommandPersistResult).OK)
 
 	now := util.TimeNow()
 
@@ -1068,12 +1094,12 @@ func TestFormaCommandPersister_LateCompletion_TerminalResourceGuard(t *testing.T
 	}
 	lateRes := formaPersister.Call(sender, lateComplete)
 	assert.NoError(t, lateRes.Error, "late completion for already-terminal resource must not return an error")
-	assert.True(t, lateRes.Response.(bool))
+	assert.True(t, lateRes.Response.(CommandPersistResult).OK)
 
 	// The resource state must still be Canceled (not overwritten to Success).
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loaded := loadResult.Response.(*forma_command.FormaCommand)
+	loaded := loadResult.Response.(LoadFormaCommandResult).Command
 
 	ruByKsuid := make(map[string]*resource_update.ResourceUpdate)
 	for i := range loaded.ResourceUpdates {
@@ -1098,12 +1124,12 @@ func TestFormaCommandPersister_LateCompletion_TerminalResourceGuard(t *testing.T
 	}
 	normalRes := formaPersister.Call(sender, normalComplete)
 	assert.NoError(t, normalRes.Error, "normal completion after a guarded late write must succeed")
-	assert.True(t, normalRes.Response.(bool))
+	assert.True(t, normalRes.Response.(CommandPersistResult).OK)
 
 	// Both resources are now terminal; the overall command state must be Canceled.
 	finalLoad := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, finalLoad.Error)
-	finalCmd := finalLoad.Response.(*forma_command.FormaCommand)
+	finalCmd := finalLoad.Response.(LoadFormaCommandResult).Command
 	assert.Equal(t, forma_command.CommandStateCanceled, finalCmd.State,
 		"overall command state must be Canceled after all resources reach terminal state")
 }
@@ -1155,7 +1181,7 @@ func TestFormaCommandPersister_LateTargetCompletion_TerminalTargetGuard(t *testi
 	// Store the command with the target already Canceled.
 	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
 	assert.NoError(t, storeResult.Error)
-	assert.True(t, storeResult.Response.(bool))
+	assert.True(t, storeResult.Response.(CommandPersistResult).OK)
 
 	now := util.TimeNow()
 
@@ -1170,12 +1196,12 @@ func TestFormaCommandPersister_LateTargetCompletion_TerminalTargetGuard(t *testi
 	}
 	lateRes := formaPersister.Call(sender, lateTargetComplete)
 	assert.NoError(t, lateRes.Error, "late target completion for already-terminal target must not return an error")
-	assert.True(t, lateRes.Response.(bool))
+	assert.True(t, lateRes.Response.(CommandPersistResult).OK)
 
 	// The target update state must still be Canceled (not overwritten to Success).
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loaded := loadResult.Response.(*forma_command.FormaCommand)
+	loaded := loadResult.Response.(LoadFormaCommandResult).Command
 
 	assert.Equal(t, types.TargetUpdateStateCanceled, loaded.TargetUpdates[0].State,
 		"terminal (Canceled) target state must not be overwritten by a late completion")
@@ -1230,7 +1256,7 @@ func TestFormaCommandPersister_UpdateTargetStates_MergesTerminalTargets(t *testi
 	// Store the command with the target already Canceled.
 	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
 	assert.NoError(t, storeResult.Error)
-	assert.True(t, storeResult.Response.(bool))
+	assert.True(t, storeResult.Response.(CommandPersistResult).OK)
 
 	// Send updateTargetStates with the same target but a non-terminal state (InProgress).
 	// Without the merge guard, this would overwrite the Canceled state with InProgress.
@@ -1249,12 +1275,12 @@ func TestFormaCommandPersister_UpdateTargetStates_MergesTerminalTargets(t *testi
 	}
 	lateRes := formaPersister.Call(sender, lateUpdate)
 	assert.NoError(t, lateRes.Error, "late updateTargetStates must not return an error")
-	assert.True(t, lateRes.Response.(bool))
+	assert.True(t, lateRes.Response.(CommandPersistResult).OK)
 
 	// The target must remain Canceled.
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loaded := loadResult.Response.(*forma_command.FormaCommand)
+	loaded := loadResult.Response.(LoadFormaCommandResult).Command
 
 	assert.Equal(t, types.TargetUpdateStateCanceled, loaded.TargetUpdates[0].State,
 		"terminal (Canceled) target state must not be clobbered by a late updateTargetStates")
@@ -1351,7 +1377,7 @@ func TestFormaCommandPersister_BulkForceCancel_TerminalizesInFlightWork(t *testi
 	// Note: storeNewFormaCommand sets pendingCompletions = len(ResourceUpdates) = 3
 	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
 	assert.NoError(t, storeResult.Error)
-	assert.True(t, storeResult.Response.(bool))
+	assert.True(t, storeResult.Response.(CommandPersistResult).OK)
 
 	// Advance ksuid1 and ksuid2 to InProgress via UpdateResourceProgress
 	now := util.TimeNow()
@@ -1409,7 +1435,7 @@ func TestFormaCommandPersister_BulkForceCancel_TerminalizesInFlightWork(t *testi
 	// Reload from DB (command was finalized and evicted from cache)
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loaded := loadResult.Response.(*forma_command.FormaCommand)
+	loaded := loadResult.Response.(LoadFormaCommandResult).Command
 
 	// Build lookup by ksuid
 	ruByKsuid := make(map[string]*resource_update.ResourceUpdate)
@@ -1437,12 +1463,12 @@ func TestFormaCommandPersister_BulkForceCancel_TerminalizesInFlightWork(t *testi
 	}
 	lateRes := formaPersister.Call(sender, lateComplete)
 	assert.NoError(t, lateRes.Error, "late completion for already-terminal resource must be a no-op")
-	assert.True(t, lateRes.Response.(bool))
+	assert.True(t, lateRes.Response.(CommandPersistResult).OK)
 
 	// State must still be Canceled after the late no-op
 	finalLoad := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, finalLoad.Error)
-	finalCmd := finalLoad.Response.(*forma_command.FormaCommand)
+	finalCmd := finalLoad.Response.(LoadFormaCommandResult).Command
 	assert.Equal(t, forma_command.CommandStateCanceled, finalCmd.State)
 }
 
@@ -1471,7 +1497,7 @@ func TestFormaCommandPersister_MarkCompleteRecordsFailureReason(t *testing.T) {
 
 	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
 	assert.NoError(t, storeResult.Error)
-	assert.True(t, storeResult.Response.(bool))
+	assert.True(t, storeResult.Response.(CommandPersistResult).OK)
 
 	resourceURI := formaCommand.ResourceUpdates[0].DesiredState.URI()
 	reason := "resource update failed before any plugin operation ran"
@@ -1487,11 +1513,15 @@ func TestFormaCommandPersister_MarkCompleteRecordsFailureReason(t *testing.T) {
 	}
 	markRes := formaPersister.Call(sender, markComplete)
 	assert.NoError(t, markRes.Error)
-	assert.True(t, markRes.Response.(bool))
+	assert.True(t, markRes.Response.(CommandPersistResult).OK)
 
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loaded, ok := loadResult.Response.(*forma_command.FormaCommand)
+	loadedLoadRes, ok := loadResult.Response.(LoadFormaCommandResult)
+	var loaded *forma_command.FormaCommand
+	if ok {
+		loaded = loadedLoadRes.Command
+	}
 	assert.True(t, ok)
 
 	assert.Equal(t, reason, loaded.ResourceUpdates[0].FailureReason)
@@ -1511,7 +1541,7 @@ func TestFormaCommandPersister_SuccessfulRetryClearsPersistedFailureReason(t *te
 
 	storeResult := formaPersister.Call(sender, StoreNewFormaCommand{Command: *formaCommand})
 	assert.NoError(t, storeResult.Error)
-	assert.True(t, storeResult.Response.(bool))
+	assert.True(t, storeResult.Response.(CommandPersistResult).OK)
 
 	resourceURI := formaCommand.ResourceUpdates[0].DesiredState.URI()
 
@@ -1525,11 +1555,15 @@ func TestFormaCommandPersister_SuccessfulRetryClearsPersistedFailureReason(t *te
 	}
 	res := formaPersister.Call(sender, succeeded)
 	assert.NoError(t, res.Error)
-	assert.True(t, res.Response.(bool))
+	assert.True(t, res.Response.(CommandPersistResult).OK)
 
 	loadResult := formaPersister.Call(sender, LoadFormaCommand{CommandID: formaCommand.ID})
 	assert.NoError(t, loadResult.Error)
-	loaded, ok := loadResult.Response.(*forma_command.FormaCommand)
+	loadedLoadRes, ok := loadResult.Response.(LoadFormaCommandResult)
+	var loaded *forma_command.FormaCommand
+	if ok {
+		loaded = loadedLoadRes.Command
+	}
 	assert.True(t, ok)
 
 	assert.Empty(t, loaded.ResourceUpdates[0].FailureReason)

--- a/internal/metastructure/generator_rotator.go
+++ b/internal/metastructure/generator_rotator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_persister"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/generator_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
 	apimodel "github.com/platform-engineering-labs/formae/pkg/api/model"
@@ -273,10 +274,10 @@ func (g *GeneratorRotator) startRotation(info datastore.GeneratorRotationInfo) (
 		return "", nil
 	}
 
-	_, err = g.Call(
+	_, err = messages.UnwrapCall(g.Call(
 		gen.ProcessID{Name: actornames.FormaCommandPersister, Node: g.Node().Name()},
 		forma_persister.StoreNewFormaCommand{Command: *result.command},
-	)
+	))
 	if err != nil {
 		return "", fmt.Errorf("failed to store rotation command: %w", err)
 	}

--- a/internal/metastructure/messages/call_result.go
+++ b/internal/metastructure/messages/call_result.go
@@ -1,0 +1,42 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package messages
+
+import "errors"
+
+// Request-scoped failures are answers, not termination reasons: an actor that
+// returns an error from HandleCall is terminated by the framework without
+// replying, so the caller times out, every request queued in the actor's
+// mailbox dies with it, and the supervisor respawns the actor only for the
+// next bad request to repeat the cycle. The persisters therefore reply with
+// typed result messages that carry their own success/failure status, and the
+// HandleCall error return keeps the meaning ergo assigns to it: terminate the
+// actor — reserved for genuine faults (invariant violations, protocol bugs),
+// where a crash and supervised restart is the right medicine.
+
+// PersistVersionsResult is the reply to the bulk persist requests (target,
+// stack, policy, and generator updates): the stored versions on success, or
+// the failure that refused the write.
+type PersistVersionsResult struct {
+	Versions []string
+	Error    string
+}
+
+func (r PersistVersionsResult) CallError() string { return r.Error }
+
+// UnwrapCall folds a failed typed reply into the error return, so a call site
+// reads as one (result, error) pair whether the failure was transport-level
+// (the real error return) or request-scoped (a reply whose status carries the
+// failure). Wrap the Call directly:
+// result, err := messages.UnwrapCall(proc.Call(target, req)).
+func UnwrapCall(result any, err error) (any, error) {
+	if err != nil {
+		return nil, err
+	}
+	if r, ok := result.(interface{ CallError() string }); ok && r.CallError() != "" {
+		return nil, errors.New(r.CallError())
+	}
+	return result, nil
+}

--- a/internal/metastructure/messages/plugin.go
+++ b/internal/metastructure/messages/plugin.go
@@ -63,10 +63,14 @@ type GetPluginNode struct {
 	Namespace string
 }
 
-// PluginNode is the response containing the plugin's Ergo node name
+// PluginNode is the response containing the plugin's Ergo node name, or the
+// failure that prevented the lookup (no plugin serves the namespace).
 type PluginNode struct {
 	NodeName gen.Atom
+	Error    string
 }
+
+func (r PluginNode) CallError() string { return r.Error }
 
 // GetPluginInfo requests plugin metadata from PluginCoordinator
 type GetPluginInfo struct {

--- a/internal/metastructure/messages/resource_persister.go
+++ b/internal/metastructure/messages/resource_persister.go
@@ -14,10 +14,15 @@ type LoadResource struct {
 	ResourceURI pkgmodel.FormaeURI
 }
 
+// LoadResourceResult is the reply to a LoadResource call: the resource and
+// its target on success, or the failure that prevented the load.
 type LoadResourceResult struct {
 	Resource pkgmodel.Resource
 	Target   pkgmodel.Target
+	Error    string
 }
+
+func (r LoadResourceResult) CallError() string { return r.Error }
 
 // CleanupEmptyStacks is sent to ResourcePersister after a changeset completes
 // to delete any stacks that no longer have resources.
@@ -65,4 +70,7 @@ type PersistTargetReap struct {
 type PersistTargetReapResult struct {
 	Reaped            bool
 	ReapedStackLabels []string
+	Error             string
 }
+
+func (r PersistTargetReapResult) CallError() string { return r.Error }

--- a/internal/metastructure/metastructure.go
+++ b/internal/metastructure/metastructure.go
@@ -321,10 +321,12 @@ func (m *Metastructure) callActor(targetPID gen.ProcessID, message any) (any, er
 		return nil, fmt.Errorf("failed to send request to MetastructureBridge: %w", err)
 	}
 
-	// Wait for either success or error response
+	// Wait for either success or error response. A CallFailed reply is a
+	// request-scoped failure answered by the target actor; fold it into the
+	// error return so every callActor site sees one (result, error) contract.
 	select {
 	case response := <-successChan:
-		return response, nil
+		return messages.UnwrapCall(response, nil)
 	case err := <-errorChan:
 		return nil, err
 	case <-time.After(actorCallTimeout):

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator.go
@@ -203,12 +203,19 @@ func (c *PluginCoordinator) Init(args ...any) error {
 	return nil
 }
 
+// HandleCall answers every request with a typed result carrying its own
+// success/failure status. Returning an error here would terminate the
+// coordinator without a reply, dropping every registered plugin with the
+// actor and starving the requests queued in its mailbox — so a namespace no
+// plugin serves is answered, not crashed on. An unknown request type is a
+// protocol bug and keeps the terminating error return.
 func (c *PluginCoordinator) HandleCall(from gen.PID, ref gen.Ref, request any) (any, error) {
 	switch req := request.(type) {
 	case messages.GetPluginNode:
 		plugin, ok := c.findPluginByNamespace(req.Namespace)
 		if !ok {
-			return nil, fmt.Errorf("plugin not found: %s", req.Namespace)
+			c.Log().Error("PluginCoordinator: plugin not found: %s", req.Namespace)
+			return messages.PluginNode{Error: fmt.Sprintf("plugin not found: %s", req.Namespace)}, nil
 		}
 		return messages.PluginNode{NodeName: plugin.NodeName}, nil
 
@@ -223,6 +230,7 @@ func (c *PluginCoordinator) HandleCall(from gen.PID, ref gen.Ref, request any) (
 		return c.getRegisteredPlugins(), nil
 
 	default:
+		c.Log().Error("PluginCoordinator: unknown request type %T", request)
 		return nil, fmt.Errorf("unknown request: %T", request)
 	}
 }

--- a/internal/metastructure/plugin_coordinator/plugin_coordinator_replies_test.go
+++ b/internal/metastructure/plugin_coordinator/plugin_coordinator_replies_test.go
@@ -1,0 +1,36 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package plugin_coordinator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+)
+
+// A node lookup for a namespace no plugin serves is a request-scoped failure:
+// the caller must get an answer and the coordinator must keep serving.
+// Terminating instead drops every registered plugin with the actor.
+func TestPluginCoordinator_UnknownNamespaceNodeLookup_RepliesAndStaysAlive(t *testing.T) {
+	listener, sender := newCoordinatorForTest(t)
+
+	result := listener.Call(sender, messages.GetPluginNode{Namespace: "nonexistent"})
+
+	require.NoError(t, result.Error, "an unknown namespace must be answered, not terminate the coordinator")
+	node, ok := result.Response.(messages.PluginNode)
+	require.True(t, ok, "the caller must receive a typed reply, got %T", result.Response)
+	assert.Contains(t, node.Error, "plugin not found")
+
+	// The same actor instance must keep serving requests.
+	next := listener.Call(sender, messages.GetRegisteredPlugins{})
+	require.NoError(t, next.Error, "the coordinator must still serve after a failed lookup")
+	_, ok = next.Response.(messages.GetRegisteredPluginsResult)
+	assert.True(t, ok, "a valid request after a failure must succeed, got %T", next.Response)
+}

--- a/internal/metastructure/resource_persister/resource_persister.go
+++ b/internal/metastructure/resource_persister/resource_persister.go
@@ -69,37 +69,41 @@ func (rp *ResourcePersister) Init(args ...any) error {
 	return nil
 }
 
+// HandleCall answers every request with a typed result carrying its own
+// success/failure status. Returning an error here would terminate the actor
+// without a reply: the caller times out, every request queued in the mailbox
+// dies with it, and the supervisor respawns the actor only for the next bad
+// request to repeat the cycle. The error return keeps the meaning ergo
+// assigns to it — terminate — and is reserved for genuine faults: an unknown
+// request type is a protocol bug, and the persister crashes on it.
 func (rp *ResourcePersister) HandleCall(from gen.PID, ref gen.Ref, request any) (any, error) {
 	switch req := request.(type) {
 	case resource_update.PersistResourceUpdate:
 		hash, err := rp.storeResourceUpdate(req.CommandID, req.ResourceOperation, req.PluginOperation, &req.ResourceUpdate)
-		return hash, err
+		if err != nil {
+			rp.Log().Error("ResourcePersister: persist of %s failed: %s", req.ResourceUpdate.DesiredState.Label, err)
+			return resource_update.PersistResourceUpdateResult{Error: err.Error()}, nil
+		}
+		return resource_update.PersistResourceUpdateResult{Version: hash}, nil
 	case target_update.PersistTargetUpdates:
 		versions, err := rp.persistTargetUpdates(req.TargetUpdates, req.CommandID)
-		if err != nil {
-			return nil, err
-		}
-		return versions, nil
+		return persistVersionsResult(rp, "target updates", versions, err), nil
 	case stack_update.PersistStackUpdates:
 		versions, err := rp.persistStackUpdates(req.StackUpdates, req.CommandID)
-		if err != nil {
-			return nil, err
-		}
-		return versions, nil
+		return persistVersionsResult(rp, "stack updates", versions, err), nil
 	case policy_update.PersistPolicyUpdates:
 		versions, err := rp.persistPolicyUpdates(req.PolicyUpdates, req.CommandID, req.StackIDMap)
-		if err != nil {
-			return nil, err
-		}
-		return versions, nil
+		return persistVersionsResult(rp, "policy updates", versions, err), nil
 	case generator_update.PersistGeneratorUpdates:
 		versions, err := rp.persistGeneratorUpdates(req.GeneratorUpdates, req.CommandID, req.StackIDMap)
-		if err != nil {
-			return nil, err
-		}
-		return versions, nil
+		return persistVersionsResult(rp, "generator updates", versions, err), nil
 	case messages.LoadResource:
-		return rp.loadResource(req.ResourceURI)
+		result, err := rp.loadResource(req.ResourceURI)
+		if err != nil {
+			rp.Log().Error("ResourcePersister: load of %s failed: %s", req.ResourceURI, err)
+			return messages.LoadResourceResult{Error: err.Error()}, nil
+		}
+		return result, nil
 	case messages.PersistTargetReap:
 		reaped, reapedStacks, err := rp.datastore.PersistTargetReap(datastore.PersistTargetReapRequest{
 			Label:            req.Label,
@@ -109,7 +113,8 @@ func (rp *ResourcePersister) HandleCall(from gen.PID, ref gen.Ref, request any) 
 			ReapedAt:         req.ReapedAt,
 		})
 		if err != nil {
-			return nil, err
+			rp.Log().Error("ResourcePersister: target reap of %s failed: %s", req.Label, err)
+			return messages.PersistTargetReapResult{Error: err.Error()}, nil
 		}
 		if reaped && len(reapedStacks) > 0 {
 			// The reap tombstoned the last live resource(s) of one or more
@@ -124,6 +129,15 @@ func (rp *ResourcePersister) HandleCall(from gen.PID, ref gen.Ref, request any) 
 		rp.Log().Error("ResourcePersister: unknown request type=%s", fmt.Sprintf("%T", request))
 		return nil, fmt.Errorf("resource persister: unknown request type %T", request)
 	}
+}
+
+// persistVersionsResult folds one bulk-persist outcome into its reply.
+func persistVersionsResult(rp *ResourcePersister, what string, versions []string, err error) messages.PersistVersionsResult {
+	if err != nil {
+		rp.Log().Error("ResourcePersister: persist of %s failed: %s", what, err)
+		return messages.PersistVersionsResult{Error: err.Error()}
+	}
+	return messages.PersistVersionsResult{Versions: versions}
 }
 
 // HandleMessage handles asynchronous messages (sent via proc.Send).

--- a/internal/metastructure/resource_persister/resource_persister_replies_test.go
+++ b/internal/metastructure/resource_persister/resource_persister_replies_test.go
@@ -1,0 +1,148 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_persister
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"ergo.services/ergo/gen"
+	"ergo.services/ergo/testing/unit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/internal/datastore"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/platform-engineering-labs/formae/pkg/plugin"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// rejectingStore wraps a real datastore and rejects every resource-version
+// write, the shape a reaped/incarnation-guard rejection takes.
+type rejectingStore struct {
+	datastore.Datastore
+}
+
+func (s *rejectingStore) StoreResource(resource *pkgmodel.Resource, commandID string, expectedIncarnation ...string) (string, error) {
+	return "", fmt.Errorf("%w: incarnation mismatch", datastore.ErrResourceWriteRejected)
+}
+
+func newPersisterWithStore(t *testing.T, ds datastore.Datastore) (*unit.TestActor, gen.PID, error) {
+	env := map[gen.Env]any{
+		"Datastore": ds,
+		"DiscoveryConfig": pkgmodel.DiscoveryConfig{
+			Enabled:  true,
+			Interval: 10 * time.Minute,
+		},
+	}
+	sender := gen.PID{Node: "test", ID: 100}
+	actor, err := unit.Spawn(t, NewResourcePersister, unit.WithEnv(env))
+	return actor, sender, err
+}
+
+func successfulCreateUpdate(label string) resource_update.PersistResourceUpdate {
+	return resource_update.PersistResourceUpdate{
+		CommandID:         "cmd-" + label,
+		ResourceOperation: resource_update.OperationCreate,
+		PluginOperation:   resource.OperationCreate,
+		ResourceUpdate: resource_update.ResourceUpdate{
+			DesiredState: pkgmodel.Resource{
+				Label:      label,
+				Type:       "FakeAWS::S3::Bucket",
+				Properties: json.RawMessage(`{"foo":"bar"}`),
+				Stack:      "test-stack",
+				Ksuid:      util.NewID(),
+			},
+			ResourceTarget: pkgmodel.Target{Label: "test-target", Namespace: "aws"},
+			State:          resource_update.ResourceUpdateStateSuccess,
+			StackLabel:     "test-stack",
+			ProgressResult: []plugin.TrackedProgress{{
+				ProgressResult: resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					NativeID:           "native-" + label,
+					ResourceProperties: json.RawMessage(`{"foo":"bar"}`),
+				},
+				ResourceType: "FakeAWS::S3::Bucket",
+				StartTs:      util.TimeNow(),
+				ModifiedTs:   util.TimeNow(),
+				Attempts:     1,
+			}},
+		},
+	}
+}
+
+// A load for a resource that does not exist is a request-scoped failure: the
+// caller must get an answer and the persister must keep serving. Terminating
+// instead kills every request queued in the mailbox.
+func TestResourcePersister_LoadMiss_RepliesAndStaysAlive(t *testing.T) {
+	persister, sender, ds, err := newResourcePersisterForTest(t)
+	require.NoError(t, err)
+
+	result := persister.Call(sender, messages.LoadResource{
+		ResourceURI: pkgmodel.NewFormaeURI(util.NewID(), ""),
+	})
+
+	require.NoError(t, result.Error, "a load miss must not terminate the persister")
+	loadRes, ok := result.Response.(messages.LoadResourceResult)
+	require.True(t, ok, "the caller must receive a typed reply, got %T", result.Response)
+	assert.Contains(t, loadRes.Error, "not found")
+
+	// The same actor instance must keep serving requests.
+	_, err = ds.CreateTarget(&pkgmodel.Target{Label: "test-target", Namespace: "aws"})
+	require.NoError(t, err)
+	next := persister.Call(sender, successfulCreateUpdate("after-miss"))
+	require.NoError(t, next.Error, "the persister must still serve after a failed request")
+	persistRes, ok := next.Response.(resource_update.PersistResourceUpdateResult)
+	require.True(t, ok, "expected a typed persist reply, got %T", next.Response)
+	assert.Empty(t, persistRes.Error, "a valid request after a failure must succeed")
+}
+
+// A write the datastore rejects (the reaped/incarnation guard) must be
+// answered with the rejection, not terminate the persister.
+func TestResourcePersister_RejectedWrite_RepliesAndStaysAlive(t *testing.T) {
+	real, err := newTestDatastore()
+	require.NoError(t, err)
+	_, err = real.CreateTarget(&pkgmodel.Target{Label: "test-target", Namespace: "aws"})
+	require.NoError(t, err)
+
+	persister, sender, err := newPersisterWithStore(t, &rejectingStore{Datastore: real})
+	require.NoError(t, err)
+
+	result := persister.Call(sender, successfulCreateUpdate("rejected"))
+
+	require.NoError(t, result.Error, "a rejected write must not terminate the persister")
+	persistRes, ok := result.Response.(resource_update.PersistResourceUpdateResult)
+	require.True(t, ok, "the caller must receive a typed reply, got %T", result.Response)
+	assert.Contains(t, persistRes.Error, "rejected by reaped/incarnation guard")
+
+	// A read on the same actor instance must still be served.
+	load := persister.Call(sender, messages.LoadResource{
+		ResourceURI: pkgmodel.NewFormaeURI(util.NewID(), ""),
+	})
+	require.NoError(t, load.Error, "the persister must still serve after a rejected write")
+	loadRes, ok := load.Response.(messages.LoadResourceResult)
+	require.True(t, ok, "expected a typed load reply, got %T", load.Response)
+	assert.NotEmpty(t, loadRes.Error, "the load miss is itself answered, proving the actor is alive")
+}
+
+// An unknown request type is a protocol bug, not a request-scoped outcome:
+// the error return keeps the meaning ergo assigns to it and terminates the
+// actor, so supervision surfaces the defect instead of a reply masking it.
+func TestResourcePersister_UnknownRequestType_Terminates(t *testing.T) {
+	persister, sender, _, err := newResourcePersisterForTest(t)
+	require.NoError(t, err)
+
+	type notARequest struct{}
+	result := persister.Call(sender, notARequest{})
+	require.Error(t, result.Error, "an unknown request type must terminate the actor")
+}

--- a/internal/metastructure/resource_persister/resource_persister_test.go
+++ b/internal/metastructure/resource_persister/resource_persister_test.go
@@ -75,7 +75,11 @@ func TestResourcePersister_StoresResourceUpdate(t *testing.T) {
 	})
 
 	assert.NoError(t, result.Error)
-	hash, ok := result.Response.(string)
+	hashRes, ok := result.Response.(resource_update.PersistResourceUpdateResult)
+	var hash string
+	if ok {
+		hash = hashRes.Version
+	}
 	assert.True(t, ok)
 	assert.NotEmpty(t, hash)
 
@@ -195,7 +199,11 @@ func TestResourcePersister_Create(t *testing.T) {
 	})
 
 	assert.NoError(t, result.Error)
-	hash, ok := result.Response.(string)
+	hashRes, ok := result.Response.(resource_update.PersistResourceUpdateResult)
+	var hash string
+	if ok {
+		hash = hashRes.Version
+	}
 	assert.True(t, ok)
 	assert.NotEmpty(t, hash)
 
@@ -255,7 +263,11 @@ func TestResourcePersister_Update(t *testing.T) {
 		ResourceUpdate:    initialResource,
 	})
 	assert.NoError(t, createResult.Error)
-	hash, ok := createResult.Response.(string)
+	hashRes, ok := createResult.Response.(resource_update.PersistResourceUpdateResult)
+	var hash string
+	if ok {
+		hash = hashRes.Version
+	}
 	assert.True(t, ok)
 	assert.NotEmpty(t, hash)
 
@@ -303,7 +315,11 @@ func TestResourcePersister_Update(t *testing.T) {
 	})
 
 	assert.NoError(t, updateResult.Error)
-	latestHash, ok := updateResult.Response.(string)
+	latestHashRes, ok := updateResult.Response.(resource_update.PersistResourceUpdateResult)
+	var latestHash string
+	if ok {
+		latestHash = latestHashRes.Version
+	}
 	assert.True(t, ok)
 	assert.NotEmpty(t, latestHash)
 
@@ -678,15 +694,22 @@ func TestResourcePersister_MissingRequiredFields(t *testing.T) {
 
 	// Validation should fail, returning empty hash
 	assert.NoError(t, result.Error)
-	hash, ok := result.Response.(string)
+	hashRes, ok := result.Response.(resource_update.PersistResourceUpdateResult)
+	var hash string
+	if ok {
+		hash = hashRes.Version
+	}
 	assert.True(t, ok)
 	assert.Empty(t, hash)
 
-	// Verify the resource was not loaded
+	// Verify the resource was not stored: the load is answered with a failure.
 	loadResult := persister.Call(sender, messages.LoadResource{
 		ResourceURI: resourceUpdate.URI(),
 	})
-	assert.Error(t, loadResult.Error)
+	assert.NoError(t, loadResult.Error)
+	loadRes, ok := loadResult.Response.(messages.LoadResourceResult)
+	assert.True(t, ok, "expected a typed load reply, got %T", loadResult.Response)
+	assert.NotEmpty(t, loadRes.Error, "loading the never-stored resource must be answered with a failure")
 }
 
 func TestResourcePersister_IdempotentCreate(t *testing.T) {
@@ -732,7 +755,11 @@ func TestResourcePersister_IdempotentCreate(t *testing.T) {
 		ResourceUpdate:    resourceUpdate,
 	})
 	assert.NoError(t, result1.Error)
-	hash1, ok := result1.Response.(string)
+	hash1Res, ok := result1.Response.(resource_update.PersistResourceUpdateResult)
+	var hash1 string
+	if ok {
+		hash1 = hash1Res.Version
+	}
 	assert.True(t, ok)
 	assert.NotEmpty(t, hash1)
 
@@ -743,7 +770,11 @@ func TestResourcePersister_IdempotentCreate(t *testing.T) {
 		ResourceUpdate:    resourceUpdate,
 	})
 	assert.NoError(t, result2.Error)
-	hash2, ok := result2.Response.(string)
+	hash2Res, ok := result2.Response.(resource_update.PersistResourceUpdateResult)
+	var hash2 string
+	if ok {
+		hash2 = hash2Res.Version
+	}
 	assert.True(t, ok)
 	assert.NotEmpty(t, hash2)
 
@@ -2004,7 +2035,11 @@ func TestResourcePersister_ReadOfUnchangedSecretDoesNotDrift(t *testing.T) {
 		ResourceUpdate:    createUpdate,
 	})
 	require.NoError(t, createResult.Error)
-	createHash, ok := createResult.Response.(string)
+	createHashRes, ok := createResult.Response.(resource_update.PersistResourceUpdateResult)
+	var createHash string
+	if ok {
+		createHash = createHashRes.Version
+	}
 	require.True(t, ok)
 	require.NotEmpty(t, createHash)
 
@@ -2053,7 +2088,11 @@ func TestResourcePersister_ReadOfUnchangedSecretDoesNotDrift(t *testing.T) {
 		ResourceUpdate:    readUpdate,
 	})
 	require.NoError(t, readResult.Error)
-	readHash, ok := readResult.Response.(string)
+	readHashRes, ok := readResult.Response.(resource_update.PersistResourceUpdateResult)
+	var readHash string
+	if ok {
+		readHash = readHashRes.Version
+	}
 	require.True(t, ok)
 	assert.Empty(t, readHash,
 		"a read-back of an unchanged secret must not be treated as drift and re-persisted")
@@ -2174,7 +2213,10 @@ func TestResourcePersister_InlinePolicyDeleteFailsWithoutStackID(t *testing.T) {
 		},
 		StackIDMap: map[string]string{},
 	})
-	require.Error(t, result.Error, "an inline delete without a resolvable stack ID must fail")
+	require.NoError(t, result.Error, "the failed delete must be answered, not terminate the persister")
+	failedReply, ok := result.Response.(messages.PersistVersionsResult)
+	require.True(t, ok, "expected a typed persist reply, got %T", result.Response)
+	require.NotEmpty(t, failedReply.Error, "an inline delete without a resolvable stack ID must fail")
 
 	inlinePolicies, err := ds.GetInlinePoliciesForStack(stack.ID)
 	require.NoError(t, err)
@@ -2376,7 +2418,10 @@ func TestResourcePersister_CreateGeneratorFailsWithoutStackID(t *testing.T) {
 		},
 		StackIDMap: map[string]string{},
 	})
-	require.Error(t, result.Error)
+	require.NoError(t, result.Error, "a failed generator write must be answered, not terminate the persister")
+	failed, ok := result.Response.(messages.PersistVersionsResult)
+	require.True(t, ok, "the caller must receive a typed reply, got %T", result.Response)
+	require.NotEmpty(t, failed.Error)
 }
 
 // TestResourcePersister_UpdateGenerator covers an in-place spec change: the

--- a/internal/metastructure/resource_update/opaque_log_redaction_test.go
+++ b/internal/metastructure/resource_update/opaque_log_redaction_test.go
@@ -55,8 +55,11 @@ type persistingProcess struct {
 }
 
 func (p *persistingProcess) Log() gen.Log { return p.log }
-func (p *persistingProcess) Call(_ any, _ any) (any, error) {
-	return "resource-version-1", nil
+func (p *persistingProcess) Call(_ any, request any) (any, error) {
+	if _, ok := request.(PersistResourceUpdate); ok {
+		return PersistResourceUpdateResult{Version: "resource-version-1"}, nil
+	}
+	return true, nil
 }
 
 // opaqueGenEnvelope builds a property document whose single property holds a

--- a/internal/metastructure/resource_update/ownership_record_test.go
+++ b/internal/metastructure/resource_update/ownership_record_test.go
@@ -414,7 +414,10 @@ func (p *recordOnlyGuardProcess) Log() gen.Log { return p.log }
 
 func (p *recordOnlyGuardProcess) Call(_ any, msg any) (any, error) {
 	p.calls = append(p.calls, msg)
-	return "resource-version-1", nil
+	if _, ok := msg.(PersistResourceUpdate); ok {
+		return PersistResourceUpdateResult{Version: "resource-version-1"}, nil
+	}
+	return true, nil
 }
 
 func (p *recordOnlyGuardProcess) reachedPluginSpawn() bool {

--- a/internal/metastructure/resource_update/plugin_read.go
+++ b/internal/metastructure/resource_update/plugin_read.go
@@ -35,7 +35,7 @@ func ReadResourceViaPlugin(proc gen.Process, res pkgmodel.Resource, targetConfig
 	}
 
 	operationID := uuid.New().String()
-	spawnResult, err := proc.Call(
+	spawnResult, err := messages.UnwrapCall(proc.Call(
 		gen.ProcessID{Name: actornames.PluginCoordinator, Node: proc.Node().Name()},
 		messages.SpawnPluginOperator{
 			Namespace:   res.Namespace(),
@@ -43,7 +43,7 @@ func ReadResourceViaPlugin(proc gen.Process, res pkgmodel.Resource, targetConfig
 			Operation:   string(resource.OperationRead),
 			OperationID: operationID,
 			RequestedBy: proc.PID(),
-		})
+		}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to spawn plugin operator: %w", err)
 	}

--- a/internal/metastructure/resource_update/resolve_target_config.go
+++ b/internal/metastructure/resource_update/resolve_target_config.go
@@ -67,10 +67,10 @@ func ResolveOpaqueTargetConfig(proc gen.Process, target pkgmodel.Target) (json.R
 
 	for _, uri := range uris {
 		// Load the source resource from the persister.
-		rawResult, err := proc.Call(
+		rawResult, err := messages.UnwrapCall(proc.Call(
 			gen.ProcessID{Name: actornames.ResourcePersister, Node: proc.Node().Name()},
 			messages.LoadResource{ResourceURI: uri.Stripped()},
-		)
+		))
 		if err != nil {
 			proc.Log().Error(
 				"failed to load resource for opaque ref resolution uri=%s target=%s: %v",

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -178,6 +178,16 @@ type ResolveTimedOut struct{}
 
 type Shutdown struct{}
 
+// PersistResourceUpdateResult is the reply to a PersistResourceUpdate call:
+// the stored version hash on success (empty when the update needed no
+// persist), or the failure that refused the write.
+type PersistResourceUpdateResult struct {
+	Version string
+	Error   string
+}
+
+func (r PersistResourceUpdateResult) CallError() string { return r.Error }
+
 // PersistResourceUpdate is sent to the ResourcePersister actor to store a resource update
 // in the datastore after a successful plugin operation.
 type PersistResourceUpdate struct {
@@ -354,7 +364,7 @@ func onStateChange(oldState gen.Atom, newState gen.Atom, data ResourceUpdateData
 
 	if newState == StateFinishedSuccessfully || newState == StateFinishedWithError || newState == StateRejected {
 		proc.Log().Debug("ResourceUpdater: sending completion message to forma command persister state=%s commandID=%s", newState, data.commandID)
-		_, err := proc.Call(
+		_, err := messages.UnwrapCall(proc.Call(
 			formaCommandPersisterProcess(proc),
 			messages.MarkResourceUpdateAsComplete{
 				CommandID:                  data.commandID,
@@ -368,7 +378,7 @@ func onStateChange(oldState gen.Atom, newState gen.Atom, data ResourceUpdateData
 				Version:                    data.resourceUpdate.Version,
 				FailureReason:              data.resourceUpdate.FailureReason,
 			},
-		)
+		))
 		if err != nil {
 			proc.Log().Error("Failed to send MarkAsComplete message to forma command persister commandID=%s ksuid=%s operation=%s: %v",
 				data.commandID, data.originalResourceKsuidURI.KSUID(), data.resourceUpdate.Operation, err)
@@ -434,9 +444,9 @@ func start(from gen.PID, state gen.Atom, data ResourceUpdateData, message StartR
 
 	// Get LabelConfig from PluginCoordinator (handles both external and local plugins)
 	namespace := data.resourceUpdate.DesiredState.Namespace()
-	result, err := proc.Call(
+	result, err := messages.UnwrapCall(proc.Call(
 		gen.ProcessID{Name: actornames.PluginCoordinator, Node: proc.Node().Name()},
-		messages.GetPluginInfo{Namespace: namespace})
+		messages.GetPluginInfo{Namespace: namespace}))
 	if err == nil {
 		if infoResp, ok := result.(messages.PluginInfoResponse); ok && infoResp.Found {
 			data.labelConfig = infoResp.LabelConfig
@@ -1136,12 +1146,12 @@ func handleProgressUpdate(from gen.PID, state gen.Atom, data ResourceUpdateData,
 		}
 
 		operation := currentOperation(state)
-		hash, err := proc.Call(resourcePersisterProcess(proc), PersistResourceUpdate{
+		persisted, err := messages.UnwrapCall(proc.Call(resourcePersisterProcess(proc), PersistResourceUpdate{
 			CommandID:         data.commandID,
 			ResourceOperation: data.resourceUpdate.Operation,
 			PluginOperation:   operation,
 			ResourceUpdate:    *data.resourceUpdate,
-		})
+		}))
 
 		if err != nil {
 			proc.Log().Error("failed to persist resource update: %v", err)
@@ -1149,11 +1159,12 @@ func handleProgressUpdate(from gen.PID, state gen.Atom, data ResourceUpdateData,
 			data.resourceUpdate.MarkAsFailed()
 			return StateFinishedWithError, data, nil, nil
 		}
-		data.resourceUpdate.Version = hash.(string)
+		version := persisted.(PersistResourceUpdateResult).Version
+		data.resourceUpdate.Version = version
 
 		// If we successfully persisted the read operation in the Synchronizing state, we should reject the resource update
 		// and exit the state machine.
-		if state == StateSynchronizing && data.resourceUpdate.Operation != OperationRead && operation == resource.OperationRead && hash != "" && !data.resourceUpdate.IsDelete() {
+		if state == StateSynchronizing && data.resourceUpdate.Operation != OperationRead && operation == resource.OperationRead && version != "" && !data.resourceUpdate.IsDelete() {
 			proc.Log().Debug("Resource update rejected as a change to the resource was detected previousProperties=%s currentProperties=%s",
 				pkgmodel.RedactOpaqueJSONForLog(data.resourceUpdate.PreviousProperties),
 				pkgmodel.RedactOpaqueJSONForLog(data.resourceUpdate.DesiredState.Properties))
@@ -1168,7 +1179,7 @@ func handleProgressUpdate(from gen.PID, state gen.Atom, data ResourceUpdateData,
 		// command re-run will handle it correctly (idempotent).
 		proc.Log().Debug("ResourceUpdater: persisting success progress after resource persist state=%s resourceURI=%v",
 			state, data.resourceUpdate.DesiredState.URI())
-		_, err = proc.Call(
+		_, err = messages.UnwrapCall(proc.Call(
 			formaCommandPersisterProcess(proc),
 			messages.UpdateResourceProgress{
 				CommandID:           data.commandID,
@@ -1180,7 +1191,7 @@ func handleProgressUpdate(from gen.PID, state gen.Atom, data ResourceUpdateData,
 				Progress:            message,
 				ResolvedRootDigests: data.resourceUpdate.ResolvedRootDigests,
 			},
-		)
+		))
 		if err != nil {
 			proc.Log().Error("failed to send UpdateResourceProgress after resource persist: %v", err)
 			// Resource is already persisted; don't fail the update for a
@@ -1195,7 +1206,7 @@ func handleProgressUpdate(from gen.PID, state gen.Atom, data ResourceUpdateData,
 	// to the command record immediately.
 	proc.Log().Debug("ResourceUpdater: sending progress update to the forma command persister state=%s resourceURI=%v progress=%s",
 		state, data.resourceUpdate.DesiredState.URI(), message.Operation)
-	_, err = proc.Call(
+	_, err = messages.UnwrapCall(proc.Call(
 		formaCommandPersisterProcess(proc),
 		messages.UpdateResourceProgress{
 			CommandID:           data.commandID,
@@ -1207,7 +1218,7 @@ func handleProgressUpdate(from gen.PID, state gen.Atom, data ResourceUpdateData,
 			Progress:            message,
 			ResolvedRootDigests: data.resourceUpdate.ResolvedRootDigests,
 		},
-	)
+	))
 	if err != nil {
 		proc.Log().Error("failed to send UpdateResourceProgress message to forma command persister: %v", err)
 		data.resourceUpdate.MarkAsFailed()
@@ -1300,7 +1311,7 @@ func doPluginOperation(resourceURI pkgmodel.FormaeURI, operation plugin.PluginOp
 	proc.Log().Debug("Spawning plugin operator via PluginCoordinator resourceURI=%v operation=%s namespace=%s",
 		resourceURI, string(operation.Operation()), operation.PluginNamespace())
 
-	spawnResult, err := proc.Call(
+	spawnResult, err := messages.UnwrapCall(proc.Call(
 		gen.ProcessID{Name: actornames.PluginCoordinator, Node: proc.Node().Name()},
 		messages.SpawnPluginOperator{
 			Namespace:   operation.PluginNamespace(),
@@ -1308,7 +1319,7 @@ func doPluginOperation(resourceURI pkgmodel.FormaeURI, operation plugin.PluginOp
 			Operation:   string(operation.Operation()),
 			OperationID: operationID,
 			RequestedBy: proc.PID(),
-		})
+		}))
 	if err != nil {
 		proc.Log().Error("failed to spawn plugin operator: %v", err)
 		return nil, nil, fmt.Errorf("failed to spawn plugin operator: %w", err)

--- a/internal/metastructure/stack_expirer.go
+++ b/internal/metastructure/stack_expirer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_persister"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/stack_update"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/target_update"
@@ -130,10 +131,10 @@ func (s *StackExpirer) destroyExpiredStack(stackInfo datastore.ExpiredStackInfo)
 	}
 
 	// Store the forma command
-	_, err = s.Call(
+	_, err = messages.UnwrapCall(s.Call(
 		gen.ProcessID{Name: actornames.FormaCommandPersister, Node: s.Node().Name()},
 		forma_persister.StoreNewFormaCommand{Command: *result.command},
-	)
+	))
 	if err != nil {
 		return fmt.Errorf("failed to store destroy command: %w", err)
 	}

--- a/internal/metastructure/synchronizer.go
+++ b/internal/metastructure/synchronizer.go
@@ -199,10 +199,10 @@ func synchronizeAllResources(state gen.Atom, data SynchronizerData, proc gen.Pro
 	}
 	pluginInfoByNamespace := make(map[string]pluginCache)
 	for namespace := range namespaceSeen {
-		response, err := proc.Call(
+		response, err := messages.UnwrapCall(proc.Call(
 			gen.ProcessID{Name: actornames.PluginCoordinator, Node: proc.Node().Name()},
 			messages.GetPluginInfo{Namespace: namespace},
-		)
+		))
 		if err != nil {
 			proc.Log().Debug("Failed to check plugin availability, skipping namespace=%s: %v",
 				namespace, err)
@@ -330,9 +330,9 @@ func synchronizeAllResources(state gen.Atom, data SynchronizerData, proc gen.Pro
 	data.commandID = syncCommand.ID
 	proc.Log().Debug("Synchronizer: created sync command commandID=%s resourceUpdateCount=%d", syncCommand.ID, len(allResourceUpdates))
 
-	_, err = proc.Call(
+	_, err = messages.UnwrapCall(proc.Call(
 		gen.ProcessID{Name: actornames.FormaCommandPersister, Node: proc.Node().Name()},
-		forma_persister.StoreNewFormaCommand{Command: *syncCommand})
+		forma_persister.StoreNewFormaCommand{Command: *syncCommand}))
 	if err != nil {
 		proc.Log().Error("failed to store batch forma command: %v", err)
 		return state, data, nil, gen.TerminateReasonPanic
@@ -434,16 +434,16 @@ func finalizeFailedCommand(cmd *forma_command.FormaCommand, proc gen.Process) {
 	}
 	persister := gen.ProcessID{Name: actornames.FormaCommandPersister, Node: proc.Node().Name()}
 	if len(refs) > 0 {
-		if _, err := proc.Call(persister, forma_persister.MarkResourcesAsFailed{
+		if _, err := messages.UnwrapCall(proc.Call(persister, forma_persister.MarkResourcesAsFailed{
 			CommandID:          cmd.ID,
 			Resources:          refs,
 			ResourceModifiedTs: time.Now(),
-		}); err != nil {
+		})); err != nil {
 			proc.Log().Error("Synchronizer: failed to mark resources as failed for aborted command commandID=%s: %v", cmd.ID, err)
 			return
 		}
 	}
-	if _, err := proc.Call(persister, forma_persister.FinalizeIncompleteCommand{CommandID: cmd.ID}); err != nil {
+	if _, err := messages.UnwrapCall(proc.Call(persister, forma_persister.FinalizeIncompleteCommand{CommandID: cmd.ID})); err != nil {
 		proc.Log().Error("Synchronizer: failed to finalize aborted command commandID=%s: %v", cmd.ID, err)
 	}
 }

--- a/internal/metastructure/target_reaper/target_reaper.go
+++ b/internal/metastructure/target_reaper/target_reaper.go
@@ -182,7 +182,7 @@ func (r *TargetReaper) reap(candidate ReapCandidate, now time.Time) {
 	resourceURIs := r.announceToSynchronizer(candidate.TargetLabel)
 	defer r.unannounceFromSynchronizer(resourceURIs)
 
-	response, err := r.Call(
+	response, err := messages.UnwrapCall(r.Call(
 		gen.ProcessID{Name: actornames.ResourcePersister, Node: r.Node().Name()},
 		messages.PersistTargetReap{
 			Label:            candidate.TargetLabel,
@@ -191,7 +191,7 @@ func (r *TargetReaper) reap(candidate ReapCandidate, now time.Time) {
 			LastSampleBefore: now,
 			ReapedAt:         now,
 		},
-	)
+	))
 	if err != nil {
 		r.Log().Error("Failed to call PersistTargetReap for target label=%s: %v", candidate.TargetLabel, err)
 		return

--- a/internal/metastructure/target_update/target_updater.go
+++ b/internal/metastructure/target_update/target_updater.go
@@ -225,13 +225,13 @@ func targetResolveCacheTimeout(from gen.PID, state gen.Atom, data TargetUpdaterD
 
 // persistTarget sends the target update to the ResourcePersister for storage.
 func persistTarget(data TargetUpdaterData, proc gen.Process) (gen.Atom, TargetUpdaterData, []statemachine.Action, error) {
-	_, err := proc.Call(
+	_, err := messages.UnwrapCall(proc.Call(
 		resourcePersisterProcess(proc),
 		PersistTargetUpdates{
 			TargetUpdates: []TargetUpdate{data.targetUpdate},
 			CommandID:     data.commandID,
 		},
-	)
+	))
 	if err != nil {
 		proc.Log().Error("TargetUpdater: failed to persist target update target=%s: %v", data.targetUpdate.Target.Label, err)
 		return StateFinishedWithError, data, nil, nil

--- a/internal/workflow_tests/local/changeset_executor_test.go
+++ b/internal/workflow_tests/local/changeset_executor_test.go
@@ -93,7 +93,15 @@ func TestChangesetExecutor_SingleResourceUpdate(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Equal(t, forma_command.CommandStateSuccess, command.State)
 		assert.Len(t, command.ResourceUpdates, 1)
@@ -197,7 +205,15 @@ func TestChangesetExecutor_DependentResources(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Equal(t, forma_command.CommandStateSuccess, command.State)
 		assert.Len(t, command.ResourceUpdates, 2)
@@ -291,7 +307,15 @@ func TestChangesetExecutor_CascadeFailure(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 
 		// VPC should have failed, subnet should also have failed (cascade)
@@ -451,7 +475,15 @@ func TestChangesetExecutor_HashesAllResourcesOnCompletion(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Equal(t, forma_command.CommandStateSuccess, command.State)
 	})
@@ -523,7 +555,15 @@ func TestChangesetExecutor_HashesAllResourcesOnFailure(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		// Verify the resource update failed
 		assert.Len(t, command.ResourceUpdates, 1)

--- a/internal/workflow_tests/local/resource_updater_test.go
+++ b/internal/workflow_tests/local/resource_updater_test.go
@@ -129,7 +129,15 @@ func TestResourceUpdater_HandlesThrottlingDuringSynchronization(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Equal(t, forma_command.CommandStateSuccess, command.State)
 	})
@@ -224,7 +232,15 @@ func TestResourceUpdater_RejectsUpdateWhenTheResourceIsOutOfSync(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Equal(t, forma_command.CommandStateFailed, command.State)
 		assert.Len(t, command.ResourceUpdates, 1)
@@ -314,7 +330,15 @@ func TestResourceUpdater_SuccessfullySynchronizesAResource(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Equal(t, forma_command.CommandStateSuccess, command.State)
 		assert.Len(t, command.ResourceUpdates, 1)
@@ -427,7 +451,15 @@ func TestResourceUpdater_SuccessfullyDeletesAResource(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Equal(t, forma_command.CommandStateSuccess, command.State)
 		assert.Len(t, command.ResourceUpdates, 1)
@@ -521,7 +553,15 @@ func TestResourceUpdater_DeleteOperationFailsWhenPluginCrashes(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Equal(t, forma_command.CommandStateFailed, command.State)
 		assert.Len(t, command.ResourceUpdates, 1)
@@ -603,7 +643,15 @@ func TestResourceUpdater_PreservesPluginErrorMessageOnDeleteFailure(t *testing.T
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Len(t, command.ResourceUpdates, 1)
 		assert.Contains(t, command.ResourceUpdates[0].MostRecentFailureMessage(), pluginErr,
@@ -783,7 +831,15 @@ func TestResourceUpdater_SuccessfullyCreatesAResource(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		loadedCommand, ok := commandRes.(*forma_command.FormaCommand)
+		loadedCommandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var loadedCommand *forma_command.FormaCommand
+
+		if ok {
+
+			loadedCommand = loadedCommandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Equal(t, forma_command.CommandStateSuccess, loadedCommand.State)
 		assert.Len(t, loadedCommand.ResourceUpdates, 1)
@@ -893,7 +949,15 @@ func TestResourceUpdater_SuccessfullyUpdatesAResource(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Equal(t, forma_command.CommandStateSuccess, command.State)
 		assert.Len(t, command.ResourceUpdates, 1)
@@ -978,7 +1042,15 @@ func TestResourceUpdater_PreservesPluginErrorMessageOnUpdateFailure(t *testing.T
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Len(t, command.ResourceUpdates, 1)
 		assert.Contains(t, command.ResourceUpdates[0].MostRecentFailureMessage(), pluginErr,
@@ -1096,7 +1168,15 @@ func TestResourceUpdater_SuccessfullyRecoversFromADeleteOperationLeftInInProgres
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Equal(t, forma_command.CommandStateSuccess, command.State)
 		assert.Len(t, command.ResourceUpdates, 1)
@@ -1219,7 +1299,15 @@ func TestResourceUpdater_SuccessfullyRecoversFromACreateOperationLeftInInProgres
 		})
 		assert.NoError(t, err)
 
-		loadFormaCommand, ok := commandRes.(*forma_command.FormaCommand)
+		loadFormaCommandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var loadFormaCommand *forma_command.FormaCommand
+
+		if ok {
+
+			loadFormaCommand = loadFormaCommandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Equal(t, forma_command.CommandStateSuccess, loadFormaCommand.State)
 		assert.Len(t, loadFormaCommand.ResourceUpdates, 1)
@@ -1366,7 +1454,15 @@ func TestResourceUpdater_SuccessfullyRecoversFromAnUpdateOperationLeftInInFailed
 		})
 		assert.NoError(t, err)
 
-		command, ok := commandRes.(*forma_command.FormaCommand)
+		commandLoadRes, ok := commandRes.(forma_persister.LoadFormaCommandResult)
+
+		var command *forma_command.FormaCommand
+
+		if ok {
+
+			command = commandLoadRes.Command
+
+		}
 		assert.True(t, ok)
 		assert.Equal(t, forma_command.CommandStateSuccess, command.State)
 		assert.Len(t, command.ResourceUpdates, 1)


### PR DESCRIPTION
## Summary

- Returning a non-nil error from an actor's `HandleCall` does not reply to the caller: the framework terminates the actor with that reason and the caller times out. `ResourcePersister`, `FormaCommandPersister`, and `PluginCoordinator` returned per-request errors straight through, so a single rejected write (a reaped/incarnation-guard rejection, a load for a row that no longer exists, a lookup for an unregistered plugin namespace) killed the actor, every request queued in its mailbox died with it, concurrent callers surfaced generic timeouts, and the supervisor respawned the actor only for the next bad request to repeat the cycle. With a periodic synchronization retrying one rejected write, the persister flapped indefinitely; a burst of three failures within a second collapses the whole supervision tree (which, since the exit-on-collapse hook, restarts the entire agent).
- Request-scoped failures are now answered with **typed result messages carrying their own status** (`PersistResourceUpdateResult`, `PersistVersionsResult`, `CommandPersistResult`, `LoadFormaCommandResult`, and an `Error` field on the existing `LoadResourceResult`, `PersistTargetReapResult`, and `PluginNode` replies). Callers fold a failed status into their existing error handling through `messages.UnwrapCall`, seeing the real failure text instead of a timeout; the metastructure bridge unwraps at its single choke point. The `HandleCall` error return keeps the meaning ergo assigns to it and stays reserved for genuine faults: unknown request types and invariant violations still terminate the actor for supervision to handle.
- The `FormaCommandPersister`'s command cache stays coherent across failed writes: a datastore write failure marks the cached command dirty, and the next request touching it flushes the cached state (through full finalization for terminal commands, preserving sync-command deletion and cache eviction) before being served, failing the request when the flush cannot be made durable. Snapshot hashing in progress updates runs before any cache mutation, so a hashing failure cannot strand a half-applied mutation behind the terminality guard.
- Resolve failures caused by a failed persister load now carry the load error as the operator-facing reason instead of an empty message at stage 'resolving'.

Verified with failing-first tests at every seam: rejected writes and load misses answered with the actor still serving on the same instance, dirty-cache flush on next touch (store, sync-delete, and non-final meta-write faces), pre-mutation hashing, and termination pinned for unknown request types.