### PR TITLE
test(blackbox): correct TTL properties and delete outcome predictions

### DIFF
--- a/tests/blackbox/cascade_outcomes.go
+++ b/tests/blackbox/cascade_outcomes.go
@@ -1,0 +1,112 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build integration || property
+
+package blackbox
+
+import (
+	"sort"
+
+	"github.com/platform-engineering-labs/formae/tests/testcontrol"
+)
+
+// cascadeDeletePlan keeps the submitted roots separate from the operations the
+// agent expands from them. The same plan drives injection and model prediction.
+type cascadeDeletePlan struct {
+	affected   []ResourceSlotRef
+	attempted  []ResourceSlotRef
+	successful []ResourceSlotRef
+}
+
+func planCascadeDeletes(op *Operation, model *StateModel, roots []int) cascadeDeletePlan {
+	return planDeletes(op, model, roots, true)
+}
+
+func planDeletes(op *Operation, model *StateModel, roots []int, cascade bool) cascadeDeletePlan {
+	var plan cascadeDeletePlan
+	selected := make(map[ResourceSlotRef]bool)
+	for _, root := range roots {
+		selected[ResourceSlotRef{op.StackIndex, root}] = true
+	}
+	visited := make(map[ResourceSlotRef]bool)
+	succeeded := make(map[ResourceSlotRef]bool)
+	var visit func(ResourceSlotRef) bool
+	visit = func(ref ResourceSlotRef) bool {
+		if visited[ref] {
+			return succeeded[ref]
+		}
+		visited[ref] = true
+		dependenciesOK := true
+		if model.Pool != nil {
+			for _, child := range model.Pool.Slots[ref.SlotIndex].ChildIndices {
+				if !visit(ResourceSlotRef{ref.StackIndex, child}) {
+					dependenciesOK = false
+				}
+			}
+			if ref.StackIndex == 0 && model.ProviderStackLabel != "" {
+				for si := 1; si < len(model.Stacks); si++ {
+					for _, child := range model.Pool.CrossStackDependents(ref.SlotIndex) {
+						if !visit(ResourceSlotRef{si, child}) {
+							dependenciesOK = false
+						}
+					}
+				}
+			}
+		}
+		if !cascade && !selected[ref] {
+			succeeded[ref] = dependenciesOK
+			return dependenciesOK
+		}
+		res := model.Resource(ref.StackIndex, ref.SlotIndex)
+		if res == nil || res.State != StateExists {
+			succeeded[ref] = dependenciesOK
+			return dependenciesOK
+		}
+		plan.affected = append(plan.affected, ref)
+		if !dependenciesOK {
+			return false
+		}
+		plan.attempted = append(plan.attempted, ref)
+		outcome := op.DrawnOutcomes[outcomeKey(ref.StackIndex, ref.SlotIndex)]
+		succeeded[ref] = willOperationSucceed(outcome.ReadSteps) && willOperationSucceed(outcome.CRUDSteps)
+		if succeeded[ref] {
+			plan.successful = append(plan.successful, ref)
+		}
+		return succeeded[ref]
+	}
+	for _, root := range roots {
+		visit(ResourceSlotRef{op.StackIndex, root})
+	}
+	return plan
+}
+
+func (plan cascadeDeletePlan) sequences(op *Operation, model *StateModel) []testcontrol.PluginOpSequence {
+	var sequences []testcontrol.PluginOpSequence
+	for _, ref := range plan.attempted {
+		sequences = append(sequences, buildPluginOpSequences(op.DrawnOutcomes, ref.StackIndex, model.Stack(ref.StackIndex).Label, []int{ref.SlotIndex}, model, true, model.Pool)...)
+	}
+	return sequences
+}
+
+func (plan cascadeDeletePlan) apply(model *StateModel) {
+	for _, ref := range plan.successful {
+		model.ApplyDestroyed(ref.StackIndex, []int{ref.SlotIndex})
+	}
+}
+
+func omittedResourceIDs(model *StateModel, stackIndex int, kept []int) []int {
+	keep := make(map[int]bool, len(kept))
+	for _, id := range kept {
+		keep[id] = true
+	}
+	var omitted []int
+	for id, res := range model.Stack(stackIndex).Resources {
+		if !keep[id] && res.State == StateExists {
+			omitted = append(omitted, id)
+		}
+	}
+	sort.Ints(omitted)
+	return omitted
+}

