### PR TITLE
fix(connect): serve the templates that mark artifacts as formae's own

### DIFF
--- a/internal/cli/connect/assets/connect-azure.json
+++ b/internal/cli/connect/assets/connect-azure.json
@@ -58,7 +58,7 @@
               "name": "[parameters('identityName')]",
               "location": "[parameters('location')]",
               "tags": {
-                "formae:owned": "true"
+                "formae-owned": "true"
               }
             },
             {

--- a/internal/cli/connect/azuretemplate_marker_test.go
+++ b/internal/cli/connect/azuretemplate_marker_test.go
@@ -1,0 +1,68 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package connect
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The marker the cloud plugins' discovery filters key on. Spelled identically
+// on AWS, Azure and GCP, and hyphenated because a GCP label key cannot hold a
+// colon. Pinned here because it is a cross-repo contract: this template writes
+// it and the azure plugin reads it, and the two drifting apart is silent. The
+// filter simply matches nothing, which is indistinguishable from the resource
+// not being there.
+const ownershipMarkerKey = "formae-owned"
+
+// tagsOf walks the template to the managed identity the nested deployment
+// creates and returns its tags.
+func identityTags(t *testing.T) map[string]any {
+	t.Helper()
+
+	var doc struct {
+		Resources []struct {
+			Type       string `json:"type"`
+			Properties struct {
+				Template struct {
+					Resources []struct {
+						Type string         `json:"type"`
+						Tags map[string]any `json:"tags"`
+					} `json:"resources"`
+				} `json:"template"`
+			} `json:"properties"`
+		} `json:"resources"`
+	}
+	require.NoError(t, json.Unmarshal(azureTemplateJSON, &doc))
+
+	for _, outer := range doc.Resources {
+		for _, inner := range outer.Properties.Template.Resources {
+			if inner.Type == "Microsoft.ManagedIdentity/userAssignedIdentities" {
+				return inner.Tags
+			}
+		}
+	}
+	t.Fatal("the template declares no user-assigned identity")
+	return nil
+}
+
+func TestAzureTemplateMarksTheIdentityAsFormaeOwned(t *testing.T) {
+	tags := identityTags(t)
+
+	assert.Equal(t, "true", tags[ownershipMarkerKey],
+		"the identity must carry the marker discovery filters on, or connect artifacts stay importable")
+}
+
+// The marker was spelled with a colon before the three clouds were unified on
+// one key. A template still writing the old spelling produces artifacts no
+// filter matches.
+func TestAzureTemplateDoesNotWriteTheSupersededMarker(t *testing.T) {
+	tags := identityTags(t)
+
+	assert.NotContains(t, tags, "formae:owned")
+}

--- a/internal/cli/connect/quickcreate.go
+++ b/internal/cli/connect/quickcreate.go
@@ -30,8 +30,8 @@ const (
 	// Template 0.2.0: the shared OIDC provider rides in the role template
 	// behind CreateProvider, so quick-create emits exactly one link.
 	roleTemplateKey       = "formae-connect-role.yaml"
-	roleTemplateVersionID = "xxcZ8mU5TG82MLf5iyJrlmnB4i2wOZ_f"
-	roleTemplateSHA256    = "12fe0ff79a73387c2e591fb0348558406f5b085917d879b91dc9b21de2306ee2"
+	roleTemplateVersionID = "3HS6qBEG_iQ0xWskLMcfnDTM42seWsRw"
+	roleTemplateSHA256    = "9c732a3dc510c1a289c85cc935da4fa423191dcb50ee8c3241ef4debe1e01c61"
 
 	quickCreateConsole = "https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review"
 )

--- a/internal/cli/connect/quickcreate_freshness_test.go
+++ b/internal/cli/connect/quickcreate_freshness_test.go
@@ -1,0 +1,81 @@
+// © 2026 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build releasecheck
+
+package connect
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"testing"
+)
+
+// The pinned coordinates are immutable by design: Object Lock means the
+// version this fetches can never change under us. The cost of that is
+// silence in the other direction. Publishing a new template does not move
+// the pin, so the repo can hold a template the CLI will never serve, and
+// nothing about it looks wrong: connect succeeds, and the artifacts are
+// simply built from the older template.
+//
+// So the gate checks two things against the live bucket. The pinned version
+// must still fetch and still hash to what is recorded, which catches a
+// tampered or vanished object; and the pinned version must be the current
+// one for its key, which catches a publication the pin never picked up.
+//
+// Anonymous reads are enough: the bucket policy grants public GetObject and
+// GetObjectVersion on exactly these keys, and a GET without a versionId
+// returns the current version and names it in x-amz-version-id.
+func TestPinnedTemplateIsTheCurrentPublication(t *testing.T) {
+	pinnedURL := defaultTemplateBase + "/" + roleTemplateKey + "?versionId=" + roleTemplateVersionID
+
+	body, _, err := fetch(pinnedURL)
+	if err != nil {
+		t.Fatalf("the pinned template version does not fetch: %v", err)
+	}
+	if got := sha256hex(body); got != roleTemplateSHA256 {
+		t.Errorf("pinned template digest = %s, recorded %s; the recorded digest no longer describes what the pin serves",
+			got, roleTemplateSHA256)
+	}
+
+	_, currentVersion, err := fetch(defaultTemplateBase + "/" + roleTemplateKey)
+	if err != nil {
+		t.Fatalf("the template key does not fetch: %v", err)
+	}
+	if currentVersion != "" && currentVersion != roleTemplateVersionID {
+		t.Errorf("pin is stale: %s is published as version %s but the CLI serves %s. "+
+			"A template change has been published that customers will never receive; "+
+			"re-pin roleTemplateVersionID and roleTemplateSHA256 from the current publication.",
+			roleTemplateKey, currentVersion, roleTemplateVersionID)
+	}
+}
+
+func fetch(url string) (body []byte, versionID string, err error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", &statusError{url: url, code: resp.StatusCode}
+	}
+	b, err := io.ReadAll(resp.Body)
+	return b, resp.Header.Get("x-amz-version-id"), err
+}
+
+type statusError struct {
+	url  string
+	code int
+}
+
+func (e *statusError) Error() string {
+	return http.StatusText(e.code) + " fetching " + e.url
+}
+
+func sha256hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}


