### PR TITLE
fix(extract): escape data keys that are not PKL identifiers

### DIFF
--- a/internal/schema/pkl/generator/gen.pkl
+++ b/internal/schema/pkl/generator/gen.pkl
@@ -1517,6 +1517,39 @@ local function formatNestedContent(map: Map<String, Any>, indent: String): Strin
   ))
     lines.join("\n")
 
+/// PKL keywords cannot stand as a bare property name; a key shaped like one
+/// still needs escaping. Not the full grammar — only the words that can
+/// plausibly arrive as a data key.
+local pklKeywords: Set<String> = Set(
+  "abstract", "amends", "as", "class", "const", "else", "extends", "external",
+  "false", "fixed", "for", "function", "hidden", "if", "import", "in", "is",
+  "let", "local", "module", "new", "nothing", "null", "open", "out", "outer",
+  "read", "super", "this", "throw", "trace", "true", "typealias", "unknown",
+  "when"
+)
+
+/// True when `key` can stand unescaped as a PKL property name.
+local function isPklIdentifier(key: String): Boolean =
+  key.matches(Regex("[A-Za-z_$][A-Za-z0-9_$]*")) && !pklKeywords.contains(key)
+
+/// Renders a data key so the generated forma parses. Dots, slashes and hyphens
+/// are ordinary in provider data (Kubernetes annotations, `x-kubernetes-*` CRD
+/// flags, HTTP header names) and none of them may stand bare.
+///
+/// A `Mapping` takes entries, so its keys are always bracketed. Everywhere else
+/// the key is a property — of a typed class or of a Dynamic — and a bracketed
+/// entry would be rejected on a typed class, so escaping is by backticks.
+local function renderDataKey(key: String, isMapping: Boolean): String =
+  // ponytail: a key containing a backtick cannot be backtick-escaped; bracket
+  // it, which is right for Dynamic and Mapping. A typed class cannot carry
+  // such a property name in the first place.
+  if (isMapping || key.contains(":") || key.contains("`"))
+    "[\"" + key + "\"]"
+  else if (isPklIdentifier(key))
+    key
+  else
+    "`" + key + "`"
+
 local function formatNestedContentWithTypes(map: Map<String, Any>, indent: String): String =
   let (isMapping = map.getOrNull("__type__") == "Mapping")
   // Tag classes (Tag, DefinedTag, FreeformTag, etc.) use hidden lowercase properties