--- a/tests/blackbox/cascade_outcomes_test.go
+++ b/tests/blackbox/cascade_outcomes_test.go
@@ -1,0 +1,124 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build integration || property
+
+package blackbox
+
+import (
+	"testing"
+	"time"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/tests/testcontrol"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeletesUseDependentOutcomes(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		failed       ResourceSlotRef
+		kind         OperationKind
+		ids          []int
+		onDependents string
+	}{
+		{"cascade_local", ResourceSlotRef{0, 2}, OpDestroy, []int{0}, "cascade"},
+		{"cascade_cross_stack", ResourceSlotRef{1, 10}, OpDestroy, []int{0}, "cascade"},
+		{"explicit_tree", ResourceSlotRef{0, 2}, OpDestroy, []int{0, 1, 2, 3, 4}, "abort"},
+		{"reconcile_implicit", ResourceSlotRef{0, 2}, OpApply, []int{5}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			failed := tc.failed
+			testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+				h := NewTestHarness(t, 10*time.Second)
+				defer h.Cleanup()
+				model := NewStateModel(2, 10)
+				for si, ids := range [][]int{{0, 1, 2, 3, 4, 5}, {10, 11}} {
+					if si == 1 && tc.onDependents != "cascade" {
+						continue
+					}
+					op := Operation{Kind: OpApply, StackIndex: si, ApplyMode: "reconcile", ResourceIDs: ids,
+						Properties: defaultDestroyParentProps, ChildProperties: defaultDestroyChildProps}
+					h.ExecuteOperation(t, &op, model)
+					require.Len(t, model.AcceptedCommands, 1)
+					cmd := h.WaitForCommandDone(model.AcceptedCommands[0].CommandID, 30*time.Second)
+					require.Equal(t, "Success", cmd.State)
+					h.DrainPendingCommands(t, model, 30*time.Second)
+				}
+				original := model.Resource(failed.StackIndex, failed.SlotIndex).Properties
+				require.NotEmpty(t, model.GetNativeID(failed.StackIndex, failed.SlotIndex), "persisted create outcome must supply the injection key")
+				op := Operation{Kind: tc.kind, StackIndex: 0, ResourceIDs: tc.ids, OnDependents: tc.onDependents, ApplyMode: "reconcile",
+					Properties: defaultDestroyParentProps, ChildProperties: defaultDestroyChildProps,
+					DrawnOutcomes: map[string]DrawnOutcome{outcomeKey(0, 0): {
+						CRUDSteps: []testcontrol.ResponseStep{{ErrorCode: "AccessDenied"}},
+					}, outcomeKey(failed.StackIndex, failed.SlotIndex): {
+						CRUDSteps: []testcontrol.ResponseStep{{ErrorCode: "AccessDenied"}},
+					}}}
+				h.ExecuteOperation(t, &op, model)
+				require.Len(t, model.AcceptedCommands, 1)
+				require.Equal(t, StateExists, model.Resource(failed.StackIndex, failed.SlotIndex).State, "failed delete must preserve prediction")
+				require.Equal(t, original, model.Resource(failed.StackIndex, failed.SlotIndex).Properties)
+				require.Equal(t, StateExists, model.Resource(0, 0).State, "ancestor delete is blocked")
+				cmd := h.WaitForCommandDone(model.AcceptedCommands[0].CommandID, 30*time.Second)
+				require.NotEqual(t, "Success", cmd.State, "dependent failure must actually reach the plugin")
+				h.DrainPendingCommands(t, model, 30*time.Second)
+				require.Equal(t, StateExists, model.Resource(failed.StackIndex, failed.SlotIndex).State)
+				require.Equal(t, original, model.Resource(failed.StackIndex, failed.SlotIndex).Properties)
+				require.Equal(t, StateNotExist, model.Resource(0, 4).State, "independent sibling delete succeeds")
+				// The root's drawn error must not remain queued: its delete was
+				// blocked, so no plugin operation could consume that response.
+				op.DrawnOutcomes = nil
+				h.ExecuteOperation(t, &op, model)
+				require.Len(t, model.AcceptedCommands, 1)
+				cmd = h.WaitForCommandDone(model.AcceptedCommands[0].CommandID, 30*time.Second)
+				require.Equal(t, "Success", cmd.State, "blocked operations must not poison a later command")
+				h.DrainPendingCommands(t, model, 30*time.Second)
+				require.Equal(t, StateNotExist, model.Resource(0, 0).State)
+
+			})
+		})
+	}
+}
+
+// Reconcile can update a cross-stack reference while deleting its provider.
+// The provider's drawn delete failure must be consumed by that command.
+func TestImplicitDeleteWithCrossStackDependentUsesDrawnOutcome(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		h := NewTestHarness(t, 10*time.Second)
+		defer h.Cleanup()
+		model := NewStateModel(2, 10)
+		for si, ids := range [][]int{{0, 5}, {10}} {
+			op := Operation{Kind: OpApply, StackIndex: si, ApplyMode: "reconcile", ResourceIDs: ids,
+				Properties: defaultDestroyParentProps, ChildProperties: defaultDestroyChildProps}
+			h.ExecuteOperation(t, &op, model)
+			require.Len(t, model.AcceptedCommands, 1)
+			cmd := h.WaitForCommandDone(model.AcceptedCommands[0].CommandID, 30*time.Second)
+			require.Equal(t, "Success", cmd.State)
+			h.DrainPendingCommands(t, model, 30*time.Second)
+		}
+		op := Operation{Kind: OpApply, StackIndex: 0, ApplyMode: "reconcile", ResourceIDs: []int{5},
+			Properties: defaultDestroyParentProps, ChildProperties: defaultDestroyChildProps,
+			DrawnOutcomes: map[string]DrawnOutcome{outcomeKey(0, 0): {CRUDSteps: []testcontrol.ResponseStep{{ErrorCode: "AccessDenied"}}}}}
+		h.ExecuteOperation(t, &op, model)
+		require.Len(t, model.AcceptedCommands, 1)
+		result := h.WaitForCommandDone(model.AcceptedCommands[0].CommandID, 30*time.Second)
+		require.Equal(t, "Failed", result.State)
+		providerFailure := false
+		for _, update := range result.ResourceUpdates {
+			if update.StackName == "stack-0" && update.ResourceLabel == model.LabelForResource(0, 0) && update.Operation == "delete" {
+				require.Equal(t, "Failed", update.State)
+				require.Contains(t, update.ErrorMessage, "injected error")
+				providerFailure = true
+			}
+		}
+		require.True(t, providerFailure, "implicit provider delete must consume its drawn failure")
+		h.DrainPendingCommands(t, model, 30*time.Second)
+		destroy := Operation{Kind: OpDestroy, StackIndex: 0, ResourceIDs: []int{0}, OnDependents: "cascade"}
+		h.ExecuteOperation(t, &destroy, model)
+		require.Len(t, model.AcceptedCommands, 1)
+		cmd := h.WaitForCommandDone(model.AcceptedCommands[0].CommandID, 30*time.Second)
+		require.Equal(t, "Success", cmd.State, "a consumed reconcile error must not poison a later cascade")
+		h.DrainPendingCommands(t, model, 30*time.Second)
+	})
+}

