### PR TITLE
fix(sync): preserve newer writes against stale successful reads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,8 +57,8 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1
 	github.com/platform-engineering-labs/formae/pkg/auth v0.0.0-00010101000000-000000000000
-	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-20260821213704-ba68bacf6dd6
-	github.com/platform-engineering-labs/formae/pkg/model v0.1.6
+	github.com/platform-engineering-labs/formae/pkg/credential v0.1.0
+	github.com/platform-engineering-labs/formae/pkg/model v0.1.28
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.0.0-00010101000000-000000000000
 	github.com/platform-engineering-labs/formae/tests/testcontrol v0.0.0-00010101000000-000000000000
 	github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902161127-c895b20a3c9e

--- a/go.sum
+++ b/go.sum
@@ -481,8 +481,6 @@ github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902161127-c895b20a3c9
 github.com/platform-engineering-labs/jsonpatch v0.0.0-20260902161127-c895b20a3c9e/go.mod h1:pKZWs1WAxW55mYtE0kAtpvrIMPzaQhZoBWSKqUMndvY=
 github.com/platform-engineering-labs/oox/gcpname v0.0.0-20260825170105-3bd97cb18d15 h1:GXw4nPEfPsfSZNOla+IFrIb0gfkVUzjFW7lCXWcqRwQ=
 github.com/platform-engineering-labs/oox/gcpname v0.0.0-20260825170105-3bd97cb18d15/go.mod h1:wytVDQEOgo/0PLmMj0nOnisBzzqwemanNy9gpueH9Ik=
-github.com/platform-engineering-labs/oox/provx v0.0.0-20260831005205-99489fc5e7ca h1:ryZD/AytTmkmulsezbuBEH5BbOPpbbPU1cnHUF0OOUY=
-github.com/platform-engineering-labs/oox/provx v0.0.0-20260831005205-99489fc5e7ca/go.mod h1:ySd/XvwrvHJv9Qqb4JM5SOrvmMf3BdQMGo2Ae77U+UM=
 github.com/platform-engineering-labs/oox/provx v0.0.0-20260905021850-40f9d81e8f38 h1:mXV1j81cMGKoEKal3trLT617utgH8l04I1xzHoUHACA=
 github.com/platform-engineering-labs/oox/provx v0.0.0-20260905021850-40f9d81e8f38/go.mod h1:ySd/XvwrvHJv9Qqb4JM5SOrvmMf3BdQMGo2Ae77U+UM=
 github.com/platform-engineering-labs/orbital v0.2.5 h1:7rihasWnR68ORytqLubR5WMJchv/mxoWSCB7MqaB9tU=

