### PR TITLE
fix(changeset): let the PluginOperator own retry for resolve reads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,8 +57,8 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1
 	github.com/platform-engineering-labs/formae/pkg/auth v0.0.0-00010101000000-000000000000
-	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-20260821213704-ba68bacf6dd6
-	github.com/platform-engineering-labs/formae/pkg/model v0.1.6
+	github.com/platform-engineering-labs/formae/pkg/credential v0.1.0
+	github.com/platform-engineering-labs/formae/pkg/model v0.1.28
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.0.0-00010101000000-000000000000
 	github.com/platform-engineering-labs/formae/tests/testcontrol v0.0.0-00010101000000-000000000000
 	github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902161127-c895b20a3c9e

--- a/go.sum
+++ b/go.sum
@@ -481,8 +481,6 @@ github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902161127-c895b20a3c9
 github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902161127-c895b20a3c9e/go.mod h1:pKZWs1WAxW55mYtE0kAtpvrIMPzaQhZoBWSKqUMndvY=
 github.com/platform-engineering-labs/oox/gcpname v0.0.0-20260825170105-3bd97cb18d15 h1:GXw4nPEfPsfSZNOla+IFrIb0gfkVUzjFW7lCXWcqRwQ=
 github.com/platform-engineering-labs/oox/gcpname v0.0.0-20260825170105-3bd97cb18d15/go.mod h1:wytVDQEOgo/0PLmMj0nOnisBzzqwemanNy9gpueH9Ik=
-github.com/platform-engineering-labs/oox/provx v0.0.0-20260831005205-99489fc5e7ca h1:ryZD/AytTmkmulsezbuBEH5BbOPpbbPU1cnHUF0OOUY=
-github.com/platform-engineering-labs/oox/provx v0.0.0-20260831005205-99489fc5e7ca/go.mod h1:ySd/XvwrvHJv9Qqb4JM5SOrvmMf3BdQMGo2Ae77U+UM=
 github.com/platform-engineering-labs/oox/provx v0.0.0-20260905021850-40f9d81e8f38 h1:mXV1j81cMGKoEKal3trLT617utgH8l04I1xzHoUHACA=
 github.com/platform-engineering-labs/oox/provx v0.0.0-20260905021850-40f9d81e8f38/go.mod h1:ySd/XvwrvHJv9Qqb4JM5SOrvmMf3BdQMGo2Ae77U+UM=
 github.com/platform-engineering-labs/orbital v0.2.5 h1:7rihasWnR68ORytqLubR5WMJchv/mxoWSCB7MqaB9tU=

--- a/internal/metastructure/changeset/resolve_cache.go
+++ b/internal/metastructure/changeset/resolve_cache.go
@@ -7,11 +7,9 @@ package changeset
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
-	"time"
 
 	"ergo.services/ergo/act"
 	"ergo.services/ergo/gen"
@@ -20,32 +18,49 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/provenance"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
-	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
 // The ResolveCache is a transient cache that lives for the duration of a changeset execution. In a changeset
 // multiple resources often resolve the same value. We do not want to do a read for each of these resolvables,
 // therefore we cache these values.
+//
+// A resolve is answered from the cache when it can be, and otherwise reads the
+// source through a PluginOperator. The operator owns retry: the first attempt
+// comes back synchronously, and every later attempt is pushed here as a
+// plugin.TrackedProgress from the operator's PID. A resolve waiting on such a
+// read is parked in inFlight under that PID until the operator reports a
+// finished result.
 type ResolveCache struct {
 	act.Actor
 
-	cache      map[pkgmodel.FormaeURI]gjson.Result
-	maxRetries int
-	retryDelay time.Duration
+	cache    map[pkgmodel.FormaeURI]gjson.Result
+	inFlight map[gen.PID]*resolveInFlight
 }
 
-// resolveRetry is an internal message scheduled via SendAfter to retry a
-// resolve operation without blocking the actor's message loop.
-type resolveRetry struct {
-	From        gen.PID
-	ResourceURI pkgmodel.FormaeURI
-	Attempt     int
-	// Pre-loaded state from the first attempt so we don't re-fetch from persister.
-	loadResult messages.LoadResourceResult
+// resolveInFlight is a resolve that has left the cache-hit fast path. It
+// carries the requester and everything a read's completion needs, so the
+// operator's pushed progress, which names only the native id, can be matched
+// back to the resolve it answers.
+type resolveInFlight struct {
+	from        gen.PID
+	resourceURI pkgmodel.FormaeURI
+	loadResult  messages.LoadResourceResult
+
+	// configRefs are the opaque references in the source target's config whose
+	// live value has not been injected into config yet. At rest such a
+	// credential is a bare $ref with no $value (reference-don't-store), so the
+	// source resource cannot be read until each is resolved, and each resolves
+	// like any other reference: from the cache, or by reading its source.
+	configRefs []pkgmodel.FormaeURI
 	config     json.RawMessage
+
+	// reading is the resource whose read this resolve is parked on: the
+	// source of a config ref, or the resolve's own source resource.
+	reading pkgmodel.Resource
 }
 
 type Shutdown struct{}
@@ -56,20 +71,8 @@ func NewResolveCache() gen.ProcessBehavior {
 
 func (r *ResolveCache) Init(args ...any) error {
 	r.cache = make(map[pkgmodel.FormaeURI]gjson.Result)
-
-	cfg, ok := r.Env("RetryConfig")
-	if !ok {
-		return fmt.Errorf("resolveCache: missing 'RetryConfig' environment variable")
-	}
-	retryCfg, ok := cfg.(pkgmodel.RetryConfig)
-	if !ok {
-		return fmt.Errorf("resolveCache: 'RetryConfig' environment variable has wrong type %T", cfg)
-	}
-	r.maxRetries = retryCfg.MaxRetries
-	r.retryDelay = retryCfg.RetryDelay
-
-	r.Log().Debug("ResolveCache actor initialized maxRetries=%d retryDelay=%s", r.maxRetries, r.retryDelay)
-
+	r.inFlight = make(map[gen.PID]*resolveInFlight)
+	r.Log().Debug("ResolveCache actor initialized")
 	return nil
 }
 
@@ -77,8 +80,8 @@ func (r *ResolveCache) HandleMessage(from gen.PID, message any) error {
 	switch msg := message.(type) {
 	case messages.ResolveValue:
 		r.startResolve(from, msg.ResourceURI)
-	case resolveRetry:
-		r.continueResolve(msg)
+	case plugin.TrackedProgress:
+		r.handleProgress(from, msg)
 	case Shutdown:
 		r.Log().Debug("ResolveCache received shutdown request")
 		return gen.TerminateReasonNormal
@@ -116,159 +119,179 @@ func rootDigestOf(value gjson.Result) string {
 	return provenance.DigestOfJSON(unwrapped.Raw)
 }
 
-// startResolve handles a new ResolveValue request: checks the cache, loads from
-// the persister if needed, and kicks off the first read attempt.
+// startResolve handles a new ResolveValue request: answers from the cache when
+// it can, otherwise loads the source resource from the persister and advances
+// the resolve towards its first read.
 func (r *ResolveCache) startResolve(from gen.PID, resourceURI pkgmodel.FormaeURI) {
-	// Check if the resource is already in the cache
-	if json, ok := r.cache[resourceURI.Stripped()]; ok {
+	if props, ok := r.cache[resourceURI.Stripped()]; ok {
 		r.Log().Debug("Cache hit for resource URI uri=%v", resourceURI)
-		value := resolvedValueAt(json, resourceURI.PropertyPath())
-		if !value.Exists() {
-			r.Log().Error("Unable to resolve property in cached properties property=%s resourceURI=%v", resourceURI.PropertyPath(), resourceURI)
-			_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI, Reason: resolveMissReason(resourceURI, nil)})
-			return
-		}
-		_ = r.Send(from, messages.ValueResolved{ResourceURI: resourceURI, Value: value.String(),
-			SourceRootDigest: rootDigestOf(value)})
+		r.answer(from, resourceURI, props, nil)
 		return
 	}
 
-	// Load the resource from the stack to get the native id
 	r.Log().Debug("Cache miss for resource URI uri=%v", resourceURI)
-	stackerResult, err := messages.UnwrapCall(r.Call(
-		gen.ProcessID{Name: actornames.ResourcePersister, Node: r.Node().Name()},
-		messages.LoadResource{
-			ResourceURI: resourceURI.Stripped(),
-		}))
+	loadResult, err := r.loadResource(resourceURI)
 	if err != nil {
 		r.Log().Error("Failed to load resource from resource persister resourceURI=%v: %v", resourceURI, err)
 		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI,
 			Reason: fmt.Sprintf("could not resolve reference %q: %v", string(resourceURI), err)})
 		return
 	}
-	loadResourceResult, ok := stackerResult.(messages.LoadResourceResult)
-	if !ok {
-		r.Log().Error("Unexpected result type from resource persister resultType=%v", reflect.TypeOf(stackerResult))
-		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI,
-			Reason: fmt.Sprintf("could not resolve reference %q: unexpected reply from the resource store", string(resourceURI))})
-		return
-	}
 
