### PR TITLE
fix(metastructure): preserve frozen opaque secret references

### DIFF
--- a/internal/datastore/dstest/suite_forma_commands.go
+++ b/internal/datastore/dstest/suite_forma_commands.go
@@ -1483,6 +1483,7 @@ func RunResourceUpdateProvenanceRoundTrip(t *testing.T, newDS func(t *testing.T)
 		digest := "v1:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 		records := []resource_update.OccurrenceRecord{{
 			DestinationPath:   "Password",
+			FrozenSetOnce:     &resource_update.FrozenSetOnceRef{Path: "Password", Pointer: "/Password", HintPath: "Password"},
 			DesiredIdentity:   resource_update.OccurrenceIdentity{Ksuid: "2abcdefghijklmnopqrstuvwxyz", PropertyPath: "S"},
 			StoredIdentity:    resource_update.OccurrenceIdentity{Ksuid: "2abcdefghijklmnopqrstuvwxyz", PropertyPath: "S"},
 			HasStoredWritten:  true,

--- a/internal/metastructure/resource_update/occurrence_classification.go
+++ b/internal/metastructure/resource_update/occurrence_classification.go
@@ -120,6 +120,10 @@ func NormalizeOccurrenceIdentity(envelope gjson.Result, tripletLookup TripletLoo
 // execution-time regeneration. It carries only digests, identities, and
 // paths - never a value.
 type OccurrenceRecord struct {
+	// FrozenSetOnce records a destination-preservation decision separately
+	// from source movement. It uses the existing immutable JSON column, so
+	// all datastores retain the decision across progress and recovery.
+	FrozenSetOnce *FrozenSetOnceRef `json:"FrozenSetOnce,omitempty"`
 	// DestinationPath is the consumer-side dotted path of the occurrence
 	// (unique per document; the resolver's walk convention).
 	DestinationPath string `json:"DestinationPath"`

--- a/internal/metastructure/resource_update/opaque_setonce_ref.go
+++ b/internal/metastructure/resource_update/opaque_setonce_ref.go
@@ -1,0 +1,205 @@
+// © 2026 Platform Engineering Labs Inc.
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package resource_update
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/pathkey"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// FrozenSetOnceRef records a destination frozen at planning, not a claim that
+// its source is unchanged. Paths only; the stored envelope remains in
+// PreviousProperties. Persisting the decision keeps reads and recovery from
+// changing which destinations this update is allowed to write.
+type FrozenSetOnceRef struct {
+	HintPath     string `json:"HintPath"`
+	Path         string `json:"Path"`
+	Pointer      string `json:"Pointer"`
+	ArrayRoot    string `json:"ArrayRoot,omitempty"`
+	ArrayElement bool   `json:"ArrayElement,omitempty"`
+}
+
+func classifyFrozenSetOnceRefs(stored, desired json.RawMessage) []FrozenSetOnceRef {
+	var refs []FrozenSetOnceRef
+	prior := gjson.ParseBytes(stored)
+	var walk func(gjson.Result, string, string, string, string, bool)
+	walk = func(node gjson.Result, path, pointer, hintPath, arrayRoot string, arrayElement bool) {
+		if node.IsObject() && node.Get("$ref").Type == gjson.String {
+			old := prior.Get(path)
+			// An explicit strategy/visibility change or a reference repoint is
+			// not an unresolved restatement of this frozen destination.
+			if node.Get("$value").Exists() || old.Get("$hashed").Type != gjson.True ||
+				old.Get("$value").Type != gjson.String || old.Get("$strategy").String() != "SetOnce" ||
+				old.Get("$visibility").String() != "Opaque" || node.Get("$ref").String() == "" ||
+				old.Get("$ref").String() != node.Get("$ref").String() ||
+				old.Get("$json").Raw != node.Get("$json").Raw {
+				return
+			}
+			for key, value := range node.Map() {
+				switch key {
+				case "$ref", "$json":
+				case "$strategy":
+					if value.String() != "SetOnce" {
+						return
+					}
+				case "$visibility":
+					if value.String() != "Opaque" {
+						return
+					}
+				default:
+					return
+				}
+			}
+			refs = append(refs, FrozenSetOnceRef{Path: path, Pointer: pointer, HintPath: hintPath, ArrayRoot: arrayRoot, ArrayElement: arrayElement})
+			return
+		}
+		if node.IsArray() && arrayRoot == "" {
+			arrayRoot = pointer
+		}
+		if node.IsObject() || node.IsArray() {
+			node.ForEach(func(key, val gjson.Result) bool {
+				k := key.String()
+				p := strings.ReplaceAll(strings.ReplaceAll(k, "~", "~0"), "/", "~1")
+				nextHint := hintPath
+				if !node.IsArray() {
+					nextHint = childName(hintPath, k)
+				}
+				// Empty keys cannot be addressed safely by gjson/sjson.
+				if k != "" {
+					walk(val, buildPath(path, k), pointer+"/"+p, nextHint, arrayRoot, node.IsArray())
+				}
+				return true
+			})
+		}
+	}
+	walk(gjson.ParseBytes(desired), "", "", "", "", false)
+	return refs
+}
+
+// stripFrozenSetOnceRefs operates only on diff/resolution copies. Direct array
+// members become null to keep indices intact; real updates involving frozen
+// array members are refused because positional matching cannot prove identity.
+func stripFrozenSetOnceRefs(props json.RawMessage, refs []FrozenSetOnceRef) (json.RawMessage, error) {
+	out := string(props)
+	for _, ref := range refs {
+		var err error
+		if ref.ArrayElement {
+			out, err = sjson.SetRaw(out, ref.Path, "null")
+		} else {
+			out, err = sjson.Delete(out, ref.Path)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to suppress a frozen secret reference: %w", err)
+		}
+	}
+	return json.RawMessage(out), nil
+}
+
+func restoreFrozenSetOnceRefs(props, baseline json.RawMessage, refs []FrozenSetOnceRef) (json.RawMessage, error) {
+	out := string(props)
+	for _, ref := range refs {
+		value := gjson.GetBytes(baseline, ref.Path)
+		if !value.Exists() {
+			return nil, fmt.Errorf("frozen secret reference has no recorded baseline")
+		}
+		var err error
+		out, err = sjson.SetRaw(out, ref.Path, value.Raw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retain a frozen secret reference: %w", err)
+		}
+	}
+	return json.RawMessage(out), nil
+}
+
+func freezeSetOnceRefsForPlugin(props json.RawMessage, refs []FrozenSetOnceRef) (json.RawMessage, error) {
+	out := string(props)
+	for _, ref := range refs {
+		var err error
+		out, err = sjson.SetRaw(out, ref.Path, opaquePreservedSentinel)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare a frozen secret reference: %w", err)
+		}
+	}
+	return json.RawMessage(out), nil
+}
+
+// A leaf omitted from both diff inputs is safe only if no enclosing write
+// needs it. Never emit a partial atomic object/array or silently omit a field
+// required on update. Replacement must fail before scheduling any delete.
+func validateFrozenSetOncePatch(patch, createOnly json.RawMessage, refs []FrozenSetOnceRef, required []string) error {
+	if len(refs) == 0 {
+		return nil
+	}
+	if len(createOnly) > 0 {
+		return fmt.Errorf("replacement requires a usable value for a frozen SetOnce secret reference")
+	}
+	var ops []struct {
+		Path string `json:"path"`
+	}
+	if len(patch) > 0 {
+		if err := json.Unmarshal(patch, &ops); err != nil {
+			return err
+		}
+	}
+	if len(ops) == 0 {
+		return nil
+	}
+	ancestor := func(a, b string) bool { return a == b || strings.HasPrefix(b, a+"/") }
+	for _, ref := range refs {
+		// Positional pairing cannot preserve an array member's identity
+		// through a provider response that reorders members. No-op arrays
+		// converge, but an update needs a recoverable value for them.
+		if ref.ArrayRoot != "" {
+			return fmt.Errorf("update requires a usable value for a frozen SetOnce secret reference in an array")
+		}
+		for _, field := range required {
+			if field == ref.HintPath || strings.HasPrefix(ref.HintPath, field+".") {
+				return fmt.Errorf("update requires a usable value for a frozen SetOnce secret reference")
+			}
+		}
+		for _, op := range ops {
+			if ancestor(op.Path, ref.Pointer) {
+				return fmt.Errorf("enclosing update requires a usable value for a frozen SetOnce secret reference")
+			}
+		}
+	}
+	return nil
+}
+
+// Attach to the existing immutable, datastore-backed occurrence records.
+// Ambiguous legacy dotted paths fail closed rather than attaching a freeze
+// to the wrong occurrence.
+func recordFrozenSetOnceRefs(records []OccurrenceRecord, refs []FrozenSetOnceRef) error {
+	for _, ref := range refs {
+		path := strings.Join(pathkey.Split(ref.Path), ".")
+		index, count := 0, 0
+		for i := range records {
+			if records[i].DestinationPath == path {
+				index = i
+				count++
+			}
+		}
+		if count != 1 {
+			return fmt.Errorf("cannot record an ambiguous frozen secret reference")
+		}
+		copy := ref
+		records[index].FrozenSetOnce = &copy
+	}
+	return nil
+}
+
+func (ru *ResourceUpdate) frozenSetOnceRefs() []FrozenSetOnceRef {
+	var refs []FrozenSetOnceRef
+	for _, rec := range ru.ProvenanceRecords {
+		if rec.FrozenSetOnce != nil {
+			refs = append(refs, *rec.FrozenSetOnce)
+		}
+	}
+	return refs
+}

--- a/internal/metastructure/resource_update/opaque_setonce_ref.go
+++ b/internal/metastructure/resource_update/opaque_setonce_ref.go
@@ -151,6 +151,22 @@ func validateFrozenSetOncePatch(patch, createOnly json.RawMessage, refs []Frozen
 		return nil
 	}
 	ancestor := func(a, b string) bool { return a == b || strings.HasPrefix(b, a+"/") }
+	if err := validateFrozenSetOnceWrite(refs, required); err != nil {
+		return err
+	}
+	for _, ref := range refs {
+		for _, op := range ops {
+			if ancestor(op.Path, ref.Pointer) {
+				return fmt.Errorf("enclosing update requires a usable value for a frozen SetOnce secret reference")
+			}
+		}
+	}
+	return nil
+}
+
+// validateFrozenSetOnceWrite applies whenever a provider Update is dispatched,
+// even if stack/metadata changes kept an otherwise empty patch in the plan.
+func validateFrozenSetOnceWrite(refs []FrozenSetOnceRef, required []string) error {
 	for _, ref := range refs {
 		// Positional pairing cannot preserve an array member's identity
 		// through a provider response that reorders members. No-op arrays
@@ -161,11 +177,6 @@ func validateFrozenSetOncePatch(patch, createOnly json.RawMessage, refs []Frozen
 		for _, field := range required {
 			if field == ref.HintPath || strings.HasPrefix(ref.HintPath, field+".") {
 				return fmt.Errorf("update requires a usable value for a frozen SetOnce secret reference")
-			}
-		}
-		for _, op := range ops {
-			if ancestor(op.Path, ref.Pointer) {
-				return fmt.Errorf("enclosing update requires a usable value for a frozen SetOnce secret reference")
 			}
 		}
 	}

--- a/internal/metastructure/resource_update/opaque_setonce_ref_test.go
+++ b/internal/metastructure/resource_update/opaque_setonce_ref_test.go
@@ -1,0 +1,159 @@
+// © 2026 Platform Engineering Labs Inc.
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package resource_update
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
+	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+const frozenRef = `{"$ref":"formae://2abcdefghijklmnopqrstuvwxyz#/SecretString","$value":"a-stored-digest","$hashed":true,"$visibility":"Opaque","$strategy":"SetOnce"}`
+const bareFrozenRef = `{"$ref":"formae://2abcdefghijklmnopqrstuvwxyz#/SecretString"}`
+
+func planFrozenRef(t *testing.T, stored, desired string, schema pkgmodel.Schema) ([]ResourceUpdate, error) {
+	t.Helper()
+	prior := pkgmodel.Resource{Label: "db", Type: "TEST::DB", Properties: json.RawMessage(stored), Schema: schema}
+	next := prior
+	next.Properties = json.RawMessage(desired)
+	return NewResourceUpdateForExisting(resolver.NewResolvableProperties(), nil, prior, next,
+		pkgmodel.Target{}, pkgmodel.Target{}, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+}
+
+func TestOpaqueSetOnceRef_NoOp(t *testing.T) {
+	updates, err := planFrozenRef(t, `{"Password":`+frozenRef+`}`, `{"Password":`+bareFrozenRef+`}`,
+		pkgmodel.Schema{Fields: []string{"Password"}})
+	require.NoError(t, err)
+	require.Empty(t, updates, "a bare reference to the frozen destination must converge")
+}
+
+func TestOpaqueSetOnceRef_SiblingUpdate(t *testing.T) {
+	updates, err := planFrozenRef(t, `{"Password":`+frozenRef+`,"Name":"old"}`, `{"Password":`+bareFrozenRef+`,"Name":"new"}`,
+		pkgmodel.Schema{Fields: []string{"Password", "Name"}})
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	require.JSONEq(t, `[{"op":"replace","path":"/Name","value":"new"}]`, string(updates[0].DesiredState.PatchDocument))
+	require.Empty(t, updates[0].RemainingResolvables)
+}
+
+func TestOpaqueSetOnceRef_ReplacementNeedsValue(t *testing.T) {
+	updates, err := planFrozenRef(t, `{"Password":`+frozenRef+`,"Name":"old"}`, `{"Password":`+bareFrozenRef+`,"Name":"new"}`,
+		pkgmodel.Schema{Fields: []string{"Password", "Name"}, Hints: map[string]pkgmodel.FieldHint{"Name": {CreateOnly: true}}})
+	require.Error(t, err, "must refuse before scheduling the destructive half of replacement")
+	require.Empty(t, updates)
+}
+
+func TestOpaqueSetOnceRef_Eligibility(t *testing.T) {
+	for _, tc := range []struct {
+		name, old, desired string
+		frozen             bool
+	}{
+		{"live shape", frozenRef, bareFrozenRef, true},
+		{"source witness changed", strings.Replace(frozenRef, `"$hashed":true`, `"$hashed":true,"$resolvedFrom":"old-source"`, 1), bareFrozenRef, true},
+		{"strategy absent", strings.Replace(frozenRef, `,"$strategy":"SetOnce"`, "", 1), bareFrozenRef, false},
+		{"rotating destination", strings.Replace(frozenRef, "SetOnce", "Update", 1), bareFrozenRef, false},
+		{"explicit update", frozenRef, strings.Replace(bareFrozenRef, `}`, `,"$strategy":"Update"}`, 1), false},
+		{"json repoint", frozenRef, strings.Replace(bareFrozenRef, `}`, `,"$json":"password"}`, 1), false},
+		{"reference repoint", frozenRef, strings.Replace(bareFrozenRef, "SecretString", "Other", 1), false},
+		{"new destination", `{}`, bareFrozenRef, false},
+		{"desired plaintext", frozenRef, strings.Replace(bareFrozenRef, `}`, `,"$value":"new-secret"}`, 1), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			refs := classifyFrozenSetOnceRefs(json.RawMessage(`{"Password":`+tc.old+`}`), json.RawMessage(`{"Password":`+tc.desired+`}`))
+			require.Equal(t, tc.frozen, len(refs) == 1)
+		})
+	}
+}
+
+func TestOpaqueSetOnceRef_EnclosingWritesRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name, old, desired string
+		hints              map[string]pkgmodel.FieldHint
+	}{
+		{"atomic sibling", `{"Settings":{"Password":` + frozenRef + `,"Name":"old"}}`, `{"Settings":{"Password":` + bareFrozenRef + `,"Name":"new"}}`, map[string]pkgmodel.FieldHint{"Settings": {UpdateMethod: pkgmodel.FieldUpdateMethodAtomic}}},
+		{"array sibling", `{"Entries":[{"Password":` + frozenRef + `,"Name":"old"}]}`, `{"Entries":[{"Password":` + bareFrozenRef + `,"Name":"new"}]}`, map[string]pkgmodel.FieldHint{"Entries": {UpdateMethod: pkgmodel.FieldUpdateMethodArray}}},
+		{"array reorder duplicate refs", `{"Entries":[{"Password":` + frozenRef + `,"Name":"a"},{"Password":` + frozenRef + `,"Name":"b"}]}`, `{"Entries":[{"Password":` + bareFrozenRef + `,"Name":"b"},{"Password":` + bareFrozenRef + `,"Name":"a"}]}`, map[string]pkgmodel.FieldHint{"Entries": {UpdateMethod: pkgmodel.FieldUpdateMethodArray}}},
+		{"required nested leaf", `{"Settings":{"Password":` + frozenRef + `},"Name":"old"}`, `{"Settings":{"Password":` + bareFrozenRef + `},"Name":"new"}`, map[string]pkgmodel.FieldHint{"Settings.Password": {RequiredOnUpdate: true}}},
+		{"required leaf", `{"Password":` + frozenRef + `,"Name":"old"}`, `{"Password":` + bareFrozenRef + `,"Name":"new"}`, map[string]pkgmodel.FieldHint{"Password": {RequiredOnUpdate: true}}},
+		{"required parent", `{"Settings":{"Password":` + frozenRef + `},"Name":"old"}`, `{"Settings":{"Password":` + bareFrozenRef + `},"Name":"new"}`, map[string]pkgmodel.FieldHint{"Settings": {RequiredOnUpdate: true}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			updates, err := planFrozenRef(t, tc.old, tc.desired, pkgmodel.Schema{Fields: []string{"Settings", "Entries", "Password", "Name"}, Hints: tc.hints})
+			require.Error(t, err)
+			require.Empty(t, updates)
+			require.NotContains(t, err.Error(), "a-stored-digest")
+		})
+	}
+}
+
+func TestOpaqueSetOnceRef_ArraysConverge(t *testing.T) {
+	for _, wrap := range []func(string) string{
+		func(ref string) string { return `{"Entries":[` + ref + `,` + ref + `]}` },
+		func(ref string) string {
+			return `{"Entries":[{"Password":` + ref + `,"Name":"a"},{"Password":` + ref + `,"Name":"b"}]}`
+		},
+	} {
+		updates, err := planFrozenRef(t, wrap(frozenRef), wrap(bareFrozenRef), pkgmodel.Schema{Fields: []string{"Entries"}})
+		require.NoError(t, err)
+		require.Empty(t, updates)
+	}
+}
+
+func TestOpaqueSetOnceRef_ExecutionAndRecovery(t *testing.T) {
+	schema := pkgmodel.Schema{Fields: []string{"Password", "Name"}}
+	updates, err := planFrozenRef(t, `{"Password":`+frozenRef+`,"Name":"old"}`, `{"Password":`+bareFrozenRef+`,"Name":"new"}`, schema)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	// Recovery must retain the decision, including when an enriching Read
+	// replaced the prior digest with different live plaintext.
+	wire, err := json.Marshal(updates[0])
+	require.NoError(t, err)
+	var ru ResourceUpdate
+	require.NoError(t, json.Unmarshal(wire, &ru))
+	require.NoError(t, ru.updateExistingResourceProperties(`{"Password":"different-live-secret","Name":"old"}`))
+	patch, _, err := ru.regeneratePatchDocument(pkgmodel.FormaApplyModeReconcile)
+	require.NoError(t, err)
+	require.JSONEq(t, `[{"op":"replace","path":"/Name","value":"new"}]`, string(patch))
+	proc := newOperationCapturingProcess()
+	ru.ResourceTarget = pkgmodel.Target{Config: json.RawMessage(`{}`)}
+	_, _, _, err = update(StateUpdating, ResourceUpdateData{resourceUpdate: &ru}, proc)
+	require.NoError(t, err)
+	op := proc.capturedUpdate(t)
+	require.JSONEq(t, `{"$opaque":"preserved"}`, gjson.GetBytes(op.DesiredProperties, "Password").Raw)
+	require.NotContains(t, string(op.DesiredProperties), "a-stored-digest")
+	require.NotContains(t, string(op.PatchDocument), "a-stored-digest")
+	require.NoError(t, ru.updateResourceProperties(`{"Name":"new"}`, true))
+	require.JSONEq(t, frozenRef, gjson.GetBytes(ru.DesiredState.Properties, "Password").Raw)
+	next := ru.DesiredState
+	next.Properties = json.RawMessage(`{"Password":` + bareFrozenRef + `,"Name":"new"}`)
+	again, err := NewResourceUpdateForExisting(resolver.NewResolvableProperties(), nil, ru.DesiredState, next, pkgmodel.Target{}, pkgmodel.Target{}, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.NoError(t, err)
+	require.Empty(t, again, "the update must preserve convergence on the next apply")
+}
+
+func TestOpaqueSetOnceRef_SharedSourceResolution(t *testing.T) {
+	schema := pkgmodel.Schema{Fields: []string{"Password", "Other"}}
+	updates, err := planFrozenRef(t, `{"Password":`+frozenRef+`,"Other":"old"}`, `{"Password":`+bareFrozenRef+`,"Other":`+bareFrozenRef+`}`, schema)
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	ru := &updates[0]
+	require.Len(t, ru.RemainingResolvables, 1, "the unfrozen consumer still needs this source")
+	require.NoError(t, ru.ResolveValue("formae://2abcdefghijklmnopqrstuvwxyz#/SecretString", "rotated-source", pkgmodel.FormaApplyModeReconcile))
+	require.JSONEq(t, bareFrozenRef, gjson.GetBytes(ru.DesiredState.Properties, "Password").Raw)
+	require.Equal(t, "rotated-source", gjson.GetBytes(ru.DesiredState.Properties, "Other.$value").String())
+	require.JSONEq(t, `[{"op":"replace","path":"/Other","value":"rotated-source"}]`, string(ru.DesiredState.PatchDocument))
+}
+
+func TestOpaqueSetOnceRef_ForceResentOnlyStillConverges(t *testing.T) {
+	updates, err := planFrozenRef(t, `{"Entries":[`+frozenRef+`],"Name":"same"}`, `{"Entries":[`+bareFrozenRef+`],"Name":"same"}`, pkgmodel.Schema{Fields: []string{"Entries", "Name"}, Hints: map[string]pkgmodel.FieldHint{"Name": {RequiredOnUpdate: true}}})
+	require.NoError(t, err)
+	require.Empty(t, updates)
+}

--- a/internal/metastructure/resource_update/opaque_setonce_ref_test.go
+++ b/internal/metastructure/resource_update/opaque_setonce_ref_test.go
@@ -172,9 +172,12 @@ func TestOpaqueSetOnceRef_EmptyPatchDispatchRefused(t *testing.T) {
 			desired.Stack = "new-stack"
 			desired.Properties = json.RawMessage(tc.desired)
 			updates, err := NewResourceUpdateForExisting(resolver.NewResolvableProperties(), nil, prior, desired, pkgmodel.Target{}, pkgmodel.Target{}, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
-			require.NoError(t, err)
-			require.Len(t, updates, 1)
-			ru := &updates[0]
+			require.Error(t, err, "refuse before sibling operations can execute")
+			require.Empty(t, updates)
+			// The dispatch guard also protects updates persisted by an older planner.
+			records := buildProvenanceRecords(desired.Properties, prior.Properties, resolver.NewResolvableProperties(), tc.schema, false)
+			require.NoError(t, recordFrozenSetOnceRefs(records, classifyFrozenSetOnceRefs(prior.Properties, desired.Properties)))
+			ru := &ResourceUpdate{Operation: OperationUpdate, PriorState: prior, DesiredState: desired, PreviousProperties: prior.Properties, ProvenanceRecords: records}
 			require.Empty(t, ru.DesiredState.PatchDocument)
 			ru.ResourceTarget = pkgmodel.Target{Config: json.RawMessage(`{}`)}
 			proc := newOperationCapturingProcess()
@@ -190,5 +193,16 @@ func TestOpaqueSetOnceRef_EmptyPatchDispatchRefused(t *testing.T) {
 func TestOpaqueSetOnceRef_EntitySetConverges(t *testing.T) {
 	updates, err := planFrozenRef(t, `{"Entries":[{"Name":"a","Password":`+frozenRef+`}]}`, `{"Entries":[{"Name":"a","Password":`+bareFrozenRef+`}]}`, pkgmodel.Schema{Fields: []string{"Entries"}, Hints: map[string]pkgmodel.FieldHint{"Entries": {UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Name"}}})
 	require.NoError(t, err)
+	require.Empty(t, updates)
+}
+
+func TestOpaqueSetOnceRef_MetadataArrayRefusedAtPlanning(t *testing.T) {
+	prior := pkgmodel.Resource{Label: "db", Stack: "stack", Type: "TEST::DB", Properties: json.RawMessage(`{"Entries":[{"Name":"a","Password":` + frozenRef + `}]}`), Schema: pkgmodel.Schema{Fields: []string{"Entries"}}}
+	desired := prior
+	desired.Label = "renamed"
+	desired.Alias = "db"
+	desired.Properties = json.RawMessage(`{"Entries":[{"Name":"a","Password":` + bareFrozenRef + `}]}`)
+	updates, err := NewResourceUpdateForExisting(resolver.NewResolvableProperties(), nil, prior, desired, pkgmodel.Target{}, pkgmodel.Target{}, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+	require.Error(t, err, "even a synthetic rename cannot safely restore array entries by their planning-time indices")
 	require.Empty(t, updates)
 }

--- a/internal/metastructure/resource_update/opaque_setonce_ref_test.go
+++ b/internal/metastructure/resource_update/opaque_setonce_ref_test.go
@@ -157,3 +157,38 @@ func TestOpaqueSetOnceRef_ForceResentOnlyStillConverges(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, updates)
 }
+
+func TestOpaqueSetOnceRef_EmptyPatchDispatchRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name, stored, desired string
+		schema                pkgmodel.Schema
+	}{
+		{"array", `{"Entries":[{"Name":"a","Password":` + frozenRef + `}]}`, `{"Entries":[{"Name":"a","Password":` + bareFrozenRef + `}]}`, pkgmodel.Schema{Fields: []string{"Entries"}}},
+		{"required", `{"Password":` + frozenRef + `}`, `{"Password":` + bareFrozenRef + `}`, pkgmodel.Schema{Fields: []string{"Password"}, Hints: map[string]pkgmodel.FieldHint{"Password": {RequiredOnUpdate: true}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prior := pkgmodel.Resource{Label: "db", Stack: "old-stack", Type: "TEST::DB", Properties: json.RawMessage(tc.stored), Schema: tc.schema}
+			desired := prior
+			desired.Stack = "new-stack"
+			desired.Properties = json.RawMessage(tc.desired)
+			updates, err := NewResourceUpdateForExisting(resolver.NewResolvableProperties(), nil, prior, desired, pkgmodel.Target{}, pkgmodel.Target{}, pkgmodel.FormaApplyModeReconcile, FormaCommandSourceUser, false, false)
+			require.NoError(t, err)
+			require.Len(t, updates, 1)
+			ru := &updates[0]
+			require.Empty(t, ru.DesiredState.PatchDocument)
+			ru.ResourceTarget = pkgmodel.Target{Config: json.RawMessage(`{}`)}
+			proc := newOperationCapturingProcess()
+			state, _, _, err := update(StateUpdating, ResourceUpdateData{resourceUpdate: ru}, proc)
+			require.NoError(t, err)
+			require.Nil(t, proc.operation, "an empty patch must not bypass the frozen-value boundary")
+			require.Equal(t, StateFinishedWithError, state)
+			require.Contains(t, ru.FailureReason, "usable")
+		})
+	}
+}
+
+func TestOpaqueSetOnceRef_EntitySetConverges(t *testing.T) {
+	updates, err := planFrozenRef(t, `{"Entries":[{"Name":"a","Password":`+frozenRef+`}]}`, `{"Entries":[{"Name":"a","Password":`+bareFrozenRef+`}]}`, pkgmodel.Schema{Fields: []string{"Entries"}, Hints: map[string]pkgmodel.FieldHint{"Entries": {UpdateMethod: pkgmodel.FieldUpdateMethodEntitySet, IndexField: "Name"}}})
+	require.NoError(t, err)
+	require.Empty(t, updates)
+}

--- a/internal/metastructure/resource_update/resource_update.go
+++ b/internal/metastructure/resource_update/resource_update.go
@@ -151,10 +151,18 @@ func (ru *ResourceUpdate) ListResolvables() []pkgmodel.FormaeURI {
 // use identical semantics or a reconcile-planned removal can silently
 // vanish when a resolvable resolves at execution time.
 func (ru *ResourceUpdate) ResolveValue(formaeUri pkgmodel.FormaeURI, value string, mode pkgmodel.FormaApplyMode) error {
-	properties, err := resolver.ResolvePropertyReferences(formaeUri, ru.DesiredState.Properties, value)
+	resolutionProps, err := stripFrozenSetOnceRefs(ru.DesiredState.Properties, ru.frozenSetOnceRefs())
+	if err != nil {
+		return err
+	}
+	properties, err := resolver.ResolvePropertyReferences(formaeUri, resolutionProps, value)
 	if err != nil {
 		slog.Error("Failed to resolve dynamic properties", "error", err)
 		return fmt.Errorf("failed to resolve dynamic properties: %w", err)
+	}
+	properties, err = restoreFrozenSetOnceRefs(properties, ru.DesiredState.Properties, ru.frozenSetOnceRefs())
+	if err != nil {
+		return err
 	}
 	ru.DesiredState.Properties = properties
 
@@ -341,8 +349,16 @@ func (ru *ResourceUpdate) reDerivePatchAfterSubstitution(mode pkgmodel.FormaAppl
 // patch semantics. Returns (patch, createOnlyPatch, err); the caller decides
 // what to do with a createOnly diff surfaced this late.
 func (ru *ResourceUpdate) regeneratePatchDocument(mode pkgmodel.FormaApplyMode) (json.RawMessage, json.RawMessage, error) {
-	existingForPatch, desiredForPatch, err := SuppressUnchangedOpaqueValues(
-		ru.PriorState.Properties, ru.DesiredState.Properties, ru.DesiredState.Schema, ru.DesiredState.Type)
+	existingForPatch, err := stripFrozenSetOnceRefs(ru.PriorState.Properties, ru.frozenSetOnceRefs())
+	if err != nil {
+		return nil, nil, err
+	}
+	desiredForPatch, err := stripFrozenSetOnceRefs(ru.DesiredState.Properties, ru.frozenSetOnceRefs())
+	if err != nil {
+		return nil, nil, err
+	}
+	existingForPatch, desiredForPatch, err = SuppressUnchangedOpaqueValues(
+		existingForPatch, desiredForPatch, ru.DesiredState.Schema, ru.DesiredState.Type)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to suppress unchanged opaque values: %w", err)
 	}
@@ -413,6 +429,9 @@ func (ru *ResourceUpdate) regeneratePatchDocument(mode pkgmodel.FormaApplyMode) 
 		return nil, nil, err
 	}
 
+	if err := validateFrozenSetOncePatch(patchDoc, createOnlyPatch, ru.frozenSetOnceRefs(), ru.DesiredState.Schema.RequiredOnUpdate()); err != nil {
+		return nil, nil, err
+	}
 	return patchDoc, createOnlyPatch, nil
 }
 
@@ -701,7 +720,18 @@ func (ru *ResourceUpdate) updateResourceProperties(incomingProperties string, wr
 	if writeOrigin {
 		digests = ru.ResolvedRootDigests
 	}
-	return ru.updateProperties(incomingProperties, &ru.DesiredState.Properties, &ru.DesiredState.ReadOnlyProperties, writeOrigin, digests)
+	if err := ru.updateProperties(incomingProperties, &ru.DesiredState.Properties, &ru.DesiredState.ReadOnlyProperties, writeOrigin, digests); err != nil {
+		return err
+	}
+	// These destinations were not written. Preserve their original envelope,
+	// including its digest and provenance, rather than attesting the source
+	// or provider echo as a value this update supplied.
+	props, err := restoreFrozenSetOnceRefs(ru.DesiredState.Properties, ru.PreviousProperties, ru.frozenSetOnceRefs())
+	if err != nil {
+		return err
+	}
+	ru.DesiredState.Properties = props
+	return nil
 }
 
 func (ru *ResourceUpdate) updateExistingResourceProperties(incomingProperties string) error {

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -75,6 +75,7 @@ func NewResourceUpdateForExisting(
 	var patchDocument json.RawMessage
 	var createOnlyPatch json.RawMessage
 	var onlyForceResent bool
+	frozenRefs := classifyFrozenSetOnceRefs(existingResource.Properties, filteredProps)
 
 	// Provenance classification runs BEFORE any opaque suppression or patch
 	// generation: it decides per reference occurrence whether the source
@@ -82,6 +83,9 @@ func NewResourceUpdateForExisting(
 	// flattening seam, and produces the immutable records regeneration reads
 	// back after recovery.
 	provenanceRecords := buildProvenanceRecords(filteredProps, existingResource.Properties, resolvableProperties, newResource.Schema, force)
+	if err := recordFrozenSetOnceRefs(provenanceRecords, frozenRefs); err != nil {
+		return nil, err
+	}
 
 	if hasChanges {
 		// Drop opaque values that are unchanged from what is stored so a sibling
@@ -90,7 +94,15 @@ func NewResourceUpdateForExisting(
 		// stay, so rotation still produces a patch op. filteredProps is left
 		// untouched for DesiredState.Properties below — only the patch inputs are
 		// stripped.
-		existingForPatch, desiredForPatch, err := SuppressUnchangedOpaqueValues(existingResource.Properties, filteredProps, newResource.Schema, newResource.Type)
+		existingForPatch, err := stripFrozenSetOnceRefs(existingResource.Properties, frozenRefs)
+		if err != nil {
+			return nil, err
+		}
+		desiredForPatch, err := stripFrozenSetOnceRefs(filteredProps, frozenRefs)
+		if err != nil {
+			return nil, err
+		}
+		existingForPatch, desiredForPatch, err = SuppressUnchangedOpaqueValues(existingForPatch, desiredForPatch, newResource.Schema, newResource.Type)
 		if err != nil {
 			return nil, fmt.Errorf("failed to suppress unchanged opaque values for resource %s: %w", existingResource.Label, err)
 		}
@@ -132,6 +144,10 @@ func NewResourceUpdateForExisting(
 		if (patchDocument == nil || onlyForceResent) && len(createOnlyPatch) == 0 && !stackChanged && !labelChanged && !bool(coPlanned) {
 			return []ResourceUpdate{}, nil
 		}
+		if err := validateFrozenSetOncePatch(patchDocument, createOnlyPatch, frozenRefs, newResource.Schema.RequiredOnUpdate()); err != nil {
+			return nil, err
+		}
+
 	} else {
 		patchDocument = json.RawMessage(`[]`)
 		filteredProps = existingResource.Properties
@@ -147,7 +163,12 @@ func NewResourceUpdateForExisting(
 	}
 
 	// Extract resolvables for the new resource
-	newRemainingResolvables := resolver.ExtractResolvableURIs(newResource)
+	resolutionResource := newResource
+	resolutionResource.Properties, err = stripFrozenSetOnceRefs(newResource.Properties, frozenRefs)
+	if err != nil {
+		return nil, err
+	}
+	newRemainingResolvables := resolver.ExtractResolvableURIs(resolutionResource)
 
 	// Runs after the patch is derived, so what the provider is asked to do is
 	// unaffected: a stable occurrence is already suppressed from the diff.

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"reflect"
 
+	"github.com/platform-engineering-labs/formae/internal/constants"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/patch"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/util"
@@ -151,6 +152,20 @@ func NewResourceUpdateForExisting(
 	} else {
 		patchDocument = json.RawMessage(`[]`)
 		filteredProps = existingResource.Properties
+	}
+
+	// Every retained operation must preserve array identity, including a
+	// synthetic metadata update. Only a genuine planning no-op may freeze
+	// array members. Required fields matter only when a provider is called.
+	patchEmpty := len(patchDocument) == 0 || string(patchDocument) == "[]"
+	metadataOnly := patchEmpty && ((existingResource.Stack == constants.UnmanagedStack && newResource.Stack != constants.UnmanagedStack) ||
+		(labelChanged && !stackChanged && existingResource.Target == newResource.Target))
+	required := newResource.Schema.RequiredOnUpdate()
+	if metadataOnly {
+		required = nil
+	}
+	if err := validateFrozenSetOnceWrite(frozenRefs, required); err != nil {
+		return nil, fmt.Errorf("cannot update resource %s: %w; supply a usable secret value for this operation", existingResource.Label, err)
 	}
 
 	if len(createOnlyPatch) > 0 {

--- a/internal/metastructure/resource_update/resource_update_factory.go
+++ b/internal/metastructure/resource_update/resource_update_factory.go
@@ -145,7 +145,7 @@ func NewResourceUpdateForExisting(
 			return []ResourceUpdate{}, nil
 		}
 		if err := validateFrozenSetOncePatch(patchDocument, createOnlyPatch, frozenRefs, newResource.Schema.RequiredOnUpdate()); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("cannot update resource %s: %w; supply a usable secret value for this operation", existingResource.Label, err)
 		}
 
 	} else {

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -890,6 +890,14 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 	}
 	desiredForPlugin.Properties = frozenProperties
 
+	frozenProperties, err = freezeSetOnceRefsForPlugin(desiredForPlugin.Properties, data.resourceUpdate.frozenSetOnceRefs())
+	if err != nil {
+		data.resourceUpdate.FailureReason = updateRequestFailureReason(err)
+		data.resourceUpdate.MarkAsFailed()
+		return StateFinishedWithError, data, nil, nil
+	}
+	desiredForPlugin.Properties = frozenProperties
+
 	// Convert properties to plugin format (extracts $value from opaque structures).
 	// DesiredState is the NEW value being written to the cloud as DesiredProperties,
 	// so this stays guarded: a stored hash must never be sent to a plugin in place

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -850,6 +850,14 @@ func update(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 		return handleProgressUpdate(proc.PID(), state, data, syntheticResult, proc)
 	}
 
+	// Metadata operations above never call the provider. Every real Update
+	// must satisfy this boundary, including an empty-patch stack move.
+	if err := validateFrozenSetOnceWrite(data.resourceUpdate.frozenSetOnceRefs(), data.resourceUpdate.DesiredState.Schema.RequiredOnUpdate()); err != nil {
+		data.resourceUpdate.FailureReason = fmt.Sprintf("Cannot update resource %s: %v; supply a usable secret value for this operation", data.resourceUpdate.DesiredState.Label, err)
+		data.resourceUpdate.MarkAsFailed()
+		return StateFinishedWithError, data, nil, nil
+	}
+
 	// setOnce keeps a value by substituting the STORED one into the desired
 	// properties, which for an opaque field is a digest. Swap such a leaf for a
 	// present-but-unusable sentinel before the guarded conversion below, so the


### PR DESCRIPTION
Unchanged references to opaque SetOnce values currently produce a password update on every apply because the stored digest is compared with an unresolved reference. Preserve these destinations during in-place updates and retain the decision across resolution, plugin dispatch, persistence, and recovery so unrelated edits converge without sending a digest as a secret.

Refuse replacements, enclosing writes, and required-on-update writes that need an unavailable value. Unchanged arrays converge; real updates involving frozen array members are conservatively refused because positional matching cannot preserve member identity through provider reordering.

Verified with `go test -tags unit ./internal/metastructure/... ./internal/datastore/sqlite`, including regression coverage for plugin payloads, recovery, shared-source resolution, and subsequent applies.