--- a/internal/metastructure/resource_persister/resource_persister.go
+++ b/internal/metastructure/resource_persister/resource_persister.go
@@ -176,6 +176,18 @@ func (rp *ResourcePersister) storeResourceUpdate(commandID string, resourceOpera
 
 	resourceUpdate.Operation = resourceOperationFromPluginOperation(resourceOperation, pluginOperation, relevantProgress)
 
+	// A successful sync read can also carry properties from its planning
+	// snapshot (including declared inputs the provider cannot read). Do not let
+	// it overwrite a newer apply; the next cycle reads from the current model.
+	if pluginOperation == pkgresource.OperationRead &&
+		resourceUpdate.Source == resource_update.FormaCommandSourceSynchronize &&
+		resourceUpdate.Operation == resource_update.OperationRead &&
+		rp.recordMovedSinceGenerated(resourceUpdate) {
+		slog.Debug("Skipping stale successful sync read; the record moved since planning",
+			"resourceLabel", resourceUpdate.DesiredState.Label)
+		return "", nil
+	}
+
 	// A NotFound Read is converted into a delete above so out-of-band deletions
 	// get absorbed. That conversion is only sound while the record still
 	// describes the object the Read probed. A sync cycle plans against a
@@ -420,7 +432,7 @@ func (rp *ResourcePersister) recordMovedSinceGenerated(resourceUpdate *resource_
 		if resourceUpdate.Source != resource_update.FormaCommandSourceSynchronize {
 			return false
 		}
-		slog.Debug("Treating a NotFound read as stale: the snapshot carries no row version",
+		slog.Debug("Treating a read as stale: the snapshot carries no row version",
 			"resourceLabel", generated.Label)
 		return true
 	}
@@ -433,7 +445,7 @@ func (rp *ResourcePersister) recordMovedSinceGenerated(resourceUpdate *resource_
 		// exists to prevent. A lookup we could not complete is no evidence that
 		// the record still matches, so treat it as moved and let the next sync
 		// cycle decide on fresh state.
-		slog.Warn("Treating a NotFound read as stale: the staleness lookup failed",
+		slog.Warn("Treating a read as stale: the staleness lookup failed",
 			"resourceLabel", generated.Label,
 			"error", err)
 		return true

--- a/internal/metastructure/resource_persister/resource_persister_test.go
+++ b/internal/metastructure/resource_persister/resource_persister_test.go
@@ -3011,7 +3011,15 @@ func TestResourcePersister_StaleReadGuardFailsClosedWhenLookupErrors(t *testing.
 func TestResourcePersister_StaleSuccessfulSyncReadPreservesBuildInputs(t *testing.T) {
 	persister, sender, ds, err := newResourcePersisterForTest(t)
 	require.NoError(t, err)
-	old := pkgmodel.Resource{Label: "image", Type: "FakeAWS::ImageBuild", Stack: "test-stack", Ksuid: util.NewID(), Managed: true, NativeID: "repo|current|builder", Properties: json.RawMessage(`{"Dockerfile":"old","ImageDigest":"old"}`)}
+	old := pkgmodel.Resource{
+		Label:      "image",
+		Type:       "FakeAWS::ImageBuild",
+		Stack:      "test-stack",
+		Ksuid:      util.NewID(),
+		Managed:    true,
+		NativeID:   "repo|current|builder",
+		Properties: json.RawMessage(`{"Dockerfile":"old","ImageDigest":"old"}`),
+	}
 	persistCreateForTest(t, persister, sender, old, "cmd-old")
 	snapshot, err := ds.LoadResource(old.URI())
 	require.NoError(t, err)
@@ -3022,7 +3030,12 @@ func TestResourcePersister_StaleSuccessfulSyncReadPreservesBuildInputs(t *testin
 	read.DesiredState.Properties = json.RawMessage(`{"Dockerfile":"old","ImageDigest":"new"}`)
 	read.ProgressResult[0].ErrorCode = ""
 	read.ProgressResult[0].ResourceProperties = read.DesiredState.Properties
-	result := persister.Call(sender, resource_update.PersistResourceUpdate{CommandID: "cmd-sync", ResourceOperation: resource_update.OperationRead, PluginOperation: resource.OperationRead, ResourceUpdate: read})
+	result := persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "cmd-sync",
+		ResourceOperation: resource_update.OperationRead,
+		PluginOperation:   resource.OperationRead,
+		ResourceUpdate:    read,
+	})
 	require.NoError(t, result.Error)
 	stored, err := ds.LoadResource(old.URI())
 	require.NoError(t, err)
@@ -3034,7 +3047,12 @@ func TestResourcePersister_StaleSuccessfulSyncReadPreservesBuildInputs(t *testin
 	currentRead.DesiredState.Properties = json.RawMessage(`{"Dockerfile":"new","ImageDigest":"newer","VersionUri":"repo:release"}`)
 	currentRead.ProgressResult[0].ErrorCode = ""
 	currentRead.ProgressResult[0].ResourceProperties = currentRead.DesiredState.Properties
-	result = persister.Call(sender, resource_update.PersistResourceUpdate{CommandID: "cmd-fresh-sync", ResourceOperation: resource_update.OperationRead, PluginOperation: resource.OperationRead, ResourceUpdate: currentRead})
+	result = persister.Call(sender, resource_update.PersistResourceUpdate{
+		CommandID:         "cmd-fresh-sync",
+		ResourceOperation: resource_update.OperationRead,
+		PluginOperation:   resource.OperationRead,
+		ResourceUpdate:    currentRead,
+	})
 	require.NoError(t, result.Error)
 	stored, err = ds.LoadResource(old.URI())
 	require.NoError(t, err)

--- a/internal/metastructure/resource_persister/resource_persister_test.go
+++ b/internal/metastructure/resource_persister/resource_persister_test.go
@@ -3005,3 +3005,38 @@ func TestResourcePersister_StaleReadGuardFailsClosedWhenLookupErrors(t *testing.
 	require.NoError(t, err)
 	require.Len(t, resources, 1, "a staleness lookup that errors must not let the delete through")
 }
+
+// A queued successful read can combine a fresh digest with build inputs from
+// its old snapshot. It must not overwrite a completed apply's version reference.
+func TestResourcePersister_StaleSuccessfulSyncReadPreservesBuildInputs(t *testing.T) {
+	persister, sender, ds, err := newResourcePersisterForTest(t)
+	require.NoError(t, err)
+	old := pkgmodel.Resource{Label: "image", Type: "FakeAWS::ImageBuild", Stack: "test-stack", Ksuid: util.NewID(), Managed: true, NativeID: "repo|current|builder", Properties: json.RawMessage(`{"Dockerfile":"old","ImageDigest":"old"}`)}
+	persistCreateForTest(t, persister, sender, old, "cmd-old")
+	snapshot, err := ds.LoadResource(old.URI())
+	require.NoError(t, err)
+	fresh := old
+	fresh.Properties = json.RawMessage(`{"Dockerfile":"new","ImageDigest":"new","VersionUri":"repo:release"}`)
+	persistCreateForTest(t, persister, sender, fresh, "cmd-build")
+	read := syncReadNotFoundForTest(*snapshot, old.NativeID)
+	read.DesiredState.Properties = json.RawMessage(`{"Dockerfile":"old","ImageDigest":"new"}`)
+	read.ProgressResult[0].ErrorCode = ""
+	read.ProgressResult[0].ResourceProperties = read.DesiredState.Properties
+	result := persister.Call(sender, resource_update.PersistResourceUpdate{CommandID: "cmd-sync", ResourceOperation: resource_update.OperationRead, PluginOperation: resource.OperationRead, ResourceUpdate: read})
+	require.NoError(t, result.Error)
+	stored, err := ds.LoadResource(old.URI())
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.JSONEq(t, string(fresh.Properties), string(stored.Properties))
+
+	// A later cycle planned from the current row must still absorb cloud changes.
+	currentRead := syncReadNotFoundForTest(*stored, old.NativeID)
+	currentRead.DesiredState.Properties = json.RawMessage(`{"Dockerfile":"new","ImageDigest":"newer","VersionUri":"repo:release"}`)
+	currentRead.ProgressResult[0].ErrorCode = ""
+	currentRead.ProgressResult[0].ResourceProperties = currentRead.DesiredState.Properties
+	result = persister.Call(sender, resource_update.PersistResourceUpdate{CommandID: "cmd-fresh-sync", ResourceOperation: resource_update.OperationRead, PluginOperation: resource.OperationRead, ResourceUpdate: currentRead})
+	require.NoError(t, result.Error)
+	stored, err = ds.LoadResource(old.URI())
+	require.NoError(t, err)
+	require.JSONEq(t, string(currentRead.DesiredState.Properties), string(stored.Properties))
+}

--- a/internal/workflow_tests/local/synchronizer_stale_read_test.go
+++ b/internal/workflow_tests/local/synchronizer_stale_read_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/platform-engineering-labs/formae/internal/datastore"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/config"
+	"github.com/platform-engineering-labs/formae/internal/metastructure/forma_command"
 	"github.com/platform-engineering-labs/formae/internal/metastructure/testutil"
 	"github.com/platform-engineering-labs/formae/internal/workflow_tests/test_helpers"
 	pkgmodel "github.com/platform-engineering-labs/formae/pkg/model"
@@ -143,5 +144,111 @@ func TestSynchronizer_StaleReadDoesNotDeleteReplacedResource(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, stored, 1, "exactly one record must remain")
 		require.Equal(t, replacedID, stored[0].NativeID, "the surviving record must be the replacement")
+	})
+}
+
+// Registration excludes resources from future sync batches. It does not cancel
+// a read already executing when the changeset executor registers an update.
+func TestSynchronizer_StaleSuccessfulReadDoesNotOverwriteApply(t *testing.T) {
+	testutil.RunTestFromProjectRoot(t, func(t *testing.T) {
+		const stackLabel = "stale-success-stack"
+		logCapture := test_helpers.SetupTestLogger()
+		var armed atomic.Bool
+		var updated atomic.Bool
+		started := make(chan struct{})
+		release := make(chan struct{})
+		var releaseOnce sync.Once
+		unblock := func() { releaseOnce.Do(func() { close(release) }) }
+		overrides := &plugin.ResourcePluginOverrides{
+			Create: func(request *resource.CreateRequest) (*resource.CreateResult, error) {
+				return &resource.CreateResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationCreate,
+					OperationStatus: resource.OperationStatusSuccess,
+					RequestID:       "create-1",
+					NativeID:        "resource-1",
+				}}, nil
+			},
+			Update: func(request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+				updated.Store(true)
+				return &resource.UpdateResult{ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationUpdate,
+					OperationStatus: resource.OperationStatusSuccess,
+					RequestID:       "update-1",
+					NativeID:        "resource-1",
+				}}, nil
+			},
+			Read: func(request *resource.ReadRequest) (*resource.ReadResult, error) {
+				if armed.CompareAndSwap(true, false) {
+					close(started)
+					<-release
+					return &resource.ReadResult{ResourceType: request.ResourceType, Properties: `{"memory":"768"}`}, nil
+				}
+				properties := `{"memory":"512"}`
+				if updated.Load() {
+					properties = `{"memory":"1024"}`
+				}
+				return &resource.ReadResult{ResourceType: request.ResourceType, Properties: properties}, nil
+			},
+		}
+		cfg := test_helpers.NewTestMetastructureConfig()
+		cfg.Agent.Synchronization.Enabled = false
+		m, cleanup, err := test_helpers.NewTestMetastructureWithConfig(t, overrides, cfg)
+		defer cleanup()
+		defer unblock()
+		require.NoError(t, err)
+		waitCommand := func(id string) {
+			t.Helper()
+			require.Eventually(t, func() bool {
+				commands, err := m.Datastore.LoadFormaCommands()
+				if err != nil {
+					return false
+				}
+				for _, cmd := range commands {
+					if cmd.ID == id {
+						return cmd.State == forma_command.CommandStateSuccess
+					}
+				}
+				return false
+			}, 15*time.Second, 100*time.Millisecond, "command %s should succeed", id)
+		}
+		f := &pkgmodel.Forma{
+			Stacks: []pkgmodel.Stack{{Label: stackLabel}},
+			Resources: []pkgmodel.Resource{{
+				Label:      "resource",
+				Type:       "FakeAWS::Resource",
+				Stack:      stackLabel,
+				Target:     "test-target",
+				Properties: json.RawMessage(`{"memory":"512"}`),
+				Schema:     pkgmodel.Schema{Fields: []string{"memory"}},
+			}},
+			Targets: []pkgmodel.Target{{Label: "test-target"}},
+		}
+		initial, err := m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
+		require.NoError(t, err)
+		waitCommand(initial.CommandID)
+		armed.Store(true)
+		require.NoError(t, m.ForceSync())
+		select {
+		case <-started:
+		case <-time.After(15 * time.Second):
+			t.Fatal("sync read did not start")
+		}
+		// This is a real update through the changeset executor and its registration.
+		f.Resources[0].Properties = json.RawMessage(`{"memory":"1024"}`)
+		apply, err := m.ApplyForma(f, &config.FormaCommandConfig{Mode: pkgmodel.FormaApplyModeReconcile}, "test", "", "")
+		require.NoError(t, err)
+		waitCommand(apply.CommandID)
+		require.True(t, updated.Load(), "the plugin update must run while the sync read is blocked")
+		unblock()
+		// Unchanged sync commands are discarded; wait for the synchronizer's
+		// completion signal instead of expecting a command-history entry.
+		require.Eventually(t, func() bool {
+			return logCapture.ContainsAll("Synchronization finished")
+		}, 15*time.Second, 100*time.Millisecond, "sync should finish after its read is released")
+
+		stored, err := m.Datastore.LoadResourcesByStack(stackLabel)
+		require.NoError(t, err)
+		require.Len(t, stored, 1)
+		require.JSONEq(t, `{"memory":"1024"}`, string(stored[0].Properties))
 	})
 }