-	// Execute the first attempt inline (no delay). Both the source target's
-	// config resolution and the Read happen in continueResolve, so a recoverable
-	// failure in EITHER reschedules via SendAfter on one non-blocking budget.
-	retry := resolveRetry{
-		From:        from,
-		ResourceURI: resourceURI,
-		Attempt:     1,
-		loadResult:  loadResourceResult,
-	}
-	r.continueResolve(retry)
+	r.advance(&resolveInFlight{
+		from:        from,
+		resourceURI: resourceURI,
+		loadResult:  loadResult,
+		configRefs:  resolver.ExtractOpaqueResolvableURIsFromJSON(loadResult.Target.Config),
+		config:      bytes.Clone(loadResult.Target.Config),
+	})
 }
 
-// strategy is the retry strategy for a resolve read: exponential-for-throttling,
-// and the single source of truth the caller's timeout budget is derived from.
-// It uses the command-global RetryConfig the actor reads at startup. Honoring a
-// per-plugin retry override for the source namespace is a known gap: it would
-// need the cache to query the coordinator for that namespace's config, plus a
-// per-namespace timeout budget (a resource can reference secrets across several
-// plugins), so it is deferred.
-func (r *ResolveCache) strategy() resource.RetryStrategy {
-	return resource.RetryStrategy{MaxRetries: r.maxRetries, BaseDelay: r.retryDelay}
-}
-
-// scheduleRetry reschedules a resolve attempt without blocking the actor loop.
-func (r *ResolveCache) scheduleRetry(retry resolveRetry, after time.Duration) {
-	if _, err := r.SendAfter(r.PID(), retry, after); err != nil {
-		r.Log().Error("Failed to schedule resolve retry: %v", err)
-		_ = r.Send(retry.From, messages.FailedToResolveValue{ResourceURI: retry.ResourceURI})
-	}
-}
-
-// continueResolve resolves the source target's config (single-shot) and executes
-// a read attempt; on a recoverable failure in either it schedules a retry via
-// SendAfter (non-blocking), otherwise it resolves or reports failure.
-func (r *ResolveCache) continueResolve(retry resolveRetry) {
-	resourceURI := retry.ResourceURI
-	from := retry.From
-
-	// Resolve the source target's opaque config (single-shot) before the Read.
-	// When the target authenticates from a secret, its persisted config carries a
-	// bare opaque $ref with no $value at rest (reference-don't-store), and
-	// ConvertToPluginFormat only strips metadata — it does not read the source. A
-	// recoverable failure here reschedules the whole resolve via SendAfter, on the
-	// same non-blocking budget as the Read below.
-	if retry.config == nil {
-		targetConfig, err := resource_update.ResolveOpaqueTargetConfig(r, retry.loadResult.Target)
-		if err != nil {
-			var rec *resource_update.RecoverableResolveError
-			if errors.As(err, &rec) {
-				if dec := r.strategy().Decide(retry.Attempt, rec.Code); dec.Retry {
-					r.Log().Info("ResolveCache: recoverable target-config resolve error, retrying errorCode=%s resourceURI=%v attempt=%d",
-						rec.Code, resourceURI, retry.Attempt)
-					retry.Attempt++
-					r.scheduleRetry(retry, dec.After)
-					return
-				}
-			}
-			r.Log().Error("Failed to resolve target config for resolve-read resourceURI=%v: %v", resourceURI, err)
-			_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI, Reason: err.Error()})
-			return
-		}
-		retry.config = targetConfig
-	}
-
-	progress, err := r.readViaPlugin(retry)
+// loadResource fetches a resource and its target from the persister.
+func (r *ResolveCache) loadResource(uri pkgmodel.FormaeURI) (messages.LoadResourceResult, error) {
+	result, err := messages.UnwrapCall(r.Call(
+		gen.ProcessID{Name: actornames.ResourcePersister, Node: r.Node().Name()},
+		messages.LoadResource{ResourceURI: uri.Stripped()}))
 	if err != nil {
-		r.Log().Error("Failed to read resource via plugin resourceURI=%v: %v", resourceURI, err)
-		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI})
-		return
+		return messages.LoadResourceResult{}, err
 	}
+	loadResult, ok := result.(messages.LoadResourceResult)
+	if !ok {
+		return messages.LoadResourceResult{}, fmt.Errorf("unexpected reply from the resource store: %T", result)
+	}
+	return loadResult, nil
+}
 
