### PR TITLE
fix(metastructure): judge late createOnly changes only on resolved references

### DIFF
--- a/internal/metastructure/resource_update/regenerate_createonly_test.go
+++ b/internal/metastructure/resource_update/regenerate_createonly_test.go
@@ -162,3 +162,34 @@ func TestResolveValue_ChangedNestedCreateOnlyRef_RefusedWithFullPath(t *testing.
 	require.True(t, errors.As(err, &late), "the failure must be the typed late-createOnly error")
 	assert.Contains(t, late.Fields, "LinkedNetwork.Uri")
 }
+
+// A pending reference nested under a property key containing a JSON Pointer
+// special character ('/' — RFC 6901-escaped as ~1 in op paths) is still
+// recognized as pending: sibling deliveries must not judge it just because
+// its op path spells the key differently than the document does.
+func TestResolveValue_PendingRefUnderSlashedKeyStaysUnjudged(t *testing.T) {
+	schema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Description", "Hub", "Config"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Hub":    {CreateOnly: true},
+			"Config": {CreateOnly: true},
+		},
+	}
+	ru := ResourceUpdate{
+		Operation: OperationUpdate,
+		PriorState: pkgmodel.Resource{
+			Label: "consumer", Type: "Test::Config::Entry", Schema: schema,
+			Properties: json.RawMessage(`{"Name": "c1", "Description": "old", "Hub": "hub-1", "Config": {"example.com/role": "value-1"}}`),
+		},
+		DesiredState: pkgmodel.Resource{
+			Label: "consumer", Type: "Test::Config::Entry", Schema: schema,
+			Properties: json.RawMessage(`{"Name": "c1", "Description": "new", "Hub": {"$ref": "formae://k-hub#/Name"}, "Config": {"example.com/role": {"$ref": "formae://k-src#/Role"}}}`),
+		},
+		RemainingResolvables: []pkgmodel.FormaeURI{"formae://k-hub#/Name", "formae://k-src#/Role"},
+	}
+
+	err := ru.ResolveValue("formae://k-hub#/Name", "hub-1", pkgmodel.FormaApplyModePatch)
+
+	require.NoError(t, err, "a pending reference under an escaped key is still pending")
+}

--- a/internal/metastructure/resource_update/regenerate_createonly_test.go
+++ b/internal/metastructure/resource_update/regenerate_createonly_test.go
@@ -92,3 +92,73 @@ func TestResourceResolved_LateCreateOnlyDiff_PersistsReason(t *testing.T) {
 	assert.Contains(t, message, "createOnly")
 	assert.Contains(t, message, "Anchor")
 }
+
+// spokeShapedUpdate builds the two-reference shape that exercises judgment
+// timing: a top-level createOnly reference plus a reference nested inside a
+// createOnly sub-resource, with prior state holding the currently applied
+// values. References resolve one at a time at execution, so the patch is
+// re-derived while sibling references are still pending.
+func spokeShapedUpdate() ResourceUpdate {
+	schema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Description", "Hub", "LinkedNetwork"},
+		Hints: map[string]pkgmodel.FieldHint{
+			"Hub":           {CreateOnly: true},
+			"LinkedNetwork": {CreateOnly: true},
+		},
+	}
+	return ResourceUpdate{
+		Operation: OperationUpdate,
+		PriorState: pkgmodel.Resource{
+			Label: "spoke", Type: "Test::Network::Spoke", Schema: schema,
+			Properties: json.RawMessage(`{"Name": "s1", "Description": "old", "Hub": "hub-1", "LinkedNetwork": {"Uri": "https://net-1"}}`),
+		},
+		DesiredState: pkgmodel.Resource{
+			Label: "spoke", Type: "Test::Network::Spoke", Schema: schema,
+			Properties: json.RawMessage(`{"Name": "s1", "Description": "new", "Hub": {"$ref": "formae://k-hub#/Name"}, "LinkedNetwork": {"Uri": {"$ref": "formae://k-net#/SelfLink"}}}`),
+		},
+		RemainingResolvables: []pkgmodel.FormaeURI{"formae://k-hub#/Name", "formae://k-net#/SelfLink"},
+	}
+}
+
+// A createOnly path whose reference has not delivered its value yet cannot be
+// judged: re-deriving the patch after a SIBLING reference resolves must not
+// refuse the update over the still-pending path.
+func TestResolveValue_SiblingDeliveryLeavesPendingCreateOnlyRefUnjudged(t *testing.T) {
+	ru := spokeShapedUpdate()
+
+	err := ru.ResolveValue("formae://k-hub#/Name", "hub-1", pkgmodel.FormaApplyModePatch)
+
+	require.NoError(t, err, "a pending reference is not judgeable; only delivered values are")
+}
+
+// Once every reference has delivered a value equal to the applied one, the
+// update proceeds and the re-derived patch carries only the real change.
+func TestResolveValue_AllRefsResolveUnchanged_UpdateProceeds(t *testing.T) {
+	ru := spokeShapedUpdate()
+
+	require.NoError(t, ru.ResolveValue("formae://k-hub#/Name", "hub-1", pkgmodel.FormaApplyModePatch))
+	require.NoError(t, ru.ResolveValue("formae://k-net#/SelfLink", "https://net-1", pkgmodel.FormaApplyModePatch))
+
+	var ops []struct {
+		Path string `json:"path"`
+	}
+	require.NoError(t, json.Unmarshal(ru.DesiredState.PatchDocument, &ops))
+	require.Len(t, ops, 1)
+	assert.Equal(t, "/Description", ops[0].Path)
+}
+
+// A reference that delivers a genuinely different value on a createOnly path
+// is still refused — at its own delivery, with the full path of the changed
+// member, not just the top-level property.
+func TestResolveValue_ChangedNestedCreateOnlyRef_RefusedWithFullPath(t *testing.T) {
+	ru := spokeShapedUpdate()
+
+	require.NoError(t, ru.ResolveValue("formae://k-hub#/Name", "hub-1", pkgmodel.FormaApplyModePatch))
+	err := ru.ResolveValue("formae://k-net#/SelfLink", "https://net-2", pkgmodel.FormaApplyModePatch)
+
+	require.Error(t, err)
+	var late LateCreateOnlyChangeError
+	require.True(t, errors.As(err, &late), "the failure must be the typed late-createOnly error")
+	assert.Contains(t, late.Fields, "LinkedNetwork.Uri")
+}