@@ -1532,10 +1565,8 @@ local function formatNestedContentWithTypes(map: Map<String, Any>, indent: Strin
       let (formattedKey =
         if (isTag)
           key.take(1).toLowerCase() + key.drop(1)
-        else if (key.contains(":") || isMapping)
-          "[\"" + key + "\"]"
         else
-          key
+          renderDataKey(key, isMapping)
       )
       let (formattedValue =
         if (value is List && key == "tags")
@@ -1553,13 +1584,12 @@ local function formatNestedContentWithTypes(map: Map<String, Any>, indent: Strin
     lines.join("\n")
 
 local function mapToPklStringWithTypes(map: Map<String, Any>, indent: String): String =
+  // Reads its own tag: `isMapping` used to be read from the enclosing module,
+  // where nothing declares it, so every map reaching this function died with
+  // "Cannot find property `isMapping`".
+  let (isMapping = map.getOrNull("__type__") == "Mapping")
   let (lines = map.fold(List(), (acc: List<String>, key: String, value:Any) ->
-    let (formattedKey =
-      if (key.contains(":") || isMapping)
-        "[\"" + key + "\"]"
-      else
-        key
-    )
+    let (formattedKey = renderDataKey(key, isMapping))
     let (formattedValue = formatValueWithTypes(value, indent + "  "))
     let (line = (indent + "  ") + formattedKey + " = " + formattedValue)
       acc.add(line)

--- a/internal/schema/pkl/generator/gen.pkl
+++ b/internal/schema/pkl/generator/gen.pkl
@@ -1518,14 +1518,15 @@ local function formatNestedContent(map: Map<String, Any>, indent: String): Strin
     lines.join("\n")
 
 /// PKL keywords cannot stand as a bare property name; a key shaped like one
-/// still needs escaping. Not the full grammar — only the words that can
-/// plausibly arrive as a data key.
+/// still needs escaping. Includes the words the grammar reserves for future
+/// use ("case", "switch", ...), which it refuses as bare identifiers today.
 local pklKeywords: Set<String> = Set(
-  "abstract", "amends", "as", "class", "const", "else", "extends", "external",
-  "false", "fixed", "for", "function", "hidden", "if", "import", "in", "is",
-  "let", "local", "module", "new", "nothing", "null", "open", "out", "outer",
-  "read", "super", "this", "throw", "trace", "true", "typealias", "unknown",
-  "when"
+  "abstract", "amends", "as", "case", "class", "const", "delete", "else",
+  "extends", "external", "false", "fixed", "for", "function", "hidden", "if",
+  "import", "in", "is", "let", "local", "module", "new", "nothing", "null",
+  "open", "out", "outer", "override", "protected", "read", "record", "super",
+  "switch", "this", "throw", "trace", "true", "typealias", "unknown",
+  "vararg", "when"
 )
 
 /// True when `key` can stand unescaped as a PKL property name.
@@ -1540,11 +1541,12 @@ local function isPklIdentifier(key: String): Boolean =
 /// the key is a property — of a typed class or of a Dynamic — and a bracketed
 /// entry would be rejected on a typed class, so escaping is by backticks.
 local function renderDataKey(key: String, isMapping: Boolean): String =
-  // ponytail: a key containing a backtick cannot be backtick-escaped; bracket
-  // it, which is right for Dynamic and Mapping. A typed class cannot carry
-  // such a property name in the first place.
+  // A key containing a backtick cannot be backtick-escaped; bracket it,
+  // which is right for Dynamic and Mapping. A typed class cannot carry such
+  // a property name in the first place. The bracketed form is a quoted
+  // string, so the key's own specials are escaped like any string value.
   if (isMapping || key.contains(":") || key.contains("`"))
-    "[\"" + key + "\"]"
+    "[\"" + escapeString(key) + "\"]"
   else if (isPklIdentifier(key))
     key
   else

--- a/internal/schema/pkl/generator/gen.pkl
+++ b/internal/schema/pkl/generator/gen.pkl
@@ -1541,11 +1541,12 @@ local function isPklIdentifier(key: String): Boolean =
 /// the key is a property — of a typed class or of a Dynamic — and a bracketed
 /// entry would be rejected on a typed class, so escaping is by backticks.
 local function renderDataKey(key: String, isMapping: Boolean): String =
-  // A key containing a backtick cannot be backtick-escaped; bracket it,
-  // which is right for Dynamic and Mapping. A typed class cannot carry such
-  // a property name in the first place. The bracketed form is a quoted
-  // string, so the key's own specials are escaped like any string value.
-  if (isMapping || key.contains(":") || key.contains("`"))
+  // A key containing a backtick cannot be backtick-escaped, and a backtick
+  // identifier cannot span lines; bracket both, which is right for Dynamic
+  // and Mapping. A typed class cannot carry such a property name in the
+  // first place. The bracketed form is a quoted string, so the key's own
+  // specials are escaped like any string value.
+  if (isMapping || key.contains(":") || key.contains("`") || key.contains("\n") || key.contains("\r"))
     "[\"" + escapeString(key) + "\"]"
   else if (isPklIdentifier(key))
     key

--- a/internal/schema/pkl/generator/gen.pkl
+++ b/internal/schema/pkl/generator/gen.pkl
@@ -1529,9 +1529,10 @@ local pklKeywords: Set<String> = Set(
   "vararg", "when"
 )
 
-/// True when `key` can stand unescaped as a PKL property name.
+/// True when `key` can stand unescaped as a PKL property name. A standalone
+/// underscore matches the identifier shape but is placeholder syntax.
 local function isPklIdentifier(key: String): Boolean =
-  key.matches(Regex("[A-Za-z_$][A-Za-z0-9_$]*")) && !pklKeywords.contains(key)
+  key.matches(Regex("[A-Za-z_$][A-Za-z0-9_$]*")) && !pklKeywords.contains(key) && key != "_"
 
 /// Renders a data key so the generated forma parses. Dots, slashes and hyphens
 /// are ordinary in provider data (Kubernetes annotations, `x-kubernetes-*` CRD

--- a/internal/schema/pkl/generator/tests/gen.pkl
+++ b/internal/schema/pkl/generator/tests/gen.pkl
@@ -1332,6 +1332,17 @@ facts {
         rendered.contains("`switch` = \"on\"") && rendered.contains("`delete` = \"never\"")
     }
 
+    ["a key containing a line break is bracketed and escaped"] {
+        // A backtick identifier cannot span lines, so such a key must take
+        // the bracketed form, where the break is escaped like any string.
+        let (nested = new Dynamic {
+            ["__type__"] = "Dynamic"
+            ["line\nbreak"] = "v"
+        })
+        let (rendered = gen.genMapToPklStringWithTypes("TestResource", Map("spec", nested), "test"))
+        rendered.contains("[\"line\\nbreak\"] = \"v\"")
+    }
+
     ["a bracketed key with string-literal specials is escaped"] {
         // A Mapping key is rendered inside a quoted string, so a quote or a
         // backslash in the key must be escaped or the emitted forma does not

--- a/internal/schema/pkl/generator/tests/gen.pkl
+++ b/internal/schema/pkl/generator/tests/gen.pkl
@@ -1270,6 +1270,56 @@ facts {
         rendered.contains("\\(")
     }
 
+    // --- Non-identifier keys in untyped content (PLA-465) ---
+
+    ["untyped nested content quotes keys that are not PKL identifiers"] {
+        // Kubernetes annotations and CRD schema flags are ordinary content in an
+        // opaque field. Rendered bare, the generated forma does not parse.
+        let (nested = new Dynamic {
+            ["__type__"] = "Dynamic"
+            ["objectset.rio.cattle.io/applied"] = "H4"
+            ["x-kubernetes-preserve-unknown-fields"] = true
+            ["plain"] = "ok"
+        })
+        let (rendered = gen.genMapToPklStringWithTypes("TestResource", Map("spec", nested), "test"))
+        // Backticks, not brackets: the same renderer serves typed classes, which
+        // take properties and reject entries.
+        rendered.contains("`objectset.rio.cattle.io/applied` = \"H4\"")
+          && rendered.contains("`x-kubernetes-preserve-unknown-fields` = true")
+          && rendered.contains("plain = \"ok\"")
+    }
+
+    ["untyped map without a type tag quotes keys that are not PKL identifiers"] {
+        let (nested = new Dynamic {
+            ["prometheus.io/scrape"] = "true"
+            ["plain"] = "ok"
+        })
+        let (rendered = gen.genMapToPklStringWithTypes("TestResource", Map("spec", nested), "test"))
+        rendered.contains("`prometheus.io/scrape` = \"true\"")
+          && rendered.contains("plain = \"ok\"")
+    }
+
+    ["a Mapping still renders its keys as entries"] {
+        let (nested = new Dynamic {
+            ["__type__"] = "Mapping"
+            ["prometheus.io/scrape"] = "true"
+            ["plain"] = "ok"
+        })
+        let (rendered = gen.genMapToPklStringWithTypes("TestResource", Map("spec", nested), "test"))
+        rendered.contains("[\"prometheus.io/scrape\"] = \"true\"")
+          && rendered.contains("[\"plain\"] = \"ok\"")
+    }
+
+    ["a key shaped like a PKL keyword is escaped"] {
+        let (nested = new Dynamic {
+            ["__type__"] = "Dynamic"
+            ["module"] = "cattle"
+            ["for"] = "everyone"
+        })
+        let (rendered = gen.genMapToPklStringWithTypes("TestResource", Map("spec", nested), "test"))
+        rendered.contains("`module` = \"cattle\"") && rendered.contains("`for` = \"everyone\"")
+    }
+
     // --- String escaping (roundtrip) tests ---
 
     ["String type conversion preserves quotes (escaping is a serialization concern)"] {

--- a/internal/schema/pkl/generator/tests/gen.pkl
+++ b/internal/schema/pkl/generator/tests/gen.pkl
@@ -1270,7 +1270,7 @@ facts {
         rendered.contains("\\(")
     }
 
-    // --- Non-identifier keys in untyped content (PLA-465) ---
+    // --- Non-identifier keys in untyped content ---
 
     ["untyped nested content quotes keys that are not PKL identifiers"] {
         // Kubernetes annotations and CRD schema flags are ordinary content in an
@@ -1318,6 +1318,32 @@ facts {
         })
         let (rendered = gen.genMapToPklStringWithTypes("TestResource", Map("spec", nested), "test"))
         rendered.contains("`module` = \"cattle\"") && rendered.contains("`for` = \"everyone\"")
+    }
+
+    ["a key shaped like a reserved-for-future word is escaped"] {
+        // "switch", "case" and friends are not keywords yet, but the grammar
+        // already refuses them as bare property names.
+        let (nested = new Dynamic {
+            ["__type__"] = "Dynamic"
+            ["switch"] = "on"
+            ["delete"] = "never"
+        })
+        let (rendered = gen.genMapToPklStringWithTypes("TestResource", Map("spec", nested), "test"))
+        rendered.contains("`switch` = \"on\"") && rendered.contains("`delete` = \"never\"")
+    }
+
+    ["a bracketed key with string-literal specials is escaped"] {
+        // A Mapping key is rendered inside a quoted string, so a quote or a
+        // backslash in the key must be escaped or the emitted forma does not
+        // parse.
+        let (nested = new Dynamic {
+            ["__type__"] = "Mapping"
+            ["say \"hi\""] = "v"
+            ["back\\slash"] = "w"
+        })
+        let (rendered = gen.genMapToPklStringWithTypes("TestResource", Map("spec", nested), "test"))
+        rendered.contains("[\"say \\\"hi\\\"\"] = \"v\"")
+          && rendered.contains("[\"back\\\\slash\"] = \"w\"")
     }
 
     // --- String escaping (roundtrip) tests ---

--- a/internal/schema/pkl/generator/tests/gen.pkl
+++ b/internal/schema/pkl/generator/tests/gen.pkl
@@ -1332,6 +1332,17 @@ facts {
         rendered.contains("`switch` = \"on\"") && rendered.contains("`delete` = \"never\"")
     }
 
+    ["a standalone underscore key is escaped"] {
+        // "_" matches the identifier shape but is placeholder syntax, not a
+        // usable bare property name.
+        let (nested = new Dynamic {
+            ["__type__"] = "Dynamic"
+            ["_"] = "x"
+        })
+        let (rendered = gen.genMapToPklStringWithTypes("TestResource", Map("spec", nested), "test"))
+        rendered.contains("`_` = \"x\"")
+    }
+
     ["a key containing a line break is bracketed and escaped"] {
         // A backtick identifier cannot span lines, so such a key must take
         // the bracketed form, where the break is escaped like any string.

--- a/internal/schema/pkl/pkl_generate_test.go
+++ b/internal/schema/pkl/pkl_generate_test.go
@@ -318,6 +318,59 @@ func TestGenerateSourceCode_GeneratorRotation_RoundTrips(t *testing.T) {
 	assert.Equal(t, 3600, round.Rotation.EverySeconds)
 }
 
+// TestGenerateSourceCode_NonIdentifierKeys_RoundTripThroughPkl verifies that a
+// key which cannot stand as a bare PKL identifier survives extraction: it is
+// escaped in the emitted source, that source evaluates, and the key comes back
+// spelled exactly as it was stored. An opaque field carries provider data
+// verbatim — Kubernetes annotations, `x-kubernetes-*` CRD flags, HTTP header
+// names — and none of those are identifiers. Rendered bare (the PLA-465
+// behavior) the emitted forma does not parse at all, so generateAndEvaluate
+// fails before any assertion here runs.
+func TestGenerateSourceCode_NonIdentifierKeys_RoundTripThroughPkl(t *testing.T) {
+	forma := &model.Forma{
+		Stacks:  []model.Stack{{Label: "default"}},
+		Targets: []model.Target{fakeawsTarget()},
+		Resources: []model.Resource{{
+			Label:  "dotted-policy",
+			Type:   "FakeAWS::IAM::RolePolicy",
+			Stack:  "default",
+			Target: "aws",
+			Properties: []byte(`{
+				"policyName": "p",
+				"roleName": "r",
+				"policyDocument": {
+					"objectset.rio.cattle.io/applied": "H4",
+					"x-kubernetes-preserve-unknown-fields": true,
+					"Content-Type": "application/json",
+					"class": "nginx",
+					"plain": "ok"
+				}
+			}`),
+		}},
+	}
+
+	generated, evaluated := generateAndEvaluate(t, forma)
+
+	// Escaped by backticks, not brackets: the same renderer serves typed
+	// classes, which take properties and reject entries.
+	assert.Contains(t, generated, "`objectset.rio.cattle.io/applied` = \"H4\"")
+	assert.Contains(t, generated, "`x-kubernetes-preserve-unknown-fields` = true")
+	assert.Contains(t, generated, "`Content-Type` = \"application/json\"")
+	// A key shaped like a PKL keyword needs the same escape.
+	assert.Contains(t, generated, "`class` = \"nginx\"")
+	// An ordinary key stays bare.
+	assert.Contains(t, generated, "plain = \"ok\"")
+
+	// The schema's field mapping capitalizes the property; the data keys under
+	// it are the plugin's own and come back untouched.
+	doc := gjson.Get(evaluated.ToJSON(), `Resources.#(Label=="dotted-policy").Properties.PolicyDocument`)
+	assert.Equal(t, "H4", doc.Get(`objectset\.rio\.cattle\.io/applied`).String())
+	assert.True(t, doc.Get(`x-kubernetes-preserve-unknown-fields`).Bool())
+	assert.Equal(t, "application/json", doc.Get(`Content-Type`).String())
+	assert.Equal(t, "nginx", doc.Get("class").String())
+	assert.Equal(t, "ok", doc.Get("plain").String())
+}
+
 func TestGenerateSourceCode_GeneratorBinding_RoundTripsThroughPkl(t *testing.T) {
 	forma := &model.Forma{
 		Stacks:  []model.Stack{{Label: "secrets"}},

--- a/internal/schema/pkl/pkl_generate_test.go
+++ b/internal/schema/pkl/pkl_generate_test.go
@@ -323,9 +323,9 @@ func TestGenerateSourceCode_GeneratorRotation_RoundTrips(t *testing.T) {
 // escaped in the emitted source, that source evaluates, and the key comes back
 // spelled exactly as it was stored. An opaque field carries provider data
 // verbatim — Kubernetes annotations, `x-kubernetes-*` CRD flags, HTTP header
-// names — and none of those are identifiers. Rendered bare (the PLA-465
-// behavior) the emitted forma does not parse at all, so generateAndEvaluate
-// fails before any assertion here runs.
+// names — and none of those are identifiers. Rendered bare, the emitted
+// forma does not parse at all, so generateAndEvaluate fails before any
+// assertion here runs.
 func TestGenerateSourceCode_NonIdentifierKeys_RoundTripThroughPkl(t *testing.T) {
 	forma := &model.Forma{
 		Stacks:  []model.Stack{{Label: "default"}},


### PR DESCRIPTION
Closes PLA-465. Also closes the field-name half of PLA-67 (its module-path-segment half is untouched).

## The bug

Extract rendered every key of an untyped nested object as a bare identifier, so any key carrying a dot, slash or hyphen produced a forma that does not parse. The typed `Mapping` path already bracketed its keys, which is why this only ever showed in free-form positions.

Two shapes hit it constantly on Kubernetes:

```pkl
spec = new Dynamic { template = new Dynamic { metadata = new Dynamic { annotations = new Dynamic {
  objectset.rio.cattle.io/applied = "H4sIAAAAAAAA"   # invalid
  prometheus.io/scrape = "true"                       # invalid
}}}}
...
x-kubernetes-preserve-unknown-fields = true           # invalid — in most real CRDs
```

```
$ pkl eval extracted.pkl
–– Pkl Error ––
Unexpected token `=`. Expected `}`.
```

A key shaped like a PKL keyword fails the same way, and that is not hypothetical: extracting the DQC `dqc-pe-eastus-app` stack on today's stable produces a cert-manager ClusterIssuer with `solvers[].http01.ingress.class = "nginx"`, which dies with `Missing } delimiter`. So extract → re-apply is broken today for any cluster carrying CRDs or Kubernetes annotations.

Second defect, found by the tests rather than by reading: `mapToPklStringWithTypes` read `isMapping` from the enclosing module, where nothing declares it, so every map reaching that function died with ``Cannot find property `isMapping` ``.

## The fix

One `renderDataKey` helper, escaping by shape:

- a `Mapping` takes entries, so its keys stay bracketed — unchanged behavior;
- everywhere else the key is a property, of a typed class or of a `Dynamic`, and a bracketed entry would be rejected on a typed class, so escaping is by backticks;
- a key shaped like a PKL keyword is escaped for the same reason;
- `mapToPklStringWithTypes` now reads its own tag.

A key containing a backtick cannot be backtick-escaped, so it falls back to brackets — right for `Dynamic` and `Mapping`, and a typed class cannot carry such a property name in the first place.

## Verification

- **PKL tests** (`internal/schema/pkl/generator/tests/gen.pkl`, 4 new): untyped content escapes non-identifier keys; the untagged-map path (this one previously died on `isMapping`); a `Mapping` still renders entries; a keyword-shaped key is escaped. 137/137 pass, and the two new ones fail without the fix.
- **Go unit test** (`TestGenerateSourceCode_NonIdentifierKeys_RoundTripThroughPkl`): the whole user path — stored opaque property → `GenerateSourceCode` → real `Evaluate` of the emitted file → every key back verbatim. Reverting `gen.pkl` to the pre-fix version makes it fail at evaluation with ``Unexpected token `=` `` before any assertion.
- `make test-pkl` exit 0 · `go test -tags unit ./internal/schema/pkl/...` 169 passed · `go test ./internal/cli/...` 584 passed in 40 packages.
- **Live, kind cluster, binary built from this branch**: a stack with a CRD, a ConfigMap carrying dotted annotations, and custom resources whose opaque specs carry dotted, slashed, hyphenated and keyword-shaped keys — `formae extract` output now `pkl eval`s clean (exit 0, was a parse error) and re-applies with **No changes needed**.
- **No-regression**: extracted all 28 unmanaged resources on that cluster with the stable binary and with this one — byte-identical output, zero backticks, because none of them carry a non-identifier key. On the real DQC stack the diff is exactly the one `class` line.

## Not in scope

`formatNestedContent` / `mapToPklString` (the non-`WithTypes` variants) still emit bare keys. Nothing reported reaches them and `formatNestedContent` has no caller, so they are left alone rather than changed blind.

Noticed while testing, unrelated and pre-existing on stable: `formae extract --query 'managed:false'` emits a forma that fails validation with `Tried to read property 'label' but its value is undefined` at `FormaRender.hasStack`, because extracted unmanaged resources reference the `$unmanaged` stack the file never declares. Identical before and after this change; not ticketed yet.