-	// Retry on recoverable read errors via SendAfter (non-blocking), sharing the
-	// same attempt budget as the config resolution above.
-	if progress.OperationStatus == resource.OperationStatusFailure && resource.IsRecoverable(progress.ErrorCode) {
-		if dec := r.strategy().Decide(retry.Attempt, progress.ErrorCode); dec.Retry {
-			r.Log().Info("ResolveCache: recoverable error, retrying errorCode=%s resourceURI=%v attempt=%d maxRetries=%d",
-				progress.ErrorCode, resourceURI, retry.Attempt, r.maxRetries)
-			retry.Attempt++
-			r.scheduleRetry(retry, dec.After)
+// advance takes a resolve as far as the cache allows: it injects every config
+// ref whose source is cached, then answers from the cache when the source
+// resource is there. The first thing it cannot find in the cache it reads,
+// parking the resolve until that read finishes; completing a read re-enters
+// advance, so a resolve is a sequence of reads separated by waits on the
+// operator, each one closer to the answer.
+func (r *ResolveCache) advance(rf *resolveInFlight) {
+	for len(rf.configRefs) > 0 {
+		ref := rf.configRefs[0]
+		props, ok := r.cache[ref.Stripped()]
+		if !ok {
+			source, err := r.loadResource(ref)
+			if err != nil {
+				r.Log().Error("Failed to load credential source for target config ref=%v target=%s: %v", ref, rf.loadResult.Target.Label, err)
+				r.fail(rf, fmt.Sprintf("failed to resolve opaque reference %q for target %q: load error", ref, rf.loadResult.Target.Label))
+				return
+			}
+			// The source of a credential is itself a managed resource whose own
+			// target auth is a plain credential, not another opaque ref
+			// (transitive-opaque is rejected at admission), so a metadata strip
+			// is sufficient for its config.
+			sourceConfig := source.Target.Config
+			if plain, err := resolver.ConvertToPluginFormat(sourceConfig); err == nil {
+				sourceConfig = plain
+			}
+			r.read(rf, source.Resource, sourceConfig)
 			return
 		}
-		r.Log().Error("ResolveCache: exhausted retries errorCode=%s resourceURI=%v attempts=%d",
-			progress.ErrorCode, resourceURI, retry.Attempt)
-		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI})
+		value := resolvedValueAt(props, ref.PropertyPath())
+		if !value.Exists() {
+			r.Log().Error("Credential source has no such property for target config ref=%v target=%s", ref, rf.loadResult.Target.Label)
+			r.fail(rf, fmt.Sprintf("failed to resolve opaque reference %q for target %q: property %q absent from read result",
+				ref, rf.loadResult.Target.Label, ref.PropertyPath()))
+			return
+		}
+		config, err := resolver.ResolvePropertyReferences(ref, rf.config, provenance.UnwrapEffectiveValue(value).String())
+		if err != nil {
+			r.Log().Error("Failed to inject credential into target config ref=%v target=%s: %v", ref, rf.loadResult.Target.Label, err)
+			r.fail(rf, fmt.Sprintf("failed to resolve opaque reference %q for target %q: inject error", ref, rf.loadResult.Target.Label))
+			return
+		}
+		rf.config = config
+		rf.configRefs = rf.configRefs[1:]
+	}
+
+	if props, ok := r.cache[rf.resourceURI.Stripped()]; ok {
+		r.answer(rf.from, rf.resourceURI, props, &rf.loadResult.Resource)
 		return
 	}
 
-	// Non-recoverable failure — do not cache, report immediately.
-	if progress.OperationStatus == resource.OperationStatusFailure {
-		r.Log().Error("ResolveCache: non-recoverable error reading resource errorCode=%s resourceURI=%v",
-			progress.ErrorCode, resourceURI)
-		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI})
+	// Strip the $ref/$value/$visibility wrappers so the plugin receives plain
+	// JSON. Fail closed on a conversion error (e.g. an irrecoverable $hashed
+	// field) rather than hand the raw envelope to the plugin.
+	config, err := resolver.ConvertToPluginFormat(rf.config)
+	if err != nil {
+		r.Log().Error("Failed to prepare target config for resolve-read resourceURI=%v target=%s: %v", rf.resourceURI, rf.loadResult.Target.Label, err)
+		r.fail(rf, fmt.Sprintf("failed to prepare resolved config for target %q: convert error", rf.loadResult.Target.Label))
 		return
 	}
+	r.read(rf, rf.loadResult.Resource, config)
+}
 
-	// Success — cache and respond.
+// read starts a plugin Read of res on behalf of rf. A first attempt that has
+// finished completes inline; otherwise the resolve is parked on the operator,
+// whose later attempts arrive as TrackedProgress pushes.
+func (r *ResolveCache) read(rf *resolveInFlight, res pkgmodel.Resource, config json.RawMessage) {
+	rf.reading = res
+	progress, operator, err := resource_update.ReadResourceViaPlugin(r, res, config)
+	if err != nil {
+		r.Log().Error("Failed to read resource via plugin resourceURI=%v: %v", res.URI(), err)
+		r.fail(rf, fmt.Sprintf("could not read %q: %v", string(res.URI()), err))
+		return
+	}
+	if !progress.HasFinished() {
+		r.inFlight[operator] = rf
+		return
+	}
+	r.completeRead(rf, progress)
+}
+
+// handleProgress consumes an attempt the operator pushed. Only a finished
+// attempt moves the parked resolve on; an unfinished one means the operator is
+// still retrying, and a push no resolve is waiting on is from an operator
+// whose resolve already finished.
+func (r *ResolveCache) handleProgress(operator gen.PID, progress plugin.TrackedProgress) {
+	rf, ok := r.inFlight[operator]
+	if !ok {
+		r.Log().Debug("Ignoring progress from an operator no resolve is waiting on operator=%v nativeID=%s", operator, progress.NativeID)
+		return
+	}
+	if !progress.HasFinished() {
+		r.Log().Debug("Operator retrying read resourceURI=%v errorCode=%s attempt=%d/%d",
+			rf.reading.URI(), progress.ErrorCode, progress.Attempts, progress.MaxAttempts)
+		return
+	}
+	delete(r.inFlight, operator)
+	r.completeRead(rf, &progress)
+}
+
+// completeRead caches a finished read's properties and advances the resolve, or
+// fails it when the operator gave up.
+func (r *ResolveCache) completeRead(rf *resolveInFlight, progress *plugin.TrackedProgress) {
+	if !progress.FinishedSuccessfully() {
+		r.Log().Error("ResolveCache: read failed errorCode=%s resourceURI=%v attempts=%d",
+			progress.ErrorCode, rf.reading.URI(), progress.Attempts)
+		r.fail(rf, fmt.Sprintf("could not read %q: %s after %d attempt(s)", string(rf.reading.URI()), progress.ErrorCode, progress.Attempts))
+		return
+	}
 	parsed := gjson.ParseBytes([]byte(progress.ResourceProperties))
-	enhancedParsed := r.preserveRefMetadata(retry.loadResult.Resource, parsed)
+	r.cache[rf.reading.URI()] = r.preserveRefMetadata(rf.reading, parsed)
+	r.Log().Debug("Cached resolved properties uri=%v", rf.reading.URI())
+	r.advance(rf)
+}
 
-	r.cache[resourceURI.Stripped()] = enhancedParsed
-	r.Log().Debug("Cached resolved properties uri=%v", resourceURI)
-	value := resolvedValueAt(enhancedParsed, resourceURI.PropertyPath())
+// answer sends the requested property out of the source's cached properties,
+// or a terminal miss naming the property when it is absent. source, when
+// known, identifies the resource by triplet in the miss reason.
+func (r *ResolveCache) answer(from gen.PID, resourceURI pkgmodel.FormaeURI, props gjson.Result, source *pkgmodel.Resource) {
+	value := resolvedValueAt(props, resourceURI.PropertyPath())
 	if !value.Exists() {
 		r.Log().Error("Unable to resolve property in cached properties property=%s resourceURI=%v", resourceURI.PropertyPath(), resourceURI)
-		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI, Reason: resolveMissReason(resourceURI, &retry.loadResult.Resource)})
+		_ = r.Send(from, messages.FailedToResolveValue{ResourceURI: resourceURI, Reason: resolveMissReason(resourceURI, source)})
 		return
 	}
-
 	_ = r.Send(from, messages.ValueResolved{ResourceURI: resourceURI, Value: value.String(),
 		SourceRootDigest: rootDigestOf(value)})
 }
 
