### PR TITLE
fix(conformance): back off recoverable OOB operations

### DIFF
--- a/pkg/plugin-conformance-tests/harness.go
+++ b/pkg/plugin-conformance-tests/harness.go
@@ -77,6 +77,10 @@ type TestHarness struct {
 	// Plugin info for cleanup operations
 	lastPluginBinaryPath string
 	lastPluginNamespace  string
+
+	// retrySleep is injectable so retry policy tests do not wait in real time.
+	// Production harnesses leave it nil and use time.Sleep.
+	retrySleep func(time.Duration)
 }
 
 // getFreePort asks the kernel for a free open port that is ready to use.
@@ -1976,7 +1980,14 @@ func oobOperationTimeout() time.Duration {
 // The opFn performs the actor call and returns the initial result. The caller's label is used for logging.
 func (h *TestHarness) retryOnRecoverable(label string, opFn func() (*pluginOperationResult, error)) (resource.ProgressResult, error) {
 	const maxRetries = 6
-	const retryDelay = 10 * time.Second
+	retryStrategy := resource.RetryStrategy{
+		MaxRetries: maxRetries,
+		BaseDelay:  10 * time.Second,
+	}
+	sleep := time.Sleep
+	if h.retrySleep != nil {
+		sleep = h.retrySleep
+	}
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		res, err := opFn()
@@ -1998,9 +2009,10 @@ func (h *TestHarness) retryOnRecoverable(label string, opFn func() (*pluginOpera
 
 		if progress.OperationStatus == resource.OperationStatusFailure {
 			if resource.IsRecoverable(progress.ErrorCode) && attempt < maxRetries {
-				h.t.Logf("%s failed with recoverable error (code: %s), retry %d/%d: %s",
-					label, progress.ErrorCode, attempt+1, maxRetries, progress.StatusMessage)
-				time.Sleep(retryDelay)
+				delay := retryStrategy.Backoff(attempt + 1)
+				h.t.Logf("%s failed with recoverable error (code: %s), retry %d/%d after %s: %s",
+					label, progress.ErrorCode, attempt+1, maxRetries, delay, progress.StatusMessage)
+				sleep(delay)
 				continue
 			}
 			return resource.ProgressResult{}, fmt.Errorf("%s failed: %s (code: %s)", label, progress.StatusMessage, progress.ErrorCode)

--- a/pkg/plugin-conformance-tests/harness_test.go
+++ b/pkg/plugin-conformance-tests/harness_test.go
@@ -9,10 +9,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 	"unicode/utf8"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
 // fakeReporter is a local testReporter fake, shaped like collectingReporter,
@@ -214,6 +217,41 @@ func TestKeepTempDirRequested(t *testing.T) {
 				t.Errorf("expected no log messages for a well-formed value, got %v", r.logs)
 			}
 		})
+	}
+}
+
+func TestRetryOnRecoverableBacksOffAcrossRecoverableFailures(t *testing.T) {
+	var (
+		calls  int
+		delays []time.Duration
+	)
+	h := &TestHarness{
+		t: t,
+		retrySleep: func(delay time.Duration) {
+			delays = append(delays, delay)
+		},
+	}
+	results := []resource.ProgressResult{
+		{OperationStatus: resource.OperationStatusFailure, ErrorCode: resource.OperationErrorCodeThrottling},
+		{OperationStatus: resource.OperationStatusFailure, ErrorCode: resource.OperationErrorCodeResourceConflict},
+		{OperationStatus: resource.OperationStatusSuccess},
+	}
+
+	progress, err := h.retryOnRecoverable("OOB delete", func() (*pluginOperationResult, error) {
+		result := results[calls]
+		calls++
+		return &pluginOperationResult{initialProgress: result}, nil
+	})
+
+	if err != nil {
+		t.Fatalf("retryOnRecoverable() error = %v", err)
+	}
+	if progress.OperationStatus != resource.OperationStatusSuccess {
+		t.Fatalf("retryOnRecoverable() status = %s, want Success", progress.OperationStatus)
+	}
+	want := []time.Duration{10 * time.Second, 20 * time.Second}
+	if !slices.Equal(delays, want) {
+		t.Fatalf("retry delays = %v, want %v", delays, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- apply exponential backoff when an out-of-band create or delete returns a recoverable failure
- give provider-side operation locks time to clear after throttling or resource-conflict responses
- cover the throttling-to-resource-conflict recovery sequence without real sleeps