--- a/internal/metastructure/resource_update/regenerate_createonly_test.go
+++ b/internal/metastructure/resource_update/regenerate_createonly_test.go
@@ -193,3 +193,17 @@ func TestResolveValue_PendingRefUnderSlashedKeyStaysUnjudged(t *testing.T) {
 
 	require.NoError(t, err, "a pending reference under an escaped key is still pending")
 }
+
+// A reference whose URI is still queued for delivery is pending even when its
+// envelope carries a value from an earlier delivery (a resumed update
+// re-resolves it): a sibling delivery must not judge the carried value; the
+// reference is judged when its own re-delivery arrives.
+func TestResolveValue_QueuedRefWithCarriedValueStaysUnjudged(t *testing.T) {
+	ru := spokeShapedUpdate()
+	ru.DesiredState.Properties = json.RawMessage(
+		`{"Name": "s1", "Description": "new", "Hub": {"$ref": "formae://k-hub#/Name"}, "LinkedNetwork": {"Uri": {"$ref": "formae://k-net#/SelfLink", "$value": "https://net-STALE"}}}`)
+
+	err := ru.ResolveValue("formae://k-hub#/Name", "hub-1", pkgmodel.FormaApplyModePatch)
+
+	require.NoError(t, err, "a queued reference is pending regardless of a carried value")
+}

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -490,10 +491,10 @@ func opsOutsidePendingReferences(createOnlyPatch json.RawMessage, desiredPropert
 	var judgeable []map[string]any
 	for _, op := range ops {
 		path, _ := op["path"].(string)
-		dotted := strings.ReplaceAll(strings.TrimPrefix(path, "/"), "/", ".")
+		segments := jsonPointerSegments(path)
 		touchesPending := false
 		for _, p := range pending {
-			if dotted == p || strings.HasPrefix(dotted, p+".") || strings.HasPrefix(p, dotted+".") {
+			if segmentsOverlap(segments, p) {
 				touchesPending = true
 				break
 			}
@@ -512,40 +513,60 @@ func opsOutsidePendingReferences(createOnlyPatch json.RawMessage, desiredPropert
 	return out, nil
 }
 
-// unresolvedReferencePaths lists the dotted destination paths of reference
-// envelopes that still hold a $ref without a $value — the exact set the
-// flatten step renders as placeholders. Numeric segments index arrays.
-func unresolvedReferencePaths(properties json.RawMessage) ([]string, error) {
+// unresolvedReferencePaths lists the destination paths, as raw key segments,
+// of reference envelopes that still hold a $ref without a $value — the exact
+// set the flatten step renders as placeholders. Numeric segments index arrays.
+func unresolvedReferencePaths(properties json.RawMessage) ([][]string, error) {
 	var doc map[string]any
 	if err := json.Unmarshal(properties, &doc); err != nil {
 		return nil, fmt.Errorf("failed to parse desired properties: %w", err)
 	}
-	var paths []string
-	var walk func(prefix string, node any)
-	walk = func(prefix string, node any) {
+	var paths [][]string
+	var walk func(prefix []string, node any)
+	walk = func(prefix []string, node any) {
 		switch n := node.(type) {
 		case map[string]any:
 			if _, hasRef := n["$ref"]; hasRef {
 				if _, hasVal := n["$value"]; !hasVal {
-					paths = append(paths, prefix)
+					paths = append(paths, append([]string{}, prefix...))
 				}
 				return
 			}
 			for k, v := range n {
-				key := k
-				if prefix != "" {
-					key = prefix + "." + k
-				}
-				walk(key, v)
+				walk(append(prefix, k), v)
 			}
 		case []any:
 			for i, elem := range n {
-				walk(fmt.Sprintf("%s.%d", prefix, i), elem)
+				walk(append(prefix, strconv.Itoa(i)), elem)
 			}
 		}
 	}
-	walk("", doc)
+	walk(nil, doc)
 	return paths, nil
+}
+
+// jsonPointerSegments splits an RFC 6901 JSON Pointer into raw key segments,
+// unescaping ~1 to '/' and ~0 to '~' so segments compare against document
+// keys as written.
+func jsonPointerSegments(path string) []string {
+	segments := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	for i, s := range segments {
+		s = strings.ReplaceAll(s, "~1", "/")
+		segments[i] = strings.ReplaceAll(s, "~0", "~")
+	}
+	return segments
+}
+
+// segmentsOverlap reports whether one segment path is equal to or a prefix of
+// the other — an op at, under, or above a pending destination.
+func segmentsOverlap(a, b []string) bool {
+	n := min(len(a), len(b))
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // createOnlyPatchFields extracts the distinct field paths touched by a
@@ -564,7 +585,7 @@ func createOnlyPatchFields(createOnlyPatch json.RawMessage) ([]string, error) {
 	seen := make(map[string]struct{}, len(ops))
 	var fields []string
 	for _, op := range ops {
-		field := strings.ReplaceAll(strings.TrimPrefix(op.Path, "/"), "/", ".")
+		field := strings.Join(jsonPointerSegments(op.Path), ".")
 		if field == "" {
 			continue
 		}

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -164,7 +164,7 @@ func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value strin
 	}
 	ru.DesiredState.Properties = properties
 
-	return ru.reDerivePatchAfterSubstitution(mode, string(formaeUri))
+	return ru.reDerivePatchAfterSubstitution(mode, string(formaeUri), formaeUri)
 }
 
 // ResolveGeneratorValue delivers a generator's freshly drawn value to every
@@ -251,7 +251,7 @@ func (ru *ResourceUpdate) PrepareGeneratorValues(generatorKsuid string, values m
 func (ru *ResourceUpdate) CommitGeneratorValues(prepared *PreparedGenDelivery, generatorKsuid string, generationID string, mode pkgmodel.FormaApplyMode) error {
 	ru.DesiredState.Properties = prepared.properties
 	ru.stampDrawnGeneration(generatorKsuid, prepared.outputs, generationID)
-	return ru.reDerivePatchAfterSubstitution(mode, "generator "+generatorKsuid)
+	return ru.reDerivePatchAfterSubstitution(mode, "generator "+generatorKsuid, "")
 }
 
 // ResolveGeneratorValue prepares and commits in one step, for a caller
@@ -308,7 +308,7 @@ func (ru *ResourceUpdate) stampDrawnGeneration(generatorKsuid string, outputs []
 // Only Updates need a fresh patch — Create/Delete/Replace carry full
 // desired/prior state to the provider rather than a diff. Patch regen is also
 // a no-op when no Schema is available (sync/discovery paths).
-func (ru *ResourceUpdate) reDerivePatchAfterSubstitution(mode pkgmodel.FormaApplyMode, subject string) error {
+func (ru *ResourceUpdate) reDerivePatchAfterSubstitution(mode pkgmodel.FormaApplyMode, subject string, deliveredURI pkgmodel.FormaeURI) error {
 	if ru.Operation != OperationUpdate || len(ru.DesiredState.Schema.Fields) == 0 {
 		return nil
 	}
@@ -319,11 +319,19 @@ func (ru *ResourceUpdate) reDerivePatchAfterSubstitution(mode pkgmodel.FormaAppl
 	}
 	if len(createOnlyPatch) > 0 {
 		// References deliver one at a time, and each delivery re-derives the
-		// patch. A path whose own reference has not delivered yet diffs as the
-		// unresolved-envelope placeholder, not as a value, so it cannot be
-		// judged on this re-derivation — its turn comes when its value
-		// arrives. Only ops on fully-resolved paths count against the guard.
-		judgeable, ferr := opsOutsidePendingReferences(createOnlyPatch, ru.DesiredState.Properties)
+		// patch. A path whose own reference has not delivered yet — its
+		// envelope holds no value, or its URI is still queued for delivery —
+		// cannot be judged on this re-derivation: a placeholder or a carried
+		// value is not the value the update will execute with. Its turn comes
+		// when its own delivery arrives. Only ops on fully-delivered paths
+		// count against the guard.
+		queued := make(map[string]bool, len(ru.RemainingResolvables))
+		for _, uri := range ru.RemainingResolvables {
+			if uri != deliveredURI {
+				queued[string(uri)] = true
+			}
+		}
+		judgeable, ferr := opsOutsidePendingReferences(createOnlyPatch, ru.DesiredState.Properties, queued)
 		if ferr != nil {
 			return fmt.Errorf("failed to inspect createOnly patch after resolving %s: %w", subject, ferr)
 		}
@@ -473,14 +481,16 @@ func (ru *ResourceUpdate) ConvergenceOnly() bool {
 // opsOutsidePendingReferences returns the subset of createOnly patch ops that
 // can be judged now: ops whose path does not touch a reference that has not
 // delivered its value yet. An op at, under, or above a pending destination is
-// diffing the unresolved-envelope placeholder rather than a value, so it is
-// excluded; it gets judged on the re-derivation its own delivery triggers.
-func opsOutsidePendingReferences(createOnlyPatch json.RawMessage, desiredProperties json.RawMessage) (json.RawMessage, error) {
+// diffing a placeholder or a carried value rather than the value the update
+// will execute with, so it is excluded; it gets judged on the re-derivation
+// its own delivery triggers. queuedURIs names the references still awaiting
+// delivery, keyed by their $ref URI.
+func opsOutsidePendingReferences(createOnlyPatch json.RawMessage, desiredProperties json.RawMessage, queuedURIs map[string]bool) (json.RawMessage, error) {
 	var ops []map[string]any
 	if err := json.Unmarshal(createOnlyPatch, &ops); err != nil {
 		return nil, fmt.Errorf("failed to parse createOnly patch ops: %w", err)
 	}
-	pending, err := unresolvedReferencePaths(desiredProperties)
+	pending, err := unresolvedReferencePaths(desiredProperties, queuedURIs)
 	if err != nil {
 		return nil, err
 	}
@@ -514,9 +524,12 @@ func opsOutsidePendingReferences(createOnlyPatch json.RawMessage, desiredPropert
 }
 
 // unresolvedReferencePaths lists the destination paths, as raw key segments,
-// of reference envelopes that still hold a $ref without a $value — the exact
-// set the flatten step renders as placeholders. Numeric segments index arrays.
-func unresolvedReferencePaths(properties json.RawMessage) ([][]string, error) {
+// of reference envelopes that have not delivered their value: envelopes
+// holding a $ref without a $value (the set the flatten step renders as
+// placeholders), plus envelopes whose $ref URI is in queuedURIs — a queued
+// reference's carried value is a prior delivery's, not this update's.
+// Numeric segments index arrays.
+func unresolvedReferencePaths(properties json.RawMessage, queuedURIs map[string]bool) ([][]string, error) {
 	var doc map[string]any
 	if err := json.Unmarshal(properties, &doc); err != nil {
 		return nil, fmt.Errorf("failed to parse desired properties: %w", err)
@@ -526,8 +539,10 @@ func unresolvedReferencePaths(properties json.RawMessage) ([][]string, error) {
 	walk = func(prefix []string, node any) {
 		switch n := node.(type) {
 		case map[string]any:
-			if _, hasRef := n["$ref"]; hasRef {
-				if _, hasVal := n["$value"]; !hasVal {
+			if ref, hasRef := n["$ref"]; hasRef {
+				_, hasVal := n["$value"]
+				refURI, _ := ref.(string)
+				if !hasVal || queuedURIs[refURI] {
 					paths = append(paths, append([]string{}, prefix...))
 				}
 				return

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -317,11 +317,22 @@ func (ru *ResourceUpdate) reDerivePatchAfterSubstitution(mode pkgmodel.FormaAppl
 		return fmt.Errorf("failed to re-derive patch document after resolving %s: %w", subject, derr)
 	}
 	if len(createOnlyPatch) > 0 {
-		fields, ferr := createOnlyPatchFields(createOnlyPatch)
+		// References deliver one at a time, and each delivery re-derives the
+		// patch. A path whose own reference has not delivered yet diffs as the
+		// unresolved-envelope placeholder, not as a value, so it cannot be
+		// judged on this re-derivation — its turn comes when its value
+		// arrives. Only ops on fully-resolved paths count against the guard.
+		judgeable, ferr := opsOutsidePendingReferences(createOnlyPatch, ru.DesiredState.Properties)
 		if ferr != nil {
 			return fmt.Errorf("failed to inspect createOnly patch after resolving %s: %w", subject, ferr)
 		}
-		return LateCreateOnlyChangeError{ResourceLabel: ru.DesiredState.Label, Fields: fields}
+		if len(judgeable) > 0 {
+			fields, ferr := createOnlyPatchFields(judgeable)
+			if ferr != nil {
+				return fmt.Errorf("failed to inspect createOnly patch after resolving %s: %w", subject, ferr)
+			}
+			return LateCreateOnlyChangeError{ResourceLabel: ru.DesiredState.Label, Fields: fields}
+		}
 	}
 	ru.DesiredState.PatchDocument = patchDoc
 
@@ -458,10 +469,90 @@ func (ru *ResourceUpdate) ConvergenceOnly() bool {
 	return true
 }
 
-// createOnlyPatchFields extracts the distinct top-level field names touched
-// by a createOnly patch document, in first-seen order, so
-// LateCreateOnlyChangeError can name what changed without exposing the raw
-// JSON-patch op shape to callers.
+// opsOutsidePendingReferences returns the subset of createOnly patch ops that
+// can be judged now: ops whose path does not touch a reference that has not
+// delivered its value yet. An op at, under, or above a pending destination is
+// diffing the unresolved-envelope placeholder rather than a value, so it is
+// excluded; it gets judged on the re-derivation its own delivery triggers.
+func opsOutsidePendingReferences(createOnlyPatch json.RawMessage, desiredProperties json.RawMessage) (json.RawMessage, error) {
+	var ops []map[string]any
+	if err := json.Unmarshal(createOnlyPatch, &ops); err != nil {
+		return nil, fmt.Errorf("failed to parse createOnly patch ops: %w", err)
+	}
+	pending, err := unresolvedReferencePaths(desiredProperties)
+	if err != nil {
+		return nil, err
+	}
+	if len(pending) == 0 {
+		return createOnlyPatch, nil
+	}
+
+	var judgeable []map[string]any
+	for _, op := range ops {
+		path, _ := op["path"].(string)
+		dotted := strings.ReplaceAll(strings.TrimPrefix(path, "/"), "/", ".")
+		touchesPending := false
+		for _, p := range pending {
+			if dotted == p || strings.HasPrefix(dotted, p+".") || strings.HasPrefix(p, dotted+".") {
+				touchesPending = true
+				break
+			}
+		}
+		if !touchesPending {
+			judgeable = append(judgeable, op)
+		}
+	}
+	if len(judgeable) == 0 {
+		return nil, nil
+	}
+	out, err := json.Marshal(judgeable)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize judgeable createOnly patch ops: %w", err)
+	}
+	return out, nil
+}
+
+// unresolvedReferencePaths lists the dotted destination paths of reference
+// envelopes that still hold a $ref without a $value — the exact set the
+// flatten step renders as placeholders. Numeric segments index arrays.
+func unresolvedReferencePaths(properties json.RawMessage) ([]string, error) {
+	var doc map[string]any
+	if err := json.Unmarshal(properties, &doc); err != nil {
+		return nil, fmt.Errorf("failed to parse desired properties: %w", err)
+	}
+	var paths []string
+	var walk func(prefix string, node any)
+	walk = func(prefix string, node any) {
+		switch n := node.(type) {
+		case map[string]any:
+			if _, hasRef := n["$ref"]; hasRef {
+				if _, hasVal := n["$value"]; !hasVal {
+					paths = append(paths, prefix)
+				}
+				return
+			}
+			for k, v := range n {
+				key := k
+				if prefix != "" {
+					key = prefix + "." + k
+				}
+				walk(key, v)
+			}
+		case []any:
+			for i, elem := range n {
+				walk(fmt.Sprintf("%s.%d", prefix, i), elem)
+			}
+		}
+	}
+	walk("", doc)
+	return paths, nil
+}
+
+// createOnlyPatchFields extracts the distinct field paths touched by a
+// createOnly patch document, in first-seen order and at full depth
+// ("LinkedNetwork.Uri", not "LinkedNetwork"), so LateCreateOnlyChangeError
+// names the member that actually changed without exposing the raw JSON-patch
+// op shape to callers.
 func createOnlyPatchFields(createOnlyPatch json.RawMessage) ([]string, error) {
 	var ops []struct {
 		Path string `json:"path"`
@@ -473,7 +564,7 @@ func createOnlyPatchFields(createOnlyPatch json.RawMessage) ([]string, error) {
 	seen := make(map[string]struct{}, len(ops))
 	var fields []string
 	for _, op := range ops {
-		field, _, _ := strings.Cut(strings.TrimPrefix(op.Path, "/"), "/")
+		field := strings.ReplaceAll(strings.TrimPrefix(op.Path, "/"), "/", ".")
 		if field == "" {
 			continue
 		}

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -1638,14 +1638,32 @@ func findDependencyUpdates(allDeleteUpdates []ResourceUpdate, replacedKsuids map
 // points at a resource in deletedKsuids via a CreateOnly field on dep's
 // schema. A single CreateOnly ref to a deletion target forces cascade-replace
 // for the whole dependent (mixed-refs case).
+//
+// A reference counts as CreateOnly when its destination path sits at or below
+// a CreateOnly-hinted field — the same at-or-below matching the patch
+// pipeline uses to classify createOnly ops — so a hint on a wrapper object
+// covers a reference on one of its members, matching how such an update
+// would be judged at execution time.
 func anyRefIsCreateOnly(dep pkgmodel.Resource, deletedKsuids map[string]bool) bool {
+	createOnlyFields := dep.Schema.CreateOnly()
 	for _, ref := range resolver.ExtractResolvableRefs(dep) {
 		ksuid := strings.TrimPrefix(string(ref.URI), "formae://")
 		if !deletedKsuids[ksuid] {
 			continue
 		}
-		hint := dep.Schema.Hints[stripArrayIndicesForHintLookup(ref.TargetPath)]
-		if hint.CreateOnly {
+		if pathIsAtOrBelowAnyField(stripArrayIndicesForHintLookup(ref.TargetPath), createOnlyFields) {
+			return true
+		}
+	}
+	return false
+}
+
+// pathIsAtOrBelowAnyField reports whether a dotted, index-stripped destination
+// path targets one of the dotted schema field paths or a nested path within
+// one.
+func pathIsAtOrBelowAnyField(path string, fields []string) bool {
+	for _, field := range fields {
+		if path == field || strings.HasPrefix(path, field+".") {
 			return true
 		}
 	}

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -1664,9 +1664,12 @@ func anyRefIsCreateOnly(dep pkgmodel.Resource, deletedKsuids map[string]bool) bo
 // dotted key stays one segment and never matches a field that merely spells
 // its dot-prefix.
 func pathIsAtOrBelowAnyField(path string, fields []string) bool {
+	segments := pathkey.Split(path)
 	var pathSegments []string
-	for _, segment := range pathkey.Split(path) {
-		if isAllDigits(segment) {
+	for _, segment := range segments {
+		// A lone all-digits segment is a top-level field name, not an array
+		// index — an index can only appear under a field.
+		if isAllDigits(segment) && len(segments) > 1 {
 			continue
 		}
 		pathSegments = append(pathSegments, segment)

--- a/internal/metastructure/resource_update/resource_update_generator.go
+++ b/internal/metastructure/resource_update/resource_update_generator.go
@@ -1651,19 +1651,39 @@ func anyRefIsCreateOnly(dep pkgmodel.Resource, deletedKsuids map[string]bool) bo
 		if !deletedKsuids[ksuid] {
 			continue
 		}
-		if pathIsAtOrBelowAnyField(stripArrayIndicesForHintLookup(ref.TargetPath), createOnlyFields) {
+		if pathIsAtOrBelowAnyField(ref.TargetPath, createOnlyFields) {
 			return true
 		}
 	}
 	return false
 }
 
-// pathIsAtOrBelowAnyField reports whether a dotted, index-stripped destination
-// path targets one of the dotted schema field paths or a nested path within
-// one.
+// pathIsAtOrBelowAnyField reports whether a destination path (pathkey-escaped,
+// possibly with array-index segments) targets one of the dotted schema field
+// paths or a nested path within one. Comparison is by segments so a literal
+// dotted key stays one segment and never matches a field that merely spells
+// its dot-prefix.
 func pathIsAtOrBelowAnyField(path string, fields []string) bool {
+	var pathSegments []string
+	for _, segment := range pathkey.Split(path) {
+		if isAllDigits(segment) {
+			continue
+		}
+		pathSegments = append(pathSegments, segment)
+	}
 	for _, field := range fields {
-		if path == field || strings.HasPrefix(path, field+".") {
+		fieldSegments := strings.Split(field, ".")
+		if len(pathSegments) < len(fieldSegments) {
+			continue
+		}
+		matched := true
+		for i, fs := range fieldSegments {
+			if pathSegments[i] != fs {
+				matched = false
+				break
+			}
+		}
+		if matched {
 			return true
 		}
 	}

--- a/internal/metastructure/resource_update/resource_update_generator_patch_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_patch_test.go
@@ -565,3 +565,79 @@ func TestTargetReplace_Patch_NonPortable_Rejected(t *testing.T) {
 	assert.Equal(t, "aws-prod", nonPortableErr.TargetLabel)
 	assert.NotEmpty(t, nonPortableErr.Resources)
 }
+
+// A createOnly reference whose target was replaced by an EARLIER command is
+// judged at plan time from the target's persisted state: the provider-assigned
+// source property lives in the target row's ReadOnlyProperties, plan-time
+// classification resolves it from there, and the resulting createOnly diff
+// plans a replacement of the dependent instead of an in-place update that
+// would only discover the change at execution time.
+func TestGenerateResourceUpdatesForPatch_StaleCreateOnlyRefPlansReplace(t *testing.T) {
+	ds, _ := GetDeps(t)
+
+	netKsuid := util.NewID()
+	spokeKsuid := util.NewID()
+
+	network := pkgmodel.Resource{
+		Label: "net", Type: "GCP::Compute::Network", Stack: "infrastructure", Target: "test-target",
+		Ksuid: netKsuid, NativeID: "net-native-2",
+		Schema:     pkgmodel.Schema{Identifier: "Name", Fields: []string{"Name"}},
+		Properties: json.RawMessage(`{"Name": "net"}`),
+		// The provider-assigned output as the latest replacement's echo left it.
+		ReadOnlyProperties: json.RawMessage(`{"SelfLink": "https://net-NEW"}`),
+	}
+	spokeSchema := pkgmodel.Schema{
+		Identifier: "Name",
+		Fields:     []string{"Name", "Description", "LinkedNetwork"},
+		Hints:      map[string]pkgmodel.FieldHint{"LinkedNetwork": {CreateOnly: true}},
+	}
+	storedSpoke := pkgmodel.Resource{
+		Label: "spoke", Type: "GCP::NetworkConnectivity::Spoke", Stack: "infrastructure", Target: "test-target",
+		Ksuid: spokeKsuid, NativeID: "spoke-native-1",
+		Schema: spokeSchema,
+		Properties: json.RawMessage(fmt.Sprintf(
+			`{"Name": "spoke", "Description": "old", "LinkedNetwork": {"Uri": {"$ref": "formae://%s#/SelfLink", "$value": "https://net-OLD", "$applied": "https://net-OLD"}}}`,
+			netKsuid)),
+	}
+	_, err := ds.StoreStack(&pkgmodel.Forma{
+		Stacks:    []pkgmodel.Stack{{Label: "infrastructure"}},
+		Resources: []pkgmodel.Resource{network, storedSpoke},
+	}, "earlier-command")
+	require.NoError(t, err)
+
+	desiredSpoke := storedSpoke
+	desiredSpoke.NativeID = ""
+	desiredSpoke.Properties = json.RawMessage(fmt.Sprintf(
+		`{"Name": "spoke", "Description": "new", "LinkedNetwork": {"Uri": {"$ref": "formae://%s#/SelfLink"}}}`,
+		netKsuid))
+	forma := &pkgmodel.Forma{
+		Stacks:    []pkgmodel.Stack{{Label: "infrastructure"}},
+		Resources: []pkgmodel.Resource{desiredSpoke},
+	}
+	targetMap := map[string]*pkgmodel.Target{
+		"test-target": {Label: "test-target", Namespace: "GCP", Config: json.RawMessage(`{}`)},
+	}
+
+	updates, err := generateResourceUpdatesForApply(forma, pkgmodel.FormaApplyModePatch, FormaCommandSourceUser, targetMap, targetMap, ds, nil, false)
+	require.NoError(t, err)
+
+	var deleteHalf, createHalf *ResourceUpdate
+	for i := range updates {
+		if updates[i].DesiredState.Label != "spoke" {
+			continue
+		}
+		switch updates[i].Operation {
+		case OperationDelete:
+			deleteHalf = &updates[i]
+		case OperationCreate:
+			createHalf = &updates[i]
+		case OperationUpdate:
+			t.Fatalf("the stale createOnly reference must plan a replacement, not an in-place update")
+		}
+	}
+	require.NotNil(t, deleteHalf, "replacement must carry a delete half")
+	require.NotNil(t, createHalf, "replacement must carry a create half")
+	assert.Equal(t, deleteHalf.GroupID, createHalf.GroupID, "the halves must be grouped as one replacement")
+	assert.Contains(t, string(deleteHalf.CreateOnlyPatch), "LinkedNetwork",
+		"the replacement must name the immutable field that forced it")
+}

--- a/internal/metastructure/resource_update/resource_update_generator_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_test.go
@@ -1158,6 +1158,9 @@ func TestFindDependencyUpdates_CreateOnlyBranch(t *testing.T) {
 	nestedWrapperRefJSON := fmt.Sprintf(
 		`{"LinkedNetwork":{"Uri":{"$ref":"formae://%s#/SelfLink","$value":"https://net-1"}}}`, parentKsuid,
 	)
+	literalDottedKeyRefJSON := fmt.Sprintf(
+		`{"Foo.Bar":{"$ref":"formae://%s#/Name","$value":"parent-v1"}}`, parentKsuid,
+	)
 
 	cases := []struct {
 		name              string
@@ -1210,6 +1213,16 @@ func TestFindDependencyUpdates_CreateOnlyBranch(t *testing.T) {
 				"LinkedNetwork": {CreateOnly: true},
 			}),
 			wantCascadeDelete: true,
+		},
+		{
+			// A literal dotted key is one segment, not nesting: a ref under
+			// the top-level key "Foo.Bar" does not sit below a field named
+			// "Foo", so a CreateOnly hint there must not force a replacement.
+			name: "literal dotted key is not below a dot-prefix field",
+			dependent: makeDependent(literalDottedKeyRefJSON, map[string]pkgmodel.FieldHint{
+				"Foo": {CreateOnly: true},
+			}),
+			wantCascadeDelete: false,
 		},
 	}
 

--- a/internal/metastructure/resource_update/resource_update_generator_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_test.go
@@ -1155,6 +1155,9 @@ func TestFindDependencyUpdates_CreateOnlyBranch(t *testing.T) {
 		`{"ImmutableRef":{"$ref":"formae://%s#/Name","$value":"parent-v1"},"MutableRef":{"$ref":"formae://%s#/Other","$value":"x"}}`,
 		parentKsuid, otherKsuid,
 	)
+	nestedWrapperRefJSON := fmt.Sprintf(
+		`{"LinkedNetwork":{"Uri":{"$ref":"formae://%s#/SelfLink","$value":"https://net-1"}}}`, parentKsuid,
+	)
 
 	cases := []struct {
 		name              string
@@ -1193,6 +1196,18 @@ func TestFindDependencyUpdates_CreateOnlyBranch(t *testing.T) {
 			name: "array-indexed path uses stripped hint key",
 			dependent: makeDependent(parentRefArrayJSON, map[string]pkgmodel.FieldHint{
 				"Refs.Target": {CreateOnly: true},
+			}),
+			wantCascadeDelete: true,
+		},
+		{
+			// A CreateOnly hint on a wrapper field covers references nested
+			// inside it — the same at-or-below matching the patch pipeline
+			// uses to classify createOnly ops, so a schema annotating the
+			// provider's immutability unit (the wrapper object) cascades the
+			// same way one annotating the leaf member does.
+			name: "wrapper-level createOnly covers a nested ref",
+			dependent: makeDependent(nestedWrapperRefJSON, map[string]pkgmodel.FieldHint{
+				"LinkedNetwork": {CreateOnly: true},
 			}),
 			wantCascadeDelete: true,
 		},

--- a/internal/metastructure/resource_update/resource_update_generator_test.go
+++ b/internal/metastructure/resource_update/resource_update_generator_test.go
@@ -1161,6 +1161,9 @@ func TestFindDependencyUpdates_CreateOnlyBranch(t *testing.T) {
 	literalDottedKeyRefJSON := fmt.Sprintf(
 		`{"Foo.Bar":{"$ref":"formae://%s#/Name","$value":"parent-v1"}}`, parentKsuid,
 	)
+	digitFieldRefJSON := fmt.Sprintf(
+		`{"42":{"$ref":"formae://%s#/Name","$value":"parent-v1"}}`, parentKsuid,
+	)
 
 	cases := []struct {
 		name              string
@@ -1223,6 +1226,16 @@ func TestFindDependencyUpdates_CreateOnlyBranch(t *testing.T) {
 				"Foo": {CreateOnly: true},
 			}),
 			wantCascadeDelete: false,
+		},
+		{
+			// A single all-digits segment is a top-level field name, not an
+			// array index — an index can only appear under a field. Its hint
+			// must still be found.
+			name: "digit-named top-level field keeps its hint",
+			dependent: makeDependent(digitFieldRefJSON, map[string]pkgmodel.FieldHint{
+				"42": {CreateOnly: true},
+			}),
+			wantCascadeDelete: true,
 		},
 	}
 


### PR DESCRIPTION
## Summary

A resource with a reference nested inside a `createOnly` sub-resource could never be updated in patch mode: every update was refused with `resolving references at execution time changed createOnly fields [...]`, even when the update touched only mutable fields and nothing about the immutable field changed. Found on `GCP::NetworkConnectivity::Spoke` (`linkedVpcNetwork.uri`), which carried a plugin-side flattening workaround (formae-plugin-gcp #196) that can be reverted once this lands.

### Mechanism

References deliver one at a time at execution, and each delivery re-derives the update's patch (`reDerivePatchAfterSubstitution`). The re-derivation diffs the full document, in which a reference that has not delivered yet flattens to the unresolved-envelope placeholder. Diffing that placeholder against stored state mints a phantom op on the pending path; when that path is `createOnly`, the whole update is refused. A top-level pending reference escapes only because the top-level empty-string drop filters its placeholder before the diff — which is why the failure looked nesting-specific. Whether a given resource failed depended purely on the delivery order of its references, which is why the same case could pass on one machine and fail deterministically on another.

### Fix

Ops on paths whose reference envelope still lacks a delivered `$value` are excluded from the late-createOnly refusal — a pending path is not judgeable, and its turn comes on the re-derivation its own delivery triggers. A reference that genuinely resolves to a different value is still refused, at its own delivery. The judgment keys on envelope state, never on the placeholder value, so an explicit empty-string property is unaffected.

`LateCreateOnlyChangeError` now reports the full member path (`linkedVpcNetwork.uri`) instead of the truncated top-level property, which previously sent debugging to the wrong place.

### Verification

- Three new unit tests: a sibling delivery leaves a pending createOnly reference unjudged; an update proceeds once all references resolve unchanged, with the re-derived patch carrying only the real change; a reference resolving to a different value on a createOnly path is refused at its own delivery, naming the full path. All three fail on main.
- Full unit suite green.
- The `networkconnectivity-spoke` CRUD conformance case (formae-plugin-gcp, pre-workaround fixture), which reproduced the refusal deterministically on this machine with the released binary, passes its complete lifecycle against a binary built from this branch.

### Review

Six cross-model adversarial review passes, iterating fix-and-re-review until a clean pass:

- **Declined (pass 1):** recursing into a resolved envelope's `$value` for unresolved references nested inside it. That document shape is not producible — `$value` is written either from the resolve cache (a plain string) or from the applied-value carry (plugin-format content, which contains no envelopes) — and the flatten step does not recurse into `$value` either, so the proposed handling would not correspond to any diff the pipeline can produce.
- **Fixed (pass 2):** pending-path matching mis-compared op paths containing RFC 6901 escapes (`~1`/`~0`) against raw document keys; paths now compare as unescaped segments, and the refusal's field names come out unescaped too.
- **Fixed (pass 3):** a reference still queued for delivery could carry a value from an earlier delivery (a resumed update re-resolves every queued reference) and be judged from it; pending-ness now also keys on queue membership, excluding the reference being delivered.
- **Fixed (pass 4):** the cascade classifier's at-or-below matching flattened paths into dotted strings, letting a createOnly hint match a literal dotted key spelling its dot-prefix and force a spurious replacement; comparison is now segment-wise over pathkey-escaped paths.
- **Fixed (pass 5):** the segment filter dropped a lone all-digits segment, losing the hint of a top-level digit-named field; a single segment cannot be an array index and is now kept.
- **Pass 6: clean.**

Each accepted finding landed with a failing test first.

### Also in this PR: two adjacent judgment gaps found during the investigation

**Cascade classification now honors wrapper-level createOnly hints.** The classifier that decides whether a dependent of a delete/replace is cascade-replaced or cascade-updated looked up the FieldHint at the reference's leaf path with an exact match, so a createOnly hint on a wrapper object (the provider's immutability unit, e.g. a hint on `linkedVpcNetwork` covering a reference on `.uri`) was invisible: the dependent was planned as a cascade-update, which then failed at execution when the reference delivered its new value. It now uses the same at-or-below matching the patch pipeline applies to createOnly ops, so both hint placements behave identically in both judgments. Covered by a new case in the existing classification table test, red before the change.

**A covering test for plan-time replacement on a stale createOnly reference.** When a reference's target was replaced by an *earlier* command, the dependent's next update resolves the target's provider-assigned property from its persisted read-only properties at plan time and plans a replacement, rather than discovering the change mid-execution. That behavior already worked end to end but nothing covered it; the new test pins it, and a negative control (unchanged persisted value plans an in-place update) confirmed the test discriminates on the mechanism.