-// readViaPlugin spawns a PluginOperator and executes a single Read call.
-func (r *ResolveCache) readViaPlugin(retry resolveRetry) (*plugin.TrackedProgress, error) {
-	return resource_update.ReadResourceViaPlugin(r, retry.loadResult.Resource, retry.config)
+func (r *ResolveCache) fail(rf *resolveInFlight, reason string) {
+	_ = r.Send(rf.from, messages.FailedToResolveValue{ResourceURI: rf.resourceURI, Reason: reason})
 }
 
 func (r *ResolveCache) preserveRefMetadata(originalResource pkgmodel.Resource, pluginResult gjson.Result) gjson.Result {

--- a/internal/metastructure/discovery/resolve_target_config_test.go
+++ b/internal/metastructure/discovery/resolve_target_config_test.go
@@ -8,7 +8,6 @@ package discovery
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -22,7 +21,6 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/changeset"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
-	"github.com/platform-engineering-labs/formae/internal/metastructure/resource_update"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
@@ -257,9 +255,10 @@ func TestResolveTargetConfigForList_NonRecoverableReadFailure(t *testing.T) {
 		"error must not include raw $ref envelope fields")
 }
 
-// TestResolveTargetConfigForList_RecoverableFailureThenSuccess asserts that a
-// recoverable failure followed by success within the attempt budget resolves
-// successfully, and that exceeding the budget returns an error.
+// TestResolveTargetConfigForList_RecoverableFailureIsSingleShot asserts that
+// resolution reads each source exactly once: a recoverable first attempt the
+// PluginOperator would go on to retry is reported as an error here, because
+// this synchronous path cannot wait for the operator's later attempts.
 func TestResolveTargetConfigForList_RecoverableFailureIsSingleShot(t *testing.T) {
 	const ksuid = "35R2vyf6mT5wEs0mTWT5bp1Lf0E"
 	const prop = "SecretString"
@@ -278,7 +277,7 @@ func TestResolveTargetConfigForList_RecoverableFailureIsSingleShot(t *testing.T)
 		Config: targetCfg,
 	}
 
-	t.Run("recoverable failure is single-shot and typed", func(t *testing.T) {
+	t.Run("recoverable failure is single-shot", func(t *testing.T) {
 		proc := &resolveStubProcess{
 			loadResult: messages.LoadResourceResult{
 				Resource: srcResource,
@@ -300,10 +299,8 @@ func TestResolveTargetConfigForList_RecoverableFailureIsSingleShot(t *testing.T)
 
 		require.Error(t, err, "a recoverable read failure must surface as an error")
 		assert.Nil(t, result)
-		var rec *resource_update.RecoverableResolveError
-		require.True(t, errors.As(err, &rec),
-			"a recoverable failure must surface as *RecoverableResolveError so the caller can reschedule")
-		assert.Equal(t, resource.OperationErrorCodeServiceTimeout, rec.Code)
+		assert.Contains(t, err.Error(), string(resource.OperationErrorCodeServiceTimeout),
+			"the error must name the code the read failed with")
 		assert.Equal(t, 1, proc.readAttempts,
 			"resolution is single-shot: exactly one read, no in-place retry")
 	})

--- a/internal/metastructure/resource_update/plugin_read.go
+++ b/internal/metastructure/resource_update/plugin_read.go
@@ -20,10 +20,14 @@ import (
 )
 
 // ReadResourceViaPlugin spawns a PluginOperator for the given resource and
-// executes a single Read call, returning the plugin's progress result.
-// It is a pure dispatch helper — callers own caching, retry, and result
-// interpretation.
-func ReadResourceViaPlugin(proc gen.Process, res pkgmodel.Resource, targetConfig json.RawMessage) (*plugin.TrackedProgress, error) {
+// starts a Read on it, returning the first attempt's progress and the
+// operator's PID. The operator owns retry: when the first attempt fails with
+// a recoverable error and retries remain, the returned progress has not
+// finished (TrackedProgress.HasFinished) and the operator pushes every later
+// attempt's progress to proc as a plugin.TrackedProgress sent from that PID.
+// A caller that can wait must consume those pushes; a caller that cannot
+// treats an unfinished first attempt as a failure of this call.
+func ReadResourceViaPlugin(proc gen.Process, res pkgmodel.Resource, targetConfig json.RawMessage) (*plugin.TrackedProgress, gen.PID, error) {
 	// The provider boundary for this dispatch. A generator reference in the
 	// target's config names a credential that was never drawn, and the envelope
 	// is never that credential: handing it over puts a JSON object where a
@@ -31,7 +35,7 @@ func ReadResourceViaPlugin(proc gen.Process, res pkgmodel.Resource, targetConfig
 	// credentials formae does not have. Only the config is checked — the
 	// resource's own properties are context for a Read, never values written.
 	if err := resolver.GuardNoUnresolvedGenerators(targetConfig); err != nil {
-		return nil, fmt.Errorf("cannot read %s: its target's configuration is bound to a generator whose value has not been drawn: %w", res.URI(), err)
+		return nil, gen.PID{}, fmt.Errorf("cannot read %s: its target's configuration is bound to a generator whose value has not been drawn: %w", res.URI(), err)
 	}
 
 	operationID := uuid.New().String()
@@ -45,14 +49,14 @@ func ReadResourceViaPlugin(proc gen.Process, res pkgmodel.Resource, targetConfig
 			RequestedBy: proc.PID(),
 		}))
 	if err != nil {
-		return nil, fmt.Errorf("failed to spawn plugin operator: %w", err)
+		return nil, gen.PID{}, fmt.Errorf("failed to spawn plugin operator: %w", err)
 	}
 	spawnRes, ok := spawnResult.(messages.SpawnPluginOperatorResult)
 	if !ok {
-		return nil, fmt.Errorf("unexpected result type from PluginCoordinator: %T", spawnResult)
+		return nil, gen.PID{}, fmt.Errorf("unexpected result type from PluginCoordinator: %T", spawnResult)
 	}
 	if spawnRes.Error != "" {
-		return nil, fmt.Errorf("failed to spawn plugin operator: %s", spawnRes.Error)
+		return nil, gen.PID{}, fmt.Errorf("failed to spawn plugin operator: %s", spawnRes.Error)
 	}
 
 	// Use the same call budget as ResourceUpdater.doPluginOperation. The default
@@ -72,12 +76,12 @@ func ReadResourceViaPlugin(proc gen.Process, res pkgmodel.Resource, targetConfig
 		},
 		PluginOperationCallTimeout)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read resource: %w", err)
+		return nil, gen.PID{}, fmt.Errorf("failed to read resource: %w", err)
 	}
 
 	progress, ok := progressResult.(plugin.TrackedProgress)
 	if !ok {
-		return nil, fmt.Errorf("unexpected result type from plugin operator: %T", progressResult)
+		return nil, gen.PID{}, fmt.Errorf("unexpected result type from plugin operator: %T", progressResult)
 	}
-	return &progress, nil
+	return &progress, spawnRes.PID, nil
 }

--- a/internal/metastructure/resource_update/plugin_read_guard_test.go
+++ b/internal/metastructure/resource_update/plugin_read_guard_test.go
@@ -58,7 +58,7 @@ func TestReadResourceViaPlugin_UndrawnGeneratorConfigNeverReachesAPlugin(t *test
 		}
 	}`)
 
-	_, err := ReadResourceViaPlugin(proc, readableResource(), cfg)
+	_, _, err := ReadResourceViaPlugin(proc, readableResource(), cfg)
 
 	assert.Zero(t, proc.calls, "the read must be refused before a plugin operator is even spawned")
 	if assert.Error(t, err) {
@@ -72,7 +72,7 @@ func TestReadResourceViaPlugin_UndrawnGeneratorConfigNeverReachesAPlugin(t *test
 func TestReadResourceViaPlugin_OrdinaryConfigStillDispatches(t *testing.T) {
 	proc := &countingCallProcess{}
 
-	_, err := ReadResourceViaPlugin(proc, readableResource(), json.RawMessage(`{"Region":"us-east-1"}`))
+	_, _, err := ReadResourceViaPlugin(proc, readableResource(), json.RawMessage(`{"Region":"us-east-1"}`))
 
 	require.Error(t, err, "this double has no plugin coordinator, so the spawn fails")
 	assert.Equal(t, 1, proc.calls, "an ordinary config must get as far as the spawn")

--- a/internal/metastructure/resource_update/resolve_target_config.go
+++ b/internal/metastructure/resource_update/resolve_target_config.go
@@ -18,33 +18,23 @@ import (
 	"github.com/platform-engineering-labs/formae/internal/metastructure/resolver"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
-	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
-
-// RecoverableResolveError marks a target-config resolution failure whose
-// underlying plugin Read returned a recoverable error code. Resolution is
-// single-shot and never blocks; a caller running on an actor loop should detect
-// this (errors.As) and reschedule the resolve non-blockingly rather than fail.
-type RecoverableResolveError struct {
-	Code resource.OperationErrorCode
-}
-
-func (e *RecoverableResolveError) Error() string {
-	return fmt.Sprintf("recoverable resolve read error: %s", e.Code)
-}
 
 // ResolveOpaqueTargetConfig returns an ephemeral copy of target.Config with
 // every opaque $ref replaced by its live plaintext value, ready to hand to a
 // plugin call. When the config carries no opaque references it is returned
 // unchanged (after stripping any cached metadata).
 //
-// This is the single resolution routine for every plugin-call path that loads a
-// PERSISTED target config and must authenticate a plugin operation: at rest an
-// opaque secret-sourced credential is a bare $ref with no $value (reference-
-// don't-store), and resolver.ConvertToPluginFormat only strips metadata — it
-// does NOT read the source. So any such path (discovery List, the resolve-read
-// path in ResolveCache, ...) must call this first; the primary apply/changeset
-// path instead resolves via a synthetic Resolve target op and propagation.
+// At rest an opaque secret-sourced credential is a bare $ref with no $value
+// (reference-don't-store), and resolver.ConvertToPluginFormat only strips
+// metadata — it does NOT read the source. So a synchronous plugin-call path
+// that loads a PERSISTED target config (discovery List) must call this first.
+// It is single-shot: each source is read once, and a first attempt the
+// PluginOperator will retry is reported as a failure here, because a caller
+// blocked in this routine cannot consume the operator's later pushes. The
+// ResolveCache resolves the same references itself, on its own message loop,
+// so it can wait for those pushes; the primary apply/changeset path resolves
+// via a synthetic Resolve target op and propagation.
 //
 // Any resolve failure returns a redacted error that names the reference and
 // target but never the plaintext secret.
@@ -110,8 +100,6 @@ func ResolveOpaqueTargetConfig(proc gen.Process, target pkgmodel.Target) (json.R
 				"failed to read resource for opaque ref resolution uri=%s target=%s: %v",
 				uri, target.Label, err,
 			)
-			// Wrap with %w so a caller on an actor loop can detect a
-			// RecoverableResolveError and reschedule non-blockingly.
 			return nil, fmt.Errorf(
 				"failed to resolve opaque reference %q for target %q: %w",
 				uri, target.Label, err,
@@ -163,20 +151,17 @@ func ResolveOpaqueTargetConfig(proc gen.Process, target pkgmodel.Target) (json.R
 	return plain, nil
 }
 
-// readSource performs a SINGLE plugin Read of a credential source resource. It
-// never retries and never blocks: a recoverable failure is surfaced as a
-// *RecoverableResolveError so the actor-loop caller can reschedule the whole
-// resolve via SendAfter. A non-recoverable failure is a plain terminal error.
+// readSource performs one plugin Read of a credential source resource and
+// returns its first attempt. Anything but a finished, successful first attempt
+// is an error: this routine blocks its caller, so it cannot wait for the
+// PluginOperator's retries.
 func readSource(proc gen.Process, res pkgmodel.Resource, cfg json.RawMessage) (*plugin.TrackedProgress, error) {
-	progress, err := ReadResourceViaPlugin(proc, res, cfg)
+	progress, _, err := ReadResourceViaPlugin(proc, res, cfg)
 	if err != nil {
 		return nil, err
 	}
-	if progress.OperationStatus == resource.OperationStatusFailure {
-		if resource.IsRecoverable(progress.ErrorCode) {
-			return nil, &RecoverableResolveError{Code: progress.ErrorCode}
-		}
-		return nil, fmt.Errorf("read failed: non-recoverable error %s", progress.ErrorCode)
+	if !progress.FinishedSuccessfully() {
+		return nil, fmt.Errorf("read failed: %s", progress.ErrorCode)
 	}
 	return progress, nil
 }

--- a/internal/metastructure/resource_update/resolve_timeout_test.go
+++ b/internal/metastructure/resource_update/resolve_timeout_test.go
@@ -22,7 +22,7 @@ import (
 // TestResolveTimeoutTimeout_CoversExponentialBackoff asserts the resolve
 // timeout envelope is derived from RetryStrategy.MaxTotalDelay and, for a large
 // MaxRetries, strictly exceeds the old flat (MaxRetries-1)*RetryDelay estimate,
-// so ResolveCache's exponential-backoff retries cannot trip the timeout.
+// so the operator's exponential-backoff retries cannot trip the timeout.
 func TestResolveTimeoutTimeout_CoversExponentialBackoff(t *testing.T) {
 	cfg := pkgmodel.RetryConfig{MaxRetries: 8, RetryDelay: 1 * time.Second}
 

--- a/internal/metastructure/resource_update/resource_updater.go
+++ b/internal/metastructure/resource_update/resource_updater.go
@@ -559,14 +559,15 @@ func delete(state gen.Atom, data ResourceUpdateData, proc gen.Process) (gen.Atom
 	return handleProgressUpdate(gen.PID{}, state, data, *result, proc)
 }
 
-// resolvingTimeout sizes the ResolveCache timeout to outlive the cache's
-// worst-case resolve wall time: MaxRetries+1 reads (the initial read plus
-// MaxRetries retries, each up to the updater's own call timeout) plus the exponential
-// backoff budget the ResolveCache schedules with (RetryStrategy.MaxTotalDelay),
-// plus a margin. The backoff term is derived from the same RetryStrategy the
-// cache retries with, so a tuned or exponential policy cannot make the two
-// drift: a flat MaxRetries*RetryDelay estimate would under-cover exponential
-// throttling backoff and trip this timeout mid-retry.
+// resolvingTimeout sizes the ResolveCache timeout to outlive the worst-case
+// wall time of the PluginOperator ladder a resolve read runs on: MaxRetries+1
+// reads (the initial read plus MaxRetries retries, each up to the updater's
+// own call timeout) plus the exponential backoff budget the operator schedules
+// with (RetryStrategy.MaxTotalDelay), plus a margin. The backoff term is
+// derived from the same RetryStrategy the operator backs off with, so a tuned
+// or exponential policy cannot make the two drift: a flat MaxRetries*RetryDelay
+// estimate would under-cover exponential throttling backoff and trip this
+// timeout mid-retry.
 func resolvingTimeout(cfg pkgmodel.RetryConfig) time.Duration {
 	const resolveCacheMargin = 30 * time.Second
 	perAttempt := time.Duration(PluginOperationCallTimeout) * time.Second

--- a/internal/workflow_tests/local/resolve_cache_test.go
+++ b/internal/workflow_tests/local/resolve_cache_test.go
@@ -8,8 +8,13 @@ package workflow_tests_local
 
 import (
 	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"ergo.services/ergo/gen"
 
 	"github.com/platform-engineering-labs/formae/internal/metastructure/actornames"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/messages"
@@ -22,6 +27,7 @@ import (
 	"github.com/platform-engineering-labs/formae/pkg/plugin"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveCache(t *testing.T) {
@@ -282,5 +288,306 @@ func TestResolveCache_MissingPropertyReportsReason(t *testing.T) {
 				"Reason must name the property that could not be resolved")
 			return true
 		})
+	})
+}
+
+// persistResolveCacheTarget stores a target so LoadResource can return it as the
+// resource's target.
+func persistResolveCacheTarget(t *testing.T, node gen.Node, target pkgmodel.Target) {
+	t.Helper()
+	_, err := testutil.Call(node, "ResourcePersister", target_update.PersistTargetUpdates{
+		TargetUpdates: []target_update.TargetUpdate{{
+			Target:    target,
+			Operation: target_update.TargetOperationCreate,
+			State:     target_update.TargetUpdateStateNotStarted,
+		}},
+		CommandID: "test-command-1",
+	})
+	require.NoError(t, err)
+}
+
+// persistResolveCacheResource stores a successfully created resource so the
+// ResolveCache can load it and read it back through the plugin.
+func persistResolveCacheResource(t *testing.T, node gen.Node, res pkgmodel.Resource, target pkgmodel.Target) {
+	t.Helper()
+	hash, err := testutil.Call(node, "ResourcePersister", resource_update.PersistResourceUpdate{
+		PluginOperation: resource.OperationCreate,
+		ResourceUpdate: resource_update.ResourceUpdate{
+			DesiredState:   res,
+			ResourceTarget: target,
+			State:          resource_update.ResourceUpdateStateSuccess,
+			Version:        "test-persist-hash-" + res.Label,
+			ProgressResult: []plugin.TrackedProgress{{
+				ProgressResult: resource.ProgressResult{
+					Operation:          resource.OperationCreate,
+					OperationStatus:    resource.OperationStatusSuccess,
+					NativeID:           res.NativeID,
+					ResourceProperties: res.Properties,
+				},
+				ResourceType: res.Type,
+				StartTs:      util.TimeNow(),
+				ModifiedTs:   util.TimeNow(),
+				Attempts:     1,
+			}},
+			RemainingResolvables: []pkgmodel.FormaeURI{},
+			StackLabel:           res.Stack,
+			GroupID:              "test-group-id-1",
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, hash)
+}
+
+// TestResolveCache_ThrottledReadResolvesThroughOperatorRetry: a resolve whose
+// plugin Read is throttled on its first attempt resolves once the
+// PluginOperator's own retry succeeds. The operator owns the retry ladder, so
+// the read runs exactly once per attempt: no second operator is spawned for the
+// same resolve, and the operator's pushed progress is consumed rather than
+// logged as an unknown message. The resolved properties are cached like any
+// other, so a second resolve of the same resource issues no read.
+func TestResolveCache_ThrottledReadResolvesThroughOperatorRetry(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		logs := test_helpers.SetupTestLogger()
+
+		var reads atomic.Int32
+		overrides := &plugin.ResourcePluginOverrides{
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				if reads.Add(1) == 1 {
+					return &resource.ReadResult{
+						ResourceType: "FakeAWS::S3::Bucket",
+						ErrorCode:    resource.OperationErrorCodeThrottling,
+					}, nil
+				}
+				return &resource.ReadResult{
+					ResourceType: "FakeAWS::S3::Bucket",
+					Properties:   `{"name":"bucket1"}`,
+				}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Retry.RetryDelay = 100 * time.Millisecond
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		received := make(chan any, 1)
+		_, err = testutil.StartTestHelperActor(m.Node, received)
+		require.NoError(t, err)
+
+		target := pkgmodel.Target{Label: "test-target", Namespace: "test-namespace", Config: json.RawMessage(`{}`)}
+		persistResolveCacheTarget(t, m.Node, target)
+		bucket := pkgmodel.Resource{
+			Label:      "resource-1",
+			Type:       "FakeAWS::S3::Bucket",
+			Properties: json.RawMessage(`{"name":"bucket1"}`),
+			Stack:      "test-stack",
+			Target:     target.Label,
+			NativeID:   "test-native-id-1",
+			Ksuid:      util.NewID(),
+		}
+		persistResolveCacheResource(t, m.Node, bucket, target)
+		require.NoError(t, spawnResolveCache(t, m.Node, "test-command-1"))
+
+		uri := pkgmodel.NewFormaeURI(bucket.Ksuid, "name")
+		testutil.Send(m.Node, actornames.ResolveCache("test-command-1"), messages.ResolveValue{ResourceURI: uri})
+
+		testutil.ExpectMessageWithPredicate(t, received, 5*time.Second, func(msg any) bool {
+			resolved, ok := msg.(messages.ValueResolved)
+			require.True(t, ok, "expected ValueResolved, got %T", msg)
+			return resolved.Value == "bucket1"
+		})
+
+		// Give any second retry ladder time to fire before counting.
+		time.Sleep(5 * cfg.Agent.Retry.RetryDelay)
+		assert.Equal(t, int32(2), reads.Load(), "one read per operator attempt: the throttled first attempt and its retry")
+		assert.False(t, logs.ContainsAll("Received unknown message type"),
+			"the operator's pushed progress must be consumed, not logged as unknown")
+
+		testutil.Send(m.Node, actornames.ResolveCache("test-command-1"), messages.ResolveValue{ResourceURI: uri})
+		testutil.ExpectMessageWithPredicate(t, received, 5*time.Second, func(msg any) bool {
+			resolved, ok := msg.(messages.ValueResolved)
+			require.True(t, ok, "expected ValueResolved, got %T", msg)
+			return resolved.Value == "bucket1"
+		})
+		assert.Equal(t, int32(2), reads.Load(), "a resolve completed via the operator's retry is cached like any other")
+	})
+}
+
+// TestResolveCache_ExhaustedReadRetriesFailTheResolve: when every attempt of
+// the PluginOperator's ladder is throttled, the resolve fails with a Reason
+// naming the error, and only after the operator has given up: no read is
+// issued once the failure has been reported.
+func TestResolveCache_ExhaustedReadRetriesFailTheResolve(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		var reads atomic.Int32
+		overrides := &plugin.ResourcePluginOverrides{
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				reads.Add(1)
+				return &resource.ReadResult{
+					ResourceType: "FakeAWS::S3::Bucket",
+					ErrorCode:    resource.OperationErrorCodeThrottling,
+				}, nil
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Retry.MaxRetries = 0
+		cfg.Agent.Retry.RetryDelay = 50 * time.Millisecond
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		received := make(chan any, 1)
+		_, err = testutil.StartTestHelperActor(m.Node, received)
+		require.NoError(t, err)
+
+		target := pkgmodel.Target{Label: "test-target", Namespace: "test-namespace", Config: json.RawMessage(`{}`)}
+		persistResolveCacheTarget(t, m.Node, target)
+		bucket := pkgmodel.Resource{
+			Label:      "resource-1",
+			Type:       "FakeAWS::S3::Bucket",
+			Properties: json.RawMessage(`{"name":"bucket1"}`),
+			Stack:      "test-stack",
+			Target:     target.Label,
+			NativeID:   "test-native-id-1",
+			Ksuid:      util.NewID(),
+		}
+		persistResolveCacheResource(t, m.Node, bucket, target)
+		require.NoError(t, spawnResolveCache(t, m.Node, "test-command-1"))
+
+		uri := pkgmodel.NewFormaeURI(bucket.Ksuid, "name")
+		testutil.Send(m.Node, actornames.ResolveCache("test-command-1"), messages.ResolveValue{ResourceURI: uri})
+
+		testutil.ExpectMessageWithPredicate(t, received, 5*time.Second, func(msg any) bool {
+			failed, ok := msg.(messages.FailedToResolveValue)
+			require.True(t, ok, "expected FailedToResolveValue, got %T", msg)
+			assert.Contains(t, failed.Reason, string(resource.OperationErrorCodeThrottling),
+				"a terminal read failure must name the error the operator gave up on")
+			return true
+		})
+
+		readsAtFailure := reads.Load()
+		time.Sleep(5 * cfg.Agent.Retry.RetryDelay)
+		assert.Equal(t, readsAtFailure, reads.Load(),
+			"the failure is reported once the operator has given up; no orphaned operator keeps reading")
+	})
+}
+
+// TestResolveCache_ThrottledSecretSourceReadResolvesThroughOperatorRetry: a
+// resource on a target whose config holds an opaque $ref resolves that ref by
+// reading the secret through the same operator-owned retry ladder as any other
+// read. A throttled first attempt on the secret is retried by its operator
+// once, the resolved plaintext reaches the resource's Read, and the secret's
+// properties are cached so a second resource on the same target reads the
+// secret no further time.
+func TestResolveCache_ThrottledSecretSourceReadResolvesThroughOperatorRetry(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		logs := test_helpers.SetupTestLogger()
+		const plaintext = "resolve-cache-secret-value"
+
+		var secretReads atomic.Int32
+		var bucketConfigs sync.Map
+		overrides := &plugin.ResourcePluginOverrides{
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				switch request.ResourceType {
+				case "FakeAWS::SecretsManager::Secret":
+					if secretReads.Add(1) == 1 {
+						return &resource.ReadResult{ResourceType: request.ResourceType, ErrorCode: resource.OperationErrorCodeThrottling}, nil
+					}
+					return &resource.ReadResult{
+						ResourceType: request.ResourceType,
+						Properties:   fmt.Sprintf(`{"Name":"my-secret","SecretString":%q}`, plaintext),
+					}, nil
+				case "FakeAWS::S3::Bucket":
+					bucketConfigs.Store(request.NativeID, string(request.TargetConfig))
+					return &resource.ReadResult{
+						ResourceType: request.ResourceType,
+						Properties:   fmt.Sprintf(`{"name":%q}`, request.NativeID),
+					}, nil
+				}
+				return nil, fmt.Errorf("unexpected resource type in Read: %s", request.ResourceType)
+			},
+		}
+
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Retry.RetryDelay = 100 * time.Millisecond
+		m, def, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer def()
+		require.NoError(t, err)
+
+		received := make(chan any, 1)
+		_, err = testutil.StartTestHelperActor(m.Node, received)
+		require.NoError(t, err)
+
+		provider := pkgmodel.Target{Label: "provider", Namespace: "test-namespace", Config: json.RawMessage(`{}`)}
+		persistResolveCacheTarget(t, m.Node, provider)
+		secret := pkgmodel.Resource{
+			Label:    "my-secret",
+			Type:     "FakeAWS::SecretsManager::Secret",
+			Stack:    "test-stack",
+			Target:   provider.Label,
+			NativeID: "secret-native-id",
+			Ksuid:    util.NewID(),
+			Schema: pkgmodel.Schema{
+				Identifier: "Id",
+				Fields:     []string{"Name", "SecretString"},
+				Hints:      map[string]pkgmodel.FieldHint{"SecretString": {Opaque: true}},
+			},
+			Properties: json.RawMessage(fmt.Sprintf(`{"Name":"my-secret","SecretString":%q}`, plaintext)),
+		}
+		persistResolveCacheResource(t, m.Node, secret, provider)
+
+		secretTarget := pkgmodel.Target{
+			Label:     "secret-target",
+			Namespace: "test-namespace",
+			Config: json.RawMessage(fmt.Sprintf(
+				`{"region":"us-east-1","apiKey":{"$ref":"formae://%s#/SecretString","$visibility":"Opaque"}}`, secret.Ksuid)),
+		}
+		persistResolveCacheTarget(t, m.Node, secretTarget)
+		bucket1 := pkgmodel.Resource{
+			Label:      "bucket-1",
+			Type:       "FakeAWS::S3::Bucket",
+			Properties: json.RawMessage(`{"name":"bucket-1"}`),
+			Stack:      "test-stack",
+			Target:     secretTarget.Label,
+			NativeID:   "bucket-1",
+			Ksuid:      util.NewID(),
+		}
+		bucket2 := bucket1
+		bucket2.Label, bucket2.NativeID, bucket2.Ksuid = "bucket-2", "bucket-2", util.NewID()
+		bucket2.Properties = json.RawMessage(`{"name":"bucket-2"}`)
+		persistResolveCacheResource(t, m.Node, bucket1, secretTarget)
+		persistResolveCacheResource(t, m.Node, bucket2, secretTarget)
+		require.NoError(t, spawnResolveCache(t, m.Node, "test-command-1"))
+
+		testutil.Send(m.Node, actornames.ResolveCache("test-command-1"),
+			messages.ResolveValue{ResourceURI: pkgmodel.NewFormaeURI(bucket1.Ksuid, "name")})
+		testutil.ExpectMessageWithPredicate(t, received, 5*time.Second, func(msg any) bool {
+			resolved, ok := msg.(messages.ValueResolved)
+			require.True(t, ok, "expected ValueResolved, got %T", msg)
+			return resolved.Value == "bucket-1"
+		})
+
+		time.Sleep(5 * cfg.Agent.Retry.RetryDelay)
+		assert.Equal(t, int32(2), secretReads.Load(), "the throttled secret read is retried by its own operator exactly once")
+		assert.False(t, logs.ContainsAll("Received unknown message type"),
+			"the operator's pushed progress must be consumed, not logged as unknown")
+		cfg1, ok := bucketConfigs.Load("bucket-1")
+		require.True(t, ok, "bucket-1 must have been read")
+		assert.Contains(t, cfg1.(string), plaintext, "the resource Read must receive the resolved credential")
+		assert.NotContains(t, cfg1.(string), "$ref", "the resource Read must not receive a raw $ref")
+
+		testutil.Send(m.Node, actornames.ResolveCache("test-command-1"),
+			messages.ResolveValue{ResourceURI: pkgmodel.NewFormaeURI(bucket2.Ksuid, "name")})
+		testutil.ExpectMessageWithPredicate(t, received, 5*time.Second, func(msg any) bool {
+			resolved, ok := msg.(messages.ValueResolved)
+			require.True(t, ok, "expected ValueResolved, got %T", msg)
+			return resolved.Value == "bucket-2"
+		})
+		assert.Equal(t, int32(2), secretReads.Load(), "a second resource on the same target reuses the cached secret")
+		cfg2, ok := bucketConfigs.Load("bucket-2")
+		require.True(t, ok, "bucket-2 must have been read")
+		assert.Contains(t, cfg2.(string), plaintext)
 	})
 }

--- a/pkg/plugin/resource/retry.go
+++ b/pkg/plugin/resource/retry.go
@@ -11,11 +11,11 @@ import "time"
 const DefaultMaxBackoff = 30 * time.Second
 
 // RetryStrategy is a pure, actor-agnostic description of how a recoverable
-// plugin operation should be retried. It performs no I/O, no sleeping, and holds
-// no actor state: callers ask it for a decision and then schedule their own
-// (non-blocking) reschedule. It is the single source of truth for both the
-// per-attempt backoff and the total retry budget, so a waiting actor's watchdog
-// (derived from MaxTotalDelay) can never drift from the actual backoff.
+// plugin operation is retried. It performs no I/O, no sleeping, and holds no
+// actor state. It is the single source of truth for both the per-attempt
+// backoff the PluginOperator sleeps and the total retry budget, so a waiting
+// actor's watchdog (derived from MaxTotalDelay) can never drift from the
+// actual backoff.
 type RetryStrategy struct {
 	// MaxRetries is the number of retries allowed after the first attempt.
 	MaxRetries int
@@ -25,12 +25,6 @@ type RetryStrategy struct {
 	// MaxBackoff caps a single exponential backoff delay. Zero means
 	// DefaultMaxBackoff.
 	MaxBackoff time.Duration
-}
-
-// RetryDecision is the result of RetryStrategy.Decide.
-type RetryDecision struct {
-	Retry bool
-	After time.Duration
 }
 
 func (s RetryStrategy) maxBackoff() time.Duration {
@@ -58,21 +52,6 @@ func (s RetryStrategy) Backoff(attempt int) time.Duration {
 		return s.maxBackoff()
 	}
 	return backoff
-}
-
-// Decide reports whether an operation that has just failed on its `attempt`-th
-// try (1-based) with error code `code` should retry, and after how long.
-// Throttling uses exponential Backoff; other recoverable codes use the flat
-// BaseDelay. It gives up on a non-recoverable code or once attempt reaches
-// MaxRetries.
-func (s RetryStrategy) Decide(attempt int, code OperationErrorCode) RetryDecision {
-	if !IsRecoverable(code) || attempt > s.MaxRetries {
-		return RetryDecision{Retry: false}
-	}
-	if code == OperationErrorCodeThrottling {
-		return RetryDecision{Retry: true, After: s.Backoff(attempt)}
-	}
-	return RetryDecision{Retry: true, After: s.BaseDelay}
 }
 
 // MaxTotalDelay is the worst-case total time spent backing off across all

--- a/pkg/plugin/resource/retry_test.go
+++ b/pkg/plugin/resource/retry_test.go
@@ -30,32 +30,6 @@ func TestRetryStrategy_Backoff_ZeroMaxBackoffUsesDefault(t *testing.T) {
 	assert.Equal(t, DefaultMaxBackoff, s.Backoff(10))
 }
 
-func TestRetryStrategy_Decide_NonRecoverable(t *testing.T) {
-	s := RetryStrategy{MaxRetries: 5, BaseDelay: time.Second}
-	d := s.Decide(1, OperationErrorCodeInvalidRequest)
-	assert.False(t, d.Retry)
-}
-
-func TestRetryStrategy_Decide_ExhaustedAttempts(t *testing.T) {
-	s := RetryStrategy{MaxRetries: 3, BaseDelay: time.Second}
-	assert.True(t, s.Decide(3, OperationErrorCodeThrottling).Retry)
-	assert.False(t, s.Decide(4, OperationErrorCodeThrottling).Retry, "attempt beyond MaxRetries gives up")
-}
-
-func TestRetryStrategy_Decide_ThrottlingIsExponential(t *testing.T) {
-	s := RetryStrategy{MaxRetries: 5, BaseDelay: time.Second}
-	assert.Equal(t, time.Second, s.Decide(1, OperationErrorCodeThrottling).After)
-	assert.Equal(t, 2*time.Second, s.Decide(2, OperationErrorCodeThrottling).After)
-	assert.Equal(t, 4*time.Second, s.Decide(3, OperationErrorCodeThrottling).After)
-}
-
-func TestRetryStrategy_Decide_OtherRecoverableIsFlat(t *testing.T) {
-	s := RetryStrategy{MaxRetries: 5, BaseDelay: time.Second}
-	assert.Equal(t, time.Second, s.Decide(1, OperationErrorCodeThrottling).After)
-	// NetworkFailure is recoverable but not throttling -> flat BaseDelay each time.
-	assert.Equal(t, time.Second, s.Decide(3, OperationErrorCodeNetworkFailure).After)
-}
-
 func TestRetryStrategy_MaxTotalDelay(t *testing.T) {
 	// MaxRetries=4, base 1s: 1 + 2 + 4 + 8 = 15s.
 	s := RetryStrategy{MaxRetries: 4, BaseDelay: time.Second, MaxBackoff: 30 * time.Second}

--- a/tests/e2e/go/fixtures/oidc-echo-plugin/go.mod
+++ b/tests/e2e/go/fixtures/oidc-echo-plugin/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.38
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.7
 	github.com/aws/smithy-go v1.27.8
-	github.com/platform-engineering-labs/formae/pkg/model v0.1.6
+	github.com/platform-engineering-labs/formae/pkg/model v0.1.28
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.0.0
 )
 
@@ -50,7 +50,7 @@ require (
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
 	github.com/masterminds/semver v1.5.0 // indirect
-	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-20260821213704-ba68bacf6dd6 // indirect
+	github.com/platform-engineering-labs/formae/pkg/credential v0.1.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.1 // indirect
 	github.com/theory/jsonpath v0.10.2 // indirect

--- a/tests/testplugin/go.mod
+++ b/tests/testplugin/go.mod
@@ -21,7 +21,7 @@ replace ergo.services/actor/statemachine => github.com/JeroenSoeters/actor/state
 require (
 	ergo.services/ergo v1.999.320
 	github.com/masterminds/semver v1.5.0
-	github.com/platform-engineering-labs/formae/pkg/model v0.1.6
+	github.com/platform-engineering-labs/formae/pkg/model v0.1.28
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.0.0
 	github.com/platform-engineering-labs/formae/tests/testcontrol v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.11.1
@@ -41,7 +41,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
-	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-20260821213704-ba68bacf6dd6 // indirect
+	github.com/platform-engineering-labs/formae/pkg/credential v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.1 // indirect


### PR DESCRIPTION
## Summary

Two retry ladders ran over the same plugin Read. The PluginOperator retries every recoverable error code and pushes each attempt's progress to its requester; the ResourceUpdater consumes those pushes, but the ResolveCache logged them as `Received unknown message type=plugin.TrackedProgress` and ran its own `SendAfter` ladder instead, spawning a fresh operator per retry while the previous one kept retrying in the background. Under `Throttling`, when extra reads hurt most, one recoverable read could fan out to roughly `MaxRetries x MaxRetries` provider reads, and every retry decision left an ERROR line behind.

- **ResolveCache consumes the operator's progress.** A resolve that misses the cache is parked in `inFlight`, keyed on the PID of the operator it is waiting on, until that operator reports a finished result (`TrackedProgress.HasFinished`). An unfinished attempt means the operator is still retrying. The cache's `maxRetries`, `retryDelay`, `resolveRetry`, `strategy()`, `scheduleRetry()` and both retry branches in `continueResolve` are gone, as is its `RetryConfig` env requirement. A terminal read failure now carries the error code and attempt count in its `Reason`.
- **Opaque target-config refs resolve through the cache.** A target authenticating from a secret holds an opaque `$ref` that has to be read before the resource can be. That read ran inside the synchronous `ResolveOpaqueTargetConfig`, which cannot wait for operator pushes either, so the cache now resolves such refs itself through the same parked path and caches the secret like any other source: one read per changeset instead of one per resolve. `ResolveOpaqueTargetConfig` remains discovery's synchronous path and is single-shot: a first attempt the operator will go on to retry is a failure for that discovery cycle, which is how discovery already treated it. `RecoverableResolveError` is removed.
- **`ReadResourceViaPlugin` returns the operator PID** with the first attempt, and its doc comment now states that the operator owns retry rather than "callers own retry".
- **`RetryStrategy.Decide` and `RetryDecision` are removed from `pkg/plugin/resource`.** Their only caller was the deleted cache ladder. This is an exported-API removal in the SDK module; no plugin in the org uses them.
- `resolvingTimeout` is unchanged in value; it now measures the operator's ladder instead of the cache's, and its comment says so.

Three new workflow tests drive the real PluginOperator with a throttling fake plugin and assert one read per attempt, no unknown-message log, no orphaned read after a terminal failure, and a single secret read shared by two resources on the same secret-authed target. They fail on `main` with 3 reads where 2 are expected.

Not exercised by tests: the remote-spawn path. The workflow harness spawns operators in-process; in a deployed agent the operator lives on the plugin's node. The PID key matches by construction (the spawn reply carries the remote process's own `gen.PID`, the same value `LinkPID(requestedBy)` already depends on), but no automated test covers it.

Discovery still receives a Warning-level unhandled `TrackedProgress` from an operator that keeps retrying after a first-attempt failure; that predates this change and is unchanged.

https://claude.ai/code/session_012jBbEzP4rvkm1tYJesdgSg