### PR DESCRIPTION
## Summary

Neither connect template path produced the `formae-owned` marker the cloud plugins' discovery filters key on, so a connection created through either one left its artifacts discoverable and importable — the failure the marker exists to prevent. Caught on a real connect against a test account: the role carried only `formae-ai:owner` / `formae-ai:subject`, and the OIDC provider carried no tags at all.

**Quick-create (CloudFormation).** The template is fetched by a pinned S3 `versionId`, immutable by design so the bytes a release serves cannot change underneath it. The template gained the marker and CI published it on merge, but the pin still named the version published *before* that, so the console kept building stacks from the older template. Re-pinned to `3HS6qBEG…` with its digest.

**Azure (ARM).** The embedded template writes the marker under the superseded `formae:owned` spelling. The three clouds now share one hyphenated key (a GCP label key cannot hold a colon), so the Azure plugin's filter matches nothing.

## Why this could happen quietly

Both failures point the same way: the filter matches nothing, which is indistinguishable from the resource not being there. Publishing a template and pinning it are separate steps, and nothing compared them — the existing release gate only checks the coordinates aren't still the literal placeholder, which cannot detect a pin that is real but stale.

So the gate now also fetches the key without a `versionId` and compares the current publication against the pin, failing the release with the actual versions named. Verified both ways: it passes on the corrected pin, and restoring the stale values reproduces the failure with the message a releaser needs. Anonymous reads suffice, since the bucket policy already grants public `GetObject` on exactly these keys.

A unit test pins the Azure template's marker key, since it is a cross-repo contract between this template and the plugin that filters on it.

## Not changed

The ARM template still leaves the resource group untagged, while the credentialed provisioning path tags one it creates. A template deployment can target a resource group that already exists, and tagging one formae did not create claims an ownership it could never act on — the same reason the provisioning path refuses to tag an adopted group.