--- a/tests/blackbox/executor.go
+++ b/tests/blackbox/executor.go
@@ -3136,9 +3136,27 @@ func (h *TestHarness) executeSetTTLPolicy(t *testing.T, op *Operation, model *St
 	overrides := model.LabelOverrides(model.StackIndexByLabel(stackLabel))
 	if model.Pool != nil {
 		forma = FormaFromPoolResources(model.Pool, stackLabel, model.ProviderStackLabel, existingIDs,
-			resourceProperties(stackLabel, existingIDs), defaultDestroyChildProps, overrides, model.LabelOverrides(0))
+			defaultDestroyParentProps, defaultDestroyChildProps, overrides, model.LabelOverrides(0))
 	} else {
-		forma = FormaFromStackResources(stackLabel, existingIDs, overrides, resourceProperties(stackLabel, existingIDs))
+		forma = FormaFromStackResources(stackLabel, existingIDs, overrides)
+	}
+	// Setting a policy must not rewrite resource names, values or collections.
+	// Keep each slot's predicted properties; the builders supply the reference
+	// envelopes that the normalized model intentionally stores as plain values.
+	for i := range forma.Resources {
+		res := &forma.Resources[i]
+		si, slot, found := model.findResourceSlot(res.Stack, res.Label)
+		require.True(t, found, "policy resource must have a model slot")
+		var props map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal([]byte(model.Resource(si, slot).Properties), &props))
+		if model.Pool != nil && !model.Pool.IsParent(slot) {
+			var declared map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(res.Properties, &declared))
+			props["ParentId"] = declared["ParentId"]
+		}
+		var err error
+		res.Properties, err = json.Marshal(props)
+		require.NoError(t, err)
 	}
 	for i := range forma.Stacks {
 		if forma.Stacks[i].Label == stackLabel {

--- a/tests/blackbox/executor.go
+++ b/tests/blackbox/executor.go
@@ -1284,10 +1284,18 @@ func (h *TestHarness) executeApply(t *testing.T, op *Operation, model *StateMode
 		performRename = found
 	}
 
+	// Reconcile also deletes resources omitted from the declaration. Those
+	// operations have drawn outcomes just like explicitly requested updates.
+	var implicitDeletes cascadeDeletePlan
+	if op.ApplyMode == "reconcile" {
+		implicitDeletes = planDeletes(op, model, omittedResourceIDs(model, op.StackIndex, op.ResourceIDs), false)
+	}
+
 	// Program response sequences before submitting the command.
 	var programmedSeqs []testcontrol.PluginOpSequence
 	if op.DrawnOutcomes != nil {
 		programmedSeqs = buildPluginOpSequences(op.DrawnOutcomes, op.StackIndex, stackLabel, op.ResourceIDs, model, false, model.Pool)
+		programmedSeqs = append(programmedSeqs, implicitDeletes.sequences(op, model)...)
 		if len(programmedSeqs) > 0 {
 			h.ProgramResponses(t, programmedSeqs)
 		}
@@ -1368,10 +1376,7 @@ func (h *TestHarness) executeApply(t *testing.T, op *Operation, model *StateMode
 		model.ApplyCreatedResolved(op.StackIndex, resolvedProps)
 	}
 	if op.ApplyMode == "reconcile" {
-		// Reconcile guarantee: resources NOT in the forma are deleted by the
-		// agent. Implicit deletes have no failure injection programmed, so
-		// they always succeed. Apply the guarantee regardless of DrawnOutcomes.
-		applyReconcileGuarantee(model, op.StackIndex, op.ResourceIDs)
+		implicitDeletes.apply(model)
 		// Save the reconcile state for ForceReconcile prediction.
 		resolvedProps := model.ResolvePropertiesForResources(op.StackIndex, op.ResourceIDs, op.Properties, op.ChildProperties)
 		model.SaveLastReconcile(op.StackIndex, op.ResourceIDs, resolvedProps)
@@ -1427,10 +1432,12 @@ func (h *TestHarness) executeDestroyDefault(t *testing.T, op *Operation, model *
 
 	forma := FormaFromStackResources(stackLabel, existingIDs, model.LabelOverrides(op.StackIndex))
 
+	plan := planDeletes(op, model, existingIDs, false)
+
 	// Program response sequences before submitting the command.
 	var programmedSeqs []testcontrol.PluginOpSequence
 	if op.DrawnOutcomes != nil {
-		programmedSeqs = buildPluginOpSequences(op.DrawnOutcomes, op.StackIndex, stackLabel, existingIDs, model, true, model.Pool)
+		programmedSeqs = plan.sequences(op, model)
 		if len(programmedSeqs) > 0 {
 			h.ProgramResponses(t, programmedSeqs)
 		}
@@ -1460,12 +1467,9 @@ func (h *TestHarness) executeDestroyDefault(t *testing.T, op *Operation, model *
 	snapshots := model.SnapshotResources(op.StackIndex, existingIDs)
 
 	// Immediate model update: predict outcomes at submission time.
-	successIDs := successfulResourceIDs(op, op.StackIndex, existingIDs, model.Pool, true, model)
-	if len(successIDs) > 0 {
-		model.ApplyDestroyed(op.StackIndex, successIDs)
-	}
+	plan.apply(model)
 	model.TrackAcceptedCommand(commandID, snapshots, requestedSlotRefs(op.StackIndex, existingIDs), h.currentOperationLogSize(t), false)
-	t.Logf("[op %d] Destroy stack=%s resources %v → accepted, model updated (success=%v)", op.SequenceNum, stackLabel, existingIDs, successIDs)
+	t.Logf("[op %d] Destroy stack=%s resources %v → accepted, model updated (success=%v)", op.SequenceNum, stackLabel, existingIDs, plan.successful)
 }
 
 // executeDestroyAbort handles destroy with on-dependents="abort". If any resource
@@ -1507,10 +1511,12 @@ func (h *TestHarness) executeDestroyAbort(t *testing.T, op *Operation, model *St
 	}
 
 	// No dependents (or simulation confirmed no cascades) — proceed with real destroy.
+	plan := planDeletes(op, model, existingIDs, false)
+
 	// Program response sequences before submitting the command.
 	var programmedSeqs []testcontrol.PluginOpSequence
 	if op.DrawnOutcomes != nil {
-		programmedSeqs = buildPluginOpSequences(op.DrawnOutcomes, op.StackIndex, stackLabel, existingIDs, model, true, model.Pool)
+		programmedSeqs = plan.sequences(op, model)
 		if len(programmedSeqs) > 0 {
 			h.ProgramResponses(t, programmedSeqs)
 		}
@@ -1542,12 +1548,9 @@ func (h *TestHarness) executeDestroyAbort(t *testing.T, op *Operation, model *St
 	// Since the abort path only proceeds when simulation confirmed no cascades,
 	// only the explicitly drawn resources can be affected — descendants are safe.
 	// Immediate model update: predict outcomes at submission time.
-	successIDs := successfulResourceIDs(op, op.StackIndex, existingIDs, model.Pool, true, model)
-	if len(successIDs) > 0 {
-		model.ApplyDestroyed(op.StackIndex, successIDs)
-	}
+	plan.apply(model)
 	model.TrackAcceptedCommand(commandID, snapshots, requestedSlotRefs(op.StackIndex, existingIDs), h.currentOperationLogSize(t), false)
-	t.Logf("[op %d] Destroy (abort) stack=%s resources %v → accepted, model updated (success=%v)", op.SequenceNum, stackLabel, existingIDs, successIDs)
+	t.Logf("[op %d] Destroy (abort) stack=%s resources %v → accepted, model updated (success=%v)", op.SequenceNum, stackLabel, existingIDs, plan.successful)
 }
 
 // executeDestroyCascade handles destroy with on-dependents="cascade". The agent
@@ -1558,10 +1561,13 @@ func (h *TestHarness) executeDestroyCascade(t *testing.T, op *Operation, model *
 
 	forma := FormaFromPoolResources(model.Pool, stackLabel, model.ProviderStackLabel, existingIDs, defaultDestroyParentProps, defaultDestroyChildProps, model.LabelOverrides(op.StackIndex), model.LabelOverrides(0))
 
-	// Program response sequences before submitting the command.
+	// Plan the complete deletion closure, including implicit cross-stack dependents.
+	plan := planCascadeDeletes(op, model, existingIDs)
+
+	// Program only operations the dependency graph can actually execute.
 	var programmedSeqs []testcontrol.PluginOpSequence
 	if op.DrawnOutcomes != nil {
-		programmedSeqs = buildPluginOpSequences(op.DrawnOutcomes, op.StackIndex, stackLabel, existingIDs, model, true, model.Pool)
+		programmedSeqs = plan.sequences(op, model)
 		if len(programmedSeqs) > 0 {
 			h.ProgramResponses(t, programmedSeqs)
 		}
@@ -1587,26 +1593,16 @@ func (h *TestHarness) executeDestroyCascade(t *testing.T, op *Operation, model *
 	commandID := resp.CommandID
 	t.Logf("[op %d] Destroy (cascade) stack=%s resources %v → command %s", op.SequenceNum, stackLabel, existingIDs, commandID)
 
-	// Snapshot slots that will actually change: cascade destroys only affect
-	// Exists slots. Slots already NotExist can't be destroyed, and including
-	// them causes false reverts when concurrent commands create those slots.
 	var snapshots []ResourceSnapshot
-	for _, si := range model.ComputeAffectedStacks(op.StackIndex, existingIDs, op.OnDependents) {
-		for id, res := range model.Stack(si).Resources {
-			if res.State == StateExists {
-				snapshots = append(snapshots, model.SnapshotResources(si, []int{id})...)
-			}
-		}
+	for _, ref := range plan.affected {
+		snapshots = append(snapshots, model.SnapshotResources(ref.StackIndex, []int{ref.SlotIndex})...)
 	}
 
-	// Immediate model update: predict outcomes at submission time.
-	// For cascade destroy, successful resources and all their descendants are destroyed.
-	successIDs := successfulResourceIDs(op, op.StackIndex, existingIDs, model.Pool, true, model)
-	for _, idx := range successIDs {
-		model.ApplyCascadeDestroyed(op.StackIndex, idx)
-	}
+	// A failed dependent blocks its ancestors, but independent siblings can
+	// still be deleted. Preserve failed and blocked slots, including properties.
+	plan.apply(model)
 	model.TrackAcceptedCommand(commandID, snapshots, requestedSlotRefs(op.StackIndex, existingIDs), h.currentOperationLogSize(t), false)
-	t.Logf("[op %d] Destroy (cascade) stack=%s resources %v → accepted, model updated (success=%v)", op.SequenceNum, stackLabel, existingIDs, successIDs)
+	t.Logf("[op %d] Destroy (cascade) stack=%s resources %v → accepted, model updated (success=%v)", op.SequenceNum, stackLabel, existingIDs, plan.successful)
 }
 
 // allResourceIDs returns all resource indices for a stack.

--- a/tests/blackbox/executor.go
+++ b/tests/blackbox/executor.go
@@ -380,20 +380,21 @@ func (h *TestHarness) reconcileCompletedAcceptedCommands(t *testing.T, model *St
 	var completed []completedCmd
 	remaining := make([]AcceptedCommand, 0, len(model.AcceptedCommands))
 	for _, ac := range model.AcceptedCommands {
-		statusResp, err := h.client.GetFormaCommandsStatus("id:"+ac.CommandID, clientID, 1, apimodel.CommandScopeAgent)
-		if err != nil || statusResp == nil || len(statusResp.Commands) == 0 {
+		// Scheduler commands are absent from the user-command API. Use the
+		// same persisted outcomes as the final drain for every accepted command.
+		cmd, err := h.commandFromDB(ac.CommandID)
+		if err != nil || cmd == nil {
 			remaining = append(remaining, ac)
 			continue
 		}
 
-		cmd := statusResp.Commands[0]
 		h.ObserveCommandState(t, cmd.CommandID, cmd.State)
 		if cmd.State != "Success" && cmd.State != "Failed" && cmd.State != "Canceled" {
 			remaining = append(remaining, ac)
 			continue
 		}
 
-		completed = append(completed, completedCmd{ac: ac, cmd: cmd})
+		completed = append(completed, completedCmd{ac: ac, cmd: *cmd})
 	}
 
 	// Process completed commands in REVERSE order (most recent first) so
@@ -1122,6 +1123,18 @@ func correctModelFromCommandOutcome(t *testing.T, cmd *apimodel.Command, model *
 						t.Logf("correctModelFromCommandOutcome: reverting failed delete stack=%s slot=%d to Exists",
 							model.Stack(stackIdx).Label, slotIdx)
 						res.State = StateExists
+					}
+					// An implicit delete can target a resource missing from the
+					// optimistic model. Its persisted delete declaration contains
+					// the pre-delete properties even when we have no snapshot.
+					if res.Properties == "" && len(ru.Properties) > 0 {
+						res.Properties = model.NormalizePropertiesForResource(stackIdx, slotIdx, string(ru.Properties))
+					}
+					if model.GetNativeID(stackIdx, slotIdx) == "" {
+						model.SetNativeID(stackIdx, slotIdx, ru.NativeID)
+					}
+					if model.GetKsuid(stackIdx, slotIdx) == "" {
+						model.SetKsuid(stackIdx, slotIdx, ru.ResourceID)
 					}
 				}
 			}
@@ -3238,22 +3251,18 @@ func (h *TestHarness) executeCheckTTL(t *testing.T, op *Operation, model *StateM
 			continue
 		}
 
-		// Snapshot only Exists slots (TTL destroys all, NotExist can't change).
-		resourceIDs := allResourceIDs(model, stackIdx)
-		var existingForSnapshot []int
-		for _, idx := range resourceIDs {
-			if res := model.Resource(stackIdx, idx); res != nil && res.State == StateExists {
-				existingForSnapshot = append(existingForSnapshot, idx)
-			}
+		// TTL cascades can delete dependents on other stacks. Snapshot the
+		// complete closure before prediction clears any properties, so failed
+		// deletes can restore their original state on every affected stack.
+		resourceIDs := filterExistingResources(allResourceIDs(model, stackIdx), stackIdx, model)
+		plan := planCascadeDeletes(&Operation{StackIndex: stackIdx}, model, resourceIDs)
+		var snapshots []ResourceSnapshot
+		for _, ref := range plan.affected {
+			snapshots = append(snapshots, model.SnapshotResources(ref.StackIndex, []int{ref.SlotIndex})...)
 		}
-		snapshots := model.SnapshotResources(stackIdx, existingForSnapshot)
-
-		// Immediate model update: TTL expiry destroys all resources on the stack (cascade).
-		for _, idx := range resourceIDs {
-			model.ApplyCascadeDestroyed(stackIdx, idx)
-		}
+		plan.apply(model)
 		model.Stacks[stackIdx].TTLExpired = false
-		model.TrackAcceptedCommand(commandID, snapshots, requestedSlotRefs(op.StackIndex, resourceIDs), h.currentOperationLogSize(t), false)
+		model.TrackAcceptedCommand(commandID, snapshots, requestedSlotRefs(stackIdx, resourceIDs), h.currentOperationLogSize(t), false)
 		t.Logf("[op %d] CheckTTL stack=%s command %s → accepted, model updated (destroyed all)", op.SequenceNum, expiredLabel, commandID)
 	}
 }

--- a/tests/blackbox/harness.go
+++ b/tests/blackbox/harness.go
@@ -296,7 +296,7 @@ func (h *TestHarness) commandFromDB(commandID string) (*apimodel.Command, error)
 	defer db.Close() //nolint:errcheck
 
 	rows, err := db.Query(
-		"SELECT state, operation, stack_label, resource FROM resource_updates WHERE command_id = ? ORDER BY ksuid ASC",
+		"SELECT ksuid, state, operation, stack_label, resource, most_recent_progress, is_cascade FROM resource_updates WHERE command_id = ? ORDER BY ksuid ASC",
 		commandID)
 	if err != nil {
 		return nil, err
@@ -304,9 +304,10 @@ func (h *TestHarness) commandFromDB(commandID string) (*apimodel.Command, error)
 	defer rows.Close() //nolint:errcheck
 
 	for rows.Next() {
-		var state, operation, stackLabel string
-		var resourceJSON []byte
-		if err := rows.Scan(&state, &operation, &stackLabel, &resourceJSON); err != nil {
+		var ksuid, state, operation, stackLabel string
+		var resourceJSON, progressJSON []byte
+		var isCascade bool
+		if err := rows.Scan(&ksuid, &state, &operation, &stackLabel, &resourceJSON, &progressJSON, &isCascade); err != nil {
 			return nil, err
 		}
 		var desired pkgmodel.Resource
@@ -315,7 +316,21 @@ func (h *TestHarness) commandFromDB(commandID string) (*apimodel.Command, error)
 				return nil, fmt.Errorf("decoding resource update of command %s: %w", commandID, err)
 			}
 		}
+		// The resource column is the planning-time declaration. Generated native
+		// IDs live in persisted plugin progress, and the KSUID is a row column.
+		// Omitting them silently disables failure injection after a create.
+		desired.Ksuid = ksuid
+		var progress plugin.TrackedProgress
+		if len(progressJSON) > 0 {
+			if err := json.Unmarshal(progressJSON, &progress); err != nil {
+				return nil, fmt.Errorf("decoding resource progress of command %s: %w", commandID, err)
+			}
+			if progress.NativeID != "" {
+				desired.NativeID = progress.NativeID
+			}
+		}
 		cmd.ResourceUpdates = append(cmd.ResourceUpdates, apimodel.ResourceUpdate{
+			IsCascade:     isCascade,
 			ResourceID:    desired.Ksuid,
 			ResourceType:  desired.Type,
 			ResourceLabel: desired.Label,

--- a/tests/blackbox/state_model_test.go
+++ b/tests/blackbox/state_model_test.go
@@ -7,6 +7,7 @@
 package blackbox
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -970,4 +971,22 @@ func TestMergePatchProperties_ArrayFieldNeverRemovesElements(t *testing.T) {
 			assert.JSONEq(t, c.want, got)
 		})
 	}
+}
+
+// A delete can include a resource that wasn't in the optimistic model when the
+// command was accepted. Its persisted declaration is the rollback evidence when
+// no model snapshot exists; restoring only Exists loses its properties.
+func TestCorrectModelFromCommandOutcome_FailedDeleteWithoutSnapshotRestoresProperties(t *testing.T) {
+	model := NewStateModel(1, 1)
+	props := `{"Name":"res-stack-0-0","Value":"keep"}`
+	cmd := &apimodel.Command{CommandID: "delete-without-snapshot", State: "Failed", ResourceUpdates: []apimodel.ResourceUpdate{{
+		ResourceID: "resource-id", NativeID: "native-id", ResourceLabel: model.LabelForResource(0, 0), StackName: "stack-0",
+		Operation: "delete", State: "Failed", Properties: json.RawMessage(props),
+	}}}
+	corrected := make(map[struct{ stackIdx, slotIdx int }]bool)
+	correctModelFromCommandOutcome(t, cmd, model, model.Pool, nil, corrected, false, nil, nil)
+	require.Equal(t, StateExists, model.Resource(0, 0).State)
+	require.JSONEq(t, props, model.Resource(0, 0).Properties)
+	require.Equal(t, "native-id", model.GetNativeID(0, 0))
+	require.Equal(t, "resource-id", model.GetKsuid(0, 0))
 }

--- a/tests/blackbox/ttl_properties_test.go
+++ b/tests/blackbox/ttl_properties_test.go
@@ -1,0 +1,91 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build integration || property
+
+package blackbox
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// A policy-only operation must preserve each resource's properties and identity,
+// including a renamed parent and the reference from its child. Rebuilding from
+// defaults silently changes Name/Value and drops collections during chaos runs.
+func TestSetTTLPolicyPreservesResources(t *testing.T) {
+	for _, tc := range []struct {
+		name                     string
+		stacks, resources, stack int
+		ids                      []int
+	}{
+		{"flat", 1, 2, 0, []int{0, 1}},
+		{"tree", 1, 10, 0, []int{0, 1, 5}},
+		{"cross_stack", 2, 10, 1, []int{0, 1, 5, 10}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+				h := NewTestHarness(t, 10*time.Second)
+				defer h.Cleanup()
+				model := NewStateModel(tc.stacks, tc.resources)
+				h.SetupStacks(t, model, PropertyTestConfig{StackCount: tc.stacks, ResourceCount: tc.resources})
+				apply := Operation{Kind: OpApply, ApplyMode: "reconcile", StackIndex: tc.stack,
+					ResourceIDs: tc.ids, RenameSlotIndex: 0, RenameNewLabel: "renamed-parent",
+					Properties:      `{"Name":"NAME","Value":"v2","SetTags":["keep"],"EntityTags":[{"Key":"env","Value":"test"}],"OrderedItems":["first","second"]}`,
+					ChildProperties: `{"Name":"NAME","ParentId":"PARENT_ID","Value":"child-v2"}`}
+				h.ExecuteOperation(t, &apply, model)
+				require.Len(t, model.AcceptedCommands, 1, "setup apply must be accepted")
+				command := h.WaitForCommandDone(model.AcceptedCommands[0].CommandID, 30*time.Second)
+				require.Equal(t, "Success", command.State, "setup apply must fully succeed")
+				h.DrainPendingCommands(t, model, 30*time.Second)
+				require.Equal(t, 1, h.RenamesAccepted)
+				before, _, err := h.extractManagedAndUnmanagedInventory()
+				require.NoError(t, err)
+				require.Len(t, before, len(tc.ids)+tc.stacks-1)
+
+				policy := Operation{Kind: OpSetTTLPolicy, StackIndex: tc.stack, TTLExpired: false}
+				h.ExecuteOperation(t, &policy, model)
+				h.DrainPendingCommands(t, model, 30*time.Second)
+				stacks, err := h.client.ListStacks()
+				require.NoError(t, err)
+				policyFound := false
+				for _, stack := range stacks {
+					if stack.Label == model.Stack(tc.stack).Label {
+						require.Len(t, stack.Policies, 1)
+						var persisted struct {
+							Type, OnDependents string
+							TTLSeconds         int
+						}
+						require.NoError(t, json.Unmarshal(stack.Policies[0], &persisted))
+						require.Equal(t, "ttl", persisted.Type)
+						require.Equal(t, 86400, persisted.TTLSeconds)
+						require.Equal(t, "cascade", persisted.OnDependents)
+						policyFound = true
+					}
+				}
+				require.True(t, policyFound, "TTL policy must persist, not merely leave resources unchanged")
+				after, _, err := h.extractManagedAndUnmanagedInventory()
+				require.NoError(t, err)
+				require.Len(t, after, len(before))
+				for _, original := range before {
+					found := false
+					for _, current := range after {
+						if current.Label != original.Label {
+							continue
+						}
+						found = true
+						require.Equal(t, original.NativeID, current.NativeID, original.Label)
+						require.Equal(t, original.Ksuid, current.Ksuid, original.Label)
+						require.JSONEq(t, string(original.Properties), string(current.Properties), original.Label)
+					}
+					require.True(t, found, "missing resource %s", original.Label)
+				}
+			})
+		})
+	}
+}

--- a/tests/blackbox/ttl_properties_test.go
+++ b/tests/blackbox/ttl_properties_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
+	"github.com/platform-engineering-labs/formae/tests/testcontrol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,4 +89,57 @@ func TestSetTTLPolicyPreservesResources(t *testing.T) {
 			})
 		})
 	}
+}
+
+// A failed TTL cascade must retain cross-stack properties so a subsequent
+// policy-only operation can preserve them rather than parsing an empty model.
+func TestFailedTTLCascadePreservesDependentProperties(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		h := NewTestHarness(t, 10*time.Second)
+		defer h.Cleanup()
+		model := NewStateModel(2, 10)
+		for si, ids := range [][]int{{0}, {10, 11}} {
+			op := Operation{Kind: OpApply, StackIndex: si, ApplyMode: "reconcile", ResourceIDs: ids,
+				Properties: defaultDestroyParentProps, ChildProperties: `{"Name":"NAME","ParentId":"PARENT_ID","Value":"preserve-me"}`}
+			h.ExecuteOperation(t, &op, model)
+			require.Len(t, model.AcceptedCommands, 1)
+			cmd := h.WaitForCommandDone(model.AcceptedCommands[0].CommandID, 30*time.Second)
+			require.Equal(t, "Success", cmd.State)
+			h.DrainPendingCommands(t, model, 30*time.Second)
+		}
+		before := model.Resource(1, 10).Properties
+		policy := Operation{Kind: OpSetTTLPolicy, StackIndex: 0, TTLExpired: true}
+		h.executeSetTTLPolicy(t, &policy, model)
+		require.Len(t, model.AcceptedCommands, 1)
+		cmd := h.WaitForCommandDone(model.AcceptedCommands[0].CommandID, 30*time.Second)
+		require.Equal(t, "Success", cmd.State)
+		h.reconcileCompletedAcceptedCommands(t, model)
+		require.Empty(t, model.AcceptedCommands)
+		h.ProgramResponses(t, []testcontrol.PluginOpSequence{{MatchKey: model.GetNativeID(1, 10), Operation: "Delete", Steps: []testcontrol.ResponseStep{{ErrorCode: "AccessDenied"}}}})
+		// Expiry is one second; the harness disables the periodic expirer.
+		time.Sleep(2 * time.Second)
+		h.executeCheckTTL(t, &Operation{Kind: OpCheckTTL}, model)
+		require.Len(t, model.AcceptedCommands, 1, "must exercise an accepted TTL cascade")
+		var dependentSnapshot *ResourceSnapshot
+		for i := range model.AcceptedCommands[0].Snapshots {
+			snapshot := &model.AcceptedCommands[0].Snapshots[i]
+			if snapshot.StackIndex == 1 && snapshot.SlotIndex == 10 {
+				dependentSnapshot = snapshot
+			}
+		}
+		require.NotNil(t, dependentSnapshot, "TTL must snapshot cross-stack dependents before predicting deletes")
+		require.Equal(t, before, dependentSnapshot.Properties)
+		cmd, done := h.waitForCommandInDB(model.AcceptedCommands[0].CommandID, 30*time.Second)
+		require.True(t, done)
+		require.Equal(t, "Failed", cmd.State)
+		h.reconcileCompletedAcceptedCommands(t, model)
+		require.Empty(t, model.AcceptedCommands)
+		require.Equal(t, StateExists, model.Resource(1, 10).State)
+		require.Equal(t, before, model.Resource(1, 10).Properties, "failed cascade must restore the dependent's properties")
+		require.Equal(t, StateNotExist, model.Resource(1, 11).State, "independent dependent can be deleted")
+		h.executeSetTTLPolicy(t, &Operation{Kind: OpSetTTLPolicy, StackIndex: 1}, model)
+		require.Len(t, model.AcceptedCommands, 1, "consumer policy must execute")
+		cmd = h.WaitForCommandDone(model.AcceptedCommands[0].CommandID, 30*time.Second)
+		require.Equal(t, "Success", cmd.State)
+	})
 }


### PR DESCRIPTION
Correct several property-test harness defects without changing production code:

- Preserve each resource's properties and identity when setting a TTL policy.
- Program cascade and implicit-delete responses for attempted resources and retain failed or dependency-blocked resources in the model.
- Read persisted command identities and scheduler outcomes, snapshot cross-stack TTL dependents, and restore failed-delete properties from persisted declarations when no snapshot exists.

Deterministic regressions cover flat/tree/cross-stack policy preservation, dependent failures, implicit deletes, and a failed TTL cascade followed by another policy operation. Focused integration/model tests pass, and a local 100-case FullChaos run passed in 21 minutes.

A separate, pre-existing response-queue defect is tracked for follow-up: a partial no-op can leave a scripted error queued for a later operation that drew success. Cancellation/restart/shared-read response ownership also remains unresolved. These changes do not establish full harness determinism, and no production context or SDK metadata change is proposed.