--- a/tests/e2e/go/fixtures/oidc-echo-plugin/go.mod
+++ b/tests/e2e/go/fixtures/oidc-echo-plugin/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.38
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.7
 	github.com/aws/smithy-go v1.27.8
-	github.com/platform-engineering-labs/formae/pkg/model v0.1.6
+	github.com/platform-engineering-labs/formae/pkg/model v0.1.28
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.0.0
 )
 
@@ -50,7 +50,7 @@ require (
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
 	github.com/masterminds/semver v1.5.0 // indirect
-	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-20260821213704-ba68bacf6dd6 // indirect
+	github.com/platform-engineering-labs/formae/pkg/credential v0.1.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.1 // indirect
 	github.com/theory/jsonpath v0.10.2 // indirect

--- a/tests/testplugin/go.mod
+++ b/tests/testplugin/go.mod
@@ -21,7 +21,7 @@ replace ergo.services/actor/statemachine => github.com/JeroenSoeters/actor/state
 require (
 	ergo.services/ergo v1.999.320
 	github.com/masterminds/semver v1.5.0
-	github.com/platform-engineering-labs/formae/pkg/model v0.1.6
+	github.com/platform-engineering-labs/formae/pkg/model v0.1.28
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.0.0
 	github.com/platform-engineering-labs/formae/tests/testcontrol v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.11.1
@@ -41,7 +41,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
-	github.com/platform-engineering-labs/formae/pkg/credential v0.0.0-20260821213704-ba68bacf6dd6 // indirect
+	github.com/platform-engineering-labs/formae/pkg/credential v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.1 // indirect


### PR DESCRIPTION
A synchronization cycle can read from a snapshot captured before an apply. Even when the cloud read succeeds, merging that response with the old snapshot can overwrite newly applied properties—for example, retaining a fresh image digest while losing its declared version tag and restoring old build inputs.

Extend the existing record-version guard to successful synchronization reads. Superseded or indeterminate snapshots are skipped; a fresh cycle can still absorb cloud changes.

The persister regression checks stale-read preservation and subsequent fresh-read updates. A workflow regression blocks a synchronization read, completes a real ApplyForma update through the changeset executor (including resource registration), then releases the old read. It fails without the guard and passes with it, verifying that registration does not cancel reads already in flight.

Validated the resource-persister and synchronizer suites with `go test -tags unit ./internal/metastructure/resource_persister ./internal/workflow_tests/local -run 'TestResourcePersister|TestSynchronizer' -count=1`. Formatting checks pass, and `GOTOOLCHAIN=go1.26.2 golangci-lint run` reports zero issues.

Also reconcile the SDK requirements after the base branch’s release-pin change: without `go mod tidy`, CI fails before building.
